### PR TITLE
Go: when reading from RPC don't store into intermediary strings

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -871,6 +871,8 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 		before = s.localObjects[id]
 	}
 
+	strIntern := make(map[string]string)
+
 	fetchBatch := func() []rpc.RpcObjectData {
 		reqParams := getObjectRequest{ID: id, SourceFileType: sourceFileType}
 		paramsJSON, _ := json.Marshal(reqParams)
@@ -898,22 +900,11 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 			s.logger.Printf("No result data in bidirectional response")
 			return nil
 		}
-		var respResult any
-		if err := json.Unmarshal(resultData, &respResult); err != nil {
+
+		batch, err := rpc.DecodeBatch(resultData, strIntern)
+		if err != nil {
 			s.logger.Printf("Error parsing response result: %v", err)
 			return nil
-		}
-
-		batchData, ok := respResult.([]any)
-		if !ok || len(batchData) == 0 {
-			return nil
-		}
-
-		batch := make([]rpc.RpcObjectData, 0, len(batchData))
-		for _, item := range batchData {
-			if m, ok := item.(map[string]any); ok {
-				batch = append(batch, rpc.ParseObjectData(m))
-			}
 		}
 		return batch
 	}

--- a/rewrite-go/pkg/rpc/rpc_object_data.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data.go
@@ -71,20 +71,62 @@ func (d RpcObjectData) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func ParseObjectData(m map[string]any) RpcObjectData {
-	d := RpcObjectData{}
-	if s, ok := m["state"].(string); ok {
-		d.State = parseState(s)
+type wireObjectData struct {
+	State     string          `json:"state"`
+	ValueType *string         `json:"valueType"`
+	Value     json.RawMessage `json:"value"`
+	Ref       *int            `json:"ref"`
+}
+
+func DecodeBatch(data []byte, intern map[string]string) ([]RpcObjectData, error) {
+	var wire []wireObjectData
+	if err := json.Unmarshal(data, &wire); err != nil {
+		return nil, err
 	}
-	if vt, ok := m["valueType"].(string); ok {
-		d.ValueType = &vt
+	batch := make([]RpcObjectData, len(wire))
+	for i := range wire {
+		w := &wire[i]
+		d := RpcObjectData{State: parseState(w.State), ValueType: w.ValueType, Ref: w.Ref}
+		if len(w.Value) > 0 {
+			var v any
+			if err := json.Unmarshal(w.Value, &v); err != nil {
+				return nil, err
+			}
+			d.Value = internValue(v, intern)
+		}
+		batch[i] = d
 	}
-	d.Value = m["value"]
-	if ref, ok := m["ref"]; ok && ref != nil {
-		r := int(ref.(float64))
-		d.Ref = &r
+	return batch, nil
+}
+
+func internValue(v any, tbl map[string]string) any {
+	switch x := v.(type) {
+	case string:
+		return internString(x, tbl)
+	case []any:
+		for i := range x {
+			x[i] = internValue(x[i], tbl)
+		}
+		return x
+	case map[string]any:
+		for k, val := range x {
+			x[k] = internValue(val, tbl)
+		}
+		return x
+	default:
+		return v
 	}
-	return d
+}
+
+func internString(s string, tbl map[string]string) string {
+	if s == "" || tbl == nil {
+		return s
+	}
+	if c, ok := tbl[s]; ok {
+		return c
+	}
+	tbl[s] = s
+	return s
 }
 
 func parseState(s string) State {

--- a/rewrite-go/pkg/rpc/rpc_object_data_test.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data_test.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+	"unsafe"
+)
+
+func TestDecodeBatch_DecodesTypedFields(t *testing.T) {
+	// given
+	data := []byte(`[
+		{"state":"ADD","valueType":"org.openrewrite.marker.SearchResult","value":{"id":"x"},"ref":7},
+		{"state":"NO_CHANGE"},
+		{"state":"CHANGE","value":" "}
+	]`)
+
+	// when
+	batch, err := DecodeBatch(data, nil)
+
+	// then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(batch) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(batch))
+	}
+	if batch[0].State != Add || batch[0].ValueType == nil || *batch[0].ValueType != "org.openrewrite.marker.SearchResult" || batch[0].Ref == nil || *batch[0].Ref != 7 {
+		t.Fatalf("message 0 decoded wrong: %+v", batch[0])
+	}
+	if m, ok := batch[0].Value.(map[string]any); !ok || m["id"] != "x" {
+		t.Fatalf("message 0 value not a decoded map: %#v", batch[0].Value)
+	}
+	if batch[1].State != NoChange || batch[1].Value != nil {
+		t.Fatalf("message 1 decoded wrong: %+v", batch[1])
+	}
+	if batch[2].State != Change || batch[2].Value != " " {
+		t.Fatalf("message 2 decoded wrong: %+v", batch[2])
+	}
+}
+
+func TestDecodeBatch_InternsDuplicateStrings(t *testing.T) {
+	// given
+	data := []byte(`[
+		{"state":"CHANGE","value":"\n\t"},
+		{"state":"CHANGE","value":"\n\t"},
+		{"state":"ADD","valueType":"m","value":{"a":"\n\t","b":"\n\t"}}
+	]`)
+	intern := make(map[string]string)
+
+	// when
+	batch, err := DecodeBatch(data, intern)
+
+	// then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	s0 := batch[0].Value.(string)
+	s1 := batch[1].Value.(string)
+	nested := batch[2].Value.(map[string]any)
+	sa := nested["a"].(string)
+	sb := nested["b"].(string)
+	if s0 != "\n\t" || s1 != "\n\t" || sa != "\n\t" || sb != "\n\t" {
+		t.Fatalf("interning corrupted values: %q %q %q %q", s0, s1, sa, sb)
+	}
+	for _, s := range []string{s1, sa, sb} {
+		if strData(s0) != strData(s) {
+			t.Fatalf("duplicate string not interned to shared backing")
+		}
+	}
+}
+
+func TestDecodeBatch_NilInternKeepsDistinctBacking(t *testing.T) {
+	// given
+	data := []byte(`[{"state":"CHANGE","value":"dup"},{"state":"CHANGE","value":"dup"}]`)
+
+	// when
+	batch, err := DecodeBatch(data, nil)
+
+	// then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if batch[0].Value.(string) != "dup" || batch[1].Value.(string) != "dup" {
+		t.Fatalf("values decoded wrong without interning")
+	}
+}
+
+func strData(s string) unsafe.Pointer {
+	return unsafe.Pointer(unsafe.StringData(s))
+}


### PR DESCRIPTION
## What's changed?

- Related to #8251.
- An amendment to Go RPC deserialization. Skipping one layer of intermediary objects.

## What's your motivation?

In a hope to lower the memory footprint of Go recipe runs.
