### PR TITLE
Add data table for Python lock file regeneration outcomes

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/AddDependency.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/AddDependency.java
@@ -23,6 +23,7 @@ import org.openrewrite.json.tree.Json;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.python.internal.LockFileRegeneration;
 import org.openrewrite.python.internal.PyProjectHelper;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults;
 import org.openrewrite.python.trait.PythonDependencyFile;
 import org.openrewrite.toml.tree.Toml;
 
@@ -41,6 +42,8 @@ import java.util.function.Function;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class AddDependency extends ScanningRecipe<AddDependency.Accumulator> {
+
+    transient PythonLockFileRegenerationResults regenResults = new PythonLockFileRegenerationResults(this);
 
     @Option(displayName = "Package name",
             description = "The PyPI package name to add.",
@@ -109,6 +112,7 @@ public class AddDependency extends ScanningRecipe<AddDependency.Accumulator> {
         @Nullable String capturedLockContent;
         @Nullable SourceFile modifiedDepsFile;
         LockFileRegeneration.@Nullable Result regenResult;
+        boolean regenRowInserted;
     }
 
     @Override
@@ -185,6 +189,11 @@ public class AddDependency extends ScanningRecipe<AddDependency.Accumulator> {
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
                             out = Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
+                        }
+                        if (!ps.regenRowInserted) {
+                            ps.regenRowInserted = true;
+                            regenResults.insertRow(ctx, PyProjectHelper.regenerationRow(
+                                    ps.modifiedDepsFile, ps.capturedLockContent, ps.regenResult));
                         }
                         PyProjectHelper.putLiveDepsTree(ctx, sourcePath, out);
                         return out;

--- a/rewrite-python/src/main/java/org/openrewrite/python/ChangeDependency.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/ChangeDependency.java
@@ -23,6 +23,7 @@ import org.openrewrite.json.tree.Json;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.python.internal.LockFileRegeneration;
 import org.openrewrite.python.internal.PyProjectHelper;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults;
 import org.openrewrite.python.trait.PythonDependencyFile;
 import org.openrewrite.toml.tree.Toml;
 
@@ -40,6 +41,8 @@ import java.util.function.Function;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulator> {
+
+    transient PythonLockFileRegenerationResults regenResults = new PythonLockFileRegenerationResults(this);
 
     @Option(displayName = "Old package name",
             description = "The current PyPI package name to replace.",
@@ -88,6 +91,7 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
         @Nullable String capturedLockContent;
         @Nullable SourceFile modifiedDepsFile;
         LockFileRegeneration.@Nullable Result regenResult;
+        boolean regenRowInserted;
     }
 
     @Override
@@ -163,6 +167,11 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
                             out = Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
+                        }
+                        if (!ps.regenRowInserted) {
+                            ps.regenRowInserted = true;
+                            regenResults.insertRow(ctx, PyProjectHelper.regenerationRow(
+                                    ps.modifiedDepsFile, ps.capturedLockContent, ps.regenResult));
                         }
                         PyProjectHelper.putLiveDepsTree(ctx, sourcePath, out);
                         return out;

--- a/rewrite-python/src/main/java/org/openrewrite/python/RemoveDependency.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/RemoveDependency.java
@@ -23,6 +23,7 @@ import org.openrewrite.json.tree.Json;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.python.internal.LockFileRegeneration;
 import org.openrewrite.python.internal.PyProjectHelper;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults;
 import org.openrewrite.python.trait.PythonDependencyFile;
 import org.openrewrite.toml.tree.Toml;
 
@@ -42,6 +43,8 @@ import java.util.function.Function;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class RemoveDependency extends ScanningRecipe<RemoveDependency.Accumulator> {
+
+    transient PythonLockFileRegenerationResults regenResults = new PythonLockFileRegenerationResults(this);
 
     @Option(displayName = "Package name",
             description = "The PyPI package name to remove.",
@@ -101,6 +104,7 @@ public class RemoveDependency extends ScanningRecipe<RemoveDependency.Accumulato
         @Nullable String capturedLockContent;
         @Nullable SourceFile modifiedDepsFile;
         LockFileRegeneration.@Nullable Result regenResult;
+        boolean regenRowInserted;
     }
 
     @Override
@@ -177,6 +181,11 @@ public class RemoveDependency extends ScanningRecipe<RemoveDependency.Accumulato
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
                             out = Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
+                        }
+                        if (!ps.regenRowInserted) {
+                            ps.regenRowInserted = true;
+                            regenResults.insertRow(ctx, PyProjectHelper.regenerationRow(
+                                    ps.modifiedDepsFile, ps.capturedLockContent, ps.regenResult));
                         }
                         PyProjectHelper.putLiveDepsTree(ctx, sourcePath, out);
                         return out;

--- a/rewrite-python/src/main/java/org/openrewrite/python/UpgradeDependencyVersion.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/UpgradeDependencyVersion.java
@@ -24,6 +24,7 @@ import org.openrewrite.marker.Markup;
 import org.openrewrite.python.internal.LockFileRegeneration;
 import org.openrewrite.python.internal.PyProjectHelper;
 import org.openrewrite.python.marker.PythonResolutionResult;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults;
 import org.openrewrite.python.trait.PythonDependencyFile;
 import org.openrewrite.toml.tree.Toml;
 
@@ -42,6 +43,8 @@ import java.util.function.Function;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVersion.Accumulator> {
+
+    transient PythonLockFileRegenerationResults regenResults = new PythonLockFileRegenerationResults(this);
 
     @Option(displayName = "Package name",
             description = "The PyPI package name to update.",
@@ -106,6 +109,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         @Nullable String capturedLockContent;
         @Nullable SourceFile modifiedDepsFile;
         LockFileRegeneration.@Nullable Result regenResult;
+        boolean regenRowInserted;
     }
 
     @Override
@@ -184,6 +188,11 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
                             out = Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
+                        }
+                        if (!ps.regenRowInserted) {
+                            ps.regenRowInserted = true;
+                            regenResults.insertRow(ctx, PyProjectHelper.regenerationRow(
+                                    ps.modifiedDepsFile, ps.capturedLockContent, ps.regenResult));
                         }
                         PyProjectHelper.putLiveDepsTree(ctx, sourcePath, out);
                         return out;

--- a/rewrite-python/src/main/java/org/openrewrite/python/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/UpgradeTransitiveDependencyVersion.java
@@ -24,6 +24,7 @@ import org.openrewrite.marker.Markup;
 import org.openrewrite.python.internal.LockFileRegeneration;
 import org.openrewrite.python.internal.PyProjectHelper;
 import org.openrewrite.python.marker.PythonResolutionResult;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults;
 import org.openrewrite.python.trait.PythonDependencyFile;
 import org.openrewrite.toml.tree.Toml;
 
@@ -45,6 +46,8 @@ import java.util.function.Function;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTransitiveDependencyVersion.Accumulator> {
+
+    transient PythonLockFileRegenerationResults regenResults = new PythonLockFileRegenerationResults(this);
 
     @Option(displayName = "Package name",
             description = "The PyPI package name of the transitive dependency to pin.",
@@ -86,6 +89,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
         @Nullable String capturedLockContent;
         @Nullable SourceFile modifiedDepsFile;
         LockFileRegeneration.@Nullable Result regenResult;
+        boolean regenRowInserted;
     }
 
     @Override
@@ -169,6 +173,11 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
                             out = Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
+                        }
+                        if (!ps.regenRowInserted) {
+                            ps.regenRowInserted = true;
+                            regenResults.insertRow(ctx, PyProjectHelper.regenerationRow(
+                                    ps.modifiedDepsFile, ps.capturedLockContent, ps.regenResult));
                         }
                         PyProjectHelper.putLiveDepsTree(ctx, sourcePath, out);
                         return out;

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/LockFileRegeneration.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/LockFileRegeneration.java
@@ -62,13 +62,32 @@ public final class LockFileRegeneration {
         boolean success;
         @Nullable String lockFileContent;
         @Nullable String errorMessage;
+        Reason reason;
+
+        /**
+         * Why a regeneration attempt ended the way it did. Lets downstream reporting
+         * separate "couldn't even try" ({@link #TOOL_NOT_INSTALLED}) from
+         * "tried and failed" ({@link #FAILED}) without string-matching the message.
+         */
+        public enum Reason {
+            /** Regeneration succeeded and produced lock content. */
+            SUCCESS,
+            /** The package manager executable was not found on the {@code PATH}. */
+            TOOL_NOT_INSTALLED,
+            /** The package manager ran but failed (non-zero exit, missing output, IO error, or interruption). */
+            FAILED
+        }
 
         public static Result success(String lockFileContent) {
-            return new Result(true, lockFileContent, null);
+            return new Result(true, lockFileContent, null, Reason.SUCCESS);
         }
 
         public static Result failure(String errorMessage) {
-            return new Result(false, null, errorMessage);
+            return new Result(false, null, errorMessage, Reason.FAILED);
+        }
+
+        public static Result toolNotInstalled(String errorMessage) {
+            return new Result(false, null, errorMessage, Reason.TOOL_NOT_INSTALLED);
         }
     }
 
@@ -80,6 +99,26 @@ public final class LockFileRegeneration {
         this.executor = executor;
         this.dependenciesFile = dependenciesFile;
         this.lockFile = lockFile;
+    }
+
+    /** Whether the underlying package manager executable can be found on the {@code PATH}. */
+    public boolean isToolAvailable() {
+        return executor.find() != null;
+    }
+
+    /** The name of the package manager this instance drives, e.g. {@code uv} or {@code pipenv}. */
+    public String getPackageManagerName() {
+        return executor.getName();
+    }
+
+    /** The dependencies file this instance locks, e.g. {@code pyproject.toml} or {@code Pipfile}. */
+    public String getDependenciesFileName() {
+        return dependenciesFile;
+    }
+
+    /** The lock file this instance produces, e.g. {@code uv.lock} or {@code Pipfile.lock}. */
+    public String getLockFileName() {
+        return lockFile;
     }
 
     public Result regenerate(String dependenciesContent) {
@@ -104,7 +143,7 @@ public final class LockFileRegeneration {
     public Result regenerate(String dependenciesContent, @Nullable String existingLockContent, Map<String, String> environment) {
         String executablePath = executor.find();
         if (executablePath == null) {
-            return Result.failure(executor.getName() + " is not installed. Install it with: pip install " + executor.getName());
+            return Result.toolNotInstalled(executor.getName() + " is not installed. Install it with: pip install " + executor.getName());
         }
 
         Path tempDir = null;

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PyProjectHelper.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PyProjectHelper.java
@@ -23,6 +23,7 @@ import org.openrewrite.json.tree.Json;
 import org.openrewrite.python.PipfileParser;
 import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.python.marker.PythonResolutionResult.Dependency;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults;
 import org.openrewrite.python.trait.PythonDependencyFile;
 import org.openrewrite.toml.TomlParser;
 import org.openrewrite.toml.tree.Toml;
@@ -33,6 +34,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -311,6 +313,53 @@ public class PyProjectHelper {
             return null;
         }
         return regen.regenerate(depsFile.printAll(), capturedLockContent);
+    }
+
+    /**
+     * Classify a lock-file regeneration outcome for the
+     * {@link PythonLockFileRegenerationResults} data table.
+     *
+     * @param originalLock the lock content captured before the edit, or {@code null}
+     * @param regen        the regeneration result, or {@code null} when regeneration
+     *                     was not attempted (no lock captured or no adapter)
+     */
+    public static PythonLockFileRegenerationResults.Status regenerationStatus(
+            @Nullable String originalLock, LockFileRegeneration.@Nullable Result regen) {
+        if (regen == null) {
+            return PythonLockFileRegenerationResults.Status.NO_LOCK_PRESENT;
+        }
+        if (!regen.isSuccess()) {
+            return regen.getReason() == LockFileRegeneration.Result.Reason.TOOL_NOT_INSTALLED ?
+                    PythonLockFileRegenerationResults.Status.TOOL_NOT_INSTALLED :
+                    PythonLockFileRegenerationResults.Status.FAILED;
+        }
+        return Objects.equals(originalLock, regen.getLockFileContent()) ?
+                PythonLockFileRegenerationResults.Status.UNCHANGED :
+                PythonLockFileRegenerationResults.Status.REGENERATED;
+    }
+
+    /**
+     * Build a {@link PythonLockFileRegenerationResults.Row} for a touched manifest.
+     * The package manager and lock file name are derived from the manifest's
+     * {@link PythonResolutionResult} marker; they are {@code null} when the manifest
+     * has no marker or uses a package manager without a regeneration adapter.
+     *
+     * @param manifest     the edited manifest source file (carries the marker and path)
+     * @param originalLock the lock content captured before the edit, or {@code null}
+     * @param regen        the regeneration result, or {@code null}
+     */
+    public static PythonLockFileRegenerationResults.Row regenerationRow(
+            SourceFile manifest, @Nullable String originalLock, LockFileRegeneration.@Nullable Result regen) {
+        PythonResolutionResult marker = manifest.getMarkers()
+                .findFirst(PythonResolutionResult.class).orElse(null);
+        LockFileRegeneration regeneration = marker == null ? null :
+                LockFileRegeneration.forPackageManager(marker.getPackageManager());
+        return new PythonLockFileRegenerationResults.Row(
+                manifest.getSourcePath().toString(),
+                regeneration == null ? null : regeneration.getLockFileName(),
+                regeneration == null ? null : regeneration.getPackageManagerName(),
+                regenerationStatus(originalLock, regen),
+                regen == null ? null : regen.getErrorMessage());
     }
 
     /**

--- a/rewrite-python/src/main/java/org/openrewrite/python/table/PythonLockFileRegenerationResults.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/table/PythonLockFileRegenerationResults.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.table;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
+import lombok.NonNull;
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Column;
+import org.openrewrite.DataTable;
+import org.openrewrite.Recipe;
+
+/**
+ * Records the outcome of regenerating a Python lock file after a dependency recipe edited its
+ * manifest. One {@link Row} is emitted per project the recipe touched, so that on a large org
+ * run the results can be aggregated to answer "which repos failed to regenerate their lock, and
+ * why" — distinguishing <em>couldn't try</em> from <em>tried, nothing changed</em> from
+ * <em>regenerated</em>.
+ */
+@JsonIgnoreType
+public class PythonLockFileRegenerationResults extends DataTable<PythonLockFileRegenerationResults.@NonNull Row> {
+
+    public PythonLockFileRegenerationResults(Recipe recipe) {
+        super(recipe,
+                "Python lock file regeneration results",
+                "The outcome of regenerating a Python lock file (`uv.lock` / `Pipfile.lock`) after a " +
+                        "dependency recipe edited its manifest.");
+    }
+
+    /**
+     * The regeneration outcome for a single project.
+     */
+    public enum Status {
+        /** The lock file was regenerated and its content differs from the original. */
+        REGENERATED,
+        /** Regeneration succeeded but produced content identical to the original lock. */
+        UNCHANGED,
+        /** The manifest changed but no lock file was present to regenerate. */
+        NO_LOCK_PRESENT,
+        /** The package manager (`uv` / `pipenv`) was not installed, so regeneration could not be attempted. */
+        TOOL_NOT_INSTALLED,
+        /** The package manager ran but failed to produce a new lock (see {@code detail}). */
+        FAILED
+    }
+
+    @Value
+    public static class Row {
+        @Column(displayName = "Source path",
+                description = "The path to the manifest that was edited (e.g., `Pipfile` or `pyproject.toml`).")
+        String sourcePath;
+
+        @Column(displayName = "Lock file",
+                description = "The name of the lock file corresponding to the manifest (e.g., `Pipfile.lock` or `uv.lock`).")
+        @Nullable
+        String lockFile;
+
+        @Column(displayName = "Package manager",
+                description = "The package manager responsible for the lock file (`pipenv` or `uv`).")
+        @Nullable
+        String packageManager;
+
+        @Column(displayName = "Status",
+                description = "The regeneration outcome: REGENERATED, UNCHANGED, NO_LOCK_PRESENT, TOOL_NOT_INSTALLED, or FAILED.")
+        Status status;
+
+        @Column(displayName = "Detail",
+                description = "Additional detail, such as the error message when regeneration failed. Empty on success.")
+        @Nullable
+        String detail;
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonLockFileRegenerationResultsTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonLockFileRegenerationResultsTest.java
@@ -93,7 +93,9 @@ class PythonLockFileRegenerationResultsTest implements RewriteTest {
                   "develop": {}
               }
               """,
+            // The lock cannot be regenerated, so the recipe attaches the same warning to it.
             spec -> spec.path("Pipfile.lock")
+              .after(actual -> assertThat(actual).contains("lock regeneration failed: pipenv is not installed").actual())
           )
         );
     }

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonLockFileRegenerationResultsTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonLockFileRegenerationResultsTest.java
@@ -83,10 +83,7 @@ class PythonLockFileRegenerationResultsTest implements RewriteTest {
               """,
             // The manifest change lands; the Markup.warn about the failed regeneration
             // is appended by the recipe, so accept whatever is rendered.
-            spec -> spec.after(actual -> {
-                assertThat(actual).contains("flask = \">=2.0\"");
-                return actual;
-            })
+            spec -> spec.after(actual -> assertThat(actual).contains("flask = \">=2.0\"").actual())
           ),
           json(
             """
@@ -148,10 +145,7 @@ class PythonLockFileRegenerationResultsTest implements RewriteTest {
               requires-python = ">=3.8"
               """,
             // uv rewrites the lock with resolved packages; accept whatever it produces.
-            spec -> spec.noTrim().after(actual -> {
-                assertThat(actual).contains("certifi");
-                return actual;
-            })
+            spec -> spec.noTrim().after(actual -> assertThat(actual).contains("certifi").actual())
           )
         );
     }

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonLockFileRegenerationResultsTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonLockFileRegenerationResultsTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.python.internal.LockFileRegeneration;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults.Status;
+import org.openrewrite.test.RewriteTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.openrewrite.json.Assertions.json;
+import static org.openrewrite.python.Assertions.pipfile;
+import static org.openrewrite.python.Assertions.pyproject;
+import static org.openrewrite.python.Assertions.uvLock;
+
+class PythonLockFileRegenerationResultsTest implements RewriteTest {
+
+    @Test
+    void noLockPresentEmitsRow() {
+        // A manifest change with no lock file to regenerate: couldn't try.
+        rewriteRun(
+          spec -> spec
+            .recipe(new AddDependency("flask", ">=2.0", null, null))
+            .dataTable(PythonLockFileRegenerationResults.Row.class, rows -> {
+                assertThat(rows).hasSize(1);
+                PythonLockFileRegenerationResults.Row row = rows.getFirst();
+                assertThat(row.getSourcePath()).isEqualTo("Pipfile");
+                assertThat(row.getLockFile()).isEqualTo("Pipfile.lock");
+                assertThat(row.getPackageManager()).isEqualTo("pipenv");
+                assertThat(row.getStatus()).isEqualTo(Status.NO_LOCK_PRESENT);
+                assertThat(row.getDetail()).isNull();
+            }),
+          pipfile(
+            """
+              [packages]
+              requests = ">=2.28.0"
+              """,
+            """
+              [packages]
+              requests = ">=2.28.0"
+              flask = ">=2.0"
+              """
+          )
+        );
+    }
+
+    @Test
+    void toolNotInstalledEmitsRow() {
+        // Regeneration is attempted (a lock is present) but pipenv is absent.
+        assumeTrue(!LockFileRegeneration.PIPENV.isToolAvailable(),
+                "This test requires pipenv to NOT be installed");
+        rewriteRun(
+          spec -> spec
+            .recipe(new AddDependency("flask", ">=2.0", null, null))
+            .dataTable(PythonLockFileRegenerationResults.Row.class, rows -> {
+                assertThat(rows).hasSize(1);
+                PythonLockFileRegenerationResults.Row row = rows.getFirst();
+                assertThat(row.getSourcePath()).isEqualTo("Pipfile");
+                assertThat(row.getLockFile()).isEqualTo("Pipfile.lock");
+                assertThat(row.getPackageManager()).isEqualTo("pipenv");
+                assertThat(row.getStatus()).isEqualTo(Status.TOOL_NOT_INSTALLED);
+                assertThat(row.getDetail()).contains("pipenv is not installed");
+            }),
+          pipfile(
+            """
+              [packages]
+              requests = ">=2.28.0"
+              """,
+            // The manifest change lands; the Markup.warn about the failed regeneration
+            // is appended by the recipe, so accept whatever is rendered.
+            spec -> spec.after(actual -> {
+                assertThat(actual).contains("flask = \">=2.0\"");
+                return actual;
+            })
+          ),
+          json(
+            """
+              {
+                  "_meta": {},
+                  "default": {},
+                  "develop": {}
+              }
+              """,
+            spec -> spec.path("Pipfile.lock")
+          )
+        );
+    }
+
+    @Test
+    void regeneratedEmitsRow() {
+        // uv is available: regenerating from the stub lock produces different content.
+        assumeTrue(LockFileRegeneration.UV.isToolAvailable(),
+                "This test requires uv to be installed");
+        rewriteRun(
+          spec -> spec
+            .recipe(new UpgradeDependencyVersion("certifi", ">=2021.0.0", null, null))
+            .dataTable(PythonLockFileRegenerationResults.Row.class, rows -> {
+                assertThat(rows).hasSize(1);
+                PythonLockFileRegenerationResults.Row row = rows.getFirst();
+                assertThat(row.getSourcePath()).isEqualTo("pyproject.toml");
+                assertThat(row.getLockFile()).isEqualTo("uv.lock");
+                assertThat(row.getPackageManager()).isEqualTo("uv");
+                assertThat(row.getStatus()).isEqualTo(Status.REGENERATED);
+                assertThat(row.getDetail()).isNull();
+            }),
+          pyproject(
+            """
+              [project]
+              name = "myapp"
+              version = "1.0.0"
+              requires-python = ">=3.8"
+              dependencies = [
+                  "certifi>=2020.0.0",
+              ]
+
+              [tool.uv]
+              """,
+            """
+              [project]
+              name = "myapp"
+              version = "1.0.0"
+              requires-python = ">=3.8"
+              dependencies = [
+                  "certifi>=2021.0.0",
+              ]
+
+              [tool.uv]
+              """
+          ),
+          uvLock(
+            """
+              version = 1
+              requires-python = ">=3.8"
+              """,
+            // uv rewrites the lock with resolved packages; accept whatever it produces.
+            spec -> spec.noTrim().after(actual -> {
+                assertThat(actual).contains("certifi");
+                return actual;
+            })
+          )
+        );
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonLockFileRegenerationStatusTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonLockFileRegenerationStatusTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.internal;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.python.table.PythonLockFileRegenerationResults.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit coverage for the status derivation that feeds the
+ * {@code PythonLockFileRegenerationResults} data table. Exercising the pure
+ * classification directly keeps all five outcomes deterministic, independent of
+ * whether {@code uv}/{@code pipenv} are installed in the test environment.
+ */
+class PythonLockFileRegenerationStatusTest {
+
+    @Test
+    void noRegenerationMeansNoLockPresent() {
+        assertThat(PyProjectHelper.regenerationStatus("old lock", null))
+                .isEqualTo(Status.NO_LOCK_PRESENT);
+    }
+
+    @Test
+    void toolNotInstalled() {
+        assertThat(PyProjectHelper.regenerationStatus("old lock",
+                LockFileRegeneration.Result.toolNotInstalled("pipenv is not installed")))
+                .isEqualTo(Status.TOOL_NOT_INSTALLED);
+    }
+
+    @Test
+    void failed() {
+        assertThat(PyProjectHelper.regenerationStatus("old lock",
+                LockFileRegeneration.Result.failure("pipenv lock failed (exit code 1): boom")))
+                .isEqualTo(Status.FAILED);
+    }
+
+    @Test
+    void unchangedWhenRegeneratedLockMatchesOriginal() {
+        assertThat(PyProjectHelper.regenerationStatus("same lock",
+                LockFileRegeneration.Result.success("same lock")))
+                .isEqualTo(Status.UNCHANGED);
+    }
+
+    @Test
+    void regeneratedWhenContentDiffers() {
+        assertThat(PyProjectHelper.regenerationStatus("old lock",
+                LockFileRegeneration.Result.success("new lock")))
+                .isEqualTo(Status.REGENERATED);
+    }
+
+    @Test
+    void regeneratedWhenNoOriginalLockToCompareAgainst() {
+        assertThat(PyProjectHelper.regenerationStatus(null,
+                LockFileRegeneration.Result.success("new lock")))
+                .isEqualTo(Status.REGENERATED);
+    }
+}


### PR DESCRIPTION
## What

Python dependency and version recipes shell out to `uv`/`pipenv` to regenerate a lock file after editing a manifest. Regeneration frequently can't complete (tool not installed, a dependency doesn't support the new Python so `pipenv lock` exits non-zero) or succeeds but resolves to an identical lock. Today the only signal is an inline `Markup.warn` on the manifest — there is **no data table**, so on a 200-repo org run there's no way to query "which repos failed to regenerate their lock, and why."

This adds `PythonLockFileRegenerationResults`, a data table with one row per project a recipe touched:

| Column | Description |
|--------|-------------|
| `sourcePath` | the manifest that was edited (e.g. `Pipfile`, `pyproject.toml`) |
| `lockFile` | the corresponding lock file (e.g. `Pipfile.lock`, `uv.lock`) |
| `packageManager` | `pipenv` / `uv` |
| `status` | `REGENERATED`, `UNCHANGED`, `NO_LOCK_PRESENT`, `TOOL_NOT_INSTALLED`, `FAILED` |
| `detail` | the failure message, or empty on success |

This makes outcomes aggregatable and distinguishes *couldn't try* from *tried, nothing changed* from *regenerated*.

## How

- Each of the five dependency recipes (`UpgradeDependencyVersion`, `UpgradeTransitiveDependencyVersion`, `AddDependency`, `ChangeDependency`, `RemoveDependency`) declares the table as a `transient` field (mirroring how `DependencyInsight` declares `PythonDependenciesInUse`) and inserts a row in the manifest branch of its visitor, once per project (guarded by a new `regenRowInserted` latch alongside the existing modified-manifest state).
- Status is derived in the shared `PyProjectHelper.regenerationStatus`/`regenerationRow` helpers so the six consumers stay identical.
- To distinguish `TOOL_NOT_INSTALLED` from `FAILED` cleanly (today they differ only by message text), `LockFileRegeneration.Result` now carries a `Reason` enum set at each failure site, rather than string-matching the message.
- The existing `Markup.warn` behavior is unchanged — the table is purely additive.

## Tests

- `PythonLockFileRegenerationStatusTest` covers all five status outcomes deterministically via the pure classification (independent of whether `uv`/`pipenv` are installed).
- `PythonLockFileRegenerationResultsTest` asserts emitted rows via the standard `dataTable(...)` assertion for `NO_LOCK_PRESENT`, `TOOL_NOT_INSTALLED` (guarded on pipenv being absent), and `REGENERATED` (guarded on uv being available).

A follow-up PR in `moderneinc/rewrite-migrate-python` consumes this table from `UpgradePythonVersion`; it depends on this change being released first.