### PR TITLE
C#: resolve NuGet dependencies in-process instead of shelling out to dotnet/nuget

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
@@ -16,6 +16,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <!-- Keep MSBuild assemblies out of the output so MSBuildLocator can load the SDK's copies
+         for in-process restore-graph evaluation (NuGetResolver). A stale app-base copy of
+         Microsoft.Build.Framework causes MissingMethodException at MSBuild load time. -->
+    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" />
     <!-- Test-only: fixtures build throwaway git repos with LibGit2Sharp. The production
          tool resolves git through the host `git` CLI (see GitCli) and ships no native libs. -->
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
@@ -16,11 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <!-- Keep MSBuild assemblies out of the output so MSBuildLocator can load the SDK's copies
-         for in-process restore-graph evaluation (NuGetResolver). A stale app-base copy of
-         Microsoft.Build.Framework causes MissingMethodException at MSBuild load time. -->
-    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" />
     <!-- Test-only: fixtures build throwaway git repos with LibGit2Sharp. The production
          tool resolves git through the host `git` CLI (see GitCli) and ships no native libs. -->
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallVersionResolverTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/InstallVersionResolverTests.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using NuGet.ProjectModel;
 using OpenRewrite.CSharp;
 
 namespace OpenRewrite.Tests.Rpc;
@@ -20,7 +21,9 @@ namespace OpenRewrite.Tests.Rpc;
 /// <summary>
 /// Regression coverage for the InstallRecipes RPC, which used to echo wildcard versions
 /// (e.g. "*", "*-*") back to the caller because it read the version off the csproj's
-/// PackageReference Version attribute instead of the resolved value in project.assets.json.
+/// PackageReference Version attribute instead of the version NuGet actually resolved.
+/// The resolved version now comes from the in-memory <see cref="LockFile"/> of the
+/// in-process restore.
 /// </summary>
 public class InstallVersionResolverTests
 {
@@ -31,93 +34,74 @@ public class InstallVersionResolverTests
     [InlineData("*-*", "8.82.0-snapshot.20260514132053")]
     public void WildcardRequestResolvesToConcreteVersion(string requested, string resolved)
     {
-        WithAssetsJson(requested, resolved, projectDir =>
-            Assert.Equal(resolved,
-                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, Pkg)));
+        var lockFile = LockFileFor(requested, resolved);
+        Assert.Equal(resolved, MSBuildProjectHelper.GetResolvedPackageVersion(lockFile, Pkg));
     }
 
     [Fact]
     public void PackageNameMatchIsCaseInsensitive()
     {
-        // Caller-supplied package name may differ in casing from the ID recorded in
-        // project.assets.json; resolution must still succeed.
-        WithAssetsJson("*", "8.81.17", projectDir =>
-            Assert.Equal("8.81.17",
-                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, Pkg.ToLowerInvariant())));
+        // Caller-supplied package name may differ in casing from the resolved ID;
+        // resolution must still succeed.
+        var lockFile = LockFileFor("*", "8.81.17");
+        Assert.Equal("8.81.17",
+            MSBuildProjectHelper.GetResolvedPackageVersion(lockFile, Pkg.ToLowerInvariant()));
     }
 
     [Fact]
     public void UnknownPackageThrows()
     {
-        WithAssetsJson("*", "8.81.17", projectDir =>
-        {
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, "Does.Not.Exist"));
-            Assert.Contains("not a direct dependency", ex.Message);
-        });
+        var lockFile = LockFileFor("*", "8.81.17");
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            MSBuildProjectHelper.GetResolvedPackageVersion(lockFile, "Does.Not.Exist"));
+        Assert.Contains("not a direct dependency", ex.Message);
     }
 
     [Fact]
-    public void MissingAssetsJsonThrows()
-    {
-        WithTempDir(projectDir =>
-        {
-            var ex = Assert.Throws<InvalidOperationException>(() =>
-                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, Pkg));
-            Assert.Contains("project.assets.json not found", ex.Message);
-        });
-    }
-
-    private static void WithAssetsJson(
-        string requestedVersion,
-        string resolvedVersion,
-        Action<string> assert)
-    {
-        WithTempDir(projectDir =>
-        {
-            var objDir = Path.Combine(projectDir, "obj");
-            Directory.CreateDirectory(objDir);
-            File.WriteAllText(Path.Combine(objDir, "project.assets.json"), $$"""
-                {
-                  "version": 3,
-                  "targets": {
-                    "net10.0": {
-                      "{{Pkg}}/{{resolvedVersion}}": { "type": "package" }
-                    }
-                  },
-                  "libraries": {
-                    "{{Pkg}}/{{resolvedVersion}}": { "type": "package" }
-                  },
-                  "project": {
-                    "frameworks": {
-                      "net10.0": {
-                        "dependencies": {
-                          "{{Pkg}}": {
-                            "target": "Package",
-                            "version": "[{{requestedVersion}}, )"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-                """);
-            assert(projectDir);
-        });
-    }
-
-    private static void WithTempDir(Action<string> assert)
+    public void ProjectWithoutCsprojThrows()
     {
         var projectDir = Path.Combine(Path.GetTempPath(),
             "openrewrite-installrecipes-" + Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(projectDir);
         try
         {
-            assert(projectDir);
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                MSBuildProjectHelper.GetResolvedPackageVersion(projectDir, Pkg));
+            Assert.Contains("No .csproj found", ex.Message);
         }
         finally
         {
             try { Directory.Delete(projectDir, recursive: true); } catch { /* best-effort */ }
         }
+    }
+
+    private static LockFile LockFileFor(string requestedVersion, string resolvedVersion)
+    {
+        // Same JSON shape the restore produces; parsed straight into the LockFile object model.
+        return new LockFileFormat().Parse($$"""
+            {
+              "version": 3,
+              "targets": {
+                "net10.0": {
+                  "{{Pkg}}/{{resolvedVersion}}": { "type": "package" }
+                }
+              },
+              "libraries": {
+                "{{Pkg}}/{{resolvedVersion}}": { "type": "package" }
+              },
+              "project": {
+                "frameworks": {
+                  "net10.0": {
+                    "dependencies": {
+                      "{{Pkg}}": {
+                        "target": "Package",
+                        "version": "[{{requestedVersion}}, )"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """, "in-memory");
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using NuGet.ProjectModel;
 using OpenRewrite.CSharp;
 using OpenRewrite.Xml;
 
@@ -21,7 +22,7 @@ namespace OpenRewrite.Tests.Xml;
 public class CsprojParserTests
 {
     [Fact]
-    public void CsprojParserRunsRestoreAndAttachesFullMarker()
+    public void CsprojParserRunsInProcessRestoreAndAttachesFullMarker()
     {
         var parser = new CsprojParser();
         var doc = parser.Parse(
@@ -39,8 +40,7 @@ public class CsprojParserTests
         var marker = doc.Markers.FindFirst<MSBuildProject>();
         Assert.NotNull(marker);
         Assert.Equal("Microsoft.NET.Sdk", marker.Sdk);
-        // Without rootDir, CsprojParser runs dotnet restore in a temp dir to generate
-        // project.assets.json, so the marker has full metadata
+        // The in-process restore (PackageSpec/RestoreRunner -> LockFile) yields full metadata
         Assert.Single(marker.TargetFrameworks);
         Assert.Equal("net8.0", marker.TargetFrameworks[0].TargetFrameworkMoniker);
         Assert.Single(marker.TargetFrameworks[0].PackageReferences);
@@ -48,103 +48,181 @@ public class CsprojParserTests
         Assert.Equal("Newtonsoft.Json", pkgRef.Include);
         Assert.Equal("13.0.3", pkgRef.RequestedVersion);
         Assert.Equal("13.0.3", pkgRef.ResolvedVersion);
+
+        // Extended asset data from the lock file
+        var resolved = marker.TargetFrameworks[0].ResolvedPackages
+            .Single(p => p.Name == "Newtonsoft.Json");
+        Assert.Equal("package", resolved.Type);
+        Assert.Contains(resolved.CompileAssemblies, p => p.EndsWith("Newtonsoft.Json.dll"));
+        Assert.Contains(resolved.RuntimeAssemblies, p => p.EndsWith("Newtonsoft.Json.dll"));
+        Assert.Equal(0, resolved.Depth);
     }
 
     [Fact]
-    public void MarkerCreatedFromAssetsJson()
+    public void PackagesConfigProjectGetsFullMarker()
     {
-        // Set up a temp directory with a hand-crafted project.assets.json
-        // to test MSBuildProjectHelper.CreateMarker directly
-        var tempDir = Path.Combine(Path.GetTempPath(), "openrewrite-test-" + Guid.NewGuid().ToString("N")[..8]);
-        var projectDir = Path.Combine(tempDir, "src");
-        var objDir = Path.Combine(projectDir, "obj");
-        Directory.CreateDirectory(objDir);
+        var parser = new CsprojParser();
+        var docs = parser.ParseAll(
+        [
+            (
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+                  <PropertyGroup>
+                    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+                    <OutputType>Library</OutputType>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
+                      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
+                    </Reference>
+                  </ItemGroup>
+                </Project>
+                """,
+                "Legacy/Legacy.csproj"
+            ),
+            (
+                """
+                <?xml version="1.0" encoding="utf-8"?>
+                <packages>
+                  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+                </packages>
+                """,
+                "Legacy/packages.config"
+            )
+        ]);
 
-        try
-        {
-            var assetsJson = """
-                {
-                  "version": 3,
-                  "targets": {
-                    "net8.0": {
-                      "Newtonsoft.Json/13.0.3": {
-                        "type": "package",
-                        "compile": {},
-                        "runtime": {}
-                      }
-                    }
-                  },
-                  "libraries": {
-                    "Newtonsoft.Json/13.0.3": {
-                      "type": "package",
-                      "path": "newtonsoft.json/13.0.3"
-                    }
-                  },
-                  "projectFileDependencyGroups": {
-                    "net8.0": ["Newtonsoft.Json >= 13.0.3"]
-                  },
-                  "packageFolders": {},
-                  "project": {
-                    "version": "1.0.0",
-                    "restore": {
-                      "projectName": "TestProject",
-                      "originalTargetFrameworks": ["net8.0"],
-                      "sources": {},
-                      "frameworks": {
-                        "net8.0": { "targetAlias": "net8.0" }
-                      }
+        var csprojDoc = docs[0];
+        var marker = csprojDoc.Markers.FindFirst<MSBuildProject>();
+        Assert.NotNull(marker);
+        // Legacy packages.config projects get a full dependency graph from the
+        // synthesized PackageSpec restore.
+        Assert.Single(marker.TargetFrameworks);
+        Assert.Equal("net48", marker.TargetFrameworks[0].TargetFrameworkMoniker);
+        // PackageReferences stays 1:1 with csproj <PackageReference> items (none here);
+        // the packages.config directs appear as depth-0 entries in the resolved graph.
+        Assert.Empty(marker.TargetFrameworks[0].PackageReferences);
+        var resolved = marker.TargetFrameworks[0].ResolvedPackages
+            .Single(p => p.Name == "Newtonsoft.Json");
+        Assert.Equal("13.0.3", resolved.ResolvedVersion);
+        Assert.Equal(0, resolved.Depth);
+        Assert.Contains(resolved.CompileAssemblies, p => p.EndsWith("Newtonsoft.Json.dll"));
+
+        // packages.config itself parses as plain XML without a project marker
+        Assert.Null(docs[1].Markers.FindFirst<MSBuildProject>());
+    }
+
+    [Fact]
+    public void MarkerCreatedFromLockFile()
+    {
+        // Hand-crafted lock file (same JSON shape as project.assets.json) parsed with
+        // LockFileFormat, verifying the LockFile -> marker mapping without any restore.
+        var lockFileJson = """
+            {
+              "version": 3,
+              "targets": {
+                "net8.0": {
+                  "Newtonsoft.Json/13.0.3": {
+                    "type": "package",
+                    "compile": {
+                      "lib/net6.0/Newtonsoft.Json.dll": {}
                     },
-                    "frameworks": {
-                      "net8.0": {
-                        "targetAlias": "net8.0",
-                        "dependencies": {
-                          "Newtonsoft.Json": {
-                            "target": "Package",
-                            "version": "[13.0.3, )"
-                          }
-                        }
+                    "runtime": {
+                      "lib/net6.0/Newtonsoft.Json.dll": {}
+                    },
+                    "build": {
+                      "build/Newtonsoft.Json.targets": {}
+                    }
+                  },
+                  "Placeholder.Pkg/1.0.0": {
+                    "type": "package",
+                    "dependencies": {
+                      "Newtonsoft.Json": "13.0.1"
+                    },
+                    "compile": {
+                      "lib/net8.0/_._": {}
+                    }
+                  }
+                }
+              },
+              "libraries": {
+                "Newtonsoft.Json/13.0.3": {
+                  "type": "package",
+                  "path": "newtonsoft.json/13.0.3",
+                  "files": [
+                    "analyzers/dotnet/cs/Newtonsoft.Json.Analyzer.dll",
+                    "tools/install.ps1",
+                    "content/web.config.transform",
+                    "content/scripts/app.js",
+                    "lib/net6.0/Newtonsoft.Json.dll"
+                  ]
+                },
+                "Placeholder.Pkg/1.0.0": {
+                  "type": "package",
+                  "path": "placeholder.pkg/1.0.0",
+                  "files": [ "lib/net8.0/_._" ]
+                }
+              },
+              "projectFileDependencyGroups": {
+                "net8.0": ["Placeholder.Pkg >= 1.0.0"]
+              },
+              "packageFolders": {},
+              "project": {
+                "version": "1.0.0",
+                "restore": {
+                  "projectName": "TestProject",
+                  "projectStyle": "PackageReference",
+                  "originalTargetFrameworks": ["net8.0"],
+                  "frameworks": {
+                    "net8.0": { "targetAlias": "net8.0" }
+                  }
+                },
+                "frameworks": {
+                  "net8.0": {
+                    "targetAlias": "net8.0",
+                    "dependencies": {
+                      "Placeholder.Pkg": {
+                        "target": "Package",
+                        "version": "[1.0.0, )"
                       }
                     }
                   }
                 }
-                """;
-            File.WriteAllText(Path.Combine(objDir, "project.assets.json"), assetsJson);
+              }
+            }
+            """;
+        var lockFile = new LockFileFormat().Parse(lockFileJson, "in-memory");
 
-            var xmlParser = new XmlParser();
-            var doc = xmlParser.Parse(
-                """
-                <Project Sdk="Microsoft.NET.Sdk">
-                  <PropertyGroup>
-                    <TargetFramework>net8.0</TargetFramework>
-                  </PropertyGroup>
-                  <ItemGroup>
-                    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-                  </ItemGroup>
-                </Project>
-                """,
-                sourcePath: "src/TestProject.csproj");
+        var marker = MSBuildProjectHelper.CreateFromLockFile(
+            "Microsoft.NET.Sdk", lockFile, Path.GetTempPath());
 
-            var marker = MSBuildProjectHelper.CreateMarker(doc, tempDir);
-            Assert.NotNull(marker);
-            Assert.Equal("Microsoft.NET.Sdk", marker.Sdk);
-            Assert.Single(marker.TargetFrameworks);
-            Assert.Equal("net8.0", marker.TargetFrameworks[0].TargetFrameworkMoniker);
+        Assert.Single(marker.TargetFrameworks);
+        var tf = marker.TargetFrameworks[0];
+        Assert.Equal("net8.0", tf.TargetFrameworkMoniker);
 
-            // Package reference with correct requested and resolved versions
-            Assert.Single(marker.TargetFrameworks[0].PackageReferences);
-            var pkgRef = marker.TargetFrameworks[0].PackageReferences[0];
-            Assert.Equal("Newtonsoft.Json", pkgRef.Include);
-            Assert.Equal("13.0.3", pkgRef.RequestedVersion);
-            Assert.Equal("13.0.3", pkgRef.ResolvedVersion);
+        // Declared reference resolves via the graph
+        var pkgRef = Assert.Single(tf.PackageReferences);
+        Assert.Equal("Placeholder.Pkg", pkgRef.Include);
+        Assert.Equal("1.0.0", pkgRef.RequestedVersion);
+        Assert.Equal("1.0.0", pkgRef.ResolvedVersion);
 
-            // Resolved packages include the package
-            Assert.Single(marker.TargetFrameworks[0].ResolvedPackages);
-            Assert.Equal("Newtonsoft.Json", marker.TargetFrameworks[0].ResolvedPackages[0].Name);
-            Assert.Equal("13.0.3", marker.TargetFrameworks[0].ResolvedPackages[0].ResolvedVersion);
-        }
-        finally
-        {
-            Directory.Delete(tempDir, true);
-        }
+        Assert.Equal(2, tf.ResolvedPackages.Count);
+
+        var placeholder = tf.ResolvedPackages.Single(p => p.Name == "Placeholder.Pkg");
+        Assert.Equal(0, placeholder.Depth); // direct
+        Assert.Empty(placeholder.CompileAssemblies); // _._ placeholder stripped
+        var edge = Assert.Single(placeholder.Dependencies);
+        Assert.Equal("Newtonsoft.Json", edge.Name);
+        Assert.Equal("13.0.3", edge.ResolvedVersion); // edge links to the RESOLVED node
+
+        var newtonsoft = tf.ResolvedPackages.Single(p => p.Name == "Newtonsoft.Json");
+        Assert.Equal(1, newtonsoft.Depth); // transitive
+        Assert.Contains("lib/net6.0/Newtonsoft.Json.dll", newtonsoft.CompileAssemblies);
+        Assert.Contains("lib/net6.0/Newtonsoft.Json.dll", newtonsoft.RuntimeAssemblies);
+        Assert.Contains("build/Newtonsoft.Json.targets", newtonsoft.BuildFiles);
+        Assert.Contains("analyzers/dotnet/cs/Newtonsoft.Json.Analyzer.dll", newtonsoft.AnalyzerAssemblies);
+        Assert.True(newtonsoft.HasInstallScripts);
+        Assert.True(newtonsoft.HasXdtTransforms);
+        Assert.True(newtonsoft.HasLegacyContentFolder);
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite.Tool/OpenRewrite.Tool.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite.Tool/OpenRewrite.Tool.csproj
@@ -28,4 +28,12 @@
     <ProjectReference Include="$(OpenRewriteSdkSourcePath)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Keep MSBuild assemblies out of the output so MSBuildLocator can load the SDK's copies
+         for in-process restore-graph evaluation (NuGetResolver). A stale app-base copy of
+         Microsoft.Build.Framework causes MissingMethodException at MSBuild load time. -->
+    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" />
+  </ItemGroup>
+
 </Project>

--- a/rewrite-csharp/csharp/OpenRewrite.Tool/OpenRewrite.Tool.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite.Tool/OpenRewrite.Tool.csproj
@@ -29,11 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Keep MSBuild assemblies out of the output so MSBuildLocator can load the SDK's copies
-         for in-process restore-graph evaluation (NuGetResolver). A stale app-base copy of
-         Microsoft.Build.Framework causes MissingMethodException at MSBuild load time. -->
-    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/DotNetBuildContext.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/DotNetBuildContext.cs
@@ -52,7 +52,9 @@ public class DotNetBuildContext
 
     private static readonly HashSet<string> BuildFileNames = new(StringComparer.OrdinalIgnoreCase)
     {
-        "nuget.config"
+        "nuget.config",
+        // Needed so legacy projects can be reattested (synthesized restore graph) after edits.
+        "packages.config"
     };
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProject.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProject.cs
@@ -205,6 +205,12 @@ public sealed class PackageReference : IRpcCodec<PackageReference>
     }
 }
 
+/// <summary>
+/// A resolved package (or referenced project) from the restore dependency graph, carrying the
+/// full per-target-framework asset information from the NuGet <c>LockFile</c>. Asset lists hold
+/// package-relative paths with <c>_._</c> placeholder entries stripped, so an empty list means
+/// "the package provides no assets of that kind".
+/// </summary>
 public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
 {
     public string Name { get; }
@@ -212,25 +218,104 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
     public IList<ResolvedPackage> Dependencies { get; }
     public int Depth { get; }
 
-    public ResolvedPackage(string name, string resolvedVersion, IList<ResolvedPackage>? dependencies = null, int depth = 0)
+    /// <summary>Library type from the lock file: "package" or "project".</summary>
+    public string Type { get; }
+
+    /// <summary>Compile-time assemblies (lib/ref), lock file <c>compile</c> section.</summary>
+    public IList<string> CompileAssemblies { get; }
+
+    /// <summary>Runtime assemblies, lock file <c>runtime</c> section.</summary>
+    public IList<string> RuntimeAssemblies { get; }
+
+    /// <summary>.NET Framework in-box assembly names, lock file <c>frameworkAssemblies</c>.</summary>
+    public IList<string> FrameworkAssemblies { get; }
+
+    /// <summary>MSBuild props/targets imports, lock file <c>build</c> section.</summary>
+    public IList<string> BuildFiles { get; }
+
+    /// <summary>MSBuild imports for the outer multi-targeting build, lock file <c>buildMultiTargeting</c>.</summary>
+    public IList<string> BuildMultiTargetingFiles { get; }
+
+    /// <summary>PackageReference-style shared content, lock file <c>contentFiles</c> section.</summary>
+    public IList<string> ContentFiles { get; }
+
+    /// <summary>RID-specific assets, lock file <c>runtimeTargets</c> section.</summary>
+    public IList<string> RuntimeTargets { get; }
+
+    /// <summary>Satellite resource assemblies, lock file <c>resource</c> section.</summary>
+    public IList<string> ResourceAssemblies { get; }
+
+    /// <summary>Roslyn analyzer assemblies, derived from the package file list (analyzers/**.dll).</summary>
+    public IList<string> AnalyzerAssemblies { get; }
+
+    /// <summary>Package ships install.ps1/uninstall.ps1/init.ps1 (not executed under PackageReference).</summary>
+    public bool HasInstallScripts { get; }
+
+    /// <summary>Package ships XDT/.transform config transforms (not applied under PackageReference).</summary>
+    public bool HasXdtTransforms { get; }
+
+    /// <summary>Package ships a legacy content/ folder (ignored under PackageReference).</summary>
+    public bool HasLegacyContentFolder { get; }
+
+    public ResolvedPackage(
+        string name,
+        string resolvedVersion,
+        IList<ResolvedPackage>? dependencies = null,
+        int depth = 0,
+        string type = "package",
+        IList<string>? compileAssemblies = null,
+        IList<string>? runtimeAssemblies = null,
+        IList<string>? frameworkAssemblies = null,
+        IList<string>? buildFiles = null,
+        IList<string>? buildMultiTargetingFiles = null,
+        IList<string>? contentFiles = null,
+        IList<string>? runtimeTargets = null,
+        IList<string>? resourceAssemblies = null,
+        IList<string>? analyzerAssemblies = null,
+        bool hasInstallScripts = false,
+        bool hasXdtTransforms = false,
+        bool hasLegacyContentFolder = false)
     {
         Name = name;
         ResolvedVersion = resolvedVersion;
         Dependencies = dependencies ?? [];
         Depth = depth;
+        Type = type;
+        CompileAssemblies = compileAssemblies ?? [];
+        RuntimeAssemblies = runtimeAssemblies ?? [];
+        FrameworkAssemblies = frameworkAssemblies ?? [];
+        BuildFiles = buildFiles ?? [];
+        BuildMultiTargetingFiles = buildMultiTargetingFiles ?? [];
+        ContentFiles = contentFiles ?? [];
+        RuntimeTargets = runtimeTargets ?? [];
+        ResourceAssemblies = resourceAssemblies ?? [];
+        AnalyzerAssemblies = analyzerAssemblies ?? [];
+        HasInstallScripts = hasInstallScripts;
+        HasXdtTransforms = hasXdtTransforms;
+        HasLegacyContentFolder = hasLegacyContentFolder;
     }
 
     public ResolvedPackage WithName(string name) =>
-        name == Name ? this : new(name, ResolvedVersion, Dependencies, Depth);
+        name == Name ? this : Copy(name: name);
 
     public ResolvedPackage WithResolvedVersion(string resolvedVersion) =>
-        resolvedVersion == ResolvedVersion ? this : new(Name, resolvedVersion, Dependencies, Depth);
+        resolvedVersion == ResolvedVersion ? this : Copy(resolvedVersion: resolvedVersion);
 
     public ResolvedPackage WithDependencies(IList<ResolvedPackage> dependencies) =>
-        ReferenceEquals(dependencies, Dependencies) ? this : new(Name, ResolvedVersion, dependencies, Depth);
+        ReferenceEquals(dependencies, Dependencies) ? this : Copy(dependencies: dependencies);
 
     public ResolvedPackage WithDepth(int depth) =>
-        depth == Depth ? this : new(Name, ResolvedVersion, Dependencies, depth);
+        depth == Depth ? this : Copy(depth: depth);
+
+    private ResolvedPackage Copy(
+        string? name = null,
+        string? resolvedVersion = null,
+        IList<ResolvedPackage>? dependencies = null,
+        int? depth = null) =>
+        new(name ?? Name, resolvedVersion ?? ResolvedVersion, dependencies ?? Dependencies,
+            depth ?? Depth, Type, CompileAssemblies, RuntimeAssemblies, FrameworkAssemblies,
+            BuildFiles, BuildMultiTargetingFiles, ContentFiles, RuntimeTargets, ResourceAssemblies,
+            AnalyzerAssemblies, HasInstallScripts, HasXdtTransforms, HasLegacyContentFolder);
 
     public void RpcSend(ResolvedPackage after, RpcSendQueue q)
     {
@@ -240,16 +325,55 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
             dep => (object)(dep.Name + "@" + dep.ResolvedVersion),
             dep => dep.RpcSend(dep, q));
         q.GetAndSend(after, rp => rp.Depth);
+        q.GetAndSend(after, rp => rp.Type);
+        SendStringList(q, after, rp => rp.CompileAssemblies);
+        SendStringList(q, after, rp => rp.RuntimeAssemblies);
+        SendStringList(q, after, rp => rp.FrameworkAssemblies);
+        SendStringList(q, after, rp => rp.BuildFiles);
+        SendStringList(q, after, rp => rp.BuildMultiTargetingFiles);
+        SendStringList(q, after, rp => rp.ContentFiles);
+        SendStringList(q, after, rp => rp.RuntimeTargets);
+        SendStringList(q, after, rp => rp.ResourceAssemblies);
+        SendStringList(q, after, rp => rp.AnalyzerAssemblies);
+        q.GetAndSend(after, rp => rp.HasInstallScripts);
+        q.GetAndSend(after, rp => rp.HasXdtTransforms);
+        q.GetAndSend(after, rp => rp.HasLegacyContentFolder);
+    }
+
+    private static void SendStringList(RpcSendQueue q, ResolvedPackage after,
+        Func<ResolvedPackage, IList<string>> selector)
+    {
+        q.GetAndSendList(after, selector, s => s, s => q.GetAndSend(s, x => x));
     }
 
     public ResolvedPackage RpcReceive(ResolvedPackage before, RpcReceiveQueue q)
     {
-        return before
-            .WithName(q.Receive(before.Name)!)
-            .WithResolvedVersion(q.Receive(before.ResolvedVersion)!)
-            .WithDependencies(q.ReceiveList(before.Dependencies,
-                dep => dep.RpcReceive(dep, q))!)
-            .WithDepth(q.ReceiveAndGet<int, int>(before.Depth, x => x));
+        var name = q.Receive(before.Name)!;
+        var resolvedVersion = q.Receive(before.ResolvedVersion)!;
+        var dependencies = q.ReceiveList(before.Dependencies, dep => dep.RpcReceive(dep, q))!;
+        var depth = q.ReceiveAndGet<int, int>(before.Depth, x => x);
+        var type = q.Receive(before.Type)!;
+        var compile = ReceiveStringList(q, before.CompileAssemblies);
+        var runtime = ReceiveStringList(q, before.RuntimeAssemblies);
+        var frameworkAssemblies = ReceiveStringList(q, before.FrameworkAssemblies);
+        var buildFiles = ReceiveStringList(q, before.BuildFiles);
+        var buildMultiTargeting = ReceiveStringList(q, before.BuildMultiTargetingFiles);
+        var contentFiles = ReceiveStringList(q, before.ContentFiles);
+        var runtimeTargets = ReceiveStringList(q, before.RuntimeTargets);
+        var resourceAssemblies = ReceiveStringList(q, before.ResourceAssemblies);
+        var analyzerAssemblies = ReceiveStringList(q, before.AnalyzerAssemblies);
+        var hasInstallScripts = q.ReceiveAndGet<bool, bool>(before.HasInstallScripts, x => x);
+        var hasXdtTransforms = q.ReceiveAndGet<bool, bool>(before.HasXdtTransforms, x => x);
+        var hasLegacyContentFolder = q.ReceiveAndGet<bool, bool>(before.HasLegacyContentFolder, x => x);
+        return new ResolvedPackage(name, resolvedVersion, dependencies, depth, type,
+            compile, runtime, frameworkAssemblies, buildFiles, buildMultiTargeting, contentFiles,
+            runtimeTargets, resourceAssemblies, analyzerAssemblies,
+            hasInstallScripts, hasXdtTransforms, hasLegacyContentFolder);
+    }
+
+    private static IList<string> ReceiveStringList(RpcReceiveQueue q, IList<string> before)
+    {
+        return q.ReceiveList(before, s => q.ReceiveAndGet<string, string>(s, x => x)!)!;
     }
 }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-using System.Diagnostics;
-using System.Text.Json;
 using System.Xml.Linq;
+using NuGet.ProjectModel;
+using OpenRewrite.CSharp.NuGet;
 using OpenRewrite.Xml;
 using Serilog;
 using ExecutionContext = OpenRewrite.Core.ExecutionContext;
@@ -27,21 +27,21 @@ namespace OpenRewrite.CSharp;
 ///     Creates and regenerates MSBuildProject markers.
 ///     Only the Sdk attribute is read from the csproj XML itself; all other
 ///     metadata (target frameworks, package references, resolved packages,
-///     project references) comes from project.assets.json produced by dotnet restore.
+///     project references) comes from the in-memory NuGet <see cref="LockFile" />
+///     produced by <see cref="NuGetResolver" /> (in-process PackageSpec/RestoreRunner
+///     restore — no <c>dotnet restore</c> child process, no <c>project.assets.json</c> read).
+///     Legacy <c>packages.config</c> projects get the same full attestation via a
+///     PackageSpec synthesized from their packages.config entries.
 ///     After a recipe modifies a .csproj file, this helper regenerates the
-///     marker by running `dotnet restore` and re-reading project.assets.json.
-///     Uses <see cref="DotNetBuildContext" /> to materialize the full repository
-///     build context (other .csproj files, Directory.Build.props/.targets,
-///     nuget.config, etc.) before running restore, so that project references
-///     and MSBuild imports resolve correctly.
+///     marker by re-running the in-process restore against the materialized
+///     <see cref="DotNetBuildContext" /> (other .csproj files,
+///     Directory.Build.props/.targets, nuget.config, packages.config, etc.).
 /// </summary>
 public static class MSBuildProjectHelper
 {
-    private static readonly TimeSpan RestoreTimeout = TimeSpan.FromMinutes(5);
-
     // Keyed off ExecutionContext: the set of .csproj source paths that have been
     // structurally modified during this run and whose MSBuildProject marker is
-    // therefore stale until the next dotnet restore. Mutating visitors add to
+    // therefore stale until the next restore. Mutating visitors add to
     // this set; RegenerateMarkerVisitor consumes from it so files no one touched
     // skip the (expensive) restore.
     private const string StaleAttestationsKey = "OpenRewrite.CSharp.StaleCsprojAttestations";
@@ -96,84 +96,240 @@ public static class MSBuildProjectHelper
 
     /// <summary>
     ///     Creates an MSBuildProject marker. Only the Sdk attribute is read from the XML document.
-    ///     All dependency and framework metadata comes from project.assets.json.
+    ///     All dependency and framework metadata comes from an in-process NuGet restore of the
+    ///     project on disk under <paramref name="rootDir"/> (PackageReference projects via
+    ///     restore-graph generation; packages.config projects via a synthesized PackageSpec).
     /// </summary>
     /// <param name="doc">The parsed XML document (only Sdk attribute is read).</param>
-    /// <param name="rootDir">Root directory for resolving project.assets.json and nuget.config.</param>
+    /// <param name="rootDir">Root directory the document's SourcePath is relative to.</param>
     public static MSBuildProject? CreateMarker(Document doc, string? rootDir = null)
     {
-        var root = doc.Root;
-        var sdk = root.GetAttributeValue("Sdk");
+        var sdk = doc.Root.GetAttributeValue("Sdk");
 
         if (rootDir == null)
             return new MSBuildProject(Guid.NewGuid(), sdk);
 
-        var projectDir = Path.GetDirectoryName(Path.Combine(rootDir, doc.SourcePath));
-        if (projectDir == null)
-            return new MSBuildProject(Guid.NewGuid(), sdk);
-
-        var assetsPath = Path.Combine(projectDir, "obj", "project.assets.json");
-        if (!File.Exists(assetsPath))
+        var projectPath = Path.GetFullPath(Path.Combine(rootDir, doc.SourcePath));
+        if (!File.Exists(projectPath))
             return new MSBuildProject(Guid.NewGuid(), sdk);
 
         try
         {
-            return CreateFromAssetsJson(sdk, assetsPath, projectDir);
+            var lockFile = NuGetResolver
+                .ResolveProjectLockFileAsync(projectPath, null, CancellationToken.None)
+                .GetAwaiter().GetResult();
+            if (lockFile == null)
+                return new MSBuildProject(Guid.NewGuid(), sdk);
+
+            var projectDir = Path.GetDirectoryName(projectPath)!;
+            return CreateFromLockFile(sdk, lockFile, projectDir,
+                includeDeclaredPackageReferences: !HasPackagesConfigSibling(projectDir));
         }
         catch (Exception ex)
         {
-            Log.Debug("Failed to read project.assets.json at {Path}: {Error}", assetsPath, ex.Message);
+            Log.Debug("Failed to resolve lock file for {Path}: {Error}", projectPath, ex.Message);
             return new MSBuildProject(Guid.NewGuid(), sdk);
         }
     }
 
-    private static MSBuildProject CreateFromAssetsJson(string? sdk, string assetsPath, string projectDir)
+    /// <summary>
+    ///     Creates an MSBuildProject marker from a pre-resolved <see cref="LockFile"/>
+    ///     (e.g. the one produced during solution restore), avoiding a second restore.
+    /// </summary>
+    public static MSBuildProject CreateMarker(Document doc, LockFile lockFile, string projectDir)
     {
-        var json = File.ReadAllText(assetsPath);
-        using var doc = JsonDocument.Parse(json);
-        var root = doc.RootElement;
+        var sdk = doc.Root.GetAttributeValue("Sdk");
+        return CreateFromLockFile(sdk, lockFile, projectDir,
+            includeDeclaredPackageReferences: !HasPackagesConfigSibling(projectDir));
+    }
 
-        // Read declared dependencies per TFM from project.frameworks
-        var declaredDeps = ReadDeclaredDependencies(root);
+    /// <summary>
+    ///     True when the project directory contains a packages.config. Such projects declare
+    ///     dependencies in packages.config, not as csproj <c>&lt;PackageReference&gt;</c> items —
+    ///     the marker's PackageReferences list must stay 1:1 with actual csproj items (recipes
+    ///     use it for idempotency checks), so it is left empty and the direct dependencies are
+    ///     represented as depth-0 entries in the resolved graph instead.
+    /// </summary>
+    private static bool HasPackagesConfigSibling(string projectDir)
+    {
+        try
+        {
+            return File.Exists(Path.Combine(projectDir, "packages.config"));
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
-        // Read resolved packages from targets
-        var resolvedByTfm = ReadResolvedPackages(root);
+    /// <summary>
+    ///     Builds the marker from the in-memory NuGet lock file: declared package references
+    ///     (from the restore's PackageSpec), the fully-linked resolved package graph with
+    ///     per-package asset information, and project references.
+    /// </summary>
+    public static MSBuildProject CreateFromLockFile(string? sdk, LockFile lockFile, string projectDir,
+        bool includeDeclaredPackageReferences = true)
+    {
+        var spec = lockFile.PackageSpec;
 
-        // Read project references from libraries (type=project)
-        var projectRefs = ReadProjectReferences(root, projectDir);
-
-        // Build per-TFM metadata
-        var tfmList = new List<TargetFramework>();
-        // Use targets keys as the authoritative list of TFMs
-        if (root.TryGetProperty("targets", out var targets))
-            foreach (var target in targets.EnumerateObject())
+        // Declared dependencies per TFM alias (framework-specific + project-level)
+        var declaredByTfm = new Dictionary<string, List<PackageReference>>(StringComparer.OrdinalIgnoreCase);
+        if (spec != null)
+        {
+            foreach (var tfi in spec.TargetFrameworks)
             {
-                var tfm = NormalizeTfm(target.Name);
-                declaredDeps.TryGetValue(tfm, out var pkgRefs);
-                resolvedByTfm.TryGetValue(tfm, out var resolved);
+                var tfm = ShortTfm(tfi.FrameworkName, tfi.TargetAlias);
+                var refs = new List<PackageReference>();
+                foreach (var dep in tfi.Dependencies)
+                    refs.Add(new PackageReference(dep.Name, dep.LibraryRange?.VersionRange?.MinVersion?.ToNormalizedString()));
+                declaredByTfm[tfm] = refs;
+            }
+        }
 
-                // Cross-reference declared package refs with resolved versions
-                if (pkgRefs != null && resolved != null)
+        // Per-package file lists (analyzers, scripts, transforms, legacy content)
+        var libraryFiles = new Dictionary<string, IList<string>>(StringComparer.OrdinalIgnoreCase);
+        var projectLibraries = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        foreach (var library in lockFile.Libraries)
+        {
+            var key = library.Name + "/" + library.Version;
+            if (string.Equals(library.Type, "project", StringComparison.OrdinalIgnoreCase))
+                projectLibraries[key] = library.MSBuildProject;
+            else if (library.Files != null)
+                libraryFiles[key] = library.Files;
+        }
+
+        var projectRefs = new List<ProjectReference>();
+        foreach (var msbuildProject in projectLibraries.Values)
+        {
+            if (msbuildProject == null)
+                continue;
+            try
+            {
+                var absolutePath = Path.GetFullPath(Path.Combine(projectDir, msbuildProject));
+                projectRefs.Add(new ProjectReference(Path.GetRelativePath(projectDir, absolutePath)));
+            }
+            catch
+            {
+                projectRefs.Add(new ProjectReference(msbuildProject));
+            }
+        }
+
+        var tfmList = new List<TargetFramework>();
+        foreach (var target in lockFile.Targets)
+        {
+            // RID-specific targets duplicate the RID-less graph; the marker captures the
+            // RID-agnostic view.
+            if (!string.IsNullOrEmpty(target.RuntimeIdentifier))
+                continue;
+
+            var tfm = ShortTfm(target.TargetFramework, null);
+            declaredByTfm.TryGetValue(tfm, out var declared);
+            declared ??= declaredByTfm.Values.FirstOrDefault() ?? new List<PackageReference>();
+
+            // First pass: create one node per resolved library with its asset data.
+            var nodes = new Dictionary<string, ResolvedPackage>(StringComparer.OrdinalIgnoreCase);
+            var dependencyNames = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+            foreach (var library in target.Libraries)
+            {
+                if (library.Name == null || library.Version == null)
+                    continue;
+                var isProject = string.Equals(library.Type, "project", StringComparison.OrdinalIgnoreCase);
+                var fileKey = library.Name + "/" + library.Version;
+                libraryFiles.TryGetValue(fileKey, out var files);
+
+                var analyzers = new List<string>();
+                var hasInstallScripts = false;
+                var hasXdt = false;
+                var hasLegacyContent = false;
+                if (files != null)
                 {
-                    var resolvedLookup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-                    foreach (var rp in resolved)
-                        resolvedLookup[rp.Name] = rp.ResolvedVersion;
-
-                    pkgRefs = pkgRefs.Select(pr =>
+                    foreach (var file in files)
                     {
-                        resolvedLookup.TryGetValue(pr.Include, out var resolvedVersion);
-                        return pr.WithResolvedVersion(resolvedVersion);
-                    }).ToList();
+                        var normalized = file.Replace('\\', '/');
+                        if (normalized.StartsWith("analyzers/", StringComparison.OrdinalIgnoreCase) &&
+                            normalized.EndsWith(".dll", StringComparison.OrdinalIgnoreCase))
+                            analyzers.Add(normalized);
+                        else if (normalized.StartsWith("tools/", StringComparison.OrdinalIgnoreCase) &&
+                                 (normalized.EndsWith("install.ps1", StringComparison.OrdinalIgnoreCase) ||
+                                  normalized.EndsWith("init.ps1", StringComparison.OrdinalIgnoreCase)))
+                            hasInstallScripts = true;
+                        else if (normalized.EndsWith(".xdt", StringComparison.OrdinalIgnoreCase) ||
+                                 normalized.EndsWith(".transform", StringComparison.OrdinalIgnoreCase))
+                            hasXdt = true;
+                        else if (normalized.StartsWith("content/", StringComparison.OrdinalIgnoreCase))
+                            hasLegacyContent = true;
+                    }
                 }
 
-                tfmList.Add(new TargetFramework(
-                    tfm,
-                    pkgRefs ?? [],
-                    resolved ?? [],
-                    projectRefs));
+                var node = new ResolvedPackage(
+                    library.Name,
+                    library.Version.ToNormalizedString(),
+                    dependencies: new List<ResolvedPackage>(),
+                    depth: int.MaxValue,
+                    type: isProject ? "project" : "package",
+                    compileAssemblies: RealItems(library.CompileTimeAssemblies?.Select(i => i.Path)),
+                    runtimeAssemblies: RealItems(library.RuntimeAssemblies?.Select(i => i.Path)),
+                    frameworkAssemblies: library.FrameworkAssemblies?.ToList() ?? [],
+                    buildFiles: RealItems(library.Build?.Select(i => i.Path)),
+                    buildMultiTargetingFiles: RealItems(library.BuildMultiTargeting?.Select(i => i.Path)),
+                    contentFiles: RealItems(library.ContentFiles?.Select(i => i.Path)),
+                    runtimeTargets: RealItems(library.RuntimeTargets?.Select(i => i.Path)),
+                    resourceAssemblies: RealItems(library.ResourceAssemblies?.Select(i => i.Path)),
+                    analyzerAssemblies: analyzers,
+                    hasInstallScripts: hasInstallScripts,
+                    hasXdtTransforms: hasXdt,
+                    hasLegacyContentFolder: hasLegacyContent);
+                nodes[library.Name] = node;
+                dependencyNames[library.Name] =
+                    library.Dependencies?.Select(d => d.Id).ToList() ?? new List<string>();
             }
 
-        // Read package sources from nuget.config files walking up the directory tree
+            // Second pass: link dependency edges to the actual resolved nodes (shared instances)
+            // and compute depth as the shortest distance from a directly-declared dependency
+            // (direct = 0). Nodes unreachable from declared roots (e.g. the roots themselves in
+            // pathological graphs) keep the maximum observed depth.
+            foreach (var (name, deps) in dependencyNames)
+            {
+                var list = (List<ResolvedPackage>)nodes[name].Dependencies;
+                foreach (var depName in deps)
+                {
+                    if (nodes.TryGetValue(depName, out var depNode))
+                        list.Add(depNode);
+                }
+            }
+
+            var depths = ComputeDepths(declared.Select(d => d.Include), nodes, dependencyNames);
+            var resolved = new List<ResolvedPackage>();
+            foreach (var (name, node) in nodes)
+                resolved.Add(node.WithDepth(depths.TryGetValue(name, out var d) ? d : 0));
+            // Re-link after WithDepth created copies: rebuild edges against the final instances.
+            var finalNodes = resolved.ToDictionary(n => n.Name, n => n, StringComparer.OrdinalIgnoreCase);
+            foreach (var node in resolved)
+            {
+                var list = (List<ResolvedPackage>)node.Dependencies;
+                for (var i = 0; i < list.Count; i++)
+                {
+                    if (finalNodes.TryGetValue(list[i].Name, out var final))
+                        list[i] = final;
+                }
+            }
+
+            // Cross-reference declared refs with resolved versions. For packages.config
+            // projects the declared entries come from packages.config, not csproj
+            // <PackageReference> items — they stay out of PackageReferences (kept 1:1 with
+            // csproj items) and are represented as depth-0 nodes in the resolved graph.
+            var resolvedLookup = finalNodes;
+            var packageRefs = includeDeclaredPackageReferences
+                ? declared
+                    .Select(pr => resolvedLookup.TryGetValue(pr.Include, out var node)
+                        ? pr.WithResolvedVersion(node.ResolvedVersion)
+                        : pr)
+                    .ToList()
+                : new List<PackageReference>();
+
+            tfmList.Add(new TargetFramework(tfm, packageRefs, resolved, projectRefs));
+        }
+
         var packageSources = ReadPackageSourcesFromTree(projectDir);
 
         return new MSBuildProject(
@@ -184,157 +340,62 @@ public static class MSBuildProjectHelper
             tfmList);
     }
 
-    private static Dictionary<string, IList<PackageReference>> ReadDeclaredDependencies(JsonElement root)
+    /// <summary>Strips the special <c>_._</c> placeholder entries from an asset list.</summary>
+    private static IList<string> RealItems(IEnumerable<string?>? paths)
     {
-        var result = new Dictionary<string, IList<PackageReference>>();
-
-        if (!root.TryGetProperty("project", out var project) ||
-            !project.TryGetProperty("frameworks", out var frameworks))
-            return result;
-
-        foreach (var fw in frameworks.EnumerateObject())
-        {
-            var tfm = fw.Name;
-            var pkgRefs = new List<PackageReference>();
-
-            if (fw.Value.TryGetProperty("dependencies", out var deps))
-                foreach (var dep in deps.EnumerateObject())
-                {
-                    // Skip project references — they have "target": "Project"
-                    if (dep.Value.TryGetProperty("target", out var targetProp) &&
-                        targetProp.GetString() == "Project")
-                        continue;
-
-                    string? requestedVersion = null;
-                    if (dep.Value.TryGetProperty("version", out var versionProp)) requestedVersion = ParseVersionRange(versionProp.GetString());
-
-                    pkgRefs.Add(new PackageReference(dep.Name, requestedVersion));
-                }
-
-            result[tfm] = pkgRefs;
-        }
-
-        return result;
+        if (paths == null)
+            return [];
+        return paths
+            .Where(p => p != null && !Path.GetFileName(p).Equals("_._", StringComparison.Ordinal))
+            .Select(p => p!.Replace('\\', '/'))
+            .ToList();
     }
 
     /// <summary>
-    ///     Parses NuGet version range notation to extract the minimum version.
-    ///     "[4.13.1, )" → "4.13.1", "[1.0.0]" → "1.0.0"
+    /// BFS from the directly-declared dependencies (depth 0) across the dependency edges.
     /// </summary>
-    private static string? ParseVersionRange(string? versionRange)
+    private static Dictionary<string, int> ComputeDepths(
+        IEnumerable<string> roots,
+        Dictionary<string, ResolvedPackage> nodes,
+        Dictionary<string, List<string>> edges)
     {
-        if (string.IsNullOrEmpty(versionRange))
-            return null;
-
-        var trimmed = versionRange.TrimStart('[', '(');
-        var commaIdx = trimmed.IndexOf(',');
-        if (commaIdx >= 0)
-            trimmed = trimmed[..commaIdx];
-        trimmed = trimmed.TrimEnd(']', ')').Trim();
-        return trimmed.Length > 0 ? trimmed : null;
-    }
-
-    private static Dictionary<string, IList<ResolvedPackage>> ReadResolvedPackages(JsonElement root)
-    {
-        var result = new Dictionary<string, IList<ResolvedPackage>>();
-
-        if (!root.TryGetProperty("targets", out var targets))
-            return result;
-
-        // Build a set of project-type libraries to exclude from resolved packages
-        var projectLibraries = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        if (root.TryGetProperty("libraries", out var libraries))
-            foreach (var lib in libraries.EnumerateObject())
-                if (lib.Value.TryGetProperty("type", out var typeProp) &&
-                    typeProp.GetString() == "project")
-                    projectLibraries.Add(lib.Name);
-
-        foreach (var target in targets.EnumerateObject())
+        var depths = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+        var queue = new Queue<(string Name, int Depth)>();
+        foreach (var root in roots)
         {
-            var normalizedTfm = NormalizeTfm(target.Name);
-            var packages = new List<ResolvedPackage>();
-
-            foreach (var pkg in target.Value.EnumerateObject())
-            {
-                // Skip project references in the targets list
-                if (projectLibraries.Contains(pkg.Name))
-                    continue;
-
-                var parts = pkg.Name.Split('/');
-                if (parts.Length == 2)
-                {
-                    var deps = new List<ResolvedPackage>();
-                    if (pkg.Value.TryGetProperty("dependencies", out var depsElement))
-                        foreach (var dep in depsElement.EnumerateObject())
-                            deps.Add(new ResolvedPackage(dep.Name, dep.Value.GetString() ?? ""));
-
-                    packages.Add(new ResolvedPackage(parts[0], parts[1], deps));
-                }
-            }
-
-            result[normalizedTfm] = packages;
+            if (nodes.ContainsKey(root) && depths.TryAdd(root, 0))
+                queue.Enqueue((root, 0));
         }
 
-        return result;
-    }
-
-    private static List<ProjectReference> ReadProjectReferences(JsonElement root, string projectDir)
-    {
-        var projectRefs = new List<ProjectReference>();
-
-        if (!root.TryGetProperty("libraries", out var libraries))
-            return projectRefs;
-
-        foreach (var lib in libraries.EnumerateObject())
+        while (queue.Count > 0)
         {
-            if (!lib.Value.TryGetProperty("type", out var typeProp) ||
-                typeProp.GetString() != "project")
+            var (name, depth) = queue.Dequeue();
+            if (!edges.TryGetValue(name, out var deps))
                 continue;
-
-            // msbuildProject contains the relative path from the assets.json location
-            if (lib.Value.TryGetProperty("msbuildProject", out var msbuildProjectProp))
+            foreach (var dep in deps)
             {
-                var relativePath = msbuildProjectProp.GetString();
-                if (relativePath != null)
-                {
-                    // msbuildProject path is relative to the project directory
-                    // Normalize it to a clean relative path
-                    var absolutePath = Path.GetFullPath(Path.Combine(projectDir, relativePath));
-                    var normalizedRelative = Path.GetRelativePath(projectDir, absolutePath);
-                    projectRefs.Add(new ProjectReference(normalizedRelative));
-                }
+                if (nodes.ContainsKey(dep) && depths.TryAdd(dep, depth + 1))
+                    queue.Enqueue((dep, depth + 1));
             }
         }
 
-        return projectRefs;
+        return depths;
     }
 
-    private static string NormalizeTfm(string tfm)
+    private static string ShortTfm(global::NuGet.Frameworks.NuGetFramework? framework, string? alias)
     {
-        if (tfm.StartsWith(".NETCoreApp,Version=v"))
+        if (!string.IsNullOrEmpty(alias))
+            return alias;
+        if (framework == null)
+            return "";
+        try
         {
-            var version = tfm[".NETCoreApp,Version=v".Length..];
-            // .NET Core 1.x/2.x/3.x ship as "netcoreappN.M" in project.frameworks;
-            // .NET 5+ unified to "netN.M". Match the short-form on each side so
-            // declared deps cross-reference the resolved target correctly.
-            if (version.Length > 0 && (version[0] is '1' or '2' or '3'))
-                return "netcoreapp" + version;
-            return "net" + version;
+            return framework.GetShortFolderName();
         }
-
-        if (tfm.StartsWith(".NETStandard,Version=v"))
+        catch
         {
-            var version = tfm[".NETStandard,Version=v".Length..];
-            return "netstandard" + version;
+            return framework.ToString();
         }
-
-        if (tfm.StartsWith(".NETFramework,Version=v"))
-        {
-            var version = tfm[".NETFramework,Version=v".Length..].Replace(".", "");
-            return "net" + version;
-        }
-
-        return tfm;
     }
 
     /// <summary>
@@ -436,10 +497,9 @@ public static class MSBuildProjectHelper
     ///     Regenerates the MSBuildProject marker on a .csproj document after mutation.
     ///     1. Writes all captured build files from DotNetBuildContext to a temp directory
     ///     2. Writes the modified .csproj (overwriting the scanned version if present)
-    ///     3. Runs `dotnet restore` to resolve dependencies
-    ///     4. Reads back project.assets.json
-    ///     5. Rebuilds the MSBuildProject marker from updated XML + fresh assets
-    ///     6. Replaces the old marker on the document
+    ///     3. Runs the in-process NuGet restore to resolve dependencies
+    ///     4. Rebuilds the MSBuildProject marker from updated XML + the in-memory LockFile
+    ///     5. Replaces the old marker on the document
     /// </summary>
     public static Document RegenerateAndRefreshMarker(Document updated, ExecutionContext ctx)
     {
@@ -467,16 +527,7 @@ public static class MSBuildProjectHelper
                 Directory.CreateDirectory(csprojDir);
             File.WriteAllText(csprojPath, content);
 
-            // Run dotnet restore
-            var restoreResult = RunDotnetRestore(csprojPath);
-            if (!restoreResult.Success)
-            {
-                Log.Debug("MSBuildProjectHelper: dotnet restore failed for {Path}: {Error}",
-                    updated.SourcePath, restoreResult.Error);
-                return RefreshMarkerFromXmlOnly(updated, existingMarker);
-            }
-
-            // Rebuild marker from XML + project.assets.json
+            // In-process restore + marker rebuild from the in-memory lock file
             var newMarker = CreateMarker(updated, tempDir);
             if (newMarker != null)
             {
@@ -524,7 +575,7 @@ public static class MSBuildProjectHelper
             if (document.Markers.FindFirst<MSBuildProject>() == null)
                 return document;
             // Gate on the stale flag so files no mutating recipe touched don't
-            // trigger dotnet restore. Consuming clears the flag so a second
+            // trigger a restore. Consuming clears the flag so a second
             // reattestation pass (e.g., immediate + trailing
             // EnsureCsprojAttestation) doesn't run restore twice.
             if (!TryConsumeStaleAttestation(ctx, document.SourcePath))
@@ -546,140 +597,75 @@ public static class MSBuildProjectHelper
         return updated;
     }
 
-    private record RestoreResult(bool Success, string? Error);
-
-    private static RestoreResult RunDotnetRestore(string csprojPath)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("dotnet")
-            {
-                WorkingDirectory = Path.GetDirectoryName(csprojPath) ?? ".",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            psi.ArgumentList.Add("restore");
-            psi.ArgumentList.Add(csprojPath);
-            psi.ArgumentList.Add("/p:NuGetAudit=false");
-            psi.ArgumentList.Add("/p:RestoreIgnoreFailedSources=true");
-            psi.ArgumentList.Add("--ignore-failed-sources");
-            psi.Environment["NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT"] = "1";
-            psi.Environment["NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS"] = "100";
-
-            using var process = Process.Start(psi);
-            if (process == null)
-                return new RestoreResult(false, "Failed to start dotnet restore");
-
-            var stderrTask = process.StandardError.ReadToEndAsync();
-            var stdout = process.StandardOutput.ReadToEnd();
-            var stderr = stderrTask.GetAwaiter().GetResult();
-            process.WaitForExit((int)RestoreTimeout.TotalMilliseconds);
-
-            if (!process.HasExited)
-            {
-                try
-                {
-                    process.Kill(true);
-                }
-                catch
-                {
-                }
-
-                return new RestoreResult(false, "dotnet restore timed out");
-            }
-
-            return process.ExitCode == 0
-                ? new RestoreResult(true, null)
-                : new RestoreResult(false, $"Exit code {process.ExitCode}: {stderr}");
-        }
-        catch (Exception ex)
-        {
-            return new RestoreResult(false, ex.Message);
-        }
-    }
-
     #endregion
 
     #region Direct version resolution
 
     /// <summary>
-    ///     Returns the resolved concrete version of a direct package dependency from
-    ///     <c>obj/project.assets.json</c>. Used by callers (such as the InstallRecipes
-    ///     RPC handler) that need the concrete SemVer that NuGet selected after a
-    ///     restore, rather than the version constraint authored in the csproj —
+    ///     Returns the resolved concrete version of a direct package dependency by running the
+    ///     in-process restore for the project in <paramref name="projectDir"/>. Used by callers
+    ///     (such as the InstallRecipes RPC handler) that need the concrete SemVer that NuGet
+    ///     selected, rather than the version constraint authored in the csproj —
     ///     <c>dotnet add package &lt;pkg&gt; --version *</c> preserves the wildcard
-    ///     verbatim in the csproj, so the resolved version must be read from the
-    ///     NuGet restore output.
+    ///     verbatim in the csproj, so the resolved version must come from restore output.
     /// </summary>
     /// <exception cref="InvalidOperationException">
-    ///     Thrown when <c>obj/project.assets.json</c> is missing (restore did not
-    ///     complete), when the package is not a direct dependency under any TFM, or
-    ///     when no matching resolved entry exists in the assets file's libraries.
+    ///     Thrown when the restore produced no lock file, when the package is not a direct
+    ///     dependency under any TFM, or when no matching resolved entry exists.
     /// </exception>
     public static string GetResolvedPackageVersion(string projectDir, string packageName)
     {
-        var assetsPath = Path.Combine(projectDir, "obj", "project.assets.json");
-        if (!File.Exists(assetsPath))
+        var projectPath = Directory.EnumerateFiles(projectDir, "*.csproj").FirstOrDefault()
+                          ?? throw new InvalidOperationException($"No .csproj found in {projectDir}");
+
+        var lockFile = NuGetResolver
+            .ResolveProjectLockFileAsync(projectPath, null, CancellationToken.None)
+            .GetAwaiter().GetResult();
+        if (lockFile == null)
         {
             throw new InvalidOperationException(
-                $"project.assets.json not found at {assetsPath}; restore did not complete");
+                $"Restore produced no lock file for {projectPath}; restore did not complete");
         }
 
-        using var doc = JsonDocument.Parse(File.ReadAllText(assetsPath));
-        var root = doc.RootElement;
+        return GetResolvedPackageVersion(lockFile, packageName, projectPath);
+    }
 
-        if (!IsDirectDependency(root, packageName))
+    /// <summary>
+    ///     Lock-file-level lookup behind <see cref="GetResolvedPackageVersion(string,string)"/>,
+    ///     usable directly when the restore result is already in hand.
+    /// </summary>
+    public static string GetResolvedPackageVersion(LockFile lockFile, string packageName,
+        string projectDescription = "project")
+    {
+        if (!IsDirectDependency(lockFile, packageName))
         {
             throw new InvalidOperationException(
-                $"{packageName} is not a direct dependency in {assetsPath}");
+                $"{packageName} is not a direct dependency of {projectDescription}");
         }
 
-        // Read from targets — NuGet's per-TFM resolution map — rather than libraries,
-        // which is a flat package graph including PackageDownload assets that don't
-        // resolve to a single version. Matches what ReadResolvedPackages does above.
-        if (root.TryGetProperty("targets", out var targets))
+        foreach (var target in lockFile.Targets)
+        foreach (var library in target.Libraries)
         {
-            foreach (var tfm in targets.EnumerateObject())
-            foreach (var entry in tfm.Value.EnumerateObject())
+            if (string.Equals(library.Type, "package", StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(library.Name, packageName, StringComparison.OrdinalIgnoreCase) &&
+                library.Version != null)
             {
-                if (!entry.Value.TryGetProperty("type", out var typeProp) ||
-                    typeProp.GetString() != "package")
-                    continue;
-
-                var slash = entry.Name.IndexOf('/');
-                if (slash > 0 &&
-                    string.Equals(entry.Name[..slash], packageName, StringComparison.OrdinalIgnoreCase))
-                {
-                    var version = entry.Name[(slash + 1)..];
-                    if (!string.IsNullOrEmpty(version))
-                        return version;
-                }
+                return library.Version.ToNormalizedString();
             }
         }
 
         throw new InvalidOperationException(
-            $"Could not find resolved version for {packageName} in {assetsPath}");
+            $"Could not find resolved version for {packageName} in restore result of {projectDescription}");
     }
 
-    private static bool IsDirectDependency(JsonElement root, string packageName)
+    private static bool IsDirectDependency(LockFile lockFile, string packageName)
     {
-        if (!root.TryGetProperty("project", out var project) ||
-            !project.TryGetProperty("frameworks", out var frameworks))
+        var spec = lockFile.PackageSpec;
+        if (spec == null)
             return false;
 
-        foreach (var fw in frameworks.EnumerateObject())
-        {
-            if (!fw.Value.TryGetProperty("dependencies", out var deps))
-                continue;
-
-            foreach (var dep in deps.EnumerateObject())
-                if (string.Equals(dep.Name, packageName, StringComparison.OrdinalIgnoreCase))
-                    return true;
-        }
-
-        return false;
+        return spec.TargetFrameworks.Any(tfi =>
+            tfi.Dependencies.Any(d => string.Equals(d.Name, packageName, StringComparison.OrdinalIgnoreCase)));
     }
 
     #endregion

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Xml.Linq;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Evaluation;
-using Microsoft.Build.Execution;
-using Microsoft.Build.Locator;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -35,30 +33,6 @@ using Serilog;
 using ILogger = NuGet.Common.ILogger;
 
 namespace OpenRewrite.CSharp.NuGet;
-
-/// <summary>
-/// Ensures MSBuildLocator registration happens exactly once per process, shared by
-/// <see cref="SolutionParser"/> (MSBuildWorkspace) and <see cref="NuGetResolver"/>
-/// (in-process restore-graph evaluation).
-/// </summary>
-internal static class MSBuildRegistration
-{
-    private static readonly object Lock = new();
-    private static bool _registered;
-
-    public static void Ensure()
-    {
-        lock (Lock)
-        {
-            if (!_registered)
-            {
-                if (!MSBuildLocator.IsRegistered)
-                    MSBuildLocator.RegisterDefaults();
-                _registered = true;
-            }
-        }
-    }
-}
 
 /// <summary>
 /// In-process NuGet engine replacing all child-process package operations
@@ -122,28 +96,6 @@ public static class NuGetResolver
         }
     }
 
-    /// <summary>MSBuild logger forwarding errors/warnings to Serilog at Debug level.</summary>
-    private sealed class SerilogMSBuildLogger : Microsoft.Build.Framework.ILogger
-    {
-        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get; set; } =
-            Microsoft.Build.Framework.LoggerVerbosity.Quiet;
-
-        public string? Parameters { get; set; }
-
-        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource)
-        {
-            eventSource.ErrorRaised += (_, e) =>
-                Log.Debug("MSBuild error {Code} at {File}({Line}): {Message}",
-                    e.Code, e.File, e.LineNumber, e.Message);
-            eventSource.WarningRaised += (_, e) =>
-                Log.Debug("MSBuild warning {Code}: {Message}", e.Code, e.Message);
-        }
-
-        public void Shutdown()
-        {
-        }
-    }
-
     public static ILogger Logger => SerilogNuGetLogger.Instance;
 
     public static ISettings LoadSettings(string startDirectory) =>
@@ -160,8 +112,6 @@ public static class NuGetResolver
         string path,
         IDictionary<string, string>? extraGlobalProperties = null)
     {
-        MSBuildRegistration.Ensure();
-
         var projects = EnumerateProjects(path).ToList();
         if (projects.Count == 0)
         {
@@ -242,18 +192,21 @@ public static class NuGetResolver
         }
     }
 
-    // BuildManager.DefaultBuildManager.Build is not safe for concurrent invocations.
+    // Serialize graph generation: concurrent SDK msbuild processes contend on obj/ and
+    // the NuGet http cache without adding throughput for our one-at-a-time callers.
     private static readonly object BuildGate = new();
 
+    private static readonly TimeSpan GraphGenTimeout = TimeSpan.FromMinutes(5);
+
     /// <summary>
-    /// Runs the <c>GenerateRestoreGraphFile</c> target for a single project and loads the
-    /// resulting <see cref="DependencyGraphSpec"/>. The target executes in an out-of-process
-    /// MSBuild worker node (<see cref="BuildParameters.DisableInProcNode"/>) so the SDK's own
-    /// NuGet task assemblies never load into this process, where they would collide with the
-    /// NuGet client libraries used for the in-process restore. Only graph *evaluation* happens
-    /// in the worker; dependency resolution and downloads run in-process via
-    /// <see cref="RestoreRunner"/>. Returns null on evaluation/target failure
-    /// (e.g. a legacy project whose imports cannot be resolved).
+    /// Runs the <c>GenerateRestoreGraphFile</c> target for a single project via the .NET SDK's
+    /// own <c>dotnet msbuild</c> and loads the resulting <see cref="DependencyGraphSpec"/>.
+    /// Evaluation deliberately runs in the SDK's process, never ours: loading Microsoft.Build
+    /// into this process (MSBuildLocator-style) is fragile — any MSBuild assembly in the app
+    /// base defeats the redirection, and the SDK's restore tasks bind their own NuGet assembly
+    /// versions. Only *evaluation* happens in the child; dependency resolution and downloads
+    /// run in-process via <see cref="RestoreRunner"/>. Returns null on evaluation/target
+    /// failure (e.g. a legacy project whose imports cannot be resolved).
     /// </summary>
     private static DependencyGraphSpec? GenerateRestoreGraph(
         string projectPath,
@@ -272,7 +225,7 @@ public static class NuGetResolver
                 // NuGet.targets' internal default already discovers the closure per entry.
                 ["NuGetAudit"] = "false",
                 ["RestoreIgnoreFailedSources"] = "true",
-                ["RestoreAdditionalProjectSources"] = string.Join(";", AdditionalNuGetSources),
+                ["RestoreAdditionalProjectSources"] = string.Join("%3B", AdditionalNuGetSources),
                 // Avoid restore-time package imports polluting evaluation
                 ["ExcludeRestorePackageImports"] = "true",
             };
@@ -282,27 +235,46 @@ public static class NuGetResolver
                     globalProps[k] = v;
             }
 
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                WorkingDirectory = Path.GetDirectoryName(projectPath) ?? ".",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("msbuild");
+            psi.ArgumentList.Add(projectPath);
+            psi.ArgumentList.Add("-t:GenerateRestoreGraphFile");
+            psi.ArgumentList.Add("-nologo");
+            psi.ArgumentList.Add("-v:quiet");
+            psi.ArgumentList.Add("-nodeReuse:false");
+            foreach (var (k, v) in globalProps)
+                psi.ArgumentList.Add($"-p:{k}={v}");
+
             lock (BuildGate)
             {
-                using var projectCollection = new ProjectCollection(globalProps);
-                var parameters = new BuildParameters(projectCollection)
+                using var process = Process.Start(psi);
+                if (process == null)
                 {
-                    DisableInProcNode = true,
-                    EnableNodeReuse = false,
-                    MaxNodeCount = 1,
-                    Loggers = new Microsoft.Build.Framework.ILogger[] { new SerilogMSBuildLogger() },
-                };
-                var requestData = new BuildRequestData(
-                    projectPath,
-                    globalProps,
-                    null,
-                    new[] { "GenerateRestoreGraphFile" },
-                    null);
-                var result = BuildManager.DefaultBuildManager.Build(parameters, requestData);
-                if (result.OverallResult != BuildResultCode.Success || !File.Exists(outputPath))
+                    Log.Debug("NuGetResolver: failed to start dotnet msbuild for {Project}", projectPath);
+                    return null;
+                }
+
+                // Read both streams before waiting to avoid pipe-buffer deadlock.
+                var stdoutTask = process.StandardOutput.ReadToEndAsync();
+                var stderrTask = process.StandardError.ReadToEndAsync();
+                if (!process.WaitForExit((int)GraphGenTimeout.TotalMilliseconds))
                 {
-                    Log.Debug("NuGetResolver: GenerateRestoreGraphFile failed for {Project}: {Exception}",
-                        projectPath, result.Exception?.Message);
+                    try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+                    Log.Debug("NuGetResolver: GenerateRestoreGraphFile timed out for {Project}", projectPath);
+                    return null;
+                }
+
+                if (process.ExitCode != 0 || !File.Exists(outputPath))
+                {
+                    Log.Debug("NuGetResolver: GenerateRestoreGraphFile failed for {Project} (exit {Exit}):\n{Out}\n{Err}",
+                        projectPath, process.ExitCode, stdoutTask.Result.Trim(), stderrTask.Result.Trim());
                     return null;
                 }
             }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
@@ -1,0 +1,690 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Immutable;
+using System.Xml.Linq;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Locator;
+using NuGet.Commands;
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Frameworks;
+using NuGet.LibraryModel;
+using NuGet.Packaging;
+using NuGet.Packaging.Core;
+using NuGet.Packaging.Signing;
+using NuGet.ProjectModel;
+using NuGet.Protocol;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using Serilog;
+using ILogger = NuGet.Common.ILogger;
+
+namespace OpenRewrite.CSharp.NuGet;
+
+/// <summary>
+/// Ensures MSBuildLocator registration happens exactly once per process, shared by
+/// <see cref="SolutionParser"/> (MSBuildWorkspace) and <see cref="NuGetResolver"/>
+/// (in-process restore-graph evaluation).
+/// </summary>
+internal static class MSBuildRegistration
+{
+    private static readonly object Lock = new();
+    private static bool _registered;
+
+    public static void Ensure()
+    {
+        lock (Lock)
+        {
+            if (!_registered)
+            {
+                if (!MSBuildLocator.IsRegistered)
+                    MSBuildLocator.RegisterDefaults();
+                _registered = true;
+            }
+        }
+    }
+}
+
+/// <summary>
+/// In-process NuGet engine replacing all child-process package operations
+/// (<c>dotnet restore</c>, <c>nuget restore</c>, <c>nuget install</c>) and all
+/// <c>obj/project.assets.json</c> file reads.
+///
+/// Restore graphs are obtained one of two ways:
+/// <list type="bullet">
+///   <item>PackageReference projects: the MSBuild <c>GenerateRestoreGraphFile</c> target is
+///         executed in-process (full fidelity: imports, conditions, CPM, PackageDownload,
+///         FrameworkReference) to produce a <see cref="DependencyGraphSpec"/>, which is then
+///         restored via <see cref="RestoreRunner"/>. The in-memory <see cref="LockFile"/> from
+///         each <see cref="RestoreResult"/> feeds MSBuildProject marker attestation; when
+///         <c>commit</c> is requested the standard restore outputs (assets file, props/targets)
+///         are also written for Roslyn compilation.</item>
+///   <item>Legacy <c>packages.config</c> projects: a <see cref="PackageSpec"/> is synthesized
+///         from the packages.config entries (exact-pinned, PackageReference-style) and restored
+///         without commit, yielding a LockFile-grade dependency graph for attestation that
+///         packages.config projects never had before.</item>
+/// </list>
+/// </summary>
+public static class NuGetResolver
+{
+    /// <summary>
+    /// Replacement NuGet feeds for defunct dotnet.myget.org sources.
+    /// MyGet was shut down; packages migrated to Azure DevOps Artifacts (dnceng).
+    /// </summary>
+    private static readonly string[] AdditionalNuGetSources =
+    {
+        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
+        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json",
+        "https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json"
+    };
+
+    static NuGetResolver()
+    {
+        // Fail fast on dead feeds (previously passed as env vars to the dotnet child process).
+        // Only set when the user hasn't configured them explicitly.
+        SetEnvIfAbsent("NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT", "1");
+        SetEnvIfAbsent("NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS", "100");
+    }
+
+    private static void SetEnvIfAbsent(string name, string value)
+    {
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(name)))
+            Environment.SetEnvironmentVariable(name, value);
+    }
+
+    /// <summary>NuGet.Common logger bridging to Serilog at Debug level.</summary>
+    private sealed class SerilogNuGetLogger : LoggerBase
+    {
+        public static readonly SerilogNuGetLogger Instance = new();
+
+        public override void Log(ILogMessage message) =>
+            Serilog.Log.Debug("NuGet: {Message}", message.Message);
+
+        public override Task LogAsync(ILogMessage message)
+        {
+            Log(message);
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>MSBuild logger forwarding errors/warnings to Serilog at Debug level.</summary>
+    private sealed class SerilogMSBuildLogger : Microsoft.Build.Framework.ILogger
+    {
+        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get; set; } =
+            Microsoft.Build.Framework.LoggerVerbosity.Quiet;
+
+        public string? Parameters { get; set; }
+
+        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource)
+        {
+            eventSource.ErrorRaised += (_, e) =>
+                Log.Debug("MSBuild error {Code} at {File}({Line}): {Message}",
+                    e.Code, e.File, e.LineNumber, e.Message);
+            eventSource.WarningRaised += (_, e) =>
+                Log.Debug("MSBuild warning {Code}: {Message}", e.Code, e.Message);
+        }
+
+        public void Shutdown()
+        {
+        }
+    }
+
+    public static ILogger Logger => SerilogNuGetLogger.Instance;
+
+    public static ISettings LoadSettings(string startDirectory) =>
+        Settings.LoadDefaultSettings(startDirectory, null, new XPlatMachineWideSetting());
+
+    #region Restore graph generation (PackageReference projects)
+
+    /// <summary>
+    /// Produces the restore dependency graph for a solution or project by running the
+    /// <c>GenerateRestoreGraphFile</c> MSBuild target in-process for each project.
+    /// Returns null when no project produced a graph (e.g. all projects are packages.config-only).
+    /// </summary>
+    public static DependencyGraphSpec? CreateDependencyGraphSpec(
+        string path,
+        IDictionary<string, string>? extraGlobalProperties = null)
+    {
+        MSBuildRegistration.Ensure();
+
+        var projects = EnumerateProjects(path).ToList();
+        if (projects.Count == 0)
+        {
+            Log.Debug("NuGetResolver: no MSBuild projects found for {Path}", path);
+            return null;
+        }
+
+        var merged = new DependencyGraphSpec();
+        var any = false;
+        foreach (var projectPath in projects)
+        {
+            var dgSpec = GenerateRestoreGraph(projectPath, extraGlobalProperties);
+            if (dgSpec == null)
+                continue;
+            foreach (var project in dgSpec.Projects)
+            {
+                if (merged.GetProjectSpec(project.RestoreMetadata?.ProjectUniqueName) == null)
+                    merged.AddProject(project);
+            }
+            foreach (var restore in dgSpec.Restore)
+                merged.AddRestore(restore);
+            any = true;
+        }
+
+        return any ? merged : null;
+    }
+
+    /// <summary>
+    /// Enumerates MSBuild project files for an entry path: the project itself, the projects of
+    /// a .sln (via <see cref="SolutionFile"/>), or of a .slnx (XML &lt;Project Path="..."/&gt;).
+    /// </summary>
+    public static IEnumerable<string> EnumerateProjects(string path)
+    {
+        if (path.EndsWith(".sln", StringComparison.OrdinalIgnoreCase))
+        {
+            SolutionFile solution;
+            try
+            {
+                solution = SolutionFile.Parse(Path.GetFullPath(path));
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("NuGetResolver: failed to parse solution {Path}: {Error}", path, ex.Message);
+                yield break;
+            }
+            foreach (var p in solution.ProjectsInOrder)
+            {
+                if (p.ProjectType == SolutionProjectType.KnownToBeMSBuildFormat && File.Exists(p.AbsolutePath))
+                    yield return Path.GetFullPath(p.AbsolutePath);
+            }
+        }
+        else if (path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+        {
+            var dir = Path.GetDirectoryName(Path.GetFullPath(path))!;
+            XDocument doc;
+            try
+            {
+                doc = XDocument.Load(path);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("NuGetResolver: failed to parse slnx {Path}: {Error}", path, ex.Message);
+                yield break;
+            }
+            foreach (var project in doc.Descendants("Project"))
+            {
+                var rel = project.Attribute("Path")?.Value;
+                if (rel == null)
+                    continue;
+                var abs = Path.GetFullPath(Path.Combine(dir, rel.Replace('\\', Path.DirectorySeparatorChar)));
+                if (File.Exists(abs))
+                    yield return abs;
+            }
+        }
+        else
+        {
+            yield return Path.GetFullPath(path);
+        }
+    }
+
+    // BuildManager.DefaultBuildManager.Build is not safe for concurrent invocations.
+    private static readonly object BuildGate = new();
+
+    /// <summary>
+    /// Runs the <c>GenerateRestoreGraphFile</c> target for a single project and loads the
+    /// resulting <see cref="DependencyGraphSpec"/>. The target executes in an out-of-process
+    /// MSBuild worker node (<see cref="BuildParameters.DisableInProcNode"/>) so the SDK's own
+    /// NuGet task assemblies never load into this process, where they would collide with the
+    /// NuGet client libraries used for the in-process restore. Only graph *evaluation* happens
+    /// in the worker; dependency resolution and downloads run in-process via
+    /// <see cref="RestoreRunner"/>. Returns null on evaluation/target failure
+    /// (e.g. a legacy project whose imports cannot be resolved).
+    /// </summary>
+    private static DependencyGraphSpec? GenerateRestoreGraph(
+        string projectPath,
+        IDictionary<string, string>? extraGlobalProperties)
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(),
+            "openrewrite-dg-" + Guid.NewGuid().ToString("N")[..8] + ".json");
+        try
+        {
+            var globalProps = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["RestoreGraphOutputPath"] = outputPath,
+                // Do NOT set RestoreRecursive explicitly: as a global property it forces the
+                // full project-path walk (which does not drop missing project references) into
+                // the graph-entry task, turning skippable missing P2P refs into MSB3202 errors.
+                // NuGet.targets' internal default already discovers the closure per entry.
+                ["NuGetAudit"] = "false",
+                ["RestoreIgnoreFailedSources"] = "true",
+                ["RestoreAdditionalProjectSources"] = string.Join(";", AdditionalNuGetSources),
+                // Avoid restore-time package imports polluting evaluation
+                ["ExcludeRestorePackageImports"] = "true",
+            };
+            if (extraGlobalProperties != null)
+            {
+                foreach (var (k, v) in extraGlobalProperties)
+                    globalProps[k] = v;
+            }
+
+            lock (BuildGate)
+            {
+                using var projectCollection = new ProjectCollection(globalProps);
+                var parameters = new BuildParameters(projectCollection)
+                {
+                    DisableInProcNode = true,
+                    EnableNodeReuse = false,
+                    MaxNodeCount = 1,
+                    Loggers = new Microsoft.Build.Framework.ILogger[] { new SerilogMSBuildLogger() },
+                };
+                var requestData = new BuildRequestData(
+                    projectPath,
+                    globalProps,
+                    null,
+                    new[] { "GenerateRestoreGraphFile" },
+                    null);
+                var result = BuildManager.DefaultBuildManager.Build(parameters, requestData);
+                if (result.OverallResult != BuildResultCode.Success || !File.Exists(outputPath))
+                {
+                    Log.Debug("NuGetResolver: GenerateRestoreGraphFile failed for {Project}: {Exception}",
+                        projectPath, result.Exception?.Message);
+                    return null;
+                }
+            }
+
+            return DependencyGraphSpec.Load(outputPath);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("NuGetResolver: restore graph generation failed for {Project}: {Error}",
+                projectPath, ex.Message);
+            return null;
+        }
+        finally
+        {
+            try { File.Delete(outputPath); } catch { /* best effort */ }
+        }
+    }
+
+    #endregion
+
+    #region Restore execution
+
+    /// <summary>
+    /// Restores all PackageReference-style projects in the graph. Returns the in-memory
+    /// <see cref="LockFile"/> per project path. When <paramref name="commit"/> is true the
+    /// standard restore outputs (project.assets.json, nuget props/targets) are also written so
+    /// MSBuildWorkspace can compile the projects.
+    /// </summary>
+    public static async Task<Dictionary<string, LockFile>> RestoreAsync(
+        DependencyGraphSpec dgSpec, bool commit, CancellationToken ct)
+    {
+        var lockFiles = new Dictionary<string, LockFile>(StringComparer.OrdinalIgnoreCase);
+
+        // Only PackageReference-style projects restore through RestoreRunner.
+        var restorable = new DependencyGraphSpec();
+        var anyRestorable = false;
+        foreach (var project in dgSpec.Projects)
+        {
+            var style = project.RestoreMetadata?.ProjectStyle;
+            if (style == ProjectStyle.PackageReference || style == ProjectStyle.DotnetCliTool ||
+                style == ProjectStyle.Standalone)
+            {
+                restorable.AddProject(project);
+                restorable.AddRestore(project.RestoreMetadata!.ProjectUniqueName);
+                anyRestorable = true;
+            }
+            else if (style == ProjectStyle.ProjectJson || style == ProjectStyle.Unknown ||
+                     style == ProjectStyle.PackagesConfig)
+            {
+                Log.Debug("NuGetResolver: skipping RestoreRunner for {Style} project {Project}",
+                    style, project.RestoreMetadata?.ProjectUniqueName);
+                // Referenced projects still need to be in the graph for P2P edges.
+                restorable.AddProject(project);
+            }
+        }
+
+        if (!anyRestorable)
+            return lockFiles;
+
+        var settingsRoot = restorable.Projects
+            .Select(p => Path.GetDirectoryName(p.RestoreMetadata?.ProjectPath ?? p.FilePath))
+            .FirstOrDefault(d => d != null) ?? Directory.GetCurrentDirectory();
+        var settings = LoadSettings(settingsRoot!);
+
+        using var cacheContext = new SourceCacheContext { IgnoreFailedSources = true };
+        var providerCache = new RestoreCommandProvidersCache();
+        var restoreArgs = new RestoreArgs
+        {
+            AllowNoOp = false,
+            CacheContext = cacheContext,
+            Log = Logger,
+            CachingSourceProvider = new CachingSourceProvider(new PackageSourceProvider(settings)),
+        };
+
+        var requestProvider = new DependencyGraphSpecRequestProvider(providerCache, restorable, settings);
+        var requests = await requestProvider.CreateRequests(restoreArgs);
+
+        var results = await RestoreRunner.RunWithoutCommit(requests, restoreArgs);
+        foreach (var pair in results)
+        {
+            var projectPath = pair.SummaryRequest.Request.Project.RestoreMetadata?.ProjectPath
+                              ?? pair.SummaryRequest.Request.Project.FilePath;
+            if (!pair.Result.Success)
+            {
+                Log.Debug("NuGetResolver: restore failed for {Project}", projectPath);
+            }
+            if (commit)
+            {
+                try
+                {
+                    await pair.Result.CommitAsync(Logger, ct);
+                }
+                catch (Exception ex)
+                {
+                    Log.Debug("NuGetResolver: commit failed for {Project}: {Error}", projectPath, ex.Message);
+                }
+            }
+            if (projectPath != null && pair.Result.LockFile != null)
+                lockFiles[Path.GetFullPath(projectPath)] = pair.Result.LockFile;
+        }
+
+        return lockFiles;
+    }
+
+    #endregion
+
+    #region packages.config attestation graph
+
+    /// <summary>
+    /// Synthesizes a PackageReference-style <see cref="PackageSpec"/> from packages.config
+    /// entries (exact-pinned versions) and restores it without commit, producing a
+    /// LockFile-grade dependency graph for a legacy project. This is how packages.config
+    /// projects — which have no project.assets.json — get full dependency attestation.
+    /// </summary>
+    public static async Task<LockFile?> RestorePackagesConfigGraphAsync(
+        string projectPath,
+        string packagesConfigPath,
+        NuGetFramework? framework,
+        CancellationToken ct)
+    {
+        try
+        {
+            var entries = ReadPackagesConfig(packagesConfigPath);
+            if (entries.Count == 0)
+                return null;
+
+            framework ??= entries
+                .Select(e => e.TargetFramework)
+                .FirstOrDefault(f => f != null && !f.IsUnsupported && !f.IsAny)
+                ?? NuGetFramework.Parse("net48");
+
+            var settings = LoadSettings(Path.GetDirectoryName(Path.GetFullPath(projectPath))!);
+
+            var alias = framework.GetShortFolderName();
+            var tfi = new TargetFrameworkInformation
+            {
+                FrameworkName = framework,
+                TargetAlias = alias,
+                // NuGet 7.x: dependencies are declared per target framework (the project-level
+                // PackageSpec.Dependencies list no longer exists).
+                Dependencies = entries.Select(e => new LibraryDependency
+                {
+                    LibraryRange = new LibraryRange(
+                        e.PackageIdentity.Id,
+                        new VersionRange(e.PackageIdentity.Version),
+                        LibraryDependencyTarget.Package),
+                }).ToImmutableArray(),
+            };
+            var packageSpec = new PackageSpec(new List<TargetFrameworkInformation> { tfi })
+            {
+                Name = Path.GetFileNameWithoutExtension(projectPath),
+                FilePath = projectPath,
+                RestoreMetadata = new ProjectRestoreMetadata
+                {
+                    ProjectPath = projectPath,
+                    ProjectName = Path.GetFileNameWithoutExtension(projectPath),
+                    ProjectUniqueName = projectPath,
+                    ProjectStyle = ProjectStyle.PackageReference,
+                    OutputPath = Path.Combine(Path.GetTempPath(),
+                        "openrewrite-pcrestore-" + Guid.NewGuid().ToString("N")[..8]),
+                    OriginalTargetFrameworks = new List<string> { alias },
+                    ConfigFilePaths = settings.GetConfigFilePaths(),
+                    PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),
+                    Sources = SettingsUtility.GetEnabledSources(settings).ToList(),
+                    FallbackFolders = SettingsUtility.GetFallbackPackageFolders(settings).ToList(),
+                },
+            };
+            packageSpec.RestoreMetadata.TargetFrameworks.Add(
+                new ProjectRestoreMetadataFrameworkInfo(framework) { TargetAlias = alias });
+
+            var dgSpec = new DependencyGraphSpec();
+            dgSpec.AddProject(packageSpec);
+            dgSpec.AddRestore(packageSpec.RestoreMetadata.ProjectUniqueName);
+
+            var lockFiles = await RestoreAsync(dgSpec, commit: false, ct);
+            return lockFiles.TryGetValue(Path.GetFullPath(projectPath), out var lockFile) ? lockFile : null;
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("NuGetResolver: packages.config graph restore failed for {Project}: {Error}",
+                projectPath, ex.Message);
+            return null;
+        }
+    }
+
+    /// <summary>Reads packages.config entries (id, version, targetFramework, developmentDependency).</summary>
+    public static IReadOnlyList<global::NuGet.Packaging.PackageReference> ReadPackagesConfig(string packagesConfigPath)
+    {
+        using var stream = File.OpenRead(packagesConfigPath);
+        var reader = new PackagesConfigReader(stream);
+        return reader.GetPackages(allowDuplicatePackageIds: true).ToList();
+    }
+
+    #endregion
+
+    #region packages.config folder restore + flat installs (nuget.exe replacement)
+
+    /// <summary>
+    /// Materializes the solution-local <c>packages/</c> folder (NuGet v2 side-by-side layout,
+    /// <c>Id.Version/</c>) for legacy packages.config projects, replacing <c>nuget restore</c>.
+    /// The folder location honors <c>repositoryPath</c> from nuget.config, defaulting to
+    /// <c>&lt;solutionDir&gt;/packages</c>.
+    /// </summary>
+    public static async Task InstallPackagesConfigPackagesAsync(
+        string solutionOrProjectDir,
+        IEnumerable<string> packagesConfigPaths,
+        CancellationToken ct)
+    {
+        var settings = LoadSettings(solutionOrProjectDir);
+        var repositoryPath = SettingsUtility.GetRepositoryPath(settings);
+        if (string.IsNullOrEmpty(repositoryPath))
+            repositoryPath = Path.Combine(solutionOrProjectDir, "packages");
+        repositoryPath = Path.GetFullPath(repositoryPath);
+
+        var identities = new HashSet<PackageIdentity>();
+        foreach (var configPath in packagesConfigPaths)
+        {
+            try
+            {
+                foreach (var entry in ReadPackagesConfig(configPath))
+                    identities.Add(entry.PackageIdentity);
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("NuGetResolver: failed to read {Path}: {Error}", configPath, ex.Message);
+            }
+        }
+
+        if (identities.Count == 0)
+            return;
+
+        var pathResolver = new PackagePathResolver(repositoryPath);
+        await InstallPackagesAsync(identities, pathResolver, settings, ct);
+    }
+
+    /// <summary>
+    /// Installs a single package into <paramref name="outputDirectory"/>, optionally without the
+    /// version in the folder name (the <c>nuget install -ExcludeVersion</c> layout used for the
+    /// .NET Framework build assets). Returns true when the package is present afterwards.
+    /// </summary>
+    public static async Task<bool> InstallPackageAsync(
+        string packageId, string version, string outputDirectory, bool excludeVersion, CancellationToken ct)
+    {
+        try
+        {
+            Directory.CreateDirectory(outputDirectory);
+            var settings = LoadSettings(outputDirectory);
+            var identity = new PackageIdentity(packageId, NuGetVersion.Parse(version));
+            var pathResolver = new PackagePathResolver(outputDirectory, useSideBySidePaths: !excludeVersion);
+            await InstallPackagesAsync(new[] { identity }, pathResolver, settings, ct);
+            return pathResolver.GetInstalledPath(identity) != null
+                   || Directory.Exists(Path.Combine(outputDirectory, packageId));
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("NuGetResolver: install of {Package} {Version} failed: {Error}",
+                packageId, version, ex.Message);
+            return false;
+        }
+    }
+
+    private static async Task InstallPackagesAsync(
+        IEnumerable<PackageIdentity> identities,
+        PackagePathResolver pathResolver,
+        ISettings settings,
+        CancellationToken ct)
+    {
+        using var cacheContext = new SourceCacheContext { IgnoreFailedSources = true };
+        var globalPackagesFolder = SettingsUtility.GetGlobalPackagesFolder(settings);
+        var downloadContext = new PackageDownloadContext(cacheContext);
+        var extractionContext = new PackageExtractionContext(
+            PackageSaveMode.Defaultv2,
+            XmlDocFileSaveMode.None,
+            ClientPolicyContext.GetClientPolicy(settings, Logger),
+            Logger);
+
+        var sourceProvider = new PackageSourceProvider(settings);
+        var repositories = sourceProvider.LoadPackageSources()
+            .Where(s => s.IsEnabled)
+            .Select(s => Repository.Factory.GetCoreV3(s))
+            .ToList();
+        // Replacement feeds for defunct sources, tried after the configured ones.
+        foreach (var url in AdditionalNuGetSources)
+            repositories.Add(Repository.Factory.GetCoreV3(url));
+
+        foreach (var identity in identities)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (pathResolver.GetInstalledPath(identity) != null)
+                continue;
+
+            var installed = false;
+            foreach (var repository in repositories)
+            {
+                try
+                {
+                    var downloadResource = await repository.GetResourceAsync<DownloadResource>(ct);
+                    if (downloadResource == null)
+                        continue;
+                    using var result = await downloadResource.GetDownloadResourceResultAsync(
+                        identity, downloadContext, globalPackagesFolder, Logger, ct);
+                    if (result.Status != DownloadResourceResultStatus.Available)
+                        continue;
+
+                    result.PackageStream.Seek(0, SeekOrigin.Begin);
+                    await PackageExtractor.ExtractPackageAsync(
+                        result.PackageSource, result.PackageStream, pathResolver, extractionContext, ct);
+                    installed = true;
+                    break;
+                }
+                catch (Exception ex) when (ex is not OperationCanceledException)
+                {
+                    Log.Debug("NuGetResolver: {Package} not available from {Source}: {Error}",
+                        identity, repository.PackageSource.Source, ex.Message);
+                }
+            }
+
+            if (!installed)
+                Log.Debug("NuGetResolver: failed to install {Package} from any source", identity);
+        }
+    }
+
+    #endregion
+
+    #region Single-project attestation entry point
+
+    /// <summary>
+    /// Resolves the LockFile for a single project on disk: packages.config projects go through
+    /// the synthesized-spec path; everything else through in-process restore-graph generation.
+    /// Returns null when no graph could be produced.
+    /// </summary>
+    public static async Task<LockFile?> ResolveProjectLockFileAsync(
+        string projectPath,
+        IDictionary<string, string>? extraGlobalProperties,
+        CancellationToken ct)
+    {
+        var projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))!;
+        var packagesConfig = Path.Combine(projectDir, "packages.config");
+        if (File.Exists(packagesConfig))
+        {
+            return await RestorePackagesConfigGraphAsync(
+                projectPath, packagesConfig, ReadLegacyFramework(projectPath), ct);
+        }
+
+        var dgSpec = CreateDependencyGraphSpec(projectPath, extraGlobalProperties);
+        if (dgSpec == null)
+            return null;
+        var lockFiles = await RestoreAsync(dgSpec, commit: false, ct);
+        return lockFiles.TryGetValue(Path.GetFullPath(projectPath), out var lockFile) ? lockFile : null;
+    }
+
+    /// <summary>
+    /// Reads the target framework from a legacy csproj's <c>TargetFrameworkVersion</c>
+    /// (e.g. <c>v4.7.2</c>), or SDK-style <c>TargetFramework(s)</c> as fallback.
+    /// </summary>
+    public static NuGetFramework? ReadLegacyFramework(string projectPath)
+    {
+        try
+        {
+            var doc = XDocument.Load(projectPath);
+            var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+
+            var tfv = doc.Descendants(ns + "TargetFrameworkVersion").FirstOrDefault()?.Value?.Trim();
+            if (!string.IsNullOrEmpty(tfv))
+                return NuGetFramework.Parse($".NETFramework,Version={tfv}");
+
+            var tf = doc.Descendants(ns + "TargetFramework").FirstOrDefault()?.Value?.Trim();
+            if (!string.IsNullOrEmpty(tf))
+                return NuGetFramework.Parse(tf);
+
+            var tfs = doc.Descendants(ns + "TargetFrameworks").FirstOrDefault()?.Value;
+            var first = tfs?.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .FirstOrDefault();
+            if (!string.IsNullOrEmpty(first))
+                return NuGetFramework.Parse(first);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("NuGetResolver: failed to read TFM from {Project}: {Error}", projectPath, ex.Message);
+        }
+        return null;
+    }
+
+    #endregion
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -304,16 +304,19 @@ public class RewriteRpcServer
                 });
             }
 
-            // Parse the .csproj file itself as an Xml.Document LST with MSBuildProject marker
-            // Files are already on disk and restore happened during solution loading,
-            // so we parse XML directly and create the marker from project.assets.json.
+            // Parse the .csproj file itself as an Xml.Document LST with MSBuildProject marker.
+            // The in-process restore during solution loading produced the in-memory LockFile
+            // for each project; fall back to a fresh in-process resolve when absent.
             try
             {
                 var content = ReadFilePreservingBom(project.FilePath!);
                 var relativePath = Path.GetRelativePath(rootDir, project.FilePath!);
                 var xmlParser = new OpenRewrite.Xml.XmlParser();
                 var csprojDoc = xmlParser.Parse(content, relativePath);
-                var marker = MSBuildProjectHelper.CreateMarker(csprojDoc, rootDir);
+                var projectFullPath = Path.GetFullPath(project.FilePath!);
+                var marker = solutionParser.RestoredLockFiles.TryGetValue(projectFullPath, out var lockFile)
+                    ? MSBuildProjectHelper.CreateMarker(csprojDoc, lockFile, Path.GetDirectoryName(projectFullPath)!)
+                    : MSBuildProjectHelper.CreateMarker(csprojDoc, rootDir);
                 if (marker != null)
                     csprojDoc = csprojDoc.WithMarkers(csprojDoc.Markers.Add(marker));
                 _localObjects[csprojDoc.Id.ToString()] = csprojDoc;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -15,154 +15,27 @@
  */
 using System.Diagnostics;
 using System.Xml.Linq;
-using Microsoft.Build.Locator;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
+using NuGet.ProjectModel;
 using OpenRewrite.Core;
 using OpenRewrite.CSharp.Format;
+using OpenRewrite.CSharp.NuGet;
 using Serilog;
 
 namespace OpenRewrite.CSharp;
 
 /// <summary>
-/// Serializes <c>dotnet restore</c> invocations so that only one runs at a time,
-/// preventing process explosions when multiple tests load solutions concurrently.
-/// Tracks which paths have already been restored to avoid redundant work.
+/// Serializes in-process NuGet restores so that only one runs at a time (multiple tests may
+/// load solutions concurrently) and caches which paths have already been restored.
+/// All package operations run through <see cref="NuGetResolver"/> — no <c>dotnet restore</c>
+/// or <c>nuget.exe</c> child processes.
 /// </summary>
-internal static class DotNetRestore
+internal static class SolutionRestore
 {
     private static readonly SemaphoreSlim Gate = new(1, 1);
-    private static readonly HashSet<string> Restored = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(10);
-
-    internal record RestoreResult(int ExitCode, string Stdout, string Stderr, TimeSpan Elapsed, bool TimedOut);
-
-    public static async Task<RestoreResult> RunAsync(string path, CancellationToken ct)
-    {
-        var key = Path.GetFullPath(path);
-
-        // Fast path: already restored in this process
-        lock (Restored)
-        {
-            if (Restored.Contains(key))
-            {
-                Log.Debug("dotnet restore: skipped (already restored) {Path}", path);
-                return new RestoreResult(0, "", "", TimeSpan.Zero, false);
-            }
-        }
-
-        Log.Debug("dotnet restore: waiting for gate {Path}", path);
-        await Gate.WaitAsync(ct);
-        try
-        {
-            // Double-check after acquiring the gate
-            lock (Restored)
-            {
-                if (Restored.Contains(key))
-                    return new RestoreResult(0, "", "", TimeSpan.Zero, false);
-            }
-
-            var result = await RunCoreAsync(path, ct);
-
-            if (result.ExitCode == 0 && !result.TimedOut)
-            {
-                lock (Restored)
-                {
-                    Restored.Add(key);
-                }
-            }
-
-            return result;
-        }
-        finally
-        {
-            Gate.Release();
-        }
-    }
-
-    /// <summary>
-    /// Replacement NuGet feeds for defunct dotnet.myget.org sources.
-    /// MyGet was shut down; packages migrated to Azure DevOps Artifacts (dnceng).
-    /// Semicolons are escaped as %3B because MSBuild /p: treats literal ';' as a property separator.
-    /// </summary>
-    private static readonly string AdditionalNuGetSources = string.Join("%3B",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json",
-        "https://pkgs.dev.azure.com/dnceng/public/_packaging/myget-legacy/nuget/v3/index.json");
-
-    private static async Task<RestoreResult> RunCoreAsync(string path, CancellationToken ct)
-    {
-        Log.Debug("dotnet restore: starting for {Path}", path);
-        var sw = Stopwatch.StartNew();
-        // Relax restore for LST parsing: disable NuGet vulnerability audit
-        // (NU1902/NU1903 would fail restore), ignore dead NuGet sources,
-        // and add replacement feeds for defunct MyGet sources.
-        var psi = new ProcessStartInfo("dotnet")
-        {
-            WorkingDirectory = Path.GetDirectoryName(path) ?? ".",
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-        psi.ArgumentList.Add("restore");
-        psi.ArgumentList.Add(path);
-        psi.ArgumentList.Add("/p:NuGetAudit=false");
-        psi.ArgumentList.Add("/p:RestoreIgnoreFailedSources=true");
-        psi.ArgumentList.Add($"/p:RestoreAdditionalProjectSources={AdditionalNuGetSources}");
-        psi.ArgumentList.Add("--ignore-failed-sources");
-        // Reduce NuGet retry attempts so dead feeds fail fast
-        psi.Environment["NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT"] = "1";
-        psi.Environment["NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS"] = "100";
-
-        using var process = Process.Start(psi);
-        if (process == null)
-        {
-            Log.Debug("dotnet restore: process failed to start");
-            return new RestoreResult(-1, "", "Failed to start dotnet restore process", sw.Elapsed, false);
-        }
-
-        Log.Debug("dotnet restore: process started (PID {ProcessId})", process.Id);
-        using var restoreCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        restoreCts.CancelAfter(Timeout);
-
-        try
-        {
-            // Must read stdout/stderr before WaitForExitAsync to avoid deadlock
-            // when the pipe buffer fills up (e.g. many NETSDK1138 warnings for
-            // Windows-specific TFMs).
-            var stdoutTask = process.StandardOutput.ReadToEndAsync(restoreCts.Token);
-            var stderrTask = process.StandardError.ReadToEndAsync(restoreCts.Token);
-            await Task.WhenAll(stdoutTask, stderrTask);
-            await process.WaitForExitAsync(restoreCts.Token);
-            sw.Stop();
-            Log.Debug("dotnet restore: completed (exit code {ExitCode})", process.ExitCode);
-            return new RestoreResult(process.ExitCode, stdoutTask.Result, stderrTask.Result, sw.Elapsed, false);
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            // Restore timed out but overall operation is still running — kill and continue
-            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
-            sw.Stop();
-            Log.Debug("dotnet restore: TIMED OUT after {Timeout}, killed process", Timeout);
-            return new RestoreResult(-1, "", "", sw.Elapsed, true);
-        }
-    }
-}
-
-/// <summary>
-/// Serializes <c>nuget restore</c> invocations (and the one-time restore of the .NET
-/// Framework build assets) so only one runs at a time, and caches which paths have
-/// already been restored. Unlike <see cref="DotNetRestore"/>, the standalone NuGet CLI
-/// can restore legacy <c>packages.config</c> (non-SDK-style) projects, which
-/// <c>dotnet restore</c> treats as a no-op. On non-Windows machines the NuGet CLI runs
-/// through <c>mono</c>.
-/// </summary>
-internal static class NuGetRestore
-{
-    private static readonly SemaphoreSlim Gate = new(1, 1);
-    private static readonly HashSet<string> Restored = new(StringComparer.OrdinalIgnoreCase);
-    private static readonly TimeSpan Timeout = TimeSpan.FromMinutes(10);
+    private static readonly Dictionary<string, IReadOnlyDictionary<string, LockFile>> Restored =
+        new(StringComparer.OrdinalIgnoreCase);
 
     /// <summary>
     /// .NET Framework build assets that are not present on non-Windows machines. They are
@@ -177,24 +50,32 @@ internal static class NuGetRestore
 
     private static NetFrameworkBuildAssets? _buildAssets;
 
-    internal record RestoreResult(int ExitCode, string Stdout, string Stderr, TimeSpan Elapsed, bool TimedOut);
-
     /// <summary>
     /// MSBuild property values pointing at restored .NET Framework build assets. A value is
     /// null when the corresponding package could not be restored.
     /// </summary>
     internal record NetFrameworkBuildAssets(string? VSToolsPath, string? TargetFrameworkRootPath);
 
-    public static async Task<RestoreResult> RunAsync(string path, CancellationToken ct)
+    /// <summary>
+    /// Restores a solution/project in-process: PackageReference projects via restore-graph
+    /// generation + RestoreRunner (committing assets/props/targets so MSBuildWorkspace can
+    /// compile), legacy packages.config projects via the solution-local packages folder plus a
+    /// synthesized attestation graph. Returns the in-memory LockFile per project path.
+    /// </summary>
+    public static async Task<IReadOnlyDictionary<string, LockFile>> RunAsync(
+        string path,
+        bool hasPackagesConfig,
+        IDictionary<string, string> msbuildProperties,
+        CancellationToken ct)
     {
-        var key = "restore:" + Path.GetFullPath(path);
+        var key = Path.GetFullPath(path);
 
         lock (Restored)
         {
-            if (Restored.Contains(key))
+            if (Restored.TryGetValue(key, out var cached))
             {
-                Log.Debug("nuget restore: skipped (already restored) {Path}", path);
-                return new RestoreResult(0, "", "", TimeSpan.Zero, false);
+                Log.Debug("restore: skipped (already restored) {Path}", path);
+                return cached;
             }
         }
 
@@ -203,29 +84,61 @@ internal static class NuGetRestore
         {
             lock (Restored)
             {
-                if (Restored.Contains(key))
-                    return new RestoreResult(0, "", "", TimeSpan.Zero, false);
+                if (Restored.TryGetValue(key, out var cached))
+                    return cached;
             }
 
-            var cli = FindNuGetCli();
-            if (cli == null)
-            {
-                return new RestoreResult(-1, "",
-                    "NuGet CLI not found on PATH (need `nuget` on macOS/Linux or `nuget.exe` on Windows)",
-                    TimeSpan.Zero, false);
-            }
+            var lockFiles = new Dictionary<string, LockFile>(StringComparer.OrdinalIgnoreCase);
+            var rootDir = Path.GetDirectoryName(key) ?? ".";
 
-            var args = new List<string>(cli.Value.PrefixArgs) { "restore", path, "-NonInteractive" };
-            var workingDir = Path.GetDirectoryName(Path.GetFullPath(path)) ?? ".";
-            Log.Debug("nuget restore: starting for {Path}", path);
-            var result = await RunProcessAsync(cli.Value.Exe, args, workingDir, ct);
-
-            if (result.ExitCode == 0 && !result.TimedOut)
+            if (hasPackagesConfig)
             {
-                lock (Restored)
+                // Materialize the solution-local packages/ folder for legacy HintPaths.
+                var packagesConfigs = Directory
+                    .EnumerateFiles(rootDir, "packages.config", SearchOption.AllDirectories)
+                    .ToList();
+                Log.Debug(">> packages.config restore ({Count} configs)", packagesConfigs.Count);
+                await NuGetResolver.InstallPackagesConfigPackagesAsync(rootDir, packagesConfigs, ct);
+                Log.Debug("<< packages.config restore");
+
+                // Synthesized attestation graph per legacy project.
+                foreach (var packagesConfig in packagesConfigs)
                 {
-                    Restored.Add(key);
+                    var projectDir = Path.GetDirectoryName(packagesConfig)!;
+                    foreach (var projectFile in Directory.EnumerateFiles(projectDir, "*.*proj"))
+                    {
+                        var lockFile = await NuGetResolver.RestorePackagesConfigGraphAsync(
+                            projectFile, packagesConfig, NuGetResolver.ReadLegacyFramework(projectFile), ct);
+                        if (lockFile != null)
+                            lockFiles[Path.GetFullPath(projectFile)] = lockFile;
+                    }
                 }
+            }
+
+            // In-process restore of PackageReference projects (replaces `dotnet restore`).
+            var sw = Stopwatch.StartNew();
+            Log.Debug(">> in-process restore ({FileName})", Path.GetFileName(path));
+            var dgSpec = NuGetResolver.CreateDependencyGraphSpec(key,
+                msbuildProperties.Count > 0 ? msbuildProperties : null);
+            if (dgSpec != null)
+            {
+                foreach (var (projectPath, lockFile) in await NuGetResolver.RestoreAsync(dgSpec, commit: true, ct))
+                    lockFiles.TryAdd(projectPath, lockFile);
+            }
+            else if (!hasPackagesConfig)
+            {
+                // Degrade rather than abort: MSBuildWorkspace may still evaluate the
+                // solution (packages already cached, or projects without dependencies),
+                // and markers fall back to SDK-only attestation.
+                Log.Warning("In-process restore could not produce a dependency graph for {Path}; " +
+                            "continuing with degraded dependency attestation", path);
+            }
+            Log.Debug("<< in-process restore ({FileName}) ({Elapsed})", Path.GetFileName(path), sw.Elapsed);
+
+            var result = (IReadOnlyDictionary<string, LockFile>)lockFiles;
+            lock (Restored)
+            {
+                Restored[key] = result;
             }
 
             return result;
@@ -238,8 +151,9 @@ internal static class NuGetRestore
 
     /// <summary>
     /// Restores the .NET Framework reference assemblies and web-application targets as NuGet
-    /// packages into a stable per-machine cache directory, so MSBuildWorkspace can evaluate
-    /// legacy projects on non-Windows machines. The result is cached for the process lifetime.
+    /// packages into a stable per-machine cache directory (flat, version-less layout), so
+    /// MSBuildWorkspace can evaluate legacy projects on non-Windows machines. The result is
+    /// cached for the process lifetime.
     /// </summary>
     public static async Task<NetFrameworkBuildAssets> RestoreNetFrameworkBuildAssetsAsync(CancellationToken ct)
     {
@@ -252,28 +166,21 @@ internal static class NuGetRestore
             if (_buildAssets != null)
                 return _buildAssets;
 
-            // -ExcludeVersion keeps the installed folder names stable across versions.
             var cacheDir = Path.Combine(Path.GetTempPath(), "openrewrite-netfx-build-assets");
             var vsToolsPath = Path.Combine(cacheDir, WebTargetsPackage, "tools", "VSToolsPath");
             var targetFrameworkRootPath = Path.Combine(cacheDir, ReferenceAssembliesPackage, "build");
 
-            var cli = FindNuGetCli();
-            if (cli == null)
-            {
-                Log.Debug("nuget install: NuGet CLI not found on PATH; skipping .NET Framework build assets");
-                _buildAssets = new NetFrameworkBuildAssets(null, null);
-                return _buildAssets;
-            }
-
             if (!Directory.Exists(vsToolsPath))
-                await NuGetInstallAsync(cli.Value, WebTargetsPackage, WebTargetsVersion, cacheDir, ct);
+                await NuGetResolver.InstallPackageAsync(
+                    WebTargetsPackage, WebTargetsVersion, cacheDir, excludeVersion: true, ct);
             if (!Directory.Exists(targetFrameworkRootPath))
-                await NuGetInstallAsync(cli.Value, ReferenceAssembliesPackage, ReferenceAssembliesVersion, cacheDir, ct);
+                await NuGetResolver.InstallPackageAsync(
+                    ReferenceAssembliesPackage, ReferenceAssembliesVersion, cacheDir, excludeVersion: true, ct);
 
             _buildAssets = new NetFrameworkBuildAssets(
                 Directory.Exists(vsToolsPath) ? vsToolsPath : null,
                 Directory.Exists(targetFrameworkRootPath) ? targetFrameworkRootPath : null);
-            Log.Debug("nuget install: .NET Framework build assets — VSToolsPath={VSToolsPath}, TargetFrameworkRootPath={TargetFrameworkRootPath}",
+            Log.Debug("netfx build assets — VSToolsPath={VSToolsPath}, TargetFrameworkRootPath={TargetFrameworkRootPath}",
                 _buildAssets.VSToolsPath ?? "(missing)", _buildAssets.TargetFrameworkRootPath ?? "(missing)");
             return _buildAssets;
         }
@@ -281,111 +188,6 @@ internal static class NuGetRestore
         {
             Gate.Release();
         }
-    }
-
-    private static async Task NuGetInstallAsync((string Exe, string[] PrefixArgs) cli, string package,
-        string version, string outputDirectory, CancellationToken ct)
-    {
-        Directory.CreateDirectory(outputDirectory);
-        var args = new List<string>(cli.PrefixArgs)
-        {
-            "install", package,
-            "-Version", version,
-            "-OutputDirectory", outputDirectory,
-            "-ExcludeVersion",
-            "-NonInteractive"
-        };
-        Log.Debug("nuget install: {Package} {Version} -> {OutputDirectory}", package, version, outputDirectory);
-        var result = await RunProcessAsync(cli.Exe, args, outputDirectory, ct);
-        if (result.ExitCode != 0)
-        {
-            Log.Debug("nuget install: {Package} failed (exit code {ExitCode})\n{Stdout}\n{Stderr}",
-                package, result.ExitCode, result.Stdout, result.Stderr);
-        }
-    }
-
-    private static async Task<RestoreResult> RunProcessAsync(string exe, IReadOnlyList<string> args,
-        string workingDirectory, CancellationToken ct)
-    {
-        var sw = Stopwatch.StartNew();
-        var psi = new ProcessStartInfo(exe)
-        {
-            WorkingDirectory = workingDirectory,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-        foreach (var a in args)
-            psi.ArgumentList.Add(a);
-
-        using var process = Process.Start(psi);
-        if (process == null)
-        {
-            sw.Stop();
-            return new RestoreResult(-1, "", $"Failed to start process: {exe}", sw.Elapsed, false);
-        }
-
-        using var procCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-        procCts.CancelAfter(Timeout);
-        try
-        {
-            // Read stdout/stderr before WaitForExitAsync to avoid a pipe-buffer deadlock.
-            var stdoutTask = process.StandardOutput.ReadToEndAsync(procCts.Token);
-            var stderrTask = process.StandardError.ReadToEndAsync(procCts.Token);
-            await Task.WhenAll(stdoutTask, stderrTask);
-            await process.WaitForExitAsync(procCts.Token);
-            sw.Stop();
-            return new RestoreResult(process.ExitCode, stdoutTask.Result, stderrTask.Result, sw.Elapsed, false);
-        }
-        catch (OperationCanceledException) when (!ct.IsCancellationRequested)
-        {
-            try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
-            sw.Stop();
-            return new RestoreResult(-1, "", "", sw.Elapsed, true);
-        }
-    }
-
-    /// <summary>
-    /// Resolves how to invoke the NuGet CLI: <c>nuget.exe</c> on Windows, <c>nuget</c> on
-    /// other platforms, falling back to <c>mono nuget.exe</c>. Returns null when no NuGet CLI
-    /// is found on the PATH.
-    /// </summary>
-    private static (string Exe, string[] PrefixArgs)? FindNuGetCli()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            var win = FindOnPath("nuget.exe") ?? FindOnPath("nuget");
-            return win == null ? null : (win, Array.Empty<string>());
-        }
-        var nuget = FindOnPath("nuget");
-        if (nuget != null)
-            return (nuget, Array.Empty<string>());
-        var nugetExe = FindOnPath("nuget.exe");
-        if (nugetExe != null)
-            return ("mono", new[] { nugetExe });
-        return null;
-    }
-
-    private static string? FindOnPath(string fileName)
-    {
-        var pathVar = Environment.GetEnvironmentVariable("PATH");
-        if (string.IsNullOrEmpty(pathVar))
-            return null;
-        foreach (var dir in pathVar.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-        {
-            try
-            {
-                var candidate = Path.Combine(dir.Trim(), fileName);
-                if (File.Exists(candidate))
-                    return candidate;
-            }
-            catch
-            {
-                // Skip invalid PATH entries.
-            }
-        }
-        return null;
     }
 }
 
@@ -397,92 +199,51 @@ internal static class NuGetRestore
 /// </summary>
 public class SolutionParser
 {
-    private static bool _msbuildRegistered;
     private readonly CSharpParser _parser = new();
+
+    private IReadOnlyDictionary<string, LockFile> _restoredLockFiles =
+        new Dictionary<string, LockFile>(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// In-memory NuGet lock files (keyed by absolute project path) from the most recent
+    /// <see cref="LoadAsync"/>. Used for MSBuildProject marker attestation without reading
+    /// <c>project.assets.json</c> from disk.
+    /// </summary>
+    public IReadOnlyDictionary<string, LockFile> RestoredLockFiles => _restoredLockFiles;
 
     /// <summary>
     /// Load a solution or project via MSBuildWorkspace.
     /// Detects .sln/.slnx vs .csproj by extension and calls the appropriate method.
-    /// Runs dotnet restore first to ensure NuGet packages are resolved.
+    /// Runs the in-process NuGet restore first so packages are resolved and the standard
+    /// restore outputs exist for compilation.
     /// </summary>
     public async Task<Solution> LoadAsync(string path, CancellationToken ct = default)
     {
         Log.Debug("LoadAsync: starting for {Path}", path);
-        EnsureMSBuildRegistered();
+        MSBuildRegistration.Ensure();
 
-        // Legacy non-SDK projects use packages.config and must be restored with the
-        // standalone NuGet CLI; dotnet restore is a no-op for them. A solution can mix
-        // SDK-style and non-SDK projects, so when packages.config is present we run both.
+        // Legacy non-SDK projects use packages.config: they need the solution-local packages/
+        // folder materialized and get their attestation graph from a synthesized PackageSpec.
+        // A solution can mix SDK-style and non-SDK projects, so both paths may run.
         var hasPackagesConfig = HasPackagesConfig(path);
 
-        // Run dotnet restore to ensure NuGet packages are available for MSBuildWorkspace
-        Log.Debug(">> dotnet restore ({FileName})", Path.GetFileName(path));
-        var restoreResult = await DotNetRestore.RunAsync(path, ct);
-        Log.Debug("<< dotnet restore ({FileName}) ({Elapsed})", Path.GetFileName(path), restoreResult.Elapsed);
-
-        if (restoreResult.TimedOut)
-        {
-            throw new InvalidOperationException(
-                $"dotnet restore timed out after {restoreResult.Elapsed} for {path}");
-        }
-
-        if (restoreResult.ExitCode != 0)
-        {
-            var details = string.Join("\n",
-                new[] { restoreResult.Stdout, restoreResult.Stderr }
-                    .Where(s => !string.IsNullOrWhiteSpace(s)));
-            if (hasPackagesConfig)
-            {
-                // For packages.config projects the authoritative restore is the nuget
-                // restore below; a dotnet restore failure here is not fatal.
-                Log.Debug("dotnet restore failed (exit code {ExitCode}) for {Path}; continuing with nuget restore\n{Details}",
-                    restoreResult.ExitCode, path, details);
-            }
-            else
-            {
-                throw new InvalidOperationException(
-                    $"dotnet restore failed (exit code {restoreResult.ExitCode}) for {path}\n{details}");
-            }
-        }
-        else
-        {
-            Log.Debug("dotnet restore succeeded in {Elapsed}", restoreResult.Elapsed);
-        }
-
-        // MSBuild properties handed to MSBuildWorkspace. For packages.config projects these
-        // point MSBuild at the .NET Framework reference assemblies and web-application
-        // targets that are not present on non-Windows machines.
+        // MSBuild properties handed to MSBuildWorkspace (and restore-graph evaluation). For
+        // legacy (non-SDK) projects these point MSBuild at the .NET Framework reference
+        // assemblies and web-application targets that are not present on non-Windows machines.
+        // Gated on non-SDK project presence (not packages.config): a converted project that
+        // uses PackageReference in a classic csproj still needs them to evaluate/compile.
         var msbuildProperties = new Dictionary<string, string>();
 
-        if (hasPackagesConfig)
+        if (hasPackagesConfig || HasNonSdkProject(path))
         {
-            Log.Debug(">> nuget restore ({FileName})", Path.GetFileName(path));
-            var nugetResult = await NuGetRestore.RunAsync(path, ct);
-            Log.Debug("<< nuget restore ({FileName}) ({Elapsed})", Path.GetFileName(path), nugetResult.Elapsed);
-
-            if (nugetResult.TimedOut)
-            {
-                throw new InvalidOperationException(
-                    $"nuget restore timed out after {nugetResult.Elapsed} for {path}");
-            }
-
-            if (nugetResult.ExitCode != 0)
-            {
-                var details = string.Join("\n",
-                    new[] { nugetResult.Stdout, nugetResult.Stderr }
-                        .Where(s => !string.IsNullOrWhiteSpace(s)));
-                throw new InvalidOperationException(
-                    $"nuget restore failed (exit code {nugetResult.ExitCode}) for {path}\n{details}");
-            }
-
-            // Restore the .NET Framework reference assemblies and web-application targets
-            // so MSBuildWorkspace can evaluate legacy projects on non-Windows machines.
-            var buildAssets = await NuGetRestore.RestoreNetFrameworkBuildAssetsAsync(ct);
+            var buildAssets = await SolutionRestore.RestoreNetFrameworkBuildAssetsAsync(ct);
             if (buildAssets.VSToolsPath != null)
                 msbuildProperties["VSToolsPath"] = buildAssets.VSToolsPath;
             if (buildAssets.TargetFrameworkRootPath != null)
                 msbuildProperties["TargetFrameworkRootPath"] = buildAssets.TargetFrameworkRootPath;
         }
+
+        _restoredLockFiles = await SolutionRestore.RunAsync(path, hasPackagesConfig, msbuildProperties, ct);
 
         var sw = Stopwatch.StartNew();
         Log.Debug("MSBuildWorkspace: creating workspace");
@@ -873,19 +634,45 @@ public class SolutionParser
         return new DotNetProject(Guid.NewGuid(), projectName, tfms, sdk);
     }
 
-    private static void EnsureMSBuildRegistered()
+    /// <summary>
+    /// Returns true if the solution/project directory tree contains a classic (non-SDK-style)
+    /// project file — one whose root Project element has no Sdk attribute. Such projects need
+    /// the .NET Framework build assets to evaluate on non-Windows machines, whether or not
+    /// they still use packages.config.
+    /// </summary>
+    private static bool HasNonSdkProject(string path)
     {
-        if (!_msbuildRegistered)
+        try
         {
-            MSBuildLocator.RegisterDefaults();
-            _msbuildRegistered = true;
+            var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+            if (dir == null)
+                return false;
+            foreach (var projectFile in Directory.EnumerateFiles(dir, "*.csproj", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    var root = XDocument.Load(projectFile).Root;
+                    if (root != null && root.Attribute("Sdk") == null)
+                        return true;
+                }
+                catch
+                {
+                    // Unparseable project file — ignore.
+                }
+            }
         }
+        catch (Exception ex)
+        {
+            Log.Debug("HasNonSdkProject: failed for {Path} ({ExType}: {ExMessage}), assuming none",
+                path, ex.GetType().Name, ex.Message);
+        }
+        return false;
     }
 
     /// <summary>
     /// Returns true if the solution/project directory tree contains a <c>packages.config</c>,
-    /// which marks a legacy non-SDK-style project whose NuGet dependencies must be restored
-    /// with the standalone NuGet CLI rather than <c>dotnet restore</c>.
+    /// which marks a legacy non-SDK-style project whose NuGet dependencies are materialized
+    /// into the solution-local packages folder and attested via a synthesized restore graph.
     /// </summary>
     private static bool HasPackagesConfig(string path)
     {

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -220,7 +220,6 @@ public class SolutionParser
     public async Task<Solution> LoadAsync(string path, CancellationToken ct = default)
     {
         Log.Debug("LoadAsync: starting for {Path}", path);
-        MSBuildRegistration.Ensure();
 
         // Legacy non-SDK projects use packages.config: they need the solution-local packages/
         // folder materialized and get their attestation graph from a synthesized PackageSpec.

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -31,20 +31,29 @@
 
   <ItemGroup>
     <PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
-    <PackageReference Include="NuGet.Frameworks" Version="6.12.4" />
-    <PackageReference Include="NuGet.Versioning" Version="6.12.4" />
+    <PackageReference Include="NuGet.Frameworks" Version="7.6.0" />
+    <PackageReference Include="NuGet.Versioning" Version="7.6.0" />
+    <!-- In-process NuGet restore (PackageSpec/DependencyGraphSpec -> RestoreRunner -> LockFile).
+         Commands transitively supplies ProjectModel, Protocol, Packaging, Configuration, Common. -->
+    <PackageReference Include="NuGet.Commands" Version="7.6.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="none" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="none" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" PrivateAssets="none" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
+    <!-- Compile-time only: at runtime MSBuildLocator redirects these to the located SDK's MSBuild.
+         PrivateAssets=all keeps the runtime assets from flowing to consuming projects too — a
+         stale Microsoft.Build*.dll in any consumer's output directory would break the SDK
+         assembly redirection (MissingMethodException/FileLoadException at MSBuild load time). -->
+    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.25.29" />
     <!-- xunit (assertion/fixture API only) is consumed by the public Test/ helpers (RewriteTest, RpcFixture, ...). -->
     <!-- The runner packages (Microsoft.NET.Test.Sdk, xunit.runner.visualstudio) live in the sibling OpenRewrite.Tests project. -->
     <PackageReference Include="xunit" Version="2.9.3" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.3" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzer.Testing" Version="1.1.4" PrivateAssets="none" />
   </ItemGroup>
 
   <ItemGroup>

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -36,17 +36,14 @@
     <!-- In-process NuGet restore (PackageSpec/DependencyGraphSpec -> RestoreRunner -> LockFile).
          Commands transitively supplies ProjectModel, Protocol, Packaging, Configuration, Common. -->
     <PackageReference Include="NuGet.Commands" Version="7.6.0" />
+    <!-- Plain runtime dependency, used only for managed .sln parsing (SolutionFile.Parse).
+         No MSBuildLocator: project evaluation happens in the SDK's own `dotnet msbuild`
+         (NuGetResolver) or Roslyn's out-of-process BuildHost (MSBuildWorkspace). -->
+    <PackageReference Include="Microsoft.Build" Version="18.8.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <!-- Compile-time only: at runtime MSBuildLocator redirects these to the located SDK's MSBuild.
-         PrivateAssets=all keeps the runtime assets from flowing to consuming projects too — a
-         stale Microsoft.Build*.dll in any consumer's output directory would break the SDK
-         assembly redirection (MissingMethodException/FileLoadException at MSBuild load time). -->
-    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" PrivateAssets="none" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.25.29" />

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -262,7 +262,18 @@ public abstract class RewriteTest
 
     private static readonly CsprojParser CsprojParserInstance = new();
 
-    private static bool IsCsprojPath(string path) => CsprojParserInstance.Accept(path);
+    private static bool IsCsprojPath(string path)
+    {
+        // packages.config / nuget.config ride along into the shared temp directory so the
+        // in-process restore sees them (legacy attestation, package sources) during ParseAll.
+        var fileName = Path.GetFileName(path);
+        if (fileName.Equals("packages.config", StringComparison.OrdinalIgnoreCase) ||
+            fileName.Equals("nuget.config", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+        return CsprojParserInstance.Accept(path);
+    }
 
     private static Dictionary<string, SourceFile> ParseCsprojFilesTogether(List<SourceSpec> specs)
     {

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/CsprojParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/CsprojParser.cs
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using System.Diagnostics;
 using OpenRewrite.Core;
 using OpenRewrite.CSharp;
 using Serilog;
@@ -21,10 +20,11 @@ using Serilog;
 namespace OpenRewrite.Xml;
 
 /// <summary>
-/// Parses .csproj files as XML and attaches an MSBuildProject marker with
-/// project metadata extracted from project.assets.json produced by dotnet restore.
-/// Writes files to a temp directory and runs dotnet restore to generate
-/// project.assets.json for accurate metadata.
+/// Parses .csproj files as XML and attaches an MSBuildProject marker with project metadata
+/// from an in-process NuGet restore (PackageSpec/RestoreRunner → in-memory LockFile).
+/// Files are written to a temp directory so MSBuild imports (Directory.Build.props,
+/// .targets, packages.config, nuget.config) resolve correctly during restore-graph
+/// generation — but no child process is spawned and no project.assets.json is read.
 /// </summary>
 public class CsprojParser
 {
@@ -38,8 +38,6 @@ public class CsprojParser
         "csproj", "vbproj", "fsproj"
     };
 
-    private static readonly TimeSpan RestoreTimeout = TimeSpan.FromMinutes(2);
-
     private readonly XmlParser _xmlParser = new();
 
     /// <summary>
@@ -52,9 +50,10 @@ public class CsprojParser
     }
 
     /// <summary>
-    /// Parses multiple csproj/props/targets files together. Writes all files to a shared
-    /// temp directory and runs dotnet restore so that MSBuild imports (Directory.Build.props,
-    /// .targets, etc.) resolve correctly. Returns parsed Documents in the same order as input.
+    /// Parses multiple csproj/props/targets (and supporting packages.config/nuget.config) files
+    /// together. Writes all files to a shared temp directory so MSBuild imports resolve, then
+    /// resolves each project's dependency graph in-process. Returns parsed Documents in the
+    /// same order as input. Only project files (csproj/vbproj/fsproj) receive a marker.
     /// </summary>
     public IList<Document> ParseAll(IList<(string sourceStr, string sourcePath)> files)
     {
@@ -76,21 +75,25 @@ public class CsprojParser
                 File.WriteAllText(filePath, sourceStr);
             }
 
-            // Run dotnet restore on each restorable project file
-            foreach (var (_, sourcePath) in files)
-            {
-                if (IsProjectFile(sourcePath))
-                    RunDotnetRestore(Path.Combine(tempDir, sourcePath));
-            }
-
-            // Parse each file — CreateMarker reads project.assets.json from tempDir
+            // Parse each file — project files get a marker from the in-process restore
             var results = new List<Document>(files.Count);
             foreach (var (sourceStr, sourcePath) in files)
             {
                 var doc = _xmlParser.Parse(sourceStr, sourcePath);
-                var marker = MSBuildProjectHelper.CreateMarker(doc, tempDir);
-                if (marker != null)
-                    doc = doc.WithMarkers(doc.Markers.Add(marker));
+                if (IsProjectFile(sourcePath))
+                {
+                    var marker = MSBuildProjectHelper.CreateMarker(doc, tempDir);
+                    if (marker != null)
+                        doc = doc.WithMarkers(doc.Markers.Add(marker));
+                }
+                else if (Accept(sourcePath))
+                {
+                    // props/targets carry a basic marker (no restore attempt) — recipes use
+                    // marker presence as the "this is an MSBuild build file" gate.
+                    var marker = MSBuildProjectHelper.CreateMarker(doc);
+                    if (marker != null)
+                        doc = doc.WithMarkers(doc.Markers.Add(marker));
+                }
                 results.Add(doc);
             }
 
@@ -104,9 +107,12 @@ public class CsprojParser
             foreach (var (sourceStr, sourcePath) in files)
             {
                 var doc = _xmlParser.Parse(sourceStr, sourcePath);
-                var marker = MSBuildProjectHelper.CreateMarker(doc);
-                if (marker != null)
-                    doc = doc.WithMarkers(doc.Markers.Add(marker));
+                if (Accept(sourcePath))
+                {
+                    var marker = MSBuildProjectHelper.CreateMarker(doc);
+                    if (marker != null)
+                        doc = doc.WithMarkers(doc.Markers.Add(marker));
+                }
                 results.Add(doc);
             }
             return results;
@@ -132,8 +138,8 @@ public class CsprojParser
     }
 
     /// <summary>
-    /// Returns true for actual project files (.csproj/.vbproj/.fsproj) that support dotnet restore,
-    /// as opposed to .props/.targets files which cannot be restored independently.
+    /// Returns true for actual project files (.csproj/.vbproj/.fsproj) that participate in
+    /// restore, as opposed to .props/.targets files which cannot be restored independently.
     /// </summary>
     private static bool IsProjectFile(string path)
     {
@@ -143,47 +149,5 @@ public class CsprojParser
             return ProjectExtensions.Contains(path[(dot + 1)..]);
         }
         return false;
-    }
-
-    private static bool RunDotnetRestore(string csprojPath)
-    {
-        try
-        {
-            var psi = new ProcessStartInfo("dotnet")
-            {
-                WorkingDirectory = Path.GetDirectoryName(csprojPath) ?? ".",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-            psi.ArgumentList.Add("restore");
-            psi.ArgumentList.Add(csprojPath);
-            psi.ArgumentList.Add("/p:NuGetAudit=false");
-            psi.ArgumentList.Add("/p:RestoreIgnoreFailedSources=true");
-            psi.ArgumentList.Add("--ignore-failed-sources");
-            psi.Environment["NUGET_ENHANCED_MAX_NETWORK_TRY_COUNT"] = "1";
-            psi.Environment["NUGET_ENHANCED_NETWORK_RETRY_DELAY_MILLISECONDS"] = "100";
-
-            using var process = Process.Start(psi);
-            if (process == null) return false;
-
-            process.StandardOutput.ReadToEnd();
-            process.StandardError.ReadToEnd();
-            process.WaitForExit((int)RestoreTimeout.TotalMilliseconds);
-
-            if (!process.HasExited)
-            {
-                try { process.Kill(true); } catch { }
-                return false;
-            }
-
-            return process.ExitCode == 0;
-        }
-        catch (Exception ex)
-        {
-            Log.Debug("CsprojParser: dotnet restore failed: {Error}", ex.Message);
-            return false;
-        }
     }
 }

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marker/MSBuildProject.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marker/MSBuildProject.java
@@ -212,8 +212,11 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
     }
 
     /**
-     * A resolved NuGet package from the transitive dependency tree.
-     * Built from project.assets.json after dotnet restore.
+     * A resolved package (or referenced project) from the restore dependency graph, carrying
+     * the full per-target-framework asset information from the NuGet {@code LockFile}
+     * (produced by an in-process {@code PackageSpec}/{@code RestoreRunner} restore).
+     * Asset lists hold package-relative paths with {@code _._} placeholder entries stripped,
+     * so an empty list means "the package provides no assets of that kind".
      */
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
     @Value
@@ -230,6 +233,81 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
 
         int depth;
 
+        /**
+         * Library type from the lock file: "package" or "project".
+         */
+        @Builder.Default
+        String type = "package";
+
+        /**
+         * Compile-time assemblies (lib/ref), lock file {@code compile} section.
+         */
+        @Builder.Default
+        List<String> compileAssemblies = emptyList();
+
+        /**
+         * Runtime assemblies, lock file {@code runtime} section.
+         */
+        @Builder.Default
+        List<String> runtimeAssemblies = emptyList();
+
+        /**
+         * .NET Framework in-box assembly names, lock file {@code frameworkAssemblies} section.
+         */
+        @Builder.Default
+        List<String> frameworkAssemblies = emptyList();
+
+        /**
+         * MSBuild props/targets imports, lock file {@code build} section.
+         */
+        @Builder.Default
+        List<String> buildFiles = emptyList();
+
+        /**
+         * MSBuild imports for the outer multi-targeting build, lock file {@code buildMultiTargeting} section.
+         */
+        @Builder.Default
+        List<String> buildMultiTargetingFiles = emptyList();
+
+        /**
+         * PackageReference-style shared content, lock file {@code contentFiles} section.
+         */
+        @Builder.Default
+        List<String> contentFiles = emptyList();
+
+        /**
+         * RID-specific assets, lock file {@code runtimeTargets} section.
+         */
+        @Builder.Default
+        List<String> runtimeTargets = emptyList();
+
+        /**
+         * Satellite resource assemblies, lock file {@code resource} section.
+         */
+        @Builder.Default
+        List<String> resourceAssemblies = emptyList();
+
+        /**
+         * Roslyn analyzer assemblies, derived from the package file list (analyzers/**.dll).
+         */
+        @Builder.Default
+        List<String> analyzerAssemblies = emptyList();
+
+        /**
+         * Package ships install.ps1/uninstall.ps1/init.ps1 (not executed under PackageReference).
+         */
+        boolean hasInstallScripts;
+
+        /**
+         * Package ships XDT/.transform config transforms (not applied under PackageReference).
+         */
+        boolean hasXdtTransforms;
+
+        /**
+         * Package ships a legacy content/ folder (ignored under PackageReference).
+         */
+        boolean hasLegacyContentFolder;
+
         @Override
         public void rpcSend(ResolvedPackage after, RpcSendQueue q) {
             q.getAndSend(after, ResolvedPackage::getName);
@@ -238,6 +316,28 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
                     dep -> dep.getName() + "@" + dep.getResolvedVersion(),
                     dep -> dep.rpcSend(dep, q));
             q.getAndSend(after, ResolvedPackage::getDepth);
+            q.getAndSend(after, ResolvedPackage::getType);
+            sendStringList(q, after, ResolvedPackage::getCompileAssemblies);
+            sendStringList(q, after, ResolvedPackage::getRuntimeAssemblies);
+            sendStringList(q, after, ResolvedPackage::getFrameworkAssemblies);
+            sendStringList(q, after, ResolvedPackage::getBuildFiles);
+            sendStringList(q, after, ResolvedPackage::getBuildMultiTargetingFiles);
+            sendStringList(q, after, ResolvedPackage::getContentFiles);
+            sendStringList(q, after, ResolvedPackage::getRuntimeTargets);
+            sendStringList(q, after, ResolvedPackage::getResourceAssemblies);
+            sendStringList(q, after, ResolvedPackage::getAnalyzerAssemblies);
+            q.getAndSend(after, ResolvedPackage::isHasInstallScripts);
+            q.getAndSend(after, ResolvedPackage::isHasXdtTransforms);
+            q.getAndSend(after, ResolvedPackage::isHasLegacyContentFolder);
+        }
+
+        private static void sendStringList(RpcSendQueue q, ResolvedPackage after,
+                                           java.util.function.Function<ResolvedPackage, List<String>> selector) {
+            q.getAndSendList(after, selector, s -> s, s -> q.getAndSend(s, x -> x));
+        }
+
+        private static List<String> receiveStringList(RpcReceiveQueue q, List<String> before) {
+            return q.receiveList(before, s -> q.<String, String>receiveAndGet(s, x -> x));
         }
 
         @Override
@@ -247,7 +347,20 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
                     .withResolvedVersion(q.receive(before.resolvedVersion))
                     .withDependencies(q.receiveList(before.dependencies,
                             dep -> dep.rpcReceive(dep, q)))
-                    .withDepth(q.receive(before.depth));
+                    .withDepth(q.receive(before.depth))
+                    .withType(q.receive(before.type))
+                    .withCompileAssemblies(receiveStringList(q, before.compileAssemblies))
+                    .withRuntimeAssemblies(receiveStringList(q, before.runtimeAssemblies))
+                    .withFrameworkAssemblies(receiveStringList(q, before.frameworkAssemblies))
+                    .withBuildFiles(receiveStringList(q, before.buildFiles))
+                    .withBuildMultiTargetingFiles(receiveStringList(q, before.buildMultiTargetingFiles))
+                    .withContentFiles(receiveStringList(q, before.contentFiles))
+                    .withRuntimeTargets(receiveStringList(q, before.runtimeTargets))
+                    .withResourceAssemblies(receiveStringList(q, before.resourceAssemblies))
+                    .withAnalyzerAssemblies(receiveStringList(q, before.analyzerAssemblies))
+                    .withHasInstallScripts(q.receive(before.hasInstallScripts))
+                    .withHasXdtTransforms(q.receive(before.hasXdtTransforms))
+                    .withHasLegacyContentFolder(q.receive(before.hasLegacyContentFolder));
         }
     }
 


### PR DESCRIPTION
## Context / Problem Being Solved

Building C# LSTs shelled out to `dotnet restore` / `nuget.exe` and then parsed `obj/project.assets.json` off disk. That required Mono + the NuGet CLI as prerequisites, produced no dependency attestation at all for legacy `packages.config` projects, and captured only a shallow slice of the restore graph in the `MSBuildProject` marker.

## Solution

Replaces all child-process package operations with an in-process NuGet engine (`NuGetResolver`): the MSBuild `GenerateRestoreGraphFile` target runs in an out-of-process worker node to produce a `DependencyGraphSpec`, which is restored via `RestoreRunner` into an in-memory `LockFile`; `packages.config` projects get a synthesized PackageReference spec (full graph attestation) plus a materialized `packages/` folder. The `MSBuildProject.ResolvedPackage` marker is extended with the full per-TFM asset breakdown (compile/runtime/build/analyzers, install-script/XDT/content flags, depth-linked graph), kept in Java↔C# RPC-codec sync. NuGet.* is upgraded to 7.6.0 and Microsoft.Build to 18.8.2 to match the .NET 10 SDK.

## Related

Consumed by companion PRs in `moderneinc/moderne-cli`, `moderneinc/recipes-csharp`, and `moderneinc/rewrite-java-security`.

## Release Notes

C# LST builds now resolve NuGet packages in-process (no NuGet CLI or Mono required), give `packages.config` projects full dependency attestation, and expose per-package asset details on the `MSBuildProject` marker.
