### PR TITLE
ChangeValue cannot update values inside TOML inline tables

### DIFF
--- a/rewrite-toml/src/main/java/org/openrewrite/toml/TomlPathMatcher.java
+++ b/rewrite-toml/src/main/java/org/openrewrite/toml/TomlPathMatcher.java
@@ -97,26 +97,17 @@ public class TomlPathMatcher {
                 Toml.KeyValue kv = (Toml.KeyValue) value;
                 TomlKey key = kv.getKey();
                 if (key instanceof Toml.Identifier) {
-                    String keyName = ((Toml.Identifier) key).getName();
-                    Cursor parent = current.getParent();
-                    while (parent != null) {
-                        Object parentValue = parent.getValue();
-                        if (parentValue instanceof Toml.Table) {
-                            Toml.Table table = (Toml.Table) parentValue;
-                            if (table.getName() != null) {
-                                String tableName = table.getName().getName();
-                                // Split dotted names: [tool.poetry]
-                                String[] parts = tableName.split("\\.");
-                                for (int i = parts.length - 1; i >= 0; i--) {
-                                    path.add(0, parts[i].trim());
-                                }
-                            }
-                            break;
-                        }
-                        parent = parent.getParent();
+                    path.add(0, ((Toml.Identifier) key).getName());
+                }
+            } else if (value instanceof Toml.Table) {
+                Toml.Table table = (Toml.Table) value;
+                Toml.Identifier tableName = table.getName();
+                if (tableName != null) {
+                    String name = tableName.getName();
+                    String[] parts = name.split("\\.");
+                    for (int i = parts.length - 1; i >= 0; i--) {
+                        path.add(0, parts[i].trim());
                     }
-                    path.add(keyName);
-                    return path;
                 }
             }
 

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/ChangeValueTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/ChangeValueTest.java
@@ -69,6 +69,24 @@ class ChangeValueTest implements RewriteTest {
     }
 
     @Test
+    void changeValueInInlineTable() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue(
+            "testcontainers-mongo.name",
+            "\"testcontainers-mongodb\""
+          )),
+          toml(
+            """
+              testcontainers-mongo = { group = "org.testcontainers", name = "mongodb" }
+              """,
+            """
+              testcontainers-mongo = { group = "org.testcontainers", name = "testcontainers-mongodb" }
+              """
+          )
+        );
+    }
+
+    @Test
     void changeBooleanValue() {
         rewriteRun(
           spec -> spec.recipe(new ChangeValue(

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/ChangeValueTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/ChangeValueTest.java
@@ -87,6 +87,41 @@ class ChangeValueTest implements RewriteTest {
     }
 
     @Test
+    void changeValueInInlineTableInsideSection() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue(
+            "deps.mongo.name",
+            "\"testcontainers-mongodb\""
+          )),
+          toml(
+            """
+              [deps]
+              mongo = { group = "org.testcontainers", name = "mongodb" }
+              """,
+            """
+              [deps]
+              mongo = { group = "org.testcontainers", name = "testcontainers-mongodb" }
+              """
+          )
+        );
+    }
+
+    @Test
+    void doesNotChangeInlineTableMemberWithBareKey() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeValue(
+            "name",
+            "\"testcontainers-mongodb\""
+          )),
+          toml(
+            """
+              testcontainers-mongo = { group = "org.testcontainers", name = "mongodb" }
+              """
+          )
+        );
+    }
+
+    @Test
     void changeBooleanValue() {
         rewriteRun(
           spec -> spec.recipe(new ChangeValue(

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/FindKeyTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/FindKeyTest.java
@@ -46,6 +46,23 @@ class FindKeyTest implements RewriteTest {
     }
 
     @Test
+    void findKeyInInlineTable() {
+        rewriteRun(
+          spec -> spec.recipe(new FindKey(
+            "testcontainers-mongo.name"
+          )),
+          toml(
+            """
+              testcontainers-mongo = { group = "org.testcontainers", name = "mongodb" }
+              """,
+            """
+              testcontainers-mongo = { group = "org.testcontainers", ~~>name = "mongodb" }
+              """
+          )
+        );
+    }
+
+    @Test
     void findMultipleMatchingKeys() {
         rewriteRun(
           spec -> spec.recipe(new FindKey(


### PR DESCRIPTION
## What's changed?

Updated TomlPathMatcher to include inline-table key paths when matching TOML values. Added a regression test covering ChangeValue updates inside inline tables.

## What's your motivation?

ChangeValue could not update a value in an inline table when using a dotted path such as testcontainers-mongo.name. The recipe completed without errors, but the value remained unchanged.

## Anything in particular you'd like reviewers to focus on?

Please review the path construction in TomlPathMatcher and confirm that matching for regular TOML tables remains unchanged.

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?

The only workaround was to edit the inline-table value manually. No alternative recipe-based workaround was available.

## Any additional context

The regression test verifies that the nested value is changed while preserving the inline-table structure and other values.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [ ] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've used the IntelliJ IDEA auto-formatter on affected files