### PR TITLE
Document HasMinimumJavaVersion behavior across version selector forms

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasMinimumJavaVersionTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/HasMinimumJavaVersionTest.java
@@ -70,4 +70,125 @@ class HasMinimumJavaVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void bareIntegerMatchesExactVersionOnly() {
+        rewriteRun(
+          spec -> spec.recipe(new HasMinimumJavaVersion("17", false)),
+          java(
+            """
+              class Test {
+              }
+              """,
+            """
+              /*~~(Java version 17)~~>*/class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(17))
+          )
+        );
+    }
+
+    @Test
+    void bareIntegerDoesNotMatchHigherVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new HasMinimumJavaVersion("17", false)),
+          java(
+            """
+              class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(21))
+          )
+        );
+    }
+
+    @Test
+    void xRangeMatchesMajorOnly() {
+        rewriteRun(
+          spec -> spec.recipe(new HasMinimumJavaVersion("17.X", false)),
+          java(
+            """
+              class Test {
+              }
+              """,
+            """
+              /*~~(Java version 17)~~>*/class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(17))
+          )
+        );
+    }
+
+    @Test
+    void xRangeDoesNotMatchHigherMajor() {
+        rewriteRun(
+          spec -> spec.recipe(new HasMinimumJavaVersion("17.X", false)),
+          java(
+            """
+              class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(21))
+          )
+        );
+    }
+
+    @Test
+    void setRangeOpenUpperMatchesAtOrAbove() {
+        rewriteRun(
+          spec -> spec.recipe(new HasMinimumJavaVersion("[17,)", false)),
+          java(
+            """
+              class Seventeen {
+              }
+              """,
+            """
+              /*~~(Java version 17)~~>*/class Seventeen {
+              }
+              """,
+            spec -> spec.markers(javaVersion(17))
+          ),
+          java(
+            """
+              class TwentyOne {
+              }
+              """,
+            spec -> spec.markers(javaVersion(21))
+          )
+        );
+    }
+
+    @Test
+    void setRangeOpenUpperMatchesSingleHigherVersion() {
+        rewriteRun(
+          spec -> spec.recipe(new HasMinimumJavaVersion("[17,)", false)),
+          java(
+            """
+              class Test {
+              }
+              """,
+            """
+              /*~~(Java version 21)~~>*/class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(21))
+          )
+        );
+    }
+
+    @Test
+    void setRangeOpenUpperDoesNotMatchBelow() {
+        rewriteRun(
+          spec -> spec.recipe(new HasMinimumJavaVersion("[17,)", false)),
+          java(
+            """
+              class Test {
+              }
+              """,
+            spec -> spec.markers(javaVersion(11))
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Adds tests to `HasMinimumJavaVersionTest` documenting how each `version` selector form (bare integer, `X` range, set range) actually maps to `JavaVersion` marker matches.
- The bare-integer and `X`-range forms both silently fail to match when the repo declares a higher Java version than the argument, which is surprising given the recipe's name. Downstream recipes using this as a precondition are silently skipped in that case.
- These tests only document current behavior; a follow-up can decide whether to change `validate()` to treat a bare integer as `[N,)`.

## Test plan
- [x] `./gradlew :rewrite-java-test:test --tests HasMinimumJavaVersionTest`
