### PR TITLE
Go: fix parser not to store quotes for literal values

### DIFF
--- a/rewrite-go/pkg/parser/basic_lit_test.go
+++ b/rewrite-go/pkg/parser/basic_lit_test.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// litRHS parses src and returns the J.Literal on the RHS of the first `:=`.
+func litRHS(t *testing.T, src string) *java.Literal {
+	t.Helper()
+	rhs := firstAssignRHS(t, src)
+	lit, ok := rhs.(*java.Literal)
+	if !ok {
+		t.Fatalf("expected *java.Literal, got %T", rhs)
+	}
+	return lit
+}
+
+// A literal's Value must carry the decoded semantic value (no quotes, escapes
+// resolved, numbers typed), matching the other rewrite parsers. The raw source
+// text — with quotes — is preserved only in Source for lossless printing.
+func TestBasicLitDecodedValue(t *testing.T) {
+	cases := []struct {
+		name       string
+		expr       string
+		wantValue  any
+		wantSource string
+	}{
+		// given
+		{"interpreted string", `"foo"`, "foo", `"foo"`},
+		{"string with escape", `"a\tb"`, "a\tb", `"a\tb"`},
+		{"raw string", "`foo`", "foo", "`foo`"},
+		{"char", `'a'`, "a", `'a'`},
+		{"int", `42`, int64(42), `42`},
+		{"hex int", `0x7f`, int64(127), `0x7f`},
+		{"underscored int", `1_000`, int64(1000), `1_000`},
+		{"float", `3.14`, 3.14, `3.14`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			src := "package main\n\nfunc main() {\n\tv := " + tc.expr + "\n\t_ = v\n}\n"
+			lit := litRHS(t, src)
+
+			// then
+			if lit.Value != tc.wantValue {
+				t.Errorf("Value = %#v (%T), want %#v (%T)", lit.Value, lit.Value, tc.wantValue, tc.wantValue)
+			}
+			if lit.Source != tc.wantSource {
+				t.Errorf("Source = %q, want %q", lit.Source, tc.wantSource)
+			}
+		})
+	}
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1915,7 +1915,7 @@ func (ctx *parseContext) mapBasicLit(lit *ast.BasicLit) *java.Literal {
 	prefix := ctx.prefix(lit.Pos())
 	ctx.skip(len(lit.Value))
 
-	l := &java.Literal{ID: uuid.New(), Prefix: prefix, Value: lit.Value, Source: lit.Value}
+	l := &java.Literal{ID: uuid.New(), Prefix: prefix, Value: decodeBasicLitValue(lit), Source: lit.Value}
 
 	// Type attribution for literal
 	if tv, ok := ctx.typeInfo.Types[lit]; ok {
@@ -1923,6 +1923,24 @@ func (ctx *parseContext) mapBasicLit(lit *ast.BasicLit) *java.Literal {
 	}
 
 	return l
+}
+
+func decodeBasicLitValue(lit *ast.BasicLit) any {
+	switch lit.Kind {
+	case token.STRING, token.CHAR:
+		if unquoted, err := strconv.Unquote(lit.Value); err == nil {
+			return unquoted
+		}
+	case token.INT:
+		if i, err := strconv.ParseInt(lit.Value, 0, 64); err == nil {
+			return i
+		}
+	case token.FLOAT:
+		if f, err := strconv.ParseFloat(lit.Value, 64); err == nil {
+			return f
+		}
+	}
+	return lit.Value
 }
 
 // hoistLeftPrefix detaches the leading whitespace from a node's first child

--- a/rewrite-go/pkg/recipe/golang/rename_package.go
+++ b/rewrite-go/pkg/recipe/golang/rename_package.go
@@ -163,7 +163,7 @@ func withImportPath(imp *java.Import, newPath string) *java.Import {
 	c := *imp
 	if lit, ok := imp.Qualid.(*java.Literal); ok {
 		ln := *lit
-		ln.Value = `"` + newPath + `"`
+		ln.Value = newPath
 		ln.Source = `"` + newPath + `"`
 		c.Qualid = &ln
 	}


### PR DESCRIPTION
## What's changed?

Fixing the Go parser not to add quotes around String literal values in `Literal.value` field.

## What's your motivation?

To be in line with other languages.
