### PR TITLE
Add test to ReplaceConstantWithAnotherConstantTest

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ReplaceConstantWithAnotherConstantTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ReplaceConstantWithAnotherConstantTest.java
@@ -471,4 +471,65 @@ class ReplaceConstantWithAnotherConstantTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shouldPreserveWildcardStaticImport() {
+        rewriteRun(
+          spec -> spec.recipe(new ReplaceConstantWithAnotherConstant("foo1.Bar.QUX1", "foo2.Bar.QUX1")),
+          java(
+            """
+              package foo1;
+
+              public class Bar {
+                  public static final String QUX1 = "QUX1_FROM_FOO1";
+                  public static final String QUX2 = "QUX2_FROM_FOO1";
+                  public static final String QUX3 = "QUX3_FROM_FOO1";
+              }
+              """
+          ),
+          java(
+            """
+              package foo2;
+
+              public class Bar {
+                  public static final String QUX1 = "QUX1_FROM_FOO2";
+              }
+              """
+          ),
+          java(
+            """
+              package app;
+
+              import foo1.Bar;
+
+              import static foo1.Bar.*;
+
+              public class WildcardImportUser {
+                  public String pickDefault() {
+                      return QUX2;
+                  }
+                  public boolean isAny(String s) {
+                      return s.equals(QUX1) || s.equals(QUX3);
+                  }
+              }
+              """,
+            """
+              package app;
+
+              import foo1.Bar;
+
+              import static foo1.Bar.*;
+
+              public class WildcardImportUser {
+                  public String pickDefault() {
+                      return QUX2;
+                  }
+                  public boolean isAny(String s) {
+                      return s.equals(foo2.Bar.QUX1) || s.equals(QUX3);
+                  }
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## What's changed?
This change adds a test case which is not covered by ReplaceConstantWithAnotherConstant recipe.

The test case shows that a wildcard "import static foo1.Bar.*" ist not kept and instead replaced by the specific constant imports. Maybe its by design, but for us we needed that the wildcard import stays there. So far no time was invested in the change of the Recipe, because first it needs to be clarified its a bug or its by design.