### PR TITLE
Attach lock-regeneration failure warning to the lock file too

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/AddDependency.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/AddDependency.java
@@ -215,13 +215,18 @@ public class AddDependency extends ScanningRecipe<AddDependency.Accumulator> {
                         }
                     }
                 }
-                if (lockPs.regenResult != null && lockPs.regenResult.isSuccess()) {
-                    String lockContent = lockPs.regenResult.getLockFileContent();
-                    if (tree instanceof Toml.Document) {
-                        return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
-                    }
-                    if (tree instanceof Json.Document) {
-                        return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                if (lockPs.regenResult != null) {
+                    if (lockPs.regenResult.isSuccess()) {
+                        String lockContent = lockPs.regenResult.getLockFileContent();
+                        if (tree instanceof Toml.Document) {
+                            return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
+                        }
+                        if (tree instanceof Json.Document) {
+                            return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                        }
+                    } else {
+                        return Markup.warn(sourceFile, new RuntimeException(
+                                "lock regeneration failed: " + lockPs.regenResult.getErrorMessage()));
                     }
                 }
                 return tree;

--- a/rewrite-python/src/main/java/org/openrewrite/python/ChangeDependency.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/ChangeDependency.java
@@ -193,13 +193,18 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                         }
                     }
                 }
-                if (lockPs.regenResult != null && lockPs.regenResult.isSuccess()) {
-                    String lockContent = lockPs.regenResult.getLockFileContent();
-                    if (tree instanceof Toml.Document) {
-                        return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
-                    }
-                    if (tree instanceof Json.Document) {
-                        return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                if (lockPs.regenResult != null) {
+                    if (lockPs.regenResult.isSuccess()) {
+                        String lockContent = lockPs.regenResult.getLockFileContent();
+                        if (tree instanceof Toml.Document) {
+                            return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
+                        }
+                        if (tree instanceof Json.Document) {
+                            return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                        }
+                    } else {
+                        return Markup.warn(sourceFile, new RuntimeException(
+                                "lock regeneration failed: " + lockPs.regenResult.getErrorMessage()));
                     }
                 }
                 return tree;

--- a/rewrite-python/src/main/java/org/openrewrite/python/RemoveDependency.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/RemoveDependency.java
@@ -207,13 +207,18 @@ public class RemoveDependency extends ScanningRecipe<RemoveDependency.Accumulato
                         }
                     }
                 }
-                if (lockPs.regenResult != null && lockPs.regenResult.isSuccess()) {
-                    String lockContent = lockPs.regenResult.getLockFileContent();
-                    if (tree instanceof Toml.Document) {
-                        return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
-                    }
-                    if (tree instanceof Json.Document) {
-                        return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                if (lockPs.regenResult != null) {
+                    if (lockPs.regenResult.isSuccess()) {
+                        String lockContent = lockPs.regenResult.getLockFileContent();
+                        if (tree instanceof Toml.Document) {
+                            return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
+                        }
+                        if (tree instanceof Json.Document) {
+                            return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                        }
+                    } else {
+                        return Markup.warn(sourceFile, new RuntimeException(
+                                "lock regeneration failed: " + lockPs.regenResult.getErrorMessage()));
                     }
                 }
                 return tree;

--- a/rewrite-python/src/main/java/org/openrewrite/python/UpgradeDependencyVersion.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/UpgradeDependencyVersion.java
@@ -214,13 +214,18 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         }
                     }
                 }
-                if (lockPs.regenResult != null && lockPs.regenResult.isSuccess()) {
-                    String lockContent = lockPs.regenResult.getLockFileContent();
-                    if (tree instanceof Toml.Document) {
-                        return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
-                    }
-                    if (tree instanceof Json.Document) {
-                        return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                if (lockPs.regenResult != null) {
+                    if (lockPs.regenResult.isSuccess()) {
+                        String lockContent = lockPs.regenResult.getLockFileContent();
+                        if (tree instanceof Toml.Document) {
+                            return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
+                        }
+                        if (tree instanceof Json.Document) {
+                            return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                        }
+                    } else {
+                        return Markup.warn(sourceFile, new RuntimeException(
+                                "lock regeneration failed: " + lockPs.regenResult.getErrorMessage()));
                     }
                 }
                 return tree;

--- a/rewrite-python/src/main/java/org/openrewrite/python/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/UpgradeTransitiveDependencyVersion.java
@@ -199,13 +199,18 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         }
                     }
                 }
-                if (lockPs.regenResult != null && lockPs.regenResult.isSuccess()) {
-                    String lockContent = lockPs.regenResult.getLockFileContent();
-                    if (tree instanceof Toml.Document) {
-                        return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
-                    }
-                    if (tree instanceof Json.Document) {
-                        return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                if (lockPs.regenResult != null) {
+                    if (lockPs.regenResult.isSuccess()) {
+                        String lockContent = lockPs.regenResult.getLockFileContent();
+                        if (tree instanceof Toml.Document) {
+                            return PyProjectHelper.reparseToml((Toml.Document) tree, lockContent);
+                        }
+                        if (tree instanceof Json.Document) {
+                            return PyProjectHelper.reparseJson((Json.Document) tree, lockContent);
+                        }
+                    } else {
+                        return Markup.warn(sourceFile, new RuntimeException(
+                                "lock regeneration failed: " + lockPs.regenResult.getErrorMessage()));
                     }
                 }
                 return tree;

--- a/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
@@ -16,14 +16,60 @@
 package org.openrewrite.python;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.marker.Markup;
 import org.openrewrite.test.RewriteTest;
 
 import java.nio.file.Path;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.python.Assertions.*;
 
 class UpgradeDependencyVersionTest implements RewriteTest {
+
+    @Test
+    @Timeout(120)
+    void warnsOnBothManifestAndLockWhenRegenerationFails() {
+        // Upgrading a dependency that cannot be resolved makes `uv lock` fail. The manifest is
+        // still bumped, but because the lock file cannot be regenerated the recipe attaches the
+        // same warning to BOTH pyproject.toml and the (otherwise untouched) uv.lock so a reviewer
+        // looking at the lock file sees why it did not change. The failure is deterministic whether
+        // or not uv is installed: an unresolvable dependency fails `uv lock`, and a missing uv
+        // reports "not installed".
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion(
+            "nonexistent-openrewrite-lock-test-package", ">=2.0", null, null)),
+          pyproject(
+            """
+              [project]
+              name = "myapp"
+              version = "1.0.0"
+              dependencies = [
+                  "nonexistent-openrewrite-lock-test-package>=1.0",
+              ]
+
+              [tool.uv]
+              """,
+            s -> s.after(actual -> {
+                assertThat(actual).contains("nonexistent-openrewrite-lock-test-package>=2.0");
+                return actual;
+            }).afterRecipe(doc -> assertThat(doc.getMarkers().findFirst(Markup.Warn.class))
+                    .as("manifest should carry the lock-regeneration-failure warning")
+                    .isPresent())
+          ),
+          uvLock(
+            """
+              version = 1
+              requires-python = ">=3.9"
+              """,
+            s -> s.after(actual -> actual)
+                    .afterRecipe(doc -> assertThat(doc.getMarkers().findFirst(Markup.Warn.class))
+                            .as("lock file should carry the lock-regeneration-failure warning")
+                            .isPresent())
+          )
+        );
+    }
 
     @Test
     void changeVersionWithResolvedProject(@TempDir Path tempDir) {

--- a/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
@@ -31,12 +31,6 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     @Test
     @Timeout(120)
     void warnsOnBothManifestAndLockWhenRegenerationFails() {
-        // Upgrading a dependency that cannot be resolved makes `uv lock` fail. The manifest is
-        // still bumped, but because the lock file cannot be regenerated the recipe attaches the
-        // same warning to BOTH pyproject.toml and the (otherwise untouched) uv.lock so a reviewer
-        // looking at the lock file sees why it did not change. The failure is deterministic whether
-        // or not uv is installed: an unresolvable dependency fails `uv lock`, and a missing uv
-        // reports "not installed".
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion(
             "nonexistent-openrewrite-lock-test-package", ">=2.0", null, null)),


### PR DESCRIPTION
## What's changed?

When the Python dependency recipes (`UpgradeDependencyVersion`, `UpgradeTransitiveDependencyVersion`, `AddDependency`, `ChangeDependency`, `RemoveDependency`) edit a manifest (`pyproject.toml` / `Pipfile`) and then fail to regenerate the lock file (e.g. `uv lock` / `pipenv lock` exits non-zero), they already attach a `Markup.warn` to the *manifest* but leave the lock file (`uv.lock` / `Pipfile.lock`) untouched with no marker. A reviewer looking at the lock file — the file that *didn't* update — sees no explanation.

Each recipe's lock-file branch now wraps the lock `SourceFile` in the same `Markup.warn` when `regenResult` is non-null and unsuccessful. The change is additive: the existing manifest warning is preserved and both files carry the warning. The success path (reparse of the regenerated lock) is unchanged.

## Why?

Marking the lock file makes the regeneration failure visible where the reviewer actually looks — on the file that did not change.

## Anything in particular you'd like reviewers to focus on?

Marking an otherwise-unchanged lock file means the recipe now reports a marker-only change on that file. That is intended, and is reflected in the new test.

## Testing

- New `UpgradeDependencyVersionTest#warnsOnBothManifestAndLockWhenRegenerationFails` asserts the `Markup.Warn` marker is present on both the manifest and the lock file when regeneration fails. The failure is forced deterministically via an unresolvable dependency, so it fails whether or not `uv` is installed on the runner.
- The five recipes share an identical lock-file branch; the existing test suites for all five still pass.