### PR TITLE
property relocation logic to nest under existing prefixes in YAML map…

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -354,8 +354,11 @@ public class ChangePropertyKey extends Recipe {
             if (start < 0 || start + keyParts.length > segments.length) {
                 return false;
             }
+            NameCaseConvention convention = !Boolean.FALSE.equals(relaxedBinding) ?
+                    NameCaseConvention.LOWER_CAMEL :
+                    NameCaseConvention.EXACT;
             for (int i = 0; i < keyParts.length; i++) {
-                if (!segments[start + i].equals(keyParts[i])) {
+                if (!convention.format(segments[start + i]).equals(convention.format(keyParts[i]))) {
                     return false;
                 }
             }

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/ChangePropertyKey.java
@@ -283,14 +283,83 @@ public class ChangePropertyKey extends Recipe {
                         }));
                     } else {
                         m = (Yaml.Mapping) new DeletePropertyVisitor<>(entryToReplace).visitNonNull(m, p);
-                        Yaml.Mapping newMapping = m.withEntries(singletonList(newEntry));
-                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, newMapping, true, null, false, null, null).visitMapping(m, p);
+                        Yaml.Mapping incoming = nestUnderExistingPrefix(m, newEntry);
+                        if (incoming == null) {
+                            incoming = m.withEntries(singletonList(newEntry));
+                        }
+                        Yaml.Mapping mergedMapping = (Yaml.Mapping) new MergeYamlVisitor<>(m, incoming, true, null, false, null, null).visitMapping(m, p);
+                        // Preserve the first entry's prefix at the document root so auto-format does not insert a blank line before it
+                        boolean atDocumentRoot = getCursor().getParentOrThrow().getValue() instanceof Yaml.Document;
+                        String firstEntryPrefix = atDocumentRoot ? mergedMapping.getEntries().get(0).getPrefix() : null;
                         m = maybeAutoFormat(m, mergedMapping, p, getCursor().getParentOrThrow());
+                        if (atDocumentRoot && !m.getEntries().isEmpty()) {
+                            m = m.withEntries(ListUtils.mapFirst(m.getEntries(), e -> e.withPrefix(firstEntryPrefix)));
+                        }
                     }
                 }
             }
 
             return m;
+        }
+
+        private Yaml.@Nullable Mapping nestUnderExistingPrefix(Yaml.Mapping mapping, Yaml.Mapping.Entry newEntry) {
+            String[] segments = ((Yaml.Scalar) newEntry.getKey()).getValue().split("\\.");
+            if (segments.length < 2) {
+                return null;
+            }
+
+            List<String> nestKeys = new ArrayList<>();
+            Yaml.Mapping current = mapping;
+            int consumed = 0;
+            while (consumed < segments.length - 1) {
+                Yaml.Mapping.Entry match = null;
+                int matchLength = 0;
+                for (Yaml.Mapping.Entry e : current.getEntries()) {
+                    if (!(e.getValue() instanceof Yaml.Mapping)) {
+                        continue;
+                    }
+                    String[] keyParts = e.getKey().getValue().split("\\.");
+                    if (consumed + keyParts.length >= segments.length ||
+                        !matchesPrefix(segments, consumed, keyParts) ||
+                        keyParts.length <= matchLength) {
+                        continue;
+                    }
+                    match = e;
+                    matchLength = keyParts.length;
+                }
+                if (match == null) {
+                    break;
+                }
+                nestKeys.add(match.getKey().getValue());
+                current = (Yaml.Mapping) match.getValue();
+                consumed += matchLength;
+            }
+            if (nestKeys.isEmpty()) {
+                return null;
+            }
+
+            String remainder = String.join(".", Arrays.copyOfRange(segments, consumed, segments.length));
+            Yaml.Mapping.Entry leaf = newEntry.withKey(((Yaml.Scalar) newEntry.getKey()).withValue(remainder));
+            Yaml.Mapping nested = new Yaml.Mapping(randomId(), Markers.EMPTY, null, singletonList(leaf), null, null, null);
+            for (int i = nestKeys.size() - 1; i >= 0; i--) {
+                Yaml.Mapping.Entry wrapper = new Yaml.Mapping.Entry(randomId(), "", Markers.EMPTY,
+                        new Yaml.Scalar(randomId(), "", Markers.EMPTY, Yaml.Scalar.Style.PLAIN, null, null, nestKeys.get(i)),
+                        "", nested);
+                nested = new Yaml.Mapping(randomId(), Markers.EMPTY, null, singletonList(wrapper), null, null, null);
+            }
+            return nested;
+        }
+
+        private boolean matchesPrefix(String[] segments, int start, String[] keyParts) {
+            if (start < 0 || start + keyParts.length > segments.length) {
+                return false;
+            }
+            for (int i = 0; i < keyParts.length; i++) {
+                if (!segments[start + i].equals(keyParts[i])) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         @Override

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
@@ -982,6 +982,42 @@ class ChangePropertyKeyTest implements RewriteTest {
         );
     }
 
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    void relocatesUnderExistingPrefixWithRelaxedBinding() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "managementServer.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              project:
+                metrics:
+                  prometheus:
+                    enabled: true
+                    percentiles: [0.99, 0.9]
+              management-server:
+                prometheus:
+                  test: true
+              """,
+            """
+              project:
+                metrics:
+                  prometheus:
+                    percentiles: [0.99, 0.9]
+              management-server:
+                prometheus:
+                  test: true
+                  metrics.export.enabled: true
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2881")
     @Test
     void embedIndentedPropertyIntoExisting() {

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
@@ -852,6 +852,136 @@ class ChangePropertyKeyTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    @Test
+    void relocatesPropertyIntoExistingMappingAtDifferentRoot() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "management.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              project:
+                metrics:
+                  prometheus:
+                    enabled: true
+                    percentiles: [0.99, 0.9]
+              management:
+                prometheus:
+                  test: true
+              """,
+            """
+              project:
+                metrics:
+                  prometheus:
+                    percentiles: [0.99, 0.9]
+              management:
+                prometheus:
+                  test: true
+                  metrics.export.enabled: true
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    @Test
+    void relocatesPropertyToNewRootWhenNoExistingPrefix() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "management.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              project:
+                metrics:
+                  prometheus:
+                    enabled: true
+                    percentiles: [0.99, 0.9]
+              """,
+            """
+              project:
+                metrics:
+                  prometheus:
+                    percentiles: [0.99, 0.9]
+              management.prometheus.metrics.export.enabled: true
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    @Test
+    void relocatesSoleSequencePropertyIntoExistingMapping() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "management.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              project:
+                metrics:
+                  prometheus:
+                    enabled: [0.99, 0.9]
+              management:
+                prometheus:
+                  test: true
+              """,
+            """
+              management:
+                prometheus:
+                  test: true
+                  metrics.export.enabled: [0.99, 0.9]
+              """
+          )
+        );
+    }
+
+    @Test
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/1047")
+    void prefersLongestExistingPrefixWhenRelocatingProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey(
+            "project.metrics.prometheus.enabled",
+            "management.prometheus.metrics.export.enabled",
+            true,
+            null,
+            null
+          )),
+          yaml(
+            """
+              management:
+                other: true
+              management.prometheus:
+                test: true
+              project:
+                metrics:
+                  prometheus:
+                    enabled: true
+              """,
+            """
+              management:
+                other: true
+              management.prometheus:
+                test: true
+                metrics.export.enabled: true
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/2881")
     @Test
     void embedIndentedPropertyIntoExisting() {


### PR DESCRIPTION
- Based on Tim's PR https://github.com/openrewrite/rewrite/pull/8099
- fixes https://github.com/openrewrite/rewrite-spring/issues/1047
- closes https://github.com/openrewrite/rewrite-spring/pull/1059

## What's changed?
Updated ChangePropertyKey to correctly relocate YAML properties under existing mapping prefixes, with regression tests covering existing prefixes, new roots, sequences, and longest-prefix matching.
## What's your motivation?
- Fixes cross-root YAML property relocation reported in rewrite-spring#1047.
## Anything in particular you'd like reviewers to focus on?
Please review the prefix-matching and nesting logic, especially dotted mapping keys and longest-prefix selection.
## Anyone you would like to review specifically?
N/A
## Have you considered any alternatives or workarounds?
The existing behavior inserts the complete relocated key at the current mapping level. This change preserves that fallback when no existing prefix can be reused.
## Any additional context
The change is limited to YAML property relocation and preserves existing behavior for unrelated mappings.
### Checklist
- [x] I've added unit tests to cover both positive and negative cases
 - [x] I've read and applied the recipe conventions and best practices
 - [ ] I've used the IntelliJ IDEA auto-formatter on affected files