### PR TITLE
Go: use type interning on recipe runs

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -84,6 +84,8 @@ type server struct {
 	reverseRemoteObjects map[string]any
 	reverseRemoteRefs    map[int]any
 
+	reverseTypePool map[string]java.JavaType
+
 	// Prepared recipe instances keyed by unique ID
 	preparedRecipes map[string]recipe.Recipe
 
@@ -207,6 +209,7 @@ func newServer(cfg serverConfig) *server {
 		remoteRefs:              make(map[int]any),
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
+		reverseTypePool:         make(map[string]java.JavaType),
 		preparedRecipes:         make(map[string]recipe.Recipe),
 		preparedRecipeNames:     make(map[string]string),
 		preparedEditorOverrides: make(map[string]recipe.TreeVisitor),
@@ -913,7 +916,7 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 		return batch
 	}
 
-	q := rpc.NewReceiveQueue(s.reverseRemoteRefs, fetchBatch)
+	q := rpc.NewReceiveQueue(s.reverseRemoteRefs, fetchBatch).WithTypePool(s.reverseTypePool)
 
 	receiver := rpc.NewGoReceiver()
 
@@ -1055,6 +1058,7 @@ func (s *server) handleReset() bool {
 	s.remoteRefs = make(map[int]any)
 	s.reverseRemoteObjects = make(map[string]any)
 	s.reverseRemoteRefs = make(map[int]any)
+	s.reverseTypePool = make(map[string]java.JavaType)
 	s.preparedRecipes = make(map[string]recipe.Recipe)
 	s.preparedRecipeNames = make(map[string]string)
 	s.preparedEditorOverrides = make(map[string]recipe.TreeVisitor)

--- a/rewrite-go/pkg/rpc/java_type_receiver.go
+++ b/rewrite-go/pkg/rpc/java_type_receiver.go
@@ -145,6 +145,10 @@ func (r *JavaTypeReceiver) VisitArray(a *java.JavaTypeArray, p any) java.JavaTyp
 	q := p.(*ReceiveQueue)
 	a.ElemType = receiveAsType[java.JavaType](r, q, a.ElemType)
 	a.Annotations = receiveClassList(r, q, a.Annotations)
+	// Annotations sit outside TypeSignature, so only canonicalize the plain case.
+	if len(a.Annotations) == 0 {
+		return q.internType(a)
+	}
 	return a
 }
 
@@ -152,7 +156,7 @@ func (r *JavaTypeReceiver) VisitArray(a *java.JavaTypeArray, p any) java.JavaTyp
 func (r *JavaTypeReceiver) VisitPrimitive(pr *java.JavaTypePrimitive, p any) java.JavaType {
 	q := p.(*ReceiveQueue)
 	pr.Keyword = receiveScalar[string](q, pr.Keyword)
-	return pr
+	return q.internType(pr)
 }
 
 // VisitMethod mirrors JavaTypeReceiver.visitMethod field order:

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -30,6 +30,28 @@ type ReceiveQueue struct {
 	batch []RpcObjectData
 	refs  map[int]any
 	pull  func() []RpcObjectData
+
+	typePool map[string]java.JavaType
+}
+
+func (q *ReceiveQueue) WithTypePool(pool map[string]java.JavaType) *ReceiveQueue {
+	q.typePool = pool
+	return q
+}
+
+func (q *ReceiveQueue) internType(t java.JavaType) java.JavaType {
+	if q.typePool == nil {
+		return t
+	}
+	sig := java.TypeSignature(t)
+	if sig == "" {
+		return t
+	}
+	if c, ok := q.typePool[sig]; ok {
+		return c
+	}
+	q.typePool[sig] = t
+	return t
 }
 
 func NewReceiveQueue(refs map[int]any, pull func() []RpcObjectData) *ReceiveQueue {

--- a/rewrite-go/pkg/rpc/type_intern_test.go
+++ b/rewrite-go/pkg/rpc/type_intern_test.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+func poolQueue(pool map[string]java.JavaType) *ReceiveQueue {
+	return NewReceiveQueue(make(map[int]any), func() []RpcObjectData { return nil }).WithTypePool(pool)
+}
+
+func TestInternType_CanonicalizesEqualSignaturesAcrossQueues(t *testing.T) {
+	// given a pool shared across two transfers (separate queues, same connection)
+	pool := map[string]java.JavaType{}
+
+	// when the same logical primitive arrives as a distinct object in each
+	first := poolQueue(pool).internType(&java.JavaTypePrimitive{Keyword: "int"})
+	second := poolQueue(pool).internType(&java.JavaTypePrimitive{Keyword: "int"})
+
+	// then both collapse to one canonical instance
+	if first != second {
+		t.Errorf("expected canonical identity across transfers, got %p and %p", first, second)
+	}
+}
+
+func TestInternType_KeepsDistinctSignaturesSeparate(t *testing.T) {
+	// given a shared pool
+	pool := map[string]java.JavaType{}
+	q := poolQueue(pool)
+
+	// when two different primitives are interned
+	i := q.internType(&java.JavaTypePrimitive{Keyword: "int"})
+	l := q.internType(&java.JavaTypePrimitive{Keyword: "long"})
+
+	// then they are not merged
+	if i == l {
+		t.Errorf("distinct signatures must not share identity: %p", i)
+	}
+}
+
+func TestInternType_FirstWins(t *testing.T) {
+	// given a primitive already registered
+	pool := map[string]java.JavaType{}
+	q := poolQueue(pool)
+	canonical := q.internType(&java.JavaTypePrimitive{Keyword: "boolean"})
+
+	// when a structurally-equal duplicate is interned
+	dup := &java.JavaTypePrimitive{Keyword: "boolean"}
+	got := q.internType(dup)
+
+	// then the canonical is returned and the duplicate is discarded
+	if got != canonical {
+		t.Errorf("want canonical %p, got %p", canonical, got)
+	}
+	if got == java.JavaType(dup) {
+		t.Errorf("duplicate should not become canonical")
+	}
+}
+
+func TestInternType_NilPoolIsNoOp(t *testing.T) {
+	// given a queue with no pool (e.g. a test or a non-shared transfer)
+	q := NewReceiveQueue(make(map[int]any), func() []RpcObjectData { return nil })
+
+	// when two equal primitives are interned
+	a := q.internType(&java.JavaTypePrimitive{Keyword: "int"})
+	b := q.internType(&java.JavaTypePrimitive{Keyword: "int"})
+
+	// then nothing is canonicalized — identity is preserved as-is
+	if a == b {
+		t.Errorf("nil pool must not canonicalize: %p", a)
+	}
+}
+
+func TestVisitPrimitive_InternsAcrossTransfers(t *testing.T) {
+	// given the type receiver and a pool shared across two transfers
+	r := NewJavaTypeReceiver()
+	pool := map[string]java.JavaType{}
+
+	// when the same primitive is received on two separate queues (Keyword
+	// arrives as NO_CHANGE against the pre-seeded baseline)
+	q1 := poolQueue(pool)
+	q1.batch = []RpcObjectData{{State: NoChange}}
+	first := r.VisitPrimitive(&java.JavaTypePrimitive{Keyword: "int"}, q1)
+
+	q2 := poolQueue(pool)
+	q2.batch = []RpcObjectData{{State: NoChange}}
+	second := r.VisitPrimitive(&java.JavaTypePrimitive{Keyword: "int"}, q2)
+
+	// then the receive path yields one canonical instance
+	if first != second {
+		t.Errorf("VisitPrimitive should canonicalize across transfers, got %p and %p", first, second)
+	}
+}
+
+func TestInternType_ArrayCanonicalizes(t *testing.T) {
+	// given a shared pool
+	pool := map[string]java.JavaType{}
+
+	// when annotation-free arrays of the same element type are interned
+	mk := func() *java.JavaTypeArray {
+		return &java.JavaTypeArray{ElemType: &java.JavaTypePrimitive{Keyword: "int"}}
+	}
+	a := poolQueue(pool).internType(mk())
+	b := poolQueue(pool).internType(mk())
+
+	// then they collapse to one instance
+	if a != b {
+		t.Errorf("equal arrays should canonicalize, got %p and %p", a, b)
+	}
+}


### PR DESCRIPTION
## What's changed?
An optimization to how Go RPC works. Interning (caching) type attribution information when receiving it via RPC from Java.

## What's your motivation?

In a hope to lower the memory footprint of Go recipe runs.