### PR TITLE
Parent-delegate GoModVisitor and GoSumVisitor in RecipeClassLoader

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -92,6 +92,8 @@ public class RecipeClassLoader extends URLClassLoader {
             "org.openrewrite.ParseErrorVisitor",
             "org.openrewrite.PrintOutputCapture",
             "org.openrewrite.ipc.http.HttpSender",
+            "org.openrewrite.golang.GoModVisitor",
+            "org.openrewrite.golang.GoSumVisitor",
             "org.openrewrite.gradle.attributes.Category",
             "org.openrewrite.gradle.attributes.ProjectAttribute",
             "org.openrewrite.java.JavadocVisitor",


### PR DESCRIPTION
Running a Go recipe over a `go.mod` fails with:

    class ...FindSecretsByPattern_1_GoModVisitor cannot be cast to class
    org.openrewrite.golang.GoModVisitor (the former in loader
    TreeVisitorAdapterClassLoader, the latter in loader 'app')

`GoModTree` and `GoSumTree` pass `GoModVisitor` / `GoSumVisitor` to `adapt()`, so
those must resolve to a single `Class`. `RecipeClassLoader` is child-first for
`org.openrewrite` unless allowlisted or matched by `isTreeMarkerStyleType`, whose
visitor rule requires the simple name to be the package segment plus `"Visitor"`:

| Class | simple name length vs `golang` + `Visitor` | Parent-delegated |
|---|---|---|
| `GolangVisitor` | 13 == 6 + 7 | yes |
| `GoModVisitor`  | 12 != 13     | no  |
| `GoSumVisitor`  | 12 != 13     | no  |

Child-loaded, `TreeVisitorAdapter` builds its proxy on the recipe artifact's copy of
the visitor, and the cast in `acceptGoMod` fails. Mirrors the existing
`org.openrewrite.protobuf.ProtoVisitor` entry, allowlisted for the same
package/class-prefix mismatch.

**Verification:** confirmed at the delegation layer — with these entries reverted,
`GoModVisitor` resolves to the child `RecipeClassLoader`; with them, to the parent.
Not yet exercised end-to-end with a Go recipe against a real `go.mod`.
