### PR TITLE
8276 - Incorrect AST values for multiline strings

### DIFF
--- a/rewrite-toml/src/main/java/org/openrewrite/toml/ChangeValue.java
+++ b/rewrite-toml/src/main/java/org/openrewrite/toml/ChangeValue.java
@@ -96,19 +96,6 @@ public class ChangeValue extends Recipe {
                     );
                 }
 
-                if ((value.startsWith("\"") && value.endsWith("\"")) ||
-                    (value.startsWith("'") && value.endsWith("'"))) {
-                    String unquoted = value.substring(1, value.length() - 1);
-                    return new Toml.Literal(
-                            Tree.randomId(),
-                            prefix,
-                            Markers.EMPTY,
-                            TomlType.Primitive.String,
-                            value,
-                            unquoted
-                    );
-                }
-
                 if (value.startsWith("\"\"\"") && value.endsWith("\"\"\"")) {
                     String unquoted = value.substring(3, value.length() - 3);
                     return new Toml.Literal(
@@ -123,6 +110,19 @@ public class ChangeValue extends Recipe {
 
                 if (value.startsWith("'''") && value.endsWith("'''")) {
                     String unquoted = value.substring(3, value.length() - 3);
+                    return new Toml.Literal(
+                            Tree.randomId(),
+                            prefix,
+                            Markers.EMPTY,
+                            TomlType.Primitive.String,
+                            value,
+                            unquoted
+                    );
+                }
+
+                if ((value.startsWith("\"") && value.endsWith("\"")) ||
+                    (value.startsWith("'") && value.endsWith("'"))) {
+                    String unquoted = value.substring(1, value.length() - 1);
                     return new Toml.Literal(
                             Tree.randomId(),
                             prefix,

--- a/rewrite-toml/src/main/java/org/openrewrite/toml/ChangeValue.java
+++ b/rewrite-toml/src/main/java/org/openrewrite/toml/ChangeValue.java
@@ -96,19 +96,8 @@ public class ChangeValue extends Recipe {
                     );
                 }
 
-                if (value.startsWith("\"\"\"") && value.endsWith("\"\"\"")) {
-                    String unquoted = value.substring(3, value.length() - 3);
-                    return new Toml.Literal(
-                            Tree.randomId(),
-                            prefix,
-                            Markers.EMPTY,
-                            TomlType.Primitive.String,
-                            value,
-                            unquoted
-                    );
-                }
-
-                if (value.startsWith("'''") && value.endsWith("'''")) {
+                if ((value.startsWith("\"\"\"") && value.endsWith("\"\"\"")) ||
+                    (value.startsWith("'''") && value.endsWith("'''"))) {
                     String unquoted = value.substring(3, value.length() - 3);
                     return new Toml.Literal(
                             Tree.randomId(),

--- a/rewrite-toml/src/main/java/org/openrewrite/toml/internal/TomlParserVisitor.java
+++ b/rewrite-toml/src/main/java/org/openrewrite/toml/internal/TomlParserVisitor.java
@@ -201,13 +201,16 @@ public class TomlParserVisitor extends TomlParserBaseVisitor<Toml> {
     public Toml visitString(TomlParser.StringContext ctx) {
         return convert(ctx, (c, prefix) -> {
             String string = c.getText();
+            String value = (string.startsWith("\"\"\"") || string.startsWith("'''"))
+                    ? string.substring(3, string.length() - 3)
+                    : string.substring(1, string.length() - 1);
             return new Toml.Literal(
                     randomId(),
                     prefix,
                     Markers.EMPTY,
                     TomlType.Primitive.String,
                     string,
-                    string.substring(1, string.length() - 1)
+                    value
             );
         });
     }

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/ChangeValueTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/ChangeValueTest.java
@@ -21,6 +21,9 @@ import org.openrewrite.Issue;
 import org.openrewrite.Recipe;
 import org.openrewrite.test.RewriteTest;
 
+import org.openrewrite.toml.tree.Toml;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.toml.Assertions.toml;
 
 class ChangeValueTest implements RewriteTest {
@@ -203,7 +206,11 @@ class ChangeValueTest implements RewriteTest {
               description = \"""A multi-line
               description\"""
               name = "project"
-              """
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Toml.Literal literal = (Toml.Literal) ((Toml.KeyValue) doc.getValues().getFirst()).getValue();
+                assertThat(literal.getValue()).isEqualTo("A multi-line\ndescription");
+            })
           )
         );
     }
@@ -219,14 +226,14 @@ class ChangeValueTest implements RewriteTest {
             """
               [package]
               version = "1.0.0"
-
+              
               [dependencies]
               version = "should-not-change"
               """,
             """
               [package]
               version = "2.0.0"
-
+              
               [dependencies]
               version = "should-not-change"
               """

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
@@ -16,12 +16,13 @@
 package org.openrewrite.toml;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.toml.tree.Toml;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.tuple;
 import static org.openrewrite.toml.Assertions.toml;
 
 class TomlParserTest implements RewriteTest {
@@ -456,26 +457,22 @@ class TomlParserTest implements RewriteTest {
         );
     }
 
-    @Test
-    void multiLineStringValueStrippedCorrectly() {
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "\"hello\"",
+      "'hello'",
+      "\"\"\"hello\"\"\"",
+      "'''hello'''"
+    })
+    void stringValueStrippedForAnyQuoteStyle(String quoted) {
         rewriteRun(
           toml(
-            """
-              basic = \"""hello\"""
-              literal = '''world'''
-              """,
-            spec -> spec.afterRecipe(doc -> {
-                assertThat(doc.getValues())
-                  .extracting(Toml.KeyValue.class::cast)
-                  .extracting(
-                    keyValue -> ((Toml.Identifier) keyValue.getKey()).getName(),
-                    keyValue -> ((Toml.Literal) keyValue.getValue()).getValue()
-                  )
-                  .containsExactly(
-                    tuple("basic", "hello"),
-                    tuple("literal", "world")
-                  );
-            })
+            "greeting = " + quoted,
+            spec -> spec.afterRecipe(doc ->
+              assertThat(doc.getValues())
+                .extracting(Toml.KeyValue.class::cast)
+                .extracting(keyValue -> ((Toml.Literal) keyValue.getValue()).getValue())
+                .containsExactly("hello"))
           )
         );
     }

--- a/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
+++ b/rewrite-toml/src/test/java/org/openrewrite/toml/TomlParserTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.toml.tree.Toml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.openrewrite.toml.Assertions.toml;
 
 class TomlParserTest implements RewriteTest {
@@ -451,6 +452,30 @@ class TomlParserTest implements RewriteTest {
               # Another inline table with trailing comma
               person = { name = "John", age = 30, }
               """
+          )
+        );
+    }
+
+    @Test
+    void multiLineStringValueStrippedCorrectly() {
+        rewriteRun(
+          toml(
+            """
+              basic = \"""hello\"""
+              literal = '''world'''
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                assertThat(doc.getValues())
+                  .extracting(Toml.KeyValue.class::cast)
+                  .extracting(
+                    keyValue -> ((Toml.Identifier) keyValue.getKey()).getName(),
+                    keyValue -> ((Toml.Literal) keyValue.getValue()).getValue()
+                  )
+                  .containsExactly(
+                    tuple("basic", "hello"),
+                    tuple("literal", "world")
+                  );
+            })
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Fixed multiline TOML string values in `rewrite-toml`.

Triple-quoted strings now correctly remove all three delimiter characters when building the AST value. This applies both when parsing TOML and when using the `ChangeValue` recipe.

## What's your motivation?

previously the rendered TOML was correct, but `Toml.Literal.getValue()` incorrectly included two quote characters at both ends of multiline strings.

## Anything in particular you'd like reviewers to focus on?

## Anyone you would like to review specifically?

## Have you considered any alternatives or workarounds?
not really
## Any additional context

The triple-quote checks must run before the single-quote checks because triple-quoted strings also start with a single quote character.