### PR TITLE
Guard recipe generate phase against invalid source paths

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/LargeSourceSet.java
+++ b/rewrite-core/src/main/java/org/openrewrite/LargeSourceSet.java
@@ -112,4 +112,15 @@ public interface LargeSourceSet {
      */
     default void onGenerateCollision(Path sourcePath, boolean existingFile) {
     }
+
+    /**
+     * Called when a recipe's {@code generate()} produces a file whose path is structurally invalid
+     * (for example absolute, empty, not normalized, or outside the source root). The generated file
+     * is dropped. Implementations may override this to detect the problem (e.g. the test framework
+     * raises an assertion failure).
+     *
+     * @param sourcePath The invalid source path.
+     */
+    default void onGenerateInvalidPath(Path sourcePath) {
+    }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/PathUtils.java
+++ b/rewrite-core/src/main/java/org/openrewrite/PathUtils.java
@@ -57,6 +57,17 @@ public class PathUtils {
         return separatorsToSystem(a).equals(separatorsToSystem(b));
     }
 
+    /**
+     * Whether {@code path} is usable as a {@link SourceFile} source path: relative and already normalized.
+     */
+    public static boolean isValidSourcePath(Path path) {
+        if (path.isAbsolute() || path.toString().isEmpty()) {
+            return false;
+        }
+        Path normalized = path.normalize();
+        return !normalized.startsWith("..") && normalized.equals(path);
+    }
+
     public static String separatorsToUnix(String path) {
         return path.replace(WINDOWS_SEPARATOR, UNIX_SEPARATOR);
     }

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -253,6 +253,12 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                         Set<Path> seenInThisBatch = new HashSet<>();
                         generated.removeIf(source -> {
                             Path sourcePath = source.getSourcePath();
+                            if (!PathUtils.isValidSourcePath(sourcePath)) {
+                                sourceSet.onGenerateInvalidPath(sourcePath);
+                                handleError(recipe, source, null, new IllegalStateException(
+                                        "Recipe " + recipe.getName() + " generated a source file with an invalid path: " + sourcePath));
+                                return true;
+                            }
                             if (sourceSet.getBefore(sourcePath) != null) {
                                 sourceSet.onGenerateCollision(sourcePath, true);
                                 return true;

--- a/rewrite-core/src/test/java/org/openrewrite/PathUtilsTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/PathUtilsTest.java
@@ -20,9 +20,24 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.PathUtils.isValidSourcePath;
 import static org.openrewrite.PathUtils.matchesGlob;
 
 class PathUtilsTest {
+
+    @Test
+    void sourcePathValidation() {
+        // valid: relative and already normalized
+        assertThat(isValidSourcePath(path("foo.txt"))).isTrue();
+        assertThat(isValidSourcePath(path("foo/bar/baz.txt"))).isTrue();
+
+        assertThat(isValidSourcePath(path("").toAbsolutePath().resolve("foo.txt"))).isFalse(); // absolute
+        assertThat(isValidSourcePath(path(""))).isFalse(); // empty
+        assertThat(isValidSourcePath(path("../foo.txt"))).isFalse(); // outside the source root
+        assertThat(isValidSourcePath(path("foo/../../bar.txt"))).isFalse(); // outside the source root
+        assertThat(isValidSourcePath(path("foo/../bar.txt"))).isFalse(); // not normalized
+        assertThat(isValidSourcePath(path("foo/./bar.txt"))).isFalse(); // not normalized
+    }
     @Test
     void globMatching() {
         // exact matches

--- a/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/RecipeSchedulerTest.java
@@ -325,6 +325,23 @@ class RecipeSchedulerTest implements RewriteTest {
 
         assertThat(generatedPaths).containsExactly("generated.txt");
     }
+
+    @Test
+    void invalidGeneratedPathIsDroppedAndSurfaced() {
+        AtomicReference<Throwable> error = new AtomicReference<>();
+        var ctx = new InMemoryExecutionContext(error::set);
+        List<SourceFile> sources = List.of(PlainText.builder().text("existing").sourcePath(Path.of("existing.txt")).build());
+
+        RecipeRun run = new RecipeScheduler().scheduleRun(
+          new GeneratesInvalidPathRecipe(), new InMemoryLargeSourceSet(sources), ctx, 3, 1);
+
+        // the invalid file is dropped, so it never enters the changeset
+        assertThat(run.getChangeset().getAllResults()).isEmpty();
+        // but the drop is surfaced for visibility rather than silently swallowed
+        assertThat(error.get())
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("generated a source file with an invalid path");
+    }
 }
 
 @AllArgsConstructor
@@ -420,6 +437,32 @@ class GeneratingRecipe extends ScanningRecipe<AtomicInteger> {
                     .build());
         }
         return List.of();
+    }
+}
+
+class GeneratesInvalidPathRecipe extends ScanningRecipe<AtomicInteger> {
+    @Getter
+    final String displayName = "Generates a file with an invalid path";
+
+    @Getter
+    final String description = "Generates a source file whose path points outside the source root.";
+
+    @Override
+    public AtomicInteger getInitialValue(ExecutionContext ctx) {
+        return new AtomicInteger(0);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(AtomicInteger acc) {
+        return TreeVisitor.noop();
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(AtomicInteger acc, ExecutionContext ctx) {
+        return List.of(PlainText.builder()
+          .text("outside")
+          .sourcePath(Path.of("../outside.txt"))
+          .build());
     }
 }
 

--- a/rewrite-test/src/main/java/org/openrewrite/test/LargeSourceSetCheckingExpectedCycles.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/LargeSourceSetCheckingExpectedCycles.java
@@ -66,6 +66,11 @@ class LargeSourceSetCheckingExpectedCycles extends InMemoryLargeSourceSet {
     }
 
     @Override
+    public void onGenerateInvalidPath(Path sourcePath) {
+        fail("Recipe generated a source file with an invalid path: " + sourcePath);
+    }
+
+    @Override
     public void afterCycle(boolean lastCycle) {
         boolean detectedChangeInThisCycle = false;
         Map<SourceFile, SourceFile> thisCycleEdits = new HashMap<>();

--- a/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/internal/RewriteTestTest.java
@@ -99,6 +99,15 @@ class RewriteTestTest implements RewriteTest {
     }
 
     @Test
+    void generatesFileWithInvalidPath() {
+        AssertionError e = assertThrows(AssertionError.class,
+          () -> rewriteRun(
+            spec -> spec.recipe(new GeneratesFileWithInvalidPath()),
+            text("hello")));
+        assertThat(e).hasStackTraceContaining("Recipe generated a source file with an invalid path");
+    }
+
+    @Test
     void cursorValidation() {
         assertThrows(AssertionError.class, () ->
           rewriteRun(
@@ -425,6 +434,34 @@ class GeneratesExistingFile extends ScanningRecipe<AtomicBoolean> {
         return List.of(PlainText.builder()
           .text("generated content")
           .sourcePath(Path.of("existing.txt"))
+          .build());
+    }
+}
+
+@EqualsAndHashCode(callSuper = false)
+@Value
+class GeneratesFileWithInvalidPath extends ScanningRecipe<AtomicBoolean> {
+
+    String displayName = "Generates a file with an invalid path";
+
+    String description = "A recipe that generates a source file whose path points outside the source root, to show " +
+      "that the test framework helps protect against this mistake.";
+
+    @Override
+    public AtomicBoolean getInitialValue(ExecutionContext ctx) {
+        return new AtomicBoolean(false);
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean acc) {
+        return TreeVisitor.noop();
+    }
+
+    @Override
+    public Collection<? extends SourceFile> generate(AtomicBoolean acc, ExecutionContext ctx) {
+        return List.of(PlainText.builder()
+          .text("outside")
+          .sourcePath(Path.of("../outside.txt"))
           .build());
     }
 }


### PR DESCRIPTION
- Fixes #8247.

A `ScanningRecipe.generate()` could return `SourceFile`s with structurally invalid paths (absolute, empty, not normalized, or outside the source root). This adds `PathUtils.isValidSourcePath(Path)` and validates each generated file in `RecipeRunCycle.generateSources`, dropping invalid ones and surfacing the drop through the existing error channel. A new `LargeSourceSet.onGenerateInvalidPath` hook (overridden to `fail(...)` in the test framework) lets recipe authors catch the mistake in tests, mirroring the existing `onGenerateCollision` machinery. Covered by unit tests in `PathUtilsTest` plus test-framework and production-path integration tests in `RewriteTestTest` and `RecipeSchedulerTest`.