### PR TITLE
Fix NPE parsing @CompileStatic Groovy with parameterless lambda arguments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2760,7 +2760,8 @@ public class GroovyParserVisitor {
                             }
                             ClosureExpression cl = (ClosureExpression) arg;
                             ClassNode actualParamTypeRaw = call.getNodeMetaData(StaticTypesMarker.INFERRED_TYPE);
-                            for (Parameter p : cl.getParameters()) {
+                            Parameter[] clParameters = cl.getParameters();
+                            for (Parameter p : clParameters == null ? Parameter.EMPTY_ARRAY : clParameters) {
                                 if (p.isDynamicTyped()) {
                                     p.setType(actualParamTypeRaw);
                                     p.removeNodeMetaData(StaticTypesMarker.INFERRED_TYPE);

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2850,7 +2850,8 @@ public class GroovyParserVisitor {
                         }
                         ClosureExpression cl = (ClosureExpression) arg;
                         ClassNode actualParamTypeRaw = call.getNodeMetaData(StaticTypesMarker.INFERRED_TYPE);
-                        for (Parameter p : cl.getParameters()) {
+                        Parameter[] clParameters = cl.getParameters();
+                        for (Parameter p : clParameters == null ? Parameter.EMPTY_ARRAY : clParameters) {
                             if (p.isDynamicTyped()) {
                                 p.setType(actualParamTypeRaw);
                                 p.removeNodeMetaData(StaticTypesMarker.INFERRED_TYPE);

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/LambdaTest.java
@@ -113,6 +113,26 @@ class LambdaTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-logging-frameworks/issues/298")
+    @Test
+    void compileStaticLambdaArgumentWithoutParameters() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.transform.CompileStatic
+
+              @CompileStatic
+              class Main {
+                  static void main(String[] args) {
+                      Optional<String> myOptional = Optional.ofNullable("test")
+                      String myStr = myOptional.orElseGet(() -> "alternative")
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2168")
     @Test
     void closureNoArguments() {


### PR DESCRIPTION
### What's changed?

Guards against `ClosureExpression.getParameters()` returning `null` when enriching closure/lambda parameter types for statically compiled method calls in the Groovy parser.

A Java-style lambda without parameters (e.g. `() -> "x"`) reports `null` (rather than an empty array) from `getParameters()`. When such a lambda is passed as an argument to a method call inside a `@CompileStatic` class, Groovy attaches `StaticTypesMarker.INFERRED_TYPE` metadata, which triggers the parameter-enrichment loop and a `NullPointerException`.

### What's your motivation?

- Reported downstream in [rewrite-logging-frameworks#298](https://github.com/openrewrite/rewrite-logging-frameworks/issues/298): `CommonsLoggingToLog4j` (and any recipe) fails to parse `@CompileStatic` Groovy sources that contain a parameterless lambda argument, so no changes are made and the run logs a `GroovyParsingException` / `NullPointerException`.

- Closes https://github.com/openrewrite/rewrite-logging-frameworks/issues/298

### Anything in particular you'd like reviewers to focus on?

The fix only affects the `@CompileStatic` path (the outer guard is `call.getNodeMetaData(StaticTypesMarker.INFERRED_TYPE) != null`), which is why it only reproduces on statically compiled code. Added a regression test to `LambdaTest`.