### PR TITLE
Go: reduce object allocations on deser by 20%

### DIFF
--- a/rewrite-go/pkg/rpc/decode_batch_bench_test.go
+++ b/rewrite-go/pkg/rpc/decode_batch_bench_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func benchBatchJSON(messages int) []byte {
+	var b strings.Builder
+	b.WriteByte('[')
+	for i := 0; i < messages; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		switch i % 4 {
+		case 0:
+			b.WriteString(`{"state":"CHANGE","value":"\n    "}`)
+		case 1:
+			b.WriteString(`{"state":"CHANGE","value":" "}`)
+		case 2:
+			b.WriteString(`{"state":"CHANGE","value":[0,1,2,3,4]}`)
+		case 3:
+			fmt.Fprintf(&b, `{"state":"ADD","valueType":"org.openrewrite.marker.SearchResult","value":{"id":"%d","desc":"\n    "},"ref":%d}`, i, i)
+		}
+	}
+	b.WriteByte(']')
+	return []byte(b.String())
+}
+
+func BenchmarkDecodeBatch(b *testing.B) {
+	data := benchBatchJSON(2000)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := DecodeBatch(data, make(map[string]string)); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/rewrite-go/pkg/rpc/decode_batch_edge_test.go
+++ b/rewrite-go/pkg/rpc/decode_batch_edge_test.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import "testing"
+
+func TestDecodeBatch_EmptyArray(t *testing.T) {
+	// given
+	data := []byte(`[]`)
+
+	// when
+	batch, err := DecodeBatch(data, nil)
+
+	// then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(batch) != 0 {
+		t.Fatalf("expected empty batch, got %d", len(batch))
+	}
+}
+
+func TestDecodeBatch_NullPayload(t *testing.T) {
+	// given
+	data := []byte(`null`)
+
+	// when
+	batch, err := DecodeBatch(data, nil)
+
+	// then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(batch) != 0 {
+		t.Fatalf("expected empty batch for null, got %d", len(batch))
+	}
+}
+
+func TestDecodeBatch_NonArrayIsError(t *testing.T) {
+	// given
+	data := []byte(`{"state":"ADD"}`)
+
+	// when
+	_, err := DecodeBatch(data, nil)
+
+	// then
+	if err == nil {
+		t.Fatalf("expected error for non-array payload")
+	}
+}
+
+func TestDecodeBatch_StreamsManyMessages(t *testing.T) {
+	// given
+	data := benchBatchJSON(500)
+
+	// when
+	batch, err := DecodeBatch(data, make(map[string]string))
+
+	// then
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(batch) != 500 {
+		t.Fatalf("expected 500 messages, got %d", len(batch))
+	}
+	if positions, ok := batch[2].Value.([]any); !ok || len(positions) != 5 {
+		t.Fatalf("message 2 positions not decoded as a list: %#v", batch[2].Value)
+	}
+	if m, ok := batch[3].Value.(map[string]any); !ok || m["desc"] != "\n    " {
+		t.Fatalf("message 3 marker map not decoded: %#v", batch[3].Value)
+	}
+}

--- a/rewrite-go/pkg/rpc/rpc_object_data.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data.go
@@ -72,10 +72,10 @@ func (d RpcObjectData) MarshalJSON() ([]byte, error) {
 }
 
 type wireObjectData struct {
-	State     string          `json:"state"`
-	ValueType *string         `json:"valueType"`
-	Value     json.RawMessage `json:"value"`
-	Ref       *int            `json:"ref"`
+	State     string  `json:"state"`
+	ValueType *string `json:"valueType"`
+	Value     any     `json:"value"`
+	Ref       *int    `json:"ref"`
 }
 
 func DecodeBatch(data []byte, intern map[string]string) ([]RpcObjectData, error) {
@@ -87,12 +87,8 @@ func DecodeBatch(data []byte, intern map[string]string) ([]RpcObjectData, error)
 	for i := range wire {
 		w := &wire[i]
 		d := RpcObjectData{State: parseState(w.State), ValueType: w.ValueType, Ref: w.Ref}
-		if len(w.Value) > 0 {
-			var v any
-			if err := json.Unmarshal(w.Value, &v); err != nil {
-				return nil, err
-			}
-			d.Value = internValue(v, intern)
+		if w.Value != nil {
+			d.Value = internValue(w.Value, intern)
 		}
 		batch[i] = d
 	}

--- a/rewrite-go/pkg/rpc/rpc_object_data.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data.go
@@ -16,7 +16,12 @@
 
 package rpc
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
 
 type State int
 
@@ -79,18 +84,32 @@ type wireObjectData struct {
 }
 
 func DecodeBatch(data []byte, intern map[string]string) ([]RpcObjectData, error) {
-	var wire []wireObjectData
-	if err := json.Unmarshal(data, &wire); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	open, err := dec.Token()
+	if err != nil {
+		if err == io.EOF {
+			return nil, nil
+		}
 		return nil, err
 	}
-	batch := make([]RpcObjectData, len(wire))
-	for i := range wire {
-		w := &wire[i]
+	if open == nil {
+		return nil, nil
+	}
+	if d, ok := open.(json.Delim); !ok || d != '[' {
+		return nil, fmt.Errorf("expected JSON array, got %v", open)
+	}
+	batch := make([]RpcObjectData, 0, len(data)/40+1)
+	var w wireObjectData
+	for dec.More() {
+		w = wireObjectData{}
+		if err := dec.Decode(&w); err != nil {
+			return nil, err
+		}
 		d := RpcObjectData{State: parseState(w.State), ValueType: w.ValueType, Ref: w.Ref}
 		if w.Value != nil {
 			d.Value = internValue(w.Value, intern)
 		}
-		batch[i] = d
+		batch = append(batch, d)
 	}
 	return batch, nil
 }


### PR DESCRIPTION
## What's changed?

- Continuation of #8253.
- Reducing the amount of object allocation on deserialization in Go RPC by roughly ~20%.

## What's your motivation?

In a hope to lower the memory footprint of Go recipe runs.
