### PR TITLE
Go: Fix the serialization of chars over RPC

### DIFF
--- a/rewrite-go/pkg/parser/basic_lit_test.go
+++ b/rewrite-go/pkg/parser/basic_lit_test.go
@@ -47,7 +47,9 @@ func TestBasicLitDecodedValue(t *testing.T) {
 		{"interpreted string", `"foo"`, "foo", `"foo"`},
 		{"string with escape", `"a\tb"`, "a\tb", `"a\tb"`},
 		{"raw string", "`foo`", "foo", "`foo`"},
-		{"char", `'a'`, "a", `'a'`},
+		{"char", `'a'`, int64('a'), `'a'`},
+		{"char escape", `'\n'`, int64('\n'), `'\n'`},
+		{"char multibyte", `'π'`, int64('π'), `'π'`},
 		{"int", `42`, int64(42), `42`},
 		{"hex int", `0x7f`, int64(127), `0x7f`},
 		{"underscored int", `1_000`, int64(1000), `1_000`},
@@ -68,5 +70,53 @@ func TestBasicLitDecodedValue(t *testing.T) {
 				t.Errorf("Source = %q, want %q", lit.Source, tc.wantSource)
 			}
 		})
+	}
+}
+
+// firstLiteralOfType parses src and returns the first *java.Literal whose
+// attributed Type is the primitive `keyword` (e.g. "byte", "char").
+func firstLiteralOfType(t *testing.T, src, keyword string) *java.Literal {
+	t.Helper()
+	cu, err := parser.NewGoParser().Parse("g.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	var found *java.Literal
+	visitor.Walk(cu, func(n java.Tree) bool {
+		if lit, ok := n.(*java.Literal); ok {
+			if prim, ok := lit.Type.(*java.JavaTypePrimitive); ok && prim.Keyword == keyword {
+				found = lit
+				return false
+			}
+		}
+		return true
+	})
+	if found == nil {
+		t.Fatalf("no *java.Literal of primitive type %q found", keyword)
+	}
+	return found
+}
+
+// A Go byte-typed character literal such as `'^'` must round-trip through the
+// JVM-side LST deserializer. That deserializer is type-directed: for a J.Literal
+// whose Type is the `byte` primitive it coerces the value with
+func TestByteCharLiteralRoundTripsAsByte(t *testing.T) {
+	// given: `'^'` in a byte context, so go/types attributes it the `byte` type
+	src := "package main\n\nfunc main() {\n\tvar b byte = '^'\n\t_ = b\n}\n"
+
+	// when
+	lit := firstLiteralOfType(t, src, "byte")
+
+	// then: the Value must be the numeric code point, so the JVM stores it
+	// without running Byte.valueOf on a character string.
+	if s, ok := lit.Value.(string); ok {
+		if _, err := strconv.ParseInt(s, 10, 8); err != nil {
+			t.Fatalf("byte literal Value = %q (string): the JVM runs Byte.valueOf(%q), "+
+				"which throws NumberFormatException (%v). A byte literal's Value must be a "+
+				"numeric code point, not the raw character string.", s, s, err)
+		}
+	}
+	if lit.Value != int64('^') {
+		t.Errorf("Value = %#v (%T), want %#v (int64)", lit.Value, lit.Value, int64('^'))
 	}
 }

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1927,9 +1927,20 @@ func (ctx *parseContext) mapBasicLit(lit *ast.BasicLit) *java.Literal {
 
 func decodeBasicLitValue(lit *ast.BasicLit) any {
 	switch lit.Kind {
-	case token.STRING, token.CHAR:
+	case token.STRING:
 		if unquoted, err := strconv.Unquote(lit.Value); err == nil {
 			return unquoted
+		}
+	case token.CHAR:
+		// A Go rune literal ('x') is an integer constant equal to its Unicode
+		// code point, and go/types resolves it to byte or int as readily as
+		// rune. Store the numeric code point, never the character string: the
+		// JVM LST deserializer is type-directed and coerces an integer-typed
+		// J.Literal via <Type>.valueOf(value.toString())
+		if unquoted, err := strconv.Unquote(lit.Value); err == nil {
+			if rs := []rune(unquoted); len(rs) == 1 {
+				return int64(rs[0])
+			}
 		}
 	case token.INT:
 		if i, err := strconv.ParseInt(lit.Value, 0, 64); err == nil {


### PR DESCRIPTION
I tried running the fix nullability recipe on openrewrite/rewrite and noticed that a "^" over RPC messed everything up.