### PR TITLE
Fix ChangeType NPE on ClassDeclaration with null type

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.tree.TypeUtils;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.TypeValidation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -2697,6 +2698,41 @@ class ChangeTypeTest implements RewriteTest {
                   Other o;
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void doesNotFailOnClassDeclarationWithNullType() {
+        // Non-Java (e.g. Python) sources may produce a J.ClassDeclaration whose type is null.
+        // When such a file also references the type being changed, the precondition passes and
+        // ChangeClassDefinition iterates every class declaration; it must skip the null-typed one
+        // rather than dereference its type. ignoreDefinition is left unset so ChangeClassDefinition runs.
+        rewriteRun(
+          spec -> spec
+            .recipe(new ChangeType("java.util.List", "java.util.Collection", null))
+            .typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              import java.util.List;
+
+              class Foo {
+                  List<String> l;
+              }
+              """,
+            """
+              import java.util.Collection;
+
+              class Foo {
+                  Collection<String> l;
+              }
+              """,
+            spec -> spec.mapBeforeRecipe(cu -> (J.CompilationUnit) new JavaIsoVisitor<>() {
+                @Override
+                public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, Object o) {
+                    return classDecl.withType(null);
+                }
+            }.visit(cu, 0))
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -748,8 +748,13 @@ public class ChangeType extends Recipe {
             if (tree instanceof JavaSourceFile) {
                 JavaSourceFile cu = (JavaSourceFile) tree;
                 for (J.ClassDeclaration declaration : cu.getClasses()) {
-                    // Check the class name instead of source path, as it might differ
-                    String fqn = declaration.getType().getFullyQualifiedName();
+                    // Check the class name instead of source path, as it might differ.
+                    // Non-Java (e.g. Python) class declarations may lack type attribution.
+                    JavaType.FullyQualified declarationType = declaration.getType();
+                    if (declarationType == null) {
+                        continue;
+                    }
+                    String fqn = declarationType.getFullyQualifiedName();
                     if (fqn.equals(originalType.getFullyQualifiedName())) {
                         getCursor().putMessage("UPDATE_PACKAGE", true);
                         break;


### PR DESCRIPTION
## What's changed?

`ChangeType.ChangeClassDefinition` iterated every class declaration in a matched source file and dereferenced `declaration.getType().getFullyQualifiedName()` with no null check:

```java
for (J.ClassDeclaration declaration : cu.getClasses()) {
    String fqn = declaration.getType().getFullyQualifiedName(); // NPE when getType() == null
```

Non-Java LSTs (e.g. rewrite-python) can produce a `J.ClassDeclaration` whose type is `null` — an unattributed class such as a `@dataclass`. Because this loop runs on *every* class in any file the recipe touches (once the precondition matches on a used/defined type), a single untyped class threw a `NullPointerException` and aborted the run for that source file.

This guards the null type and `continue`s — a class with no attributed FQN can never be the type being renamed. The sibling dereference in `visitClassDeclaration` is already null-safe via `TypeUtils.isOfClassType(...)`.

## Reproduction

Observed running `org.openrewrite.java.ChangeType` (the PEP 585 `typing.List` → `builtins.list` renames) against Python sources containing a dataclass:

```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.JavaType$FullyQualified.getFullyQualifiedName()" because the return value of "org.openrewrite.java.tree.J$ClassDeclaration.getType()" is null
	at org.openrewrite.java.ChangeType$ChangeClassDefinition.visit(ChangeType.java:752)
	...
```

## Test

Adds `ChangeTypeTest.doesNotFailOnClassDeclarationWithNullType`, which nulls a class declaration's type before running the recipe. Verified it **fails with the exact NPE without this change** and **passes with it**.

- Fixes #8293
