### PR TITLE
Go: fix object ref map in outbound RPC communication to store already assigned ids better

### DIFF
--- a/rewrite-go/cmd/rpc/get_object_test.go
+++ b/rewrite-go/cmd/rpc/get_object_test.go
@@ -44,6 +44,19 @@ func getObjectBatchForTest(t *testing.T, s *server, params json.RawMessage) []rp
 	return result.([]rpc.RpcObjectData)
 }
 
+func getCompleteObjectForTest(t *testing.T, s *server, id string) []rpc.RpcObjectData {
+	t.Helper()
+	params := getObjectParams(t, id)
+	var result []rpc.RpcObjectData
+	for {
+		batch := getObjectBatchForTest(t, s, params)
+		result = append(result, batch...)
+		if len(batch) > 0 && batch[len(batch)-1].State == rpc.EndOfObject {
+			return result
+		}
+	}
+}
+
 func getObjectTreeForTest(t *testing.T) java.Tree {
 	t.Helper()
 	cu, err := goparser.NewGoParser().Parse("main.go", "package main\n")
@@ -127,6 +140,34 @@ func TestHandleGetObjectBatchesAreConsumedByReceiveQueue(t *testing.T) {
 	if pulls < 2 {
 		t.Fatalf("GetObject pulls = %d, want a multi-batch transfer", pulls)
 	}
+}
+
+func TestHandleGetObjectReusesReferencesAcrossTransfers(t *testing.T) {
+	s, _ := newTestServer(t)
+	sharedType := &java.JavaTypeClass{
+		Kind:               "Class",
+		FullyQualifiedName: "example.Shared",
+	}
+	s.localObjects["first"] = &java.Identifier{Name: "first", Type: sharedType}
+	s.localObjects["second"] = &java.Identifier{Name: "second", Type: sharedType}
+
+	getCompleteObjectForTest(t, s, "first")
+	refsAfterFirst := len(s.localRefs)
+	if refsAfterFirst == 0 {
+		t.Fatal("first transfer did not retain any references")
+	}
+
+	second := getCompleteObjectForTest(t, s, "second")
+	if got := len(s.localRefs); got != refsAfterFirst {
+		t.Fatalf("references after second transfer = %d, want %d", got, refsAfterFirst)
+	}
+
+	for _, data := range second {
+		if data.State == rpc.Add && data.Ref != nil && data.ValueType == nil && data.Value == nil {
+			return
+		}
+	}
+	t.Fatal("second transfer did not reuse the shared type by reference")
 }
 
 func TestResetCancelsInProgressGetObject(t *testing.T) {

--- a/rewrite-go/cmd/rpc/get_object_test.go
+++ b/rewrite-go/cmd/rpc/get_object_test.go
@@ -152,13 +152,13 @@ func TestHandleGetObjectReusesReferencesAcrossTransfers(t *testing.T) {
 	s.localObjects["second"] = &java.Identifier{Name: "second", Type: sharedType}
 
 	getCompleteObjectForTest(t, s, "first")
-	refsAfterFirst := len(s.localRefs)
+	refsAfterFirst := s.localRefs.Len()
 	if refsAfterFirst == 0 {
 		t.Fatal("first transfer did not retain any references")
 	}
 
 	second := getCompleteObjectForTest(t, s, "second")
-	if got := len(s.localRefs); got != refsAfterFirst {
+	if got := s.localRefs.Len(); got != refsAfterFirst {
 		t.Fatalf("references after second transfer = %d, want %d", got, refsAfterFirst)
 	}
 
@@ -168,6 +168,54 @@ func TestHandleGetObjectReusesReferencesAcrossTransfers(t *testing.T) {
 		}
 	}
 	t.Fatal("second transfer did not reuse the shared type by reference")
+}
+
+func TestHandleGetObjectPublishesReferencesAfterFinalBatch(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.batchSize = 1
+	sharedType := &java.JavaTypeClass{
+		Kind:               "Class",
+		FullyQualifiedName: "example.Shared",
+	}
+	s.localObjects["first"] = &java.Identifier{Name: "first", Type: sharedType}
+	s.localObjects["second"] = &java.Identifier{Name: "second", Type: sharedType}
+
+	firstParams := getObjectParams(t, "first")
+	firstBatch := getObjectBatchForTest(t, s, firstParams)
+	if firstBatch[len(firstBatch)-1].State == rpc.EndOfObject {
+		t.Fatal("first transfer unexpectedly completed in one batch")
+	}
+	if got := s.localRefs.Len(); got != 0 {
+		t.Fatalf("references published before final batch = %d, want 0", got)
+	}
+
+	second := getCompleteObjectForTest(t, s, "second")
+	fullDefinition := false
+	for _, data := range second {
+		if data.State == rpc.Add && data.Ref != nil && data.ValueType != nil {
+			fullDefinition = true
+			break
+		}
+	}
+	if !fullDefinition {
+		t.Fatal("interleaved transfer referenced an object that was not committed yet")
+	}
+
+	for {
+		batch := getObjectBatchForTest(t, s, firstParams)
+		if batch[len(batch)-1].State == rpc.EndOfObject {
+			break
+		}
+	}
+
+	s.localObjects["third"] = &java.Identifier{Name: "third", Type: sharedType}
+	third := getCompleteObjectForTest(t, s, "third")
+	for _, data := range third {
+		if data.State == rpc.Add && data.Ref != nil && data.ValueType == nil && data.Value == nil {
+			return
+		}
+	}
+	t.Fatal("completed transfers did not publish their shared reference")
 }
 
 func TestResetCancelsInProgressGetObject(t *testing.T) {

--- a/rewrite-go/cmd/rpc/get_object_test.go
+++ b/rewrite-go/cmd/rpc/get_object_test.go
@@ -170,7 +170,7 @@ func TestHandleGetObjectReusesReferencesAcrossTransfers(t *testing.T) {
 	t.Fatal("second transfer did not reuse the shared type by reference")
 }
 
-func TestHandleGetObjectPublishesReferencesAfterFinalBatch(t *testing.T) {
+func TestHandleGetObjectRejectsInterleavedTransfers(t *testing.T) {
 	s, _ := newTestServer(t)
 	s.batchSize = 1
 	sharedType := &java.JavaTypeClass{
@@ -185,20 +185,9 @@ func TestHandleGetObjectPublishesReferencesAfterFinalBatch(t *testing.T) {
 	if firstBatch[len(firstBatch)-1].State == rpc.EndOfObject {
 		t.Fatal("first transfer unexpectedly completed in one batch")
 	}
-	if got := s.localRefs.Len(); got != 0 {
-		t.Fatalf("references published before final batch = %d, want 0", got)
-	}
 
-	second := getCompleteObjectForTest(t, s, "second")
-	fullDefinition := false
-	for _, data := range second {
-		if data.State == rpc.Add && data.Ref != nil && data.ValueType != nil {
-			fullDefinition = true
-			break
-		}
-	}
-	if !fullDefinition {
-		t.Fatal("interleaved transfer referenced an object that was not committed yet")
+	if _, rpcErr := s.handleGetObject(getObjectParams(t, "second")); rpcErr == nil {
+		t.Fatal("interleaved transfer was not rejected")
 	}
 
 	for {
@@ -207,15 +196,10 @@ func TestHandleGetObjectPublishesReferencesAfterFinalBatch(t *testing.T) {
 			break
 		}
 	}
-
-	s.localObjects["third"] = &java.Identifier{Name: "third", Type: sharedType}
-	third := getCompleteObjectForTest(t, s, "third")
-	for _, data := range third {
-		if data.State == rpc.Add && data.Ref != nil && data.ValueType == nil && data.Value == nil {
-			return
-		}
+	if len(s.inProgressGetObjects) != 0 {
+		t.Fatalf("in-progress GetObjects after completion = %d, want 0", len(s.inProgressGetObjects))
 	}
-	t.Fatal("completed transfers did not publish their shared reference")
+	getCompleteObjectForTest(t, s, "second")
 }
 
 func TestResetCancelsInProgressGetObject(t *testing.T) {

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -797,7 +797,7 @@ func (s *server) startGetObjectTransfer(id string, after, before any) *getObject
 		defer close(t.batches)
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				q.RollbackReferences()
+				q.DiscardNewReferences()
 
 				if _, canceled := recovered.(getObjectTransferCanceled); canceled {
 					return
@@ -856,20 +856,19 @@ func (s *server) handleGetObject(params json.RawMessage) (any, *rpcError) {
 
 	batch, ok := <-t.batches
 	if !ok {
-		t.sendQueue.RollbackReferences()
+		t.sendQueue.DiscardNewReferences()
 		delete(s.inProgressGetObjects, req.ID)
 		delete(s.remoteObjects, req.ID)
 		return nil, &rpcError{Code: -32603, Message: "GetObject traversal ended without END_OF_OBJECT"}
 	}
 	if batch.err != nil {
-		t.sendQueue.RollbackReferences()
+		t.sendQueue.DiscardNewReferences()
 		delete(s.inProgressGetObjects, req.ID)
 		delete(s.remoteObjects, req.ID)
 		return nil, &rpcError{Code: -32603, Message: batch.err.Error()}
 	}
 
 	if len(batch.data) > 0 && batch.data[len(batch.data)-1].State == rpc.EndOfObject {
-		t.sendQueue.CommitReferences()
 		delete(s.inProgressGetObjects, req.ID)
 		s.remoteObjects[req.ID] = t.after
 	}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -74,8 +74,8 @@ type rpcError struct {
 
 type server struct {
 	localObjects  map[string]any
-	remoteObjects map[string]any  // forward direction: tracks what Java has from Go
-	localRefs     map[uintptr]int // forward direction: tracks references sent to Java
+	remoteObjects map[string]any    // forward direction: tracks what Java has from Go
+	localRefs     *rpc.ReferenceMap // forward direction: tracks references sent to Java
 	batchSize     int
 
 	inProgressGetObjects map[string]*getObjectTransfer
@@ -206,7 +206,7 @@ func newServer(cfg serverConfig) *server {
 	s := &server{
 		localObjects:            make(map[string]any),
 		remoteObjects:           make(map[string]any),
-		localRefs:               make(map[uintptr]int),
+		localRefs:               rpc.NewReferenceMap(),
 		inProgressGetObjects:    make(map[string]*getObjectTransfer),
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
@@ -763,6 +763,7 @@ type getObjectTransfer struct {
 	batches    chan getObjectBatch
 	cancel     chan struct{}
 	cancelOnce sync.Once
+	refs       *rpc.ReferenceTransaction
 }
 
 type getObjectTransferCanceled struct{}
@@ -774,17 +775,17 @@ func (t *getObjectTransfer) stop() {
 }
 
 func (s *server) startGetObjectTransfer(id string, after, before any) *getObjectTransfer {
+	localRefs := s.localRefs.Begin()
 	t := &getObjectTransfer{
 		after:   after,
 		batches: make(chan getObjectBatch, 1),
 		cancel:  make(chan struct{}),
+		refs:    localRefs,
 	}
 
 	// Reference IDs are scoped to the Go→Java direction and persist until
-	// Reset, matching the lifetime of Java's receive table. Keep the map for
-	// the complete transfer so references remain valid across page boundaries.
-	localRefs := s.localRefs
-	savedRefCount := len(localRefs)
+	// Reset, matching the lifetime of Java's receive table. Allocations remain
+	// private to this transfer until its final page is delivered.
 	q := rpc.NewSendQueue(s.batchSize, func(batch []rpc.RpcObjectData) {
 		select {
 		case t.batches <- getObjectBatch{data: batch}:
@@ -797,13 +798,7 @@ func (s *server) startGetObjectTransfer(id string, after, before any) *getObject
 		defer close(t.batches)
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				// The receiver cannot have completed this transfer, so references
-				// first introduced by it must not be reused by later transfers.
-				for ptr, ref := range localRefs {
-					if ref > savedRefCount {
-						delete(localRefs, ptr)
-					}
-				}
+				localRefs.Rollback()
 
 				if _, canceled := recovered.(getObjectTransferCanceled); canceled {
 					return
@@ -855,17 +850,20 @@ func (s *server) handleGetObject(params json.RawMessage) (any, *rpcError) {
 
 	batch, ok := <-t.batches
 	if !ok {
+		t.refs.Rollback()
 		delete(s.inProgressGetObjects, req.ID)
 		delete(s.remoteObjects, req.ID)
 		return nil, &rpcError{Code: -32603, Message: "GetObject traversal ended without END_OF_OBJECT"}
 	}
 	if batch.err != nil {
+		t.refs.Rollback()
 		delete(s.inProgressGetObjects, req.ID)
 		delete(s.remoteObjects, req.ID)
 		return nil, &rpcError{Code: -32603, Message: batch.err.Error()}
 	}
 
 	if len(batch.data) > 0 && batch.data[len(batch.data)-1].State == rpc.EndOfObject {
+		t.refs.Commit()
 		delete(s.inProgressGetObjects, req.ID)
 		s.remoteObjects[req.ID] = t.after
 	}
@@ -1132,7 +1130,7 @@ func (s *server) handleReset() bool {
 	s.inProgressGetObjects = make(map[string]*getObjectTransfer)
 	s.localObjects = make(map[string]any)
 	s.remoteObjects = make(map[string]any)
-	s.localRefs = make(map[uintptr]int)
+	s.localRefs = rpc.NewReferenceMap()
 	s.reverseRemoteObjects = make(map[string]any)
 	s.reverseRemoteRefs = make(map[int]any)
 	s.reverseTypePool = make(map[string]java.JavaType)

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -763,7 +763,7 @@ type getObjectTransfer struct {
 	batches    chan getObjectBatch
 	cancel     chan struct{}
 	cancelOnce sync.Once
-	refs       *rpc.ReferenceTransaction
+	sendQueue  *rpc.SendQueue
 }
 
 type getObjectTransferCanceled struct{}
@@ -775,30 +775,29 @@ func (t *getObjectTransfer) stop() {
 }
 
 func (s *server) startGetObjectTransfer(id string, after, before any) *getObjectTransfer {
-	localRefs := s.localRefs.Begin()
 	t := &getObjectTransfer{
 		after:   after,
 		batches: make(chan getObjectBatch, 1),
 		cancel:  make(chan struct{}),
-		refs:    localRefs,
 	}
 
 	// Reference IDs are scoped to the Go→Java direction and persist until
-	// Reset, matching the lifetime of Java's receive table. Allocations remain
-	// private to this transfer until its final page is delivered.
+	// Reset, matching the lifetime of Java's receive table. GetObject exchanges
+	// are serialized so a ref cannot be reused before its defining page arrives.
 	q := rpc.NewSendQueue(s.batchSize, func(batch []rpc.RpcObjectData) {
 		select {
 		case t.batches <- getObjectBatch{data: batch}:
 		case <-t.cancel:
 			panic(getObjectTransferCanceled{})
 		}
-	}, localRefs)
+	}, s.localRefs)
+	t.sendQueue = q
 
 	go func() {
 		defer close(t.batches)
 		defer func() {
 			if recovered := recover(); recovered != nil {
-				localRefs.Rollback()
+				q.RollbackReferences()
 
 				if _, canceled := recovered.(getObjectTransferCanceled); canceled {
 					return
@@ -833,9 +832,16 @@ func (s *server) handleGetObject(params json.RawMessage) (any, *rpcError) {
 	if err := json.Unmarshal(params, &req); err != nil {
 		return nil, &rpcError{Code: -32602, Message: fmt.Sprintf("Invalid params: %v", err)}
 	}
-
 	t := s.inProgressGetObjects[req.ID]
 	if t == nil {
+		for activeID := range s.inProgressGetObjects {
+			return nil, &rpcError{
+				Code: -32603,
+				Message: fmt.Sprintf("GetObject %s is still in progress; cannot start %s",
+					activeID, req.ID),
+			}
+		}
+
 		obj := s.localObjects[req.ID]
 		if obj == nil {
 			return []rpc.RpcObjectData{
@@ -850,20 +856,20 @@ func (s *server) handleGetObject(params json.RawMessage) (any, *rpcError) {
 
 	batch, ok := <-t.batches
 	if !ok {
-		t.refs.Rollback()
+		t.sendQueue.RollbackReferences()
 		delete(s.inProgressGetObjects, req.ID)
 		delete(s.remoteObjects, req.ID)
 		return nil, &rpcError{Code: -32603, Message: "GetObject traversal ended without END_OF_OBJECT"}
 	}
 	if batch.err != nil {
-		t.refs.Rollback()
+		t.sendQueue.RollbackReferences()
 		delete(s.inProgressGetObjects, req.ID)
 		delete(s.remoteObjects, req.ID)
 		return nil, &rpcError{Code: -32603, Message: batch.err.Error()}
 	}
 
 	if len(batch.data) > 0 && batch.data[len(batch.data)-1].State == rpc.EndOfObject {
-		t.refs.Commit()
+		t.sendQueue.CommitReferences()
 		delete(s.inProgressGetObjects, req.ID)
 		s.remoteObjects[req.ID] = t.after
 	}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -74,9 +74,8 @@ type rpcError struct {
 
 type server struct {
 	localObjects  map[string]any
-	remoteObjects map[string]any // forward direction: tracks what Java has from Go
-	localRefs     map[uintptr]int
-	remoteRefs    map[int]any
+	remoteObjects map[string]any  // forward direction: tracks what Java has from Go
+	localRefs     map[uintptr]int // forward direction: tracks references sent to Java
 	batchSize     int
 
 	inProgressGetObjects map[string]*getObjectTransfer
@@ -208,7 +207,6 @@ func newServer(cfg serverConfig) *server {
 		localObjects:            make(map[string]any),
 		remoteObjects:           make(map[string]any),
 		localRefs:               make(map[uintptr]int),
-		remoteRefs:              make(map[int]any),
 		inProgressGetObjects:    make(map[string]*getObjectTransfer),
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
@@ -782,10 +780,11 @@ func (s *server) startGetObjectTransfer(id string, after, before any) *getObject
 		cancel:  make(chan struct{}),
 	}
 
-	// Use a fresh ref map for each complete GetObject exchange to avoid ref ID
-	// collisions between the reverse direction (Java→Go) and forward
-	// direction (Go→Java). It must span every batch in this transfer.
-	localRefs := make(map[uintptr]int)
+	// Reference IDs are scoped to the Go→Java direction and persist until
+	// Reset, matching the lifetime of Java's receive table. Keep the map for
+	// the complete transfer so references remain valid across page boundaries.
+	localRefs := s.localRefs
+	savedRefCount := len(localRefs)
 	q := rpc.NewSendQueue(s.batchSize, func(batch []rpc.RpcObjectData) {
 		select {
 		case t.batches <- getObjectBatch{data: batch}:
@@ -798,6 +797,14 @@ func (s *server) startGetObjectTransfer(id string, after, before any) *getObject
 		defer close(t.batches)
 		defer func() {
 			if recovered := recover(); recovered != nil {
+				// The receiver cannot have completed this transfer, so references
+				// first introduced by it must not be reused by later transfers.
+				for ptr, ref := range localRefs {
+					if ref > savedRefCount {
+						delete(localRefs, ptr)
+					}
+				}
+
 				if _, canceled := recovered.(getObjectTransferCanceled); canceled {
 					return
 				}
@@ -1126,7 +1133,6 @@ func (s *server) handleReset() bool {
 	s.localObjects = make(map[string]any)
 	s.remoteObjects = make(map[string]any)
 	s.localRefs = make(map[uintptr]int)
-	s.remoteRefs = make(map[int]any)
 	s.reverseRemoteObjects = make(map[string]any)
 	s.reverseRemoteRefs = make(map[int]any)
 	s.reverseTypePool = make(map[string]java.JavaType)

--- a/rewrite-go/pkg/rpc/annotation_rpc_test.go
+++ b/rewrite-go/pkg/rpc/annotation_rpc_test.go
@@ -35,7 +35,7 @@ func roundTripNode(t *testing.T, before java.Tree, seed java.Tree) any {
 	var messages []RpcObjectData
 	sendQ := NewSendQueue(1000, func(batch []RpcObjectData) {
 		messages = append(messages, batch...)
-	}, make(map[uintptr]int))
+	}, NewReferenceMap())
 	NewGoSender().Visit(before, sendQ)
 	sendQ.Flush()
 

--- a/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
+++ b/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
@@ -44,7 +44,7 @@ func roundTripNodeWithBefore(t *testing.T, after, before, seed java.Tree) any {
 	var messages []RpcObjectData
 	sendQ := NewSendQueue(1000, func(batch []RpcObjectData) {
 		messages = append(messages, batch...)
-	}, make(map[uintptr]int))
+	}, NewReferenceMap())
 	// Diff `after` against `before`; identical field pointers/values emit NO_CHANGE.
 	sendQ.before = before
 	NewGoSender().Visit(after, sendQ)

--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -34,7 +34,7 @@ func roundTripMarkers(t *testing.T, before java.Markers) java.Markers {
 	var messages []RpcObjectData
 	sendQ := NewSendQueue(1000, func(batch []RpcObjectData) {
 		messages = append(messages, batch...)
-	}, make(map[uintptr]int))
+	}, NewReferenceMap())
 	SendMarkersCodec(before, sendQ)
 	sendQ.Flush()
 

--- a/rewrite-go/pkg/rpc/reference.go
+++ b/rewrite-go/pkg/rpc/reference.go
@@ -16,10 +16,144 @@
 
 package rpc
 
-import "reflect"
+import (
+	"reflect"
+	"sync"
+)
 
 type Reference struct {
 	Value any
+}
+
+// ReferenceStore assigns stable wire IDs to objects sent as references.
+type ReferenceStore interface {
+	GetOrCreate(obj any) (ref int, existed bool)
+}
+
+// ReferenceMap retains referenced objects for as long as their wire IDs are
+// valid. Keeping the objects themselves as keys prevents a collected object's
+// address from being reused for a different object while the remote side still
+// has the old ID in its receive table.
+type ReferenceMap struct {
+	mu     sync.Mutex
+	refs   map[any]int
+	nextID int
+}
+
+func NewReferenceMap() *ReferenceMap {
+	return &ReferenceMap{
+		refs:   make(map[any]int),
+		nextID: 1,
+	}
+}
+
+func (m *ReferenceMap) GetOrCreate(obj any) (int, bool) {
+	assertReferenceIdentity(obj)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if ref, ok := m.refs[obj]; ok {
+		return ref, true
+	}
+	ref := m.nextID
+	m.nextID++
+	m.refs[obj] = ref
+	return ref, false
+}
+
+func (m *ReferenceMap) Len() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.refs)
+}
+
+// Begin creates an isolated allocation transaction. References allocated by
+// one transfer are visible within that transfer immediately, but become
+// reusable by other transfers only after Commit. IDs are never reused after a
+// rollback because the remote may already have received an earlier page that
+// defined one of them.
+func (m *ReferenceMap) Begin() *ReferenceTransaction {
+	return &ReferenceTransaction{
+		parent: m,
+		refs:   make(map[any]int),
+	}
+}
+
+type ReferenceTransaction struct {
+	mu          sync.Mutex
+	parent      *ReferenceMap
+	refs        map[any]int
+	allocations []any
+	closed      bool
+}
+
+func (t *ReferenceTransaction) GetOrCreate(obj any) (int, bool) {
+	assertReferenceIdentity(obj)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		panic("reference transaction is closed")
+	}
+	if ref, ok := t.refs[obj]; ok {
+		return ref, true
+	}
+
+	t.parent.mu.Lock()
+	if ref, ok := t.parent.refs[obj]; ok {
+		t.parent.mu.Unlock()
+		return ref, true
+	}
+	ref := t.parent.nextID
+	t.parent.nextID++
+	t.parent.mu.Unlock()
+
+	t.refs[obj] = ref
+	t.allocations = append(t.allocations, obj)
+	return ref, false
+}
+
+func (t *ReferenceTransaction) Commit() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.closed {
+		return
+	}
+
+	t.parent.mu.Lock()
+	for _, obj := range t.allocations {
+		if _, exists := t.parent.refs[obj]; !exists {
+			t.parent.refs[obj] = t.refs[obj]
+		}
+	}
+	t.parent.mu.Unlock()
+	t.close()
+}
+
+func (t *ReferenceTransaction) Rollback() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if !t.closed {
+		t.close()
+	}
+}
+
+func (t *ReferenceTransaction) close() {
+	t.closed = true
+	t.refs = nil
+	t.allocations = nil
+}
+
+func isReferenceIdentity(v any) bool {
+	if v == nil {
+		return false
+	}
+	rv := reflect.ValueOf(v)
+	return rv.Kind() == reflect.Ptr && !rv.IsNil()
+}
+
+func assertReferenceIdentity(v any) {
+	if !isReferenceIdentity(v) {
+		panic("references require a non-nil pointer identity")
+	}
 }
 
 // Returns nil if the value is nil (including typed nil pointers/interfaces).

--- a/rewrite-go/pkg/rpc/reference.go
+++ b/rewrite-go/pkg/rpc/reference.go
@@ -25,11 +25,6 @@ type Reference struct {
 	Value any
 }
 
-// ReferenceStore assigns stable wire IDs to objects sent as references.
-type ReferenceStore interface {
-	GetOrCreate(obj any) (ref int, existed bool)
-}
-
 // ReferenceMap retains referenced objects for as long as their wire IDs are
 // valid. Keeping the objects themselves as keys prevents a collected object's
 // address from being reused for a different object while the remote side still
@@ -66,80 +61,12 @@ func (m *ReferenceMap) Len() int {
 	return len(m.refs)
 }
 
-// Begin creates an isolated allocation transaction. References allocated by
-// one transfer are visible within that transfer immediately, but become
-// reusable by other transfers only after Commit. IDs are never reused after a
-// rollback because the remote may already have received an earlier page that
-// defined one of them.
-func (m *ReferenceMap) Begin() *ReferenceTransaction {
-	return &ReferenceTransaction{
-		parent: m,
-		refs:   make(map[any]int),
+func (m *ReferenceMap) deleteIfMatches(obj any, ref int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if current, ok := m.refs[obj]; ok && current == ref {
+		delete(m.refs, obj)
 	}
-}
-
-type ReferenceTransaction struct {
-	mu          sync.Mutex
-	parent      *ReferenceMap
-	refs        map[any]int
-	allocations []any
-	closed      bool
-}
-
-func (t *ReferenceTransaction) GetOrCreate(obj any) (int, bool) {
-	assertReferenceIdentity(obj)
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.closed {
-		panic("reference transaction is closed")
-	}
-	if ref, ok := t.refs[obj]; ok {
-		return ref, true
-	}
-
-	t.parent.mu.Lock()
-	if ref, ok := t.parent.refs[obj]; ok {
-		t.parent.mu.Unlock()
-		return ref, true
-	}
-	ref := t.parent.nextID
-	t.parent.nextID++
-	t.parent.mu.Unlock()
-
-	t.refs[obj] = ref
-	t.allocations = append(t.allocations, obj)
-	return ref, false
-}
-
-func (t *ReferenceTransaction) Commit() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.closed {
-		return
-	}
-
-	t.parent.mu.Lock()
-	for _, obj := range t.allocations {
-		if _, exists := t.parent.refs[obj]; !exists {
-			t.parent.refs[obj] = t.refs[obj]
-		}
-	}
-	t.parent.mu.Unlock()
-	t.close()
-}
-
-func (t *ReferenceTransaction) Rollback() {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if !t.closed {
-		t.close()
-	}
-}
-
-func (t *ReferenceTransaction) close() {
-	t.closed = true
-	t.refs = nil
-	t.allocations = nil
 }
 
 func isReferenceIdentity(v any) bool {

--- a/rewrite-go/pkg/rpc/reference_test.go
+++ b/rewrite-go/pkg/rpc/reference_test.go
@@ -18,60 +18,43 @@ package rpc
 
 import "testing"
 
-func TestReferenceTransactionsPublishOnlyOnCommit(t *testing.T) {
-	type object struct{}
-	shared := &object{}
+func TestReferenceMapReusesStrongIdentity(t *testing.T) {
+	type object struct{ value int }
+	shared := &object{value: 1}
 	refs := NewReferenceMap()
 
-	first := refs.Begin()
-	firstID, existed := first.GetOrCreate(shared)
+	firstID, existed := refs.GetOrCreate(shared)
 	if existed || firstID != 1 {
 		t.Fatalf("first allocation = (%d, %v), want (1, false)", firstID, existed)
 	}
-	if got := refs.Len(); got != 0 {
-		t.Fatalf("published refs before commit = %d, want 0", got)
-	}
-
-	second := refs.Begin()
-	secondID, existed := second.GetOrCreate(shared)
-	if existed || secondID != 2 {
-		t.Fatalf("isolated allocation = (%d, %v), want (2, false)", secondID, existed)
-	}
-	second.Commit()
-
 	if got := refs.Len(); got != 1 {
-		t.Fatalf("published refs after commit = %d, want 1", got)
+		t.Fatalf("reference count = %d, want 1", got)
 	}
-	if id, ok := refs.GetOrCreate(shared); !ok || id != secondID {
-		t.Fatalf("committed allocation = (%d, %v), want (%d, true)", id, ok, secondID)
-	}
-
-	// A later commit for the same sender object must not replace the ID that
-	// was published first.
-	first.Commit()
-	if id, ok := refs.GetOrCreate(shared); !ok || id != secondID {
-		t.Fatalf("allocation after competing commit = (%d, %v), want (%d, true)", id, ok, secondID)
+	if id, ok := refs.GetOrCreate(shared); !ok || id != firstID {
+		t.Fatalf("reused allocation = (%d, %v), want (%d, true)", id, ok, firstID)
 	}
 }
 
-func TestReferenceTransactionRollbackDoesNotReuseIDs(t *testing.T) {
+func TestSendQueueRollbackDoesNotReuseReferenceIDs(t *testing.T) {
 	type object struct{ value int }
 	refs := NewReferenceMap()
 
-	rolledBack := refs.Begin()
-	rolledBackID, existed := rolledBack.GetOrCreate(&object{value: 1})
-	if existed {
-		t.Fatal("new transaction unexpectedly reused a reference")
+	firstQueue := NewSendQueue(10, func([]RpcObjectData) {}, refs)
+	firstQueue.add(AsRef(&object{value: 1}), nil)
+	rolledBackID := *firstQueue.batch[0].Ref
+	firstQueue.RollbackReferences()
+	if got := refs.Len(); got != 0 {
+		t.Fatalf("reference count after rollback = %d, want 0", got)
 	}
-	rolledBack.Rollback()
 
-	committed := refs.Begin()
-	committedID, existed := committed.GetOrCreate(&object{value: 2})
-	if existed {
-		t.Fatal("new object unexpectedly reused a reference")
-	}
+	secondQueue := NewSendQueue(10, func([]RpcObjectData) {}, refs)
+	secondQueue.add(AsRef(&object{value: 2}), nil)
+	committedID := *secondQueue.batch[0].Ref
 	if committedID <= rolledBackID {
 		t.Fatalf("reference ID after rollback = %d, want greater than %d", committedID, rolledBackID)
 	}
-	committed.Commit()
+	secondQueue.CommitReferences()
+	if got := refs.Len(); got != 1 {
+		t.Fatalf("reference count after commit = %d, want 1", got)
+	}
 }

--- a/rewrite-go/pkg/rpc/reference_test.go
+++ b/rewrite-go/pkg/rpc/reference_test.go
@@ -35,14 +35,14 @@ func TestReferenceMapReusesStrongIdentity(t *testing.T) {
 	}
 }
 
-func TestSendQueueRollbackDoesNotReuseReferenceIDs(t *testing.T) {
+func TestSendQueueDiscardDoesNotReuseReferenceIDs(t *testing.T) {
 	type object struct{ value int }
 	refs := NewReferenceMap()
 
 	firstQueue := NewSendQueue(10, func([]RpcObjectData) {}, refs)
 	firstQueue.add(AsRef(&object{value: 1}), nil)
 	rolledBackID := *firstQueue.batch[0].Ref
-	firstQueue.RollbackReferences()
+	firstQueue.DiscardNewReferences()
 	if got := refs.Len(); got != 0 {
 		t.Fatalf("reference count after rollback = %d, want 0", got)
 	}
@@ -53,7 +53,6 @@ func TestSendQueueRollbackDoesNotReuseReferenceIDs(t *testing.T) {
 	if committedID <= rolledBackID {
 		t.Fatalf("reference ID after rollback = %d, want greater than %d", committedID, rolledBackID)
 	}
-	secondQueue.CommitReferences()
 	if got := refs.Len(); got != 1 {
 		t.Fatalf("reference count after commit = %d, want 1", got)
 	}

--- a/rewrite-go/pkg/rpc/reference_test.go
+++ b/rewrite-go/pkg/rpc/reference_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import "testing"
+
+func TestReferenceTransactionsPublishOnlyOnCommit(t *testing.T) {
+	type object struct{}
+	shared := &object{}
+	refs := NewReferenceMap()
+
+	first := refs.Begin()
+	firstID, existed := first.GetOrCreate(shared)
+	if existed || firstID != 1 {
+		t.Fatalf("first allocation = (%d, %v), want (1, false)", firstID, existed)
+	}
+	if got := refs.Len(); got != 0 {
+		t.Fatalf("published refs before commit = %d, want 0", got)
+	}
+
+	second := refs.Begin()
+	secondID, existed := second.GetOrCreate(shared)
+	if existed || secondID != 2 {
+		t.Fatalf("isolated allocation = (%d, %v), want (2, false)", secondID, existed)
+	}
+	second.Commit()
+
+	if got := refs.Len(); got != 1 {
+		t.Fatalf("published refs after commit = %d, want 1", got)
+	}
+	if id, ok := refs.GetOrCreate(shared); !ok || id != secondID {
+		t.Fatalf("committed allocation = (%d, %v), want (%d, true)", id, ok, secondID)
+	}
+
+	// A later commit for the same sender object must not replace the ID that
+	// was published first.
+	first.Commit()
+	if id, ok := refs.GetOrCreate(shared); !ok || id != secondID {
+		t.Fatalf("allocation after competing commit = (%d, %v), want (%d, true)", id, ok, secondID)
+	}
+}
+
+func TestReferenceTransactionRollbackDoesNotReuseIDs(t *testing.T) {
+	type object struct{ value int }
+	refs := NewReferenceMap()
+
+	rolledBack := refs.Begin()
+	rolledBackID, existed := rolledBack.GetOrCreate(&object{value: 1})
+	if existed {
+		t.Fatal("new transaction unexpectedly reused a reference")
+	}
+	rolledBack.Rollback()
+
+	committed := refs.Begin()
+	committedID, existed := committed.GetOrCreate(&object{value: 2})
+	if existed {
+		t.Fatal("new object unexpectedly reused a reference")
+	}
+	if committedID <= rolledBackID {
+		t.Fatalf("reference ID after rollback = %d, want greater than %d", committedID, rolledBackID)
+	}
+	committed.Commit()
+}

--- a/rewrite-go/pkg/rpc/send_queue.go
+++ b/rewrite-go/pkg/rpc/send_queue.go
@@ -26,20 +26,42 @@ var defaultSender = NewGoSender()
 
 // It tracks refs for deduplication and maintains a "before" state for delta encoding.
 type SendQueue struct {
-	batchSize int
-	batch     []RpcObjectData
-	drain     func([]RpcObjectData)
-	refs      ReferenceStore
-	before    any
+	batchSize     int
+	batch         []RpcObjectData
+	drain         func([]RpcObjectData)
+	refs          *ReferenceMap
+	allocatedRefs []referenceAllocation
+	before        any
 }
 
-func NewSendQueue(batchSize int, drain func([]RpcObjectData), refs ReferenceStore) *SendQueue {
+type referenceAllocation struct {
+	obj any
+	ref int
+}
+
+func NewSendQueue(batchSize int, drain func([]RpcObjectData), refs *ReferenceMap) *SendQueue {
 	return &SendQueue{
 		batchSize: batchSize,
 		batch:     make([]RpcObjectData, 0, batchSize),
 		drain:     drain,
 		refs:      refs,
 	}
+}
+
+// RollbackReferences removes references first allocated by this queue. IDs
+// remain monotonic because the receiver may already have seen definitions from
+// an earlier page of a failed transfer.
+func (q *SendQueue) RollbackReferences() {
+	for _, allocation := range q.allocatedRefs {
+		q.refs.deleteIfMatches(allocation.obj, allocation.ref)
+	}
+	q.allocatedRefs = nil
+}
+
+// CommitReferences releases the queue's temporary rollback log. The strong
+// keys remain in the session-wide ReferenceMap until Reset.
+func (q *SendQueue) CommitReferences() {
+	q.allocatedRefs = nil
 }
 
 func (q *SendQueue) Put(data RpcObjectData) {
@@ -187,6 +209,7 @@ func (q *SendQueue) add(after any, onChange func(any)) {
 			q.Put(RpcObjectData{State: Add, Ref: &r})
 			return
 		}
+		q.allocatedRefs = append(q.allocatedRefs, referenceAllocation{obj: afterVal, ref: r})
 		ref = &r
 	}
 

--- a/rewrite-go/pkg/rpc/send_queue.go
+++ b/rewrite-go/pkg/rpc/send_queue.go
@@ -29,11 +29,11 @@ type SendQueue struct {
 	batchSize int
 	batch     []RpcObjectData
 	drain     func([]RpcObjectData)
-	refs      map[uintptr]int // pointer identity -> ref number
+	refs      ReferenceStore
 	before    any
 }
 
-func NewSendQueue(batchSize int, drain func([]RpcObjectData), refs map[uintptr]int) *SendQueue {
+func NewSendQueue(batchSize int, drain func([]RpcObjectData), refs ReferenceStore) *SendQueue {
 	return &SendQueue{
 		batchSize: batchSize,
 		batch:     make([]RpcObjectData, 0, batchSize),
@@ -180,18 +180,14 @@ func (q *SendQueue) add(after any, onChange func(any)) {
 	}
 
 	var ref *int
-	if IsRef(after) {
-		ptr := ptrKey(afterVal)
-		if ptr != 0 { // Only track refs for pointer types (value types all return 0)
-			if existingRef, ok := q.refs[ptr]; ok {
-				// Already sent - emit pure ref
-				q.Put(RpcObjectData{State: Add, Ref: &existingRef})
-				return
-			}
-			r := len(q.refs) + 1
-			q.refs[ptr] = r
-			ref = &r
+	if IsRef(after) && isReferenceIdentity(afterVal) {
+		r, existed := q.refs.GetOrCreate(afterVal)
+		if existed {
+			// Already sent - emit pure ref
+			q.Put(RpcObjectData{State: Add, Ref: &r})
+			return
 		}
+		ref = &r
 	}
 
 	vt := getValueType(afterVal)
@@ -230,18 +226,6 @@ func (q *SendQueue) doChange(after, before any, onChange func(any)) {
 			defaultSender.Visit(t, q)
 		}
 	}
-}
-
-func ptrKey(v any) uintptr {
-	if v == nil {
-		return 0
-	}
-	rv := reflect.ValueOf(v)
-	if rv.Kind() == reflect.Ptr || rv.Kind() == reflect.Interface {
-		return rv.Pointer()
-	}
-	// For non-pointer types, we can't track by identity
-	return 0
 }
 
 func sameIdentity(a, b any) bool {

--- a/rewrite-go/pkg/rpc/send_queue.go
+++ b/rewrite-go/pkg/rpc/send_queue.go
@@ -48,19 +48,13 @@ func NewSendQueue(batchSize int, drain func([]RpcObjectData), refs *ReferenceMap
 	}
 }
 
-// RollbackReferences removes references first allocated by this queue. IDs
+// DiscardNewReferences removes references first allocated by this queue. IDs
 // remain monotonic because the receiver may already have seen definitions from
 // an earlier page of a failed transfer.
-func (q *SendQueue) RollbackReferences() {
+func (q *SendQueue) DiscardNewReferences() {
 	for _, allocation := range q.allocatedRefs {
 		q.refs.deleteIfMatches(allocation.obj, allocation.ref)
 	}
-	q.allocatedRefs = nil
-}
-
-// CommitReferences releases the queue's temporary rollback log. The strong
-// keys remain in the session-wide ReferenceMap until Reset.
-func (q *SendQueue) CommitReferences() {
 	q.allocatedRefs = nil
 }
 

--- a/rewrite-go/test/comment_rpc_test.go
+++ b/rewrite-go/test/comment_rpc_test.go
@@ -34,7 +34,7 @@ func TestCommentSendsTextCommentValueType(t *testing.T) {
 	var messages []rpc.RpcObjectData
 	q := rpc.NewSendQueue(1000, func(batch []rpc.RpcObjectData) {
 		messages = append(messages, batch...)
-	}, make(map[uintptr]int))
+	}, rpc.NewReferenceMap())
 	rpc.NewGoSender().Visit(cu, q)
 	q.Flush()
 

--- a/rewrite-go/test/generics_rpc_test.go
+++ b/rewrite-go/test/generics_rpc_test.go
@@ -33,7 +33,7 @@ func rpcRoundTrip(t *testing.T, cu *golang.CompilationUnit) *golang.CompilationU
 	var messages []rpc.RpcObjectData
 	sendQ := rpc.NewSendQueue(1000, func(batch []rpc.RpcObjectData) {
 		messages = append(messages, batch...)
-	}, make(map[uintptr]int))
+	}, rpc.NewReferenceMap())
 	rpc.NewGoSender().Visit(cu, sendQ)
 	sendQ.Flush()
 


### PR DESCRIPTION
## What's changed?
- Continuation of #8264.
- Keep the object reference map between requests.

## What's your motivation?

Fixing a bug in #8264, which might lead to ID re-use.