### PR TITLE
Fix javadoc 'reference not found' warnings

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/recipe/GeneratedRecipeSupport.java
@@ -50,7 +50,7 @@ import org.openrewrite.kotlin.tree.K;
  * are parallel paths selected by the LST-structural classifier in the IR
  * extension: the default is {@code methodInvocationRewriteJava} (a
  * {@link JavaVisitor} walks both Java AND Kotlin sources via
- * {@link org.openrewrite.kotlin.TreeVisitorAdapter}); the Kotlin variant kicks
+ * {@link org.openrewrite.internal.TreeVisitorAdapter}); the Kotlin variant kicks
  * in only when the before/after templates structurally reference a {@code K.*}
  * LST node — see {@code RecipeIrLanguageDescriptors.isKotlinSpecificTreeNode}.
  */
@@ -472,7 +472,7 @@ public final class GeneratedRecipeSupport {
      * Java-rooted parallel of {@link #methodInvocationRewrite}. Used when the
      * LST-structural classifier defaults a {@code rewrite { } to { }} clause
      * to a {@link JavaVisitor}: the visitor walks both Java and Kotlin sources
-     * via {@link org.openrewrite.kotlin.TreeVisitorAdapter}, but the template
+     * via {@link org.openrewrite.internal.TreeVisitorAdapter}, but the template
      * is parsed via {@link JavaTemplate}.
      *
      * <p>Matching, substitution-source semantics, and the multi-spec {@code \n}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/CachingMavenRecipeBundleResolver.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/CachingMavenRecipeBundleResolver.java
@@ -33,7 +33,7 @@ import java.util.Map;
  * <p>
  * <strong>Lifetime of handed-out readers.</strong> The readers (and the
  * {@link org.openrewrite.marketplace.RecipeClassLoader}s they own) returned by
- * {@link #resolve(RecipeBundle)} are intended to outlive this resolver. Once a {@link Recipe}
+ * {@link #resolve(RecipeBundle)} are intended to outlive this resolver. Once a {@link org.openrewrite.Recipe}
  * has been prepared from a reader, the JVM's class cache contains classes defined by that
  * classloader, and any later {@code getResourceAsStream}/inner-class load against those
  * classes requires the classloader's {@code URLClassPath} jar handles to remain open.

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
@@ -27,7 +27,7 @@ import java.util.List;
  * <p>
  * Bundles the optional, independent parsing inputs into one value so the API doesn't grow a long
  * tail of positional parameters (and adjacent same-typed arguments that are easy to transpose). Build
- * with {@link #builder()}; every field is optional and defaults to {@code null}.
+ * with {@code builder()}; every field is optional and defaults to {@code null}.
  */
 @Value
 @Builder


### PR DESCRIPTION
Resolve four javadoc `reference not found` warnings surfaced as build check annotations. Corrects the `TreeVisitorAdapter` link in `GeneratedRecipeSupport` to its actual package (`org.openrewrite.internal`, not `org.openrewrite.kotlin`), fully-qualifies the unimported `Recipe` link in `CachingMavenRecipeBundleResolver`, and switches the Lombok-generated `builder()` reference in `ParseProjectOptions` from `{@link}` to `{@code}` since it isn't visible to javadoc.