### PR TITLE
Go: fix RPC idempotency issue with statements nested within a switch

### DIFF
--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -551,7 +551,11 @@ func (r *JavaReceiver) VisitCase(cs *java.Case, p any) java.J {
 	q.Receive(nil, nil) // type enum
 	cs.Expressions = receiveContainer[java.Expression](r, q, cs.Expressions)
 	// statements - Java sends Container<RightPadded<Statement>>, extract to Go's []RightPadded[Statement]
-	if result := q.Receive(nil, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
+	var stmtsBefore any
+	if cs.Body != nil {
+		stmtsBefore = java.Container[java.Statement]{Elements: cs.Body}
+	}
+	if result := q.Receive(stmtsBefore, func(v any) any { return receiveContainerTyped[java.Statement](r, q, v) }); result != nil {
 		cont := result.(java.Container[java.Statement])
 		cs.Body = cont.Elements
 	}

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/NestedReturnEditCorruptionTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/NestedReturnEditCorruptionTest.java
@@ -28,6 +28,7 @@ import org.openrewrite.test.TypeValidation;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.openrewrite.golang.Assertions.go;
@@ -180,6 +181,62 @@ class NestedReturnEditCorruptionTest implements RewriteTest {
                         \t\treturn b
                         \t}
                         \treturn 0
+                        }
+                        """
+                )
+        );
+    }
+
+    private static org.openrewrite.Recipe lowercaseErrorfFormat() {
+        return toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
+                if ("Errorf".equals(m.getSimpleName()) && m.getArguments().size() == 3 &&
+                    m.getArguments().get(0) instanceof J.Literal lit && lit.getValue() instanceof String s &&
+                    s.startsWith("Expected error")) {
+                    String replaced = "expected error" + s.substring("Expected error".length());
+                    J.Literal newLit = lit.withValue(replaced).withValueSource("\"" + replaced + "\"");
+                    return m.withArguments(List.of(newLit, m.getArguments().get(1), m.getArguments().get(2)));
+                }
+                return m;
+            }
+        });
+    }
+
+    @Test
+    void editCaseBodyStatementKeepsSiblingFields() {
+        rewriteRun(
+                spec -> spec.recipe(lowercaseErrorfFormat()),
+                go(
+                        """
+                        package main
+
+                        func TestRun(t *T) {
+                        \tfor _, tc := range testcases {
+                        \t\terr := c.Execute()
+                        \t\tswitch {
+                        \t\tcase err == nil && len(tc.expectErr) > 0:
+                        \t\t\tt.Errorf("Expected error %q but got nil", tc.expectErr)
+                        \t\tcase err != nil && err.Error() != tc.expectErr:
+                        \t\t\tt.Errorf("Expected error %q but got %q", tc.expectErr, err)
+                        \t\t}
+                        \t}
+                        }
+                        """,
+                        """
+                        package main
+
+                        func TestRun(t *T) {
+                        \tfor _, tc := range testcases {
+                        \t\terr := c.Execute()
+                        \t\tswitch {
+                        \t\tcase err == nil && len(tc.expectErr) > 0:
+                        \t\t\tt.Errorf("Expected error %q but got nil", tc.expectErr)
+                        \t\tcase err != nil && err.Error() != tc.expectErr:
+                        \t\t\tt.Errorf("expected error %q but got %q", tc.expectErr, err)
+                        \t\t}
+                        \t}
                         }
                         """
                 )


### PR DESCRIPTION
**What and why**: Fixing a RPC idempotency issue in some examples of Go code.
Some statements within switch might have their whitespace collapsed when going though a Java recipe:

```diff
-             case err != nil && err.Error() != tc.expectErr:
-                 t.Errorf("Expected error %q but got %q", tc.expectErr, err)
+             case err != nil && err.Error() != tc.expectErr:t.Errorf("Expected error %q but got %q",tc.expectErr,err)                            
```