### PR TITLE
Python: attribute types for decorated class/function declarations

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -300,7 +300,7 @@ class PythonTypeMapping:
         if cache_key in self._lookup_cache:
             return self._lookup_cache[cache_key]
 
-        start = self._pos_to_byte_offset(node.lineno, node.col_offset)  # ty: ignore[unresolved-attribute]  # AST nodes with lineno always have col_offset
+        start = self._decorated_start(node)
         end = self._pos_to_byte_offset(end_lineno, end_col_offset) if end_lineno is not None else None
 
         result = None
@@ -321,6 +321,25 @@ class PythonTypeMapping:
 
         self._lookup_cache[cache_key] = result
         return result
+
+    def _decorated_start(self, node: ast.AST) -> int:
+        """Return the byte offset ty uses as this node's start.
+
+        CPython's ``ast`` places a decorated class/function's ``lineno``/
+        ``col_offset`` at the ``class``/``def`` keyword, but ruff (which ty is
+        built on) starts the statement's range at the first decorator's ``@``.
+        Realign to that ``@`` so the ``(start, end)`` lookup hits; otherwise
+        every decorated class or function (e.g. ``@dataclass``) resolves to no
+        type.
+        """
+        decorators = getattr(node, 'decorator_list', None)
+        if decorators:
+            first = decorators[0]
+            line = self._source_lines[first.lineno - 1] if first.lineno <= len(self._source_lines) else ""
+            at_col = line.rfind('@', 0, first.col_offset)
+            if at_col != -1:
+                return self._pos_to_byte_offset(first.lineno, at_col)
+        return self._pos_to_byte_offset(node.lineno, node.col_offset)  # ty: ignore[unresolved-attribute]  # AST nodes with lineno always have col_offset
 
     def _resolve_type(self, type_id: int) -> Optional[JavaType]:
         """Resolve a type ID to a JavaType, maximizing object reuse.

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -1481,6 +1481,94 @@ x = Multi()
             _cleanup_mapping(mapping, tmpdir, client)
 
 
+@requires_ty_types_cli
+class TestDecoratedDeclarationType:
+    """Regression tests for type attribution of *decorated* class/function declarations.
+
+    CPython's ``ast`` places a decorated class/function's ``lineno``/``col_offset``
+    at the ``class``/``def`` keyword, while ruff (ty's backend) starts the
+    statement's range at the first decorator's ``@``. The byte-offset lookup must
+    realign to the decorator, otherwise every decorated declaration resolves to no
+    type — which is what left ``J.ClassDeclaration.getType()`` null for Python
+    ``@dataclass`` classes (openrewrite/rewrite#8293).
+    """
+
+    def _class_type(self, source: str, class_name: str):
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            node = next(n for n in ast.walk(tree)
+                        if isinstance(n, ast.ClassDef) and n.name == class_name)
+            return mapping.type(node)
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_undecorated_class_declaration_has_type(self):
+        result = self._class_type('class Foo:\n    pass\n', 'Foo')
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name.endswith('Foo')
+
+    def test_dataclass_declaration_has_type(self):
+        source = '''from dataclasses import dataclass
+
+
+@dataclass
+class Foo:
+    x: int
+'''
+        result = self._class_type(source, 'Foo')
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name.endswith('Foo')
+
+    def test_custom_decorated_class_declaration_has_type(self):
+        source = '''def deco(c):
+    return c
+
+
+@deco
+class Foo:
+    pass
+'''
+        result = self._class_type(source, 'Foo')
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name.endswith('Foo')
+
+    def test_multiple_decorators_class_declaration_has_type(self):
+        source = '''def a(c):
+    return c
+
+
+def b(c):
+    return c
+
+
+@a
+@b
+class Foo:
+    pass
+'''
+        result = self._class_type(source, 'Foo')
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name.endswith('Foo')
+
+    def test_decorated_function_declaration_has_method_type(self):
+        source = '''import functools
+
+
+@functools.cache
+def f(x: int) -> int:
+    return x
+'''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            node = next(n for n in ast.walk(tree)
+                        if isinstance(n, ast.FunctionDef) and n.name == 'f')
+            result = mapping.method_declaration_type(node)
+            assert result is not None
+            assert result._return_type == JavaType.Primitive.Int
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
 class TestGenericTypeVariable:
     """Tests for typeVar → GenericTypeVariable conversion."""
 


### PR DESCRIPTION
- Decorated Python declarations (e.g. `@dataclass` classes, decorated functions) were losing their attributed type because rewrite-python looks up ty's types by byte offset, and CPython's `ast` places a decorated declaration's position at the `class`/`def` keyword while ruff (ty's backend) starts the node range at the first decorator's `@`, so the lookup missed. This left `J.ClassDeclaration.getType()` null for `@dataclass` classes, which surfaced as a NullPointerException in `ChangeType` (#8293). The fix realigns `_lookup_type_id` to the first decorator's `@` when a declaration is decorated, restoring types for single, stacked, and whitespaced decorators as well as decorated functions. Adds `TestDecoratedDeclarationType` regression tests, verified to fail without the fix and pass with it.