### PR TITLE
Quiet polyglot test-runner build output by default

### DIFF
--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -145,9 +145,11 @@ val csharpTest by tasks.registering(Exec::class) {
         // JunitXml.TestLogger resolves a relative LogFilePath against the test project's
         // TargetDir, so pin the absolute path and pass --results-directory to match.
         junitXmlFile.parentFile.mkdirs()
+        // -PverboseTests restores the per-passing-test console output
+        val dotnetVerbosity = if (project.hasProperty("verboseTests")) "normal" else "minimal"
         commandLine(
             findDotnet(), "test", "OpenRewrite.Tests/OpenRewrite.Tests.csproj",
-            "--no-build", "--verbosity", "normal",
+            "--no-build", "--verbosity", dotnetVerbosity,
             "--results-directory", junitXmlFile.parentFile.absolutePath,
             "--logger", "junit;LogFilePath=${junitXmlFile.absolutePath}"
         )
@@ -232,10 +234,14 @@ tasks.withType<Test> {
     }
     // Add timeout to identify hanging tests
     systemProperty("junit.jupiter.execution.timeout.default", "30s")
-    // Show test names as they run
     testLogging {
-        events("started", "passed", "failed", "skipped")
-        showStandardStreams = true
+        // -PverboseTests shows every test plus its stdout/stderr (for diagnosing RPC hangs)
+        if (project.hasProperty("verboseTests")) {
+            events("started", "passed", "failed", "skipped")
+            showStandardStreams = true
+        } else {
+            events("failed", "skipped")
+        }
     }
 }
 

--- a/rewrite-go/build.gradle.kts
+++ b/rewrite-go/build.gradle.kts
@@ -247,9 +247,11 @@ val goTest = tasks.register<Exec>("goTest") {
     description = "Run Go tests"
 
     workingDir = projectDir
+    // -PverboseTests restores the per-test `standard-verbose` output
+    val gotestFormat = if (project.hasProperty("verboseTests")) "standard-verbose" else "pkgname"
     commandLine("go", "run", "gotest.tools/gotestsum@latest",
         "--junitfile", junitXmlFile.relativeTo(projectDir).path,
-        "--format", "standard-verbose",
+        "--format", gotestFormat,
         "--", "-count=1", "./test/...")
 
     dependsOn(generateTestClasspath)

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -142,6 +142,11 @@ val npmTest = tasks.register<NpmTask>("npmTest") {
     outputs.files("rewrite/build/test-results/vitest/junit.xml")
     outputs.cacheIf { true }
 
+    // -PverboseTests switches vitest to its full per-test reporter (see vitest.config.mts)
+    if (project.hasProperty("verboseTests")) {
+        environment.put("VERBOSE_TESTS", "1")
+    }
+
     args = listOf("run", "ci:test")
 }
 

--- a/rewrite-javascript/rewrite/vitest.config.mts
+++ b/rewrite-javascript/rewrite/vitest.config.mts
@@ -10,8 +10,9 @@ export default defineConfig({
         testTimeout: 60_000,
         include: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],
         exclude: ['**/node_modules/**', '**/dist/**'],
+        // VERBOSE_TESTS (Gradle: -PverboseTests) restores the full per-test reporter
         reporters: [
-            'default',
+            process.env.VERBOSE_TESTS ? 'default' : 'dot',
             ['junit', {
                 outputFile: './build/test-results/vitest/junit.xml',
                 classname: '{classname}',

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -176,8 +176,13 @@ val pytestTest by tasks.registering(Exec::class) {
     workingDir = pythonDir
     // Use relative path for python executable to avoid absolute paths in cache key
     val relativePythonExe = if (isWindows) ".venv/Scripts/python.exe" else ".venv/bin/python"
-    commandLine(relativePythonExe, "-m", "pytest", "tests/", "-v",
+    val pytestArgs = mutableListOf(relativePythonExe, "-m", "pytest", "tests/",
         "--junitxml=build/test-results/pytest/junit.xml")
+    // -PverboseTests restores per-test output
+    if (project.hasProperty("verboseTests")) {
+        pytestArgs.add("-v")
+    }
+    commandLine(pytestArgs)
 
     inputs.files(fileTree(pythonDir.resolve("src")) { exclude("**/__pycache__/**") })
         .withPathSensitivity(PathSensitivity.RELATIVE)
@@ -206,10 +211,14 @@ tasks.withType<Test> {
     maxParallelForks = 1
     // Add timeout to identify hanging tests - tests that hang will fail with timeout
     systemProperty("junit.jupiter.execution.timeout.default", "30s")
-    // Show test names as they run
     testLogging {
-        events("started", "passed", "failed", "skipped")
-        showStandardStreams = true
+        // -PverboseTests shows every test plus its stdout/stderr (for diagnosing RPC hangs)
+        if (project.hasProperty("verboseTests")) {
+            events("started", "passed", "failed", "skipped")
+            showStandardStreams = true
+        } else {
+            events("failed", "skipped")
+        }
     }
 }
 


### PR DESCRIPTION
The `rewrite-go`, `rewrite-python`, `rewrite-csharp`, and `rewrite-javascript` modules ran their native test runners in verbose mode, printing one or more lines per passing test and accounting for ~7,000 of ~7,500 content lines in a full build's stdout. This switches each runner to a concise reporter (gotestsum `pkgname`, pytest non-verbose, `dotnet --verbosity minimal`, vitest `dot`) and gates the JVM-side per-test event logging in `rewrite-python`/`rewrite-csharp` behind a new `-PverboseTests` flag. Failures and the JUnit XML reports are unchanged, so nothing is lost for diagnosis; pass `-PverboseTests` (or the `VERBOSE_TESTS` env var for vitest) to restore the full per-test output. Verified with `--rerun-tasks` across all four modules: BUILD SUCCESSFUL with the per-test noise eliminated.