### PR TITLE
JavaScript: fix id=0 corner case in RPC

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -225,7 +225,7 @@ export class RpcSendQueue {
         let ref: number | undefined;
         if (isRef(after)) {
             ref = this.refs.get(after);
-            if (ref) {
+            if (ref !== undefined) {
                 this.put({
                     state: RpcObjectState.ADD,
                     ref

--- a/rewrite-javascript/rewrite/test/rpc/queue.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/queue.test.ts
@@ -18,6 +18,19 @@ describe("RPC queues", () => {
         expect(refs.has(ref2)).toBeTruthy();
     })
 
+    test("reuses reference ID zero", async () => {
+        const value = asRef({kind: Json.Kind.Space, comments: [], whitespace: "\n"});
+        const queue = new RpcSendQueue(new ReferenceMap(), Json.Kind.Document, false);
+
+        await queue.generate(value, undefined);
+        const batch = await queue.generate(value, undefined);
+
+        expect(batch).toEqual([
+            {state: RpcObjectState.ADD, ref: 0},
+            {state: RpcObjectState.END_OF_OBJECT},
+        ]);
+    });
+
     test("changePropertyType", async () => {
         // Test changing a property from one type to another type
         // This simulates a recipe that changes the type of an object assigned to a property


### PR DESCRIPTION
## What's changed?

Amend the RPC queue implementation in JavaScript to handle ids equal to 0.

## What's your motivation?

It has been found by accident, when comparing RPC implementations between languages.
The JavaScript RPC implementation has been identified to use `0` as the "first" id given out.
But `if (id)` then is conflated with undefined/null.
I suspect the consequence of this corner-case bug is some value not being cached properly and re-requested. Not a big deal. Still worth fixing, I suppose.