### PR TITLE
Decode incoming JS RPC messages without V8's 512MB string cap

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/java-rpc-client.ts
+++ b/rewrite-javascript/rewrite/src/rpc/java-rpc-client.ts
@@ -18,6 +18,7 @@ import * as path from "node:path";
 import * as readline from "node:readline";
 import {ChildProcessWithoutNullStreams, spawn} from "node:child_process";
 import * as rpc from "vscode-jsonrpc/node";
+import {chunkedJsonDecoder} from "./message-decoder";
 import {RewriteRpc} from "./rewrite-rpc";
 import {RecipeMarketplace} from "../marketplace";
 
@@ -104,7 +105,9 @@ export class JavaRpcTestServer {
         });
 
         const connection = rpc.createMessageConnection(
-            new rpc.StreamMessageReader(child.stdout),
+            // Trees and recipe descriptors cross this connection too, so it needs the same headroom
+            // as the server's: the default decoder caps an inbound message at V8's ~512 MB string limit.
+            new rpc.StreamMessageReader(child.stdout, {contentTypeDecoder: chunkedJsonDecoder}),
             new rpc.StreamMessageWriter(child.stdin),
             opts.logger,
         );

--- a/rewrite-javascript/rewrite/src/rpc/message-decoder.ts
+++ b/rewrite-javascript/rewrite/src/rpc/message-decoder.ts
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {constants} from "buffer";
+import type {Message, MessageReaderOptions} from "vscode-jsonrpc/node";
+
+/**
+ * The content-type decoder shape vscode-jsonrpc's {@link MessageReaderOptions} accepts. Derived
+ * from the reader options rather than deep-imported, because the concrete `ContentTypeDecoder`
+ * type is not re-exported from the package entrypoint.
+ */
+export type JsonRpcContentTypeDecoder = NonNullable<MessageReaderOptions["contentTypeDecoder"]>;
+
+const TAB = 0x09, NEWLINE = 0x0a, CARRIAGE_RETURN = 0x0d, SPACE = 0x20;
+const QUOTE = 0x22, PLUS = 0x2b, COMMA = 0x2c, MINUS = 0x2d, PERIOD = 0x2e;
+const ZERO = 0x30, NINE = 0x39, COLON = 0x3a, UPPER_E = 0x45;
+const OPEN_BRACKET = 0x5b, BACKSLASH = 0x5c, CLOSE_BRACKET = 0x5d;
+const LOWER_A = 0x61, LOWER_E = 0x65, LOWER_F = 0x66, LOWER_N = 0x6e, LOWER_T = 0x74, LOWER_Z = 0x7a;
+const OPEN_BRACE = 0x7b, CLOSE_BRACE = 0x7d;
+
+function isNumberByte(c: number): boolean {
+    return (c >= ZERO && c <= NINE) || c === MINUS || c === PLUS || c === PERIOD || c === LOWER_E || c === UPPER_E;
+}
+
+interface Frame {
+    readonly array?: unknown[];
+    readonly object?: Record<string, unknown>;
+    key?: string;
+}
+
+/**
+ * Parses JSON directly from its UTF-8 bytes, never materializing the whole document as one JS
+ * string. Structural punctuation is recognized byte-by-byte, while every scalar and every object key
+ * is handed to the engine's `JSON.parse` as its own small slice — so escaping, number formatting and
+ * literal validation match it exactly. This is the mirror of how `jsonFragments` defers to
+ * `JSON.stringify`, and it accepts precisely the grammar `JSON.parse` accepts.
+ *
+ * Byte-level scanning is safe for the ASCII-compatible charsets vscode-jsonrpc supports (`utf-8`,
+ * `ascii`): a UTF-8 continuation byte is always >= 0x80, so it can never be mistaken for a quote,
+ * backslash, or structural character. Containers are tracked on an explicit stack, so nesting depth
+ * is bounded by heap rather than by the call stack.
+ */
+export function parseJsonBytes(buf: Buffer, charset: BufferEncoding): unknown {
+    const len = buf.length;
+    let i = 0;
+
+    const fail = (what: string): never => {
+        throw new SyntaxError(`${what} in JSON at position ${i}`);
+    };
+
+    // Advance past insignificant whitespace and return the next byte, which must exist.
+    const seek = (): number => {
+        while (i < len) {
+            const c = buf[i];
+            if (c !== SPACE && c !== TAB && c !== NEWLINE && c !== CARRIAGE_RETURN) {
+                return c;
+            }
+            i++;
+        }
+        return fail("Unexpected end of JSON input");
+    };
+
+    const token = (start: number, end: number): unknown => JSON.parse(buf.toString(charset, start, end));
+
+    const readString = (): string => {
+        const start = i++; // opening quote
+        while (i < len) {
+            const c = buf[i];
+            if (c === BACKSLASH) {
+                i += 2; // the byte after a backslash is ASCII, so it can never be the closing quote
+            } else if (c === QUOTE) {
+                return token(start, ++i) as string;
+            } else {
+                i++;
+            }
+        }
+        return fail("Unterminated string");
+    };
+
+    const readKey = (): string => {
+        if (seek() !== QUOTE) {
+            fail("Expected property name");
+        }
+        const key = readString();
+        if (seek() !== COLON) {
+            fail("Expected ':' after property name");
+        }
+        i++;
+        return key;
+    };
+
+    // JSON.parse gives __proto__ an own data property rather than setting the prototype.
+    const setProperty = (object: Record<string, unknown>, key: string, value: unknown): void => {
+        if (key === "__proto__") {
+            Object.defineProperty(object, key, {value, writable: true, enumerable: true, configurable: true});
+        } else {
+            object[key] = value;
+        }
+    };
+
+    const parseValue = (): unknown => {
+        const stack: Frame[] = [];
+        let value: unknown;
+
+        nextValue: for (; ;) {
+            const c = seek();
+            if (c === OPEN_BRACE) {
+                i++;
+                const frame: Frame = {object: {}};
+                if (seek() === CLOSE_BRACE) {
+                    i++;
+                    value = frame.object;
+                } else {
+                    frame.key = readKey();
+                    stack.push(frame);
+                    continue nextValue;
+                }
+            } else if (c === OPEN_BRACKET) {
+                i++;
+                const frame: Frame = {array: []};
+                if (seek() === CLOSE_BRACKET) {
+                    i++;
+                    value = frame.array;
+                } else {
+                    stack.push(frame);
+                    continue nextValue;
+                }
+            } else if (c === QUOTE) {
+                value = readString();
+            } else if (c === LOWER_T || c === LOWER_F || c === LOWER_N) {
+                const start = i;
+                while (i < len && buf[i] >= LOWER_A && buf[i] <= LOWER_Z) {
+                    i++;
+                }
+                value = token(start, i); // true | false | null, validated by JSON.parse
+            } else {
+                const start = i;
+                while (i < len && isNumberByte(buf[i])) {
+                    i++;
+                }
+                if (i === start) {
+                    fail(`Unexpected token ${JSON.stringify(buf.toString(charset, i, i + 1))}`);
+                }
+                value = token(start, i);
+            }
+
+            // Attach the finished value to its container, closing containers as they end.
+            for (; ;) {
+                const frame = stack[stack.length - 1];
+                if (frame === undefined) {
+                    return value;
+                }
+                if (frame.array !== undefined) {
+                    frame.array.push(value);
+                    const c = seek();
+                    if (c === COMMA) {
+                        i++;
+                        continue nextValue;
+                    }
+                    if (c !== CLOSE_BRACKET) {
+                        fail("Expected ',' or ']' after array element");
+                    }
+                    i++;
+                    value = frame.array;
+                } else {
+                    setProperty(frame.object!, frame.key!, value);
+                    const c = seek();
+                    if (c === COMMA) {
+                        i++;
+                        frame.key = readKey();
+                        continue nextValue;
+                    }
+                    if (c !== CLOSE_BRACE) {
+                        fail("Expected ',' or '}' after property value");
+                    }
+                    i++;
+                    value = frame.object!;
+                }
+                stack.pop();
+            }
+        }
+    };
+
+    const value = parseValue();
+    while (i < len) {
+        const c = buf[i];
+        if (c !== SPACE && c !== TAB && c !== NEWLINE && c !== CARRIAGE_RETURN) {
+            fail("Unexpected non-whitespace character after JSON");
+        }
+        i++;
+    }
+    return value;
+}
+
+/**
+ * A drop-in replacement for vscode-jsonrpc's default `application/json` content-type decoder, which
+ * does {@code JSON.parse(buffer.toString(charset))}. That intermediate string is capped at V8's
+ * String.kMaxLength (~512 MB), so an inbound message above the cap throws "Cannot create a string
+ * longer than 0x1fffffe8 characters" before it is ever parsed — the reader drops the message, the
+ * peer's request is never answered, and the call hangs until it times out. Parsing straight from the
+ * bytes raises the inbound ceiling to Node's Buffer.MAX_LENGTH, matching what {@link
+ * chunkedJsonEncoder} does for outbound messages.
+ *
+ * A UTF-8 (or ASCII) decode never yields more UTF-16 code units than there are bytes, so a body at
+ * or under the cap cannot overflow the intermediate string; those take the faster single-string
+ * parse, and only genuinely oversized bodies pay for the byte-level walk.
+ */
+export const chunkedJsonDecoder: JsonRpcContentTypeDecoder = {
+    name: "application/json",
+    decode(buffer: Uint8Array, options: { charset: BufferEncoding }): Promise<Message> {
+        try {
+            const buf = Buffer.isBuffer(buffer) ?
+                buffer :
+                Buffer.from(buffer.buffer, buffer.byteOffset, buffer.byteLength);
+            return Promise.resolve((buf.byteLength <= constants.MAX_STRING_LENGTH ?
+                JSON.parse(buf.toString(options.charset)) :
+                parseJsonBytes(buf, options.charset)) as Message);
+        } catch (err) {
+            return Promise.reject(err);
+        }
+    }
+};

--- a/rewrite-javascript/rewrite/src/rpc/message-encoder.ts
+++ b/rewrite-javascript/rewrite/src/rpc/message-encoder.ts
@@ -96,7 +96,7 @@ export function* jsonFragments(value: unknown): Generator<string> {
  * serializes a message to UTF-8 bytes without ever materializing the whole document as a single JS
  * string. The default encoder does {@code Buffer.from(JSON.stringify(msg))}; a large enough
  * PrepareRecipe response (a deep recipe tree) overflows V8's single-string limit and throws
- * "Cannot create a string longer than 0x1fffffe8 characters", hanging the RPC call. Streaming the
+ * "RangeError: Invalid string length", hanging the RPC call. Streaming the
  * fragments into a Buffer raises the ceiling to Node's Buffer.MAX_LENGTH (multiple GB) while
  * producing byte-identical output. (True unbounded streaming needs chunked framing — Content-Length
  * still requires the whole body up front — so this is a ceiling raise, not a removal.)

--- a/rewrite-javascript/rewrite/src/rpc/server.ts
+++ b/rewrite-javascript/rewrite/src/rpc/server.ts
@@ -16,6 +16,7 @@
  */
 import * as rpc from "vscode-jsonrpc/node";
 import {RewriteRpc} from "./rewrite-rpc";
+import {chunkedJsonDecoder} from "./message-decoder";
 import {chunkedJsonEncoder} from "./message-encoder";
 import * as fs from "fs";
 import {Command} from 'commander';
@@ -142,10 +143,14 @@ async function main() {
 
     // Create the connection with the custom logger
     const connection = rpc.createMessageConnection(
-        new rpc.StreamMessageReader(process.stdin),
+        // Parse incoming messages straight from their bytes: a large inbound message (e.g. a tree
+        // carrying RecipesThatMadeChanges markers, whose recipe descriptors repeat per changed file)
+        // overflows V8's ~512 MB string limit in the default `JSON.parse(buffer.toString())` decoder,
+        // which drops the message and hangs the caller until it times out.
+        new rpc.StreamMessageReader(process.stdin, {contentTypeDecoder: chunkedJsonDecoder}),
         // Serialize outgoing messages without materializing the whole document as one JS string:
-        // a large PrepareRecipe response (a deep recipe tree) overflows V8's ~512 MB string limit
-        // in the default `Buffer.from(JSON.stringify(msg))` encoder and hangs the call.
+        // a large PrepareRecipe response (a deep recipe tree) overflows the same limit in the
+        // default `Buffer.from(JSON.stringify(msg))` encoder.
         new rpc.StreamMessageWriter(process.stdout, {contentTypeEncoder: chunkedJsonEncoder}),
         logger
     );

--- a/rewrite-javascript/rewrite/test/rpc/message-decoder.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/message-decoder.test.ts
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {constants} from "buffer";
+import {PassThrough} from "stream";
+import {StreamMessageReader, StreamMessageWriter} from "vscode-jsonrpc/node";
+import {chunkedJsonDecoder, parseJsonBytes} from "../../src/rpc/message-decoder";
+import {chunkedJsonEncoder} from "../../src/rpc/message-encoder";
+
+const utf8 = (json: string): Buffer => Buffer.from(json, "utf-8");
+
+// Values whose JSON text must parse to exactly what JSON.parse produces for it.
+const parityCases: [string, unknown][] = [
+    ["empty object", {}],
+    ["empty array", []],
+    ["null", null],
+    ["true", true],
+    ["false", false],
+    ["zero", 0],
+    ["negative zero", -0],
+    ["float", 1.5],
+    ["large exponent", 1e21],
+    ["small exponent", -1e-7],
+    ["empty string", ""],
+    ["plain string", "simple"],
+    ["quotes and backslash", 'with "quotes" and \\ backslash'],
+    ["escaped quote at token end", '\\"'],
+    ["control chars", "null\u0000 newline\n tab\t"],
+    ["unicode", "café 你好 😀 π"],
+    ["escaped surrogate pair", "😀"],
+    ["number array", [1, 2, 3]],
+    ["nested object", {a: {b: [1, {c: "x"}], d: true}}],
+    ["escaped keys", {'a"b': 1, "π": 2, "": 3}],
+    ["array of objects", [{a: 1}, {a: 2}]],
+    ["jsonrpc-shaped message", {
+        jsonrpc: "2.0",
+        id: 7,
+        result: {
+            id: "abc",
+            descriptor: {name: "org.example.Recipe", description: "Does a thing.", recipeList: []},
+            editVisitor: "edit:abc",
+            recipeList: [
+                {id: "d1", descriptor: {name: "org.example.Child", recipeList: []}, delegatesTo: {recipeName: "org.example.Java", options: {x: 1}}}
+            ]
+        }
+    }],
+];
+
+describe("chunked JSON message decoder", () => {
+    test.each(parityCases)("parseJsonBytes matches JSON.parse: %s", (_name, value) => {
+        const json = JSON.stringify(value);
+        expect(parseJsonBytes(utf8(json), "utf-8")).toEqual(JSON.parse(json));
+    });
+
+    test("tolerates insignificant whitespace between every token", () => {
+        const json = ' { "a" : [ 1 , { "b" : null } ] , "c" : "x" } \r\n\t';
+        expect(parseJsonBytes(utf8(json), "utf-8")).toEqual(JSON.parse(json));
+    });
+
+    test("last duplicate key wins, as in JSON.parse", () => {
+        const json = '{"a":1,"a":2}';
+        expect(parseJsonBytes(utf8(json), "utf-8")).toEqual(JSON.parse(json));
+    });
+
+    test("__proto__ becomes an own property rather than polluting the prototype", () => {
+        const parsed = parseJsonBytes(utf8('{"__proto__":{"polluted":true}}'), "utf-8") as object;
+        expect(Object.getPrototypeOf(parsed)).toBe(Object.prototype);
+        expect(Object.prototype.hasOwnProperty.call(parsed, "__proto__")).toBe(true);
+        expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    test("deep nesting does not overflow the stack", () => {
+        // An LST/recipe tree can nest far deeper than a recursive-descent parser's frame budget.
+        const depth = 50_000;
+        const json = "[".repeat(depth) + "1" + "]".repeat(depth);
+        let node = parseJsonBytes(utf8(json), "utf-8") as unknown[];
+        for (let d = 1; d < depth; d++) {
+            node = node[0] as unknown[];
+        }
+        expect(node[0]).toBe(1);
+    });
+
+    test.each([
+        ["empty input", ""],
+        ["unterminated object", "{"],
+        ["unterminated string", '"abc'],
+        ["trailing comma in array", "[1,]"],
+        ["trailing comma in object", '{"a":1,}'],
+        ["missing colon", '{"a" 1}'],
+        ["unquoted key", "{a:1}"],
+        ["truncated literal", "tru"],
+        ["leading zero", "01"],
+        ["bare minus", "-"],
+        ["two values", "1 2"],
+        ["trailing garbage", '{"a":1}x'],
+    ])("rejects malformed JSON: %s", (_name, json) => {
+        expect(() => parseJsonBytes(utf8(json), "utf-8")).toThrow(SyntaxError);
+        expect(() => JSON.parse(json)).toThrow(SyntaxError); // the reference rejects it too
+    });
+
+    test("decodes a message larger than V8's max string length", async () => {
+        // The regression: the default `application/json` decoder does JSON.parse(buffer.toString(charset)),
+        // so any inbound message above the string cap dies before it is ever parsed. Padding with
+        // insignificant whitespace keeps the *parsed* value tiny while the *encoded* body clears the cap.
+        const max = constants.MAX_STRING_LENGTH;
+        const head = '{"jsonrpc":"2.0","id":1,"method":"GetObject","params":[';
+        const tail = "1]}";
+        const body = Buffer.alloc(max + 64, 0x20 /* space */);
+        body.write(head, 0, "utf-8");
+        body.write(tail, body.length - tail.length, "utf-8");
+        expect(body.byteLength).toBeGreaterThan(max);
+
+        // This is the exact wall, and the exact error text, seen in rpc.log.
+        expect(() => body.toString("utf-8")).toThrow(/Cannot create a string longer than 0x1fffffe8 characters/);
+
+        await expect(chunkedJsonDecoder.decode(body, {charset: "utf-8"})).resolves.toEqual({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "GetObject",
+            params: [1],
+        });
+    }, 300_000);
+
+    test("round-trips through StreamMessageWriter/Reader framing", async () => {
+        // Proves the reader honors the contentTypeDecoder option and that it composes with the
+        // chunked encoder on the other side of the wire.
+        const pipe = new PassThrough();
+        const writer = new StreamMessageWriter(pipe, {contentTypeEncoder: chunkedJsonEncoder});
+        const reader = new StreamMessageReader(pipe, {contentTypeDecoder: chunkedJsonDecoder});
+        const msg = {
+            jsonrpc: "2.0",
+            id: 5,
+            result: {
+                recipeList: Array.from({length: 5_000}, (_, i) => ({name: `org.example.R${i}`, description: "😀 does a thing"}))
+            }
+        };
+        const received = new Promise<unknown>((resolve) => reader.listen(m => resolve(m)));
+        await writer.write(msg as never);
+        expect(await received).toEqual(msg);
+    });
+});


### PR DESCRIPTION
## What

vscode-jsonrpc's default `application/json` content-type decoder does `JSON.parse(buffer.toString(charset))`. That intermediate string is capped at V8's `String.kMaxLength` (~512 MB), so any inbound message above the cap throws `Cannot create a string longer than 0x1fffffe8 characters` before it is ever parsed. The reader drops the message, the peer's request goes unanswered, and the call hangs until it times out — observed as a ~1 hr CI hang on a large recipe run against `rewrite-angular`.

- This is the read-side mirror of the earlier write-side fix (#8191) for the same limit. A large message crossing the boundary in **either** direction overflows the same wall; #8191 only lifted the outbound (encoder) side.

## Fix

Add `chunkedJsonDecoder`, a drop-in replacement for the default decoder that parses straight from the UTF-8 bytes without ever materializing the whole document as one JS string:

- Structural punctuation is recognized byte-by-byte; every scalar and object key is handed to the engine's `JSON.parse` as its own small slice, so escaping, number formatting, and literal validation match natively.
- Containers are tracked on an explicit stack, so nesting depth is bounded by heap rather than the call stack.
- A body at or under the cap cannot overflow the intermediate string (a UTF-8 decode never yields more UTF-16 code units than bytes), so those keep the faster single-string parse; only oversized bodies pay for the byte walk.
- The ceiling rises from ~512 MB to Node's `Buffer.MAX_LENGTH`.

Wired into both live connections — the server's stdin and the Java child's stdout. The writer's default-connection field in `rewrite-rpc.ts` is dead code (nothing constructs `RewriteRpc` without passing a connection) and is left alone.

Also corrects the `message-encoder.ts` doc comment, which named the decoder's error text (`Cannot create a string...`) rather than the encoder's actual `RangeError: Invalid string length`.

## Verified

Reproduced end-to-end against the real failing recipe (`org.openrewrite.angular.UpgradeToAngular21` on the `javascript-angular-recipe-demo` repo), released CLI 4.3.11 + bundled engine 8.86.3:

- **Before:** `rpc.log` shows the exact `0x1fffffe8` error as its last line (no `Sending response failed.`, confirming the reader path); run canceled at the timeout.
- **After:** clean `rpc.log`, `MOD SUCCEEDED`, 379 result rows.
- Instrumenting the decoder showed exactly one inbound message over the cap — **576 MiB**, 80% of all inbound traffic — parsed successfully. That message is a large document of small scalars (not one oversized string), which the byte walk handles.

`test/rpc/message-decoder.test.ts` adds 40 tests: `JSON.parse` parity across scalars/escapes/unicode/whitespace/duplicate-keys/`__proto__`, malformed-input rejection cross-checked against `JSON.parse`, 50k-deep nesting without stack overflow, and a genuine over-the-cap message. `npx vitest run test/rpc` passes (151 + this file).

## Note

This lifts the transport ceiling; it does not reduce the payload. The 576 MiB is duplicated recipe descriptors carried by `RecipesThatMadeChanges` markers (recipe objects shipped to a peer that models them as an opaque marker bag and never reads them). Payload reduction — an `RpcCodec` on the marker that sends recipe refs/names instead of whole recipes — is worthwhile follow-up but out of scope here.