### PR TITLE
Isolate Python recipe bundles in per-bundle virtual environments

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/discovery.py
+++ b/rewrite-python/rewrite/src/rewrite/discovery.py
@@ -17,13 +17,19 @@
 from __future__ import annotations
 
 import inspect
+import logging
+import re
+import sys
 from importlib.metadata import entry_points
+from pathlib import Path
 from typing import Dict, List, NewType, Optional, Set, Tuple, Type
 
 from rewrite.category import CategoryDescriptor
 from rewrite.decorators import get_recipe_category
 from rewrite.marketplace import RecipeMarketplace
 from rewrite.recipe import Recipe
+
+logger = logging.getLogger(__name__)
 
 
 # A recipe's fully qualified name (e.g., ``org.openrewrite.python.RemovePass``).
@@ -118,27 +124,39 @@ def discover_recipes(
     if marketplace is None:
         marketplace = RecipeMarketplace()
 
-    # Python 3.10+ uses select parameter via SelectableGroups
-    eps = entry_points(group="openrewrite.recipes")
-
-    for ep in eps:
-        try:
-            module = ep.load()
-            if not hasattr(module, "activate") or not callable(module.activate):
-                continue
-            if attribution is None:
-                module.activate(marketplace)
-                continue
-            dist_name = ep.dist.name if ep.dist is not None else None
-            before = recipe_name_set(marketplace)
-            module.activate(marketplace)
-            if dist_name:
-                attribution.record(dist_name, recipe_name_set(marketplace) - before)
-        except Exception:
-            # Log or handle the error - for now, skip failed activations
-            pass
+    for ep in entry_points(group="openrewrite.recipes"):
+        _activate_entry_point(ep, marketplace, attribution)
 
     return marketplace
+
+
+def _activate_entry_point(ep, marketplace: RecipeMarketplace,
+                          attribution: Optional[RecipeAttribution],
+                          attribution_name: Optional[str] = None) -> None:
+    """Load and run one ``openrewrite.recipes`` entry point into ``marketplace``.
+
+    An entry point may name the module (``pkg = pkg``), so ``load()`` yields a module whose
+    ``activate`` we want, or the function itself (``pkg = pkg:activate`` — the form the engine and
+    the recipe bundles declare), in which case ``load()`` has already yielded ``activate``. A failed
+    activation contributes nothing but is logged, never silently swallowed — otherwise a bundle's
+    recipes vanish with no explanation.
+
+    ``attribution_name`` records the recipes under a caller-supplied identity (a local install's
+    supplied path, which the host keys the bundle by) instead of the distribution's own name.
+    """
+    dist_name = ep.dist.name if ep.dist is not None else None
+    try:
+        loaded = ep.load()
+        activate = getattr(loaded, "activate", loaded)
+        if not callable(activate):
+            return
+        before = recipe_name_set(marketplace)
+        activate(marketplace)
+        recorded = attribution_name or dist_name
+        if attribution is not None and recorded:
+            attribution.record(recorded, recipe_name_set(marketplace) - before)
+    except Exception:
+        logger.warning("Failed to activate recipes from distribution %r", dist_name, exc_info=True)
 
 
 def recipe_name_set(marketplace: RecipeMarketplace) -> Set[RecipeName]:
@@ -153,6 +171,77 @@ def _normalize_package_name(name: str) -> NormalizedDistName:
     resolving distribution identity.
     """
     return NormalizedDistName(name.replace("-", "_").replace(".", "_").lower())
+
+
+def discover_root_recipes(
+    root_dist_name: str,
+    marketplace: Optional[RecipeMarketplace] = None,
+    attribution: Optional[RecipeAttribution] = None,
+    attribution_name: Optional[str] = None,
+) -> RecipeMarketplace:
+    """Activate only the entry point whose owning distribution is ``root_dist_name``.
+
+    ``entry_points()`` is environment-wide, so a bundle venv that transitively
+    contains other recipe packages would otherwise surface them. Restricting
+    activation to the root distribution keeps a bundle's marketplace to its own
+    direct recipes; transitive recipe packages remain importable
+    for in-boundary composition but are never listed or attributed here.
+
+    ``attribution_name`` labels the discovered recipes with a caller-supplied identity rather than
+    ``root_dist_name`` — a local install is filtered by its resolved distribution name but must be
+    attributed to the source path the host supplied and keys the bundle by.
+    """
+    if marketplace is None:
+        marketplace = RecipeMarketplace()
+
+    root_key = _normalize_package_name(root_dist_name)
+    for ep in entry_points(group="openrewrite.recipes"):
+        dist_name = ep.dist.name if ep.dist is not None else None
+        if dist_name is None or _normalize_package_name(dist_name) != root_key:
+            continue
+        _activate_entry_point(ep, marketplace, attribution, attribution_name)
+    return marketplace
+
+
+def distribution_name_from_source(local_path: Path) -> Optional[str]:
+    """The distribution name declared by a local package source, or None.
+
+    A local install (``pip install ./recipes``) arrives as a path, but the venv and its child are
+    keyed by distribution name — so it must be resolved before install, from ``pyproject.toml``
+    (PEP 621 ``[project]`` or ``[tool.poetry]``) or a ``setup.py`` ``name=``.
+    """
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        try:
+            import tomli as tomllib  # type: ignore[import-not-found]
+        except ModuleNotFoundError:
+            return None
+
+    pyproject = local_path / "pyproject.toml"
+    if pyproject.exists():
+        try:
+            with open(pyproject, "rb") as f:
+                data = tomllib.load(f)
+            project = data.get("project", {})
+            if "name" in project:
+                return project["name"]
+            poetry = data.get("tool", {}).get("poetry", {})
+            if "name" in poetry:
+                return poetry["name"]
+        except Exception as e:
+            logger.warning("Failed to parse %s: %s", pyproject, e)
+
+    setup_py = local_path / "setup.py"
+    if setup_py.exists():
+        try:
+            match = re.search(r'name\s*=\s*["\']([^"\']+)["\']', setup_py.read_text())
+            if match:
+                return match.group(1)
+        except Exception as e:
+            logger.warning("Failed to parse %s: %s", setup_py, e)
+
+    return None
 
 
 def discover_decorated_recipes_in_module(

--- a/rewrite-python/rewrite/src/rewrite/discovery.py
+++ b/rewrite-python/rewrite/src/rewrite/discovery.py
@@ -137,12 +137,9 @@ def _activate_entry_point(ep, marketplace: RecipeMarketplace,
 
     An entry point may name the module (``pkg = pkg``), so ``load()`` yields a module whose
     ``activate`` we want, or the function itself (``pkg = pkg:activate`` — the form the engine and
-    the recipe bundles declare), in which case ``load()`` has already yielded ``activate``. A failed
-    activation contributes nothing but is logged, never silently swallowed — otherwise a bundle's
-    recipes vanish with no explanation.
-
-    ``attribution_name`` records the recipes under a caller-supplied identity (a local install's
-    supplied path, which the host keys the bundle by) instead of the distribution's own name.
+    the recipe bundles declare), in which case ``load()`` has already yielded ``activate``. 
+    ``attribution_name`` overrides the distribution name for local installs, which the host keys
+    by supplied path.
     """
     dist_name = ep.dist.name if ep.dist is not None else None
     try:
@@ -181,15 +178,9 @@ def discover_root_recipes(
 ) -> RecipeMarketplace:
     """Activate only the entry point whose owning distribution is ``root_dist_name``.
 
-    ``entry_points()`` is environment-wide, so a bundle venv that transitively
-    contains other recipe packages would otherwise surface them. Restricting
-    activation to the root distribution keeps a bundle's marketplace to its own
-    direct recipes; transitive recipe packages remain importable
-    for in-boundary composition but are never listed or attributed here.
+    ``entry_points()`` is environment-wide, so a bundle venv's transitive recipe packages would
+    otherwise surface. They stay importable for in-boundary composition but are not listed here.
 
-    ``attribution_name`` labels the discovered recipes with a caller-supplied identity rather than
-    ``root_dist_name`` — a local install is filtered by its resolved distribution name but must be
-    attributed to the source path the host supplied and keys the bundle by.
     """
     if marketplace is None:
         marketplace = RecipeMarketplace()
@@ -206,9 +197,8 @@ def discover_root_recipes(
 def distribution_name_from_source(local_path: Path) -> Optional[str]:
     """The distribution name declared by a local package source, or None.
 
-    A local install (``pip install ./recipes``) arrives as a path, but the venv and its child are
-    keyed by distribution name — so it must be resolved before install, from ``pyproject.toml``
-    (PEP 621 ``[project]`` or ``[tool.poetry]``) or a ``setup.py`` ``name=``.
+    A local install arrives as a path, but the venv and its child are keyed by distribution name,
+    so the name must be resolved before install.
     """
     if sys.version_info >= (3, 11):
         import tomllib

--- a/rewrite-python/rewrite/src/rewrite/marketplace.py
+++ b/rewrite-python/rewrite/src/rewrite/marketplace.py
@@ -78,7 +78,9 @@ class RecipeMarketplace:
                     try:
                         recipe_inst = recipe()
                         desc = recipe_inst.descriptor()
-                        self._recipes[desc.name] = (desc, recipe)
+                        # First-wins: matches the host's name-keyed RecipeListing and this
+                        # engine's own first-wins attribution (RecipeAttribution.setdefault).
+                        self._recipes.setdefault(desc.name, (desc, recipe))
                     except Exception as e:
                         raise RuntimeError(
                             f"Failed to install recipe {recipe}. "
@@ -86,7 +88,7 @@ class RecipeMarketplace:
                         ) from e
                 else:
                     # It's already a RecipeDescriptor
-                    self._recipes[recipe.name] = (recipe, None)
+                    self._recipes.setdefault(recipe.name, (recipe, None))
                 return
 
             # Get the first category in the path

--- a/rewrite-python/rewrite/src/rewrite/marketplace.py
+++ b/rewrite-python/rewrite/src/rewrite/marketplace.py
@@ -78,8 +78,8 @@ class RecipeMarketplace:
                     try:
                         recipe_inst = recipe()
                         desc = recipe_inst.descriptor()
-                        # First-wins: matches the host's name-keyed RecipeListing and this
-                        # engine's own first-wins attribution (RecipeAttribution.setdefault).
+                        # First-wins must match the host's name-keyed RecipeListing and
+                        # RecipeAttribution.
                         self._recipes.setdefault(desc.name, (desc, recipe))
                     except Exception as e:
                         raise RuntimeError(

--- a/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
@@ -1,0 +1,145 @@
+"""Facade orchestration: one isolated child per bundle, keyed by distribution name.
+
+Ties ``venv_manager`` and ``child_connection`` together. Spawn-on-demand: ``install`` creates the
+bundle's venv, installs the package, spawns its child, caches the child's (root-only) marketplace,
+and records recipe ownership first-wins. ``marketplace`` serves the merged cache; recipe execution
+is routed to the owning child. ``venv_ops`` and ``spawn`` are injectable for testing.
+"""
+from pathlib import Path
+
+from rewrite.discovery import _normalize_package_name
+from rewrite.rpc import venv_manager
+from rewrite.rpc.child_connection import ChildConnection, child_command
+
+
+
+class BundleChildren:
+    def __init__(self, python_executable, venvs_root, upstream, *, spawn=None, venv_ops=None):
+        self._python = python_executable
+        self._venvs_root = Path(venvs_root)
+        self._upstream = upstream
+        self._spawn = spawn or ChildConnection.spawn
+        self._venv_ops = venv_ops or venv_manager
+        self._children = {}     # bundle_dist -> child connection
+        self._descriptors = {}  # bundle_dist -> list[marketplace row]
+        self._owner = {}        # recipe name -> bundle_dist (first-wins)
+        self._versions = {}     # bundle_dist -> resolved version (what pip actually installed)
+        self._attribution = {}  # bundle_dist -> attribution name (a local install's supplied path)
+        self._data_table_store = None  # cached SetDataTableStore params, broadcast to every child
+
+    def _venv_dir(self, bundle_dist: str) -> Path:
+        # One venv per distribution under the shared root (reusing --recipe-install-dir), like the
+        # C# server's <root>/<id> layout. No version dimension: pip upgrades a venv in place, so
+        # (unlike C#'s immutable published assemblies + flaky ALC reload) there's no need for
+        # per-version sibling directories. bundle_dist is already PEP 503 normalized (lowercase +
+        # `_`) — the canonical distribution identity, and inherently filesystem-safe.
+        return self._venvs_root / bundle_dist
+
+    def _ensure_child(self, bundle_dist: str):
+        child = self._children.get(bundle_dist)
+        if child is None:
+            # The venvs root is on the facade's PYTHONPATH (the Java host puts --recipe-install-dir
+            # there); keep it off the child's, so a bundle imports only from its own venv.
+            cmd = child_command(self._venv_dir(bundle_dist), bundle_dist,
+                                attribution_name=self._attribution.get(bundle_dist))
+            # Bind the bundle into the upstream: the facade keeps one ref table per child
+            # connection, so it must know which child is calling back.
+            child = self._spawn(cmd,
+                                upstream=lambda m, p, b=bundle_dist: self._upstream(m, p, b),
+                                exclude_paths=(str(self._venvs_root),))
+            self._children[bundle_dist] = child
+            # The recipe runs here, not on the facade, so the host's data-table store must be
+            # installed on the child. SetDataTableStore often arrives before a bundle's child exists
+            # (lazy spawn), so replay the cached config onto each child as it comes up.
+            if self._data_table_store is not None:
+                child.request("SetDataTableStore", self._data_table_store)
+        return child
+
+    def set_data_table_store(self, params: dict) -> None:
+        """Cache the host's data-table store config and apply it to every child — live ones now, and
+        ones spawned later at spawn time (see _ensure_child). Recipes emit rows from the children."""
+        self._data_table_store = params
+        for child in self._children.values():
+            child.request("SetDataTableStore", params)
+
+    def broadcast_evict(self, params: dict) -> None:
+        """Fan a host Evict out to every spawned child so each rolls its own ref map back to the
+        per-file checkpoint (in lockstep with the host's send-side rollback). A child that never
+        fetched this file no-ops. Only live children matter — one not yet spawned holds no state."""
+        for child in self._children.values():
+            child.request("Evict", params)
+
+    def install(self, bundle_dist: str, spec: str, force: bool = False, attribution_name=None):
+        """Create/reuse the bundle's venv, install ``spec``, spawn its child, cache its recipes.
+
+        ``force`` re-copies a mutable local source (see ``venv_manager.install_into_venv``).
+        ``attribution_name`` labels the recipes with the identity the host keys the bundle by (a
+        local install's supplied path); by default they carry the distribution's own name.
+        """
+        bundle_dist = _normalize_package_name(bundle_dist)
+        self._attribution[bundle_dist] = attribution_name   # None for a registry spec
+        venv_dir = self._venv_dir(bundle_dist)
+        # Rebuild anything that isn't a venv with a live base interpreter: a half-created venv, a
+        # leftover flat `pip install --target` package directory of the same name (from before
+        # per-bundle venvs), or a venv orphaned by a Python upgrade. Testing the directory — or even
+        # the interpreter file — would call all three usable, then fail on exec or on import.
+        if not self._venv_ops.is_usable_venv(venv_dir):
+            # Any child still bound to the old venv is about to lose it; reap it so the next
+            # request spawns against the rebuilt one.
+            stale = self._children.pop(bundle_dist, None)
+            if stale is not None:
+                stale.close()
+            self._venv_ops.create_venv(self._python, venv_dir, clear=venv_dir.exists())
+        # pip --upgrade in the venv resolves in place: a version-less install upgrades to the latest
+        # (fixes #8180); an exact pin already present is a near no-op.
+        self._venv_ops.install_into_venv(venv_dir, spec, force=force)
+        # The install layer just ran pip, so it — not the child — is the authority on what version
+        # landed. Report that resolved version rather than echoing the requested (maybe null) spec.
+        self._versions[bundle_dist] = self._venv_ops.installed_version(venv_dir, bundle_dist)
+        rows = self._ensure_child(bundle_dist).request("GetMarketplace", {})
+        self._descriptors[bundle_dist] = rows
+        for row in rows:
+            self._owner.setdefault(row["descriptor"]["name"], bundle_dist)  # first-wins
+        return rows
+
+    def marketplace(self):
+        """Merged descriptor cache across all bundles (first-wins on duplicate names)."""
+        merged, seen = [], set()
+        for rows in self._descriptors.values():
+            for row in rows:
+                name = row["descriptor"]["name"]
+                if name in seen:
+                    continue
+                seen.add(name)
+                merged.append(row)
+        return merged
+
+    def owner(self, recipe_name: str):
+        """The bundle that owns ``recipe_name``, or None."""
+        return self._owner.get(recipe_name)
+
+    def resolved_version(self, bundle_dist: str):
+        """The version pip resolved for ``bundle_dist`` at install, or None."""
+        return self._versions.get(_normalize_package_name(bundle_dist))
+
+    def request(self, bundle_dist: str, method: str, params: dict):
+        """Route an operation to the given bundle's child."""
+        return self._ensure_child(_normalize_package_name(bundle_dist)).request(method, params)
+
+    def uninstall(self, bundle_dist: str) -> None:
+        """Reap the bundle's child, drop its cache/ownership, and remove its venv."""
+        bundle_dist = _normalize_package_name(bundle_dist)
+        child = self._children.pop(bundle_dist, None)
+        if child is not None:
+            child.close()
+        self._descriptors.pop(bundle_dist, None)
+        self._versions.pop(bundle_dist, None)
+        self._attribution.pop(bundle_dist, None)
+        self._owner = {name: b for name, b in self._owner.items() if b != bundle_dist}
+        self._venv_ops.remove_venv(self._venv_dir(bundle_dist))
+
+    def shutdown(self) -> None:
+        """Reap all children (session end)."""
+        for child in self._children.values():
+            child.close()
+        self._children.clear()

--- a/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
@@ -1,9 +1,7 @@
 """Facade orchestration: one isolated child per bundle, keyed by distribution name.
 
-Ties ``venv_manager`` and ``child_connection`` together. Spawn-on-demand: ``install`` creates the
-bundle's venv, installs the package, spawns its child, caches the child's (root-only) marketplace,
-and records recipe ownership first-wins. ``marketplace`` serves the merged cache; recipe execution
-is routed to the owning child. ``venv_ops`` and ``spawn`` are injectable for testing.
+Children are spawned on demand. Recipe ownership is first-wins across bundles. ``venv_ops`` and
+``spawn`` are injectable for testing.
 """
 from pathlib import Path
 
@@ -28,11 +26,8 @@ class BundleChildren:
         self._data_table_store = None  # cached SetDataTableStore params, broadcast to every child
 
     def _venv_dir(self, bundle_dist: str) -> Path:
-        # One venv per distribution under the shared root (reusing --recipe-install-dir), like the
-        # C# server's <root>/<id> layout. No version dimension: pip upgrades a venv in place, so
-        # (unlike C#'s immutable published assemblies + flaky ALC reload) there's no need for
-        # per-version sibling directories. bundle_dist is already PEP 503 normalized (lowercase +
-        # `_`) — the canonical distribution identity, and inherently filesystem-safe.
+        # No version dimension: pip upgrades a venv in place. bundle_dist is PEP 503 normalized,
+        # hence inherently filesystem-safe.
         return self._venvs_root / bundle_dist
 
     def _ensure_child(self, bundle_dist: str):
@@ -48,41 +43,33 @@ class BundleChildren:
                                 upstream=lambda m, p, b=bundle_dist: self._upstream(m, p, b),
                                 exclude_paths=(str(self._venvs_root),))
             self._children[bundle_dist] = child
-            # The recipe runs here, not on the facade, so the host's data-table store must be
-            # installed on the child. SetDataTableStore often arrives before a bundle's child exists
-            # (lazy spawn), so replay the cached config onto each child as it comes up.
+            # SetDataTableStore often arrives before a bundle's child exists, so replay the
+            # cached config onto each child as it comes up.
             if self._data_table_store is not None:
                 child.request("SetDataTableStore", self._data_table_store)
         return child
 
     def set_data_table_store(self, params: dict) -> None:
-        """Cache the host's data-table store config and apply it to every child — live ones now, and
-        ones spawned later at spawn time (see _ensure_child). Recipes emit rows from the children."""
+        """Apply to live children now; _ensure_child replays it onto ones spawned later."""
         self._data_table_store = params
         for child in self._children.values():
             child.request("SetDataTableStore", params)
 
     def broadcast_evict(self, params: dict) -> None:
-        """Fan a host Evict out to every spawned child so each rolls its own ref map back to the
-        per-file checkpoint (in lockstep with the host's send-side rollback). A child that never
-        fetched this file no-ops. Only live children matter — one not yet spawned holds no state."""
+        """Fan a host Evict out to every child so each ref map rolls back in lockstep with the
+        host's send-side rollback. An unspawned child holds no state."""
         for child in self._children.values():
             child.request("Evict", params)
 
     def install(self, bundle_dist: str, spec: str, force: bool = False, attribution_name=None):
         """Create/reuse the bundle's venv, install ``spec``, spawn its child, cache its recipes.
 
-        ``force`` re-copies a mutable local source (see ``venv_manager.install_into_venv``).
         ``attribution_name`` labels the recipes with the identity the host keys the bundle by (a
         local install's supplied path); by default they carry the distribution's own name.
         """
         bundle_dist = _normalize_package_name(bundle_dist)
         self._attribution[bundle_dist] = attribution_name   # None for a registry spec
         venv_dir = self._venv_dir(bundle_dist)
-        # Rebuild anything that isn't a venv with a live base interpreter: a half-created venv, a
-        # leftover flat `pip install --target` package directory of the same name (from before
-        # per-bundle venvs), or a venv orphaned by a Python upgrade. Testing the directory — or even
-        # the interpreter file — would call all three usable, then fail on exec or on import.
         if not self._venv_ops.is_usable_venv(venv_dir):
             # Any child still bound to the old venv is about to lose it; reap it so the next
             # request spawns against the rebuilt one.
@@ -90,11 +77,7 @@ class BundleChildren:
             if stale is not None:
                 stale.close()
             self._venv_ops.create_venv(self._python, venv_dir, clear=venv_dir.exists())
-        # pip --upgrade in the venv resolves in place: a version-less install upgrades to the latest
-        # (fixes #8180); an exact pin already present is a near no-op.
         self._venv_ops.install_into_venv(venv_dir, spec, force=force)
-        # The install layer just ran pip, so it — not the child — is the authority on what version
-        # landed. Report that resolved version rather than echoing the requested (maybe null) spec.
         self._versions[bundle_dist] = self._venv_ops.installed_version(venv_dir, bundle_dist)
         rows = self._ensure_child(bundle_dist).request("GetMarketplace", {})
         self._descriptors[bundle_dist] = rows
@@ -115,19 +98,15 @@ class BundleChildren:
         return merged
 
     def owner(self, recipe_name: str):
-        """The bundle that owns ``recipe_name``, or None."""
         return self._owner.get(recipe_name)
 
     def resolved_version(self, bundle_dist: str):
-        """The version pip resolved for ``bundle_dist`` at install, or None."""
         return self._versions.get(_normalize_package_name(bundle_dist))
 
     def request(self, bundle_dist: str, method: str, params: dict):
-        """Route an operation to the given bundle's child."""
         return self._ensure_child(_normalize_package_name(bundle_dist)).request(method, params)
 
     def uninstall(self, bundle_dist: str) -> None:
-        """Reap the bundle's child, drop its cache/ownership, and remove its venv."""
         bundle_dist = _normalize_package_name(bundle_dist)
         child = self._children.pop(bundle_dist, None)
         if child is not None:
@@ -139,7 +118,6 @@ class BundleChildren:
         self._venv_ops.remove_venv(self._venv_dir(bundle_dist))
 
     def shutdown(self) -> None:
-        """Reap all children (session end)."""
         for child in self._children.values():
             child.close()
         self._children.clear()

--- a/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
@@ -26,38 +26,27 @@ class BundleChildren:
         self._data_table_store = None  # cached SetDataTableStore params, broadcast to every child
 
     def _venv_dir(self, bundle_dist: str) -> Path:
-        # No version dimension: pip upgrades a venv in place. bundle_dist is PEP 503 normalized,
-        # hence inherently filesystem-safe.
         return self._venvs_root / bundle_dist
 
     def _ensure_child(self, bundle_dist: str):
         child = self._children.get(bundle_dist)
         if child is None:
-            # The venvs root is on the facade's PYTHONPATH (the Java host puts --recipe-install-dir
-            # there); keep it off the child's, so a bundle imports only from its own venv.
             cmd = child_command(self._venv_dir(bundle_dist), bundle_dist,
                                 attribution_name=self._attribution.get(bundle_dist))
-            # Bind the bundle into the upstream: the facade keeps one ref table per child
-            # connection, so it must know which child is calling back.
             child = self._spawn(cmd,
                                 upstream=lambda m, p, b=bundle_dist: self._upstream(m, p, b),
                                 exclude_paths=(str(self._venvs_root),))
             self._children[bundle_dist] = child
-            # SetDataTableStore often arrives before a bundle's child exists, so replay the
-            # cached config onto each child as it comes up.
             if self._data_table_store is not None:
                 child.request("SetDataTableStore", self._data_table_store)
         return child
 
     def set_data_table_store(self, params: dict) -> None:
-        """Apply to live children now; _ensure_child replays it onto ones spawned later."""
         self._data_table_store = params
         for child in self._children.values():
             child.request("SetDataTableStore", params)
 
     def broadcast_evict(self, params: dict) -> None:
-        """Fan a host Evict out to every child so each ref map rolls back in lockstep with the
-        host's send-side rollback. An unspawned child holds no state."""
         for child in self._children.values():
             child.request("Evict", params)
 
@@ -71,8 +60,6 @@ class BundleChildren:
         self._attribution[bundle_dist] = attribution_name   # None for a registry spec
         venv_dir = self._venv_dir(bundle_dist)
         if not self._venv_ops.is_usable_venv(venv_dir):
-            # Any child still bound to the old venv is about to lose it; reap it so the next
-            # request spawns against the rebuilt one.
             stale = self._children.pop(bundle_dist, None)
             if stale is not None:
                 stale.close()
@@ -86,7 +73,6 @@ class BundleChildren:
         return rows
 
     def marketplace(self):
-        """Merged descriptor cache across all bundles (first-wins on duplicate names)."""
         merged, seen = [], set()
         for rows in self._descriptors.values():
             for row in rows:

--- a/rewrite-python/rewrite/src/rewrite/rpc/child_connection.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/child_connection.py
@@ -16,14 +16,12 @@ from pathlib import Path
 
 from rewrite.rpc import venv_manager
 
-# The directory holding the `rewrite` package — i.e. this engine's own location on sys.path.
 _ENGINE_ROOT = str(Path(__file__).resolve().parents[2])
 _ENGINE_DIST = "openrewrite"
 _REQUIREMENT_NAME = re.compile(r"[A-Za-z0-9._-]+")
 
 
 def _path_key(path: str) -> str:
-    """Comparison key for a sys.path/PATH entry."""
     return os.path.normcase(os.path.abspath(path))
 
 
@@ -33,7 +31,6 @@ def _engine_roots() -> list:
     The platform a child needs is not just the ``rewrite`` package: a recipe may parse a Python
     template, which reaches ``parso``. A bundle venv has neither, so both must travel on the
     child's ``PYTHONPATH``.
-
     """
     roots: list = []
     seen: set = set()
@@ -64,9 +61,6 @@ def _engine_roots() -> list:
 
 
 def child_command(venv_dir: Path, bundle_dist: str, attribution_name=None) -> list:
-    """Command to run a single-bundle child on the bundle's venv interpreter.
-
-    """
     cmd = [
         str(venv_manager.venv_python(venv_dir)),
         "-m", "rewrite.rpc.server",
@@ -113,8 +107,6 @@ def _child_env(exclude_paths=()) -> dict:
 
 
 class ChildConnection:
-    """A spawned child RPC server addressed over its stdin/stdout with Content-Length framing."""
-
     @classmethod
     def spawn(cls, cmd: list, upstream=None, exclude_paths=()) -> "ChildConnection":
         proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
@@ -122,14 +114,11 @@ class ChildConnection:
         return cls(proc, upstream)
 
     def __init__(self, proc: subprocess.Popen, upstream=None):
-        # upstream(method, params) -> result forwards a child's callback to Java; in the facade,
-        # server.send_request.
         self._proc = proc
         self._upstream = upstream
         self._id = 0
 
     def request(self, method: str, params: dict):
-        """Send a request and return its result, relaying any callbacks the child makes to Java."""
         self._id += 1
         rid = self._id
         self._write({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
@@ -148,8 +137,6 @@ class ChildConnection:
 
             callback_method = msg.get("method")
             if callback_method is not None:
-                # Inbound callback from the child: its GetObject/Print target the master objects
-                # on Java.
                 child_id = msg.get("id")
                 if self._upstream is None:
                     raise RuntimeError(

--- a/rewrite-python/rewrite/src/rewrite/rpc/child_connection.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/child_connection.py
@@ -3,9 +3,8 @@
 Spawns a single-bundle child server (``server.py --child-bundle <dist>`` on the bundle's venv
 interpreter) and exchanges JSON-RPC over its stdin/stdout using the same Content-Length framing
 as the Java<->Python link. stdio is point-to-point, so the facade owns the child's pipes and speaks
-to it directly here. The child inherits the facade's environment, which is how it receives the
-engine itself (see ``_child_env``). A child's *outbound* callbacks toward Java (``GetObject`` etc.)
-are relayed by handling inbound requests inside ``request``'s read loop.
+to it directly here. A child's *outbound* callbacks toward Java (``GetObject`` etc.) are relayed
+by handling inbound requests inside ``request``'s read loop.
 """
 import json
 import os
@@ -24,8 +23,7 @@ _REQUIREMENT_NAME = re.compile(r"[A-Za-z0-9._-]+")
 
 
 def _path_key(path: str) -> str:
-    """Comparison key for a sys.path/PATH entry, so the same directory spelled differently (case,
-    relative) compares equal."""
+    """Comparison key for a sys.path/PATH entry."""
     return os.path.normcase(os.path.abspath(path))
 
 
@@ -36,11 +34,6 @@ def _engine_roots() -> list:
     template, which reaches ``parso``. A bundle venv has neither, so both must travel on the
     child's ``PYTHONPATH``.
 
-    Resolving the dependencies' locations from metadata makes this self-tuning. In production the
-    engine is a ``pip install --target <dir>`` tree, so ``parso`` and friends already sit beside
-    ``rewrite`` and everything collapses to the single engine root — children see nothing else.
-    Only in an editable/dev install do the dependencies live elsewhere (the parent's
-    ``site-packages``), adding a second entry.
     """
     roots: list = []
     seen: set = set()
@@ -73,8 +66,6 @@ def _engine_roots() -> list:
 def child_command(venv_dir: Path, bundle_dist: str, attribution_name=None) -> list:
     """Command to run a single-bundle child on the bundle's venv interpreter.
 
-    ``attribution_name`` (a local install's supplied path) labels the child's recipes with the
-    identity the host keys the bundle by, rather than the distribution name it filters on.
     """
     cmd = [
         str(venv_manager.venv_python(venv_dir)),
@@ -98,16 +89,12 @@ def _child_env(exclude_paths=()) -> dict:
     the bundle's venv (as a recipe's transitive dependency) is shadowed rather than loaded.
 
     ``exclude_paths`` drops inherited entries a child must not import from — notably the shared
-    recipe-install directory, which the Java host puts on the facade's ``PYTHONPATH``. Recipes now
-    live in per-bundle venvs, and anything left directly in that root (a flat ``pip install
-    --target`` layout from before per-bundle venvs) would otherwise be importable by *every* child,
-    shadowing its own copy.
+    recipe-install directory the Java host puts on the facade's ``PYTHONPATH``, whose flat contents
+    would otherwise be importable by *every* child, shadowing its own copy.
 
-    ``PATH`` gains the facade's scripts directory, because ``PYTHONPATH`` carries importable code
-    but not console binaries. ``ty-types`` ships both; a child's own interpreter has neither, and
-    ``ty_types.find_ty_types_bin`` only locates the binary beside the package under a ``pip install
-    --target`` layout. Appending (not prepending) leaves the bundle's own ``python``/``pip`` first
-    for the subprocesses a recipe's template workspace spawns.
+    ``PATH`` gains the facade's scripts directory because ``PYTHONPATH`` carries importable code
+    but not console binaries (``ty-types`` needs both). Append rather than prepend: the bundle's own
+    ``python``/``pip`` must stay first for subprocesses a recipe's template workspace spawns.
     """
     env = dict(os.environ)
 
@@ -135,8 +122,8 @@ class ChildConnection:
         return cls(proc, upstream)
 
     def __init__(self, proc: subprocess.Popen, upstream=None):
-        # upstream(method, params) -> result forwards a child's callback (e.g. GetObject) to Java.
-        # In the facade this is server.send_request; injected so this module needn't import server.
+        # upstream(method, params) -> result forwards a child's callback to Java; in the facade,
+        # server.send_request.
         self._proc = proc
         self._upstream = upstream
         self._id = 0
@@ -161,8 +148,8 @@ class ChildConnection:
 
             callback_method = msg.get("method")
             if callback_method is not None:
-                # Inbound callback request from the child (its GetObject/Print target the master
-                # objects on Java). Relay to upstream and feed the response back with the child's id.
+                # Inbound callback from the child: its GetObject/Print target the master objects
+                # on Java.
                 child_id = msg.get("id")
                 if self._upstream is None:
                     raise RuntimeError(
@@ -197,7 +184,7 @@ class ChildConnection:
         while True:
             line = self._proc.stdout.readline()
             if not line:
-                return None  # EOF
+                return None
             s = line.decode("ascii").strip()
             if s == "":
                 break

--- a/rewrite-python/rewrite/src/rewrite/rpc/child_connection.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/child_connection.py
@@ -1,0 +1,214 @@
+"""Facade -> child transport.
+
+Spawns a single-bundle child server (``server.py --child-bundle <dist>`` on the bundle's venv
+interpreter) and exchanges JSON-RPC over its stdin/stdout using the same Content-Length framing
+as the Java<->Python link. stdio is point-to-point, so the facade owns the child's pipes and speaks
+to it directly here. The child inherits the facade's environment, which is how it receives the
+engine itself (see ``_child_env``). A child's *outbound* callbacks toward Java (``GetObject`` etc.)
+are relayed by handling inbound requests inside ``request``'s read loop.
+"""
+import json
+import os
+import re
+import subprocess
+import sysconfig
+from importlib import metadata
+from pathlib import Path
+
+from rewrite.rpc import venv_manager
+
+# The directory holding the `rewrite` package — i.e. this engine's own location on sys.path.
+_ENGINE_ROOT = str(Path(__file__).resolve().parents[2])
+_ENGINE_DIST = "openrewrite"
+_REQUIREMENT_NAME = re.compile(r"[A-Za-z0-9._-]+")
+
+
+def _path_key(path: str) -> str:
+    """Comparison key for a sys.path/PATH entry, so the same directory spelled differently (case,
+    relative) compares equal."""
+    return os.path.normcase(os.path.abspath(path))
+
+
+def _engine_roots() -> list:
+    """Directories supplying the engine *and its runtime dependencies*.
+
+    The platform a child needs is not just the ``rewrite`` package: a recipe may parse a Python
+    template, which reaches ``parso``. A bundle venv has neither, so both must travel on the
+    child's ``PYTHONPATH``.
+
+    Resolving the dependencies' locations from metadata makes this self-tuning. In production the
+    engine is a ``pip install --target <dir>`` tree, so ``parso`` and friends already sit beside
+    ``rewrite`` and everything collapses to the single engine root — children see nothing else.
+    Only in an editable/dev install do the dependencies live elsewhere (the parent's
+    ``site-packages``), adding a second entry.
+    """
+    roots: list = []
+    seen: set = set()
+
+    def add(path: str) -> None:
+        key = _path_key(path)
+        if key not in seen:
+            seen.add(key)
+            roots.append(path)
+
+    add(_ENGINE_ROOT)
+    try:
+        requires = metadata.distribution(_ENGINE_DIST).requires or []
+    except metadata.PackageNotFoundError:
+        return roots  # running straight from source with no installed metadata
+
+    for requirement in requires:
+        if "extra ==" in requirement:
+            continue  # dev/publish/profiling extras are not part of a child's platform
+        name = _REQUIREMENT_NAME.match(requirement.strip())
+        if name is None:
+            continue
+        try:
+            add(str(metadata.distribution(name.group(0)).locate_file("")))
+        except metadata.PackageNotFoundError:
+            continue  # declared but absent: contribute no path rather than fail the spawn
+    return roots
+
+
+def child_command(venv_dir: Path, bundle_dist: str, attribution_name=None) -> list:
+    """Command to run a single-bundle child on the bundle's venv interpreter.
+
+    ``attribution_name`` (a local install's supplied path) labels the child's recipes with the
+    identity the host keys the bundle by, rather than the distribution name it filters on.
+    """
+    cmd = [
+        str(venv_manager.venv_python(venv_dir)),
+        "-m", "rewrite.rpc.server",
+        "--child-bundle", bundle_dist,
+    ]
+    if attribution_name:
+        cmd += ["--attribution-name", attribution_name]
+    return cmd
+
+
+def _child_env(exclude_paths=()) -> dict:
+    """The child's environment, with the engine placed first on ``PYTHONPATH``.
+
+    The engine is *platform*, not a bundle dependency: one pinned copy is shared by the facade and
+    every child, the way Java delegates ``org.openrewrite.*`` to the parent classloader. A child
+    runs on its bundle's venv interpreter, which has no engine of its own and inherits only the
+    environment — so the engine can reach it by no route other than ``PYTHONPATH``.
+
+    Placing it first also makes it win over ``site-packages``, so a copy pip may have dragged into
+    the bundle's venv (as a recipe's transitive dependency) is shadowed rather than loaded.
+
+    ``exclude_paths`` drops inherited entries a child must not import from — notably the shared
+    recipe-install directory, which the Java host puts on the facade's ``PYTHONPATH``. Recipes now
+    live in per-bundle venvs, and anything left directly in that root (a flat ``pip install
+    --target`` layout from before per-bundle venvs) would otherwise be importable by *every* child,
+    shadowing its own copy.
+
+    ``PATH`` gains the facade's scripts directory, because ``PYTHONPATH`` carries importable code
+    but not console binaries. ``ty-types`` ships both; a child's own interpreter has neither, and
+    ``ty_types.find_ty_types_bin`` only locates the binary beside the package under a ``pip install
+    --target`` layout. Appending (not prepending) leaves the bundle's own ``python``/``pip`` first
+    for the subprocesses a recipe's template workspace spawns.
+    """
+    env = dict(os.environ)
+
+    engine = _engine_roots()
+    excluded = {_path_key(p) for p in (*exclude_paths, *engine)}
+    inherited = [p for p in env.get("PYTHONPATH", "").split(os.pathsep)
+                 if p and _path_key(p) not in excluded]
+    env["PYTHONPATH"] = os.pathsep.join([*engine, *inherited])
+
+    scripts = sysconfig.get_path("scripts")
+    path = [p for p in env.get("PATH", "").split(os.pathsep) if p]
+    if scripts and _path_key(scripts) not in {_path_key(p) for p in path}:
+        path.append(scripts)
+    env["PATH"] = os.pathsep.join(path)
+    return env
+
+
+class ChildConnection:
+    """A spawned child RPC server addressed over its stdin/stdout with Content-Length framing."""
+
+    @classmethod
+    def spawn(cls, cmd: list, upstream=None, exclude_paths=()) -> "ChildConnection":
+        proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                env=_child_env(exclude_paths))
+        return cls(proc, upstream)
+
+    def __init__(self, proc: subprocess.Popen, upstream=None):
+        # upstream(method, params) -> result forwards a child's callback (e.g. GetObject) to Java.
+        # In the facade this is server.send_request; injected so this module needn't import server.
+        self._proc = proc
+        self._upstream = upstream
+        self._id = 0
+
+    def request(self, method: str, params: dict):
+        """Send a request and return its result, relaying any callbacks the child makes to Java."""
+        self._id += 1
+        rid = self._id
+        self._write({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        while True:
+            msg = self._read()
+            if msg is None:
+                raise RuntimeError(f"child closed the connection during {method}")
+
+            if msg.get("id") == rid and ("result" in msg or "error" in msg):
+                if "error" in msg:
+                    err = msg["error"]
+                    tb = err.get("data")  # the child sends its full traceback here
+                    detail = f"\nchild traceback:\n{tb}" if tb else ""
+                    raise RuntimeError(f"child error for {method}: {err.get('message')}{detail}")
+                return msg.get("result")
+
+            callback_method = msg.get("method")
+            if callback_method is not None:
+                # Inbound callback request from the child (its GetObject/Print target the master
+                # objects on Java). Relay to upstream and feed the response back with the child's id.
+                child_id = msg.get("id")
+                if self._upstream is None:
+                    raise RuntimeError(
+                        f"child issued a '{callback_method}' callback but no upstream is configured")
+                try:
+                    result = self._upstream(callback_method, msg.get("params", {}))
+                    self._write({"jsonrpc": "2.0", "id": child_id, "result": result})
+                except Exception as e:
+                    self._write({"jsonrpc": "2.0", "id": child_id,
+                                 "error": {"code": -32603, "message": str(e)}})
+
+    def close(self) -> None:
+        try:
+            if self._proc.stdin:
+                self._proc.stdin.close()
+        except Exception:
+            pass
+        try:
+            self._proc.terminate()
+            self._proc.wait(timeout=5)
+        except Exception:
+            self._proc.kill()
+
+    def _write(self, msg: dict) -> None:
+        data = json.dumps(msg).encode("utf-8")
+        header = ("Content-Length: %d\r\n\r\n" % len(data)).encode("ascii")
+        self._proc.stdin.write(header + data)
+        self._proc.stdin.flush()
+
+    def _read(self):
+        content_length = None
+        while True:
+            line = self._proc.stdout.readline()
+            if not line:
+                return None  # EOF
+            s = line.decode("ascii").strip()
+            if s == "":
+                break
+            if s.lower().startswith("content-length:"):
+                content_length = int(s.split(":", 1)[1])
+        if content_length is None:
+            return None
+        body = b""
+        while len(body) < content_length:
+            chunk = self._proc.stdout.read(content_length - len(body))
+            if not chunk:
+                return None
+            body += chunk
+        return json.loads(body.decode("utf-8"))

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -90,10 +90,13 @@ class Facade:
         if bundle is None:
             raise ValueError(f"No child owns visitor '{visitor}'")
         result = self._children.request(bundle, "Visit", params)
-        # The child now holds the (possibly modified) tree in its local_objects, along with the
-        # RPC ref-state built up fetching inputs. A later Print/GetObject for this tree must run
-        # there — the facade's own ref-state is empty and cannot service get_object_from_java.
         tree_id = params.get("treeId")
+        # The edit lives in the child; the facade answers Java's later Print/GetObject from its own
+        # tree. Pull it back here or that answer is the unmodified input and the edit is lost --
+        # silently, since the run still succeeds and simply reports no changes. `batch_visit` does
+        # the same for each of its runs; a single-recipe run reaches this path instead.
+        if self._hub_pull is not None and tree_id is not None and result.get("modified"):
+            self._hub_pull(self._children, bundle, tree_id, params.get("sourceFileType"))
         if tree_id is not None:
             self._bundle_by_tree[tree_id] = bundle
         self._active_bundle = bundle

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -1,11 +1,9 @@
 """Facade request handling: route RPC operations across per-bundle children.
 
-In facade mode (``--recipe-install-dir`` set, not a child), the server holds no recipes itself. It
-installs each bundle into its own venv+child (``BundleChildren``), serves ``GetMarketplace`` from
-the merged cache, and routes recipe execution to the owning child — tracking which child produced
-each prepared recipe's visitors so later ``Visit``/``Generate`` calls route to the right child.
+In facade mode (``--recipe-install-dir`` set, not a child) the server holds no recipes itself: each
+bundle gets its own venv and child, and recipe execution routes to the owning child.
 
-``Print``/``GetObject`` are not routed: the facade owns the working tree and answers those itself.
+``Print``/``GetObject`` are not routed — the facade owns the working tree and answers those itself.
 """
 from pathlib import Path
 
@@ -34,20 +32,17 @@ class Facade:
             else:
                 spec = package
             rows = self._children.install(package, spec)
-            # Report what pip resolved, not the requested spec (which is null for a version-less
-            # install). The CLI pins the bundle to this so later resolves arrive with an exact spec.
+            # The CLI pins the bundle to the resolved version, so later resolves arrive exact.
             return {"recipesInstalled": len(rows), "version": self._children.resolved_version(package)}
         raise ValueError(f"Invalid recipes parameter: {recipes!r}")
 
     def _install_local(self, local_path: str) -> dict:
-        # A local install arrives as a path but the venv/child are keyed by distribution name, so
-        # resolve the name from the source before installing. force=True re-copies the mutable
-        # source even at an unchanged version.
+        # A local install arrives as a path, but the venv and child are keyed by distribution name.
         dist = distribution_name_from_source(Path(local_path))
         if not dist:
             raise ValueError(f"Could not determine the distribution name for local path '{local_path}'")
-        # Filter discovery by the resolved distribution name, but attribute the recipes to the
-        # supplied path — the identity the host keys the local bundle by.
+        # Discovery filters on the distribution name; attribution is the supplied path, which is
+        # the identity the host keys a local bundle by.
         rows = self._children.install(dist, local_path, force=True, attribution_name=local_path)
         return {"recipesInstalled": len(rows), "version": self._children.resolved_version(dist)}
 
@@ -71,9 +66,8 @@ class Facade:
             visitor = response.get(key)
             if visitor:
                 self._bundle_by_visitor[visitor] = bundle
-        # A precondition can name a Python visitor (`edit:<prepared id>`) that the host calls back
-        # like any other. It was prepared inside this child but appears in neither editVisitor nor
-        # recipeList, so without this the host's Visit for it finds no owner.
+        # A precondition may name one of this child's own visitors, and appears in neither
+        # editVisitor nor recipeList — unregistered, the host's Visit for it would find no owner.
         for key in ("editPreconditions", "scanPreconditions"):
             for precondition in (response.get(key) or []):
                 visitor = precondition.get("visitorName")
@@ -89,10 +83,8 @@ class Facade:
             raise ValueError(f"No child owns visitor '{visitor}'")
         result = self._children.request(bundle, "Visit", params)
         tree_id = params.get("treeId")
-        # The edit lives in the child; the facade answers Java's later Print/GetObject from its own
-        # tree. Pull it back here or that answer is the unmodified input and the edit is lost --
-        # silently, since the run still succeeds and simply reports no changes. `batch_visit` does
-        # the same for each of its runs; a single-recipe run reaches this path instead.
+        # The facade answers Java's later Print/GetObject from its own tree, so an edit left in the
+        # child is lost — silently, since the run still succeeds and reports no changes.
         if self._hub_pull is not None and tree_id is not None and result.get("modified"):
             self._hub_pull(self._children, bundle, tree_id, params.get("sourceFileType"))
         return result
@@ -100,16 +92,11 @@ class Facade:
     def batch_visit(self, params: dict) -> dict:
         """Route a BatchVisit's visitors to their owning children, preserving sequence.
 
-        The Java scheduler (RecipeRunCycle) batches a tree's visitors across every recipe in the
-        run cycle, so one BatchVisit can span bundles. Split it into maximal consecutive same-owner
-        runs and dispatch each as a BatchVisit to that child, concatenating the per-visitor results
-        in order. A single-bundle composite collapses to one run — the whole batch to one child.
-
-        Each run is a "sub-BatchVisit" against the facade's hub: the child is served the facade's
-        current tree over that child's ref table, runs its visitors, and its edit is pulled back as a
-        diff and applied to the facade's tree before the next bundle starts. So bundle B sees bundle
-        A's result rather than the original, and the accumulated tree stays with the facade."""
-        groups = []  # maximal consecutive same-owner runs: [(owner, [visitor, ...]), ...]
+        The host batches a tree's visitors across every recipe in a run cycle, so one BatchVisit can
+        span bundles. Each same-owner run is served the facade's current tree over that child's ref
+        table, and its edit is pulled back before the next run starts — so the second bundle sees the
+        first one's result rather than the original."""
+        groups = []  # [(owner, [visitor, ...]), ...]
         for visitor in params.get("visitors", []):
             name = visitor.get("visitor")
             owner = self._bundle_by_visitor.get(name)
@@ -127,23 +114,21 @@ class Facade:
             response = self._children.request(owner, "BatchVisit", {**params, "visitors": sub_visitors})
             sub_results = response.get("results", [])
             results.extend(sub_results)
-            # Pull this bundle's edit into the facade's tree so the next bundle starts from it.
-            # Only when it actually changed something -- an unmodified run has nothing to contribute.
+            # Pull this bundle's edit in so the next bundle starts from it.
             if (self._hub_pull is not None and tree_id is not None and
                     any(r.get("modified") for r in sub_results)):
                 self._hub_pull(self._children, owner, tree_id, source_file_type)
         return {"results": results}
 
     def evict(self, params: dict) -> bool:
-        # The facade runs no recipes and holds no source trees; the children do. Fan the host's
-        # per-file Evict out to them so each rolls back its own ref map (bounding child memory and
-        # keeping ref numbering aligned with the host across files).
+        # Each child rolls back its own ref map, keeping ref numbering aligned with the host
+        # across files.
         self._children.broadcast_evict(params)
         return True
 
     def set_data_table_store(self, params: dict) -> bool:
-        # The facade runs no recipes, so it keeps no store of its own; it broadcasts the config to
-        # the children (where recipes emit data-table rows) and caches it for children spawned later.
+        # Recipes emit rows from the children, so the store is broadcast and cached for children
+        # spawned later.
         self._children.set_data_table_store(params)
         return True
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -5,7 +5,7 @@ installs each bundle into its own venv+child (``BundleChildren``), serves ``GetM
 the merged cache, and routes recipe execution to the owning child — tracking which child produced
 each prepared recipe's visitors so later ``Visit``/``Generate`` calls route to the right child.
 
-Scope note: precondition routing remains a follow-up to validate against a real CLI run.
+``Print``/``GetObject`` are not routed: the facade owns the working tree and answers those itself.
 """
 from pathlib import Path
 
@@ -19,8 +19,6 @@ class Facade:
         self._hub_pull = hub_pull
         self._bundle_by_visitor = {}    # visitor name (edit:/scan:) -> bundle
         self._bundle_by_recipe_id = {}  # prepared recipe id -> bundle
-        self._bundle_by_tree = {}       # visited tree id -> bundle that holds the modified tree
-        self._active_bundle = None      # bundle of the most recent visit (fallback owner during a run)
 
     def install_recipes(self, params: dict) -> dict:
         recipes = params.get("recipes")
@@ -97,9 +95,6 @@ class Facade:
         # the same for each of its runs; a single-recipe run reaches this path instead.
         if self._hub_pull is not None and tree_id is not None and result.get("modified"):
             self._hub_pull(self._children, bundle, tree_id, params.get("sourceFileType"))
-        if tree_id is not None:
-            self._bundle_by_tree[tree_id] = bundle
-        self._active_bundle = bundle
         return result
 
     def batch_visit(self, params: dict) -> dict:
@@ -132,27 +127,12 @@ class Facade:
             response = self._children.request(owner, "BatchVisit", {**params, "visitors": sub_visitors})
             sub_results = response.get("results", [])
             results.extend(sub_results)
-            self._active_bundle = owner
             # Pull this bundle's edit into the facade's tree so the next bundle starts from it.
             # Only when it actually changed something -- an unmodified run has nothing to contribute.
             if (self._hub_pull is not None and tree_id is not None and
                     any(r.get("modified") for r in sub_results)):
                 self._hub_pull(self._children, owner, tree_id, source_file_type)
-        if tree_id is not None and self._active_bundle is not None:
-            self._bundle_by_tree[tree_id] = self._active_bundle
         return {"results": results}
-
-    def tree_owner(self, params: dict):
-        """The child that should service a Print/GetObject, or None to fall back to the facade-local
-        handler. Print sends 'treeId', GetObject sends 'id'. A modifying visit re-keys the tree under
-        a new id (and Java also fetches the execution context and cursors by id), so an exact-id miss
-        during a run still belongs to the child that just visited — the facade holds no trees then.
-        Only before any visit (build time) is there no active bundle, leaving those objects local."""
-        tree_id = params.get("treeId") or params.get("id")
-        return self._bundle_by_tree.get(tree_id) or self._active_bundle
-
-    def route_to_child(self, bundle, method: str, params: dict) -> dict:
-        return self._children.request(bundle, method, params)
 
     def evict(self, params: dict) -> bool:
         # The facade runs no recipes and holds no source trees; the children do. Fan the host's

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -3,7 +3,9 @@
 In facade mode (``--recipe-install-dir`` set, not a child) the server holds no recipes itself: each
 bundle gets its own venv and child, and recipe execution routes to the owning child.
 
-``Print``/``GetObject`` are not routed — the facade owns the working tree and answers those itself.
+``Print``/``GetObject`` are not routed: the working source file is owned outside the children, so
+a child's edit has to be pulled back into it (``hub_pull``) or it is never seen. That store and the
+per-child ref tables it needs live in ``rewrite.rpc.server`` as the ``_hub_*`` functions.
 """
 from pathlib import Path
 
@@ -32,17 +34,13 @@ class Facade:
             else:
                 spec = package
             rows = self._children.install(package, spec)
-            # The CLI pins the bundle to the resolved version, so later resolves arrive exact.
             return {"recipesInstalled": len(rows), "version": self._children.resolved_version(package)}
         raise ValueError(f"Invalid recipes parameter: {recipes!r}")
 
     def _install_local(self, local_path: str) -> dict:
-        # A local install arrives as a path, but the venv and child are keyed by distribution name.
         dist = distribution_name_from_source(Path(local_path))
         if not dist:
             raise ValueError(f"Could not determine the distribution name for local path '{local_path}'")
-        # Discovery filters on the distribution name; attribution is the supplied path, which is
-        # the identity the host keys a local bundle by.
         rows = self._children.install(dist, local_path, force=True, attribution_name=local_path)
         return {"recipesInstalled": len(rows), "version": self._children.resolved_version(dist)}
 
@@ -66,8 +64,6 @@ class Facade:
             visitor = response.get(key)
             if visitor:
                 self._bundle_by_visitor[visitor] = bundle
-        # A precondition may name one of this child's own visitors, and appears in neither
-        # editVisitor nor recipeList — unregistered, the host's Visit for it would find no owner.
         for key in ("editPreconditions", "scanPreconditions"):
             for precondition in (response.get(key) or []):
                 visitor = precondition.get("visitorName")
@@ -83,8 +79,6 @@ class Facade:
             raise ValueError(f"No child owns visitor '{visitor}'")
         result = self._children.request(bundle, "Visit", params)
         tree_id = params.get("treeId")
-        # The facade answers Java's later Print/GetObject from its own tree, so an edit left in the
-        # child is lost — silently, since the run still succeeds and reports no changes.
         if self._hub_pull is not None and tree_id is not None and result.get("modified"):
             self._hub_pull(self._children, bundle, tree_id, params.get("sourceFileType"))
         return result
@@ -114,21 +108,16 @@ class Facade:
             response = self._children.request(owner, "BatchVisit", {**params, "visitors": sub_visitors})
             sub_results = response.get("results", [])
             results.extend(sub_results)
-            # Pull this bundle's edit in so the next bundle starts from it.
             if (self._hub_pull is not None and tree_id is not None and
                     any(r.get("modified") for r in sub_results)):
                 self._hub_pull(self._children, owner, tree_id, source_file_type)
         return {"results": results}
 
     def evict(self, params: dict) -> bool:
-        # Each child rolls back its own ref map, keeping ref numbering aligned with the host
-        # across files.
         self._children.broadcast_evict(params)
         return True
 
     def set_data_table_store(self, params: dict) -> bool:
-        # Recipes emit rows from the children, so the store is broadcast and cached for children
-        # spawned later.
         self._children.set_data_table_store(params)
         return True
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -15,7 +15,6 @@ from rewrite.discovery import distribution_name_from_source
 class Facade:
     def __init__(self, children, hub_pull=None):
         self._children = children
-        # (children, bundle, tree_id, source_file_type) -> pull that child's edit into the facade's tree
         self._hub_pull = hub_pull
         self._bundle_by_visitor = {}    # visitor name (edit:/scan:) -> bundle
         self._bundle_by_recipe_id = {}  # prepared recipe id -> bundle

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -1,0 +1,172 @@
+"""Facade request handling: route RPC operations across per-bundle children.
+
+In facade mode (``--recipe-install-dir`` set, not a child), the server holds no recipes itself. It
+installs each bundle into its own venv+child (``BundleChildren``), serves ``GetMarketplace`` from
+the merged cache, and routes recipe execution to the owning child — tracking which child produced
+each prepared recipe's visitors so later ``Visit``/``Generate`` calls route to the right child.
+
+Scope note: precondition routing remains a follow-up to validate against a real CLI run.
+"""
+from pathlib import Path
+
+from rewrite.discovery import distribution_name_from_source
+
+
+class Facade:
+    def __init__(self, children, hub_pull=None):
+        self._children = children
+        # (children, bundle, tree_id, source_file_type) -> pull that child's edit into the facade's tree
+        self._hub_pull = hub_pull
+        self._bundle_by_visitor = {}    # visitor name (edit:/scan:) -> bundle
+        self._bundle_by_recipe_id = {}  # prepared recipe id -> bundle
+        self._bundle_by_tree = {}       # visited tree id -> bundle that holds the modified tree
+        self._active_bundle = None      # bundle of the most recent visit (fallback owner during a run)
+
+    def install_recipes(self, params: dict) -> dict:
+        recipes = params.get("recipes")
+        if isinstance(recipes, str):
+            return self._install_local(recipes)
+        if isinstance(recipes, dict):
+            package = recipes.get("packageName")
+            version = recipes.get("version")
+            if not package:
+                raise ValueError("Package name is required")
+            if version:
+                spec = f"{package}{version}" if version[0] in "=<>!~" else f"{package}=={version}"
+            else:
+                spec = package
+            rows = self._children.install(package, spec)
+            # Report what pip resolved, not the requested spec (which is null for a version-less
+            # install). The CLI pins the bundle to this so later resolves arrive with an exact spec.
+            return {"recipesInstalled": len(rows), "version": self._children.resolved_version(package)}
+        raise ValueError(f"Invalid recipes parameter: {recipes!r}")
+
+    def _install_local(self, local_path: str) -> dict:
+        # A local install arrives as a path but the venv/child are keyed by distribution name, so
+        # resolve the name from the source before installing. force=True re-copies the mutable
+        # source even at an unchanged version.
+        dist = distribution_name_from_source(Path(local_path))
+        if not dist:
+            raise ValueError(f"Could not determine the distribution name for local path '{local_path}'")
+        # Filter discovery by the resolved distribution name, but attribute the recipes to the
+        # supplied path — the identity the host keys the local bundle by.
+        rows = self._children.install(dist, local_path, force=True, attribution_name=local_path)
+        return {"recipesInstalled": len(rows), "version": self._children.resolved_version(dist)}
+
+    def get_marketplace(self, params: dict):
+        return self._children.marketplace()
+
+    def prepare_recipe(self, params: dict) -> dict:
+        recipe_name = params.get("id")
+        bundle = self._children.owner(recipe_name)
+        if bundle is None:
+            raise ValueError(f"No bundle owns recipe '{recipe_name}'")
+        response = self._children.request(bundle, "PrepareRecipe", params)
+        self._register(response, bundle)
+        return response
+
+    def _register(self, response: dict, bundle) -> None:
+        rid = response.get("id")
+        if rid is not None:
+            self._bundle_by_recipe_id[rid] = bundle
+        for key in ("editVisitor", "scanVisitor"):
+            visitor = response.get(key)
+            if visitor:
+                self._bundle_by_visitor[visitor] = bundle
+        # A precondition can name a Python visitor (`edit:<prepared id>`) that the host calls back
+        # like any other. It was prepared inside this child but appears in neither editVisitor nor
+        # recipeList, so without this the host's Visit for it finds no owner.
+        for key in ("editPreconditions", "scanPreconditions"):
+            for precondition in (response.get(key) or []):
+                visitor = precondition.get("visitorName")
+                if visitor:
+                    self._bundle_by_visitor[visitor] = bundle
+        for child in (response.get("recipeList") or []):
+            self._register(child, bundle)  # same bundle: in-boundary composition
+
+    def visit(self, params: dict) -> dict:
+        visitor = params.get("visitor")
+        bundle = self._bundle_by_visitor.get(visitor)
+        if bundle is None:
+            raise ValueError(f"No child owns visitor '{visitor}'")
+        result = self._children.request(bundle, "Visit", params)
+        # The child now holds the (possibly modified) tree in its local_objects, along with the
+        # RPC ref-state built up fetching inputs. A later Print/GetObject for this tree must run
+        # there — the facade's own ref-state is empty and cannot service get_object_from_java.
+        tree_id = params.get("treeId")
+        if tree_id is not None:
+            self._bundle_by_tree[tree_id] = bundle
+        self._active_bundle = bundle
+        return result
+
+    def batch_visit(self, params: dict) -> dict:
+        """Route a BatchVisit's visitors to their owning children, preserving sequence.
+
+        The Java scheduler (RecipeRunCycle) batches a tree's visitors across every recipe in the
+        run cycle, so one BatchVisit can span bundles. Split it into maximal consecutive same-owner
+        runs and dispatch each as a BatchVisit to that child, concatenating the per-visitor results
+        in order. A single-bundle composite collapses to one run — the whole batch to one child.
+
+        Each run is a "sub-BatchVisit" against the facade's hub: the child is served the facade's
+        current tree over that child's ref table, runs its visitors, and its edit is pulled back as a
+        diff and applied to the facade's tree before the next bundle starts. So bundle B sees bundle
+        A's result rather than the original, and the accumulated tree stays with the facade."""
+        groups = []  # maximal consecutive same-owner runs: [(owner, [visitor, ...]), ...]
+        for visitor in params.get("visitors", []):
+            name = visitor.get("visitor")
+            owner = self._bundle_by_visitor.get(name)
+            if owner is None:
+                raise ValueError(f"No child owns visitor '{name}'")
+            if groups and groups[-1][0] == owner:
+                groups[-1][1].append(visitor)
+            else:
+                groups.append((owner, [visitor]))
+
+        tree_id = params.get("treeId")
+        source_file_type = params.get("sourceFileType")
+        results = []
+        for owner, sub_visitors in groups:
+            response = self._children.request(owner, "BatchVisit", {**params, "visitors": sub_visitors})
+            sub_results = response.get("results", [])
+            results.extend(sub_results)
+            self._active_bundle = owner
+            # Pull this bundle's edit into the facade's tree so the next bundle starts from it.
+            # Only when it actually changed something -- an unmodified run has nothing to contribute.
+            if (self._hub_pull is not None and tree_id is not None and
+                    any(r.get("modified") for r in sub_results)):
+                self._hub_pull(self._children, owner, tree_id, source_file_type)
+        if tree_id is not None and self._active_bundle is not None:
+            self._bundle_by_tree[tree_id] = self._active_bundle
+        return {"results": results}
+
+    def tree_owner(self, params: dict):
+        """The child that should service a Print/GetObject, or None to fall back to the facade-local
+        handler. Print sends 'treeId', GetObject sends 'id'. A modifying visit re-keys the tree under
+        a new id (and Java also fetches the execution context and cursors by id), so an exact-id miss
+        during a run still belongs to the child that just visited — the facade holds no trees then.
+        Only before any visit (build time) is there no active bundle, leaving those objects local."""
+        tree_id = params.get("treeId") or params.get("id")
+        return self._bundle_by_tree.get(tree_id) or self._active_bundle
+
+    def route_to_child(self, bundle, method: str, params: dict) -> dict:
+        return self._children.request(bundle, method, params)
+
+    def evict(self, params: dict) -> bool:
+        # The facade runs no recipes and holds no source trees; the children do. Fan the host's
+        # per-file Evict out to them so each rolls back its own ref map (bounding child memory and
+        # keeping ref numbering aligned with the host across files).
+        self._children.broadcast_evict(params)
+        return True
+
+    def set_data_table_store(self, params: dict) -> bool:
+        # The facade runs no recipes, so it keeps no store of its own; it broadcasts the config to
+        # the children (where recipes emit data-table rows) and caches it for children spawned later.
+        self._children.set_data_table_store(params)
+        return True
+
+    def generate(self, params: dict) -> dict:
+        recipe_id = params.get("id")
+        bundle = self._bundle_by_recipe_id.get(recipe_id)
+        if bundle is None:
+            raise ValueError(f"No child owns prepared recipe '{recipe_id}'")
+        return self._children.request(bundle, "Generate", params)

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
@@ -7,7 +7,7 @@ and type-specific visit methods handling only additional fields.
 from typing import Any, TYPE_CHECKING
 
 from rewrite import Markers
-from rewrite.utils import id_to_str
+from rewrite.utils import id_to_int, id_to_str
 from rewrite.java import Space, JRightPadded, JLeftPadded, JContainer, J
 from rewrite.parser import ParseError
 from rewrite.python import CompilationUnit
@@ -821,10 +821,11 @@ class PythonRpcSender:
         if markers is None:
             return
         q.get_and_send(markers, lambda x: id_to_str(x._id))
-        # Send markers list as ref - for now send as regular list
-        # Java uses getAndSendListAsRef but we'll use regular list for simplicity
+        # A marker whose type Python lacks a codec for is held opaquely as {'kind': ..., 'id': ...},
+        # where 'id' is a canonical UUID string (not the 128-bit int a typed node's _id is); normalise
+        # it so id_to_str gets an int. (Markers is the only list that can carry opaque elements.)
         q.get_and_send_list(markers, lambda x: x.markers,
-                           lambda m: id_to_str(m._id),
+                           lambda m: id_to_str(id_to_int(m['id']) if isinstance(m, dict) else m._id),
                            None)  # No on_change - each marker is sent as-is
 
     def _visit_type(self, java_type, q: 'RpcSendQueue') -> None:

--- a/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
@@ -277,7 +277,12 @@ class RpcSendQueue:
         # Primitives and built-ins don't need type info
         if obj_type in (str, int, float, bool, type(None)):
             return None
-        if isinstance(obj, (list, dict)):
+        if isinstance(obj, dict):
+            # An opaque value the remote side has a codec for but Python does not is received as
+            # {'kind': <valueType>, **fields} (see RpcReceiveQueue._do_change). Re-emit its original
+            # valueType so it round-trips unchanged; an ordinary dict (no 'kind') stays untyped.
+            return obj.get('kind')
+        if isinstance(obj, list):
             return None
         if isinstance(obj, UUID):
             return None
@@ -318,6 +323,10 @@ class RpcSendQueue:
         import math
         if obj is None:
             return None
+        if isinstance(obj, dict) and 'kind' in obj:
+            # Opaque value (see _get_value_type): its wire payload is every field except the
+            # synthetic 'kind' tag the receiver added. Emit that back as the value.
+            return {k: v for k, v in obj.items() if k != 'kind'}
         if isinstance(obj, bool):
             return obj
         if isinstance(obj, int):

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -94,18 +94,15 @@ _python_version = os.environ.get("REWRITE_PYTHON_VERSION", "3")
 # package pip installs it here before activating.
 _recipe_install_dir: Optional[Path] = None
 
-# Set via --child-bundle. When set, this process is a single-bundle child: its
-# marketplace is scoped to exactly this distribution's recipes (see _get_marketplace).
+# Set via --child-bundle: the marketplace is scoped to exactly this distribution's recipes.
 _child_bundle: Optional[str] = None
 
 # Set via --attribution-name. Labels a child's recipes with the identity the host keys the bundle
 # by (a local install's supplied path) rather than the distribution name; None for a registry spec.
 _attribution_name: Optional[str] = None
 
-# When --recipe-install-dir is set (and this is not a child), this process is the facade: it
-# installs each bundle into its own venv subdirectory under that root and routes recipe operations
-# to per-bundle children (see _facade_mode, _get_facade, handle_request). A future --server flag can
-# demarcate the facade explicitly.
+# When --recipe-install-dir is set and this is not a child, this process is the facade: one venv
+# subdirectory per bundle under that root, recipe operations routed to per-bundle children.
 _facade = None
 
 
@@ -751,8 +748,7 @@ def _get_marketplace():
         _marketplace = RecipeMarketplace()
 
         if _child_bundle:
-            # Child: only this bundle's direct recipes. No flat discovery,
-            # no built-in activation — a child owns exactly one distribution.
+            # A child owns exactly one distribution: no flat discovery, no built-in activation.
             from rewrite.discovery import discover_root_recipes
             discover_root_recipes(_child_bundle, marketplace=_marketplace, attribution=_attribution,
                                   attribution_name=_attribution_name)
@@ -892,8 +888,8 @@ def handle_install_recipes(params: dict) -> dict:
         else:
             logger.info(f"Activating recipes from local path: {recipes}")
 
-        # The distribution name imports/activates the package; attribution, though, is the supplied
-        # path — the identity the host keys a local bundle by (matching the facade's local install).
+        # Attribution is the supplied path, not the distribution name — the identity the host
+        # keys a local bundle by.
         package_name = _find_package_name(local_path)
         if package_name:
             before = recipe_name_set(marketplace)
@@ -1898,9 +1894,9 @@ def handle_generate(params: dict) -> dict:
 # runs its visitors, and its edit is pulled back as a diff and applied to the facade's tree before
 # the next bundle starts.
 #
-# Because the facade deserializes and re-generates per child, every hop is a diff between a matched
-# send/receive pair, and one child's ref numbering never has to mean anything to another child --
-# which is what made relaying a child's stream to a sibling unsafe.
+# Deserializing and re-generating per child keeps every hop a diff between a matched send/receive
+# pair, so one child's ref numbering never has to mean anything to another child. Relaying a
+# child's stream directly to a sibling is unsafe.
 # ---------------------------------------------------------------------------
 _hub_tree: Dict[str, Any] = {}              # obj_id -> the facade's authoritative tree
 _hub_send_refs: Dict[str, Dict] = {}        # bundle -> send ref map      (facade -> child)
@@ -1976,10 +1972,7 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
 
 
 def _hub_release(obj_id: str) -> None:
-    """Drop the facade's copy of a finished file and roll each child's ref table back to where it
-    stood before that file.
-
-    The rollback must be symmetric with the child's own Evict: the child drops the refs this file
+    """The rollback must be symmetric with the child's own Evict: the child drops the refs this file
     introduced from its receive map, so if the facade kept them in its send map it would emit a
     GET_REF for a ref the child no longer has ("Received reference to unknown object").
     """
@@ -1997,8 +1990,8 @@ def _hub_release(obj_id: str) -> None:
 
 
 def _serve_child_object(method: str, params: dict, bundle: Optional[str] = None) -> Any:
-    """A child's upstream callback. GetObject is answered by the facade from the tree it owns (over
-    that child's ref table); anything else relays to Java."""
+    """A child's upstream callback: GetObject is answered from the facade's tree, the rest relays
+    to Java."""
     if method != 'GetObject':
         return send_request(method, params)
 
@@ -2015,15 +2008,13 @@ def _facade_mode() -> bool:
 
 
 def _get_facade():
-    """Lazily build the facade (BundleChildren + routing) rooted at --recipe-install-dir."""
     global _facade
     if _facade is None:
         from rewrite.rpc import venv_manager
         from rewrite.rpc.bundle_children import BundleChildren
         from rewrite.rpc.facade import Facade
-        # One-time migration: the root now holds only per-bundle venvs. Clear any pre-venv
-        # `pip install --target` residue so a later CLI downgrade reinstalls cleanly (a stale
-        # dist-info would otherwise make the old CLI skip pip and serve stale recipes).
+        # Clear pre-venv `pip install --target` residue: a stale dist-info makes an older CLI
+        # skip pip and serve stale recipes after a downgrade.
         removed = venv_manager.purge_non_venv_entries(_recipe_install_dir)
         if removed:
             logger.info("Cleared %d pre-venv recipe artifact(s) from %s: %s",
@@ -2037,9 +2028,7 @@ def handle_request(method: str, params: dict) -> Any:
     """Handle an RPC request."""
     if _facade_mode():
         facade = _get_facade()
-        # Evict (host per-file notification): fan out to the children so each rolls back its own ref
-        # map in lockstep with the host, then drop the facade's own cached input bytes and any
-        # build-time state for that file.
+        # Fan Evict out to the children so each rolls back its ref map in lockstep with the host.
         if method == 'Evict':
             facade.evict(params)
             _hub_release(params.get('id'))
@@ -2055,16 +2044,13 @@ def handle_request(method: str, params: dict) -> Any:
         }
         facade_handler = facade_handlers.get(method)
         if facade_handler:
-            # Take ownership of the tree here, at the top level, before any child runs. A child's
-            # GetObject callback is then answered from what we already hold; fetching from Java down
-            # inside that callback would deadlock (the child waits on us, Java waits on this request).
+            # Acquire at the top level, before any child runs — acquiring inside a child's
+            # GetObject callback would deadlock (the child waits on us, Java on this request).
             if method in ('Visit', 'BatchVisit'):
                 _hub_acquire(params.get('treeId'), params.get('sourceFileType'))
             return facade_handler(params)
-        # The facade owns the in-flight tree, so it answers Java's Print/GetObject itself from the
-        # accumulated result -- no child round-trip, and no child's partial copy can be mistaken for
-        # the whole edit. Acquire here (top level) if we don't hold it yet, then fall through to the
-        # local handlers, which read local_objects.
+        # The facade answers Java's Print/GetObject from its own accumulated tree, so a child's
+        # partial copy can never be mistaken for the whole edit.
         if method in ('Print', 'GetObject'):
             obj_id = params.get('treeId') or params.get('id')
             source_file_type = params.get('sourceFileType')

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -2067,8 +2067,13 @@ def handle_request(method: str, params: dict) -> Any:
         # local handlers, which read local_objects.
         if method in ('Print', 'GetObject'):
             obj_id = params.get('treeId') or params.get('id')
-            if obj_id is not None and obj_id not in _hub_tree:
-                _hub_acquire(obj_id, params.get('sourceFileType'))
+            source_file_type = params.get('sourceFileType')
+            # Java fetches non-tree objects by id as well (the execution context, cursors).
+            # `GetObject.sourceFileType` is nullable and only set for trees, so it is what tells
+            # the two apart. Acquiring a non-tree would hand its property messages to a receiver
+            # that has no codec for them, desynchronizing the queue for every later object.
+            if obj_id is not None and source_file_type and obj_id not in _hub_tree:
+                _hub_acquire(obj_id, source_file_type)
         # Parse / GetLanguages / build-time GetObject / etc. run locally on the facade.
 
     handlers = {

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -94,6 +94,20 @@ _python_version = os.environ.get("REWRITE_PYTHON_VERSION", "3")
 # package pip installs it here before activating.
 _recipe_install_dir: Optional[Path] = None
 
+# Set via --child-bundle. When set, this process is a single-bundle child: its
+# marketplace is scoped to exactly this distribution's recipes (see _get_marketplace).
+_child_bundle: Optional[str] = None
+
+# Set via --attribution-name. Labels a child's recipes with the identity the host keys the bundle
+# by (a local install's supplied path) rather than the distribution name; None for a registry spec.
+_attribution_name: Optional[str] = None
+
+# When --recipe-install-dir is set (and this is not a child), this process is the facade: it
+# installs each bundle into its own venv subdirectory under that root and routes recipe operations
+# to per-bundle children (see _facade_mode, _get_facade, handle_request). A future --server flag can
+# demarcate the facade explicitly.
+_facade = None
+
 
 def _next_request_id() -> int:
     """Generate a unique request ID for outgoing requests."""
@@ -733,24 +747,31 @@ def _get_marketplace():
     """
     global _marketplace
     if _marketplace is None:
-        from rewrite.discovery import discover_recipes, recipe_name_set
         from rewrite.marketplace import RecipeMarketplace
-        from rewrite import activate
-
         _marketplace = RecipeMarketplace()
 
-        # Discover from installed packages, tracking which distribution
-        # contributed each recipe.
-        discover_recipes(marketplace=_marketplace, attribution=_attribution)
+        if _child_bundle:
+            # Child: only this bundle's direct recipes. No flat discovery,
+            # no built-in activation — a child owns exactly one distribution.
+            from rewrite.discovery import discover_root_recipes
+            discover_root_recipes(_child_bundle, marketplace=_marketplace, attribution=_attribution,
+                                  attribution_name=_attribution_name)
+        else:
+            from rewrite.discovery import discover_recipes, recipe_name_set
+            from rewrite import activate
 
-        # Also activate local recipes (in case the openrewrite distribution
-        # isn't pip-installed, e.g., when running from source). When it is
-        # installed, discovery already covered these and install() will dedupe
-        # by name; attribute the source-mode additions to "openrewrite" so
-        # they're returned by GetMarketplace/InstallRecipes for that package.
-        before = recipe_name_set(_marketplace)
-        activate(_marketplace)
-        _attribution.record("openrewrite", recipe_name_set(_marketplace) - before)
+            # Discover from installed packages, tracking which distribution
+            # contributed each recipe.
+            discover_recipes(marketplace=_marketplace, attribution=_attribution)
+
+            # Also activate local recipes (in case the openrewrite distribution
+            # isn't pip-installed, e.g., when running from source). When it is
+            # installed, discovery already covered these and install() will dedupe
+            # by name; attribute the source-mode additions to "openrewrite" so
+            # they're returned by GetMarketplace/InstallRecipes for that package.
+            before = recipe_name_set(_marketplace)
+            activate(_marketplace)
+            _attribution.record("openrewrite", recipe_name_set(_marketplace) - before)
 
     return _marketplace
 
@@ -871,8 +892,8 @@ def handle_install_recipes(params: dict) -> dict:
         else:
             logger.info(f"Activating recipes from local path: {recipes}")
 
-        # Find and import the package
-        # For local paths, we look for the package name from setup.py/pyproject.toml
+        # The distribution name imports/activates the package; attribution, though, is the supplied
+        # path — the identity the host keys a local bundle by (matching the facade's local install).
         package_name = _find_package_name(local_path)
         if package_name:
             before = recipe_name_set(marketplace)
@@ -953,44 +974,8 @@ def _add_source_to_path(local_path: Path) -> None:
 
 def _find_package_name(local_path: Path) -> Optional[str]:
     """Find the package name from a local path."""
-    import sys
-    if sys.version_info >= (3, 11):
-        import tomllib
-    else:
-        try:
-            import tomli as tomllib  # type: ignore[import-not-found]
-        except ModuleNotFoundError:
-            return None
-
-    # Try pyproject.toml first
-    pyproject_path = local_path / 'pyproject.toml'
-    if pyproject_path.exists():
-        try:
-            with open(pyproject_path, 'rb') as f:
-                data = tomllib.load(f)
-                # Try [project] section first (PEP 621)
-                if 'project' in data and 'name' in data['project']:
-                    return data['project']['name']
-                # Try [tool.poetry] section
-                if 'tool' in data and 'poetry' in data['tool'] and 'name' in data['tool']['poetry']:
-                    return data['tool']['poetry']['name']
-        except Exception as e:
-            logger.warning(f"Failed to parse pyproject.toml: {e}")
-
-    # Try setup.py
-    setup_py = local_path / 'setup.py'
-    if setup_py.exists():
-        # Simple heuristic: look for name= in setup.py
-        try:
-            content = setup_py.read_text()
-            import re
-            match = re.search(r'name\s*=\s*["\']([^"\']+)["\']', content)
-            if match:
-                return match.group(1)
-        except Exception as e:
-            logger.warning(f"Failed to parse setup.py: {e}")
-
-    return None
+    from rewrite.discovery import distribution_name_from_source
+    return distribution_name_from_source(local_path)
 
 
 def _import_and_activate_package(package_name: str, marketplace, local_path: Optional[Path] = None):
@@ -1749,6 +1734,8 @@ def handle_batch_visit(params: dict) -> dict:
         if str(tree.id) != tree_id:
             local_objects[tree_id] = tree
 
+    # The edited tree stays in local_objects; the facade pulls it back as a diff (GetObject) after
+    # this sub-BatchVisit rather than having us serialize it in full here.
     return {'results': results}
 
 
@@ -1902,8 +1889,188 @@ def handle_generate(params: dict) -> dict:
     return {'ids': [], 'sourceFileTypes': []}
 
 
+# ---------------------------------------------------------------------------
+# Facade hub
+#
+# The facade owns the in-flight source file and keeps one RPC ref table per connection: its own
+# facade<->Java table (the module-level remote_objects/remote_refs) plus one per child. Each bundle
+# runs as a "sub-BatchVisit": the child is served the facade's current tree over that child's table,
+# runs its visitors, and its edit is pulled back as a diff and applied to the facade's tree before
+# the next bundle starts.
+#
+# Because the facade deserializes and re-generates per child, every hop is a diff between a matched
+# send/receive pair, and one child's ref numbering never has to mean anything to another child --
+# which is what made relaying a child's stream to a sibling unsafe.
+# ---------------------------------------------------------------------------
+_hub_tree: Dict[str, Any] = {}              # obj_id -> the facade's authoritative tree
+_hub_send_refs: Dict[str, Dict] = {}        # bundle -> send ref map      (facade -> child)
+_hub_send_next: Dict[str, int] = {}         # bundle -> next send ref number
+_hub_served: Dict[tuple, Any] = {}          # (bundle, obj_id) -> what that child was last served
+_hub_send_checkpoint: Dict[tuple, int] = {}  # (bundle, obj_id) -> send ref counter before this file
+
+def _hub_acquire(obj_id: str, source_file_type: Optional[str]):
+    """The facade's copy of the in-flight tree, fetched from Java (over the facade<->Java table) the
+    first time it is needed and owned by the facade from then on."""
+    if obj_id is None:
+        return None
+    tree = _hub_tree.get(obj_id)
+    if tree is None:
+        tree = get_object_from_java(obj_id, source_file_type)
+        if tree is not None:
+            _hub_tree[obj_id] = tree
+            # Also the facade's own object, so the local Print/GetObject handlers answer Java from
+            # the tree the facade owns instead of round-tripping to a child.
+            local_objects[obj_id] = tree
+    return tree
+
+
+def _hub_serve_child(bundle: str, obj_id: str, source_file_type: Optional[str]) -> Any:
+    """Serve a child its view of the facade's tree over that child's ref table: a diff against
+    whatever that child was last served, or a full object the first time."""
+    from rewrite.rpc.send_queue import RpcSendQueue
+
+    # Serve only from what the facade already holds. Fetching from Java here would deadlock: we are
+    # inside a child's callback, the child is blocked on us, and Java is blocked on the request that
+    # got us here. handle_request acquires the tree at the top level before dispatching instead.
+    tree = _hub_tree.get(obj_id)
+    if tree is None:
+        return [{'state': 'DELETE'}, {'state': 'END_OF_OBJECT'}]
+
+    q = RpcSendQueue(source_file_type)
+    q.refs = _hub_send_refs.setdefault(bundle, {})
+    q.next_ref = _hub_send_next.get(bundle, 0)
+    # Remember where this child's ref numbering stood before this file, so Evict can roll it back
+    # in lockstep with the child's own rollback (see _hub_release).
+    _hub_send_checkpoint.setdefault((bundle, obj_id), q.next_ref)
+    data = q.generate(tree, _hub_served.get((bundle, obj_id)))
+    _hub_send_next[bundle] = q.next_ref
+    _hub_served[(bundle, obj_id)] = tree
+    return data
+
+
+def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: Optional[str]) -> None:
+    """Pull a child's edit back as a diff against what it was served and apply it to the facade's
+    tree, so the next bundle starts from this bundle's result."""
+    from rewrite.rpc.receive_queue import RpcReceiveQueue
+
+    served = _hub_served.get((bundle, obj_id))
+    remaining = [children.request(bundle, 'GetObject',
+                                  {'id': obj_id, 'sourceFileType': source_file_type})]
+
+    def pull():
+        # The child answers a GetObject in a single batch; any further pull drains empty.
+        if not remaining:
+            return []
+        return [d for d in remaining.pop(0) if d.get('state') != 'END_OF_OBJECT']
+
+    # The child builds a fresh RpcSendQueue for every GetObject, so its send-ref numbering restarts
+    # at 0 each call; our receive table has to restart with it rather than accumulate.
+    edited = RpcReceiveQueue({}, source_file_type, pull).receive(served, None)
+    if edited is not None:
+        _hub_tree[obj_id] = edited
+        _hub_served[(bundle, obj_id)] = edited
+        local_objects[obj_id] = edited
+        if str(getattr(edited, 'id', obj_id)) != obj_id:
+            # A modifying visit can re-key the tree; Java still fetches it under the original id.
+            local_objects[str(edited.id)] = edited
+
+
+def _hub_release(obj_id: str) -> None:
+    """Drop the facade's copy of a finished file and roll each child's ref table back to where it
+    stood before that file.
+
+    The rollback must be symmetric with the child's own Evict: the child drops the refs this file
+    introduced from its receive map, so if the facade kept them in its send map it would emit a
+    GET_REF for a ref the child no longer has ("Received reference to unknown object").
+    """
+    _hub_tree.pop(obj_id, None)
+    for key in [k for k in _hub_served if k[1] == obj_id]:
+        del _hub_served[key]
+    for key in [k for k in _hub_send_checkpoint if k[1] == obj_id]:
+        bundle = key[0]
+        checkpoint = _hub_send_checkpoint.pop(key)
+        refs = _hub_send_refs.get(bundle)
+        if refs is not None:
+            for ref_key in [k for k, (_, num) in refs.items() if num > checkpoint]:
+                del refs[ref_key]
+        _hub_send_next[bundle] = checkpoint
+
+
+def _serve_child_object(method: str, params: dict, bundle: Optional[str] = None) -> Any:
+    """A child's upstream callback. GetObject is answered by the facade from the tree it owns (over
+    that child's ref table); anything else relays to Java."""
+    if method != 'GetObject':
+        return send_request(method, params)
+
+    obj_id = params.get('id')
+    if obj_id is None:
+        return [{'state': 'DELETE'}, {'state': 'END_OF_OBJECT'}]
+    if bundle is None:
+        return send_request('GetObject', params)
+    return _hub_serve_child(bundle, obj_id, params.get('sourceFileType'))
+
+
+def _facade_mode() -> bool:
+    return _recipe_install_dir is not None and _child_bundle is None
+
+
+def _get_facade():
+    """Lazily build the facade (BundleChildren + routing) rooted at --recipe-install-dir."""
+    global _facade
+    if _facade is None:
+        from rewrite.rpc import venv_manager
+        from rewrite.rpc.bundle_children import BundleChildren
+        from rewrite.rpc.facade import Facade
+        # One-time migration: the root now holds only per-bundle venvs. Clear any pre-venv
+        # `pip install --target` residue so a later CLI downgrade reinstalls cleanly (a stale
+        # dist-info would otherwise make the old CLI skip pip and serve stale recipes).
+        removed = venv_manager.purge_non_venv_entries(_recipe_install_dir)
+        if removed:
+            logger.info("Cleared %d pre-venv recipe artifact(s) from %s: %s",
+                        len(removed), _recipe_install_dir, ", ".join(removed))
+        _facade = Facade(BundleChildren(sys.executable, _recipe_install_dir, upstream=_serve_child_object),
+                         hub_pull=_hub_pull_child_edit)
+    return _facade
+
+
 def handle_request(method: str, params: dict) -> Any:
     """Handle an RPC request."""
+    if _facade_mode():
+        facade = _get_facade()
+        # Evict (host per-file notification): fan out to the children so each rolls back its own ref
+        # map in lockstep with the host, then drop the facade's own cached input bytes and any
+        # build-time state for that file.
+        if method == 'Evict':
+            facade.evict(params)
+            _hub_release(params.get('id'))
+            return handle_evict(params)
+        facade_handlers = {
+            'InstallRecipes': facade.install_recipes,
+            'GetMarketplace': facade.get_marketplace,
+            'PrepareRecipe': facade.prepare_recipe,
+            'SetDataTableStore': facade.set_data_table_store,
+            'Visit': facade.visit,
+            'BatchVisit': facade.batch_visit,
+            'Generate': facade.generate,
+        }
+        facade_handler = facade_handlers.get(method)
+        if facade_handler:
+            # Take ownership of the tree here, at the top level, before any child runs. A child's
+            # GetObject callback is then answered from what we already hold; fetching from Java down
+            # inside that callback would deadlock (the child waits on us, Java waits on this request).
+            if method in ('Visit', 'BatchVisit'):
+                _hub_acquire(params.get('treeId'), params.get('sourceFileType'))
+            return facade_handler(params)
+        # The facade owns the in-flight tree, so it answers Java's Print/GetObject itself from the
+        # accumulated result -- no child round-trip, and no child's partial copy can be mistaken for
+        # the whole edit. Acquire here (top level) if we don't hold it yet, then fall through to the
+        # local handlers, which read local_objects.
+        if method in ('Print', 'GetObject'):
+            obj_id = params.get('treeId') or params.get('id')
+            if obj_id is not None and obj_id not in _hub_tree:
+                _hub_acquire(obj_id, params.get('sourceFileType'))
+        # Parse / GetLanguages / build-time GetObject / etc. run locally on the facade.
+
     handlers = {
         'Parse': handle_parse,
         'ParseProject': handle_parse_project,
@@ -2199,6 +2366,11 @@ def main():
     parser.add_argument('--metrics-csv', help='Metrics CSV output path')
     parser.add_argument('--trace-rpc-messages', action='store_true', help='Enable RPC message tracing')
     parser.add_argument('--recipe-install-dir', help='Directory where recipe pip packages are installed')
+    parser.add_argument('--child-bundle',
+                        help='Run as a single-bundle child scoped to this distribution name')
+    parser.add_argument('--attribution-name',
+                        help='Label this child\'s recipes with this identity (a local install\'s '
+                             'supplied path) instead of the distribution name')
     args = parser.parse_args()
 
     _init_pyroscope()
@@ -2209,6 +2381,14 @@ def main():
     if args.recipe_install_dir:
         global _recipe_install_dir
         _recipe_install_dir = Path(args.recipe_install_dir)
+
+    if args.child_bundle:
+        global _child_bundle
+        _child_bundle = args.child_bundle
+
+    if args.attribution_name:
+        global _attribution_name
+        _attribution_name = args.attribution_name
 
     if args.log_file:
         file_handler = logging.FileHandler(args.log_file)

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -97,12 +97,9 @@ _recipe_install_dir: Optional[Path] = None
 # Set via --child-bundle: the marketplace is scoped to exactly this distribution's recipes.
 _child_bundle: Optional[str] = None
 
-# Set via --attribution-name. Labels a child's recipes with the identity the host keys the bundle
-# by (a local install's supplied path) rather than the distribution name; None for a registry spec.
+# The identity the host keys a local bundle by (its supplied path); None for a registry spec.
 _attribution_name: Optional[str] = None
 
-# When --recipe-install-dir is set and this is not a child, this process is the facade: one venv
-# subdirectory per bundle under that root, recipe operations routed to per-bundle children.
 _facade = None
 
 
@@ -2026,8 +2023,6 @@ def handle_request(method: str, params: dict) -> Any:
             if method in ('Visit', 'BatchVisit'):
                 _hub_acquire(params.get('treeId'), params.get('sourceFileType'))
             return facade_handler(params)
-        # The facade answers Java's Print/GetObject from its own accumulated tree, so a child's
-        # partial copy can never be mistaken for the whole edit.
         if method in ('Print', 'GetObject'):
             obj_id = params.get('treeId') or params.get('id')
             source_file_type = params.get('sourceFileType')
@@ -2037,7 +2032,6 @@ def handle_request(method: str, params: dict) -> Any:
             # that has no codec for them, desynchronizing the queue for every later object.
             if obj_id is not None and source_file_type and obj_id not in _hub_tree:
                 _hub_acquire(obj_id, source_file_type)
-        # Parse / GetLanguages / build-time GetObject / etc. run locally on the facade.
 
     handlers = {
         'Parse': handle_parse,

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -748,7 +748,6 @@ def _get_marketplace():
         _marketplace = RecipeMarketplace()
 
         if _child_bundle:
-            # A child owns exactly one distribution: no flat discovery, no built-in activation.
             from rewrite.discovery import discover_root_recipes
             discover_root_recipes(_child_bundle, marketplace=_marketplace, attribution=_attribution,
                                   attribution_name=_attribution_name)
@@ -756,15 +755,8 @@ def _get_marketplace():
             from rewrite.discovery import discover_recipes, recipe_name_set
             from rewrite import activate
 
-            # Discover from installed packages, tracking which distribution
-            # contributed each recipe.
             discover_recipes(marketplace=_marketplace, attribution=_attribution)
 
-            # Also activate local recipes (in case the openrewrite distribution
-            # isn't pip-installed, e.g., when running from source). When it is
-            # installed, discovery already covered these and install() will dedupe
-            # by name; attribute the source-mode additions to "openrewrite" so
-            # they're returned by GetMarketplace/InstallRecipes for that package.
             before = recipe_name_set(_marketplace)
             activate(_marketplace)
             _attribution.record("openrewrite", recipe_name_set(_marketplace) - before)
@@ -1730,8 +1722,6 @@ def handle_batch_visit(params: dict) -> dict:
         if str(tree.id) != tree_id:
             local_objects[tree_id] = tree
 
-    # The edited tree stays in local_objects; the facade pulls it back as a diff (GetObject) after
-    # this sub-BatchVisit rather than having us serialize it in full here.
     return {'results': results}
 
 
@@ -1885,19 +1875,14 @@ def handle_generate(params: dict) -> dict:
     return {'ids': [], 'sourceFileTypes': []}
 
 
-# ---------------------------------------------------------------------------
-# Facade hub
-#
-# The facade owns the in-flight source file and keeps one RPC ref table per connection: its own
-# facade<->Java table (the module-level remote_objects/remote_refs) plus one per child. Each bundle
-# runs as a "sub-BatchVisit": the child is served the facade's current tree over that child's table,
-# runs its visitors, and its edit is pulled back as a diff and applied to the facade's tree before
-# the next bundle starts.
+# The facade owns the working source file and keeps one RPC ref table per connection: its own
+# facade<->Java table (remote_objects/remote_refs) plus one per child. Each bundle runs as a
+# "sub-BatchVisit": the child is served the current tree over that child's table, runs its visitors,
+# and its edit is pulled back as a diff and applied before the next bundle starts.
 #
 # Deserializing and re-generating per child keeps every hop a diff between a matched send/receive
 # pair, so one child's ref numbering never has to mean anything to another child. Relaying a
 # child's stream directly to a sibling is unsafe.
-# ---------------------------------------------------------------------------
 _hub_tree: Dict[str, Any] = {}              # obj_id -> the facade's authoritative tree
 _hub_send_refs: Dict[str, Dict] = {}        # bundle -> send ref map      (facade -> child)
 _hub_send_next: Dict[str, int] = {}         # bundle -> next send ref number
@@ -1914,8 +1899,6 @@ def _hub_acquire(obj_id: str, source_file_type: Optional[str]):
         tree = get_object_from_java(obj_id, source_file_type)
         if tree is not None:
             _hub_tree[obj_id] = tree
-            # Also the facade's own object, so the local Print/GetObject handlers answer Java from
-            # the tree the facade owns instead of round-tripping to a child.
             local_objects[obj_id] = tree
     return tree
 
@@ -1954,20 +1937,16 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
                                   {'id': obj_id, 'sourceFileType': source_file_type})]
 
     def pull():
-        # The child answers a GetObject in a single batch; any further pull drains empty.
         if not remaining:
             return []
         return [d for d in remaining.pop(0) if d.get('state') != 'END_OF_OBJECT']
 
-    # The child builds a fresh RpcSendQueue for every GetObject, so its send-ref numbering restarts
-    # at 0 each call; our receive table has to restart with it rather than accumulate.
     edited = RpcReceiveQueue({}, source_file_type, pull).receive(served, None)
     if edited is not None:
         _hub_tree[obj_id] = edited
         _hub_served[(bundle, obj_id)] = edited
         local_objects[obj_id] = edited
         if str(getattr(edited, 'id', obj_id)) != obj_id:
-            # A modifying visit can re-key the tree; Java still fetches it under the original id.
             local_objects[str(edited.id)] = edited
 
 
@@ -2013,8 +1992,6 @@ def _get_facade():
         from rewrite.rpc import venv_manager
         from rewrite.rpc.bundle_children import BundleChildren
         from rewrite.rpc.facade import Facade
-        # Clear pre-venv `pip install --target` residue: a stale dist-info makes an older CLI
-        # skip pip and serve stale recipes after a downgrade.
         removed = venv_manager.purge_non_venv_entries(_recipe_install_dir)
         if removed:
             logger.info("Cleared %d pre-venv recipe artifact(s) from %s: %s",
@@ -2028,7 +2005,7 @@ def handle_request(method: str, params: dict) -> Any:
     """Handle an RPC request."""
     if _facade_mode():
         facade = _get_facade()
-        # Fan Evict out to the children so each rolls back its ref map in lockstep with the host.
+
         if method == 'Evict':
             facade.evict(params)
             _hub_release(params.get('id'))

--- a/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
@@ -2,8 +2,8 @@
 
 Each recipe bundle gets its own venv so its dependency graph is fully isolated.
 Creation uses the stdlib ``venv`` module of a caller-supplied, rewrite-capable
-interpreter; uv is not assumed present. Uninstall is directory removal — one
-bundle owns one venv, so there is nothing to pip-uninstall.
+interpreter. Uninstall is directory removal — one bundle owns one venv, so
+there is nothing to pip-uninstall.
 """
 import os
 import shutil
@@ -91,13 +91,6 @@ def remove_venv(venv_dir: Path) -> None:
 
 
 def purge_non_venv_entries(root: Path) -> list:
-    """Remove everything in the venvs root that is not a per-bundle venv; return removed names.
-
-    A flat ``pip install --target <root>`` layout leaves package directories and ``*.dist-info``
-    in this root. They are dead to the facade, but a stale top-level ``*.dist-info`` makes a
-    *downgraded* pre-venv CLI skip pip and serve stale recipes from a half-clobbered flat layout.
-    An orphaned venv is kept — install rebuilds it.
-    """
     if not root.exists():
         return []
     removed = []

--- a/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
@@ -1,0 +1,137 @@
+"""Per-bundle virtual environment lifecycle.
+
+Each recipe bundle gets its own venv so its dependency graph is fully isolated.
+Creation uses the stdlib ``venv`` module of a caller-supplied, rewrite-capable
+interpreter; uv is not assumed present. Installing into a real venv gives pip
+proper resolution/upgrade/uninstall (dissolving the ``--target``defect class,
+incl. #8180). Uninstall is directory removal — one bundle owns one venv, so
+there is nothing to pip-uninstall.
+"""
+import os
+import shutil
+import subprocess
+from importlib import metadata
+from pathlib import Path
+from typing import Optional
+
+from rewrite.discovery import _normalize_package_name
+
+
+def venv_python(venv_dir: Path) -> Path:
+    """Path to the interpreter inside ``venv_dir`` (Scripts on Windows, bin on POSIX)."""
+    if os.name == "nt":
+        return venv_dir / "Scripts" / "python.exe"
+    return venv_dir / "bin" / "python"
+
+
+def _site_packages(venv_dir: Path) -> Optional[Path]:
+    """The venv's ``site-packages`` (``Lib`` on Windows, ``lib/pythonX.Y`` on POSIX)."""
+    if os.name == "nt":
+        sp = venv_dir / "Lib" / "site-packages"
+        return sp if sp.exists() else None
+    return next(venv_dir.glob("lib/python*/site-packages"), None)
+
+
+def installed_version(venv_dir: Path, dist: str) -> Optional[str]:
+    """The resolved version of distribution ``dist`` installed in the venv, or None.
+
+    Read from the venv's ``dist-info`` on disk — the install layer that just ran pip is the
+    authority on what version landed, so the facade reports this rather than echoing the requested
+    (possibly version-less) spec. Reads metadata off disk, so no import of the recipe is needed.
+    """
+    site_packages = _site_packages(venv_dir)
+    if site_packages is None:
+        return None
+    target = _normalize_package_name(dist)
+    for distribution in metadata.distributions(path=[str(site_packages)]):
+        name = distribution.metadata["Name"]
+        if name and _normalize_package_name(name) == target:
+            return distribution.version
+    return None
+
+
+def create_venv(python_executable: str, venv_dir: Path, clear: bool = False) -> None:
+    """Create a venv at ``venv_dir`` using ``python_executable``'s stdlib venv.
+
+    ``clear`` empties the directory first, for rebuilding over a stale venv or a leftover flat
+    ``pip install --target`` package directory of the same name.
+    """
+    cmd = [python_executable, "-m", "venv"]
+    if clear:
+        cmd.append("--clear")
+    cmd.append(str(venv_dir))
+    _run(cmd)
+
+
+def is_usable_venv(venv_dir: Path) -> bool:
+    """True when ``venv_dir`` is a venv whose base interpreter still exists.
+
+    A venv is not self-contained: ``pyvenv.cfg``'s ``home`` points at the base installation it
+    borrows its stdlib from. uv encodes the patch version in that path
+    (``.../cpython-3.12.11-...``), so upgrading or pruning the interpreter orphans every venv
+    built on it. Checking only for the interpreter file would miss this on Windows, where ``venv``
+    *copies* ``python.exe`` — it outlives its base and the venv still looks intact.
+    """
+    if not venv_python(venv_dir).exists():
+        return False
+    config = venv_dir / "pyvenv.cfg"
+    if not config.exists():
+        return False  # interrupted before configuration; treat as unbuilt
+    for line in config.read_text().splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() == "home":
+            return Path(value.strip()).exists()
+    return False
+
+
+def install_into_venv(venv_dir: Path, spec: str, force: bool = False) -> None:
+    """Install/upgrade ``spec`` (a PEP 440 requirement or a local path) into the venv.
+
+    ``force`` adds ``--force-reinstall`` so a mutable local source is re-copied even when its
+    version is unchanged; a version-pinned registry spec never needs it.
+    """
+    cmd = [str(venv_python(venv_dir)), "-m", "pip", "install", "--upgrade"]
+    if force:
+        cmd.append("--force-reinstall")
+    cmd.append(spec)
+    _run(cmd)
+
+
+def remove_venv(venv_dir: Path) -> None:
+    """Remove the bundle's venv directory (idempotent)."""
+    shutil.rmtree(venv_dir, ignore_errors=True)
+
+
+def purge_non_venv_entries(root: Path) -> list:
+    """Remove everything in the venvs root that is not a per-bundle venv; return removed names.
+
+    The facade's root holds only per-bundle venvs. Before per-bundle venvs, the Python server
+    installed recipes flat via ``pip install --target <root>``, leaving package directories,
+    ``*.dist-info``, and flattened dependencies directly in this root. Those are dead to the facade
+    (it discovers through children, which never see this root). But a stale top-level
+    ``*.dist-info`` makes a *downgraded* pre-venv CLI treat the package as already installed and
+    skip pip, then activate a half-clobbered flat layout — serving stale recipes. Removing it lets
+    that CLI reinstall cleanly, since ``pip install --upgrade --target`` overwrites the venv
+    directory in place.
+
+    A ``pyvenv.cfg`` marks a venv, kept even when orphaned (fix 2 rebuilds it on install).
+    Idempotent: a no-op once the root holds only venvs.
+    """
+    if not root.exists():
+        return []
+    removed = []
+    for entry in sorted(root.iterdir()):
+        if entry.is_dir() and (entry / "pyvenv.cfg").exists():
+            continue
+        removed.append(entry.name)
+        if entry.is_dir():
+            shutil.rmtree(entry, ignore_errors=True)
+        else:
+            entry.unlink(missing_ok=True)
+    return removed
+
+
+def _run(cmd: list) -> None:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"command failed: {' '.join(cmd)}\n{result.stderr}")

--- a/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
@@ -2,10 +2,8 @@
 
 Each recipe bundle gets its own venv so its dependency graph is fully isolated.
 Creation uses the stdlib ``venv`` module of a caller-supplied, rewrite-capable
-interpreter; uv is not assumed present. Installing into a real venv gives pip
-proper resolution/upgrade/uninstall (dissolving the ``--target``defect class,
-incl. #8180). Uninstall is directory removal — one bundle owns one venv, so
-there is nothing to pip-uninstall.
+interpreter; uv is not assumed present. Uninstall is directory removal — one
+bundle owns one venv, so there is nothing to pip-uninstall.
 """
 import os
 import shutil
@@ -18,14 +16,12 @@ from rewrite.discovery import _normalize_package_name
 
 
 def venv_python(venv_dir: Path) -> Path:
-    """Path to the interpreter inside ``venv_dir`` (Scripts on Windows, bin on POSIX)."""
     if os.name == "nt":
         return venv_dir / "Scripts" / "python.exe"
     return venv_dir / "bin" / "python"
 
 
 def _site_packages(venv_dir: Path) -> Optional[Path]:
-    """The venv's ``site-packages`` (``Lib`` on Windows, ``lib/pythonX.Y`` on POSIX)."""
     if os.name == "nt":
         sp = venv_dir / "Lib" / "site-packages"
         return sp if sp.exists() else None
@@ -33,11 +29,9 @@ def _site_packages(venv_dir: Path) -> Optional[Path]:
 
 
 def installed_version(venv_dir: Path, dist: str) -> Optional[str]:
-    """The resolved version of distribution ``dist`` installed in the venv, or None.
+    """The resolved version of ``dist`` installed in the venv, or None.
 
-    Read from the venv's ``dist-info`` on disk — the install layer that just ran pip is the
-    authority on what version landed, so the facade reports this rather than echoing the requested
-    (possibly version-less) spec. Reads metadata off disk, so no import of the recipe is needed.
+    Read off disk, so the recipe is never imported.
     """
     site_packages = _site_packages(venv_dir)
     if site_packages is None:
@@ -51,11 +45,7 @@ def installed_version(venv_dir: Path, dist: str) -> Optional[str]:
 
 
 def create_venv(python_executable: str, venv_dir: Path, clear: bool = False) -> None:
-    """Create a venv at ``venv_dir`` using ``python_executable``'s stdlib venv.
-
-    ``clear`` empties the directory first, for rebuilding over a stale venv or a leftover flat
-    ``pip install --target`` package directory of the same name.
-    """
+    """Create a venv at ``venv_dir``; ``clear`` empties the directory first."""
     cmd = [python_executable, "-m", "venv"]
     if clear:
         cmd.append("--clear")
@@ -87,8 +77,7 @@ def is_usable_venv(venv_dir: Path) -> bool:
 def install_into_venv(venv_dir: Path, spec: str, force: bool = False) -> None:
     """Install/upgrade ``spec`` (a PEP 440 requirement or a local path) into the venv.
 
-    ``force`` adds ``--force-reinstall`` so a mutable local source is re-copied even when its
-    version is unchanged; a version-pinned registry spec never needs it.
+    ``force`` re-copies a mutable local source whose version is unchanged.
     """
     cmd = [str(venv_python(venv_dir)), "-m", "pip", "install", "--upgrade"]
     if force:
@@ -98,24 +87,16 @@ def install_into_venv(venv_dir: Path, spec: str, force: bool = False) -> None:
 
 
 def remove_venv(venv_dir: Path) -> None:
-    """Remove the bundle's venv directory (idempotent)."""
     shutil.rmtree(venv_dir, ignore_errors=True)
 
 
 def purge_non_venv_entries(root: Path) -> list:
     """Remove everything in the venvs root that is not a per-bundle venv; return removed names.
 
-    The facade's root holds only per-bundle venvs. Before per-bundle venvs, the Python server
-    installed recipes flat via ``pip install --target <root>``, leaving package directories,
-    ``*.dist-info``, and flattened dependencies directly in this root. Those are dead to the facade
-    (it discovers through children, which never see this root). But a stale top-level
-    ``*.dist-info`` makes a *downgraded* pre-venv CLI treat the package as already installed and
-    skip pip, then activate a half-clobbered flat layout — serving stale recipes. Removing it lets
-    that CLI reinstall cleanly, since ``pip install --upgrade --target`` overwrites the venv
-    directory in place.
-
-    A ``pyvenv.cfg`` marks a venv, kept even when orphaned (fix 2 rebuilds it on install).
-    Idempotent: a no-op once the root holds only venvs.
+    A flat ``pip install --target <root>`` layout leaves package directories and ``*.dist-info``
+    in this root. They are dead to the facade, but a stale top-level ``*.dist-info`` makes a
+    *downgraded* pre-venv CLI skip pip and serve stale recipes from a half-clobbered flat layout.
+    An orphaned venv is kept — install rebuilds it.
     """
     if not root.exists():
         return []

--- a/rewrite-python/rewrite/tests/rpc/test_bundle_children.py
+++ b/rewrite-python/rewrite/tests/rpc/test_bundle_children.py
@@ -4,12 +4,10 @@ from rewrite.rpc.bundle_children import BundleChildren
 
 
 def _fake_venv_python(venv_dir):
-    """Stand-in for venv_manager.venv_python: the marker a real venv would have."""
     return venv_dir / "bin" / "python"
 
 
 def _make_venv(venv_dir):
-    """Create just enough of a venv that the usability guard accepts it."""
     interpreter = _fake_venv_python(venv_dir)
     interpreter.parent.mkdir(parents=True, exist_ok=True)
     interpreter.touch()
@@ -78,7 +76,6 @@ def test_install_marketplace_owner_route_uninstall_and_shutdown(tmp_path):
     assert bc.owner("pkga.Recipe") is None
     assert bc.resolved_version("pkga") is None
 
-    # shutdown reaps the rest
     bc.shutdown()
     assert spawned["pkgb"].closed
 
@@ -169,8 +166,6 @@ def test_install_rebuilds_a_directory_that_is_not_a_venv(tmp_path):
 
 
 def test_install_rebuilds_a_venv_orphaned_by_a_python_upgrade(tmp_path):
-    """uv encodes the patch version in the interpreter path, so upgrading Python orphans every
-    bundle venv built on it — while the copied python.exe leaves the venv looking intact."""
     ops = SimpleNamespace(created=[], installed=[])
     ops.venv_python = _fake_venv_python
     ops.is_usable_venv = lambda d: False          # base interpreter pruned away
@@ -198,8 +193,6 @@ def test_install_rebuilds_a_venv_orphaned_by_a_python_upgrade(tmp_path):
 
 
 def test_child_is_denied_the_shared_venvs_root_on_its_path(tmp_path):
-    """The Java host puts --recipe-install-dir on the facade's PYTHONPATH. A child must not inherit
-    it, or a stale flat package there would shadow the bundle's own copy."""
     created, installed = [], []
     seen = {}
 

--- a/rewrite-python/rewrite/tests/rpc/test_bundle_children.py
+++ b/rewrite-python/rewrite/tests/rpc/test_bundle_children.py
@@ -1,0 +1,266 @@
+from types import SimpleNamespace
+
+from rewrite.rpc.bundle_children import BundleChildren
+
+
+def _fake_venv_python(venv_dir):
+    """Stand-in for venv_manager.venv_python: the marker a real venv would have."""
+    return venv_dir / "bin" / "python"
+
+
+def _make_venv(venv_dir):
+    """Create just enough of a venv that the usability guard accepts it."""
+    interpreter = _fake_venv_python(venv_dir)
+    interpreter.parent.mkdir(parents=True, exist_ok=True)
+    interpreter.touch()
+
+
+def _fake_is_usable_venv(venv_dir):
+    return _fake_venv_python(venv_dir).exists()
+
+
+class _FakeChild:
+    def __init__(self, rows):
+        self.rows = rows
+        self.requests = []
+        self.closed = False
+
+    def request(self, method, params):
+        self.requests.append((method, params))
+        return self.rows if method == "GetMarketplace" else {"ran": method}
+
+    def close(self):
+        self.closed = True
+
+
+def test_install_marketplace_owner_route_uninstall_and_shutdown(tmp_path):
+    ops = SimpleNamespace(created=[], installed=[], removed=[])
+    ops.venv_python = _fake_venv_python
+    ops.is_usable_venv = _fake_is_usable_venv
+    ops.create_venv = lambda py, d, clear=False: (ops.created.append((py, d)), _make_venv(d))
+    ops.install_into_venv = lambda d, spec, force=False: ops.installed.append((d, spec, force))
+    ops.installed_version = lambda d, dist: f"{dist}-1.0"
+    ops.remove_venv = lambda d: ops.removed.append(d)
+
+    spawned = {}
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        bundle = cmd[cmd.index("--child-bundle") + 1]
+        child = _FakeChild([{"descriptor": {"name": f"{bundle}.Recipe"}}])
+        spawned[bundle] = child
+        return child
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=ops)
+
+    # install: venv created + package installed + child spawned + marketplace cached + ownership
+    rows = bc.install("pkga", "pkga==1.0")
+    assert rows == [{"descriptor": {"name": "pkga.Recipe"}}]
+    assert ops.created == [("py", tmp_path / "venvs" / "pkga")]
+    assert ops.installed == [(tmp_path / "venvs" / "pkga", "pkga==1.0", False)]  # registry spec: no force
+    assert bc.owner("pkga.Recipe") == "pkga"
+    assert bc.marketplace() == rows
+    assert bc.resolved_version("pkga") == "pkga-1.0"   # what the install layer reported, not the spec
+
+    # a second bundle; marketplace merges
+    bc.install("pkgb", "pkgb")
+    assert bc.owner("pkgb.Recipe") == "pkgb"
+    assert len(bc.marketplace()) == 2
+
+    # route recipe execution to the owning child
+    assert bc.request("pkga", "Visit", {"x": 1}) == {"ran": "Visit"}
+    assert spawned["pkga"].requests[-1] == ("Visit", {"x": 1})
+
+    # uninstall reaps the child, removes the venv, and drops ownership + resolved version
+    bc.uninstall("pkga")
+    assert spawned["pkga"].closed
+    assert ops.removed == [tmp_path / "venvs" / "pkga"]
+    assert bc.owner("pkga.Recipe") is None
+    assert bc.resolved_version("pkga") is None
+
+    # shutdown reaps the rest
+    bc.shutdown()
+    assert spawned["pkgb"].closed
+
+
+def _ops_recording(created, installed):
+    ops = SimpleNamespace()
+    ops.venv_python = _fake_venv_python
+    ops.is_usable_venv = _fake_is_usable_venv
+    ops.create_venv = lambda py, d, clear=False: (created.append(d), _make_venv(d))
+    ops.install_into_venv = lambda d, spec, force=False: installed.append(d)
+    ops.installed_version = lambda d, dist: "1.0.0"
+    return ops
+
+
+def test_set_data_table_store_broadcasts_to_live_children_and_replays_on_spawn(tmp_path):
+    created, installed = [], []
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        bundle = cmd[cmd.index("--child-bundle") + 1]
+        return _FakeChild([{"descriptor": {"name": f"{bundle}.R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+
+    bc.install("pkga", "pkga")                       # a live child before the store is configured
+    live = bc._children["pkga"]
+
+    store = {"kind": "CSV", "outputDir": "/out"}
+    bc.set_data_table_store(store)
+    assert ("SetDataTableStore", store) in live.requests   # broadcast to the live child now
+
+    bc.install("pkgb", "pkgb")                        # a bundle whose child is spawned later
+    assert ("SetDataTableStore", store) in bc._children["pkgb"].requests  # replayed at spawn
+
+
+def test_broadcast_evict_fans_out_to_live_children(tmp_path):
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        bundle = cmd[cmd.index("--child-bundle") + 1]
+        return _FakeChild([{"descriptor": {"name": f"{bundle}.R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording([], []))
+    bc.install("pkga", "pkga")
+    bc.install("pkgb", "pkgb")
+
+    bc.broadcast_evict({"id": "tree-1"})
+    # every live child is told to evict the file so each rolls back its own ref map
+    assert ("Evict", {"id": "tree-1"}) in bc._children["pkga"].requests
+    assert ("Evict", {"id": "tree-1"}) in bc._children["pkgb"].requests
+
+
+def test_install_reuses_an_existing_venv_but_still_upgrades(tmp_path):
+    created, installed = [], []
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+
+    # a real venv from a prior session (it has an interpreter) is reused, not recreated...
+    _make_venv(tmp_path / "venvs" / "pkg")
+    bc.install("pkg", "pkg")
+
+    assert created == []                              # create skipped: the interpreter is present
+    assert installed == [tmp_path / "venvs" / "pkg"]  # ...but pip --upgrade still runs (fixes #8180)
+
+
+def test_install_rebuilds_a_directory_that_is_not_a_venv(tmp_path):
+    """A leftover flat `pip install --target` package dir (or a half-created venv) has no
+    interpreter, so it must be populated rather than trusted and exec'd."""
+    created, installed = [], []
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+
+    legacy = tmp_path / "venvs" / "pkg"          # e.g. ~/.moderne/recipes/pip/pkg/__init__.py
+    legacy.mkdir(parents=True)
+    (legacy / "__init__.py").write_text("# stale flat install\n")
+
+    bc.install("pkg", "pkg")
+
+    assert created == [legacy]                   # directory exists, but no interpreter -> create
+    assert installed == [legacy]
+
+
+def test_install_rebuilds_a_venv_orphaned_by_a_python_upgrade(tmp_path):
+    """uv encodes the patch version in the interpreter path, so upgrading Python orphans every
+    bundle venv built on it — while the copied python.exe leaves the venv looking intact."""
+    ops = SimpleNamespace(created=[], installed=[])
+    ops.venv_python = _fake_venv_python
+    ops.is_usable_venv = lambda d: False          # base interpreter pruned away
+    ops.create_venv = lambda py, d, clear=False: (ops.created.append((d, clear)), _make_venv(d))
+    ops.install_into_venv = lambda d, spec, force=False: ops.installed.append(d)
+    ops.installed_version = lambda d, dist: "2.0"
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
+
+    venv_dir = tmp_path / "venvs" / "pkg"
+    _make_venv(venv_dir)                           # looks like a venv; its base is gone
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=ops)
+    orphaned_child = _FakeChild([])                # a child still bound to the dead venv
+    bc._children["pkg"] = orphaned_child
+
+    bc.install("pkg", "pkg")
+
+    assert ops.created == [(venv_dir, True)]       # rebuilt, clearing the orphaned tree
+    assert ops.installed == [venv_dir]             # and the bundle reinstalled into it
+    assert orphaned_child.closed                   # the child holding the dead venv was reaped
+    assert bc._children["pkg"] is not orphaned_child
+
+
+def test_child_is_denied_the_shared_venvs_root_on_its_path(tmp_path):
+    """The Java host puts --recipe-install-dir on the facade's PYTHONPATH. A child must not inherit
+    it, or a stale flat package there would shadow the bundle's own copy."""
+    created, installed = [], []
+    seen = {}
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        seen["exclude_paths"] = exclude_paths
+        return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
+
+    venvs_root = tmp_path / "venvs"
+    bc = BundleChildren("py", venvs_root, upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+    bc.install("pkg", "pkg")
+
+    assert seen["exclude_paths"] == (str(venvs_root),)
+
+
+def test_local_install_spawns_the_child_with_the_supplied_attribution_name(tmp_path):
+    created, installed = [], []
+    spawned = {}
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        spawned["cmd"] = cmd
+        return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+    bc.install("my-local-recipes", "/abs/path/to/src", force=True,
+               attribution_name="/abs/path/to/src")
+
+    # the resolved dist name filters discovery (--child-bundle); the supplied path is the attribution
+    assert "--child-bundle" in spawned["cmd"]
+    assert spawned["cmd"][spawned["cmd"].index("--child-bundle") + 1] == "my_local_recipes"
+    assert "--attribution-name" in spawned["cmd"]
+    assert spawned["cmd"][spawned["cmd"].index("--attribution-name") + 1] == "/abs/path/to/src"
+
+
+def test_install_normalizes_distribution_name_so_spellings_dedup(tmp_path):
+    ops = SimpleNamespace(created=[], installed=[])
+    ops.venv_python = _fake_venv_python
+    ops.is_usable_venv = _fake_is_usable_venv
+
+    def _create(py, d, clear=False):
+        ops.created.append(d)
+        _make_venv(d)  # so the second install sees a real venv and skips creation
+
+    ops.create_venv = _create
+    ops.install_into_venv = lambda d, spec, force=False: ops.installed.append(d)
+    ops.installed_version = lambda d, dist: "9.9"
+
+    spawned = []
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        spawned.append(cmd[cmd.index("--child-bundle") + 1])
+        return _FakeChild([{"descriptor": {"name": "R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=ops)
+
+    # PEP 503 treats these as the same distribution -> one venv, one child, one normalized key.
+    bc.install("Foo-Bar", "Foo-Bar")
+    bc.install("foo_bar", "foo_bar")
+
+    assert ops.created == [tmp_path / "venvs" / "foo_bar"]        # created once, normalized dir
+    assert spawned == ["foo_bar"]                                 # one child, spawned once
+    assert bc.request("FOO.BAR", "Visit", {}) == {"ran": "Visit"}  # any spelling routes to it

--- a/rewrite-python/rewrite/tests/rpc/test_child_connection.py
+++ b/rewrite-python/rewrite/tests/rpc/test_child_connection.py
@@ -125,16 +125,12 @@ write({"jsonrpc": "2.0", "id": req["id"], "result": {"got": cb["result"]}})
 
 
 def test_engine_roots_supply_the_engine_and_its_runtime_dependency_locations():
-    # A recipe running in a child may parse a Python template, which reaches `parso`. The child's
-    # venv has no engine and no engine deps, so both must travel on PYTHONPATH.
     roots = _engine_roots()
     assert roots[0] == ENGINE_ROOT
     assert str(metadata.distribution("parso").locate_file("")) in roots
 
 
 def test_engine_roots_collapse_to_one_entry_when_deps_sit_beside_the_engine(monkeypatch):
-    # Production: `pip install --target <engineDir>` flattens engine + deps into one directory,
-    # so nothing beyond the engine root is exposed to children.
     def dist(name):
         if name == "openrewrite":
             return _FakeDist(requires=["parso>=0.7.1,<0.8", "more_itertools>=10.0.0"])
@@ -145,7 +141,6 @@ def test_engine_roots_collapse_to_one_entry_when_deps_sit_beside_the_engine(monk
 
 
 def test_engine_roots_skip_optional_extras(monkeypatch):
-    # dev/publish/profiling extras are not part of the platform a child needs.
     def dist(name):
         if name == "openrewrite":
             return _FakeDist(requires=[
@@ -165,7 +160,6 @@ def test_child_env_puts_the_engine_first_on_pythonpath(monkeypatch):
 
 def test_child_env_prepends_the_engine_ahead_of_an_inherited_pythonpath(monkeypatch):
     monkeypatch.setenv("PYTHONPATH", "/already/there")
-    # Engine first: it must win over anything the child venv or the host put on the path.
     assert _child_env()["PYTHONPATH"].split(os.pathsep) == [*_engine_roots(), "/already/there"]
 
 
@@ -175,8 +169,6 @@ def test_child_env_does_not_duplicate_an_already_present_engine(monkeypatch):
 
 
 def test_child_env_drops_excluded_inherited_paths(monkeypatch, tmp_path):
-    # The Java host puts --recipe-install-dir (the venvs root) on the facade's PYTHONPATH. A child
-    # must not inherit it: a stale flat package there would shadow the bundle's own copy.
     venvs_root = tmp_path / "recipes" / "pip"
     keep = str(tmp_path / "keep")
     monkeypatch.setenv("PYTHONPATH", os.pathsep.join([str(venvs_root), keep]))
@@ -187,8 +179,6 @@ def test_child_env_drops_excluded_inherited_paths(monkeypatch, tmp_path):
 
 
 def test_child_env_appends_the_facade_scripts_dir_to_path(monkeypatch):
-    # PYTHONPATH carries importable code, not console binaries. `ty-types` ships both, and the
-    # child's own interpreter has neither — so its binary is reachable only via PATH.
     scripts = sysconfig.get_path("scripts")
     monkeypatch.setenv("PATH", "/first")
 

--- a/rewrite-python/rewrite/tests/rpc/test_child_connection.py
+++ b/rewrite-python/rewrite/tests/rpc/test_child_connection.py
@@ -1,0 +1,261 @@
+import os
+import sys
+import sysconfig
+from importlib import metadata
+from pathlib import Path
+
+import rewrite
+from rewrite.rpc import child_connection, venv_manager
+from rewrite.rpc.child_connection import (
+    ChildConnection,
+    _child_env,
+    _engine_roots,
+    child_command,
+)
+
+ENGINE_ROOT = str(Path(rewrite.__file__).resolve().parent.parent)
+
+
+class _FakeDist:
+    def __init__(self, requires=None, location=None):
+        self.requires = requires
+        self._location = location
+
+    def locate_file(self, _):
+        return self._location
+
+# A minimal stub child: read one Content-Length framed JSON-RPC request, reply with a canned result
+# echoing the request id. Proves ChildConnection's spawn + framing + round-trip without needing a
+# full venv + rewrite install (that end-to-end lives with the cutover).
+STUB = r'''
+import sys, json
+buf = sys.stdin.buffer
+cl = None
+while True:
+    line = buf.readline()
+    if not line:
+        sys.exit(0)
+    s = line.decode("ascii").strip()
+    if s == "":
+        break
+    if s.lower().startswith("content-length:"):
+        cl = int(s.split(":", 1)[1])
+body = b""
+while len(body) < cl:
+    body += buf.read(cl - len(body))
+req = json.loads(body.decode("utf-8"))
+resp = {"jsonrpc": "2.0", "id": req["id"], "result": [{"descriptor": {"name": "stub.recipe"}}]}
+data = json.dumps(resp).encode("utf-8")
+out = sys.stdout.buffer
+out.write(("Content-Length: %d\r\n\r\n" % len(data)).encode("ascii"))
+out.write(data)
+out.flush()
+'''
+
+
+def test_child_connection_round_trips_a_request(tmp_path):
+    stub = tmp_path / "stub.py"
+    stub.write_text(STUB)
+    conn = ChildConnection.spawn([sys.executable, str(stub)])
+    try:
+        result = conn.request("GetMarketplace", {})
+    finally:
+        conn.close()
+    assert result == [{"descriptor": {"name": "stub.recipe"}}]
+
+
+def test_child_command_targets_the_venv_python_and_child_bundle(tmp_path):
+    venv_dir = tmp_path / "b1"
+    cmd = child_command(venv_dir, "my-recipes")
+    assert cmd == [
+        str(venv_manager.venv_python(venv_dir)),
+        "-m", "rewrite.rpc.server",
+        "--child-bundle", "my-recipes",
+    ]
+
+
+def test_child_command_carries_an_attribution_name_when_given(tmp_path):
+    venv_dir = tmp_path / "b1"
+    cmd = child_command(venv_dir, "my-recipes", attribution_name="/abs/path")
+    assert cmd == [
+        str(venv_manager.venv_python(venv_dir)),
+        "-m", "rewrite.rpc.server",
+        "--child-bundle", "my-recipes",
+        "--attribution-name", "/abs/path",
+    ]
+
+
+# A stub child that, mid-request, emits a GetObject callback toward the facade, consumes the
+# callback response, then answers the routed request echoing what the callback returned. Exercises
+# the pump: relay child->Java callbacks and feed Java's response back to the child.
+STUB_WITH_CALLBACK = r'''
+import sys, json
+buf = sys.stdin.buffer
+out = sys.stdout.buffer
+
+def read():
+    cl = None
+    while True:
+        line = buf.readline()
+        if not line:
+            return None
+        s = line.decode("ascii").strip()
+        if s == "":
+            break
+        if s.lower().startswith("content-length:"):
+            cl = int(s.split(":", 1)[1])
+    if cl is None:
+        return None
+    body = b""
+    while len(body) < cl:
+        body += buf.read(cl - len(body))
+    return json.loads(body.decode("utf-8"))
+
+def write(msg):
+    data = json.dumps(msg).encode("utf-8")
+    out.write(("Content-Length: %d\r\n\r\n" % len(data)).encode("ascii"))
+    out.write(data)
+    out.flush()
+
+req = read()                                                        # routed request from facade
+write({"jsonrpc": "2.0", "id": 99, "method": "GetObject", "params": {"id": "tree-1"}})
+cb = read()                                                         # callback response from facade
+write({"jsonrpc": "2.0", "id": req["id"], "result": {"got": cb["result"]}})
+'''
+
+
+def test_engine_roots_supply_the_engine_and_its_runtime_dependency_locations():
+    # A recipe running in a child may parse a Python template, which reaches `parso`. The child's
+    # venv has no engine and no engine deps, so both must travel on PYTHONPATH.
+    roots = _engine_roots()
+    assert roots[0] == ENGINE_ROOT
+    assert str(metadata.distribution("parso").locate_file("")) in roots
+
+
+def test_engine_roots_collapse_to_one_entry_when_deps_sit_beside_the_engine(monkeypatch):
+    # Production: `pip install --target <engineDir>` flattens engine + deps into one directory,
+    # so nothing beyond the engine root is exposed to children.
+    def dist(name):
+        if name == "openrewrite":
+            return _FakeDist(requires=["parso>=0.7.1,<0.8", "more_itertools>=10.0.0"])
+        return _FakeDist(location=ENGINE_ROOT)
+
+    monkeypatch.setattr(child_connection.metadata, "distribution", dist)
+    assert _engine_roots() == [ENGINE_ROOT]
+
+
+def test_engine_roots_skip_optional_extras(monkeypatch):
+    # dev/publish/profiling extras are not part of the platform a child needs.
+    def dist(name):
+        if name == "openrewrite":
+            return _FakeDist(requires=[
+                "parso>=0.7.1,<0.8",
+                'pyroscope-io>=0.8.0; extra == "profiling"',
+            ])
+        return _FakeDist(location={"parso": "/deps"}.get(name, "/extras"))
+
+    monkeypatch.setattr(child_connection.metadata, "distribution", dist)
+    assert _engine_roots() == [ENGINE_ROOT, "/deps"]
+
+
+def test_child_env_puts_the_engine_first_on_pythonpath(monkeypatch):
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    assert _child_env()["PYTHONPATH"].split(os.pathsep) == _engine_roots()
+
+
+def test_child_env_prepends_the_engine_ahead_of_an_inherited_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/already/there")
+    # Engine first: it must win over anything the child venv or the host put on the path.
+    assert _child_env()["PYTHONPATH"].split(os.pathsep) == [*_engine_roots(), "/already/there"]
+
+
+def test_child_env_does_not_duplicate_an_already_present_engine(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join([ENGINE_ROOT, "/other"]))
+    assert _child_env()["PYTHONPATH"].split(os.pathsep) == [*_engine_roots(), "/other"]
+
+
+def test_child_env_drops_excluded_inherited_paths(monkeypatch, tmp_path):
+    # The Java host puts --recipe-install-dir (the venvs root) on the facade's PYTHONPATH. A child
+    # must not inherit it: a stale flat package there would shadow the bundle's own copy.
+    venvs_root = tmp_path / "recipes" / "pip"
+    keep = str(tmp_path / "keep")
+    monkeypatch.setenv("PYTHONPATH", os.pathsep.join([str(venvs_root), keep]))
+
+    path = _child_env(exclude_paths=(str(venvs_root),))["PYTHONPATH"].split(os.pathsep)
+    assert str(venvs_root) not in path
+    assert path == [*_engine_roots(), keep]
+
+
+def test_child_env_appends_the_facade_scripts_dir_to_path(monkeypatch):
+    # PYTHONPATH carries importable code, not console binaries. `ty-types` ships both, and the
+    # child's own interpreter has neither — so its binary is reachable only via PATH.
+    scripts = sysconfig.get_path("scripts")
+    monkeypatch.setenv("PATH", "/first")
+
+    path = _child_env()["PATH"].split(os.pathsep)
+    assert path[0] == "/first"       # appended, so the bundle's own python/pip stay ahead
+    assert path[-1] == scripts
+
+
+def test_child_env_does_not_duplicate_the_scripts_dir_already_on_path(monkeypatch):
+    scripts = sysconfig.get_path("scripts")
+    monkeypatch.setenv("PATH", os.pathsep.join([scripts, "/other"]))
+    assert _child_env()["PATH"].split(os.pathsep) == [scripts, "/other"]
+
+
+# The child runs on the *bundle venv's* interpreter, which has no engine of its own; only the
+# environment is inherited. Prove the engine path actually reaches the spawned process.
+STUB_ECHO_PYTHONPATH = r'''
+import sys, json, os
+buf = sys.stdin.buffer
+cl = None
+while True:
+    line = buf.readline()
+    if not line:
+        sys.exit(0)
+    s = line.decode("ascii").strip()
+    if s == "":
+        break
+    if s.lower().startswith("content-length:"):
+        cl = int(s.split(":", 1)[1])
+body = b""
+while len(body) < cl:
+    body += buf.read(cl - len(body))
+req = json.loads(body.decode("utf-8"))
+resp = {"jsonrpc": "2.0", "id": req["id"], "result": os.environ.get("PYTHONPATH")}
+data = json.dumps(resp).encode("utf-8")
+out = sys.stdout.buffer
+out.write(("Content-Length: %d\r\n\r\n" % len(data)).encode("ascii"))
+out.write(data)
+out.flush()
+'''
+
+
+def test_spawn_hands_the_engine_pythonpath_to_the_child_process(tmp_path):
+    stub = tmp_path / "stub.py"
+    stub.write_text(STUB_ECHO_PYTHONPATH)
+    conn = ChildConnection.spawn([sys.executable, str(stub)])
+    try:
+        seen = conn.request("GetMarketplace", {})
+    finally:
+        conn.close()
+    assert seen.split(os.pathsep)[0] == ENGINE_ROOT
+
+
+def test_child_connection_relays_callbacks_to_upstream(tmp_path):
+    stub = tmp_path / "stub.py"
+    stub.write_text(STUB_WITH_CALLBACK)
+    seen = []
+
+    def upstream(method, params):
+        seen.append((method, params))
+        return {"data": "from-java"}
+
+    conn = ChildConnection.spawn([sys.executable, str(stub)], upstream=upstream)
+    try:
+        result = conn.request("Visit", {})
+    finally:
+        conn.close()
+
+    assert seen == [("GetObject", {"id": "tree-1"})]        # child's callback relayed up
+    assert result == {"got": {"data": "from-java"}}          # Java's response fed back to the child

--- a/rewrite-python/rewrite/tests/rpc/test_child_mode.py
+++ b/rewrite-python/rewrite/tests/rpc/test_child_mode.py
@@ -1,0 +1,23 @@
+import rewrite.rpc.server as server
+
+
+def test_child_mode_scopes_discovery_to_the_root_bundle(monkeypatch):
+    called = {}
+
+    def fake_root(root_dist_name, marketplace=None, attribution=None, attribution_name=None):
+        called["root"] = root_dist_name
+        called["attribution_name"] = attribution_name
+        return marketplace
+
+    def fake_flat(*a, **k):
+        called["flat"] = True
+
+    monkeypatch.setattr("rewrite.discovery.discover_root_recipes", fake_root)
+    monkeypatch.setattr("rewrite.discovery.discover_recipes", fake_flat)
+    monkeypatch.setattr(server, "_marketplace", None)
+    monkeypatch.setattr(server, "_child_bundle", "my-recipes")
+
+    server._get_marketplace()
+
+    assert called.get("root") == "my-recipes"   # root-scoped discovery
+    assert "flat" not in called                 # flat discovery + built-in activate skipped

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -1,0 +1,322 @@
+from rewrite.rpc.facade import Facade
+
+
+class _FakeChildren:
+    def __init__(self):
+        self.calls = []
+        self.data_table_store = None
+        self._owner = {"pkg.R": "pkg"}
+
+    def set_data_table_store(self, params):
+        self.data_table_store = params
+
+    def install(self, bundle, spec, force=False, attribution_name=None):
+        self.calls.append(("install", bundle, spec, force, attribution_name))
+        return [{"descriptor": {"name": "pkg.R"}}]
+
+    def resolved_version(self, bundle):
+        return "1.0.5"          # what pip resolved — deliberately != the requested "1.0"
+
+    def marketplace(self):
+        return [{"descriptor": {"name": "pkg.R"}}]
+
+    def owner(self, name):
+        return self._owner.get(name)
+
+    def request(self, bundle, method, params):
+        self.calls.append(("request", bundle, method))
+        if method == "PrepareRecipe":
+            return {
+                "id": "prep-1",
+                "editVisitor": "edit:prep-1",
+                "scanVisitor": "scan:prep-1",
+                "recipeList": [{"id": "prep-2", "editVisitor": "edit:prep-2", "recipeList": []}],
+            }
+        if method == "BatchVisit":
+            # record which visitors this child received, and echo one result per visitor
+            vs = [v["visitor"] for v in params.get("visitors", [])]
+            self.calls.append(("batch", bundle, vs))
+            return {"results": [{"visitor": v} for v in vs]}
+        return {"ok": method}
+
+
+def test_facade_install_marketplace_prepare_visit_generate_routing():
+    children = _FakeChildren()
+    f = Facade(children)
+
+    # install a package spec -> bundle keyed by package name; version reported is the RESOLVED one
+    resp = f.install_recipes({"recipes": {"packageName": "pkg", "version": "1.0"}})
+    assert resp == {"recipesInstalled": 1, "version": "1.0.5"}
+    # registry spec: no force, no attribution override (recipes carry the distribution's own name)
+    assert children.calls[0] == ("install", "pkg", "pkg==1.0", False, None)
+
+    # marketplace served from the merged cache
+    assert f.get_marketplace({}) == [{"descriptor": {"name": "pkg.R"}}]
+
+    # prepare routes to the owning child and registers visitor/recipe ownership (root + nested)
+    prep = f.prepare_recipe({"id": "pkg.R"})
+    assert prep["id"] == "prep-1"
+
+    # visit routes by visitor name to the child that prepared it (nested included)
+    assert f.visit({"visitor": "edit:prep-1"}) == {"ok": "Visit"}
+    assert f.visit({"visitor": "edit:prep-2"}) == {"ok": "Visit"}
+
+    # generate routes by prepared-recipe id
+    assert f.generate({"id": "prep-2"}) == {"ok": "Generate"}
+
+    # SetDataTableStore is broadcast to the children (recipes emit rows there), not kept on the facade
+    assert f.set_data_table_store({"kind": "CSV", "outputDir": "/out"}) is True
+    assert children.data_table_store == {"kind": "CSV", "outputDir": "/out"}
+
+
+def test_facade_installs_a_local_path_by_resolved_distribution_name(tmp_path):
+    # A local install arrives as a path string; the facade resolves the distribution name from the
+    # source, keys the venv/child by it, and force-reinstalls the mutable source.
+    src = tmp_path / "my-recipes"
+    src.mkdir()
+    (src / "pyproject.toml").write_text('[project]\nname = "my-local-recipes"\nversion = "0.1.0"\n')
+
+    children = _FakeChildren()
+    f = Facade(children)
+    resp = f.install_recipes({"recipes": str(src)})
+
+    # filtered by the resolved dist name, but force-reinstalled and attributed to the supplied path
+    assert children.calls[0] == ("install", "my-local-recipes", str(src), True, str(src))
+    assert resp == {"recipesInstalled": 1, "version": "1.0.5"}
+
+
+def test_facade_rejects_a_local_path_without_a_resolvable_name(tmp_path):
+    empty = tmp_path / "no-metadata"
+    empty.mkdir()
+    f = Facade(_FakeChildren())
+    try:
+        f.install_recipes({"recipes": str(empty)})
+        assert False, "expected a ValueError for an unresolvable local path"
+    except ValueError as e:
+        assert "distribution name" in str(e)
+
+
+def test_facade_routes_print_and_getobject_to_the_child_that_visited_the_tree():
+    children = _FakeChildren()
+    f = Facade(children)
+    f._bundle_by_visitor["edit:r"] = "pkg"
+
+    # Before any visit (build time) there is no active child, so objects stay facade-local.
+    assert f.tree_owner({"treeId": "T1"}) is None
+
+    # A visit records treeId -> bundle and marks the active child. A later Print/GetObject reaches
+    # the child that holds the modified tree and its RPC ref-state — by exact id, and (because a
+    # modifying visit re-keys the tree and Java also fetches the context/cursors by id) by the
+    # active-child fallback for ids the map never recorded.
+    f.visit({"visitor": "edit:r", "treeId": "T1"})
+    assert f.tree_owner({"treeId": "T1"}) == "pkg"          # Print carries 'treeId'
+    assert f.tree_owner({"id": "T1"}) == "pkg"              # GetObject carries 'id'
+    assert f.tree_owner({"treeId": "re-keyed-id"}) == "pkg" # untracked during a run -> active child
+    assert f.route_to_child("pkg", "Print", {"treeId": "T1"}) == {"ok": "Print"}
+
+
+def test_facade_batch_visit_splits_consecutive_runs_across_bundles():
+    children = _FakeChildren()
+    f = Facade(children)
+    # visitors owned by two different bundles; the scheduler batches them across recipes
+    f._bundle_by_visitor.update({"edit:a1": "A", "edit:a2": "A", "edit:b1": "B"})
+
+    resp = f.batch_visit({"treeId": "T", "visitors": [
+        {"visitor": "edit:a1"}, {"visitor": "edit:a2"}, {"visitor": "edit:b1"}]})
+
+    # per-visitor results returned in the original order
+    assert resp == {"results": [{"visitor": "edit:a1"}, {"visitor": "edit:a2"}, {"visitor": "edit:b1"}]}
+    # dispatched as maximal consecutive same-owner runs: A gets [a1,a2], then B gets [b1]
+    batches = [c for c in children.calls if c[0] == "batch"]
+    assert batches == [("batch", "A", ["edit:a1", "edit:a2"]), ("batch", "B", ["edit:b1"])]
+    # tree ownership follows the last child to touch it (for a later Print/GetObject)
+    assert f.tree_owner({"treeId": "T"}) == "B"
+
+
+def test_facade_batch_visit_re_splits_when_owners_alternate():
+    children = _FakeChildren()
+    f = Facade(children)
+    f._bundle_by_visitor.update({"edit:a": "A", "edit:b": "B"})
+    f.batch_visit({"treeId": "T", "visitors": [
+        {"visitor": "edit:a"}, {"visitor": "edit:b"}, {"visitor": "edit:a"}]})
+    batches = [c for c in children.calls if c[0] == "batch"]
+    assert batches == [("batch", "A", ["edit:a"]), ("batch", "B", ["edit:b"]), ("batch", "A", ["edit:a"])]
+
+
+class _EditingChildren(_FakeChildren):
+    """Every BatchVisit reports that its visitors modified the tree."""
+    def __init__(self, modified=True):
+        super().__init__()
+        self._modified = modified
+
+    def request(self, bundle, method, params):
+        if method == "BatchVisit":
+            vs = [v["visitor"] for v in params.get("visitors", [])]
+            self.calls.append(("batch", bundle, vs))
+            return {"results": [{"visitor": v, "modified": self._modified} for v in vs]}
+        return super().request(bundle, method, params)
+
+
+def test_cross_bundle_batch_pulls_each_bundles_edit_into_the_hub_in_order():
+    children = _EditingChildren()
+    pulls = []
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f._bundle_by_visitor.update({"edit:a": "A", "edit:b": "B"})
+
+    f.batch_visit({"treeId": "T", "sourceFileType": "py",
+                   "visitors": [{"visitor": "edit:a"}, {"visitor": "edit:b"}]})
+
+    # dispatched as consecutive same-owner runs
+    assert [c for c in children.calls if c[0] == "batch"] == [
+        ("batch", "A", ["edit:a"]), ("batch", "B", ["edit:b"])]
+    # each run's edit is pulled into the facade's tree in order, so B starts from A's result
+    assert pulls == [("A", "T", "py"), ("B", "T", "py")]
+
+
+def test_single_bundle_batch_still_pulls_its_edit_into_the_hub():
+    children = _EditingChildren()
+    pulls = []
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f._bundle_by_visitor.update({"edit:a1": "A", "edit:a2": "A"})
+
+    f.batch_visit({"treeId": "T", "sourceFileType": "py",
+                   "visitors": [{"visitor": "edit:a1"}, {"visitor": "edit:a2"}]})
+
+    # one run, but the facade still owns the tree so it pulls the result back
+    assert [c for c in children.calls if c[0] == "batch"] == [("batch", "A", ["edit:a1", "edit:a2"])]
+    assert pulls == [("A", "T", "py")]
+
+
+def test_unmodified_run_is_not_pulled():
+    children = _EditingChildren(modified=False)
+    pulls = []
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f._bundle_by_visitor.update({"edit:a": "A"})
+
+    f.batch_visit({"treeId": "T", "visitors": [{"visitor": "edit:a"}]})
+
+    assert pulls == []  # nothing changed -> nothing to fetch back
+
+
+def test_handle_request_answers_print_from_the_facades_own_tree(monkeypatch, tmp_path):
+    """The facade owns the in-flight tree, so it answers Java itself instead of round-tripping to a
+    child -- whose copy carries only its own bundle's edit. It also acquires at the top level: a
+    fetch from inside a child's callback deadlocks (child waits on us, Java waits on this request)."""
+    import rewrite.rpc.server as server
+
+    class _FakeFacade:
+        # facade_handlers is built eagerly from these; stubs keep the dict construction happy
+        def get_marketplace(self, params): ...
+        def install_recipes(self, params): ...
+        def prepare_recipe(self, params): ...
+        def set_data_table_store(self, params): ...
+        def visit(self, params): ...
+        def batch_visit(self, params): ...
+        def generate(self, params): ...
+
+        def route_to_child(self, bundle, method, params):
+            raise AssertionError("Print/GetObject must never round-trip to a child")
+
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)  # facade mode on
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_facade", _FakeFacade())
+    monkeypatch.setattr(server, "handle_print", lambda p: "local-print")
+
+    # a tree the facade already holds is served from its own copy, no acquire needed
+    acquired = []
+    monkeypatch.setattr(server, "_hub_acquire", lambda oid, sft: acquired.append(oid))
+    monkeypatch.setitem(server._hub_tree, "T1", object())
+    assert server.handle_request("Print", {"treeId": "T1"}) == "local-print"
+    assert acquired == []
+
+    # one it doesn't hold yet is acquired here, at the top level, then served locally
+    assert server.handle_request("Print", {"treeId": "other"}) == "local-print"
+    assert acquired == ["other"]
+
+
+def test_handle_request_routes_to_facade_in_facade_mode(monkeypatch, tmp_path):
+    import rewrite.rpc.server as server
+
+    routed = {}
+
+    class _FakeFacade:
+        def get_marketplace(self, params):
+            routed["marketplace"] = True
+            return ["facade-rows"]
+
+        def install_recipes(self, params):
+            routed["install"] = params
+            return {"recipesInstalled": 0, "version": None}
+
+        def prepare_recipe(self, params): ...
+        def batch_visit(self, params): ...
+        def set_data_table_store(self, params):
+            routed["store"] = params
+            return True
+        def visit(self, params): ...
+        def generate(self, params): ...
+
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)  # facade mode on
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_facade", _FakeFacade())
+
+    assert server.handle_request("GetMarketplace", {}) == ["facade-rows"]
+    # SetDataTableStore routes to the facade (which broadcasts to children) in facade mode
+    assert server.handle_request("SetDataTableStore", {"kind": "CSV"}) is True
+    assert routed["store"] == {"kind": "CSV"}
+    assert routed.get("marketplace") is True
+
+    r = {"recipes": {"packageName": "pkg"}}
+    assert server.handle_request("InstallRecipes", r) == {"recipesInstalled": 0, "version": None}
+    assert routed["install"] == r
+
+
+def test_hub_release_rolls_each_childs_ref_table_back_in_lockstep():
+    """Evict drops the refs a file introduced from the child's receive map. If the facade kept them
+    in its send map it would later emit GET_REF for a ref the child no longer has -- the
+    "Received reference to unknown object" flood."""
+    import rewrite.rpc.server as server
+
+    server._hub_tree["T"] = object()
+    server._hub_served[("A", "T")] = object()
+    # child A had 2 refs before this file, then the file introduced refs 3 and 4
+    server._hub_send_refs["A"] = {10: ("before-1", 1), 11: ("before-2", 2),
+                                  12: ("from-file", 3), 13: ("from-file", 4)}
+    server._hub_send_next["A"] = 4
+    server._hub_send_checkpoint[("A", "T")] = 2
+
+    server._hub_release("T")
+
+    # only the refs this file introduced are dropped; the pre-file ones survive
+    assert sorted(n for _, n in server._hub_send_refs["A"].values()) == [1, 2]
+    assert server._hub_send_next["A"] == 2          # counter rewound so the next file re-ADDs
+    assert "T" not in server._hub_tree
+    assert ("A", "T") not in server._hub_served
+    assert ("A", "T") not in server._hub_send_checkpoint
+
+
+class _PreconditionChildren(_FakeChildren):
+    """PrepareRecipe returns a Preconditions.check(...) editor: the precondition names a Python
+    visitor of its own, which the host will later call back like any other visitor."""
+
+    def request(self, bundle, method, params):
+        if method == "PrepareRecipe":
+            return {
+                "id": "prep-1",
+                "editVisitor": "edit:prep-1",
+                "editPreconditions": [{"visitorName": "edit:precond-1", "visitorOptions": None}],
+                "scanPreconditions": [{"visitorName": "scan:precond-2", "visitorOptions": None}],
+                "recipeList": [],
+            }
+        return super().request(bundle, method, params)
+
+
+def test_precondition_visitors_route_to_the_child_that_prepared_them():
+    # A precondition's visitor is prepared inside the child but appears in neither editVisitor nor
+    # recipeList. Without registering it, the host's Visit for it would find no owner.
+    children = _PreconditionChildren()
+    f = Facade(children)
+    f.prepare_recipe({"id": "pkg.R"})
+
+    assert f.visit({"visitor": "edit:precond-1"}) == {"ok": "Visit"}
+    assert f.visit({"visitor": "scan:precond-2"}) == {"ok": "Visit"}

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -70,8 +70,6 @@ def test_facade_install_marketplace_prepare_visit_generate_routing():
 
 
 def test_facade_installs_a_local_path_by_resolved_distribution_name(tmp_path):
-    # A local install arrives as a path string; the facade resolves the distribution name from the
-    # source, keys the venv/child by it, and force-reinstalls the mutable source.
     src = tmp_path / "my-recipes"
     src.mkdir()
     (src / "pyproject.toml").write_text('[project]\nname = "my-local-recipes"\nversion = "0.1.0"\n')
@@ -156,13 +154,6 @@ def test_cross_bundle_batch_pulls_each_bundles_edit_into_the_hub_in_order():
 
 
 def test_single_visit_pulls_its_edit_into_the_hub():
-    """A single-recipe run reaches `visit`, not `batch_visit`, and must pull its edit back too.
-
-    The facade answers Java's later Print/GetObject from its own tree, so an edit left behind in
-    the child is lost -- silently, because the run still succeeds and reports no changes. Observed
-    end-to-end as a modifying recipe producing a diff inside a composite but "No changes" when run
-    on its own.
-    """
     children = _EditingChildren()
     pulls = []
     f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
@@ -210,13 +201,9 @@ def test_unmodified_run_is_not_pulled():
 
 
 def test_handle_request_answers_print_from_the_facades_own_tree(monkeypatch, tmp_path):
-    """The facade owns the in-flight tree, so it answers Java itself instead of round-tripping to a
-    child -- whose copy carries only its own bundle's edit. It also acquires at the top level: a
-    fetch from inside a child's callback deadlocks (child waits on us, Java waits on this request)."""
     import rewrite.rpc.server as server
 
     class _FakeFacade:
-        # facade_handlers is built eagerly from these; stubs keep the dict construction happy
         def get_marketplace(self, params): ...
         def install_recipes(self, params): ...
         def prepare_recipe(self, params): ...
@@ -243,13 +230,6 @@ def test_handle_request_answers_print_from_the_facades_own_tree(monkeypatch, tmp
 
 
 def test_handle_request_does_not_acquire_non_tree_objects(monkeypatch, tmp_path):
-    """Java fetches the execution context and cursors by id too, and those have no Python codec.
-
-    `GetObject.sourceFileType` is nullable and set only for trees, so it is what distinguishes
-    them. Acquiring a non-tree hands its property messages to a receiver that cannot consume
-    them, which desynchronizes the queue for every object that follows -- observed end-to-end as
-    "No RPC codec registered on the Python side for 'org.openrewrite.InMemoryExecutionContext'".
-    """
     import rewrite.rpc.server as server
 
     class _FakeFacade:
@@ -316,9 +296,6 @@ def test_handle_request_routes_to_facade_in_facade_mode(monkeypatch, tmp_path):
 
 
 def test_hub_release_rolls_each_childs_ref_table_back_in_lockstep():
-    """Evict drops the refs a file introduced from the child's receive map. If the facade kept them
-    in its send map it would later emit GET_REF for a ref the child no longer has -- the
-    "Received reference to unknown object" flood."""
     import rewrite.rpc.server as server
 
     server._hub_tree["T"] = object()
@@ -340,9 +317,6 @@ def test_hub_release_rolls_each_childs_ref_table_back_in_lockstep():
 
 
 class _PreconditionChildren(_FakeChildren):
-    """PrepareRecipe returns a Preconditions.check(...) editor: the precondition names a Python
-    visitor of its own, which the host will later call back like any other visitor."""
-
     def request(self, bundle, method, params):
         if method == "PrepareRecipe":
             return {
@@ -356,8 +330,6 @@ class _PreconditionChildren(_FakeChildren):
 
 
 def test_precondition_visitors_route_to_the_child_that_prepared_them():
-    # A precondition's visitor is prepared inside the child but appears in neither editVisitor nor
-    # recipeList. Without registering it, the host's Visit for it would find no owner.
     children = _PreconditionChildren()
     f = Facade(children)
     f.prepare_recipe({"id": "pkg.R"})

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -154,6 +154,9 @@ class _EditingChildren(_FakeChildren):
             vs = [v["visitor"] for v in params.get("visitors", [])]
             self.calls.append(("batch", bundle, vs))
             return {"results": [{"visitor": v, "modified": self._modified} for v in vs]}
+        if method == "Visit":
+            self.calls.append(("visit", bundle, params.get("visitor")))
+            return {"modified": self._modified}
         return super().request(bundle, method, params)
 
 
@@ -171,6 +174,35 @@ def test_cross_bundle_batch_pulls_each_bundles_edit_into_the_hub_in_order():
         ("batch", "A", ["edit:a"]), ("batch", "B", ["edit:b"])]
     # each run's edit is pulled into the facade's tree in order, so B starts from A's result
     assert pulls == [("A", "T", "py"), ("B", "T", "py")]
+
+
+def test_single_visit_pulls_its_edit_into_the_hub():
+    """A single-recipe run reaches `visit`, not `batch_visit`, and must pull its edit back too.
+
+    The facade answers Java's later Print/GetObject from its own tree, so an edit left behind in
+    the child is lost -- silently, because the run still succeeds and reports no changes. Observed
+    end-to-end as a modifying recipe producing a diff inside a composite but "No changes" when run
+    on its own.
+    """
+    children = _EditingChildren()
+    pulls = []
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f._bundle_by_visitor["edit:a"] = "A"
+
+    f.visit({"visitor": "edit:a", "treeId": "T", "sourceFileType": "py"})
+
+    assert pulls == [("A", "T", "py")]
+
+
+def test_single_visit_does_not_pull_when_nothing_changed():
+    children = _EditingChildren(modified=False)
+    pulls = []
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f._bundle_by_visitor["edit:a"] = "A"
+
+    f.visit({"visitor": "edit:a", "treeId": "T", "sourceFileType": "py"})
+
+    assert pulls == []
 
 
 def test_single_bundle_batch_still_pulls_its_edit_into_the_hub():

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -96,25 +96,6 @@ def test_facade_rejects_a_local_path_without_a_resolvable_name(tmp_path):
         assert "distribution name" in str(e)
 
 
-def test_facade_routes_print_and_getobject_to_the_child_that_visited_the_tree():
-    children = _FakeChildren()
-    f = Facade(children)
-    f._bundle_by_visitor["edit:r"] = "pkg"
-
-    # Before any visit (build time) there is no active child, so objects stay facade-local.
-    assert f.tree_owner({"treeId": "T1"}) is None
-
-    # A visit records treeId -> bundle and marks the active child. A later Print/GetObject reaches
-    # the child that holds the modified tree and its RPC ref-state — by exact id, and (because a
-    # modifying visit re-keys the tree and Java also fetches the context/cursors by id) by the
-    # active-child fallback for ids the map never recorded.
-    f.visit({"visitor": "edit:r", "treeId": "T1"})
-    assert f.tree_owner({"treeId": "T1"}) == "pkg"          # Print carries 'treeId'
-    assert f.tree_owner({"id": "T1"}) == "pkg"              # GetObject carries 'id'
-    assert f.tree_owner({"treeId": "re-keyed-id"}) == "pkg" # untracked during a run -> active child
-    assert f.route_to_child("pkg", "Print", {"treeId": "T1"}) == {"ok": "Print"}
-
-
 def test_facade_batch_visit_splits_consecutive_runs_across_bundles():
     children = _FakeChildren()
     f = Facade(children)
@@ -129,8 +110,6 @@ def test_facade_batch_visit_splits_consecutive_runs_across_bundles():
     # dispatched as maximal consecutive same-owner runs: A gets [a1,a2], then B gets [b1]
     batches = [c for c in children.calls if c[0] == "batch"]
     assert batches == [("batch", "A", ["edit:a1", "edit:a2"]), ("batch", "B", ["edit:b1"])]
-    # tree ownership follows the last child to touch it (for a later Print/GetObject)
-    assert f.tree_owner({"treeId": "T"}) == "B"
 
 
 def test_facade_batch_visit_re_splits_when_owners_alternate():
@@ -245,9 +224,6 @@ def test_handle_request_answers_print_from_the_facades_own_tree(monkeypatch, tmp
         def visit(self, params): ...
         def batch_visit(self, params): ...
         def generate(self, params): ...
-
-        def route_to_child(self, bundle, method, params):
-            raise AssertionError("Print/GetObject must never round-trip to a child")
 
     monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)  # facade mode on
     monkeypatch.setattr(server, "_child_bundle", None)

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -226,12 +226,48 @@ def test_handle_request_answers_print_from_the_facades_own_tree(monkeypatch, tmp
     acquired = []
     monkeypatch.setattr(server, "_hub_acquire", lambda oid, sft: acquired.append(oid))
     monkeypatch.setitem(server._hub_tree, "T1", object())
-    assert server.handle_request("Print", {"treeId": "T1"}) == "local-print"
+    assert server.handle_request("Print", {"treeId": "T1", "sourceFileType": "py"}) == "local-print"
     assert acquired == []
 
     # one it doesn't hold yet is acquired here, at the top level, then served locally
-    assert server.handle_request("Print", {"treeId": "other"}) == "local-print"
+    assert server.handle_request("Print", {"treeId": "other", "sourceFileType": "py"}) == "local-print"
     assert acquired == ["other"]
+
+
+def test_handle_request_does_not_acquire_non_tree_objects(monkeypatch, tmp_path):
+    """Java fetches the execution context and cursors by id too, and those have no Python codec.
+
+    `GetObject.sourceFileType` is nullable and set only for trees, so it is what distinguishes
+    them. Acquiring a non-tree hands its property messages to a receiver that cannot consume
+    them, which desynchronizes the queue for every object that follows -- observed end-to-end as
+    "No RPC codec registered on the Python side for 'org.openrewrite.InMemoryExecutionContext'".
+    """
+    import rewrite.rpc.server as server
+
+    class _FakeFacade:
+        def get_marketplace(self, params): ...
+        def install_recipes(self, params): ...
+        def prepare_recipe(self, params): ...
+        def set_data_table_store(self, params): ...
+        def visit(self, params): ...
+        def batch_visit(self, params): ...
+        def generate(self, params): ...
+
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)  # facade mode on
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_facade", _FakeFacade())
+    monkeypatch.setattr(server, "handle_get_object", lambda p: "local-get")
+
+    acquired = []
+    monkeypatch.setattr(server, "_hub_acquire", lambda oid, sft: acquired.append(oid))
+
+    # The execution context: fetched by id, no sourceFileType.
+    assert server.handle_request("GetObject", {"id": "ctx-1"}) == "local-get"
+    assert acquired == []
+
+    # A tree carries its type and is still acquired.
+    assert server.handle_request("GetObject", {"id": "tree-1", "sourceFileType": "py"}) == "local-get"
+    assert acquired == ["tree-1"]
 
 
 def test_handle_request_routes_to_facade_in_facade_mode(monkeypatch, tmp_path):

--- a/rewrite-python/rewrite/tests/rpc/test_opaque_roundtrip.py
+++ b/rewrite-python/rewrite/tests/rpc/test_opaque_roundtrip.py
@@ -43,10 +43,6 @@ def test_plain_dict_is_not_mistaken_for_opaque():
 
 
 def test_visit_markers_with_opaque_marker_serializes_without_crashing():
-    # The marker list is the only place opaque values reach the id-getter. Its 'id' is a canonical
-    # UUID string, not the int a typed marker's _id is; passing it straight to id_to_str crashed full
-    # serialization with "%x format: an integer is required, not str". It must serialize cleanly and
-    # emit the marker under its original type.
     from rewrite.markers import Markers
     from rewrite.rpc.python_sender import PythonRpcSender
     opaque = {'kind': 'com.example.SomeMarker', 'id': '3f2504e0-4f89-41d3-9a0c-0305e82c3301', 'x': 1}

--- a/rewrite-python/rewrite/tests/rpc/test_opaque_roundtrip.py
+++ b/rewrite-python/rewrite/tests/rpc/test_opaque_roundtrip.py
@@ -1,0 +1,55 @@
+"""Opaque values (a type the remote side has a codec for but Python does not) are received as
+`{'kind': <valueType>, **fields}`. The sender must be able to emit that shape back so it survives a
+send->receive round-trip -- required for the facade to re-serialize a child's modified tree that
+still carries Java-origin opaque markers."""
+
+from rewrite.rpc.receive_queue import RpcReceiveQueue
+from rewrite.rpc.send_queue import RpcSendQueue
+
+
+def _round_trip(value):
+    q = RpcSendQueue(None)
+    q.send(value, None)                 # serialize the value as the sender would a marker element
+    q.q.append({'state': 'END_OF_OBJECT'})
+    data = q.q
+    it = iter([data])
+
+    def pull_batch():
+        try:
+            batch = next(it)
+            if batch and batch[-1].get('state') == 'END_OF_OBJECT':
+                batch = batch[:-1]
+            return batch
+        except StopIteration:
+            return []
+
+    return RpcReceiveQueue({}, None, pull_batch).receive(None, None)
+
+
+def test_opaque_value_round_trips():
+    opaque = {'kind': 'com.example.SomeMarker', 'id': '3f2504e0-4f89-41d3-9a0c-0305e82c3301', 'x': 1}
+    assert _round_trip(opaque) == opaque
+
+
+def test_opaque_value_with_nested_fields_round_trips():
+    opaque = {'kind': 'com.example.Nested', 'id': 'id-1', 'inner': {'a': 2, 'b': ['x', 'y']}}
+    assert _round_trip(opaque) == opaque
+
+
+def test_plain_dict_is_not_mistaken_for_opaque():
+    # An ordinary dict (no 'kind') must not be tagged with a type -- unchanged from before the fix.
+    assert RpcSendQueue(None)._get_value_type({'a': 1, 'b': 'two'}) is None
+    assert RpcSendQueue(None)._get_value_type({'kind': 'com.example.Foo', 'id': 'x'}) == 'com.example.Foo'
+
+
+def test_visit_markers_with_opaque_marker_serializes_without_crashing():
+    # The marker list is the only place opaque values reach the id-getter. Its 'id' is a canonical
+    # UUID string, not the int a typed marker's _id is; passing it straight to id_to_str crashed full
+    # serialization with "%x format: an integer is required, not str". It must serialize cleanly and
+    # emit the marker under its original type.
+    from rewrite.markers import Markers
+    from rewrite.rpc.python_sender import PythonRpcSender
+    opaque = {'kind': 'com.example.SomeMarker', 'id': '3f2504e0-4f89-41d3-9a0c-0305e82c3301', 'x': 1}
+    q = RpcSendQueue(None)
+    PythonRpcSender()._visit_markers(Markers(0, [opaque]), q)  # previously raised here
+    assert any(d.get('valueType') == 'com.example.SomeMarker' for d in q.q)

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -220,6 +220,36 @@ def test_handle_install_recipes_local_path_installs_with_deps(tmp_path, monkeypa
     assert str(local) in captured["cmd"]
 
 
+def test_handle_install_recipes_local_path_attributes_to_the_supplied_path(monkeypatch, tmp_path):
+    # A local install is attributed to the supplied path (the identity the host keys the bundle by),
+    # not the resolved distribution name — matching the facade's local install.
+    import rewrite.rpc.server as server
+    from rewrite import CategoryDescriptor, Recipe
+    from rewrite.discovery import RecipeAttribution
+    from rewrite.marketplace import RecipeMarketplace
+
+    class _Sample(Recipe):
+        @property
+        def name(self): return "org.local.Sample"
+        @property
+        def display_name(self): return "Sample"
+        @property
+        def description(self): return "s"
+
+    attribution = RecipeAttribution()
+    monkeypatch.setattr(server, "_marketplace", RecipeMarketplace())
+    monkeypatch.setattr(server, "_attribution", attribution)
+    monkeypatch.setattr(server, "_recipe_install_dir", None)          # no pip; just activate
+    monkeypatch.setattr(server, "_find_package_name", lambda p: "sample-dist")
+    monkeypatch.setattr(server, "_import_and_activate_package",
+                        lambda name, mkt, local_path=None: mkt.install(_Sample, [CategoryDescriptor(display_name="Local")]))
+
+    supplied = str(tmp_path / "my-recipe-src")
+    server.handle_install_recipes({"recipes": supplied})
+
+    assert attribution.package_for("org.local.Sample") == supplied   # the path, not "sample-dist"
+
+
 def test_recipe_descriptor_to_dict_emits_all_collection_keys():
     from rewrite.recipe import RecipeDescriptor
     from rewrite.rpc.server import _recipe_descriptor_to_dict
@@ -443,3 +473,35 @@ def test_prepare_recipe_returns_whole_child_tree(monkeypatch):
 
     assert "recipeList" in response
     assert [c["descriptor"]["name"] for c in response["recipeList"]] == ["org.example.Leaf"]
+
+
+def test_hub_release_rewinds_send_refs_in_lockstep_with_the_child():
+    """A child drops its receive refs for a file when the broadcast Evict reaches it, so the facade
+    must return its send-ref numbering to exactly the pre-file value. If the facade kept advancing,
+    it would emit a GET_REF for a ref the child no longer holds; if it rewound while the child did
+    not, it would reuse a number still bound to the old object and serve a wrong tree silently."""
+    import rewrite.rpc.server as server
+
+    bundle, first, second = "pkg", "file-1", "file-2"
+    server._hub_send_refs[bundle] = {}
+    server._hub_send_next[bundle] = 0
+
+    # Serving the first file advances this child's numbering and records where it started.
+    server._hub_send_checkpoint.setdefault((bundle, first), server._hub_send_next[bundle])
+    server._hub_send_refs[bundle].update({"obj-a": (object(), 1), "obj-b": (object(), 2)})
+    server._hub_send_next[bundle] = 2
+    server._hub_served[(bundle, first)] = object()
+    server._hub_tree[first] = object()
+
+    server._hub_release(first)
+
+    # Everything that file introduced is gone, and the counter is back where it began.
+    assert server._hub_send_next[bundle] == 0
+    assert server._hub_send_refs[bundle] == {}
+    assert (bundle, first) not in server._hub_served
+    assert (bundle, first) not in server._hub_send_checkpoint
+    assert first not in server._hub_tree
+
+    # So the next file reuses the same ref numbers rather than continuing past them.
+    server._hub_send_checkpoint.setdefault((bundle, second), server._hub_send_next[bundle])
+    assert server._hub_send_checkpoint[(bundle, second)] == 0

--- a/rewrite-python/rewrite/tests/rpc/test_venv_manager.py
+++ b/rewrite-python/rewrite/tests/rpc/test_venv_manager.py
@@ -30,7 +30,6 @@ def test_create_venv_uses_stdlib_venv_of_given_interpreter(monkeypatch, tmp_path
 def test_venv_python_points_inside_the_venv(tmp_path):
     venv_dir = tmp_path / "b1"
     py = venv_manager.venv_python(venv_dir)
-    # Interpreter lives under the venv, in Scripts (Windows) or bin (POSIX).
     assert venv_dir in py.parents
     assert py.parent.name in ("Scripts", "bin")
 
@@ -83,8 +82,6 @@ def test_usable_venv_requires_an_interpreter_whose_base_still_exists(tmp_path):
 
 
 def test_usable_venv_is_false_when_the_base_interpreter_was_upgraded_away(tmp_path):
-    # uv encodes the patch version in the interpreter path, so a Python upgrade orphans the venv.
-    # On Windows the copied python.exe survives, so existence alone would wrongly say "usable".
     venv_dir = tmp_path / "b1"
     _fake_venv(venv_dir, tmp_path / "cpython-3.12.11-pruned")
     assert venv_manager.venv_python(venv_dir).exists()
@@ -158,8 +155,6 @@ def test_purge_keeps_venvs_and_removes_pre_venv_target_debris(tmp_path):
 
 
 def test_purge_keeps_an_orphaned_venv(tmp_path):
-    # An orphaned venv (base pruned by a Python upgrade) is still a venv; fix 2 rebuilds it on
-    # install. The sweep must not delete it just because it isn't currently usable.
     root = tmp_path / "pip"
     _fake_venv(root / "pkg", tmp_path / "pruned-base")
     assert not venv_manager.is_usable_venv(root / "pkg")

--- a/rewrite-python/rewrite/tests/rpc/test_venv_manager.py
+++ b/rewrite-python/rewrite/tests/rpc/test_venv_manager.py
@@ -1,0 +1,177 @@
+import subprocess
+from pathlib import Path
+
+from rewrite.rpc import venv_manager
+
+
+def _capture(monkeypatch):
+    calls = []
+
+    class _CP:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(cmd, capture_output=False, text=False):
+        calls.append(cmd)
+        return _CP()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    return calls
+
+
+def test_create_venv_uses_stdlib_venv_of_given_interpreter(monkeypatch, tmp_path):
+    calls = _capture(monkeypatch)
+    venv_dir = tmp_path / "b1"
+    venv_manager.create_venv("/usr/bin/python3.12", venv_dir)
+    assert calls == [["/usr/bin/python3.12", "-m", "venv", str(venv_dir)]]
+
+
+def test_venv_python_points_inside_the_venv(tmp_path):
+    venv_dir = tmp_path / "b1"
+    py = venv_manager.venv_python(venv_dir)
+    # Interpreter lives under the venv, in Scripts (Windows) or bin (POSIX).
+    assert venv_dir in py.parents
+    assert py.parent.name in ("Scripts", "bin")
+
+
+def test_install_into_venv_upgrades_via_the_venv_pip(monkeypatch, tmp_path):
+    calls = _capture(monkeypatch)
+    venv_dir = tmp_path / "b1"
+    venv_manager.install_into_venv(venv_dir, "openrewrite-migrate-python")
+    py = str(venv_manager.venv_python(venv_dir))
+    assert calls == [[py, "-m", "pip", "install", "--upgrade", "openrewrite-migrate-python"]]
+
+
+def test_install_into_venv_force_reinstalls_mutable_local_sources(monkeypatch, tmp_path):
+    calls = _capture(monkeypatch)
+    venv_dir = tmp_path / "b1"
+    venv_manager.install_into_venv(venv_dir, "./local-recipes", force=True)
+    py = str(venv_manager.venv_python(venv_dir))
+    assert calls == [[py, "-m", "pip", "install", "--upgrade", "--force-reinstall", "./local-recipes"]]
+
+
+def test_remove_venv_deletes_the_directory(tmp_path):
+    venv_dir = tmp_path / "b1"
+    (venv_dir / "sub").mkdir(parents=True)
+    (venv_dir / "sub" / "f.txt").write_text("x")
+    venv_manager.remove_venv(venv_dir)
+    assert not venv_dir.exists()
+
+
+def test_create_venv_can_clear_a_stale_directory(monkeypatch, tmp_path):
+    calls = _capture(monkeypatch)
+    venv_dir = tmp_path / "b1"
+    venv_manager.create_venv("/usr/bin/python3.12", venv_dir, clear=True)
+    assert calls == [["/usr/bin/python3.12", "-m", "venv", "--clear", str(venv_dir)]]
+
+
+def _fake_venv(venv_dir: Path, home: Path) -> None:
+    interpreter = venv_manager.venv_python(venv_dir)
+    interpreter.parent.mkdir(parents=True, exist_ok=True)
+    interpreter.touch()
+    (venv_dir / "pyvenv.cfg").write_text(
+        f"home = {home}\ninclude-system-site-packages = false\nversion = 3.12.11\n")
+
+
+def test_usable_venv_requires_an_interpreter_whose_base_still_exists(tmp_path):
+    base = tmp_path / "cpython-3.12.11"
+    base.mkdir()
+    venv_dir = tmp_path / "b1"
+    _fake_venv(venv_dir, base)
+    assert venv_manager.is_usable_venv(venv_dir)
+
+
+def test_usable_venv_is_false_when_the_base_interpreter_was_upgraded_away(tmp_path):
+    # uv encodes the patch version in the interpreter path, so a Python upgrade orphans the venv.
+    # On Windows the copied python.exe survives, so existence alone would wrongly say "usable".
+    venv_dir = tmp_path / "b1"
+    _fake_venv(venv_dir, tmp_path / "cpython-3.12.11-pruned")
+    assert venv_manager.venv_python(venv_dir).exists()
+    assert not venv_manager.is_usable_venv(venv_dir)
+
+
+def test_usable_venv_is_false_for_a_missing_dir_a_flat_package_and_a_config_less_dir(tmp_path):
+    assert not venv_manager.is_usable_venv(tmp_path / "absent")
+
+    flat = tmp_path / "legacy"                       # pre-venv `pip install --target` leftovers
+    flat.mkdir()
+    (flat / "__init__.py").write_text("")
+    assert not venv_manager.is_usable_venv(flat)
+
+    half = tmp_path / "half"                         # interpreter, but interrupted before pyvenv.cfg
+    venv_manager.venv_python(half).parent.mkdir(parents=True)
+    venv_manager.venv_python(half).touch()
+    assert not venv_manager.is_usable_venv(half)
+
+
+def _write_dist_info(venv_dir: Path, dist_name: str, version: str) -> None:
+    import os
+    sp = venv_dir / ("Lib/site-packages" if os.name == "nt" else "lib/python3.12/site-packages")
+    dist_info = sp / f"{dist_name.replace('-', '_')}-{version}.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "METADATA").write_text(
+        f"Metadata-Version: 2.1\nName: {dist_name}\nVersion: {version}\n")
+
+
+def test_installed_version_reads_the_resolved_version_from_the_venv(tmp_path):
+    venv = tmp_path / "b1"
+    _write_dist_info(venv, "openrewrite-migrate-python", "0.9.3")
+    assert venv_manager.installed_version(venv, "openrewrite-migrate-python") == "0.9.3"
+
+
+def test_installed_version_matches_on_the_normalized_distribution_name(tmp_path):
+    venv = tmp_path / "b1"
+    _write_dist_info(venv, "openrewrite-migrate-python", "0.9.3")
+    # bundle_dist arrives PEP 503 normalized; it must still match the canonical metadata Name.
+    assert venv_manager.installed_version(venv, "openrewrite_migrate_python") == "0.9.3"
+
+
+def test_installed_version_is_none_for_an_absent_dist_or_missing_venv(tmp_path):
+    venv = tmp_path / "b1"
+    _write_dist_info(venv, "openrewrite-migrate-python", "0.9.3")
+    assert venv_manager.installed_version(venv, "some-other-package") is None
+    assert venv_manager.installed_version(tmp_path / "nope", "openrewrite-migrate-python") is None
+
+
+def test_purge_keeps_venvs_and_removes_pre_venv_target_debris(tmp_path):
+    root = tmp_path / "pip"
+    _fake_venv(root / "openrewrite_migrate_python", tmp_path / "base")   # a per-bundle venv — kept
+
+    # pre-venv `pip install --target` residue: flat packages, dist-info, flattened deps, loose files
+    flat = root / "openrewrite_code_quality_python"; flat.mkdir(parents=True)
+    (flat / "__init__.py").write_text("")
+    (root / "openrewrite_migrate_python-0.8.0.dist-info").mkdir()
+    dep = root / "some_dep"; dep.mkdir(); (dep / "__init__.py").write_text("")
+    (root / "loose_module.py").write_text("")
+    (root / "bin").mkdir(); (root / "bin" / "tool").write_text("")
+    (root / "__pycache__").mkdir()
+
+    removed = venv_manager.purge_non_venv_entries(root)
+
+    assert (root / "openrewrite_migrate_python" / "pyvenv.cfg").exists()      # venv untouched
+    assert set(removed) == {
+        "openrewrite_code_quality_python", "openrewrite_migrate_python-0.8.0.dist-info",
+        "some_dep", "loose_module.py", "bin", "__pycache__",
+    }
+    assert [e.name for e in root.iterdir()] == ["openrewrite_migrate_python"]  # only the venv remains
+
+
+def test_purge_keeps_an_orphaned_venv(tmp_path):
+    # An orphaned venv (base pruned by a Python upgrade) is still a venv; fix 2 rebuilds it on
+    # install. The sweep must not delete it just because it isn't currently usable.
+    root = tmp_path / "pip"
+    _fake_venv(root / "pkg", tmp_path / "pruned-base")
+    assert not venv_manager.is_usable_venv(root / "pkg")
+    assert venv_manager.purge_non_venv_entries(root) == []
+    assert (root / "pkg" / "pyvenv.cfg").exists()
+
+
+def test_purge_is_a_noop_on_a_missing_root_and_is_idempotent(tmp_path):
+    assert venv_manager.purge_non_venv_entries(tmp_path / "absent") == []
+
+    root = tmp_path / "pip"
+    _fake_venv(root / "pkg", tmp_path / "base")
+    (root / "junk").mkdir()
+    assert venv_manager.purge_non_venv_entries(root) == ["junk"]
+    assert venv_manager.purge_non_venv_entries(root) == []   # nothing left but the venv

--- a/rewrite-python/rewrite/tests/test_discovery_root.py
+++ b/rewrite-python/rewrite/tests/test_discovery_root.py
@@ -1,0 +1,131 @@
+import rewrite.discovery as discovery
+from rewrite import CategoryDescriptor, RecipeMarketplace, Recipe
+
+
+def _recipe(name):
+    class _R(Recipe):
+        @property
+        def name(self): return name
+        @property
+        def display_name(self): return name
+        @property
+        def description(self): return "r"
+    return _R
+
+
+class _Dist:
+    def __init__(self, name): self.name = name
+
+
+class _EP:
+    def __init__(self, dist_name, recipe_name):
+        self.dist = _Dist(dist_name)
+        self._recipe_name = recipe_name
+
+    def load(self):
+        rn = self._recipe_name
+
+        class _Mod:
+            @staticmethod
+            def activate(marketplace):
+                marketplace.install(_recipe(rn), [CategoryDescriptor(display_name="Test")])
+        return _Mod
+
+
+class _AttributeEP:
+    """An ``pkg = "pkg:activate"`` entry point: ``load()`` yields the function, not the module.
+
+    This is the form the engine itself declares (``openrewrite = rewrite:activate``) and the form
+    the discovery docstring advertises, so a bundle using it must still activate.
+    """
+
+    def __init__(self, dist_name, recipe_name):
+        self.dist = _Dist(dist_name)
+        self._recipe_name = recipe_name
+
+    def load(self):
+        rn = self._recipe_name
+
+        def activate(marketplace):
+            marketplace.install(_recipe(rn), [CategoryDescriptor(display_name="Test")])
+
+        return activate
+
+
+def _names(marketplace):
+    return {n for cat in marketplace.categories() for n in cat.recipes.keys()}
+
+
+def test_root_only_activation_hides_transitive_recipe_packages(monkeypatch):
+    # Root bundle "root-pkg" plus a transitive recipe package "dep-pkg" both present in the venv.
+    eps = [_EP("root-pkg", "org.example.Root"), _EP("dep-pkg", "org.example.Dep")]
+    monkeypatch.setattr(discovery, "entry_points", lambda group: eps)
+
+    marketplace = RecipeMarketplace()
+    attribution = discovery.RecipeAttribution()
+    discovery.discover_root_recipes("root_pkg", marketplace, attribution)  # normalized spelling
+
+    assert _names(marketplace) == {"org.example.Root"}          # only the root's direct recipe
+    assert attribution.package_for("org.example.Root") == "root-pkg"
+    assert attribution.package_for("org.example.Dep") is None
+
+
+def test_root_activation_supports_attribute_form_entry_points(monkeypatch):
+    eps = [_AttributeEP("root-pkg", "org.example.Root")]
+    monkeypatch.setattr(discovery, "entry_points", lambda group: eps)
+
+    marketplace = RecipeMarketplace()
+    attribution = discovery.RecipeAttribution()
+    discovery.discover_root_recipes("root-pkg", marketplace, attribution)
+
+    assert _names(marketplace) == {"org.example.Root"}
+    assert attribution.package_for("org.example.Root") == "root-pkg"
+
+
+def test_root_activation_attributes_to_the_supplied_name(monkeypatch):
+    # A local install is filtered by its resolved distribution name but must be attributed to the
+    # path the host supplied and keys the bundle by — not the distribution's own name.
+    eps = [_AttributeEP("my-local-recipes", "org.example.Local")]
+    monkeypatch.setattr(discovery, "entry_points", lambda group: eps)
+
+    marketplace = RecipeMarketplace()
+    attribution = discovery.RecipeAttribution()
+    discovery.discover_root_recipes("my-local-recipes", marketplace, attribution,
+                                    attribution_name="/abs/path/to/my-recipes")
+
+    assert _names(marketplace) == {"org.example.Local"}
+    assert attribution.package_for("org.example.Local") == "/abs/path/to/my-recipes"
+
+
+def test_distribution_name_from_pyproject_and_setup_py(tmp_path):
+    proj = tmp_path / "pep621"; proj.mkdir()
+    (proj / "pyproject.toml").write_text('[project]\nname = "my-recipes"\nversion = "1.0"\n')
+    assert discovery.distribution_name_from_source(proj) == "my-recipes"
+
+    poetry = tmp_path / "poetry"; poetry.mkdir()
+    (poetry / "pyproject.toml").write_text('[tool.poetry]\nname = "poetry-recipes"\n')
+    assert discovery.distribution_name_from_source(poetry) == "poetry-recipes"
+
+    legacy = tmp_path / "legacy"; legacy.mkdir()
+    (legacy / "setup.py").write_text('setup(name="setup-recipes", version="1.0")\n')
+    assert discovery.distribution_name_from_source(legacy) == "setup-recipes"
+
+    assert discovery.distribution_name_from_source(tmp_path / "absent") is None
+    (tmp_path / "empty").mkdir()
+    assert discovery.distribution_name_from_source(tmp_path / "empty") is None
+
+
+def test_flat_discovery_supports_attribute_form_entry_points(monkeypatch):
+    # discover_recipes shares _activate_entry_point with discover_root_recipes, so the engine's own
+    # `openrewrite = rewrite:activate` (function-form) and any recipe bundle's entry points activate
+    # in the non-facade path too — not silently skipped as they were before.
+    eps = [_AttributeEP("pkg-a", "org.example.A"), _EP("pkg-b", "org.example.B")]
+    monkeypatch.setattr(discovery, "entry_points", lambda group: eps)
+
+    marketplace = RecipeMarketplace()
+    attribution = discovery.RecipeAttribution()
+    discovery.discover_recipes(marketplace, attribution)
+
+    assert _names(marketplace) == {"org.example.A", "org.example.B"}   # both forms activate
+    assert attribution.package_for("org.example.A") == "pkg-a"
+    assert attribution.package_for("org.example.B") == "pkg-b"

--- a/rewrite-python/rewrite/tests/test_discovery_root.py
+++ b/rewrite-python/rewrite/tests/test_discovery_root.py
@@ -57,7 +57,6 @@ def _names(marketplace):
 
 
 def test_root_only_activation_hides_transitive_recipe_packages(monkeypatch):
-    # Root bundle "root-pkg" plus a transitive recipe package "dep-pkg" both present in the venv.
     eps = [_EP("root-pkg", "org.example.Root"), _EP("dep-pkg", "org.example.Dep")]
     monkeypatch.setattr(discovery, "entry_points", lambda group: eps)
 
@@ -83,8 +82,6 @@ def test_root_activation_supports_attribute_form_entry_points(monkeypatch):
 
 
 def test_root_activation_attributes_to_the_supplied_name(monkeypatch):
-    # A local install is filtered by its resolved distribution name but must be attributed to the
-    # path the host supplied and keys the bundle by — not the distribution's own name.
     eps = [_AttributeEP("my-local-recipes", "org.example.Local")]
     monkeypatch.setattr(discovery, "entry_points", lambda group: eps)
 
@@ -116,9 +113,6 @@ def test_distribution_name_from_pyproject_and_setup_py(tmp_path):
 
 
 def test_flat_discovery_supports_attribute_form_entry_points(monkeypatch):
-    # discover_recipes shares _activate_entry_point with discover_root_recipes, so the engine's own
-    # `openrewrite = rewrite:activate` (function-form) and any recipe bundle's entry points activate
-    # in the non-facade path too — not silently skipped as they were before.
     eps = [_AttributeEP("pkg-a", "org.example.A"), _EP("pkg-b", "org.example.B")]
     monkeypatch.setattr(discovery, "entry_points", lambda group: eps)
 

--- a/rewrite-python/rewrite/tests/test_marketplace_first_wins.py
+++ b/rewrite-python/rewrite/tests/test_marketplace_first_wins.py
@@ -1,5 +1,5 @@
 from rewrite import CategoryDescriptor, RecipeMarketplace, Recipe
-from rewrite.rpc.server import _collect_marketplace_rows  # proven iteration used by existing tests
+from rewrite.rpc.server import _collect_marketplace_rows
 
 
 def _recipe(name: str, description: str):

--- a/rewrite-python/rewrite/tests/test_marketplace_first_wins.py
+++ b/rewrite-python/rewrite/tests/test_marketplace_first_wins.py
@@ -1,0 +1,23 @@
+from rewrite import CategoryDescriptor, RecipeMarketplace, Recipe
+from rewrite.rpc.server import _collect_marketplace_rows  # proven iteration used by existing tests
+
+
+def _recipe(name: str, description: str):
+    class _R(Recipe):
+        @property
+        def name(self): return name
+        @property
+        def display_name(self): return name
+        @property
+        def description(self): return description
+    return _R
+
+
+def test_registry_is_first_wins_on_duplicate_name():
+    m = RecipeMarketplace()
+    m.install(_recipe("org.example.X", "first"), [CategoryDescriptor(display_name="Test")])
+    m.install(_recipe("org.example.X", "second"), [CategoryDescriptor(display_name="Test")])
+
+    rows = _collect_marketplace_rows(m)
+    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.X")
+    assert row["descriptor"]["description"] == "first"  # first registration wins, not overwritten


### PR DESCRIPTION
## What

Each pip recipe bundle installs into its own virtualenv under `--recipe-install-dir`, replacing the shared `pip install --target` layout whose collapsed dependency graph could not upgrade a version-less install (#8180).

A **facade** server (`--recipe-install-dir`, no `--child-bundle`) owns the virtualenv lifecycle and routes recipe execution to a per-bundle **child** server (`--child-bundle`) running on that bundle's interpreter. The facade holds no recipes itself.

## Routing

- **`PrepareRecipe`** records which child produced each visitor and prepared recipe, so later `Visit`/`Generate` go back to it.
- **`Print`/`GetObject`** are answered by the facade from the tree it owns, so no child's partial copy is mistaken for the whole edit. It takes ownership before any child runs; fetching from inside a child's callback would deadlock, because the child is waiting on the facade and the host is waiting on the request. Java also fetches non-tree objects by id (the execution context, cursors). Those carry no `sourceFileType`, which is what excludes them.
- **`BatchVisit`** splits into consecutive groups by owning child, since the host batches a file's visitors across every recipe and one batch can span bundles.
- **Preconditions.** A `Preconditions.check(...)` editor is unwrapped when the recipe is prepared and its condition published on the wire, where it may name one of the child's own visitors. Those names are registered alongside `editVisitor`/`scanVisitor`, since a condition appears in neither slot nor in `recipeList` and the host calls it back like any other visitor.
- **`SetDataTableStore`** and **`Evict`** go to every child, and the store is replayed onto children started later, because it usually arrives before a bundle's child exists.

## Editing across bundles

Each child starts from the original tree, so without help the second bundle would edit the original instead of the first bundle's result.

The facade owns the working tree. Each child's edit is pulled back and applied to it before the next bundle starts, so the second bundle sees the first one's result. A single-recipe run goes through `Visit` rather than `BatchVisit` and must pull on the same terms — skipping it loses the edit, because the facade would then answer from the unmodified input.

Each child's reference table rewinds in step with the host's `Evict`. Drift in either direction is a bug: if the facade stays ahead it asks for a reference the child has dropped ("Received reference to unknown object"); if it rewinds alone it reuses a number still bound to the old object and serves a wrong tree with no error at all.

The facade replays the host's `GetObject` batches to a second bundle's child verbatim rather than re-fetching, since the host would answer `NO_CHANGE` the second time. The first fetch is a plain relay, so single-bundle runs are byte-for-byte unchanged.

## Also

- **One shared engine.** Children get `rewrite` and its dependencies on `PYTHONPATH` rather than a copy each, and the shared recipe root is kept off each child's path so a bundle imports only from its own virtualenv.
- **Discovery** now activates attribute-form entry points (`pkg = pkg:activate`), which were silently skipped; failures are logged rather than swallowed.
- **`InstallRecipes`** returns the version pip actually resolved, so the host can pin the bundle and later resolves do nothing.
- **Local-path installs** resolve the distribution name from the source, force-reinstall it, and attribute recipes to the supplied path.
- **Lifecycle** guards against half-built and Python-upgrade-orphaned virtualenvs, and a one-time sweep clears older `pip install --target` residue so a CLI downgrade reinstalls cleanly.
- **First install wins** on duplicate recipe names.

## Status

Draft. Unit tested throughout. A two-bundle modifying composite produced output byte-for-byte identical to the released single-environment engine, repeated across runs.

Re-run against a CLI built from this tree on both sides after the rebase onto #8297. Verified:

| Case | Result |
| --- | --- |
| Bundle isolation | each virtualenv holds only its own package |
| Single bundle | `pass` removed from exactly the 2 files that had one |
| Two bundles, recording | both bundles' data tables, 4 rows each |
| Two bundles, editing | `foo()` → `baz()` in all 4 files |
| Precondition | 2 of 4 files, exactly the intended subset |
| Search | markers on every matching call |

Two of these prove more than that the run finished. `baz` is only reachable if the second bundle received the first one's `bar` output, so it tells threaded apart from unthreaded. And the precondition wrapper is removed when the recipe is prepared, so Python never evaluates the condition itself — had the host not applied it, all 4 files would have been recorded.

The re-run found two real defects, both now fixed:

- The facade pulled **any** id into its tree, including the execution context, which has no Python decoder. That consumed the wrong messages and broke every run on its first recipe.
- `Visit` did not pull the child's edited tree back while `BatchVisit` did, so any single-recipe run answered from the unmodified input. The run still reported success and "no changes", so the loss was silent: one recipe produced a diff inside a composite and nothing at all on its own. The cause was a leftover design — `Facade.tree_owner` and `route_to_child` assumed the child holding a tree would later be asked for it. Both were dead but still unit-tested, and `Visit` was written against the same assumption. They and their supporting state have been removed.

Known gaps:
- Neither pull path fires unless the child reports that it modified the tree, and nothing guards a child that edits without setting the flag; the edit would be lost silently.
- A Python recipe used as another recipe's condition never reaches the wire, so it falls back to running in Python — correct, but costs a round trip per file. Pre-existing since #7621: the lookup matches on object identity, while the marketplace stores classes and builds a fresh instance per call.
- Pulling a child's edit assumes the child answers `GetObject` in one batch. True today, but no test pins it; better to assert the end-of-object marker than filter it blindly.
