### PR TITLE
Maven FindProperties: gate ${property} usage marking on valuePattern

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindProperties.java
@@ -81,9 +81,12 @@ public class FindProperties extends Recipe {
 
                 Optional<String> value = t.getValue();
                 if (value.isPresent() && propertyUsageMatcher.matcher(value.get()).matches()) {
-                    //noinspection unchecked
-                    t = t.withContent(ListUtils.mapFirst((List<Content>) t.getContent(), v ->
-                            SearchResult.found(v, getResolutionResult().getPom().getValue(value.get()))));
+                    String resolvedValue = getResolutionResult().getPom().getValue(value.get());
+                    if (valueMatcher == null || (resolvedValue != null && valueMatcher.matcher(resolvedValue).matches())) {
+                        //noinspection unchecked
+                        t = t.withContent(ListUtils.mapFirst((List<Content>) t.getContent(), v ->
+                                SearchResult.found(v, resolvedValue)));
+                    }
                 }
                 return t;
             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPropertiesTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/search/FindPropertiesTest.java
@@ -129,6 +129,60 @@ class FindPropertiesTest implements RewriteTest {
     }
 
     @Test
+    void doesNotMatchUsageWhenResolvedValueDoesNotMatchValuePattern() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperties("sample.target", "24")),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <properties>
+                  <sample.target>21</sample.target>
+                  <sample.compiler.release>${sample.target}</sample.compiler.release>
+                </properties>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void matchesDefinitionAndUsageWhenValuePatternMatches() {
+        rewriteRun(
+          spec -> spec.recipe(new FindProperties("sample.target", "21")),
+          pomXml(
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <properties>
+                  <sample.target>21</sample.target>
+                  <sample.compiler.release>${sample.target}</sample.compiler.release>
+                </properties>
+              </project>
+              """,
+            """
+              <project>
+                <modelVersion>4.0.0</modelVersion>
+                <groupId>com.sample</groupId>
+                <artifactId>sample</artifactId>
+                <version>1.0-SNAPSHOT</version>
+                <properties>
+                  <!--~~>--><sample.target>21</sample.target>
+                  <sample.compiler.release><!--~~(21)~~>-->${sample.target}</sample.compiler.release>
+                </properties>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void doesNotMatchOtherPropertyUsages() {
         rewriteRun(
           spec -> spec.recipe(new FindProperties("guava.*", null)),


### PR DESCRIPTION
- Fixes #8281

## Problem

`FindProperties` accepts a `propertyPattern` and an optional `valuePattern`. When `valuePattern` is supplied, the property-definition branch correctly requires a matching value. However, the second branch — which marks any tag whose textual value contains a `${property}` usage — completely ignored `valuePattern`.

As a result, the mere presence of a `${property}` reference anywhere in the pom yielded a `SearchResult` even when the resolved value did not match `valuePattern`. When `FindProperties` is used as a precondition, that stray result satisfied the precondition and downstream recipes ran against poms they should have been filtered out of (e.g. an `UpgradeJavaVersion` precondition keyed on `java.version`/`24` firing on a Java 21 project via `<maven.compiler.release>${java.version}</maven.compiler.release>`).

## Fix

In the usage branch, resolve the value and only mark it when `valueMatcher == null || (resolvedValue != null && valueMatcher.matcher(resolvedValue).matches())`. This preserves the existing backward-compatible behavior when `valuePattern` is null.

## Tests

- `doesNotMatchUsageWhenResolvedValueDoesNotMatchValuePattern` — the bug reproduction from the issue (now green).
- `matchesDefinitionAndUsageWhenValuePatternMatches` — control case confirming both definition and usage are still marked when the value matches.