### PR TITLE
Scala: Use `TrailingComma` marker

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -89,7 +89,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             JRightPadded<? extends J> node = nodes.get(i);
             visit(node.getElement(), p);
             boolean isLast = i == nodes.size() - 1;
-            if (isLast && node.getMarkers().findFirst(TrailingComma.class).isPresent()) {
+            Optional<TrailingComma> trailingComma = isLast ? node.getMarkers().findFirst(TrailingComma.class) : Optional.empty();
+            if (trailingComma.isPresent()) {
+                visitSpace(trailingComma.get().getPrefix(), location.getAfterLocation(), p);
                 p.append(suffixBetween);
                 visitSpace(node.getAfter(), location.getAfterLocation(), p);
                 visitMarkers(node.getMarkers(), p);
@@ -110,7 +112,9 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
      * that don't go through {@link #visitRightPadded}.
      */
     private void visitListElementSuffix(JRightPadded<? extends J> node, boolean isLast, Space.Location afterLocation, PrintOutputCapture<P> p) {
-        if (isLast && node.getMarkers().findFirst(TrailingComma.class).isPresent()) {
+        Optional<TrailingComma> trailingComma = isLast ? node.getMarkers().findFirst(TrailingComma.class) : Optional.empty();
+        if (trailingComma.isPresent()) {
+            visitSpace(trailingComma.get().getPrefix(), afterLocation, p);
             p.append(',');
             visitSpace(node.getAfter(), afterLocation, p);
         } else {

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -41,6 +41,7 @@ import org.openrewrite.scala.marker.IndentedSyntax;
 import org.openrewrite.scala.marker.InfixTypeNotation;
 import org.openrewrite.scala.marker.SObject;
 import org.openrewrite.scala.marker.Semicolon;
+import org.openrewrite.scala.marker.TrailingComma;
 import org.openrewrite.scala.marker.TypeProjection;
 import org.openrewrite.scala.marker.ScalaForLoop;
 import org.openrewrite.scala.marker.TypeAscription;
@@ -81,7 +82,45 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             super.visitContainer(before, container, location, suffixBetween, after, p);
         }
     }
-    
+
+    @Override
+    protected void visitRightPadded(List<? extends JRightPadded<? extends J>> nodes, JRightPadded.Location location, String suffixBetween, PrintOutputCapture<P> p) {
+        for (int i = 0; i < nodes.size(); i++) {
+            JRightPadded<? extends J> node = nodes.get(i);
+            visit(node.getElement(), p);
+            boolean isLast = i == nodes.size() - 1;
+            if (isLast && node.getMarkers().findFirst(TrailingComma.class).isPresent()) {
+                p.append(suffixBetween);
+                visitSpace(node.getAfter(), location.getAfterLocation(), p);
+                visitMarkers(node.getMarkers(), p);
+            } else {
+                visitSpace(node.getAfter(), location.getAfterLocation(), p);
+                visitMarkers(node.getMarkers(), p);
+                if (!isLast) {
+                    p.append(suffixBetween);
+                }
+            }
+        }
+    }
+
+    /**
+     * Emit the separator following a comma-separated list element, honoring a
+     * {@link TrailingComma} marker on the last element so a source trailing comma
+     * round-trips. Used by the hand-written parameter/type-parameter print loops
+     * that don't go through {@link #visitRightPadded}.
+     */
+    private void visitListElementSuffix(JRightPadded<? extends J> node, boolean isLast, Space.Location afterLocation, PrintOutputCapture<P> p) {
+        if (isLast && node.getMarkers().findFirst(TrailingComma.class).isPresent()) {
+            p.append(',');
+            visitSpace(node.getAfter(), afterLocation, p);
+        } else {
+            visitSpace(node.getAfter(), afterLocation, p);
+            if (!isLast) {
+                p.append(',');
+            }
+        }
+    }
+
     @Override
     public J visitTypeParameters(J.TypeParameters typeParams, PrintOutputCapture<P> p) {
         // Use Scala-style square brackets instead of angle brackets
@@ -470,10 +509,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             } else {
                 visit(element, p);
             }
-            visitSpace(param.getAfter(), JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
-            if (i < paramList.size() - 1) {
-                p.append(',');
-            }
+            visitListElementSuffix(param, i == paramList.size() - 1, JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
         }
         if (hasParens) {
             p.append(')');
@@ -631,10 +667,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             } else {
                 visit(elem, p);
             }
-            visitSpace(lp.getAfter(), JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
-            if (j < lps.size() - 1) {
-                p.append(',');
-            }
+            visitListElementSuffix(lp, j == lps.size() - 1, JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
         }
         if (lambdaParams.isParenthesized()) {
             p.append(')');
@@ -973,16 +1006,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     } else {
                         visit(element, p);
                     }
-                    boolean isTrailingComma = rp.getMarkers().findFirst(org.openrewrite.scala.marker.TrailingComma.class).isPresent();
-                    if (isTrailingComma) {
-                        p.append(',');
-                        visitSpace(rp.getAfter(), Space.Location.RECORD_STATE_VECTOR_SUFFIX, p);
-                    } else {
-                        visitSpace(rp.getAfter(), Space.Location.RECORD_STATE_VECTOR_SUFFIX, p);
-                        if (i < ctorElements.size() - 1) {
-                            p.append(',');
-                        }
-                    }
+                    visitListElementSuffix(rp, i == ctorElements.size() - 1, Space.Location.RECORD_STATE_VECTOR_SUFFIX, p);
                 }
                 p.append(')');
                 // Re-emit any additional curried constructor param lists captured verbatim
@@ -1055,10 +1079,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             List<JRightPadded<J.TypeParameter>> elements = typeParams.getPadding().getElements();
             for (int i = 0; i < elements.size(); i++) {
                 visit(elements.get(i).getElement(), p);
-                visitSpace(elements.get(i).getAfter(), Space.Location.TYPE_PARAMETER_SUFFIX, p);
-                if (i < elements.size() - 1) {
-                    p.append(',');
-                }
+                visitListElementSuffix(elements.get(i), i == elements.size() - 1, Space.Location.TYPE_PARAMETER_SUFFIX, p);
             }
             p.append(']');
         }
@@ -2075,10 +2096,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
             } else {
                 visit(element, p);
             }
-            visitSpace(param.getAfter(), JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
-            if (i < paramList.size() - 1) {
-                p.append(',');
-            }
+            visitListElementSuffix(param, i == paramList.size() - 1, JRightPadded.Location.METHOD_DECLARATION_PARAMETER.getAfterLocation(), p);
         }
         p.append(')');
         visit(ext.getBody(), p);

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -973,9 +973,15 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                     } else {
                         visit(element, p);
                     }
-                    visitSpace(rp.getAfter(), Space.Location.RECORD_STATE_VECTOR_SUFFIX, p);
-                    if (i < ctorElements.size() - 1) {
+                    boolean isTrailingComma = rp.getMarkers().findFirst(org.openrewrite.scala.marker.TrailingComma.class).isPresent();
+                    if (isTrailingComma) {
                         p.append(',');
+                        visitSpace(rp.getAfter(), Space.Location.RECORD_STATE_VECTOR_SUFFIX, p);
+                    } else {
+                        visitSpace(rp.getAfter(), Space.Location.RECORD_STATE_VECTOR_SUFFIX, p);
+                        if (i < ctorElements.size() - 1) {
+                            p.append(',');
+                        }
                     }
                 }
                 p.append(')');

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/TrailingComma.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/TrailingComma.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.marker;
+
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * Marks a constructor parameter (or other comma-separated element) that was
+ * followed by a trailing comma in the source. The printer emits a {@code ,}
+ * after the marked element even though it is the last in its list.
+ */
+public class TrailingComma implements Marker {
+    private final UUID id;
+
+    public TrailingComma(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public UUID getId() {
+        return id;
+    }
+
+    @Override
+    public TrailingComma withId(UUID id) {
+        return new TrailingComma(id);
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/marker/TrailingComma.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/marker/TrailingComma.java
@@ -15,6 +15,10 @@
  */
 package org.openrewrite.scala.marker;
 
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 
 import java.util.UUID;
@@ -23,21 +27,18 @@ import java.util.UUID;
  * Marks a constructor parameter (or other comma-separated element) that was
  * followed by a trailing comma in the source. The printer emits a {@code ,}
  * after the marked element even though it is the last in its list.
+ * <p>
+ * {@code prefix} holds the whitespace between the element and the trailing
+ * comma (e.g. the space in {@code (x: Int ,)}); the whitespace after the comma
+ * is stored in the element's own right-padding.
  */
+@Value
+@With
 public class TrailingComma implements Marker {
-    private final UUID id;
+    UUID id;
+    Space prefix;
 
-    public TrailingComma(UUID id) {
-        this.id = id;
-    }
-
-    @Override
-    public UUID getId() {
-        return id;
-    }
-
-    @Override
-    public TrailingComma withId(UUID id) {
-        return new TrailingComma(id);
+    public static TrailingComma create(Space prefix) {
+        return new TrailingComma(Tree.randomId(), prefix);
     }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -38,6 +38,7 @@ import org.openrewrite.scala.marker.OmitImportBraces
 import org.openrewrite.scala.marker.PackageObject
 import org.openrewrite.scala.marker.SObject
 import org.openrewrite.scala.marker.Semicolon
+import org.openrewrite.scala.marker.TrailingComma
 import org.openrewrite.scala.marker.TypeProjection
 import org.openrewrite.scala.marker.ScalaForLoop
 import org.openrewrite.scala.marker.BlockArgument
@@ -85,6 +86,21 @@ class ScalaTreeVisitor(
 
   /** Resolve a fully-qualified type name to a JavaType. */
   private def typeForFqn(fqn: String): JavaType = typeMapping.map(_.typeForFqn(fqn)).orNull
+
+  /** Dotty sometimes produces an extra erroneous ValDef/TypeDef element in a comma-separated
+    * list when the source has a trailing comma (e.g. `class Foo(x: Int,)` produces two ValDef
+    * entries — the real `x` and an `<error>` artifact). Strip it so the LST has the right count. */
+  private def stripTrailingCommaArtifact[T <: Trees.Tree[?]](nodes: List[T]): List[T] = {
+    if (nodes.nonEmpty) {
+      val last = nodes.last
+      val name = last match {
+        case vd: Trees.ValDef[?] => vd.name.toString
+        case td: Trees.TypeDef[?] => td.name.toString
+        case _ => ""
+      }
+      if (name.isEmpty || name.startsWith("<")) nodes.init else nodes
+    } else nodes
+  }
 
   /** Extract JavaType from a tree node: try span-based, then direct .tpe, then name-based. */
   private def typeOfTree(tree: Trees.Tree[?]): JavaType = {
@@ -5021,11 +5037,12 @@ class ScalaTreeVisitor(
         // Update cursor to after opening bracket
         cursor = bracketStart + 1
         
-        // Convert TypeDef nodes to J.TypeParameter
+        val effectiveTypeParams = stripTrailingCommaArtifact(typeParams)
         val jTypeParams = new util.ArrayList[JRightPadded[J.TypeParameter]]()
-        typeParams.zipWithIndex.foreach { case (tparam, idx) =>
+        effectiveTypeParams.zipWithIndex.foreach { case (tparam, idx) =>
           val jTypeParam = visitTypeParameter(tparam)
-          val isLast = idx == typeParams.size - 1
+          val isLast = idx == effectiveTypeParams.size - 1
+          var trailingCommaFound = false
 
           val afterParam: Space = if (!isLast && cursor < source.length) {
             val commaPos = positionOfNext(",", cursor)
@@ -5035,13 +5052,22 @@ class ScalaTreeVisitor(
               before
             } else Space.EMPTY
           } else if (isLast && cursor < source.length) {
-            // Capture whitespace between last type parameter and closing `]`
             val closePos = positionOfNext("]", cursor)
-            if (closePos >= 0) ScalaSpace.format(source, cursor, closePos)
-            else Space.EMPTY
+            if (closePos >= 0) {
+              val betweenStr = source.substring(cursor, closePos)
+              val commaIdx = positionOfNextIn(betweenStr, ",", 0)
+              if (commaIdx >= 0) {
+                trailingCommaFound = true
+                cursor = cursor + commaIdx + 1
+                ScalaSpace.format(source, cursor, closePos)
+              } else {
+                ScalaSpace.format(source, cursor, closePos)
+              }
+            } else Space.EMPTY
           } else Space.EMPTY
 
-          jTypeParams.add(new JRightPadded(jTypeParam, afterParam, Markers.EMPTY))
+          val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+          jTypeParams.add(new JRightPadded(jTypeParam, afterParam, markers))
         }
         
         // Update cursor to after closing bracket.
@@ -5082,7 +5108,11 @@ class ScalaTreeVisitor(
     }
 
     val primaryConstructor: JContainer[Statement] = if (ctorParenPos >= 0) {
-      val params = firstValueParamList.getOrElse(Nil)
+      val rawParams = firstValueParamList.getOrElse(Nil)
+      val params = if (rawParams.nonEmpty) {
+        val lastName = rawParams.last.name.toString
+        if (lastName.isEmpty || lastName.startsWith("<")) rawParams.init else rawParams
+      } else rawParams
       val parenSpace = ScalaSpace.format(source, cursor, ctorParenPos)
       cursor = ctorParenPos + 1
 
@@ -5092,6 +5122,8 @@ class ScalaTreeVisitor(
         val param = visitConstructorParameter(vd, isFirstInList = idx == 0)
         val paramEnd = if (vd.span.exists) Math.max(0, vd.span.end - offsetAdjustment) else cursor
         cursor = Math.max(cursor, paramEnd)
+
+        var trailingCommaFound = false
         val afterParam: Space = if (!isLast) {
           val nextParamStart = if (params(idx + 1).span.exists) Math.max(0, params(idx + 1).span.start - offsetAdjustment) else cursor
           if (cursor < nextParamStart && nextParamStart <= source.length) {
@@ -5104,14 +5136,30 @@ class ScalaTreeVisitor(
             } else Space.EMPTY
           } else Space.EMPTY
         } else {
-          // Capture whitespace between last parameter and closing `)`
+          // Capture whitespace between last parameter and closing `)`,
+          // handling a possible trailing comma.
           if (cursor < source.length) {
             val remaining = source.substring(cursor, Math.min(cursor + 500, source.length))
             val closeParen = positionOfNextIn(remaining, ")", 0)
-            if (closeParen >= 0) Space.format(remaining.substring(0, closeParen)) else Space.EMPTY
+            if (closeParen >= 0) {
+              val between = remaining.substring(0, closeParen)
+              val commaIdx = positionOfNextIn(between, ",", 0)
+              if (commaIdx >= 0) {
+                trailingCommaFound = true
+                cursor = cursor + commaIdx + 1
+                Space.format(between.substring(commaIdx + 1))
+              } else {
+                Space.format(between)
+              }
+            } else Space.EMPTY
           } else Space.EMPTY
         }
-        jParams.add(new JRightPadded(param.asInstanceOf[Statement], afterParam, Markers.EMPTY))
+        val paramMarkers = if (trailingCommaFound) {
+          Markers.EMPTY.add(new TrailingComma(Tree.randomId()))
+        } else {
+          Markers.EMPTY
+        }
+        jParams.add(new JRightPadded(param.asInstanceOf[Statement], afterParam, paramMarkers))
       }
 
       // Advance cursor past closing `)`
@@ -6288,10 +6336,12 @@ class ScalaTreeVisitor(
         val bracketSpace = if (bracketIdx > 0) Space.format(searchText.substring(0, bracketIdx)) else Space.EMPTY
         cursor = cursor + bracketIdx + 1
 
+        val effectiveTypeParams = stripTrailingCommaArtifact(typeParams)
         val jTypeParams = new util.ArrayList[JRightPadded[J.TypeParameter]]()
-        typeParams.zipWithIndex.foreach { case (tp, idx) =>
+        effectiveTypeParams.zipWithIndex.foreach { case (tp, idx) =>
           val jtp = visitTypeParameter(tp)
-          val isLast = idx == typeParams.size - 1
+          val isLast = idx == effectiveTypeParams.size - 1
+          var trailingCommaFound = false
           val afterParam = if (cursor < source.length) {
             if (!isLast) {
               val s = source.substring(cursor, Math.min(cursor + 200, source.length))
@@ -6301,14 +6351,24 @@ class ScalaTreeVisitor(
                 Space.format(s.substring(0, commaIdx))
               } else Space.EMPTY
             } else {
-              // Capture whitespace between last type parameter and closing `]`
               val s = source.substring(cursor, Math.min(cursor + 200, source.length))
               val closeIdx = positionOfNextIn(s, "]", 0)
-              if (closeIdx >= 0) Space.format(s.substring(0, closeIdx))
-              else Space.EMPTY
+              if (closeIdx >= 0) {
+                val betweenStr = s.substring(0, closeIdx)
+                val commaIdx = positionOfNextIn(betweenStr, ",", 0)
+                if (commaIdx >= 0) {
+                  trailingCommaFound = true
+                  cursor = cursor + commaIdx + 1
+                  val afterCursor = cursor
+                  Space.format(s.substring(commaIdx + 1, closeIdx))
+                } else {
+                  Space.format(s.substring(0, closeIdx))
+                }
+              } else Space.EMPTY
             }
           } else Space.EMPTY
-          jTypeParams.add(new JRightPadded(jtp, afterParam, Markers.EMPTY))
+          val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+          jTypeParams.add(new JRightPadded(jtp, afterParam, markers))
         }
 
         val afterSearch = source.substring(cursor, Math.min(cursor + 200, source.length))
@@ -6322,7 +6382,8 @@ class ScalaTreeVisitor(
     } else null
 
     // Visit a parameter list from source, returning J.Lambda.Parameters and advancing cursor past `)`
-    def visitParamListAsLambdaParams(params: List[Trees.ValDef[?]]): J.Lambda.Parameters = {
+    def visitParamListAsLambdaParams(rawParams: List[Trees.ValDef[?]]): J.Lambda.Parameters = {
+      val params = stripTrailingCommaArtifact(rawParams)
       val parenIdx = positionOfNextIn(source, "(", cursor)
       val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
       if (parenIdx >= 0) cursor = parenIdx + 1
@@ -6331,6 +6392,7 @@ class ScalaTreeVisitor(
       params.zipWithIndex.foreach { case (vd, idx) =>
         val param = visitMethodParameter(vd)
         val isLast = idx == params.size - 1
+        var trailingCommaFound = false
         val afterParam = if (!isLast) {
           val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
           cursor = Math.max(cursor, paramEnd)
@@ -6345,18 +6407,26 @@ class ScalaTreeVisitor(
             } else Space.EMPTY
           } else Space.EMPTY
         } else {
-          // Capture whitespace between last parameter and closing `)` so
-          // multi-line parameter lists with `)` on its own line round-trip.
           val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
           val lookupStart = Math.max(cursor, paramEnd)
           if (lookupStart < source.length) {
             val remaining = source.substring(lookupStart, Math.min(lookupStart + 200, source.length))
             val closeParen = positionOfNextIn(remaining, ")", 0)
-            if (closeParen >= 0) Space.format(remaining.substring(0, closeParen))
-            else Space.EMPTY
+            if (closeParen >= 0) {
+              val betweenStr = remaining.substring(0, closeParen)
+              val commaIdx = positionOfNextIn(betweenStr, ",", 0)
+              if (commaIdx >= 0) {
+                trailingCommaFound = true
+                cursor = lookupStart + commaIdx + 1
+                Space.format(betweenStr.substring(commaIdx + 1))
+              } else {
+                Space.format(betweenStr)
+              }
+            } else Space.EMPTY
           } else Space.EMPTY
         }
-        jParams.add(new JRightPadded(param.asInstanceOf[J], afterParam, Markers.EMPTY))
+        val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+        jParams.add(new JRightPadded(param.asInstanceOf[J], afterParam, markers))
       }
 
       // Find closing paren — search the full remaining source (comment-aware) so a
@@ -6403,14 +6473,16 @@ class ScalaTreeVisitor(
         val parenSpace = if (parenIdx > cursor) Space.format(source.substring(cursor, parenIdx)) else Space.EMPTY
         if (parenIdx >= 0) cursor = parenIdx + 1
 
+        val effectiveFirstList = stripTrailingCommaArtifact(firstList)
         val jParams = new util.ArrayList[JRightPadded[Statement]]()
-        firstList.zipWithIndex.foreach { case (vd, idx) =>
+        effectiveFirstList.zipWithIndex.foreach { case (vd, idx) =>
           val param = visitMethodParameter(vd)
-          val isLast = idx == firstList.size - 1
+          val isLast = idx == effectiveFirstList.size - 1
+          var trailingCommaFound = false
           val afterParam = if (!isLast) {
             val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
             cursor = Math.max(cursor, paramEnd)
-            val nextParamStart = Math.max(0, firstList(idx + 1).span.start - offsetAdjustment)
+            val nextParamStart = Math.max(0, effectiveFirstList(idx + 1).span.start - offsetAdjustment)
             if (cursor < nextParamStart && nextParamStart <= source.length) {
               val between = source.substring(cursor, nextParamStart)
               val commaIdx = positionOfNextIn(between, ",", 0)
@@ -6421,20 +6493,28 @@ class ScalaTreeVisitor(
               } else Space.EMPTY
             } else Space.EMPTY
           } else {
-            // Capture whitespace between last parameter and closing `)` so
-            // multi-line parameter lists with `)` on its own line round-trip.
             val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
             val lookupStart = Math.max(cursor, paramEnd)
             if (lookupStart < source.length) {
               val remaining = source.substring(lookupStart, Math.min(lookupStart + 200, source.length))
               val closeParen = positionOfNextIn(remaining, ")", 0)
-              if (closeParen >= 0) Space.format(remaining.substring(0, closeParen))
-              else Space.EMPTY
+              if (closeParen >= 0) {
+                val betweenStr = remaining.substring(0, closeParen)
+                val commaIdx = positionOfNextIn(betweenStr, ",", 0)
+                if (commaIdx >= 0) {
+                  trailingCommaFound = true
+                  cursor = lookupStart + commaIdx + 1
+                  Space.format(betweenStr.substring(commaIdx + 1))
+                } else {
+                  Space.format(betweenStr)
+                }
+              } else Space.EMPTY
             } else Space.EMPTY
           }
-          jParams.add(new JRightPadded(param.asInstanceOf[Statement], afterParam, Markers.EMPTY))
+          val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+          jParams.add(new JRightPadded(param.asInstanceOf[Statement], afterParam, markers))
         }
-        val lastParamEnd = if (firstList.nonEmpty) Math.max(0, firstList.last.span.end - offsetAdjustment) else cursor
+        val lastParamEnd = if (effectiveFirstList.nonEmpty) Math.max(0, effectiveFirstList.last.span.end - offsetAdjustment) else cursor
         cursor = Math.max(cursor, lastParamEnd)
         if (cursor < source.length) {
           val closeParen = positionOfNextIn(source, ")", cursor)
@@ -7885,10 +7965,12 @@ class ScalaTreeVisitor(
       val bracketSpace = if (bracketIdx > 0) Space.format(searchText.substring(0, bracketIdx)) else Space.EMPTY
       cursor = cursor + bracketIdx + 1
 
+      val effectiveTypeParams = stripTrailingCommaArtifact(typeParams)
       val jTypeParams = new util.ArrayList[JRightPadded[J.TypeParameter]]()
-      typeParams.zipWithIndex.foreach { case (tp, idx) =>
+      effectiveTypeParams.zipWithIndex.foreach { case (tp, idx) =>
         val jtp = visitTypeParameter(tp)
-        val isLast = idx == typeParams.size - 1
+        val isLast = idx == effectiveTypeParams.size - 1
+        var trailingCommaFound = false
         val afterParam = if (cursor < source.length) {
           if (!isLast) {
             val s = source.substring(cursor, Math.min(cursor + 200, source.length))
@@ -7900,10 +7982,21 @@ class ScalaTreeVisitor(
           } else {
             val s = source.substring(cursor, Math.min(cursor + 200, source.length))
             val closeIdx = positionOfNextIn(s, "]", 0)
-            if (closeIdx >= 0) Space.format(s.substring(0, closeIdx)) else Space.EMPTY
+            if (closeIdx >= 0) {
+              val betweenStr = s.substring(0, closeIdx)
+              val commaIdx = positionOfNextIn(betweenStr, ",", 0)
+              if (commaIdx >= 0) {
+                trailingCommaFound = true
+                cursor = cursor + commaIdx + 1
+                Space.format(s.substring(commaIdx + 1, closeIdx))
+              } else {
+                Space.format(s.substring(0, closeIdx))
+              }
+            } else Space.EMPTY
           }
         } else Space.EMPTY
-        jTypeParams.add(new JRightPadded(jtp, afterParam, Markers.EMPTY))
+        val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+        jTypeParams.add(new JRightPadded(jtp, afterParam, markers))
       }
 
       val afterSearch = source.substring(cursor, Math.min(cursor + 200, source.length))

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -5042,7 +5042,7 @@ class ScalaTreeVisitor(
         effectiveTypeParams.zipWithIndex.foreach { case (tparam, idx) =>
           val jTypeParam = visitTypeParameter(tparam)
           val isLast = idx == effectiveTypeParams.size - 1
-          var trailingCommaFound = false
+          var trailingCommaPrefix: Space = null
 
           val afterParam: Space = if (!isLast && cursor < source.length) {
             val commaPos = positionOfNext(",", cursor)
@@ -5057,7 +5057,7 @@ class ScalaTreeVisitor(
               val betweenStr = source.substring(cursor, closePos)
               val commaIdx = positionOfNextIn(betweenStr, ",", 0)
               if (commaIdx >= 0) {
-                trailingCommaFound = true
+                trailingCommaPrefix = Space.format(betweenStr.substring(0, commaIdx))
                 cursor = cursor + commaIdx + 1
                 ScalaSpace.format(source, cursor, closePos)
               } else {
@@ -5066,7 +5066,7 @@ class ScalaTreeVisitor(
             } else Space.EMPTY
           } else Space.EMPTY
 
-          val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+          val markers = if (trailingCommaPrefix != null) Markers.EMPTY.add(TrailingComma.create(trailingCommaPrefix)) else Markers.EMPTY
           jTypeParams.add(new JRightPadded(jTypeParam, afterParam, markers))
         }
         
@@ -5108,11 +5108,7 @@ class ScalaTreeVisitor(
     }
 
     val primaryConstructor: JContainer[Statement] = if (ctorParenPos >= 0) {
-      val rawParams = firstValueParamList.getOrElse(Nil)
-      val params = if (rawParams.nonEmpty) {
-        val lastName = rawParams.last.name.toString
-        if (lastName.isEmpty || lastName.startsWith("<")) rawParams.init else rawParams
-      } else rawParams
+      val params = stripTrailingCommaArtifact(firstValueParamList.getOrElse(Nil))
       val parenSpace = ScalaSpace.format(source, cursor, ctorParenPos)
       cursor = ctorParenPos + 1
 
@@ -5123,7 +5119,7 @@ class ScalaTreeVisitor(
         val paramEnd = if (vd.span.exists) Math.max(0, vd.span.end - offsetAdjustment) else cursor
         cursor = Math.max(cursor, paramEnd)
 
-        var trailingCommaFound = false
+        var trailingCommaPrefix: Space = null
         val afterParam: Space = if (!isLast) {
           val nextParamStart = if (params(idx + 1).span.exists) Math.max(0, params(idx + 1).span.start - offsetAdjustment) else cursor
           if (cursor < nextParamStart && nextParamStart <= source.length) {
@@ -5145,7 +5141,7 @@ class ScalaTreeVisitor(
               val between = remaining.substring(0, closeParen)
               val commaIdx = positionOfNextIn(between, ",", 0)
               if (commaIdx >= 0) {
-                trailingCommaFound = true
+                trailingCommaPrefix = Space.format(between.substring(0, commaIdx))
                 cursor = cursor + commaIdx + 1
                 Space.format(between.substring(commaIdx + 1))
               } else {
@@ -5154,8 +5150,8 @@ class ScalaTreeVisitor(
             } else Space.EMPTY
           } else Space.EMPTY
         }
-        val paramMarkers = if (trailingCommaFound) {
-          Markers.EMPTY.add(new TrailingComma(Tree.randomId()))
+        val paramMarkers = if (trailingCommaPrefix != null) {
+          Markers.EMPTY.add(TrailingComma.create(trailingCommaPrefix))
         } else {
           Markers.EMPTY
         }
@@ -6341,7 +6337,7 @@ class ScalaTreeVisitor(
         effectiveTypeParams.zipWithIndex.foreach { case (tp, idx) =>
           val jtp = visitTypeParameter(tp)
           val isLast = idx == effectiveTypeParams.size - 1
-          var trailingCommaFound = false
+          var trailingCommaPrefix: Space = null
           val afterParam = if (cursor < source.length) {
             if (!isLast) {
               val s = source.substring(cursor, Math.min(cursor + 200, source.length))
@@ -6357,7 +6353,7 @@ class ScalaTreeVisitor(
                 val betweenStr = s.substring(0, closeIdx)
                 val commaIdx = positionOfNextIn(betweenStr, ",", 0)
                 if (commaIdx >= 0) {
-                  trailingCommaFound = true
+                  trailingCommaPrefix = Space.format(betweenStr.substring(0, commaIdx))
                   cursor = cursor + commaIdx + 1
                   Space.format(s.substring(commaIdx + 1, closeIdx))
                 } else {
@@ -6366,7 +6362,7 @@ class ScalaTreeVisitor(
               } else Space.EMPTY
             }
           } else Space.EMPTY
-          val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+          val markers = if (trailingCommaPrefix != null) Markers.EMPTY.add(TrailingComma.create(trailingCommaPrefix)) else Markers.EMPTY
           jTypeParams.add(new JRightPadded(jtp, afterParam, markers))
         }
 
@@ -6391,7 +6387,7 @@ class ScalaTreeVisitor(
       params.zipWithIndex.foreach { case (vd, idx) =>
         val param = visitMethodParameter(vd)
         val isLast = idx == params.size - 1
-        var trailingCommaFound = false
+        var trailingCommaPrefix: Space = null
         val afterParam = if (!isLast) {
           val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
           cursor = Math.max(cursor, paramEnd)
@@ -6415,7 +6411,7 @@ class ScalaTreeVisitor(
               val betweenStr = remaining.substring(0, closeParen)
               val commaIdx = positionOfNextIn(betweenStr, ",", 0)
               if (commaIdx >= 0) {
-                trailingCommaFound = true
+                trailingCommaPrefix = Space.format(betweenStr.substring(0, commaIdx))
                 cursor = lookupStart + commaIdx + 1
                 Space.format(betweenStr.substring(commaIdx + 1))
               } else {
@@ -6424,7 +6420,7 @@ class ScalaTreeVisitor(
             } else Space.EMPTY
           } else Space.EMPTY
         }
-        val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+        val markers = if (trailingCommaPrefix != null) Markers.EMPTY.add(TrailingComma.create(trailingCommaPrefix)) else Markers.EMPTY
         jParams.add(new JRightPadded(param.asInstanceOf[J], afterParam, markers))
       }
 
@@ -6477,7 +6473,7 @@ class ScalaTreeVisitor(
         effectiveFirstList.zipWithIndex.foreach { case (vd, idx) =>
           val param = visitMethodParameter(vd)
           val isLast = idx == effectiveFirstList.size - 1
-          var trailingCommaFound = false
+          var trailingCommaPrefix: Space = null
           val afterParam = if (!isLast) {
             val paramEnd = Math.max(0, vd.span.end - offsetAdjustment)
             cursor = Math.max(cursor, paramEnd)
@@ -6501,7 +6497,7 @@ class ScalaTreeVisitor(
                 val betweenStr = remaining.substring(0, closeParen)
                 val commaIdx = positionOfNextIn(betweenStr, ",", 0)
                 if (commaIdx >= 0) {
-                  trailingCommaFound = true
+                  trailingCommaPrefix = Space.format(betweenStr.substring(0, commaIdx))
                   cursor = lookupStart + commaIdx + 1
                   Space.format(betweenStr.substring(commaIdx + 1))
                 } else {
@@ -6510,7 +6506,7 @@ class ScalaTreeVisitor(
               } else Space.EMPTY
             } else Space.EMPTY
           }
-          val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+          val markers = if (trailingCommaPrefix != null) Markers.EMPTY.add(TrailingComma.create(trailingCommaPrefix)) else Markers.EMPTY
           jParams.add(new JRightPadded(param.asInstanceOf[Statement], afterParam, markers))
         }
         val lastParamEnd = if (effectiveFirstList.nonEmpty) Math.max(0, effectiveFirstList.last.span.end - offsetAdjustment) else cursor
@@ -7969,7 +7965,7 @@ class ScalaTreeVisitor(
       effectiveTypeParams.zipWithIndex.foreach { case (tp, idx) =>
         val jtp = visitTypeParameter(tp)
         val isLast = idx == effectiveTypeParams.size - 1
-        var trailingCommaFound = false
+        var trailingCommaPrefix: Space = null
         val afterParam = if (cursor < source.length) {
           if (!isLast) {
             val s = source.substring(cursor, Math.min(cursor + 200, source.length))
@@ -7985,7 +7981,7 @@ class ScalaTreeVisitor(
               val betweenStr = s.substring(0, closeIdx)
               val commaIdx = positionOfNextIn(betweenStr, ",", 0)
               if (commaIdx >= 0) {
-                trailingCommaFound = true
+                trailingCommaPrefix = Space.format(betweenStr.substring(0, commaIdx))
                 cursor = cursor + commaIdx + 1
                 Space.format(s.substring(commaIdx + 1, closeIdx))
               } else {
@@ -7994,7 +7990,7 @@ class ScalaTreeVisitor(
             } else Space.EMPTY
           }
         } else Space.EMPTY
-        val markers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+        val markers = if (trailingCommaPrefix != null) Markers.EMPTY.add(TrailingComma.create(trailingCommaPrefix)) else Markers.EMPTY
         jTypeParams.add(new JRightPadded(jtp, afterParam, markers))
       }
 
@@ -9841,7 +9837,7 @@ class ScalaTreeVisitor(
 
       // Extract space after the parameter (before comma or closing paren)
       var afterSpace = Space.EMPTY
-      var trailingCommaFound = false
+      var trailingCommaPrefix: Space = null
       if (i < effectiveArgs.length - 1) {
         // Not the last parameter, space before comma
         val currentEnd = param.span.end - offsetAdjustment
@@ -9869,7 +9865,7 @@ class ScalaTreeVisitor(
             val between = source.substring(cursor, closeParen)
             val commaIdx = positionOfNextIn(between, ",", 0)
             if (commaIdx >= 0) {
-              trailingCommaFound = true
+              trailingCommaPrefix = Space.format(between.substring(0, commaIdx))
               cursor = cursor + commaIdx + 1
             }
             afterSpace = ScalaSpace.format(source, cursor, closeParen)
@@ -9878,7 +9874,7 @@ class ScalaTreeVisitor(
         }
       }
 
-      val paramMarkers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+      val paramMarkers = if (trailingCommaPrefix != null) Markers.EMPTY.add(TrailingComma.create(trailingCommaPrefix)) else Markers.EMPTY
       params.add(new JRightPadded(paramTree, afterSpace, paramMarkers))
     }
     

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -6359,7 +6359,6 @@ class ScalaTreeVisitor(
                 if (commaIdx >= 0) {
                   trailingCommaFound = true
                   cursor = cursor + commaIdx + 1
-                  val afterCursor = cursor
                   Space.format(s.substring(commaIdx + 1, closeIdx))
                 } else {
                   Space.format(s.substring(0, closeIdx))
@@ -9813,13 +9812,14 @@ class ScalaTreeVisitor(
       if (funcEnd >= cursor && funcEnd <= source.length) cursor = funcEnd
     }
 
-    for (i <- func.args.indices) {
-      val param = func.args(i)
+    val effectiveArgs = stripTrailingCommaArtifact(func.args)
+    for (i <- effectiveArgs.indices) {
+      val param = effectiveArgs(i)
 
       // For parameters after the first, we need to handle the comma and space
       if (i > 0) {
         // Look for comma between previous and current parameter
-        val prevParam = func.args(i - 1)
+        val prevParam = effectiveArgs(i - 1)
         val prevEnd = prevParam.span.end - offsetAdjustment
         val currentStart = param.span.start - offsetAdjustment
 
@@ -9841,7 +9841,8 @@ class ScalaTreeVisitor(
 
       // Extract space after the parameter (before comma or closing paren)
       var afterSpace = Space.EMPTY
-      if (i < func.args.length - 1) {
+      var trailingCommaFound = false
+      if (i < effectiveArgs.length - 1) {
         // Not the last parameter, space before comma
         val currentEnd = param.span.end - offsetAdjustment
         if (currentEnd >= cursor) {
@@ -9856,7 +9857,8 @@ class ScalaTreeVisitor(
           }
         }
       } else {
-        // Last parameter — when parenthesized, capture whitespace before `)`.
+        // Last parameter — when parenthesized, capture whitespace before `)`,
+        // handling a possible trailing comma.
         val paramEnd = param.span.end - offsetAdjustment
         if (paramEnd >= cursor) {
           cursor = paramEnd
@@ -9864,13 +9866,20 @@ class ScalaTreeVisitor(
         if (hasParentheses) {
           val closeParen = positionOfNext(")", cursor)
           if (closeParen >= cursor && closeParen < source.length) {
+            val between = source.substring(cursor, closeParen)
+            val commaIdx = positionOfNextIn(between, ",", 0)
+            if (commaIdx >= 0) {
+              trailingCommaFound = true
+              cursor = cursor + commaIdx + 1
+            }
             afterSpace = ScalaSpace.format(source, cursor, closeParen)
             cursor = closeParen
           }
         }
       }
 
-      params.add(JRightPadded.build(paramTree).withAfter(afterSpace))
+      val paramMarkers = if (trailingCommaFound) Markers.EMPTY.add(new TrailingComma(Tree.randomId())) else Markers.EMPTY
+      params.add(new JRightPadded(paramTree, afterSpace, paramMarkers))
     }
     
     // Update parameters with the actual params

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -981,4 +981,62 @@ class MethodDeclarationTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void trailingCommaInParameters() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def foo(
+                x: Int,
+                y: Int,
+              ): Int = x
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void trailingCommaInParametersSingleLine() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def foo(x: Int,): Int = x
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void trailingCommaInTypeParameters() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def foo[
+                A,
+                B,
+              ](x: A): A = x
+            }
+            """
+          )
+        );
+    }
+
+    @Test
+    void trailingCommaInTypeParametersSingleLine() {
+        rewriteRun(
+          scala(
+            """
+            object Test {
+              def foo[A,](x: A): A = x
+            }
+            """
+          )
+        );
+    }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -572,6 +572,17 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void classWithTrailingCommaAndWhitespaceBeforeComma() {
+        rewriteRun(
+            scala(
+                """
+                class Foo(x: Int ,)
+                """
+            )
+        );
+    }
+
+    @Test
     void classWithTrailingCommaInTypeParameters() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -572,6 +572,31 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void classWithTrailingCommaInTypeParameters() {
+        rewriteRun(
+            scala(
+                """
+                class Foo[
+                    A,
+                    B,
+                ](x: A)
+                """
+            )
+        );
+    }
+
+    @Test
+    void classWithTrailingCommaInTypeParametersSingleLine() {
+        rewriteRun(
+            scala(
+                """
+                class Foo[A,](x: A)
+                """
+            )
+        );
+    }
+
+    @Test
     void colonBodyWithTrailingCommentAfterColon() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/ClassDeclarationTest.java
@@ -523,6 +523,55 @@ class ClassDeclarationTest implements RewriteTest {
     }
 
     @Test
+    void classWithTrailingCommaInParameters() {
+        rewriteRun(
+            scala(
+                """
+                class Foo(
+                    val x: String,
+                    val y: Int,
+                )
+                """
+            )
+        );
+    }
+
+    @Test
+    void classWithTrailingCommaSingleParameter() {
+        rewriteRun(
+            scala(
+                """
+                class Foo(
+                    x: Int,
+                )
+                """
+            )
+        );
+    }
+
+    @Test
+    void classWithTrailingCommaSingleLine() {
+        rewriteRun(
+            scala(
+                """
+                class Foo(x: Int,)
+                """
+            )
+        );
+    }
+
+    @Test
+    void classWithoutTrailingCommaDoesNotFail() {
+        rewriteRun(
+            scala(
+                """
+                class Foo(x: Int)
+                """
+            )
+        );
+    }
+
+    @Test
     void colonBodyWithTrailingCommentAfterColon() {
         rewriteRun(
             scala(

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/LambdaTest.java
@@ -375,4 +375,17 @@ class LambdaTest implements RewriteTest {
             )
         );
     }
+
+    @Test
+    void trailingCommaInLambdaParams() {
+        rewriteRun(
+            scala(
+                """
+                object Test {
+                  val f = (x: Int, y: Int,) => x + y
+                }
+                """
+            )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
Adding `TrailingComma` marker for Scala similar to what we have for other languages.

## What's your motivation?

Correct the parsing of cases like:
```scala
new MyClass(
   1,
   2,
   3,
)
```