### PR TITLE
Fix `MergeYaml` inserting a new entry after surrounding blank lines

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -207,14 +207,19 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                     String partOne = substringOfBeforeFirstLineBreak(afterInsertEntry.getPrefix());
                     String partTwo = substringOfAfterFirstLineBreak(afterInsertEntry.getPrefix());
 
-                    String newFirstPrefix = partOne + firstNewlyAddedEntry.getPrefix();
-                    if (afterInsertEntry.getPrefix().isEmpty() && partOne.isEmpty() && newFirstPrefix.startsWith("\n")) {
-                        // Remove leading newline since the previous element already provides line separation
-                        newFirstPrefix = newFirstPrefix.substring(1);
-                    }
+                    if (insertMode == Before && partOne.isEmpty() && hasLineBreak(partTwo) && !partTwo.contains("#")) {
+                        mutatedEntries.ls.set(mutatedEntries.lastNewlyAddedItemIndex + 1, afterInsertEntry.withPrefix(firstNewlyAddedEntry.getPrefix()));
+                        mutatedEntries.ls.set(mutatedEntries.firstNewlyAddedItemIndex, firstNewlyAddedEntry.withPrefix(afterInsertEntry.getPrefix()));
+                    } else {
+                        String newFirstPrefix = partOne + firstNewlyAddedEntry.getPrefix();
+                        if (afterInsertEntry.getPrefix().isEmpty() && partOne.isEmpty() && newFirstPrefix.startsWith("\n")) {
+                            // Remove leading newline since the previous element already provides line separation
+                            newFirstPrefix = newFirstPrefix.substring(1);
+                        }
 
-                    mutatedEntries.ls.set(mutatedEntries.firstNewlyAddedItemIndex, firstNewlyAddedEntry.withPrefix(newFirstPrefix));
-                    mutatedEntries.ls.set(mutatedEntries.lastNewlyAddedItemIndex + 1, afterInsertEntry.withPrefix(linebreak() + partTwo));
+                        mutatedEntries.ls.set(mutatedEntries.firstNewlyAddedItemIndex, firstNewlyAddedEntry.withPrefix(newFirstPrefix));
+                        mutatedEntries.ls.set(mutatedEntries.lastNewlyAddedItemIndex + 1, afterInsertEntry.withPrefix(linebreak() + partTwo));
+                    }
                 }
             } else {
                 Cursor c = getCursor().dropParentUntil(it -> {
@@ -236,7 +241,10 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                     Yaml.Document doc = c.getValue();
                     // Don't treat document end prefix as comment if it contains a document separator
                     if (!preserveDocumentSeparator(doc)) {
-                        comment = doc.getEnd().getPrefix();
+                        String endPrefix = doc.getEnd().getPrefix();
+                        if (endPrefix != null && endPrefix.contains("#")) {
+                            comment = endPrefix;
+                        }
                     }
                 } else if (c.getValue() instanceof Yaml.Mapping) {
                     List<Yaml.Mapping.Entry> entries = ((Yaml.Mapping) c.getValue()).getEntries();

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -3139,6 +3139,154 @@ class MergeYamlTest implements RewriteTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("insertNextToLastSiblingFollowedByBlankLinesOptions")
+    void insertNewKeyDirectlyNextToLastSiblingWhenFollowedByBlankLines(MergeYaml.@Nullable InsertMode insertMode,
+                                                                       @Nullable String insertProperty,
+                                                                       String after) {
+        rewriteRun(spec -> spec
+            .recipe(new MergeYaml(//language=jsonpath
+              "$.service_config",
+              // language=yaml
+              """
+                enabled: true
+                """,
+              false,
+              null,
+              null,
+              insertMode,
+              insertProperty,
+              null
+            )),
+
+          yaml(// language=yaml
+            """
+              service_config:
+                name: 'hello'
+
+
+
+              """,
+            after
+          )
+        );
+    }
+
+    static Stream<Arguments> insertNextToLastSiblingFollowedByBlankLinesOptions() {
+        return Stream.of(
+          arguments(null, null,
+            """
+              service_config:
+                name: 'hello'
+                enabled: true
+
+
+
+              """),
+          arguments(Last, null,
+            """
+              service_config:
+                name: 'hello'
+                enabled: true
+
+
+
+              """),
+          arguments(After, "name",
+            """
+              service_config:
+                name: 'hello'
+                enabled: true
+
+
+
+              """),
+          arguments(Before, "name",
+            """
+              service_config:
+                enabled: true
+                name: 'hello'
+
+
+
+              """)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("insertNextToLastSiblingPrecededByBlankLinesOptions")
+    void insertNewKeyDirectlyNextToLastSiblingWhenPrecededByBlankLines(MergeYaml.@Nullable InsertMode insertMode,
+                                                                       @Nullable String insertProperty,
+                                                                       String after) {
+        rewriteRun(spec -> spec
+            .recipe(new MergeYaml(//language=jsonpath
+              "$.service_config",
+              // language=yaml
+              """
+                enabled: true
+                """,
+              false,
+              null,
+              null,
+              insertMode,
+              insertProperty,
+              null
+            )),
+
+          yaml(// language=yaml
+            """
+              service_config:
+
+
+
+                name: 'hello'
+              """,
+            after
+          )
+        );
+    }
+
+    static Stream<Arguments> insertNextToLastSiblingPrecededByBlankLinesOptions() {
+        return Stream.of(
+          arguments(null, null,
+            """
+              service_config:
+
+
+
+                name: 'hello'
+                enabled: true
+              """),
+          arguments(Last, null,
+            """
+              service_config:
+
+
+
+                name: 'hello'
+                enabled: true
+              """),
+          arguments(After, "name",
+            """
+              service_config:
+
+
+
+                name: 'hello'
+                enabled: true
+              """),
+          arguments(Before, "name",
+            """
+              service_config:
+
+
+
+                enabled: true
+                name: 'hello'
+              """)
+        );
+    }
+
     @Test
     void invalidYaml() {
         var recipe = new MergeYaml(


### PR DESCRIPTION
### What's changed?

When `MergeYaml` merges a new entry into a mapping that is surrounded by blank lines, the recipe mistakes that plain trailing whitespace for an inline comment and moves it onto the newly inserted entry. The new entry is therefore pushed *past* the blank lines instead of landing directly next to its sibling.

**Blank lines after the last sibling** — the trailing whitespace lives on the document end prefix:

```yaml
# Before
service_config:
  name: 'hello'



# Actual (wrong)
service_config:
  name: 'hello'



  enabled: true

# Expected
service_config:
  name: 'hello'
  enabled: true



```

**Blank lines before the entry, inserting `Before` it** — the blank lines live on the entry's prefix:

```yaml
# Before
service_config:



  name: 'hello'

# Actual (wrong) — blank lines pushed between the two entries
service_config:
  enabled: true



  name: 'hello'

# Expected — blank lines stay at the top, new entry directly before `name`
service_config:



  enabled: true
  name: 'hello'
```

### The fix

Two targeted changes in `MergeYamlVisitor.mergeMapping`:

1. **Document end prefix** — only treat it as a comment to copy onto the inserted entry when it actually contains a `#`; plain trailing blank lines now stay at the document end. (Mirrors the guard already present on the sibling-mapping branch.)
2. **`Before` insertion** — when inserting before an entry whose prefix carries leading blank lines but no comment, keep those blank lines at the top of the block and place the new entry directly before the existing sibling.

### Testing

Two parameterized tests in `MergeYamlTest` exercise every `insertMode`/`insertProperty` placement (`null`, `Last`, `After`, `Before`) for both the blank-lines-after and blank-lines-before scenarios. Existing `Before`/comment tests (e.g. `insertBeforeElementWithCommentsWithNesting`) confirm full-line comments above the target still stay attached to it, and the whole `rewrite-yaml` module is green.