### PR TITLE
Go: add outbound pagination of GetObject RPC

### DIFF
--- a/rewrite-go/cmd/rpc/get_object_test.go
+++ b/rewrite-go/cmd/rpc/get_object_test.go
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"testing"
+
+	goparser "github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/rpc"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+func getObjectParams(t *testing.T, id string) json.RawMessage {
+	t.Helper()
+	params, err := json.Marshal(getObjectRequest{ID: id})
+	if err != nil {
+		t.Fatalf("marshal GetObject params: %v", err)
+	}
+	return params
+}
+
+func getObjectBatchForTest(t *testing.T, s *server, params json.RawMessage) []rpc.RpcObjectData {
+	t.Helper()
+	result, rpcErr := s.handleGetObject(params)
+	if rpcErr != nil {
+		t.Fatalf("GetObject failed: %+v", rpcErr)
+	}
+	return result.([]rpc.RpcObjectData)
+}
+
+func getObjectTreeForTest(t *testing.T) java.Tree {
+	t.Helper()
+	cu, err := goparser.NewGoParser().Parse("main.go", "package main\n")
+	if err != nil {
+		t.Fatalf("parse test source: %v", err)
+	}
+	return cu
+}
+
+func TestHandleGetObjectReturnsOneBatchPerRequest(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.batchSize = 3
+
+	const id = "tree"
+	tree := getObjectTreeForTest(t)
+	s.localObjects[id] = tree
+	params := getObjectParams(t, id)
+
+	first := getObjectBatchForTest(t, s, params)
+	if len(first) != s.batchSize || first[0].State != rpc.Add {
+		t.Fatalf("first batch = %+v, want a full batch beginning with ADD", first)
+	}
+	if _, complete := s.remoteObjects[id]; complete {
+		t.Fatal("remote baseline was updated before END_OF_OBJECT was delivered")
+	}
+	if _, active := s.inProgressGetObjects[id]; !active {
+		t.Fatal("transfer was not retained for the next GetObject request")
+	}
+
+	for {
+		batch := getObjectBatchForTest(t, s, params)
+		if len(batch) > s.batchSize {
+			t.Fatalf("batch length = %d, want at most %d", len(batch), s.batchSize)
+		}
+		if batch[len(batch)-1].State == rpc.EndOfObject {
+			break
+		}
+		if _, complete := s.remoteObjects[id]; complete {
+			t.Fatal("remote baseline was updated before END_OF_OBJECT was delivered")
+		}
+	}
+	if got := s.remoteObjects[id]; got != tree {
+		t.Fatalf("remote baseline = %#v, want transferred object", got)
+	}
+	if _, active := s.inProgressGetObjects[id]; active {
+		t.Fatal("completed transfer was not removed")
+	}
+}
+
+func TestHandleGetObjectBatchesAreConsumedByReceiveQueue(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.batchSize = 3
+
+	const id = "tree"
+	const want = "package main\n"
+	s.localObjects[id] = getObjectTreeForTest(t)
+	params := getObjectParams(t, id)
+	pulls := 0
+
+	q := rpc.NewReceiveQueue(make(map[int]any), func() []rpc.RpcObjectData {
+		pulls++
+		return getObjectBatchForTest(t, s, params)
+	})
+	receiver := rpc.NewGoReceiver()
+	got := q.Receive(nil, func(v any) any {
+		if tree, ok := v.(java.Tree); ok {
+			return receiver.Visit(tree, q)
+		}
+		return v
+	})
+	gotTree, ok := got.(java.Tree)
+	if !ok {
+		t.Fatalf("received object = %T, want java.Tree", got)
+	}
+	if printed := printer.Print(gotTree); printed != want {
+		t.Fatalf("received source = %q, want %q", printed, want)
+	}
+	if end := q.Take(); end.State != rpc.EndOfObject {
+		t.Fatalf("end marker = %s, want END_OF_OBJECT", end.State)
+	}
+	if pulls < 2 {
+		t.Fatalf("GetObject pulls = %d, want a multi-batch transfer", pulls)
+	}
+}
+
+func TestResetCancelsInProgressGetObject(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.batchSize = 1
+
+	const id = "tree"
+	s.localObjects[id] = getObjectTreeForTest(t)
+	params := getObjectParams(t, id)
+	_ = getObjectBatchForTest(t, s, params)
+
+	s.handleReset()
+	if len(s.inProgressGetObjects) != 0 {
+		t.Fatalf("in-progress transfers after Reset = %d, want 0", len(s.inProgressGetObjects))
+	}
+	if len(s.localObjects) != 0 || len(s.remoteObjects) != 0 {
+		t.Fatal("Reset did not clear object state")
+	}
+}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -79,6 +79,8 @@ type server struct {
 	remoteRefs    map[int]any
 	batchSize     int
 
+	inProgressGetObjects map[string]*getObjectTransfer
+
 	// Separate state for reverse GetObject (Java→Go) to avoid conflating
 	// with forward direction state
 	reverseRemoteObjects map[string]any
@@ -207,6 +209,7 @@ func newServer(cfg serverConfig) *server {
 		remoteObjects:           make(map[string]any),
 		localRefs:               make(map[uintptr]int),
 		remoteRefs:              make(map[int]any),
+		inProgressGetObjects:    make(map[string]*getObjectTransfer),
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
 		reverseTypePool:         make(map[string]java.JavaType),
@@ -752,42 +755,115 @@ type getObjectRequest struct {
 	SourceFileType string `json:"sourceFileType"`
 }
 
+type getObjectBatch struct {
+	data []rpc.RpcObjectData
+	err  error
+}
+
+type getObjectTransfer struct {
+	after      any
+	batches    chan getObjectBatch
+	cancel     chan struct{}
+	cancelOnce sync.Once
+}
+
+type getObjectTransferCanceled struct{}
+
+func (t *getObjectTransfer) stop() {
+	t.cancelOnce.Do(func() {
+		close(t.cancel)
+	})
+}
+
+func (s *server) startGetObjectTransfer(id string, after, before any) *getObjectTransfer {
+	t := &getObjectTransfer{
+		after:   after,
+		batches: make(chan getObjectBatch, 1),
+		cancel:  make(chan struct{}),
+	}
+
+	// Use a fresh ref map for each complete GetObject exchange to avoid ref ID
+	// collisions between the reverse direction (Java→Go) and forward
+	// direction (Go→Java). It must span every batch in this transfer.
+	localRefs := make(map[uintptr]int)
+	q := rpc.NewSendQueue(s.batchSize, func(batch []rpc.RpcObjectData) {
+		select {
+		case t.batches <- getObjectBatch{data: batch}:
+		case <-t.cancel:
+			panic(getObjectTransferCanceled{})
+		}
+	}, localRefs)
+
+	go func() {
+		defer close(t.batches)
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if _, canceled := recovered.(getObjectTransferCanceled); canceled {
+					return
+				}
+
+				buf := make([]byte, 4096)
+				n := runtime.Stack(buf, false)
+				s.logger.Printf("PANIC producing GetObject %s: %v\n%s", id, recovered, buf[:n])
+				err := fmt.Errorf("GetObject traversal failed: %v", recovered)
+				select {
+				case t.batches <- getObjectBatch{err: err}:
+				case <-t.cancel:
+				}
+			}
+		}()
+
+		sender := rpc.NewGoSender()
+		q.Send(after, before, func(v any) {
+			if tree, ok := v.(java.Tree); ok {
+				sender.Visit(tree, q)
+			}
+		})
+		q.Put(rpc.RpcObjectData{State: rpc.EndOfObject})
+		q.Flush()
+	}()
+
+	return t
+}
+
 func (s *server) handleGetObject(params json.RawMessage) (any, *rpcError) {
 	var req getObjectRequest
 	if err := json.Unmarshal(params, &req); err != nil {
 		return nil, &rpcError{Code: -32602, Message: fmt.Sprintf("Invalid params: %v", err)}
 	}
 
-	obj := s.localObjects[req.ID]
-	if obj == nil {
-		return []rpc.RpcObjectData{
-			{State: rpc.Delete},
-			{State: rpc.EndOfObject},
-		}, nil
+	t := s.inProgressGetObjects[req.ID]
+	if t == nil {
+		obj := s.localObjects[req.ID]
+		if obj == nil {
+			return []rpc.RpcObjectData{
+				{State: rpc.Delete},
+				{State: rpc.EndOfObject},
+			}, nil
+		}
+
+		t = s.startGetObjectTransfer(req.ID, obj, s.remoteObjects[req.ID])
+		s.inProgressGetObjects[req.ID] = t
 	}
 
-	before := s.remoteObjects[req.ID]
-	// Use a fresh ref map for each GetObject to avoid ref ID collisions
-	// between the reverse direction (Java→Go) and forward direction (Go→Java).
-	localRefs := make(map[uintptr]int)
+	batch, ok := <-t.batches
+	if !ok {
+		delete(s.inProgressGetObjects, req.ID)
+		delete(s.remoteObjects, req.ID)
+		return nil, &rpcError{Code: -32603, Message: "GetObject traversal ended without END_OF_OBJECT"}
+	}
+	if batch.err != nil {
+		delete(s.inProgressGetObjects, req.ID)
+		delete(s.remoteObjects, req.ID)
+		return nil, &rpcError{Code: -32603, Message: batch.err.Error()}
+	}
 
-	var result []rpc.RpcObjectData
-	q := rpc.NewSendQueue(s.batchSize, func(batch []rpc.RpcObjectData) {
-		result = append(result, batch...)
-	}, localRefs)
+	if len(batch.data) > 0 && batch.data[len(batch.data)-1].State == rpc.EndOfObject {
+		delete(s.inProgressGetObjects, req.ID)
+		s.remoteObjects[req.ID] = t.after
+	}
 
-	sender := rpc.NewGoSender()
-	q.Send(obj, before, func(v any) {
-		if t, ok := v.(java.Tree); ok {
-			sender.Visit(t, q)
-		}
-	})
-	q.Put(rpc.RpcObjectData{State: rpc.EndOfObject})
-	q.Flush()
-
-	s.remoteObjects[req.ID] = obj
-
-	return result, nil
+	return batch.data, nil
 }
 
 type printRequest struct {
@@ -1043,6 +1119,10 @@ func (s *server) handleInstallRecipes(params json.RawMessage) (any, *rpcError) {
 }
 
 func (s *server) handleReset() bool {
+	for _, transfer := range s.inProgressGetObjects {
+		transfer.stop()
+	}
+	s.inProgressGetObjects = make(map[string]*getObjectTransfer)
 	s.localObjects = make(map[string]any)
 	s.remoteObjects = make(map[string]any)
 	s.localRefs = make(map[uintptr]int)


### PR DESCRIPTION
## What's changed?

- Related to #8251. 
- Use pagination in Go outbound `GetObject` requests, the standard way as it's done in other languages.

## What's your motivation?

In a hope to lower the memory footprint of Go recipe runs. Or at least memory allocations.
