### PR TITLE
Go: fix RPC handling of Go-specific unary operators

### DIFF
--- a/rewrite-go/pkg/rpc/go_unary_operator_rpc_test.go
+++ b/rewrite-go/pkg/rpc/go_unary_operator_rpc_test.go
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+func TestGoUnaryRoundTrip_OperatorSpaceChangePreservesAddressOf(t *testing.T) {
+	// given
+	id := uuid.New()
+	expr := makeIdent("x")
+	after := &golang.Unary{
+		ID:         id,
+		Operator:   java.LeftPadded[golang.UnaryOperator]{Before: java.EmptySpace, Element: golang.AddressOf},
+		Expression: expr,
+	}
+	before := &golang.Unary{
+		ID:         id,
+		Operator:   java.LeftPadded[golang.UnaryOperator]{Before: java.SingleSpace, Element: golang.AddressOf},
+		Expression: expr,
+	}
+	seed := &golang.Unary{
+		ID:       id,
+		Operator: java.LeftPadded[golang.UnaryOperator]{Element: golang.AddressOf},
+	}
+
+	// when
+	got := roundTripNodeWithBefore(t, after, before, seed).(*golang.Unary)
+
+	// then
+	if got.Operator.Element != golang.AddressOf {
+		t.Errorf("Operator: want AddressOf=%d (&), got %d (0 makes the printer emit '?')",
+			int(golang.AddressOf), int(got.Operator.Element))
+	}
+}

--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"fmt"
 
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
@@ -368,6 +369,12 @@ func leftPaddedBefore(lp any) any {
 		return v.Before
 	case java.LeftPadded[java.UnaryOperator]:
 		return v.Before
+	case java.LeftPadded[golang.BinaryOperator]:
+		return v.Before
+	case java.LeftPadded[golang.AssignmentOperator]:
+		return v.Before
+	case java.LeftPadded[golang.UnaryOperator]:
+		return v.Before
 	case java.LeftPadded[java.Space]:
 		return v.Before
 	case java.LeftPadded[string]:
@@ -393,6 +400,12 @@ func leftPaddedElement(lp any) any {
 		return v.Element
 	case java.LeftPadded[java.UnaryOperator]:
 		return v.Element
+	case java.LeftPadded[golang.BinaryOperator]:
+		return v.Element
+	case java.LeftPadded[golang.AssignmentOperator]:
+		return v.Element
+	case java.LeftPadded[golang.UnaryOperator]:
+		return v.Element
 	case java.LeftPadded[java.Space]:
 		return v.Element
 	case java.LeftPadded[string]:
@@ -417,6 +430,12 @@ func leftPaddedMarkers(lp any) any {
 	case java.LeftPadded[java.AssignmentOperator]:
 		return v.Markers
 	case java.LeftPadded[java.UnaryOperator]:
+		return v.Markers
+	case java.LeftPadded[golang.BinaryOperator]:
+		return v.Markers
+	case java.LeftPadded[golang.AssignmentOperator]:
+		return v.Markers
+	case java.LeftPadded[golang.UnaryOperator]:
 		return v.Markers
 	case java.LeftPadded[java.Space]:
 		return v.Markers


### PR DESCRIPTION
## What's changed?

Add explicit code to handle Go-specific unary operators in RPC logic.

## What's your motivation?

Otherwise, Java recipes in production cause some idempotency issues like:
```diff
- whenTimeOpts: &TimeOpts{
+ whenTimeOpts: ?TimeOpts{
```