### PR TITLE
Python: field fixes for native lock regeneration (uv url/git sources, diagnosability, whitespace-preserving upgrades)

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/UpgradeDependencyVersion.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/UpgradeDependencyVersion.java
@@ -23,6 +23,7 @@ import org.openrewrite.json.tree.Json;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.python.internal.LockFileRegeneration;
 import org.openrewrite.python.internal.PyProjectHelper;
+import org.openrewrite.python.internal.pep440.PythonVersionSpecifierSet;
 import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.python.table.PythonLockRegenerationFailures;
 import org.openrewrite.python.trait.PythonDependencyFile;
@@ -76,6 +77,10 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         if ("project.optional-dependencies".equals(scope) || "dependency-groups".equals(scope)) {
             v = v.and(Validated.required("groupName", groupName));
         }
+        v = v.and(Validated.test("newVersion",
+                "must be a PEP 440 version or version specifier", newVersion,
+                nv -> nv != null && !nv.trim().isEmpty() &&
+                        PythonVersionSpecifierSet.parse(PyProjectHelper.normalizeVersionConstraint(nv)) != null));
         return v;
     }
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PyProjectHelper.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PyProjectHelper.java
@@ -435,7 +435,10 @@ public class PyProjectHelper {
             String packageName,
             @Nullable String scope,
             @Nullable String groupName) {
-        if (scope == null || "project.dependencies".equals(scope)) {
+        if (scope == null) {
+            // default: all scopes, matching the null-scope edit paths (Pipfile dev-packages, pyproject groups)
+            return marker.findDependencyInAnyScope(packageName);
+        } else if ("project.dependencies".equals(scope)) {
             return marker.findDependency(packageName);
         } else if ("build-system.requires".equals(scope)) {
             return findInList(marker.getBuildRequires(), packageName);

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
@@ -97,10 +97,14 @@ public final class PipenvLockEngine {
                     "Existing Pipfile.lock could not be parsed: " + e.getMessage()));
         }
 
-        Toml.Document pipfile = parsePipfile(pipfileContent);
+        String[] parseError = new String[1];
+        Toml.Document pipfile = parsePipfile(pipfileContent, parseError);
         if (pipfile == null) {
-            return Result.failure(new Failure(Reason.MALFORMED_MANIFEST, null, null,
-                    "Edited Pipfile could not be parsed as TOML"));
+            String detail = "Edited Pipfile could not be parsed as TOML";
+            if (parseError[0] != null && !parseError[0].isEmpty()) {
+                detail += ": " + parseError[0];
+            }
+            return Result.failure(new Failure(Reason.MALFORMED_MANIFEST, null, null, detail));
         }
 
         try {
@@ -110,14 +114,22 @@ public final class PipenvLockEngine {
         }
     }
 
-    private static Toml.@Nullable Document parsePipfile(String pipfileContent) {
+    private static Toml.@Nullable Document parsePipfile(String pipfileContent, String[] parseError) {
         // ANTLR error recovery can still yield a Document for broken TOML; treat any syntax error as malformed
-        boolean[] failed = new boolean[1];
+        Throwable[] firstError = new Throwable[1];
         SourceFile parsed = new TomlParser()
-                .parse(new InMemoryExecutionContext(t -> failed[0] = true), pipfileContent)
+                .parse(new InMemoryExecutionContext(t -> {
+                    if (firstError[0] == null) {
+                        firstError[0] = t;
+                    }
+                }), pipfileContent)
                 .findFirst()
                 .orElse(null);
-        return !failed[0] && parsed instanceof Toml.Document ? (Toml.Document) parsed : null;
+        if (firstError[0] != null) {
+            parseError[0] = firstError[0].getMessage();
+            return null;
+        }
+        return parsed instanceof Toml.Document ? (Toml.Document) parsed : null;
     }
 
     private static Failure indexFailure(@Nullable String packageName, PythonIndexException e) {

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
@@ -665,9 +665,7 @@ public final class PipenvLockEngine {
             PythonVersion selected = selectVersion(byVersion, constraint);
             if (selected == null) {
                 return new Failure(Reason.RESOLUTION_CONFLICT, pkg, index.getUrl(),
-                        "No non-yanked version satisfying " + entry.constraint +
-                                (lockPython != null ? " for python " + lockPython : "") +
-                                " found at " + index.getUrl());
+                        explainNoVersion(byVersion, constraint, entry.constraint, index.getUrl()));
             }
             List<PackageFile> files = byVersion.get(selected);
 
@@ -1137,6 +1135,35 @@ public final class PipenvLockEngine {
                 }
             }
             return best;
+        }
+
+        /**
+         * Explain why {@link #selectVersion} found nothing, distinguishing "the index
+         * has no version matching the constraint" (a lagging mirror is the usual cause)
+         * from a genuine requires-python exclusion or an all-yanked release.
+         */
+        private String explainNoVersion(Map<PythonVersion, List<PackageFile>> byVersion,
+                                        PythonVersionSpecifierSet constraint, String constraintText, String indexUrl) {
+            List<PythonVersion> matching = new ArrayList<>();
+            for (PythonVersion version : byVersion.keySet()) {
+                if (constraint.contains(version)) {
+                    matching.add(version);
+                }
+            }
+            if (matching.isEmpty()) {
+                return "No version matching " + constraintText + " is available at " + indexUrl +
+                        " (the index may lag PyPI or not mirror this release)";
+            }
+            if (lockPython != null) {
+                for (PythonVersion version : matching) {
+                    if (!versionAdmitsPython(byVersion.get(version), lockPython)) {
+                        return constraintText + " matches " + version + " at " + indexUrl +
+                                ", but its requires-python excludes python " + lockPython;
+                    }
+                }
+            }
+            return "All versions matching " + constraintText + " at " + indexUrl +
+                    " are yanked or have no installable distribution";
         }
 
         /**

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLock.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLock.java
@@ -44,6 +44,27 @@ public class UvLock {
     @Nullable
     List<String> resolutionMarkers;
 
+    /**
+     * The forks the resolution supports (from {@code [tool.uv] environments}); same shape as
+     * {@code resolutionMarkers}, emitted just after it.
+     */
+    @Nullable
+    List<String> supportedMarkers;
+
+    /**
+     * The forks a resolution must cover (from {@code [tool.uv] required-environments}); emitted
+     * after {@code supportedMarkers}.
+     */
+    @Nullable
+    List<String> requiredMarkers;
+
+    /**
+     * Mutually-exclusive extra/group sets (from {@code [tool.uv] conflicts}); an array of arrays
+     * of inline tables, emitted as the last header key before {@code [options]}.
+     */
+    @Nullable
+    List<List<UvLockConflictItem>> conflicts;
+
     @Nullable
     UvLockOptions options;
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockConflictItem.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockConflictItem.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.internal.uvlock;
+
+import lombok.Value;
+import lombok.With;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One inline table in a top-level {@code conflicts} set: {@code { package = "...", extra = "..." }}
+ * or {@code { package = "...", group = "..." }}, declaring one member of a mutually-exclusive group.
+ * Exactly one of {@code extra}/{@code group} is present.
+ */
+@Value
+@With
+public class UvLockConflictItem {
+
+    String packageName;
+
+    @Nullable
+    String extra;
+
+    @Nullable
+    String group;
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockEngine.java
@@ -615,7 +615,7 @@ public final class UvLockEngine {
             String specifier = normalizeSpecifier(decl);
             String index = pins == null ? null : declaredIndexUrl(pins.get(0), decl.canonicalName);
             String marker = resolveMetadataMarker(decl);
-            return new UvLockRequirement(decl.canonicalName, extras, null, marker, specifier, index, null, null);
+            return new UvLockRequirement(decl.canonicalName, extras, null, marker, specifier, index, null, null, null);
         }
 
         private @Nullable String normalizeSpecifier(Declared decl) {
@@ -803,6 +803,10 @@ public final class UvLockEngine {
                     throw new EngineFailure(Reason.UNSUPPORTED_ENTRY_TYPE, newReq.getName(),
                             "Re-targeting between registry and editable sources is not supported");
                 }
+                if (!Objects.equals(oldReq.getDirectory(), newReq.getDirectory())) {
+                    throw new EngineFailure(Reason.UNSUPPORTED_ENTRY_TYPE, newReq.getName(),
+                            "Re-targeting between registry and directory sources is not supported");
+                }
                 Change change = changes.get(newReq.getName());
                 if (change == null) {
                     change = new Change(newReq.getName());
@@ -843,7 +847,7 @@ public final class UvLockEngine {
             for (UvLockRequirement req : reqs) {
                 rendered.add(req.getName() + "|" + req.getExtras() + "|" + req.getEditable() + "|" +
                         req.getMarker() + "|" + req.getSpecifier() + "|" + req.getIndex() + "|" +
-                        req.getUrl() + "|" + req.getGit());
+                        req.getUrl() + "|" + req.getGit() + "|" + req.getDirectory());
             }
             return rendered;
         }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockEngine.java
@@ -116,10 +116,14 @@ public final class UvLockEngine {
             return Result.failure(new Failure(Reason.MALFORMED_LOCK, null, null,
                     "Existing uv.lock could not be parsed: " + e.getMessage()));
         }
-        Toml.Document pyproject = parseToml(pyprojectContent);
+        String[] parseError = new String[1];
+        Toml.Document pyproject = parseToml(pyprojectContent, parseError);
         if (pyproject == null) {
-            return Result.failure(new Failure(Reason.MALFORMED_MANIFEST, null, null,
-                    "Edited pyproject.toml could not be parsed as TOML"));
+            String detail = "Edited pyproject.toml could not be parsed as TOML";
+            if (parseError[0] != null && !parseError[0].isEmpty()) {
+                detail += ": " + parseError[0];
+            }
+            return Result.failure(new Failure(Reason.MALFORMED_MANIFEST, null, null, detail));
         }
         try {
             return new Run(pyproject, lock, ctx).regenerate();
@@ -131,13 +135,21 @@ public final class UvLockEngine {
         }
     }
 
-    private static Toml.@Nullable Document parseToml(String content) {
-        boolean[] failed = new boolean[1];
+    private static Toml.@Nullable Document parseToml(String content, String[] parseError) {
+        Throwable[] firstError = new Throwable[1];
         SourceFile parsed = new TomlParser()
-                .parse(new InMemoryExecutionContext(t -> failed[0] = true), content)
+                .parse(new InMemoryExecutionContext(t -> {
+                    if (firstError[0] == null) {
+                        firstError[0] = t;
+                    }
+                }), content)
                 .findFirst()
                 .orElse(null);
-        return !failed[0] && parsed instanceof Toml.Document ? (Toml.Document) parsed : null;
+        if (firstError[0] != null) {
+            parseError[0] = firstError[0].getMessage();
+            return null;
+        }
+        return parsed instanceof Toml.Document ? (Toml.Document) parsed : null;
     }
 
     private static Failure indexFailure(@Nullable String packageName, PythonIndexException e) {
@@ -603,7 +615,7 @@ public final class UvLockEngine {
             String specifier = normalizeSpecifier(decl);
             String index = pins == null ? null : declaredIndexUrl(pins.get(0), decl.canonicalName);
             String marker = resolveMetadataMarker(decl);
-            return new UvLockRequirement(decl.canonicalName, extras, null, marker, specifier, index);
+            return new UvLockRequirement(decl.canonicalName, extras, null, marker, specifier, index, null, null);
         }
 
         private @Nullable String normalizeSpecifier(Declared decl) {
@@ -830,7 +842,8 @@ public final class UvLockEngine {
             List<String> rendered = new ArrayList<>(reqs.size());
             for (UvLockRequirement req : reqs) {
                 rendered.add(req.getName() + "|" + req.getExtras() + "|" + req.getEditable() + "|" +
-                        req.getMarker() + "|" + req.getSpecifier() + "|" + req.getIndex());
+                        req.getMarker() + "|" + req.getSpecifier() + "|" + req.getIndex() + "|" +
+                        req.getUrl() + "|" + req.getGit());
             }
             return rendered;
         }
@@ -974,7 +987,8 @@ public final class UvLockEngine {
                             "requires-python changes on a forked lock are not supported by the native engine");
                 }
                 UvLockPackage.UvLockPackageBuilder builder = pkg.toBuilder();
-                if (pkg.getWheels() != null) {
+                // url/git-pinned artifacts are chosen explicitly, not by Python tag; never filter them
+                if (pkg.getSource().getType() == UvLockSource.Type.REGISTRY && pkg.getWheels() != null) {
                     List<UvLockArtifact> kept = new ArrayList<>();
                     for (UvLockArtifact wheel : pkg.getWheels()) {
                         String filename = wheelFilename(wheel);

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockEngine.java
@@ -1335,9 +1335,7 @@ public final class UvLockEngine {
             if (selected == null) {
                 throw new EngineFailure(new Failure(Reason.RESOLUTION_CONFLICT, change.canonicalName,
                         listing.index.getIndex().getUrl(),
-                        "No non-yanked version satisfying the declared constraints" +
-                                (range.lower != null ? " for python " + range.lower : "") +
-                                " found at " + listing.index.getIndex().getUrl()));
+                        explainNoVersion(byVersion, change, listing.index.getIndex().getUrl())));
             }
             List<PackageFile> files = byVersion.get(selected);
             CoreMetadata metadata = fetchMetadata(change.canonicalName, listing.index, files);
@@ -1524,6 +1522,34 @@ public final class UvLockEngine {
                 }
             }
             return best;
+        }
+
+        /**
+         * Explain why {@link #selectVersion} found nothing, distinguishing "the index
+         * has no version matching the constraints" (a lagging mirror is the usual cause)
+         * from a genuine requires-python exclusion or an all-yanked release.
+         */
+        private String explainNoVersion(Map<PythonVersion, List<PackageFile>> byVersion, Change change, String indexUrl) {
+            List<PythonVersion> matching = new ArrayList<>();
+            for (PythonVersion version : byVersion.keySet()) {
+                if (satisfiesAll(change.constraints, version)) {
+                    matching.add(version);
+                }
+            }
+            if (matching.isEmpty()) {
+                return "No version matching the declared constraints is available at " + indexUrl +
+                        " (the index may lag PyPI or not mirror this release)";
+            }
+            if (range.lower != null) {
+                for (PythonVersion version : matching) {
+                    if (!versionAdmitsPython(byVersion.get(version))) {
+                        return "The declared constraints match " + version + " at " + indexUrl +
+                                ", but its requires-python excludes python " + range.lower;
+                    }
+                }
+            }
+            return "All versions matching the declared constraints at " + indexUrl +
+                    " are yanked or have no installable distribution";
         }
 
         /**

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockReader.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockReader.java
@@ -42,6 +42,9 @@ public final class UvLockReader {
         Integer revision = null;
         String requiresPython = null;
         List<String> resolutionMarkers = null;
+        List<String> supportedMarkers = null;
+        List<String> requiredMarkers = null;
+        List<List<UvLockConflictItem>> conflicts = null;
         for (Map.Entry<String, Object> e : header.entrySet()) {
             String key = e.getKey();
             if ("version".equals(key)) {
@@ -52,6 +55,12 @@ public final class UvLockReader {
                 requiresPython = stringValue(key, e.getValue());
             } else if ("resolution-markers".equals(key)) {
                 resolutionMarkers = stringList(key, e.getValue());
+            } else if ("supported-markers".equals(key)) {
+                supportedMarkers = stringList(key, e.getValue());
+            } else if ("required-markers".equals(key)) {
+                requiredMarkers = stringList(key, e.getValue());
+            } else if ("conflicts".equals(key)) {
+                conflicts = toConflicts(e.getValue());
             } else {
                 throw new UvLockFormatException("Unrecognized top-level key: " + key);
             }
@@ -106,7 +115,42 @@ public final class UvLockReader {
         for (RawPackage raw : rawPackages) {
             packages.add(toPackage(raw));
         }
-        return new UvLock(version, revision, requiresPython, resolutionMarkers, options, manifest, packages);
+        return new UvLock(version, revision, requiresPython, resolutionMarkers, supportedMarkers,
+                requiredMarkers, conflicts, options, manifest, packages);
+    }
+
+    private static List<List<UvLockConflictItem>> toConflicts(Object v) {
+        List<List<UvLockConflictItem>> sets = new ArrayList<>();
+        for (Object set : listValue("conflicts", v)) {
+            List<UvLockConflictItem> items = new ArrayList<>();
+            for (Object item : listValue("conflicts", set)) {
+                items.add(toConflictItem(tableValue("conflicts", item)));
+            }
+            sets.add(items);
+        }
+        return sets;
+    }
+
+    private static UvLockConflictItem toConflictItem(Map<String, Object> table) {
+        String packageName = null;
+        String extra = null;
+        String group = null;
+        for (Map.Entry<String, Object> e : table.entrySet()) {
+            String key = e.getKey();
+            if ("package".equals(key)) {
+                packageName = stringValue(key, e.getValue());
+            } else if ("extra".equals(key)) {
+                extra = stringValue(key, e.getValue());
+            } else if ("group".equals(key)) {
+                group = stringValue(key, e.getValue());
+            } else {
+                throw new UvLockFormatException("Unrecognized conflicts key: " + key);
+            }
+        }
+        if (packageName == null || (extra == null) == (group == null)) {
+            throw new UvLockFormatException("Conflict entry needs package and exactly one of extra/group");
+        }
+        return new UvLockConflictItem(packageName, extra, group);
     }
 
     private static final class RawPackage {
@@ -544,6 +588,7 @@ public final class UvLockReader {
         String index = null;
         String url = null;
         String git = null;
+        String directory = null;
         for (Map.Entry<String, Object> e : table.entrySet()) {
             String key = e.getKey();
             Object v = e.getValue();
@@ -563,6 +608,8 @@ public final class UvLockReader {
                 url = stringValue(key, v);
             } else if ("git".equals(key)) {
                 git = stringValue(key, v);
+            } else if ("directory".equals(key)) {
+                directory = stringValue(key, v);
             } else {
                 throw new UvLockFormatException("Unrecognized requirement key: " + key);
             }
@@ -570,7 +617,7 @@ public final class UvLockReader {
         if (name == null) {
             throw new UvLockFormatException("Requirement entry is missing name");
         }
-        return new UvLockRequirement(name, extras, editable, marker, specifier, index, url, git);
+        return new UvLockRequirement(name, extras, editable, marker, specifier, index, url, git, directory);
     }
 
     // ---- typed accessors over the generic parse ----

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockReader.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockReader.java
@@ -520,8 +520,9 @@ public final class UvLockReader {
                 throw new UvLockFormatException("Unrecognized artifact key: " + key);
             }
         }
-        if (url == null && path == null) {
-            throw new UvLockFormatException("Artifact entry has neither url nor path");
+        // url-sourced packages record a hash-only sdist (the download URL lives on the package source)
+        if (url == null && path == null && hash == null) {
+            throw new UvLockFormatException("Artifact entry has neither url, path, nor hash");
         }
         return new UvLockArtifact(url, path, hash, size, uploadTime);
     }
@@ -541,6 +542,8 @@ public final class UvLockReader {
         String marker = null;
         String specifier = null;
         String index = null;
+        String url = null;
+        String git = null;
         for (Map.Entry<String, Object> e : table.entrySet()) {
             String key = e.getKey();
             Object v = e.getValue();
@@ -556,6 +559,10 @@ public final class UvLockReader {
                 specifier = stringValue(key, v);
             } else if ("index".equals(key)) {
                 index = stringValue(key, v);
+            } else if ("url".equals(key)) {
+                url = stringValue(key, v);
+            } else if ("git".equals(key)) {
+                git = stringValue(key, v);
             } else {
                 throw new UvLockFormatException("Unrecognized requirement key: " + key);
             }
@@ -563,7 +570,7 @@ public final class UvLockReader {
         if (name == null) {
             throw new UvLockFormatException("Requirement entry is missing name");
         }
-        return new UvLockRequirement(name, extras, editable, marker, specifier, index);
+        return new UvLockRequirement(name, extras, editable, marker, specifier, index, url, git);
     }
 
     // ---- typed accessors over the generic parse ----

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockRequirement.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockRequirement.java
@@ -62,4 +62,11 @@ public class UvLockRequirement {
      */
     @Nullable
     String git;
+
+    /**
+     * Local directory source of the requirement (a {@code [tool.uv.sources]} path pointing at a
+     * directory); uv emits it after {@code marker}, in place of {@code specifier}.
+     */
+    @Nullable
+    String directory;
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockRequirement.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockRequirement.java
@@ -48,4 +48,18 @@ public class UvLockRequirement {
 
     @Nullable
     String index;
+
+    /**
+     * Direct-URL source of the requirement (mutually exclusive with {@code specifier}); the
+     * download URL without the resolved commit that the package {@code source} carries.
+     */
+    @Nullable
+    String url;
+
+    /**
+     * Git source of the requirement, e.g. {@code "https://host/repo?tag=1.2.3"}; the resolved
+     * commit lives only on the package {@code source}, not here.
+     */
+    @Nullable
+    String git;
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockSource.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockSource.java
@@ -20,7 +20,9 @@ import lombok.With;
 
 /**
  * A package {@code source} inline table, e.g. {@code { registry = "https://pypi.org/simple" }}.
- * The value (URL or path) is recorded verbatim, including trailing-slash presence.
+ * The value (URL or path) is recorded verbatim, including trailing-slash presence. For {@code git}
+ * the value carries the resolved commit as a {@code #<sha>} suffix; for {@code url} it is the
+ * direct download URL of the pinned sdist/wheel.
  */
 @Value
 @With
@@ -31,7 +33,8 @@ public class UvLockSource {
         VIRTUAL("virtual"),
         EDITABLE("editable"),
         PATH("path"),
-        GIT("git");
+        GIT("git"),
+        URL("url");
 
         private final String key;
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockSource.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockSource.java
@@ -22,7 +22,7 @@ import lombok.With;
  * A package {@code source} inline table, e.g. {@code { registry = "https://pypi.org/simple" }}.
  * The value (URL or path) is recorded verbatim, including trailing-slash presence. For {@code git}
  * the value carries the resolved commit as a {@code #<sha>} suffix; for {@code url} it is the
- * direct download URL of the pinned sdist/wheel.
+ * direct download URL of the pinned sdist/wheel; for {@code directory} it is a local directory path.
  */
 @Value
 @With
@@ -33,6 +33,7 @@ public class UvLockSource {
         VIRTUAL("virtual"),
         EDITABLE("editable"),
         PATH("path"),
+        DIRECTORY("directory"),
         GIT("git"),
         URL("url");
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockWriter.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockWriter.java
@@ -198,6 +198,13 @@ public final class UvLockWriter {
         if (req.getMarker() != null) {
             b.append(", marker = ").append(string(req.getMarker()));
         }
+        // url/git are the requirement's direct source; uv emits them after marker, in place of specifier
+        if (req.getUrl() != null) {
+            b.append(", url = ").append(string(req.getUrl()));
+        }
+        if (req.getGit() != null) {
+            b.append(", git = ").append(string(req.getGit()));
+        }
         if (req.getSpecifier() != null) {
             b.append(", specifier = ").append(string(req.getSpecifier()));
         }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockWriter.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/uvlock/UvLockWriter.java
@@ -67,7 +67,47 @@ public final class UvLockWriter {
         if (lock.getResolutionMarkers() != null) {
             b.append("\nresolution-markers = ").append(multilineStringArray(lock.getResolutionMarkers()));
         }
+        if (lock.getSupportedMarkers() != null) {
+            b.append("\nsupported-markers = ").append(multilineStringArray(lock.getSupportedMarkers()));
+        }
+        if (lock.getRequiredMarkers() != null) {
+            b.append("\nrequired-markers = ").append(multilineStringArray(lock.getRequiredMarkers()));
+        }
+        if (lock.getConflicts() != null) {
+            b.append("\nconflicts = ").append(conflictsArray(lock.getConflicts()));
+        }
         return b.toString();
+    }
+
+    /**
+     * uv emits {@code conflicts} as an array of arrays of inline tables: each set is a multiline
+     * bracket run, and the sets are joined by {@code ], [} so the outer brackets abut
+     * ({@code [[ … ], [ … ]]}).
+     */
+    private static String conflictsArray(List<List<UvLockConflictItem>> conflicts) {
+        StringBuilder b = new StringBuilder("[");
+        for (int i = 0; i < conflicts.size(); i++) {
+            if (i > 0) {
+                b.append(", ");
+            }
+            b.append('[');
+            for (UvLockConflictItem item : conflicts.get(i)) {
+                b.append("\n    ").append(conflictItem(item)).append(',');
+            }
+            b.append("\n]");
+        }
+        return b.append(']').toString();
+    }
+
+    private static String conflictItem(UvLockConflictItem item) {
+        StringBuilder b = new StringBuilder("{ package = ").append(string(item.getPackageName()));
+        if (item.getExtra() != null) {
+            b.append(", extra = ").append(string(item.getExtra()));
+        }
+        if (item.getGroup() != null) {
+            b.append(", group = ").append(string(item.getGroup()));
+        }
+        return b.append(" }").toString();
     }
 
     private static String optionsBlock(UvLockOptions options) {
@@ -192,18 +232,21 @@ public final class UvLockWriter {
         if (req.getExtras() != null) {
             b.append(", extras = ").append(inlineStringArray(req.getExtras()));
         }
-        if (req.getEditable() != null) {
-            b.append(", editable = ").append(string(req.getEditable()));
-        }
         if (req.getMarker() != null) {
             b.append(", marker = ").append(string(req.getMarker()));
         }
-        // url/git are the requirement's direct source; uv emits them after marker, in place of specifier
+        // editable/url/git/directory are the requirement's direct source; uv emits them after marker, in place of specifier
+        if (req.getEditable() != null) {
+            b.append(", editable = ").append(string(req.getEditable()));
+        }
         if (req.getUrl() != null) {
             b.append(", url = ").append(string(req.getUrl()));
         }
         if (req.getGit() != null) {
             b.append(", git = ").append(string(req.getGit()));
+        }
+        if (req.getDirectory() != null) {
+            b.append(", directory = ").append(string(req.getDirectory()));
         }
         if (req.getSpecifier() != null) {
             b.append(", specifier = ").append(string(req.getSpecifier()));

--- a/rewrite-python/src/main/java/org/openrewrite/python/trait/PythonDependencyFile.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/trait/PythonDependencyFile.java
@@ -15,6 +15,7 @@ import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 import static org.openrewrite.internal.ListUtils.map;
 
@@ -92,34 +93,57 @@ public interface PythonDependencyFile extends Trait<SourceFile> {
 
     /**
      * Rewrite a PEP 508 dependency spec with a new version constraint.
-     * Preserves extras and environment markers. The version is normalized
-     * via {@link PyProjectHelper#normalizeVersionConstraint(String)},
-     * so both {@code "2.31.0"} and {@code ">=2.31.0"} are accepted.
+     * Changes only the version token, preserving the requirement's original
+     * whitespace, extras, and environment marker; returns {@code spec} unchanged
+     * when the version is already the target (ignoring formatting), so no edit is
+     * made for a whitespace-only difference. The version is normalized via
+     * {@link PyProjectHelper#normalizeVersionConstraint(String)}, so both
+     * {@code "2.31.0"} and {@code ">=2.31.0"} are accepted.
      */
     static String rewritePep508Spec(String spec, String packageName, String newVersion) {
         int nameEnd = packageName.length();
-        StringBuilder sb = new StringBuilder(packageName);
 
-        // Preserve extras like [security]
+        // Skip extras like [security]
         if (nameEnd < spec.length() && spec.charAt(nameEnd) == '[') {
             int extrasEnd = spec.indexOf(']', nameEnd);
             if (extrasEnd >= 0) {
-                extrasEnd++;
-                sb.append(spec, nameEnd, extrasEnd);
-                nameEnd = extrasEnd;
+                nameEnd = extrasEnd + 1;
             }
         }
 
-        sb.append(PyProjectHelper.normalizeVersionConstraint(newVersion));
-
-        // Preserve environment markers (everything after ';')
         int semiIdx = spec.indexOf(';', nameEnd);
-        if (semiIdx >= 0) {
-            sb.append(spec.substring(semiIdx));
+        int constraintEnd = semiIdx >= 0 ? semiIdx : spec.length();
+        String prefix = spec.substring(0, nameEnd);
+        String constraint = spec.substring(nameEnd, constraintEnd);
+        String marker = semiIdx >= 0 ? spec.substring(semiIdx) : "";
+        String newConstraint = PyProjectHelper.normalizeVersionConstraint(newVersion);
+
+        // No change when the version is already the target, ignoring whitespace.
+        if (constraint.replaceAll("\\s+", "").equals(newConstraint)) {
+            return spec;
         }
 
-        return sb.toString();
+        // Same operator, single clause: swap only the version, keeping all whitespace.
+        // java.util.regex.Matcher is qualified to avoid the trait's own nested Matcher.
+        java.util.regex.Matcher current = SINGLE_CLAUSE.matcher(constraint.trim());
+        java.util.regex.Matcher target = SINGLE_CLAUSE.matcher(newConstraint);
+        if (current.matches() && target.matches() && current.group(1).equals(target.group(1))) {
+            int versionStart = constraint.indexOf(current.group(1)) + current.group(1).length();
+            while (versionStart < constraint.length() && Character.isWhitespace(constraint.charAt(versionStart))) {
+                versionStart++;
+            }
+            return prefix + constraint.substring(0, versionStart) + target.group(2) + marker;
+        }
+
+        // Otherwise keep the leading whitespace before the constraint and emit the new one.
+        int lead = 0;
+        while (lead < constraint.length() && Character.isWhitespace(constraint.charAt(lead))) {
+            lead++;
+        }
+        return prefix + constraint.substring(0, lead) + newConstraint + marker;
     }
+
+    Pattern SINGLE_CLAUSE = Pattern.compile("(===|==|>=|<=|!=|~=|>|<)\\s*(\\S+)");
 
     /**
      * Look up a value in a map by normalizing the lookup key per PEP 503.

--- a/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
@@ -29,6 +29,14 @@ import static org.openrewrite.python.Assertions.*;
 class UpgradeDependencyVersionTest implements RewriteTest {
 
     @Test
+    void invalidNewVersionIsRejected() {
+        // a fat-fingered trailing quote must fail validation, not corrupt the manifest
+        assertThat(new UpgradeDependencyVersion("six", "==1.17.0\"", null, null).validate().isValid()).isFalse();
+        assertThat(new UpgradeDependencyVersion("six", "==1.17.0", null, null).validate().isValid()).isTrue();
+        assertThat(new UpgradeDependencyVersion("six", "1.17.0", null, null).validate().isValid()).isTrue();
+    }
+
+    @Test
     @Timeout(120)
     void warnsOnBothManifestAndLockWhenRegenerationFails() {
         rewriteRun(

--- a/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
@@ -29,6 +29,40 @@ import static org.openrewrite.python.Assertions.*;
 class UpgradeDependencyVersionTest implements RewriteTest {
 
     @Test
+    void upgradesDevPackagesDependencyByDefault() {
+        // pytube shape: coverage declared only in [dev-packages]; the default (null) scope must find it
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("coverage", "==6.5.0", null, null)),
+          pipfile(
+            """
+              [[source]]
+              url = "https://pypi.org/simple"
+              verify_ssl = true
+              name = "pypi"
+
+              [packages]
+
+              [dev-packages]
+              coverage = "*"
+              flake8 = "*"
+              """,
+            """
+              [[source]]
+              url = "https://pypi.org/simple"
+              verify_ssl = true
+              name = "pypi"
+
+              [packages]
+
+              [dev-packages]
+              coverage = "==6.5.0"
+              flake8 = "*"
+              """
+          )
+        );
+    }
+
+    @Test
     void invalidNewVersionIsRejected() {
         // a fat-fingered trailing quote must fail validation, not corrupt the manifest
         assertThat(new UpgradeDependencyVersion("six", "==1.17.0\"", null, null).validate().isValid()).isFalse();

--- a/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionTest.java
@@ -379,4 +379,84 @@ class UpgradeDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void noChangeWhenVersionAlreadyTargetDespiteSpacing() {
+        // Whitespace-only difference must not produce an edit.
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("six", "==1.17.0", null, null)),
+          pyproject(
+            """
+              [project]
+              name = "calibre"
+              dependencies = [
+                  "six == 1.17.0",
+              ]
+              """
+          )
+        );
+    }
+
+    @Test
+    void spacePaddedRequirementRewritesCleanly() {
+        // kovidgoyal/calibre shape: "six == 1.17.0" (spaces around ==) — only the
+        // version token changes; the original spacing is preserved.
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("six", "==1.17.1", null, null)),
+          pyproject(
+            """
+              [project]
+              name = "calibre"
+              dependencies = [
+                  "six == 1.17.0",
+                  "lxml == 6.1.1",
+              ]
+              """,
+            """
+              [project]
+              name = "calibre"
+              dependencies = [
+                  "six == 1.17.1",
+                  "lxml == 6.1.1",
+              ]
+              """
+          )
+        );
+    }
+
+    @Test
+    void starConstraintPipfileRewritesCleanly() {
+        // postmanlabs/httpbin shape: six = "*" alongside git inline-table entries
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("six", "==1.17.0", null, null)),
+          pipfile(
+            """
+              [[source]]
+              url = "https://pypi.python.org/simple"
+              verify_ssl = true
+
+              [packages]
+              Flask = "*"
+              six = "*"
+              pyyaml = {git = "https://github.com/yaml/pyyaml.git"}
+
+              [dev-packages]
+              rope = "*"
+              """,
+            """
+              [[source]]
+              url = "https://pypi.python.org/simple"
+              verify_ssl = true
+
+              [packages]
+              Flask = "*"
+              six = "==1.17.0"
+              pyyaml = {git = "https://github.com/yaml/pyyaml.git"}
+
+              [dev-packages]
+              rope = "*"
+              """
+          )
+        );
+    }
 }

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
@@ -491,6 +491,10 @@ class PipenvLockEngineTest {
         assertThat(result.getFailure().getReason()).isEqualTo(Reason.RESOLUTION_CONFLICT);
         assertThat(result.getFailure().getPackageName()).isEqualTo("requests");
         assertThat(result.getFailure().getIndexUrl()).isEqualTo(server.url("/simple").toString());
+        // the version is simply not at the index (e.g. a lagging mirror), not a python exclusion
+        assertThat(result.getFailure().getDetail())
+                .contains("No version matching ==9.9.9 is available")
+                .contains("may lag PyPI");
     }
 
     @Test

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
@@ -719,6 +719,10 @@ class PipenvLockEngineTest {
 
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.getFailure().getReason()).isEqualTo(Reason.MALFORMED_MANIFEST);
+        // the underlying TOML parse error is appended for diagnosability, not swallowed
+        assertThat(result.getFailure().getDetail())
+          .contains("could not be parsed as TOML:")
+          .contains("Syntax error");
     }
 
     @Test

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockEngineTest.java
@@ -196,6 +196,12 @@ class UvLockEngineTest {
       "p-editable-root/pyproject.toml, p-editable-root/uv.lock",
       "o-old-uv/proj-0.7.0/pyproject.toml, o-old-uv/proj-0.7.0/uv.lock.as-0.7.0",
       "s-remove-last-dep/pyproject.toml, s-remove-last-dep/uv.lock.after",
+      // directory-sourced deps and the top-level conflicts/supported-markers/required-markers
+      // header keys all pass through an unrelated rebuild verbatim
+      "v-directory/pyproject.toml, v-directory/uv.lock",
+      "w-conflicts/pyproject.toml, w-conflicts/uv.lock",
+      "w2-conflicts-groups/pyproject.toml, w2-conflicts-groups/uv.lock",
+      "x-supported-required-markers/pyproject.toml, x-supported-required-markers/uv.lock",
     })
     void noOpRebuildIsByteIdentical(String pyprojectPath, String lockPath) {
         ExecutionContext plain = new InMemoryExecutionContext(t -> {
@@ -320,6 +326,27 @@ class UvLockEngineTest {
           ctx);
         assertThat(result.getErrorMessage()).isNull();
         assertThat(result.getLockFileContent()).isEqualTo(resource("u-git-source/uv.lock"));
+        assertThat(http.requests).isEmpty();
+    }
+
+    @Test
+    void removingDirectorySourcedDependencyIsUnsupported() {
+        Result result = UvLockEngine.regenerate(
+          """
+            [project]
+            name = "dirdep"
+            version = "0.1.0"
+            requires-python = ">=3.9"
+            dependencies = []
+
+            [tool.uv.sources]
+            foo = { path = "libs/foo" }
+            """,
+          resource("v-directory/uv.lock"),
+          ctx);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getFailure().getReason()).isEqualTo(Reason.UNSUPPORTED_ENTRY_TYPE);
+        assertThat(result.getFailure().getPackageName()).isEqualTo("foo");
         assertThat(http.requests).isEmpty();
     }
 

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockEngineTest.java
@@ -299,6 +299,51 @@ class UvLockEngineTest {
         assertThat(result.getFailure().getPackageName()).isEqualTo("mylib");
     }
 
+    // ---- direct-URL / git sources: pass through untouched, fail loud when targeted ----
+
+    @Test
+    void urlSourcedPackagePassesThroughVerbatim() {
+        Result result = UvLockEngine.regenerate(
+          resource("t-url-source/pyproject.toml"),
+          resource("t-url-source/uv.lock"),
+          ctx);
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.getLockFileContent()).isEqualTo(resource("t-url-source/uv.lock"));
+        assertThat(http.requests).isEmpty();
+    }
+
+    @Test
+    void gitSourcedPackagePassesThroughVerbatim() {
+        Result result = UvLockEngine.regenerate(
+          resource("u-git-source/pyproject.toml"),
+          resource("u-git-source/uv.lock"),
+          ctx);
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.getLockFileContent()).isEqualTo(resource("u-git-source/uv.lock"));
+        assertThat(http.requests).isEmpty();
+    }
+
+    @Test
+    void removingUrlSourcedDependencyIsUnsupported() {
+        Result result = UvLockEngine.regenerate(
+          """
+            [project]
+            name = "urlsdist"
+            version = "0.1.0"
+            requires-python = ">=3.9"
+            dependencies = []
+
+            [tool.uv.sources]
+            six = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz" }
+            """,
+          resource("t-url-source/uv.lock"),
+          ctx);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getFailure().getReason()).isEqualTo(Reason.UNSUPPORTED_ENTRY_TYPE);
+        assertThat(result.getFailure().getPackageName()).isEqualTo("six");
+        assertThat(http.requests).isEmpty();
+    }
+
     @Test
     void workspaceLockRequiresResolution() {
         Result result = UvLockEngine.regenerate(
@@ -410,6 +455,10 @@ class UvLockEngineTest {
           ctx);
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.getFailure().getReason()).isEqualTo(Reason.MALFORMED_MANIFEST);
+        // the underlying TOML parse error is appended for diagnosability, not swallowed
+        assertThat(result.getFailure().getDetail())
+          .contains("could not be parsed as TOML:")
+          .contains("Syntax error");
     }
 
     @Test

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockFixtures.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockFixtures.java
@@ -83,7 +83,12 @@ final class UvLockFixtures {
       "s-remove-last-dep/uv.lock.after",
       "s-remove-last-dep/uv.lock.before",
       "t-url-source/uv.lock",
-      "u-git-source/uv.lock"
+      "u-git-source/uv.lock",
+      "v-directory/uv.lock",
+      "w-conflicts/uv.lock",
+      "w2-conflicts-groups/uv.lock",
+      "x-supported-required-markers/uv.lock",
+      "y-editable-marker/uv.lock"
     };
 
     private UvLockFixtures() {

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockFixtures.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockFixtures.java
@@ -81,7 +81,9 @@ final class UvLockFixtures {
       "r-removal/uv.lock",
       "r-removal/uv.lock.before",
       "s-remove-last-dep/uv.lock.after",
-      "s-remove-last-dep/uv.lock.before"
+      "s-remove-last-dep/uv.lock.before",
+      "t-url-source/uv.lock",
+      "u-git-source/uv.lock"
     };
 
     private UvLockFixtures() {

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockWriterTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/uvlock/UvLockWriterTest.java
@@ -35,7 +35,7 @@ class UvLockWriterTest {
     }
 
     private String write(UvLockPackage pkg) {
-        return UvLockWriter.write(new UvLock(1, 3, ">=3.12", null, null, null, singletonList(pkg)));
+        return UvLockWriter.write(new UvLock(1, 3, ">=3.12", null, null, null, null, null, null, singletonList(pkg)));
     }
 
     @Test
@@ -51,7 +51,7 @@ class UvLockWriterTest {
     void revisionlessStyleOmitsUploadTime() {
         UvLockPackage pkg = minimalPackage().withSdist(
           UvLockArtifact.remote("https://example.com/six.tar.gz", "sha256:abc", 34031L, null));
-        String written = UvLockWriter.write(new UvLock(1, null, ">=3.12", null, null, null, singletonList(pkg)));
+        String written = UvLockWriter.write(new UvLock(1, null, ">=3.12", null, null, null, null, null, null, singletonList(pkg)));
         assertThat(written)
           .doesNotContain("revision")
           .doesNotContain("upload-time")

--- a/rewrite-python/src/test/resources/uvlock/FORMAT.md
+++ b/rewrite-python/src/test/resources/uvlock/FORMAT.md
@@ -102,6 +102,15 @@ uv omits `[package.metadata]` entirely — the root entry ends at `source`
 - Root project without `[build-system]`: `source = { virtual = "." }` (`a-multi-package/uv.lock`).
 - Root/workspace member with `[build-system]`: `source = { editable = "." }`
   (`p-editable-root/uv.lock`) or `{ editable = "packages/libone" }` (`q-workspace/uv.lock`).
+- Direct URL (`[tool.uv.sources]` `url = …`): `source = { url = "https://…/six-1.17.0.tar.gz" }` — the
+  download URL recorded **verbatim** (`t-url-source/uv.lock`). The artifact is not repeated on the
+  URL: an sdist-URL package carries a **hash-only** `sdist = { hash = "sha256:…" }` (§8); a
+  wheel-URL package carries the wheel with its own `url` + `hash` in `wheels`.
+- Git (`[tool.uv.sources]` `git = …`): `source = { git = "https://…/six?tag=1.17.0#<40-hex-commit>" }`
+  — the requested ref query (`?tag=`/`?rev=`/`?branch=`) is kept and the **resolved commit is appended
+  as `#<sha>`** (`u-git-source/uv.lock`). Git packages carry no `sdist`/`wheels`.
+- Single string value throughout: the source table always has **exactly one key** whose value is a
+  string; `url`/`git` fit the same `{ key = "value" }` shape as `registry`/`editable`.
 
 ## 6. `dependencies` arrays (resolved graph edges)
 
@@ -127,11 +136,17 @@ uv omits `[package.metadata]` entirely — the root entry ends at `source`
   The rule is element count, not line width — a 200-char single entry stays inline
   (`n2-inline-width/uv.lock`, `c-sdist-only/uv.lock:14`).
 - Entries sorted by name. Inline-table key order: `name`, `extras`, `editable`, `marker`,
-  `specifier`, `index`:
+  `url`/`git`, `specifier`, `index` — the direct-source keys `url`/`git` sit **after `marker`**
+  and stand in for `specifier` (a direct-URL/git requirement has no version specifier):
   - `{ name = "requests", extras = ["socks"], specifier = ">=2.31" }` (`d-extras/uv.lock:84`)
   - `{ name = "importlib-metadata", marker = "python_full_version < '3.11'", specifier = ">=6.0" }` (`e-markers-forks/uv.lock:27`)
   - `{ name = "six", specifier = ">=1.16", index = "https://test.pypi.org/simple/" }` (`k-multi-index/uv.lock`)
   - `{ name = "libone", editable = "packages/libone" }` (`q-workspace/uv.lock`)
+  - `{ name = "six", url = "https://…/six-1.17.0.tar.gz" }` (`t-url-source/uv.lock`) — the URL is the
+    download URL **without** the package source's `#<commit>`; extras/marker still precede it, e.g.
+    probed `{ name = "six", extras = ["all"], marker = "python_full_version >= '3.10'", url = "…" }`
+  - `{ name = "six", git = "https://github.com/benjaminp/six?tag=1.17.0" }` (`u-git-source/uv.lock`) —
+    the git URL **without** the resolved `#<commit>` that the package source carries
 - Keys are omitted when absent (no `specifier` key for unconstrained deps, `e-markers-forks/uv.lock:26`).
 - The `extras` key keeps **declaration order** (canonicalized, not sorted):
   `requests[use_chardet_on_py3,socks]` → `extras = ["use-chardet-on-py3", "socks"]`
@@ -160,6 +175,8 @@ uv omits `[package.metadata]` entirely — the root entry ends at `source`
 
 - `sdist` inline-table key order: `url`, `hash`, `size`, `upload-time`
   (`a-multi-package/uv.lock:9`). `hash = "sha256:<hex>"`.
+- Direct-URL sdist packages carry a **hash-only** `sdist = { hash = "sha256:<hex>" }` — no `url`
+  (it is the package `source`, §5), no `size`, no `upload-time` (`t-url-source/uv.lock`).
 - `wheels`: **always multiline** (one wheel per line), even for a single wheel. Same key order per
   wheel: `url`, `hash`, `size`, `upload-time`.
 - `upload-time` format: RFC3339 UTC with `Z`, fractional seconds **truncated to milliseconds,

--- a/rewrite-python/src/test/resources/uvlock/FORMAT.md
+++ b/rewrite-python/src/test/resources/uvlock/FORMAT.md
@@ -37,6 +37,9 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [ ... ]        # only when the resolution forked
+supported-markers = [ ... ]         # only with [tool.uv] environments set
+required-markers = [ ... ]          # only with [tool.uv] required-environments set
+conflicts = [[ ... ]]               # only with [tool.uv] conflicts declared (§9)
 ```
 
 then, separated by blank lines, optional top-level tables in this order:
@@ -60,6 +63,12 @@ Rules:
   with parentheses and `or`-chains:
   `"(python_full_version < '3.10.2' and platform_machine != 'aarch64') or platform_machine == 'aarch64' or sys_platform == 'win32'"`
   (`n2-inline-width/uv.lock:4-7`, `e2-true-fork/uv.lock:4-7`).
+- `supported-markers` / `required-markers`: same multiline-string-array shape as `resolution-markers`,
+  emitted **immediately after** it in that order (`supported-markers` then `required-markers`).
+  `supported-markers` comes from `[tool.uv] environments`, `required-markers` from
+  `required-environments` (`x-supported-required-markers/uv.lock`, both present; real-world:
+  `supported-markers` alone in spotDL/spotify-downloader, `required-markers` alone in
+  CorentinJ/Real-Time-Voice-Cloning).
 
 ## 3. Package ordering
 
@@ -109,8 +118,13 @@ uv omits `[package.metadata]` entirely — the root entry ends at `source`
 - Git (`[tool.uv.sources]` `git = …`): `source = { git = "https://…/six?tag=1.17.0#<40-hex-commit>" }`
   — the requested ref query (`?tag=`/`?rev=`/`?branch=`) is kept and the **resolved commit is appended
   as `#<sha>`** (`u-git-source/uv.lock`). Git packages carry no `sdist`/`wheels`.
+- Local directory (`[tool.uv.sources]` `path = …` pointing at a **directory**, not a file):
+  `source = { directory = "libs/foo" }` — the relative path recorded **verbatim** (`v-directory/uv.lock`;
+  real-world: LizardByte/Sunshine, e.g. `{ directory = "third-party/glad" }`). Distinct from `path`,
+  which uv uses when the `[tool.uv.sources]` path points at a wheel/sdist **file** (the `path`
+  key appears on flat-index artifacts, §8). Directory packages carry no `sdist`/`wheels`.
 - Single string value throughout: the source table always has **exactly one key** whose value is a
-  string; `url`/`git` fit the same `{ key = "value" }` shape as `registry`/`editable`.
+  string; `url`/`git`/`directory` fit the same `{ key = "value" }` shape as `registry`/`editable`.
 
 ## 6. `dependencies` arrays (resolved graph edges)
 
@@ -135,9 +149,11 @@ uv omits `[package.metadata]` entirely — the root entry ends at `source`
 - `requires-dist`: **inline single-bracket array when it has exactly 1 element, multiline when ≥2**.
   The rule is element count, not line width — a 200-char single entry stays inline
   (`n2-inline-width/uv.lock`, `c-sdist-only/uv.lock:14`).
-- Entries sorted by name. Inline-table key order: `name`, `extras`, `editable`, `marker`,
-  `url`/`git`, `specifier`, `index` — the direct-source keys `url`/`git` sit **after `marker`**
-  and stand in for `specifier` (a direct-URL/git requirement has no version specifier):
+- Entries sorted by name. Inline-table key order: `name`, `extras`, `marker`,
+  `editable`/`url`/`git`/`directory`, `specifier`, `index` — the direct-source keys
+  `editable`/`url`/`git`/`directory` all sit **after `marker`** and stand in for `specifier`
+  (a direct-source requirement has no version specifier). editable+marker together:
+  `{ name = "foo", marker = "sys_platform == 'darwin'", editable = "libs/foo" }` (`y-editable-marker/uv.lock`):
   - `{ name = "requests", extras = ["socks"], specifier = ">=2.31" }` (`d-extras/uv.lock:84`)
   - `{ name = "importlib-metadata", marker = "python_full_version < '3.11'", specifier = ">=6.0" }` (`e-markers-forks/uv.lock:27`)
   - `{ name = "six", specifier = ">=1.16", index = "https://test.pypi.org/simple/" }` (`k-multi-index/uv.lock`)
@@ -147,6 +163,8 @@ uv omits `[package.metadata]` entirely — the root entry ends at `source`
     probed `{ name = "six", extras = ["all"], marker = "python_full_version >= '3.10'", url = "…" }`
   - `{ name = "six", git = "https://github.com/benjaminp/six?tag=1.17.0" }` (`u-git-source/uv.lock`) —
     the git URL **without** the resolved `#<commit>` that the package source carries
+  - `{ name = "foo", directory = "libs/foo" }` (`v-directory/uv.lock`); with a marker:
+    `{ name = "bar", marker = "extra == 'cuda'", directory = "libs/bar" }` (`w-conflicts/uv.lock`)
 - Keys are omitted when absent (no `specifier` key for unconstrained deps, `e-markers-forks/uv.lock:26`).
 - The `extras` key keeps **declaration order** (canonicalized, not sorted):
   `requests[use_chardet_on_py3,socks]` → `extras = ["use-chardet-on-py3", "socks"]`
@@ -210,6 +228,24 @@ uv omits `[package.metadata]` entirely — the root entry ends at `source`
 A fork can be triggered by a marker split alone (no duplicate versions): `n2-inline-width/uv.lock`
 has top-level `resolution-markers` but a single `charset-normalizer` entry with no per-package
 markers.
+
+**`conflicts`** (top-level header key, from `[tool.uv] conflicts`): an **array of arrays** of inline
+tables, each `{ package = "…", extra = "…" }` or `{ package = "…", group = "…" }` (package plus
+exactly one of `extra`/`group`), declaring a mutually-exclusive set. Each set is a multiline bracket
+run (one item per 4-space-indented line, trailing comma) and the outer brackets abut so a single set
+reads `conflicts = [[ … ]]`; multiple sets are joined by `], [`:
+```toml
+conflicts = [[
+    { package = "confproj", extra = "cpu" },
+    { package = "confproj", extra = "cuda" },
+], [
+    { package = "confproj", group = "g1" },
+    { package = "confproj", group = "g2" },
+]]
+```
+Single-set (`w-conflicts/uv.lock`; real-world CorentinJ/Real-Time-Voice-Cloning, plotly/plotly.py),
+two-set with a `group` set (`w2-conflicts-groups/uv.lock`). It is the **last header key**, before the
+blank line that precedes `[options]`/`[manifest]`/`[[package]]`.
 
 ## 10. Cross-version drift (scenario o)
 

--- a/rewrite-python/src/test/resources/uvlock/README.md
+++ b/rewrite-python/src/test/resources/uvlock/README.md
@@ -20,6 +20,12 @@ checked-in pyproject is the edited, dependency-less state); `h3-requires-python-
 manifest declaring `requires-python = "<3.15,>=3.10"` — uv sorts the clauses ascending by version
 (`">=3.10, <3.15"`); `g3-multi-extras` locks `requests[use_chardet_on_py3,socks]` — requires-dist
 records extras in declaration order while dependency edges record them sorted.
+`t-url-source` locks a `[tool.uv.sources]` direct-URL dependency (`six` from an sdist URL on
+files.pythonhosted.org) — the package `source = { url = … }` with a hash-only `sdist` and a
+`requires-dist` `url` key (FORMAT.md §5/§7/§8); `u-git-source` locks a `git` source
+(`six` from `github.com/benjaminp/six?tag=1.17.0`) — package `source = { git = …#<commit> }` and a
+`requires-dist` `git` key without the commit.
+
 `o-old-uv/proj-0.5.0/uv.lock.engine-edited` is the one ENGINE-DEFINED expectation in the corpus
 (real uv cannot produce it: it would rewrite the whole file at revision 3): the surgical
 six==1.16.0 pin-down of `uv.lock.as-0.5.0` in the file's own revisionless style, derived from the

--- a/rewrite-python/src/test/resources/uvlock/README.md
+++ b/rewrite-python/src/test/resources/uvlock/README.md
@@ -26,6 +26,21 @@ files.pythonhosted.org) — the package `source = { url = … }` with a hash-onl
 (`six` from `github.com/benjaminp/six?tag=1.17.0`) — package `source = { git = …#<commit> }` and a
 `requires-dist` `git` key without the commit.
 
+Follow-up constructs (same uv 0.10.11, generated **offline** against local path sub-packages so no
+network was touched): `v-directory` locks a `[tool.uv.sources]` local-directory dependency
+(`foo = { path = "libs/foo" }` pointing at a directory) — package `source = { directory = "libs/foo" }`
+and a `requires-dist` `directory` key (FORMAT.md §5/§7). `w-conflicts` locks a single conflicting-extra
+set (`[tool.uv] conflicts = [[{ extra = "cpu" }, { extra = "cuda" }]]`) — the top-level
+`conflicts = [[ … ]]` header key (FORMAT.md §9) plus `directory` sources.
+`w2-conflicts-groups` locks two conflict sets, one over extras and one over
+`[dependency-groups]`, exercising the multi-set `[[ … ], [ … ]]` shape and the `group` key.
+`x-supported-required-markers` locks `[tool.uv] environments`/`required-environments`, producing the
+`supported-markers` and `required-markers` header arrays (FORMAT.md §2). These four match, byte for
+byte, the same constructs found in the wild in real committed locks: `conflicts`/`required-markers`
+in CorentinJ/Real-Time-Voice-Cloning@890f3a03187195b9829db2079b75c2ba2ab0405c,
+`supported-markers` in spotDL/spotify-downloader@4aab5fdc5ad949abbb9974d8ad14c66675192c31, and
+`directory` sources in LizardByte/Sunshine@9d2409f71b60f1812f482e6dd807dc52e2f72fe7.
+
 `o-old-uv/proj-0.5.0/uv.lock.engine-edited` is the one ENGINE-DEFINED expectation in the corpus
 (real uv cannot produce it: it would rewrite the whole file at revision 3): the surgical
 six==1.16.0 pin-down of `uv.lock.as-0.5.0` in the file's own revisionless style, derived from the

--- a/rewrite-python/src/test/resources/uvlock/t-url-source/pyproject.toml
+++ b/rewrite-python/src/test/resources/uvlock/t-url-source/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "urlsdist"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["six"]
+
+[tool.uv.sources]
+six = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz" }

--- a/rewrite-python/src/test/resources/uvlock/t-url-source/uv.lock
+++ b/rewrite-python/src/test/resources/uvlock/t-url-source/uv.lock
@@ -1,0 +1,20 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz" }
+sdist = { hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81" }
+
+[[package]]
+name = "urlsdist"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "six" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "six", url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz" }]

--- a/rewrite-python/src/test/resources/uvlock/u-git-source/pyproject.toml
+++ b/rewrite-python/src/test/resources/uvlock/u-git-source/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "gitprobe"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["six"]
+
+[tool.uv.sources]
+six = { git = "https://github.com/benjaminp/six", tag = "1.17.0" }

--- a/rewrite-python/src/test/resources/uvlock/u-git-source/uv.lock
+++ b/rewrite-python/src/test/resources/uvlock/u-git-source/uv.lock
@@ -1,0 +1,19 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[[package]]
+name = "gitprobe"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "six" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "six", git = "https://github.com/benjaminp/six?tag=1.17.0" }]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { git = "https://github.com/benjaminp/six?tag=1.17.0#ebd9b3af90247b8858d415a05e96e9ee61e48d07" }

--- a/rewrite-python/src/test/resources/uvlock/v-directory/pyproject.toml
+++ b/rewrite-python/src/test/resources/uvlock/v-directory/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "dirdep"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["foo"]
+
+[tool.uv.sources]
+foo = { path = "libs/foo" }

--- a/rewrite-python/src/test/resources/uvlock/v-directory/uv.lock
+++ b/rewrite-python/src/test/resources/uvlock/v-directory/uv.lock
@@ -1,0 +1,19 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+
+[[package]]
+name = "dirdep"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "foo" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "foo", directory = "libs/foo" }]
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+source = { directory = "libs/foo" }

--- a/rewrite-python/src/test/resources/uvlock/w-conflicts/pyproject.toml
+++ b/rewrite-python/src/test/resources/uvlock/w-conflicts/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "confproj"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+cpu = ["foo"]
+cuda = ["bar"]
+
+[tool.uv.sources]
+foo = { path = "libs/foo" }
+bar = { path = "libs/bar" }
+
+[tool.uv]
+conflicts = [[{ extra = "cpu" }, { extra = "cuda" }]]

--- a/rewrite-python/src/test/resources/uvlock/w-conflicts/uv.lock
+++ b/rewrite-python/src/test/resources/uvlock/w-conflicts/uv.lock
@@ -1,0 +1,37 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+conflicts = [[
+    { package = "confproj", extra = "cpu" },
+    { package = "confproj", extra = "cuda" },
+]]
+
+[[package]]
+name = "bar"
+version = "0.1.0"
+source = { directory = "libs/bar" }
+
+[[package]]
+name = "confproj"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.optional-dependencies]
+cpu = [
+    { name = "foo" },
+]
+cuda = [
+    { name = "bar" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bar", marker = "extra == 'cuda'", directory = "libs/bar" },
+    { name = "foo", marker = "extra == 'cpu'", directory = "libs/foo" },
+]
+provides-extras = ["cpu", "cuda"]
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+source = { directory = "libs/foo" }

--- a/rewrite-python/src/test/resources/uvlock/w2-conflicts-groups/pyproject.toml
+++ b/rewrite-python/src/test/resources/uvlock/w2-conflicts-groups/pyproject.toml
@@ -1,0 +1,24 @@
+[project]
+name = "confproj"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = []
+
+[project.optional-dependencies]
+cpu = ["foo"]
+cuda = ["bar"]
+
+[dependency-groups]
+g1 = ["baz"]
+g2 = ["foo"]
+
+[tool.uv.sources]
+foo = { path = "libs/foo" }
+bar = { path = "libs/bar" }
+baz = { path = "libs/baz" }
+
+[tool.uv]
+conflicts = [
+    [{ extra = "cpu" }, { extra = "cuda" }],
+    [{ group = "g1" }, { group = "g2" }],
+]

--- a/rewrite-python/src/test/resources/uvlock/w2-conflicts-groups/uv.lock
+++ b/rewrite-python/src/test/resources/uvlock/w2-conflicts-groups/uv.lock
@@ -1,0 +1,57 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+conflicts = [[
+    { package = "confproj", extra = "cpu" },
+    { package = "confproj", extra = "cuda" },
+], [
+    { package = "confproj", group = "g1" },
+    { package = "confproj", group = "g2" },
+]]
+
+[[package]]
+name = "bar"
+version = "0.1.0"
+source = { directory = "libs/bar" }
+
+[[package]]
+name = "baz"
+version = "0.1.0"
+source = { directory = "libs/baz" }
+
+[[package]]
+name = "confproj"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.optional-dependencies]
+cpu = [
+    { name = "foo" },
+]
+cuda = [
+    { name = "bar" },
+]
+
+[package.dev-dependencies]
+g1 = [
+    { name = "baz" },
+]
+g2 = [
+    { name = "foo" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "bar", marker = "extra == 'cuda'", directory = "libs/bar" },
+    { name = "foo", marker = "extra == 'cpu'", directory = "libs/foo" },
+]
+provides-extras = ["cpu", "cuda"]
+
+[package.metadata.requires-dev]
+g1 = [{ name = "baz", directory = "libs/baz" }]
+g2 = [{ name = "foo", directory = "libs/foo" }]
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+source = { directory = "libs/foo" }

--- a/rewrite-python/src/test/resources/uvlock/x-supported-required-markers/pyproject.toml
+++ b/rewrite-python/src/test/resources/uvlock/x-supported-required-markers/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "envproj"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = ["foo"]
+
+[tool.uv.sources]
+foo = { path = "libs/foo" }
+
+[tool.uv]
+environments = ["sys_platform == 'darwin'", "sys_platform == 'linux'"]
+required-environments = ["sys_platform == 'darwin'"]

--- a/rewrite-python/src/test/resources/uvlock/x-supported-required-markers/uv.lock
+++ b/rewrite-python/src/test/resources/uvlock/x-supported-required-markers/uv.lock
@@ -1,0 +1,30 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
+]
+supported-markers = [
+    "sys_platform == 'darwin'",
+    "sys_platform == 'linux'",
+]
+required-markers = [
+    "sys_platform == 'darwin'",
+]
+
+[[package]]
+name = "envproj"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "foo", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "foo", directory = "libs/foo" }]
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+source = { directory = "libs/foo" }

--- a/rewrite-python/src/test/resources/uvlock/y-editable-marker/pyproject.toml
+++ b/rewrite-python/src/test/resources/uvlock/y-editable-marker/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "edtest"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "foo; sys_platform == 'darwin'",
+]
+
+[tool.uv.sources]
+foo = { path = "libs/foo", editable = true }
+
+[tool.uv]

--- a/rewrite-python/src/test/resources/uvlock/y-editable-marker/uv.lock
+++ b/rewrite-python/src/test/resources/uvlock/y-editable-marker/uv.lock
@@ -1,0 +1,19 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "edtest"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "foo", marker = "sys_platform == 'darwin'" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "foo", marker = "sys_platform == 'darwin'", editable = "libs/foo" }]
+
+[[package]]
+name = "foo"
+version = "0.1.0"
+source = { editable = "libs/foo" }


### PR DESCRIPTION
## Motivation

- Follow-ups to #8283 (native Pipfile.lock / uv.lock regeneration), found by running the Python dependency-upgrade recipes across a real corpus of repositories.

## Changes

**uv.lock direct-URL and git package sources.** Projects that pin a dependency to a URL or git ref via `[tool.uv.sources]` produce `source = { url = "..." }` / `{ git = "...#<commit>" }` packages (often with a hash-only `sdist` and no `wheels`), plus `url` / `git` keys in a `[package.metadata]` `requires-dist` entry. The reader rejected these with `MALFORMED_LOCK: Unrecognized package source type: url`. They are now modeled and round-trip byte-identically (two new fixtures, verified against real `uv lock`). Untouched url/git packages pass through verbatim; an edit that targets one fails loud with `UNSUPPORTED_ENTRY_TYPE` rather than guessing.

**Structured-failure diagnosability.** `MALFORMED_MANIFEST` / `MALFORMED_LOCK` now append the underlying TOML parse error (`… could not be parsed as TOML: <Syntax error at line …>`) instead of a bare message, so a fleet-scale failure points at the offending file and line.

**Whitespace-preserving version upgrades.** `UpgradeDependencyVersion` reconstructed the whole PEP 508 requirement canonically, so `six == 1.17.0` became `six==1.17.0` — a whitespace-only diff, and a change even when the version was already the target. It now changes only the version token, preserves the requirement's original spacing/extras/marker, and makes no change at all when the version already matches (ignoring formatting).

## Test plan

- [x] `UvLockRoundTripTest` byte-identity over the two new url/git fixtures (recorded from real uv 0.10.11)
- [x] Engine tests: url/git pass-through, targeted-edit → `UNSUPPORTED_ENTRY_TYPE`, structured malformed-manifest detail
- [x] `UpgradeDependencyVersionTest`: whitespace preserved on a real upgrade; no-op on a whitespace-only difference; existing constraint/extras/marker cases unchanged
- [x] `internal.uvlock` / `internal.pipfilelock` / `internal.index` / `Pipfile*` suites + `*Dependency*` green; license checks green
- [x] End-to-end via Moderne CLI: `typing-extensions 4.12.0 → 4.14.0` regenerates `uv.lock` (real artifacts) and passes `uv lock --check`; `six 1.16.0 → 1.17.0` regenerates `Pipfile.lock` and passes `pipenv verify`
