### PR TITLE
Go: receiveTypedList in RPC

### DIFF
--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -124,16 +124,10 @@ func (r *GoReceiver) VisitCompilationUnit(cu *golang.CompilationUnit, p any) jav
 	// imports (container)
 	cu.Imports = receivePointerContainer[*java.Import](r, q, cu.Imports)
 	// statements
-	beforeStmts := make([]any, len(cu.Statements))
-	for i, s := range cu.Statements {
-		beforeStmts[i] = s
-	}
-	afterStmts := q.ReceiveList(beforeStmts, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterStmts != nil {
-		cu.Statements = make([]java.RightPadded[java.Statement], len(afterStmts))
-		for i, s := range afterStmts {
-			cu.Statements[i] = coerceToStatementRP(s)
-		}
+	if after := receiveTypedList(q, cu.Statements,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		coerceToStatementRP); after != nil {
+		cu.Statements = after
 	}
 	cu.EOF = receiveValue(q, cu.EOF, func(e java.Space) any { return receiveSpace(e, q) })
 	return cu
@@ -350,16 +344,10 @@ func (r *GoReceiver) VisitUnion(u *golang.Union, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *u // shallow copy to avoid mutating remoteObjects baseline
 	u = &c
-	beforeTypes := make([]any, len(u.Types))
-	for i, t := range u.Types {
-		beforeTypes[i] = t
-	}
-	afterTypes := q.ReceiveList(beforeTypes, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterTypes != nil {
-		u.Types = make([]java.RightPadded[java.Expression], len(afterTypes))
-		for i, t := range afterTypes {
-			u.Types[i] = coerceToExpressionRP(t)
-		}
+	if after := receiveTypedList(q, u.Types,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		coerceToExpressionRP); after != nil {
+		u.Types = after
 	}
 	return u
 }
@@ -377,18 +365,10 @@ func (r *GoReceiver) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
 	c := *td // shallow copy to avoid mutating remoteObjects baseline
 	td = &c
 	// leadingAnnotations
-	beforeAnns := make([]any, len(td.LeadingAnnotations))
-	for i, a := range td.LeadingAnnotations {
-		beforeAnns[i] = a
-	}
-	afterAnns := q.ReceiveList(beforeAnns, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if afterAnns != nil {
-		td.LeadingAnnotations = make([]*java.Annotation, 0, len(afterAnns))
-		for _, a := range afterAnns {
-			if a != nil {
-				td.LeadingAnnotations = append(td.LeadingAnnotations, a.(*java.Annotation))
-			}
-		}
+	if after := receiveTypedListNonNil(q, td.LeadingAnnotations,
+		func(v any) any { return r.Visit(v.(java.Tree), q) },
+		coerceAnnotation, annotationIsNil); after != nil {
+		td.LeadingAnnotations = after
 	}
 	td.Name = receiveValue(q, td.Name, func(e *java.Identifier) any { return r.Visit(e, q) })
 	// typeParameters
@@ -413,18 +393,10 @@ func (r *GoReceiver) VisitDeclarationBlock(db *golang.DeclarationBlock, p any) j
 	c := *db // shallow copy to avoid mutating remoteObjects baseline
 	db = &c
 	// leadingAnnotations
-	beforeAnns := make([]any, len(db.LeadingAnnotations))
-	for i, a := range db.LeadingAnnotations {
-		beforeAnns[i] = a
-	}
-	afterAnns := q.ReceiveList(beforeAnns, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if afterAnns != nil {
-		db.LeadingAnnotations = make([]*java.Annotation, 0, len(afterAnns))
-		for _, a := range afterAnns {
-			if a != nil {
-				db.LeadingAnnotations = append(db.LeadingAnnotations, a.(*java.Annotation))
-			}
-		}
+	if after := receiveTypedListNonNil(q, db.LeadingAnnotations,
+		func(v any) any { return r.Visit(v.(java.Tree), q) },
+		coerceAnnotation, annotationIsNil); after != nil {
+		db.LeadingAnnotations = after
 	}
 	// kind
 	kindStr := receiveScalar[string](q, "")
@@ -442,30 +414,18 @@ func (r *GoReceiver) VisitMultiAssignment(ma *golang.MultiAssignment, p any) jav
 	q := p.(*ReceiveQueue)
 	c := *ma // shallow copy to avoid mutating remoteObjects baseline
 	ma = &c
-	beforeVars := make([]any, len(ma.Variables))
-	for i, v := range ma.Variables {
-		beforeVars[i] = v
-	}
-	afterVars := q.ReceiveList(beforeVars, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterVars != nil {
-		ma.Variables = make([]java.RightPadded[java.Expression], len(afterVars))
-		for i, v := range afterVars {
-			ma.Variables[i] = coerceToExpressionRP(v)
-		}
+	if after := receiveTypedList(q, ma.Variables,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		coerceToExpressionRP); after != nil {
+		ma.Variables = after
 	}
 	if result := q.Receive(ma.Operator, func(v any) any { return receiveLeftPadded(r, q, v) }); result != nil {
 		ma.Operator = result.(java.LeftPadded[java.Space])
 	}
-	beforeVals := make([]any, len(ma.Values))
-	for i, v := range ma.Values {
-		beforeVals[i] = v
-	}
-	afterVals := q.ReceiveList(beforeVals, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterVals != nil {
-		ma.Values = make([]java.RightPadded[java.Expression], len(afterVals))
-		for i, v := range afterVals {
-			ma.Values[i] = coerceToExpressionRP(v)
-		}
+	if after := receiveTypedList(q, ma.Values,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		coerceToExpressionRP); after != nil {
+		ma.Values = after
 	}
 	return ma
 }
@@ -474,16 +434,10 @@ func (r *GoReceiver) VisitGoReturn(ret *golang.Return, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *ret // shallow copy to avoid mutating remoteObjects baseline
 	ret = &c
-	beforeExprs := make([]any, len(ret.Expressions))
-	for i, e := range ret.Expressions {
-		beforeExprs[i] = e
-	}
-	afterExprs := q.ReceiveList(beforeExprs, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterExprs != nil {
-		ret.Expressions = make([]java.RightPadded[java.Expression], len(afterExprs))
-		for i, v := range afterExprs {
-			ret.Expressions[i] = coerceToExpressionRP(v)
-		}
+	if after := receiveTypedList(q, ret.Expressions,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		coerceToExpressionRP); after != nil {
+		ret.Expressions = after
 	}
 	return ret
 }
@@ -514,16 +468,10 @@ func (r *GoReceiver) VisitCommClause(cc *golang.CommClause, p any) java.J {
 	cc = &c
 	cc.Comm = receiveValue(q, cc.Comm, func(e java.Statement) any { return r.Visit(e, q) })
 	cc.Colon = receiveValue(q, cc.Colon, func(e java.Space) any { return receiveSpace(e, q) })
-	beforeBody := make([]any, len(cc.Body))
-	for i, s := range cc.Body {
-		beforeBody[i] = s
-	}
-	afterBody := q.ReceiveList(beforeBody, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterBody != nil {
-		cc.Body = make([]java.RightPadded[java.Statement], len(afterBody))
-		for i, s := range afterBody {
-			cc.Body[i] = coerceToStatementRP(s)
-		}
+	if after := receiveTypedList(q, cc.Body,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		coerceToStatementRP); after != nil {
+		cc.Body = after
 	}
 	return cc
 }

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -121,16 +121,10 @@ func (r *JavaReceiver) VisitIdentifier(id *java.Identifier, p any) java.J {
 	c := *id // shallow copy to avoid mutating remoteObjects baseline
 	id = &c
 	// annotations
-	beforeAnns := make([]any, len(id.Annotations))
-	for i, a := range id.Annotations {
-		beforeAnns[i] = a
-	}
-	afterAnns := q.ReceiveList(beforeAnns, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if afterAnns != nil {
-		id.Annotations = make([]java.Tree, len(afterAnns))
-		for i, a := range afterAnns {
-			id.Annotations[i] = a.(java.Tree)
-		}
+	if after := receiveTypedList(q, id.Annotations,
+		func(v any) any { return r.Visit(v.(java.Tree), q) },
+		func(v any) java.Tree { return v.(java.Tree) }); after != nil {
+		id.Annotations = after
 	}
 	// simpleName
 	id.Name = receiveScalar[string](q, id.Name)
@@ -155,25 +149,12 @@ func (r *JavaReceiver) VisitLiteral(lit *java.Literal, p any) java.J {
 	// valueSource
 	lit.Source = receiveScalar[string](q, lit.Source)
 	// unicodeEscapes (typically empty for Go)
-	before := make([]any, len(lit.UnicodeEscapes))
-	for i, e := range lit.UnicodeEscapes {
-		before[i] = e
-	}
-	after := q.ReceiveList(before, func(v any) any {
+	lit.UnicodeEscapes = receiveTypedList(q, lit.UnicodeEscapes, func(v any) any {
 		e, _ := v.(java.UnicodeEscape)
 		e.ValueSourceIndex = receiveScalar[int](q, e.ValueSourceIndex)
 		e.CodePoint = receiveScalar[string](q, e.CodePoint)
 		return e
-	})
-	if after != nil {
-		escapes := make([]java.UnicodeEscape, len(after))
-		for i, v := range after {
-			escapes[i] = v.(java.UnicodeEscape)
-		}
-		lit.UnicodeEscapes = escapes
-	} else {
-		lit.UnicodeEscapes = nil
-	}
+	}, func(v any) java.UnicodeEscape { return v.(java.UnicodeEscape) })
 	// type (as ref)
 	lit.Type = r.receiveType(lit.Type, q)
 	return lit
@@ -197,16 +178,10 @@ func (r *JavaReceiver) VisitBlock(b *java.Block, p any) java.J {
 	// static (right-padded) - Java-only field, not stored in Go Block
 	q.Receive(nil, func(v any) any { return receiveRightPadded(r, q, v) })
 	// statements
-	beforeStmts := make([]any, len(b.Statements))
-	for i, s := range b.Statements {
-		beforeStmts[i] = s
-	}
-	afterStmts := q.ReceiveList(beforeStmts, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterStmts != nil {
-		b.Statements = make([]java.RightPadded[java.Statement], len(afterStmts))
-		for i, s := range afterStmts {
-			b.Statements[i] = coerceToStatementRP(s)
-		}
+	if after := receiveTypedList(q, b.Statements,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		coerceToStatementRP); after != nil {
+		b.Statements = after
 	}
 	// end space
 	b.End = receiveValue(q, b.End, func(e java.Space) any { return receiveSpace(e, q) })
@@ -305,18 +280,10 @@ func (r *JavaReceiver) VisitMethodDeclaration(md *java.MethodDeclaration, p any)
 	c := *md // shallow copy to avoid mutating remoteObjects baseline
 	md = &c
 	// leadingAnnotations
-	beforeAnns := make([]any, len(md.LeadingAnnotations))
-	for i, a := range md.LeadingAnnotations {
-		beforeAnns[i] = a
-	}
-	afterAnns := q.ReceiveList(beforeAnns, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if afterAnns != nil {
-		md.LeadingAnnotations = make([]*java.Annotation, 0, len(afterAnns))
-		for _, a := range afterAnns {
-			if a != nil {
-				md.LeadingAnnotations = append(md.LeadingAnnotations, a.(*java.Annotation))
-			}
-		}
+	if after := receiveTypedListNonNil(q, md.LeadingAnnotations,
+		func(v any) any { return r.Visit(v.(java.Tree), q) },
+		coerceAnnotation, annotationIsNil); after != nil {
+		md.LeadingAnnotations = after
 	}
 	// modifiers
 	q.ReceiveList(nil, nil)
@@ -355,16 +322,10 @@ func (r *JavaReceiver) VisitTypeParameters(tps *java.TypeParameters, p any) java
 	// annotations
 	q.ReceiveList(nil, nil)
 	// typeParameters (list of right-padded J$TypeParameter)
-	beforeElems := make([]any, len(tps.TypeParameters))
-	for i, e := range tps.TypeParameters {
-		beforeElems[i] = e
-	}
-	afterElems := q.ReceiveList(beforeElems, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterElems != nil {
-		tps.TypeParameters = make([]java.RightPadded[java.J], len(afterElems))
-		for i, e := range afterElems {
-			tps.TypeParameters[i] = e.(java.RightPadded[java.J])
-		}
+	if after := receiveTypedList(q, tps.TypeParameters,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		func(v any) java.RightPadded[java.J] { return v.(java.RightPadded[java.J]) }); after != nil {
+		tps.TypeParameters = after
 	}
 	return tps
 }
@@ -389,18 +350,10 @@ func (r *JavaReceiver) VisitVariableDeclarations(vd *java.VariableDeclarations, 
 	c := *vd // shallow copy to avoid mutating remoteObjects baseline
 	vd = &c
 	// leadingAnnotations
-	beforeAnns := make([]any, len(vd.LeadingAnnotations))
-	for i, a := range vd.LeadingAnnotations {
-		beforeAnns[i] = a
-	}
-	afterAnns := q.ReceiveList(beforeAnns, func(v any) any { return r.Visit(v.(java.Tree), q) })
-	if afterAnns != nil {
-		vd.LeadingAnnotations = make([]*java.Annotation, 0, len(afterAnns))
-		for _, a := range afterAnns {
-			if a != nil {
-				vd.LeadingAnnotations = append(vd.LeadingAnnotations, a.(*java.Annotation))
-			}
-		}
+	if after := receiveTypedListNonNil(q, vd.LeadingAnnotations,
+		func(v any) any { return r.Visit(v.(java.Tree), q) },
+		coerceAnnotation, annotationIsNil); after != nil {
+		vd.LeadingAnnotations = after
 	}
 	// modifiers
 	q.ReceiveList(nil, nil)
@@ -416,16 +369,12 @@ func (r *JavaReceiver) VisitVariableDeclarations(vd *java.VariableDeclarations, 
 		vd.Varargs = &sp
 	}
 	// variables
-	beforeVars := make([]any, len(vd.Variables))
-	for i, v := range vd.Variables {
-		beforeVars[i] = v
-	}
-	afterVars := q.ReceiveList(beforeVars, func(v any) any { return receiveRightPadded(r, q, v) })
-	if afterVars != nil {
-		vd.Variables = make([]java.RightPadded[*java.VariableDeclarator], len(afterVars))
-		for i, v := range afterVars {
-			vd.Variables[i] = v.(java.RightPadded[*java.VariableDeclarator])
-		}
+	if after := receiveTypedList(q, vd.Variables,
+		func(v any) any { return receiveRightPadded(r, q, v) },
+		func(v any) java.RightPadded[*java.VariableDeclarator] {
+			return v.(java.RightPadded[*java.VariableDeclarator])
+		}); after != nil {
+		vd.Variables = after
 	}
 	return vd
 }
@@ -511,13 +460,13 @@ func (r *JavaReceiver) VisitForControl(fc *java.ForControl, p any) java.J {
 	c := *fc // shallow copy to avoid mutating remoteObjects baseline
 	fc = &c
 	// init (list of right-padded)
-	var beforeInit []any
+	var beforeInit []java.RightPadded[java.Statement]
 	if fc.Init != nil {
-		beforeInit = []any{*fc.Init}
+		beforeInit = []java.RightPadded[java.Statement]{*fc.Init}
 	}
-	initList := q.ReceiveList(beforeInit, func(v any) any { return receiveRightPadded(r, q, v) })
+	initList := receiveTypedList(q, beforeInit, func(v any) any { return receiveRightPadded(r, q, v) }, coerceToStatementRP)
 	if len(initList) > 0 {
-		rp := coerceToStatementRP(initList[0])
+		rp := initList[0]
 		fc.Init = &rp
 	} else {
 		fc.Init = nil
@@ -534,13 +483,13 @@ func (r *JavaReceiver) VisitForControl(fc *java.ForControl, p any) java.J {
 		fc.Condition = nil
 	}
 	// update (list of right-padded)
-	var beforeUpdate []any
+	var beforeUpdate []java.RightPadded[java.Statement]
 	if fc.Update != nil {
-		beforeUpdate = []any{*fc.Update}
+		beforeUpdate = []java.RightPadded[java.Statement]{*fc.Update}
 	}
-	updateList := q.ReceiveList(beforeUpdate, func(v any) any { return receiveRightPadded(r, q, v) })
+	updateList := receiveTypedList(q, beforeUpdate, func(v any) any { return receiveRightPadded(r, q, v) }, coerceToStatementRP)
 	if len(updateList) > 0 {
-		rp := coerceToStatementRP(updateList[0])
+		rp := updateList[0]
 		fc.Update = &rp
 	} else {
 		fc.Update = nil

--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -327,6 +327,17 @@ func coerceToStatementRP(rp any) java.RightPadded[java.Statement] {
 	panic(fmt.Sprintf("coerceToStatementRP: element does not implement java.Statement (rp=%T elem=%T nil=%v)", rp, elem, elem == nil))
 }
 
+// coerceAnnotation narrows a received leadingAnnotations element to *java.Annotation,
+// mapping a nil element to nil so receiveTypedListNonNil can drop it.
+func coerceAnnotation(v any) *java.Annotation {
+	if v == nil {
+		return nil
+	}
+	return v.(*java.Annotation)
+}
+
+func annotationIsNil(a *java.Annotation) bool { return a == nil }
+
 // coerceLeftPaddedIdent converts a LeftPadded of any variant to LeftPadded[*Identifier].
 // Java may send the value generic-parameterized on Expression even though the element
 // is an *Identifier; this helper bridges that asymmetry.

--- a/rewrite-go/pkg/rpc/receive_list_bench_test.go
+++ b/rewrite-go/pkg/rpc/receive_list_bench_test.go
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+func buildUnchangedListBatch(n int) []RpcObjectData {
+	positions := make([]any, n)
+	for i := range positions {
+		positions[i] = i
+	}
+	batch := make([]RpcObjectData, 0, n+2)
+	batch = append(batch, RpcObjectData{State: Change})
+	batch = append(batch, RpcObjectData{State: Change, Value: positions})
+	for i := 0; i < n; i++ {
+		batch = append(batch, RpcObjectData{State: NoChange})
+	}
+	return batch
+}
+
+func newBatchQueue(batch []RpcObjectData) *ReceiveQueue {
+	return NewReceiveQueue(map[int]any{}, func() []RpcObjectData { return batch })
+}
+
+func makeStmtSlice(n int) []java.RightPadded[java.Statement] {
+	before := make([]java.RightPadded[java.Statement], n)
+	for i := range before {
+		before[i] = java.RightPadded[java.Statement]{}
+	}
+	return before
+}
+
+const benchListSize = 64
+
+func receiveStatementsLegacy(q *ReceiveQueue, before []java.RightPadded[java.Statement]) []java.RightPadded[java.Statement] {
+	beforeStmts := make([]any, len(before))
+	for i, s := range before {
+		beforeStmts[i] = s
+	}
+	afterStmts := q.ReceiveList(beforeStmts, func(v any) any { return v })
+	if afterStmts != nil {
+		out := make([]java.RightPadded[java.Statement], len(afterStmts))
+		for i, s := range afterStmts {
+			out[i] = coerceToStatementRP(s)
+		}
+		return out
+	}
+	return before
+}
+
+func BenchmarkReceiveList_Legacy(b *testing.B) {
+	before := makeStmtSlice(benchListSize)
+	batch := buildUnchangedListBatch(benchListSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := newBatchQueue(batch)
+		_ = receiveStatementsLegacy(q, before)
+	}
+}
+
+func BenchmarkReceiveList_Typed(b *testing.B) {
+	before := makeStmtSlice(benchListSize)
+	batch := buildUnchangedListBatch(benchListSize)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		q := newBatchQueue(batch)
+		_ = receiveTypedList(q, before, func(v any) any { return v }, coerceToStatementRP)
+	}
+}

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -76,6 +76,13 @@ func (q *ReceiveQueue) Take() RpcObjectData {
 	return msg
 }
 
+func (q *ReceiveQueue) peek() RpcObjectData {
+	if len(q.batch) == 0 {
+		q.batch = q.pull()
+	}
+	return q.batch[0]
+}
+
 // Receive reads the next value from the queue.
 // If onChange is non-nil, it's called for ADD/CHANGE states to deserialize nested fields.
 func (q *ReceiveQueue) Receive(before any, onChange func(any) any) any {
@@ -230,6 +237,11 @@ func convertTo[T any](v any) T {
 }
 
 func (q *ReceiveQueue) ReceiveList(before []any, onChange func(any) any) []any {
+	return receiveTypedList(q, before, onChange, func(v any) any { return v })
+}
+
+// receiveTypedList is the generic, allocation-lean counterpart to ReceiveList.
+func receiveTypedList[T any](q *ReceiveQueue, before []T, onChange func(any) any, coerce func(any) T) []T {
 	msg := q.Take()
 
 	switch msg.State {
@@ -238,10 +250,9 @@ func (q *ReceiveQueue) ReceiveList(before []any, onChange func(any) any) []any {
 	case Delete:
 		return nil
 	case Add:
-		before = []any{}
+		before = []T{}
 		fallthrough
 	case Change:
-		// Next message contains positions
 		posMsg := q.Take()
 		if posMsg.State != Change {
 			panic(fmt.Sprintf("expected CHANGE with positions, got %v (value=%v, valueType=%v)", posMsg.State, posMsg.Value, posMsg.ValueType))
@@ -250,23 +261,59 @@ func (q *ReceiveQueue) ReceiveList(before []any, onChange func(any) any) []any {
 		if !ok {
 			panic(fmt.Sprintf("expected []any positions, got %T", posMsg.Value))
 		}
-		after := make([]any, len(positionsRaw))
+		after := make([]T, len(positionsRaw))
 		for i, posRaw := range positionsRaw {
 			pos := toInt(posRaw)
+			hasBefore := pos >= 0 && before != nil && pos < len(before)
+			// Unchanged elements — the common case, since a recipe touches few nodes —
+			// are copied across in their static type T. Routing them through Receive
+			// would box before[pos] into `any` (a heap allocation per element for the
+			// non-pointer struct types these lists hold) only to hand the same value back.
+			if hasBefore && q.peek().State == NoChange {
+				q.Take()
+				after[i] = before[pos]
+				continue
+			}
 			var beforeItem any
-			if pos >= 0 && before != nil && pos < len(before) {
+			if hasBefore {
 				beforeItem = before[pos]
 			}
-			after[i] = q.Receive(beforeItem, onChange)
+			after[i] = coerce(q.Receive(beforeItem, onChange))
 		}
 		return after
 	case EndOfObject:
-		// Sentinel from multi-batch GetObject; push back and return before unchanged
 		q.batch = append([]RpcObjectData{msg}, q.batch...)
 		return before
 	default:
 		panic(fmt.Sprintf("unsupported state for list: %v", msg.State))
 	}
+}
+
+// receiveTypedListNonNil is receiveTypedList for fields (e.g. leadingAnnotations) that drop
+// elements onChange narrowed to the zero T. It never mutates before: compaction only ever
+// rebuilds a freshly allocated ADD/CHANGE slice, and the NO_CHANGE slice — which holds no
+// dropped elements — is returned as is.
+func receiveTypedListNonNil[T any](q *ReceiveQueue, before []T, onChange func(any) any, coerce func(any) T, isNil func(T) bool) []T {
+	after := receiveTypedList(q, before, onChange, coerce)
+	if after == nil {
+		return nil
+	}
+	kept := 0
+	for _, e := range after {
+		if !isNil(e) {
+			kept++
+		}
+	}
+	if kept == len(after) {
+		return after
+	}
+	out := make([]T, 0, kept)
+	for _, e := range after {
+		if !isNil(e) {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 func toInt(v any) int {


### PR DESCRIPTION
## What's changed?

- Related to #8251. 
- An optimization to how Go RPC receives lists/arrays. Using `receiveTypedList` method which is more efficient when it comes to object allocations.

## What's your motivation?

In a hope to lower the memory footprint of Go recipe runs.
