### PR TITLE
Do not add imports from the builtins module in rewrite-python

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -80,11 +80,7 @@ def maybe_add_import(visitor: PythonVisitor, options: AddImportOptions) -> None:
         # Add: from typing import *
         maybe_add_import(visitor, AddImportOptions(module='typing', name='*'))
     """
-    # Names from the ``builtins`` module (e.g. ``list``, ``dict``, ``set``) are
-    # always available without an import, so ``from builtins import list`` is
-    # redundant and flagged by linters. Skip adding such imports unless an
-    # explicit alias makes the import meaningful (e.g. ``from builtins import
-    # list as _list``).
+    # builtins are always available; only import them under an explicit alias
     if options.module == 'builtins' and options.alias is None:
         return
 

--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -80,6 +80,14 @@ def maybe_add_import(visitor: PythonVisitor, options: AddImportOptions) -> None:
         # Add: from typing import *
         maybe_add_import(visitor, AddImportOptions(module='typing', name='*'))
     """
+    # Names from the ``builtins`` module (e.g. ``list``, ``dict``, ``set``) are
+    # always available without an import, so ``from builtins import list`` is
+    # redundant and flagged by linters. Skip adding such imports unless an
+    # explicit alias makes the import meaningful (e.g. ``from builtins import
+    # list as _list``).
+    if options.module == 'builtins' and options.alias is None:
+        return
+
     # Check for duplicate registrations
     if visitor._after_visit is None:
         visitor._after_visit = []

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -292,3 +292,41 @@ class TestMaybeAddImport:
                 """,
             )
         )
+
+    def test_skips_builtins_import(self):
+        """Names from the 'builtins' module are always available, so no import
+        is added (e.g. 'from builtins import list' is redundant)."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('builtins', 'list')))
+        spec.rewrite_run(
+            python(
+                """
+                x: list = []
+                """,
+            )
+        )
+
+    def test_skips_builtins_direct_import(self):
+        """A direct 'import builtins' is likewise not added."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('builtins')))
+        spec.rewrite_run(
+            python(
+                """
+                x = 1
+                """,
+            )
+        )
+
+    def test_adds_aliased_builtins_import(self):
+        """An explicit alias makes a builtins import meaningful, so it is added."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('builtins', 'list', '_list')))
+        spec.rewrite_run(
+            python(
+                """
+                x = 1
+                """,
+                """
+                from builtins import list as _list
+                x = 1
+                """,
+            )
+        )

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -495,8 +495,6 @@ class TestChangeImport:
                 x: List[str] = []
                 y: Dict[str, int] = {}
                 """,
-                # 'List' dropped from the typing import and references renamed to
-                # 'list'; no 'from builtins import list' line is introduced.
                 """
                 from typing import Dict
 

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -478,6 +478,34 @@ class TestChangeImport:
             )
         )
 
+    def test_pep585_typing_to_builtin_adds_no_builtins_import(self):
+        """PEP 585: 'from typing import List' -> 'list[...]' must NOT add
+        'from builtins import list' (builtins are always available)."""
+        spec = RecipeSpec(recipe=ChangeImport(
+            old_module='typing',
+            old_name='List',
+            new_module='builtins',
+            new_name='list',
+        ))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import List, Dict
+
+                x: List[str] = []
+                y: Dict[str, int] = {}
+                """,
+                # 'List' dropped from the typing import and references renamed to
+                # 'list'; no 'from builtins import list' line is introduced.
+                """
+                from typing import Dict
+
+                x: list[str] = []
+                y: Dict[str, int] = {}
+                """,
+            )
+        )
+
     def test_both_from_import_and_direct_import(self):
         """When a file has both 'from X import name' and 'import X', handle without duplicates."""
         spec = RecipeSpec(recipe=ChangeImport(


### PR DESCRIPTION
PEP 585 typing modernization was producing a spurious `from builtins import ...` line. A customer running the Python upgrade recipes reported output like:

```diff
-from typing import List, Dict, Any, Optional
+from typing import Any
+from builtins import dict, list
```

## Root cause

The `builtins` generics migration (in `moderneinc/rewrite-migrate-python`, `UpgradeToPython39`) uses `ChangeImport(old_module="typing", old_name="List", new_module="builtins", new_name="list")`. `ChangeImport` unconditionally schedules `maybe_add_import(module=new_module, ...)`, and `maybe_add_import`/`AddImport` had no special-case for `builtins`, so it faithfully emitted `from builtins import list`.

Everything in `builtins` (`list`, `dict`, `set`, `frozenset`, `tuple`, `type`, `str`, …) is always available without an import, so `from builtins import list` is redundant and gets flagged by linters (Ruff/Flake8).

## Fix

`maybe_add_import` now skips requests to import from the `builtins` module, unless an explicit alias makes the import meaningful (e.g. `from builtins import list as _list`). The fix lives in the shared `add_import` helper so it applies to every recipe, not just the PEP 585 ones. Import *removal* and reference renaming are unaffected.

## Tests

- `test_add_import.py`: `maybe_add_import` adds nothing for `builtins` (from-import and direct-import forms); the aliased form is still added; existing non-builtins adds are unchanged.
- `test_change_import.py`: a `ChangeImport(typing.List → builtins.list)` run renames references to `list` and drops `List` from the `typing` import with **no** `from builtins import list` line introduced.

All `rewrite-python` import tests pass. (The 9 failing `py314/test_tstring_template.py` tests are pre-existing on `main` and unrelated to this change.)