### PR TITLE
Kotlin recipe DSL: attach method type on multi-param selector rewrites

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -66,7 +66,10 @@ import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
 import org.jetbrains.kotlin.ir.symbols.IrConstructorSymbol
 import org.jetbrains.kotlin.ir.symbols.IrSimpleFunctionSymbol
 import org.jetbrains.kotlin.ir.symbols.IrValueSymbol
+import org.jetbrains.kotlin.ir.types.IrSimpleType
 import org.jetbrains.kotlin.ir.types.IrType
+import org.jetbrains.kotlin.ir.types.IrTypeArgument
+import org.jetbrains.kotlin.ir.types.IrTypeProjection
 import org.jetbrains.kotlin.ir.types.classFqName
 import org.jetbrains.kotlin.ir.types.defaultType
 import org.jetbrains.kotlin.ir.util.addChild
@@ -81,6 +84,7 @@ import org.jetbrains.kotlin.load.kotlin.JvmPackagePartSource
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.types.Variance
 import java.io.File
 
 /**
@@ -1620,9 +1624,29 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         // templated call's method type. Only remap reference FQNs (those with a
         // dot); leave primitives (`int`) and non-builtins alone. KotlinTemplate
         // keeps the Kotlin spelling, which is what it resolves against.
-        if (!javaTemplate) return fqn
-        val mapped = KOTLIN_BUILTIN_TO_JAVA_FQN[fqn]
-        return if (mapped != null && mapped.contains('.')) mapped else fqn
+        if (javaTemplate) {
+            val mapped = KOTLIN_BUILTIN_TO_JAVA_FQN[fqn]
+            return if (mapped != null && mapped.contains('.')) mapped else fqn
+        }
+        // KotlinTemplate path: spell out concrete type arguments so callees whose
+        // overload resolution depends on a generic argument still attribute a
+        // JavaType.Method — e.g. `Iterable<T>.sumOf` dispatches on the selector's
+        // return type, so a raw `kotlin.Function1` leaves the call unresolved.
+        // A non-concrete argument falls back to the raw spelling (prior behavior).
+        val args = (type as? IrSimpleType)?.arguments
+        if (args.isNullOrEmpty()) return fqn
+        val rendered = args.map { renderTypeArgument(it) ?: return fqn }
+        return "$fqn<${rendered.joinToString(", ")}>"
+    }
+
+    private fun renderTypeArgument(arg: IrTypeArgument): String? {
+        if (arg !is IrTypeProjection) return null
+        val inner = renderPlaceholderType(arg.type, javaTemplate = false) ?: return null
+        return when (arg.variance) {
+            Variance.OUT_VARIANCE -> "? extends $inner"
+            Variance.IN_VARIANCE -> "? super $inner"
+            else -> inner
+        }
     }
 
     private fun renderPlaceholder(typeFqn: String?): String =

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -1630,7 +1630,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         }
         // KotlinTemplate path: spell out concrete type arguments so overloads that
         // dispatch on a generic argument resolve (e.g. `Iterable<T>.sumOf` on the
-        // selector's return type). Non-concrete arguments fall back to raw.
+        // selector's return type). Anything but an invariant, concrete argument
+        // (star projection, use-site variance, type parameter) falls back to raw.
         val args = (type as? IrSimpleType)?.arguments
         if (args.isNullOrEmpty()) return fqn
         val rendered = args.map { renderTypeArgument(it) ?: return fqn }
@@ -1638,13 +1639,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
     }
 
     private fun renderTypeArgument(arg: IrTypeArgument): String? {
-        if (arg !is IrTypeProjection) return null
-        val inner = renderPlaceholderType(arg.type, javaTemplate = false) ?: return null
-        return when (arg.variance) {
-            Variance.OUT_VARIANCE -> "? extends $inner"
-            Variance.IN_VARIANCE -> "? super $inner"
-            else -> inner
-        }
+        if (arg !is IrTypeProjection || arg.variance != Variance.INVARIANT) return null
+        return renderPlaceholderType(arg.type, javaTemplate = false)
     }
 
     private fun renderPlaceholder(typeFqn: String?): String =

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -1628,11 +1628,9 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             val mapped = KOTLIN_BUILTIN_TO_JAVA_FQN[fqn]
             return if (mapped != null && mapped.contains('.')) mapped else fqn
         }
-        // KotlinTemplate path: spell out concrete type arguments so callees whose
-        // overload resolution depends on a generic argument still attribute a
-        // JavaType.Method — e.g. `Iterable<T>.sumOf` dispatches on the selector's
-        // return type, so a raw `kotlin.Function1` leaves the call unresolved.
-        // A non-concrete argument falls back to the raw spelling (prior behavior).
+        // KotlinTemplate path: spell out concrete type arguments so overloads that
+        // dispatch on a generic argument resolve (e.g. `Iterable<T>.sumOf` on the
+        // selector's return type). Non-concrete arguments fall back to raw.
         val args = (type as? IrSimpleType)?.arguments
         if (args.isNullOrEmpty()) return fqn
         val rendered = args.map { renderTypeArgument(it) ?: return fqn }

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -700,6 +700,69 @@ class RecipePluginRewriteTest : RewriteTest {
     }
 
     @Test
+    fun `nested generic type argument in selector attaches method type`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseFlatMap = recipe(
+                    displayName = "Use flatMap",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { xs: Iterable<Int>, f: (Int) -> List<Int> -> xs.map(f).flatten() } to { xs, f -> xs.flatMap(f) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseFlatMap",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun expand(xs: List<Int>): List<Int> = xs.map { listOf(it) }.flatten()
+                """,
+                """
+                fun expand(xs: List<Int>): List<Int> = xs.flatMap { listOf(it) }
+                """,
+            ),
+        )
+    }
+
+    @Test
+    fun `use-site variance argument degrades gracefully to raw`() {
+        // Use-site variance can't be rendered concretely, so the type falls back
+        // to raw: the rewrite still applies but the method type is absent.
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseToMutableList = recipe(
+                    displayName = "Use toMutableList",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { xs: Iterable<out Number> -> xs.toList() } to { xs -> xs.toMutableList() }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseToMutableList",
+        )
+        rewriteRun(
+            { spec ->
+                spec.recipe(r)
+                spec.typeValidationOptions(TypeValidation.builder().methodInvocations(false).build())
+            },
+            kotlin(
+                """
+                fun copy(xs: List<Int>): List<Int> = xs.toList()
+                """,
+                """
+                fun copy(xs: List<Int>): List<Int> = xs.toMutableList()
+                """,
+            ),
+        )
+    }
+
+    @Test
     fun `bare single-call rewrite preserves dot-on-its-own-line layout`() {
         // Same fix, different rewrite path: `methodInvocationRewrite` (the
         // non-chain bare path) also runs the template through

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -671,6 +671,35 @@ class RecipePluginRewriteTest : RewriteTest {
     }
 
     @Test
+    fun `multi-param selector rewrite attaches method type — sumBy to sumOf`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val UseSumOf = recipe(
+                    displayName = "Use sumOf",
+                    description = "..."
+                ) {
+                    edit {
+                        rewrite { xs: Iterable<Int>, selector: (Int) -> Int -> xs.sumBy(selector) } to { xs, selector -> xs.sumOf(selector) }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "UseSumOf",
+        )
+        rewriteRun(
+            { spec -> spec.recipe(r) },
+            kotlin(
+                """
+                fun total(xs: List<Int>): Int = xs.sumBy { it * 2 }
+                """,
+                """
+                fun total(xs: List<Int>): Int = xs.sumOf { it * 2 }
+                """,
+            ),
+        )
+    }
+
+    @Test
     fun `bare single-call rewrite preserves dot-on-its-own-line layout`() {
         // Same fix, different rewrite path: `methodInvocationRewrite` (the
         // non-chain bare path) also runs the template through


### PR DESCRIPTION
The `rewrite { } to { }` after-template rendered placeholder types from `IrType.classFqName` only, which drops generic type arguments — so a raw `kotlin.Function1` placeholder was emitted for lambda/selector parameters. Callees whose overload resolution depends on that generic argument (e.g. `Iterable<T>.sumOf`, which dispatches on the selector's return type) then failed to resolve, leaving the replacement `J.MethodInvocation` with a null `JavaType.Method` that fails `assertValidTypes` under default `TypeValidation`. This spells out concrete type arguments on the KotlinTemplate path (with `? extends`/`? super` for variance), falling back to the raw spelling for non-concrete arguments so no already-resolving case regresses. Adds a `sumBy → sumOf` `RewriteTest` that fails before and passes after with full type validation.