### PR TITLE
Scala: visitUnknown -> throw unmappedException

### DIFF
--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -199,9 +199,9 @@ class ScalaTreeVisitor(
     tree match {
       // `Trees.TypeTree.isEmpty` returns true for compiler-synthesized inferred types
       // (because they have no symbol yet in the untyped tree), so this case must come
-      // *before* the general `tree.isEmpty` short-circuit that routes to visitUnknown.
+      // *before* the general `tree.isEmpty` short-circuit that routes to unmappedException.
       case tt: Trees.TypeTree[?] => visitSyntheticTypeTree(tt)
-      case _ if tree.isEmpty => visitUnknown(tree)
+      case _ if tree.isEmpty => throw unmappedException(tree)
       case lit: Trees.Literal[?] => visitLiteral(lit)
       case num: untpd.Number => visitNumber(num)
       case id: Trees.Ident[?] => visitIdent(id)
@@ -255,7 +255,7 @@ class ScalaTreeVisitor(
       case mac: untpd.MacroTree => visitMacroTree(mac)
       case ext: untpd.ExtMethods => visitExtMethods(ext)
       case forYield: untpd.ForYield => visitForYield(forYield)
-      case _ => visitUnknown(tree)
+      case _ => throw unmappedException(tree)
     }
   }
   
@@ -398,7 +398,7 @@ class ScalaTreeVisitor(
           case newTree: Trees.New[?] =>
             visitNewClassWithArgs(newTree, app)
           case _ =>
-            visitUnknown(app)
+            throw unmappedException(app)
         }
       case sel: Trees.Select[?] if app.args.isEmpty && isUnaryOperator(sel.name.toString) =>
         // This is a unary operation
@@ -583,7 +583,7 @@ class ScalaTreeVisitor(
     }
     val tpt = extractAnnotationTypeTree(app.fun) match {
       case Some(t) => t
-      case None => return visitUnknown(app)
+      case None => throw unmappedException(app)
     }
     val args = app.args
 
@@ -597,7 +597,7 @@ class ScalaTreeVisitor(
         if (selStart > cursor) cursor = selStart
         visitTree(sel) match {
           case nt: NameTree => nt
-          case _ => return visitUnknown(app)
+          case _ => throw unmappedException(app)
         }
       case at: Trees.AppliedTypeTree[?] =>
         // Parameterized annotation type like @throws[Exception]; skip the leading '@'
@@ -607,9 +607,9 @@ class ScalaTreeVisitor(
         if (atStart > cursor) cursor = atStart
         visitTree(at) match {
           case nt: NameTree => nt
-          case _ => return visitUnknown(app)
+          case _ => throw unmappedException(app)
         }
-      case _ => return visitUnknown(app)
+      case _ => throw unmappedException(app)
     }
     
     // Advance cursor past "@AnnotName(" before visiting arguments
@@ -635,7 +635,7 @@ class ScalaTreeVisitor(
           val expr = visitTree(arg) match {
             case e: Expression => e
             case j: J => new S.StatementExpression(Tree.randomId(), j)
-            case _ => visitUnknown(arg)
+            case null => throw unmappedException(arg)
           }
           updateCursor(arg.span.end)
           expr
@@ -677,7 +677,7 @@ class ScalaTreeVisitor(
     val expr = visitTree(prefixOp.od) match {
       case e: Expression => e
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(prefixOp)
+      case null => throw unmappedException(prefixOp)
     }
 
     new J.Unary(
@@ -705,7 +705,7 @@ class ScalaTreeVisitor(
           case fa: J.FieldAccess => fa.withPrefix(Space.EMPTY)
           case mi: J.MethodInvocation => mi.withPrefix(Space.EMPTY)
           case e: Expression => e  // For other expressions, keep as is
-          case _ => return visitUnknown(postfixOp)
+          case _ => throw unmappedException(postfixOp)
         }
         
         // Update cursor to the end of the expression to avoid duplication
@@ -758,7 +758,7 @@ class ScalaTreeVisitor(
         val selectExpr = visitTree(postfixOp.od) match {
           case e: Expression => e
           case j: J => new S.StatementExpression(Tree.randomId(), j)
-          case _ => return visitUnknown(postfixOp)
+          case null => throw unmappedException(postfixOp)
         }
 
         val opName = postfixOp.op.name.toString
@@ -873,7 +873,7 @@ class ScalaTreeVisitor(
         val expr: Expression = visited match {
           case e: Expression => e
           case j: J => new S.StatementExpression(Tree.randomId(), j)
-          case _ => null
+          case null => null
         }
         if (expr != null) {
           val isLast = i == app.args.length - 1
@@ -918,7 +918,6 @@ class ScalaTreeVisitor(
   }
 
   private def visitMethodInvocation(app: Trees.Apply[?]): J = {
-    val savedCursor = cursor
     val prefix = extractPrefix(app.span)
 
     // Note: We deliberately don't create J.ArrayAccess for explicit .apply() calls.
@@ -957,7 +956,7 @@ class ScalaTreeVisitor(
         val target = visitTree(sel.qualifier) match {
           case expr: Expression => expr
           case j: J => new S.StatementExpression(Tree.randomId(), j)
-          case _ => cursor = savedCursor; return visitUnknown(app)
+          case null => throw unmappedException(app)
         }
 
         // Capture space between qualifier and the `.` (for multi-line chains)
@@ -988,7 +987,7 @@ class ScalaTreeVisitor(
             val target = visitTree(sel.qualifier) match {
               case expr: Expression => expr
               case j: J => new S.StatementExpression(Tree.randomId(), j)
-              case _ => cursor = savedCursor; return visitUnknown(app)
+              case null => throw unmappedException(app)
             }
             val dotPos = positionOfNext(".", cursor)
             val selectAfter = if (dotPos > cursor) ScalaSpace.format(source, cursor, dotPos) else Space.EMPTY
@@ -1010,7 +1009,7 @@ class ScalaTreeVisitor(
             methodNameQuoted = isBacktickQuoted(id.span)
             typeParamsContainer = parseTypeApplyArgs(typeApp)
           case _ =>
-            cursor = savedCursor; return visitUnknown(app)
+            throw unmappedException(app)
         }
 
       case innerApp: Trees.Apply[?] =>
@@ -1149,7 +1148,7 @@ class ScalaTreeVisitor(
             // Keep the block as-is — the printer uses BlockArgument marker to print { }
             val blockExpr = new S.StatementExpression(Tree.randomId(), block)
             args.add(JRightPadded.build(blockExpr.asInstanceOf[Expression]))
-          case _ => cursor = savedCursor; return visitUnknown(app)
+          case _ => throw unmappedException(app)
         }
       }
     } else if (isColonArg) {
@@ -1170,7 +1169,7 @@ class ScalaTreeVisitor(
           case stmt: Statement =>
             val stmtExpr = new S.StatementExpression(Tree.randomId(), stmt)
             args.add(JRightPadded.build(stmtExpr.asInstanceOf[Expression]))
-          case _ => cursor = savedCursor; return visitUnknown(app)
+          case _ => throw unmappedException(app)
         }
       }
     } else {
@@ -1206,7 +1205,7 @@ class ScalaTreeVisitor(
             // Statements like throw are expressions in Scala — wrap
             val stmtExpr = new S.StatementExpression(Tree.randomId(), stmt)
             args.add(new JRightPadded(stmtExpr.asInstanceOf[Expression], afterSpace, Markers.EMPTY))
-          case _ => cursor = savedCursor; return visitUnknown(app)
+          case _ => throw unmappedException(app)
         }
       }
 
@@ -1279,14 +1278,14 @@ class ScalaTreeVisitor(
     val array = visitTree(sel.qualifier) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(app)
+      case null => throw unmappedException(app)
     }
 
     // Visit the index expression
     val index = visitTree(app.args.head) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(app)
+      case null => throw unmappedException(app)
     }
     
     // Create the dimension with the index
@@ -1325,7 +1324,7 @@ class ScalaTreeVisitor(
       visitTree(arg) match {
         case expr: Expression => elements.add(expr)
         case j: J => elements.add(new S.StatementExpression(Tree.randomId(), j))
-        case _ => return visitUnknown(app)
+        case null => throw unmappedException(app)
       }
     }
 
@@ -1437,9 +1436,9 @@ class ScalaTreeVisitor(
       val target = visitTree(sel.qualifier) match {
         case expr: Expression => expr
         case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ =>
+        case null =>
           // If the qualifier doesn't produce a J at all, fall back to Unknown
-          return visitUnknown(sel)
+          throw unmappedException(sel)
       }
       
       // Extract space before the dot/hash and after it (for the name prefix)
@@ -1537,7 +1536,7 @@ class ScalaTreeVisitor(
       val variable = visitTree(infixOp.left) match {
         case expr: Expression => expr
         case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ => return visitUnknown(infixOp)
+        case null => throw unmappedException(infixOp)
       }
 
       // Map the operator
@@ -1554,7 +1553,7 @@ class ScalaTreeVisitor(
         case "<<" => J.AssignmentOperation.Type.LeftShift
         case ">>" => J.AssignmentOperation.Type.RightShift
         case ">>>" => J.AssignmentOperation.Type.UnsignedRightShift
-        case _ => return visitUnknown(infixOp) // unreachable: isCompoundAssign filters
+        case _ => throw unmappedException(infixOp) // unreachable: isCompoundAssign filters
       }
       
       // Extract space around the operator
@@ -1579,7 +1578,7 @@ class ScalaTreeVisitor(
       val value = visitTree(infixOp.right) match {
         case expr: Expression => expr
         case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ => return visitUnknown(infixOp)
+        case null => throw unmappedException(infixOp)
       }
 
       // Update cursor to the end
@@ -1610,7 +1609,7 @@ class ScalaTreeVisitor(
     val left = visitTree(infixOp.left) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(infixOp)
+      case null => throw unmappedException(infixOp)
     }
 
     // Map operator
@@ -1638,7 +1637,7 @@ class ScalaTreeVisitor(
     val right = visitTree(infixOp.right) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(infixOp)
+      case null => throw unmappedException(infixOp)
     }
 
     // Update cursor
@@ -1662,7 +1661,7 @@ class ScalaTreeVisitor(
     val leftExpr = visitTree(infixOp.left) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(infixOp)
+      case null => throw unmappedException(infixOp)
     }
 
     val methodName = infixOp.op.name.toString
@@ -1694,7 +1693,6 @@ class ScalaTreeVisitor(
     }
 
     // Visit the right-hand-side expression as it appears in source
-    val savedCursorArg = cursor
     val rightExpr = visitTree(infixOp.right) match {
       case expr: Expression => expr
       case block: J.Block =>
@@ -1704,7 +1702,7 @@ class ScalaTreeVisitor(
         // A compound statement as the right operand, e.g. `x := y.match\n  case _ => ...`
         // where the dotted `.match` binds to `y`, making the J.Switch the infix argument.
         new S.StatementExpression(Tree.randomId(), j)
-      case _ => cursor = savedCursorArg; return visitUnknown(infixOp)
+      case null => throw unmappedException(infixOp)
     }
 
     // Create the method name identifier
@@ -1771,11 +1769,11 @@ class ScalaTreeVisitor(
           if (parens.productArity > 0) {
             parens.productElement(0).asInstanceOf[Trees.Tree[?]]
           } else {
-            return visitUnknown(parens)
+            throw unmappedException(parens)
           }
       }
     } catch {
-      case _: Exception => return visitUnknown(parens)
+      case _: Exception => throw unmappedException(parens)
     }
     
     // Visit the inner tree. Scala's `(if (x) a else b)` — inner may be a Statement;
@@ -1783,7 +1781,7 @@ class ScalaTreeVisitor(
     val innerExpr = visitTree(innerTree) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(parens)
+      case null => throw unmappedException(parens)
     }
     
     // Extract space before the closing parenthesis
@@ -1847,7 +1845,7 @@ class ScalaTreeVisitor(
       case typeTree: TypeTree => typeTree.withPrefix(typeSpace)
       case id: J.Identifier => id.withPrefix(typeSpace)
       case fieldAccess: J.FieldAccess => fieldAccess.withPrefix(typeSpace)
-      case _ => return visitUnknown(app)
+      case _ => throw unmappedException(app)
     }
     
     // Extract space before parentheses
@@ -1943,7 +1941,7 @@ class ScalaTreeVisitor(
             else Space.EMPTY
           } else Space.EMPTY
           args.add(new JRightPadded[Expression](stmtExpr, afterSpace, Markers.EMPTY))
-        case _ => return visitUnknown(app)
+        case null => throw unmappedException(app)
       }
     }
     
@@ -2114,7 +2112,7 @@ class ScalaTreeVisitor(
                         val visitedArg: Expression = argJ match {
                           case e: Expression => e.withPrefix(argPrefix).asInstanceOf[Expression]
                           case j: J => new S.StatementExpression(Tree.randomId(), j).asInstanceOf[Expression].withPrefix(argPrefix).asInstanceOf[Expression]
-                          case _ => visitUnknown(arg).asInstanceOf[Expression].withPrefix(argPrefix).asInstanceOf[Expression]
+                          case null => throw unmappedException(arg)
                         }
                         args.add(new JRightPadded[Expression](visitedArg, Space.EMPTY, Markers.EMPTY))
                       }
@@ -2155,7 +2153,7 @@ class ScalaTreeVisitor(
 
                     (typeTree, argContainer)
                   case _ =>
-                    (visitUnknown(sel.qualifier).asInstanceOf[TypeTree], null)
+                    throw unmappedException(sel.qualifier)
                 }
             } else {
                 // Simple interface/trait: new Runnable { ... }
@@ -2177,13 +2175,13 @@ class ScalaTreeVisitor(
           for (i <- 1 until parents.size - 1) {
             val tt = visitTree(parents(i)) match {
               case t: TypeTree => t
-              case _ => return visitUnknown(parents(i))
+              case _ => throw unmappedException(parents(i))
             }
             mixinElements.add(new JRightPadded[TypeTree](tt, sourceBefore("with"), Markers.EMPTY))
           }
           val lastTt = visitTree(parents.last) match {
             case t: TypeTree => t
-            case _ => return visitUnknown(parents.last)
+            case _ => throw unmappedException(parents.last)
           }
           mixinElements.add(JRightPadded.build(lastTt))
           new J.IntersectionType(
@@ -2319,7 +2317,7 @@ class ScalaTreeVisitor(
 
       case _ =>
         // Not an anonymous class, shouldn't happen in visitNew
-        visitUnknown(newTree)
+        throw unmappedException(newTree)
     }
   }
 
@@ -2781,7 +2779,7 @@ class ScalaTreeVisitor(
    *
    * Returns the leading `Space` (whitespace + comments before the keyword) and
    * the qualid. Advances the cursor past the end of the import/export. If the
-   * shape can't be modelled, raises via `visitUnknown` so the caller sees a
+   * shape can't be modelled, raises via `unmappedException` so the caller sees a
    * failure rather than a degraded value.
    */
   private def buildImportOrExportQualid(
@@ -3033,7 +3031,7 @@ class ScalaTreeVisitor(
   }
   
   private def visitValDef(vd: Trees.ValDef[?], isLambdaParam: Boolean = false): J = {
-    val savedCursorEntry = cursor  // Save for fallback to visitUnknown
+    val savedCursorEntry = cursor  // Save for fallback to unmappedException
     // For lambda parameters, don't look for val/var keywords
     if (isLambdaParam) {
       return visitLambdaParameter(vd)
@@ -3499,7 +3497,7 @@ class ScalaTreeVisitor(
       cursor = typeStart
       visitTypeTree(vd.tpt) match {
         case tt: TypeTree => tt.withPrefix(typePrefix)
-        case _ =>
+        case null =>
           // Fall back to source-text identifier — preserves printing fidelity but
           // intentionally drops rich typing for unmapped type expressions.
           val tText = extractSource(vd.tpt.span)
@@ -3766,7 +3764,7 @@ class ScalaTreeVisitor(
         val visitedFirstParent = visitTree(firstParent)
         val extendsType: TypeTree = parentTypeTree(visitedFirstParent) match {
           case tt: TypeTree => tt
-          case _ =>
+          case null =>
             updateCursor(firstParent.span.end)
             ident(extractSource(firstParent.span), visitedFirstParent.getPrefix).asInstanceOf[TypeTree]
         }
@@ -3796,7 +3794,7 @@ class ScalaTreeVisitor(
             val visitedParent = visitTree(parent)
             val implType: TypeTree = parentTypeTree(visitedParent) match {
               case tt: TypeTree => tt
-              case _ =>
+              case null =>
                 updateCursor(parent.span.end)
                 ident(extractSource(parent.span), visitedParent.getPrefix).asInstanceOf[TypeTree]
             }
@@ -3957,7 +3955,7 @@ class ScalaTreeVisitor(
     val variable = visitTree(asg.lhs) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(asg)
+      case null => throw unmappedException(asg)
     }
 
     // Find the position of the equals sign
@@ -4012,7 +4010,7 @@ class ScalaTreeVisitor(
     val value = visitTree(asg.rhs) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(asg)
+      case null => throw unmappedException(asg)
     }
     
     // Update cursor to the end of the assignment
@@ -4127,7 +4125,7 @@ class ScalaTreeVisitor(
     val condition = visitTree(conditionExpr) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(ifTree)
+      case null => throw unmappedException(ifTree)
     }
     
     // Extract space after condition
@@ -4175,7 +4173,7 @@ class ScalaTreeVisitor(
       case j: J =>
         // Wrap any non-Statement J (like Identifier, Literal) in StatementExpression
         JRightPadded.build(new S.StatementExpression(Tree.randomId(), j).asInstanceOf[Statement])
-      case _ => return visitUnknown(ifTree)
+      case null => throw unmappedException(ifTree)
     }
     
     // Handle optional else branch
@@ -4212,7 +4210,7 @@ class ScalaTreeVisitor(
             Markers.EMPTY,
             JRightPadded.build(new S.StatementExpression(Tree.randomId(), j).asInstanceOf[Statement])
           )
-        case _ => return visitUnknown(ifTree)
+        case null => throw unmappedException(ifTree)
       }
     }
     
@@ -4316,7 +4314,7 @@ class ScalaTreeVisitor(
     val condition = visitTree(conditionExpr) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(whileTree)
+      case null => throw unmappedException(whileTree)
     }
     
     // Extract space after condition
@@ -4358,7 +4356,7 @@ class ScalaTreeVisitor(
     val body = visitTree(whileTree.body) match {
       case stmt: Statement => JRightPadded.build(stmt)
       case j: J => JRightPadded.build(new S.StatementExpression(Tree.randomId(), j).asInstanceOf[Statement])
-      case _ => return visitUnknown(whileTree)
+      case null => throw unmappedException(whileTree)
     }
 
     // Update cursor to end of the while loop
@@ -4388,7 +4386,6 @@ class ScalaTreeVisitor(
    * stat and the condition is the block's result expression (a `Parens`).
    */
   private def visitDoWhile(whileTree: Trees.WhileDo[?], condBlock: Trees.Block[?]): J = {
-    val savedCursor = cursor
     val prefix = extractPrefix(whileTree.span)
 
     // Move past the `do` keyword so the body picks up its own prefix.
@@ -4398,18 +4395,18 @@ class ScalaTreeVisitor(
     val bodyStmt: Statement = visitTree(condBlock.stats.head) match {
       case stmt: Statement => stmt
       case j: J => new S.StatementExpression(Tree.randomId(), j).asInstanceOf[Statement]
-      case _ => cursor = savedCursor; return visitUnknown(whileTree)
+      case null => throw unmappedException(whileTree)
     }
 
     // Space between the body and the `while` keyword.
     val whileIdx = positionOfNext("while", cursor)
-    if (whileIdx < 0) { cursor = savedCursor; return visitUnknown(whileTree) }
+    if (whileIdx < 0) { throw unmappedException(whileTree) }
     val beforeWhile = if (whileIdx > cursor) ScalaSpace.format(source, cursor, whileIdx) else Space.EMPTY
     cursor = whileIdx + 5
 
     // Space between `while` and the opening parenthesis.
     val parenIdx = positionOfNext("(", cursor)
-    if (parenIdx < 0) { cursor = savedCursor; return visitUnknown(whileTree) }
+    if (parenIdx < 0) { throw unmappedException(whileTree) }
     val condParenPrefix = if (parenIdx > cursor) ScalaSpace.format(source, cursor, parenIdx) else Space.EMPTY
     cursor = parenIdx + 1
 
@@ -4421,7 +4418,7 @@ class ScalaTreeVisitor(
     val condition = visitTree(condTree) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => cursor = savedCursor; return visitUnknown(whileTree)
+      case null => throw unmappedException(whileTree)
     }
 
     // Space before the closing parenthesis.
@@ -4514,7 +4511,7 @@ class ScalaTreeVisitor(
       case ident: Trees.Ident[?] => ident.name.toString
       case _ =>
         // Complex patterns not yet supported
-        return visitUnknown(forTree)
+        throw unmappedException(forTree)
     }
 
     // Extract prefix space before the variable name
@@ -4574,7 +4571,7 @@ class ScalaTreeVisitor(
     val iterable = visitTree(genFrom.expr) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(forTree)
+      case null => throw unmappedException(forTree)
     }
 
     // Find the closing delimiter ')' or '}' after the iterable.
@@ -4614,7 +4611,7 @@ class ScalaTreeVisitor(
     val body: Statement = bodyJ match {
       case stmt: Statement => stmt
       case j: J => new S.StatementExpression(Tree.randomId(), j).asInstanceOf[Statement]
-      case _ => visitUnknown(forTree.body).asInstanceOf[Statement]
+      case null => throw unmappedException(forTree.body)
     }
 
     updateCursor(forTree.span.end)
@@ -5198,7 +5195,7 @@ class ScalaTreeVisitor(
         val visitedFirstParent = visitTree(firstParent)
         val extendsType: TypeTree = parentTypeTree(visitedFirstParent) match {
           case tt: TypeTree => tt
-          case _ =>
+          case null =>
             // Intersection type or other complex parent — preserve source
             updateCursor(firstParent.span.end)
             ident(extractSource(firstParent.span), visitedFirstParent.getPrefix).asInstanceOf[TypeTree]
@@ -5234,9 +5231,9 @@ class ScalaTreeVisitor(
 
             val implType: TypeTree = parentTypeTree(visitTree(parent)) match {
               case tt: TypeTree => tt
-              case _ =>
+              case null =>
                 cursor = savedCursorWith
-                visitUnknown(parent)
+                throw unmappedException(parent)
             }
             
             // Build the right-padded element
@@ -5478,7 +5475,7 @@ class ScalaTreeVisitor(
       visitTree(ret.expr) match {
         case expression: Expression => expression
         case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ => return visitUnknown(ret)
+        case null => throw unmappedException(ret)
       }
     }
     
@@ -5507,7 +5504,7 @@ class ScalaTreeVisitor(
     val exception = visitTree(thr.expr) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(thr)
+      case null => throw unmappedException(thr)
     }
     
     // Update cursor to the end of the throw statement
@@ -5535,7 +5532,7 @@ class ScalaTreeVisitor(
           val expr = visitTree(sel.qualifier) match {
             case e: Expression => e
             case j: J => new S.StatementExpression(Tree.randomId(), j)
-            case _ => return visitUnknown(ta)
+            case null => throw unmappedException(ta)
           }
           
           // Capture whitespace between the qualifier and ".asInstanceOf"
@@ -5574,7 +5571,7 @@ class ScalaTreeVisitor(
           // `TypeTree` rather than being misread as expressions.
           val targetType = visitTypeTree(ta.args.head) match {
             case tt: TypeTree => tt
-            case _ => return visitUnknown(ta)
+            case null => throw unmappedException(ta)
           }
           
           // Update cursor past the closing bracket
@@ -5620,7 +5617,7 @@ class ScalaTreeVisitor(
           val expr = visitTree(sel.qualifier) match {
             case e: Expression => e
             case j: J => new S.StatementExpression(Tree.randomId(), j)
-            case _ => return visitUnknown(ta)
+            case null => throw unmappedException(ta)
           }
 
           // Capture whitespace between the qualifier and ".isInstanceOf"
@@ -5648,7 +5645,7 @@ class ScalaTreeVisitor(
           // (`A => B`), tuple/union/intersection types map to a `TypeTree`.
           val clazz = visitTypeTree(ta.args.head) match {
             case tt: TypeTree => tt
-            case _ => return visitUnknown(ta)
+            case null => throw unmappedException(ta)
           }
 
           // Update cursor to the end of the TypeApply
@@ -5717,7 +5714,7 @@ class ScalaTreeVisitor(
     }
 
     // Shouldn't reach here — all cases return above
-    visitUnknown(ta)
+    throw unmappedException(ta)
   }
 
   /**
@@ -5733,7 +5730,7 @@ class ScalaTreeVisitor(
     val qual = visitTree(sel.qualifier) match {
       case e: Expression => e
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => cursor = savedCursor; return visitUnknown(ta)
+      case null => throw unmappedException(ta)
     }
 
     // Capture space between qualifier and the `.`
@@ -5789,7 +5786,7 @@ class ScalaTreeVisitor(
         else visitTree(arg) match {
           case e: Expression => e
           case j: J => new S.StatementExpression(Tree.randomId(), j)
-          case _ => visitUnknown(arg)
+          case null => throw unmappedException(arg)
         }
       },
       "]",
@@ -5807,13 +5804,12 @@ class ScalaTreeVisitor(
     }
 
     // AppliedTypeTree represents a parameterized type like List[String]
-    val savedCursor = cursor
     val prefix = extractPrefix(at.span)
 
     // Visit the base type (e.g., List, Map, Option)
     val clazz = visitTree(at.tpt) match {
       case nt: NameTree => nt
-      case _ => cursor = savedCursor; return visitUnknown(at)
+      case _ => throw unmappedException(at)
     }
 
     // Find bracket positions in absolute source coordinates, skipping comments.
@@ -5824,7 +5820,7 @@ class ScalaTreeVisitor(
     val closeBracketAbs = if (atEndAbs > atStart && atEndAbs <= source.length && source.charAt(atEndAbs - 1) == ']') atEndAbs - 1 else -1
 
     if (openBracketAbs < 0 || closeBracketAbs < 0 || openBracketAbs >= atEndAbs) {
-      cursor = savedCursor; return visitUnknown(at)
+      throw unmappedException(at)
     }
     val openBracketIdx = openBracketAbs - atStart
     val closeBracketIdx = closeBracketAbs - atStart
@@ -5859,7 +5855,7 @@ class ScalaTreeVisitor(
         else visitTree(arg) match {
           case expr: Expression => expr
           case j: J => new S.StatementExpression(Tree.randomId(), j)
-          case _ => cursor = savedCursor; return visitUnknown(at)
+          case null => throw unmappedException(at)
         }
 
         // Extract trailing comma/space
@@ -6009,7 +6005,7 @@ class ScalaTreeVisitor(
       // the gap between `cursor` and the part's span.start to capture the
       // whitespace after the previous `with` keyword.
       val tt = visitTypeTree(parts(i))
-      if (tt == null) return visitUnknown(parts(i))
+      if (tt == null) throw unmappedException(parts(i))
       val isLast = i == parts.size - 1
       val afterSpace = if (isLast) Space.EMPTY else sourceBefore("with")
       elements.add(new JRightPadded[TypeTree](tt, afterSpace, Markers.EMPTY))
@@ -7092,7 +7088,6 @@ class ScalaTreeVisitor(
   }
 
   private def visitMatchTree(matchTree: Trees.Match[?]): J = {
-    val savedCursor = cursor
     visitMatchImpl(matchTree)
   }
 
@@ -7126,7 +7121,7 @@ class ScalaTreeVisitor(
     val selector = visitTree(matchTree.selector) match {
       case expr: Expression => expr
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => return visitUnknown(matchTree)
+      case null => throw unmappedException(matchTree)
     }
 
     val ms = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 30, source.length)) else ""
@@ -7171,7 +7166,7 @@ class ScalaTreeVisitor(
     val ck = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 20, source.length)) else ""
     val cki = positionOfNextIn(ck, "case", 0); if (cki >= 0) cursor = cursor + cki + 4
 
-    val patternJ = visitTree(caseDef.pat) match { case j: J => j; case _ => ident("_", Space.format(" ")) }
+    val patternJ = visitTree(caseDef.pat) match { case j: J => j; case null => ident("_", Space.format(" ")) }
 
     // Handle guard: `case x if condition =>`
     // Store space-before-if in label's after space so the printer can emit it.
@@ -7188,7 +7183,7 @@ class ScalaTreeVisitor(
       guardResult match {
         case expr: Expression => guard = expr
         case j: J => guard = new S.StatementExpression(Tree.randomId(), j)
-        case _ =>
+        case null =>
       }
       val arrowPos = positionOfNext("=>", cursor)
       if (arrowPos >= cursor) guardArrowSpace = ScalaSpace.format(source, cursor, arrowPos)
@@ -7202,7 +7197,7 @@ class ScalaTreeVisitor(
     val as = if (cursor < source.length) source.substring(cursor, Math.min(cursor + 200, source.length)) else ""
     val ai = positionOfNextIn(as, "=>", 0); if (ai >= 0) { val aa = positionOfNext("=>", cursor); if (aa >= 0) cursor = aa + 2 }
 
-    val caseBodyJ = visitTree(caseDef.body) match { case j: J => JRightPadded.build(j); case _ => null }
+    val caseBodyJ = visitTree(caseDef.body) match { case j: J => JRightPadded.build(j); case null => null }
     // Compute the end of the body's actual content from the AST (not from
     // the cursor, which may have overshot when Dotty's body span included
     // the `;` or part of the next case).
@@ -7520,7 +7515,7 @@ class ScalaTreeVisitor(
     val arg = visitTree(namedArg.arg) match {
       case expr: Expression => expr
       case stmt: Statement => new S.StatementExpression(Tree.randomId(), stmt).asInstanceOf[Expression]
-      case other => visitUnknown(namedArg)
+      case other => throw unmappedException(namedArg)
     }
     updateCursor(namedArg.span.end)
     new J.Assignment(Tree.randomId(), prefix, Markers.EMPTY, nameId,
@@ -7539,7 +7534,7 @@ class ScalaTreeVisitor(
     val pattern: Expression = visitTree(bind.body) match {
       case e: Expression => e
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => throw new UnsupportedOperationException(
+      case null => throw new UnsupportedOperationException(
         s"Bind body did not produce an Expression: ${bind.body.getClass.getSimpleName}")
     }
     updateCursor(bind.span.end)
@@ -7561,7 +7556,7 @@ class ScalaTreeVisitor(
       val pat: Expression = visitTree(t) match {
         case e: Expression => e
         case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ => throw new UnsupportedOperationException(
+        case null => throw new UnsupportedOperationException(
           s"Alternative pattern did not produce an Expression: ${t.getClass.getSimpleName}")
       }
       // Extract space before the `|` (for all but the last pattern)
@@ -7594,7 +7589,7 @@ class ScalaTreeVisitor(
     val qualifier = visitTree(stt.ref) match {
       case e: Expression => e
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => throw new UnsupportedOperationException(
+      case null => throw new UnsupportedOperationException(
         s"SingletonTypeTree.ref did not produce an Expression: ${stt.ref.getClass.getSimpleName}")
     }
     // After visiting qualifier, cursor is at the end of qualifier.
@@ -7699,7 +7694,7 @@ class ScalaTreeVisitor(
       val expr: Expression = arg match {
         case e: Expression => e
         case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ => throw new UnsupportedOperationException(
+        case null => throw new UnsupportedOperationException(
           s"Annotated.arg did not produce an Expression: ${ann.arg.getClass.getSimpleName}")
       }
       new S.AnnotatedExpression(Tree.randomId(), prefix, Markers.EMPTY,
@@ -7737,7 +7732,7 @@ class ScalaTreeVisitor(
     val expr: Expression = visitTree(mac.expr) match {
       case e: Expression => e
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => throw new UnsupportedOperationException(
+      case null => throw new UnsupportedOperationException(
         s"MacroTree.expr did not produce an Expression: ${mac.expr.getClass.getSimpleName}")
     }
 
@@ -7962,7 +7957,7 @@ class ScalaTreeVisitor(
     val rhs: Expression = visitTree(rhsTree) match {
       case e: Expression => e
       case j: J => new S.StatementExpression(Tree.randomId(), j)
-      case _ => throw new UnsupportedOperationException(
+      case null => throw new UnsupportedOperationException(
         s"For enumerator rhs did not produce an Expression: ${rhsTree.getClass.getSimpleName}")
     }
 
@@ -8658,11 +8653,11 @@ class ScalaTreeVisitor(
     }
   }
 
-  private def visitUnknown(tree: Trees.Tree[?]): Nothing = {
+  private def unmappedException(tree: Trees.Tree[?]): UnsupportedOperationException = {
     val adjStart = Math.max(0, tree.span.start - offsetAdjustment)
     val adjEnd = Math.max(0, tree.span.end - offsetAdjustment)
     val sourceText = if (adjStart < adjEnd && adjEnd <= source.length) source.substring(adjStart, adjEnd) else ""
-    throw new UnsupportedOperationException(
+    new UnsupportedOperationException(
       s"Unmapped Scala AST node: ${tree.getClass.getSimpleName} " +
       s"at ${tree.span} source=${sourceText.take(80).replace('\n', ' ')}"
     )
@@ -9280,7 +9275,7 @@ class ScalaTreeVisitor(
               case tt: TypeTree =>
                 val loBound: TypeTree = new J.TypeBound(Tree.randomId(), loPrefix, Markers.EMPTY, J.TypeBound.Kind.Lower, tt)
                 boundList.add(JRightPadded.build(loBound))
-              case _ => cursor = savedC
+              case null => cursor = savedC
             }
           }
           if (!innerBounds.hi.isEmpty) {
@@ -9292,7 +9287,7 @@ class ScalaTreeVisitor(
               case tt: TypeTree =>
                 val hiBound: TypeTree = new J.TypeBound(Tree.randomId(), hiPrefix, Markers.EMPTY, J.TypeBound.Kind.Upper, tt)
                 boundList.add(JRightPadded.build(hiBound))
-              case _ => cursor = savedC
+              case null => cursor = savedC
             }
           }
           var contextBoundBefore = Space.EMPTY
@@ -9320,10 +9315,9 @@ class ScalaTreeVisitor(
           val loOpIdx = positionOfNext(">:", cursor)
           val loPrefix = if (loOpIdx > cursor) ScalaSpace.format(source, cursor, loOpIdx) else Space.EMPTY
           if (loOpIdx >= 0) cursor = loOpIdx + 2
-          val savedCursorLo = cursor
           val loType = visitTypeTree(tb.lo) match {
             case tt: TypeTree => tt
-            case _ => cursor = savedCursorLo; visitUnknown(tb.lo).asInstanceOf[TypeTree]
+            case null => throw unmappedException(tb.lo)
           }
           val loBound: TypeTree = new J.TypeBound(Tree.randomId(), loPrefix, Markers.EMPTY,
             J.TypeBound.Kind.Lower, loType)
@@ -9335,10 +9329,9 @@ class ScalaTreeVisitor(
           val hiOpIdx = positionOfNext("<:", cursor)
           val hiPrefix = if (hiOpIdx > cursor) ScalaSpace.format(source, cursor, hiOpIdx) else Space.EMPTY
           if (hiOpIdx >= 0) cursor = hiOpIdx + 2
-          val savedCursorHi = cursor
           val hiType = visitTypeTree(tb.hi) match {
             case tt: TypeTree => tt
-            case _ => cursor = savedCursorHi; visitUnknown(tb.hi).asInstanceOf[TypeTree]
+            case null => throw unmappedException(tb.hi)
           }
           val hiBound: TypeTree = new J.TypeBound(Tree.randomId(), hiPrefix, Markers.EMPTY,
             J.TypeBound.Kind.Upper, hiType)
@@ -9490,7 +9483,7 @@ class ScalaTreeVisitor(
         val expr = visitTree(typed.expr) match {
           case e: Expression => e
           case j: J => new S.StatementExpression(Tree.randomId(), j)
-          case _ => return visitUnknown(typed)
+          case null => throw unmappedException(typed)
         }
         
         // Create a member reference
@@ -9515,9 +9508,9 @@ class ScalaTreeVisitor(
           val expr = visitTree(typed.expr) match {
             case e: Expression => e
             case j: J => new S.StatementExpression(Tree.randomId(), j)
-            case _ =>
+            case null =>
               cursor = savedCursor
-              return visitUnknown(typed)
+              throw unmappedException(typed)
           }
 
           // Find the colon between expression and type. Capture the space BEFORE the colon
@@ -9544,7 +9537,7 @@ class ScalaTreeVisitor(
           val typeTree = visitTypeTree(typed.tpt)
           if (typeTree == null) {
             cursor = savedCursor
-            return visitUnknown(typed)
+            throw unmappedException(typed)
           }
 
           updateCursor(typed.span.end)
@@ -9564,7 +9557,7 @@ class ScalaTreeVisitor(
         } catch {
           case _: Exception =>
             cursor = savedCursor
-            visitUnknown(typed)
+            throw unmappedException(typed)
         }
     }
   }
@@ -9850,7 +9843,7 @@ class ScalaTreeVisitor(
       val elem = visitTree(tuple.trees(i)) match {
         case expr: Expression => expr
         case j: J => new S.StatementExpression(Tree.randomId(), j)
-        case _ => return visitUnknown(tuple)
+        case null => throw unmappedException(tuple)
       }
       val after = if (i < tuple.trees.size - 1) sourceBefore(",") else sourceBefore(")")
       elements.add(JRightPadded.build(elem).withAfter(after))


### PR DESCRIPTION
## What's changed?

Refactoring in the Scala parser. changing the `visitUnknown` method to return an exception instead of throwing it. 

## What's your motivation?

This way the call site can use `throw`, not `return`.
And as a consequence the compiler can narrow down the types in some cases.
Which in turn gives us less compiler warnings.
