### PR TITLE
Go: intern GoResolutionResult objects

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -84,7 +84,8 @@ type server struct {
 	reverseRemoteObjects map[string]any
 	reverseRemoteRefs    map[int]any
 
-	reverseTypePool map[string]java.JavaType
+	reverseTypePool    map[string]java.JavaType
+	goResolutionIntern *rpc.GoResolutionInternPool
 
 	// Prepared recipe instances keyed by unique ID
 	preparedRecipes map[string]recipe.Recipe
@@ -210,6 +211,7 @@ func newServer(cfg serverConfig) *server {
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
 		reverseTypePool:         make(map[string]java.JavaType),
+		goResolutionIntern:      rpc.NewGoResolutionInternPool(),
 		preparedRecipes:         make(map[string]recipe.Recipe),
 		preparedRecipeNames:     make(map[string]string),
 		preparedEditorOverrides: make(map[string]recipe.TreeVisitor),
@@ -917,6 +919,7 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 	}
 
 	q := rpc.NewReceiveQueue(s.reverseRemoteRefs, fetchBatch).WithTypePool(s.reverseTypePool)
+	q.SetGoResolutionIntern(s.goResolutionIntern)
 
 	receiver := rpc.NewGoReceiver()
 
@@ -1059,6 +1062,7 @@ func (s *server) handleReset() bool {
 	s.reverseRemoteObjects = make(map[string]any)
 	s.reverseRemoteRefs = make(map[int]any)
 	s.reverseTypePool = make(map[string]java.JavaType)
+	s.goResolutionIntern = rpc.NewGoResolutionInternPool()
 	s.preparedRecipes = make(map[string]recipe.Recipe)
 	s.preparedRecipeNames = make(map[string]string)
 	s.preparedEditorOverrides = make(map[string]recipe.TreeVisitor)

--- a/rewrite-go/pkg/rpc/go_resolution_result_codec.go
+++ b/rewrite-go/pkg/rpc/go_resolution_result_codec.go
@@ -22,6 +22,25 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 )
 
+type GoResolutionInternPool struct {
+	byIdent map[uuid.UUID]golang.GoResolutionResult
+}
+
+func NewGoResolutionInternPool() *GoResolutionInternPool {
+	return &GoResolutionInternPool{byIdent: make(map[uuid.UUID]golang.GoResolutionResult)}
+}
+
+func (p *GoResolutionInternPool) intern(r golang.GoResolutionResult) golang.GoResolutionResult {
+	if p == nil || r.Ident == uuid.Nil {
+		return r
+	}
+	if c, ok := p.byIdent[r.Ident]; ok {
+		return c
+	}
+	p.byIdent[r.Ident] = r
+	return r
+}
+
 // sendGoResolutionResult mirrors Java's
 // org.openrewrite.golang.marker.GoResolutionResult#rpcSend.
 //
@@ -163,7 +182,7 @@ func receiveGoResolutionResult(before golang.GoResolutionResult, q *ReceiveQueue
 	before.Retracts = recvRetracts(q, before.Retracts)
 	before.ResolvedDependencies = recvResolvedDeps(q, before.ResolvedDependencies)
 	before.PackageModules = recvPackageModules(q, before.PackageModules)
-	return before
+	return q.goResolutionIntern.intern(before)
 }
 
 func recvRequires(q *ReceiveQueue, before []golang.GoRequire) []golang.GoRequire {

--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -52,6 +52,121 @@ func roundTripMarkers(t *testing.T, before java.Markers) java.Markers {
 	return receiveMarkersCodec(recvQ, java.Markers{})
 }
 
+func roundTripMarkersInterned(t *testing.T, before java.Markers, pool *GoResolutionInternPool) java.Markers {
+	t.Helper()
+	var messages []RpcObjectData
+	sendQ := NewSendQueue(1000, func(batch []RpcObjectData) {
+		messages = append(messages, batch...)
+	}, make(map[uintptr]int))
+	SendMarkersCodec(before, sendQ)
+	sendQ.Flush()
+
+	delivered := false
+	recvQ := NewReceiveQueue(make(map[int]any), func() []RpcObjectData {
+		if delivered {
+			return nil
+		}
+		delivered = true
+		return messages
+	})
+	recvQ.SetGoResolutionIntern(pool)
+	return receiveMarkersCodec(recvQ, java.Markers{})
+}
+
+func sampleResolutionResult(id uuid.UUID, modulePath string) golang.GoResolutionResult {
+	return golang.GoResolutionResult{
+		Ident:      id,
+		ModulePath: modulePath,
+		GoVersion:  "1.22",
+		Path:       "/tmp/go.mod",
+		Requires: []golang.GoRequire{
+			{ModulePath: "github.com/google/uuid", Version: "v1.6.0"},
+		},
+		ResolvedDependencies: []golang.GoResolvedDependency{
+			{ModulePath: "github.com/google/uuid", Version: "v1.6.0", ModuleHash: "h1:abc="},
+		},
+		PackageModules: []golang.GoPackageModule{
+			{ImportPath: "github.com/google/uuid", ModulePath: "github.com/google/uuid", Version: "v1.6.0"},
+		},
+	}
+}
+
+func TestGoResolutionResultInterningSharesBackingSlices(t *testing.T) {
+	// given
+	id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	mrr := sampleResolutionResult(id, "example.com/foo")
+	pool := NewGoResolutionInternPool()
+
+	// when
+	after1 := roundTripMarkersInterned(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}, pool)
+	after2 := roundTripMarkersInterned(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}, pool)
+	got1 := after1.Entries[0].(golang.GoResolutionResult)
+	got2 := after2.Entries[0].(golang.GoResolutionResult)
+
+	// then
+	if !reflect.DeepEqual(mrr, got1) {
+		t.Fatalf("round-trip mismatch\nbefore: %+v\nafter:  %+v", mrr, got1)
+	}
+	if &got1.ResolvedDependencies[0] != &got2.ResolvedDependencies[0] {
+		t.Errorf("ResolvedDependencies not interned: distinct backing arrays")
+	}
+	if &got1.Requires[0] != &got2.Requires[0] {
+		t.Errorf("Requires not interned: distinct backing arrays")
+	}
+	if &got1.PackageModules[0] != &got2.PackageModules[0] {
+		t.Errorf("PackageModules not interned: distinct backing arrays")
+	}
+}
+
+func TestGoResolutionResultInterningKeepsDistinctModulesSeparate(t *testing.T) {
+	// given
+	pool := NewGoResolutionInternPool()
+	a := sampleResolutionResult(uuid.MustParse("11111111-1111-1111-1111-111111111111"), "example.com/a")
+	b := sampleResolutionResult(uuid.MustParse("22222222-2222-2222-2222-222222222222"), "example.com/b")
+
+	// when
+	gotA := roundTripMarkersInterned(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{a}}, pool).Entries[0].(golang.GoResolutionResult)
+	gotB := roundTripMarkersInterned(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{b}}, pool).Entries[0].(golang.GoResolutionResult)
+
+	// then
+	if gotA.ModulePath != "example.com/a" || gotB.ModulePath != "example.com/b" {
+		t.Errorf("distinct modules collapsed: %q / %q", gotA.ModulePath, gotB.ModulePath)
+	}
+	if &gotA.ResolvedDependencies[0] == &gotB.ResolvedDependencies[0] {
+		t.Errorf("distinct modules unexpectedly share a backing array")
+	}
+}
+
+func TestGoResolutionResultInterningPassesThroughNilIdent(t *testing.T) {
+	// given
+	pool := NewGoResolutionInternPool()
+	mrr := sampleResolutionResult(uuid.Nil, "example.com/foo")
+
+	// when
+	got1 := roundTripMarkersInterned(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}, pool).Entries[0].(golang.GoResolutionResult)
+	got2 := roundTripMarkersInterned(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}, pool).Entries[0].(golang.GoResolutionResult)
+
+	// then
+	if &got1.ResolvedDependencies[0] == &got2.ResolvedDependencies[0] {
+		t.Errorf("nil-Ident results must not be interned")
+	}
+}
+
+func TestGoResolutionResultInterningDisabledByDefault(t *testing.T) {
+	// given
+	id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+	mrr := sampleResolutionResult(id, "example.com/foo")
+
+	// when
+	got1 := roundTripMarkers(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}).Entries[0].(golang.GoResolutionResult)
+	got2 := roundTripMarkers(t, java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}).Entries[0].(golang.GoResolutionResult)
+
+	// then
+	if &got1.ResolvedDependencies[0] == &got2.ResolvedDependencies[0] {
+		t.Errorf("expected independent backing arrays without an intern pool")
+	}
+}
+
 func TestGoProjectMarkerRoundTrip(t *testing.T) {
 	id := uuid.MustParse("11111111-2222-3333-4444-555555555555")
 	gp := golang.GoProject{Ident: id, ProjectName: "example/foo"}

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -31,7 +31,8 @@ type ReceiveQueue struct {
 	refs  map[int]any
 	pull  func() []RpcObjectData
 
-	typePool map[string]java.JavaType
+	typePool           map[string]java.JavaType
+	goResolutionIntern *GoResolutionInternPool
 }
 
 func (q *ReceiveQueue) WithTypePool(pool map[string]java.JavaType) *ReceiveQueue {
@@ -52,6 +53,10 @@ func (q *ReceiveQueue) internType(t java.JavaType) java.JavaType {
 	}
 	q.typePool[sig] = t
 	return t
+}
+
+func (q *ReceiveQueue) SetGoResolutionIntern(pool *GoResolutionInternPool) {
+	q.goResolutionIntern = pool
 }
 
 func NewReceiveQueue(refs map[int]any, pull func() []RpcObjectData) *ReceiveQueue {


### PR DESCRIPTION
## What's changed?

- Similar to #8251. Interning (caching) `GoResolutionResult` objects when Go receives them over the RPC wire from Java.

## What's your motivation?

In a hope to lower the memory footprint of Go recipe runs.
