### PR TITLE
Kotlin: fix AddImport ambiguous-name test to expect no change

### DIFF
--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/AddImportTest.java
@@ -544,20 +544,11 @@ public class AddImportTest implements RewriteTest {
               class Foo
               """
           ),
-          // `a.Foo` is already imported, so `b.Foo` must stay fully qualified rather than collapse to an
-          // ambiguous `Foo`. (Not adding the conflicting `import b.Foo` is a separate concern; see #8213.)
+          // `a.Foo` is already imported, so the conflicting `b.Foo` is not imported and its usages stay fully
+          // qualified rather than collapse to an ambiguous `Foo` (see #8213).
           kotlin(
             """
               import a.Foo
-
-              class A {
-                  val x: Foo = Foo()
-                  val y: b.Foo = b.Foo()
-              }
-              """,
-            """
-              import a.Foo
-              import b.Foo
 
               class A {
                   val x: Foo = Foo()


### PR DESCRIPTION
## What's changed

`AddImportTest.doesNotShortenWhenSimpleNameIsAmbiguous()` was failing deterministically on `main` (introduced red in 9f355cd83b, #8214/#8220), blocking all PRs since CI builds `pull/*/merge`.

The test's *expected output* was wrong: it asserted that `maybeAddImport("b.Foo")` adds `import b.Foo` when `a.Foo` is already imported. But that contradicts the intended "don't add a conflicting import" behavior from #8213: when a different type is already imported under the same simple name, `AddImport` keeps the reference fully qualified and does **not** add the ambiguous import.

Since the references in the scenario are already fully qualified, the correct result is **no change**. This updates the `#8214` test's expected output accordingly. No production code changes — the don't-add behavior is preserved.

## Testing

- `./gradlew :rewrite-kotlin:test` passes (including `doesNotShortenWhenSimpleNameIsAmbiguous` and `doesNotAddImportConflictingWithExistingSimpleName`).