### PR TITLE
JavaScript: type property-key literals by their own lexical category

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -923,8 +923,40 @@ export class JavaScriptParserVisitor {
             value: unicodeEscapes.length > 0 ? cleanedSource : value,
             valueSource: cleanedSource,
             unicodeEscapes: unicodeEscapes.length > 0 ? unicodeEscapes : undefined,
-            type: this.mapPrimitiveType(node)
+            type: this.literalType(node)
         };
+    }
+
+    /**
+     * Resolve a literal's primitive type from its own lexical category rather than
+     * from the type checker.
+     *
+     * A literal's primitive is fixed by how it is written, not by its type according to the type checker.
+     */
+    private literalType(node: ts.Node): Type.Primitive {
+        switch (node.kind) {
+            case ts.SyntaxKind.StringLiteral:
+            case ts.SyntaxKind.RegularExpressionLiteral:
+            case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+            case ts.SyntaxKind.TemplateHead:
+            case ts.SyntaxKind.TemplateMiddle:
+            case ts.SyntaxKind.TemplateTail:
+            case ts.SyntaxKind.JsxText:
+                return Type.Primitive.String;
+            case ts.SyntaxKind.NumericLiteral:
+                return Type.Primitive.Double;
+            case ts.SyntaxKind.BigIntLiteral:
+                return Type.Primitive.BigInt;
+            case ts.SyntaxKind.TrueKeyword:
+            case ts.SyntaxKind.FalseKeyword:
+                return Type.Primitive.Boolean;
+            case ts.SyntaxKind.NullKeyword:
+                return Type.Primitive.Null;
+            default:
+                // Identifiers reaching mapLiteral (e.g. undefined) and any future
+                // node kinds fall back to the checker.
+                return this.mapPrimitiveType(node);
+        }
     }
 
     visitBigIntLiteral(node: ts.BigIntLiteral): J.Literal {

--- a/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
@@ -46,6 +46,34 @@ describe.each([
     }));
 });
 
+describe('property key literal types', () => {
+    // A property name literal's type must match the literal's own lexical category,
+    // not the property value's type. Regression for a string key over a numeric
+    // value ({'a"b': 1}) being typed `double`: the JVM deserializer is type-directed
+    // and ran Double.valueOf("a\"b"), throwing NumberFormatException mid-stream.
+    function keyLiteral(cu: JS.CompilationUnit): Literal {
+        const decl = cu.statements[0].element as J.VariableDeclarations;
+        const newClass = decl.variables[0].element.initializer!.element as J.NewClass;
+        const prop = newClass.body!.statements[0].element as JS.PropertyAssignment;
+        return prop.name.element as Literal;
+    }
+
+    test.each([
+        [`{'a"b': 1}`, 'a"b', Type.Primitive.String],
+        [`{'ab': 1}`, 'ab', Type.Primitive.String],
+        [`{"foo": 2}`, 'foo', Type.Primitive.String],
+        [`{1: 2}`, 1, Type.Primitive.Double],
+    ])('%s key is typed by its own literal', (obj, expectedValue, expectedType) =>
+        spec.rewriteRun({
+            ...typescript(`const o = ${obj};`),
+            afterRecipe: (cu: JS.CompilationUnit) => {
+                const key = keyLiteral(cu);
+                expect(key.value).toBe(expectedValue);
+                expect(key.type).toBe(expectedType);
+            }
+        }));
+});
+
 describe('Old-style octal literals (error 1121)', () => {
     test('should parse in .js files', () => spec.rewriteRun({
         ...javascript('0777'),


### PR DESCRIPTION
Found fractions like "1/2" being translated into a java Double, which is accurate to the type but not the text