### PR TITLE
perf(rpc): per-source-file eviction to bound polyglot RewriteRpc server memory

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -19,6 +19,7 @@ import io.moderne.jsonrpc.JsonRpc;
 import io.moderne.jsonrpc.JsonRpcMethod;
 import io.moderne.jsonrpc.JsonRpcRequest;
 import io.moderne.jsonrpc.JsonRpcSuccess;
+import io.moderne.jsonrpc.RawJson;
 import io.moderne.jsonrpc.internal.SnowflakeId;
 import org.jetbrains.annotations.VisibleForTesting;
 import org.jspecify.annotations.NonNull;
@@ -248,6 +249,15 @@ public class RewriteRpc {
                 return true;
             }
         });
+        jsonRpc.rpc("Evict", new JsonRpcMethod<Evict>() {
+            @Override
+            protected Boolean handle(Evict request) {
+                // Inbound side has no per-file checkpoint, so refs are left for Reset.
+                remoteObjects.remove(request.getId());
+                localObjects.remove(request.getId());
+                return true;
+            }
+        });
 
         jsonRpc.bind();
     }
@@ -321,6 +331,40 @@ public class RewriteRpc {
         remoteRefs.clear();
         localRefs.clear();
         remoteLanguages = null;
+    }
+
+    /**
+     * Ref high-water marks (send-side count, receive-side max key) captured before a file is
+     * visited so {@link #evict} rolls back exactly that file's refs. Receive-side uses the max
+     * key, not the size, because remote ids may be zero-based.
+     */
+    public int[] refCheckpoint() {
+        int remoteRefsMax = -1;
+        for (Integer ref : remoteRefs.keySet()) {
+            if (ref > remoteRefsMax) {
+                remoteRefsMax = ref;
+            }
+        }
+        return new int[]{localRefs.size(), remoteRefsMax};
+    }
+
+    /**
+     * Drop a file's tree from both peers and roll their refs back to the pre-file checkpoint.
+     * Symmetric by design: dropping the send-side ref forces the next file to re-{@code ADD} the
+     * interned object instead of a {@code REF_USE} the rolled-back receiver would reject. Notified
+     * fire-and-forget — under source-outer iteration the file's transfer is already complete.
+     *
+     * @param localRefsCheckpoint  {@code refCheckpoint()[0]} captured before the file was visited
+     * @param remoteRefsCheckpoint {@code refCheckpoint()[1]} captured before the file was visited
+     */
+    public void evict(String id, int localRefsCheckpoint, int remoteRefsCheckpoint) {
+        jsonRpc.notify(new JsonRpcRequest(null, "Evict", RawJson.of(new Evict(id))));
+
+        remoteObjects.remove(id);
+        localObjects.remove(id);
+
+        localRefs.values().removeIf(ref -> ref > localRefsCheckpoint);
+        remoteRefs.keySet().removeIf(ref -> ref > remoteRefsCheckpoint);
     }
 
     public <P> @Nullable Tree visit(SourceFile sourceFile, String visitorName, P p) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -81,6 +81,9 @@ public class RewriteRpcProcess extends Thread {
     private Thread stderrDrainThread;
 
     @Nullable
+    private Thread rssSamplerThread;
+
+    @Nullable
     private IOException startupFailure;
 
     public RewriteRpcProcess(String... command) {
@@ -218,6 +221,8 @@ public class RewriteRpcProcess extends Thread {
         }, "rpc-shutdown");
         Runtime.getRuntime().addShutdownHook(shutdownHook);
 
+        startRssSampler();
+
         SimpleModule module = new SimpleModule();
         module.addSerializer(Path.class, new PathSerializer());
         module.addDeserializer(Path.class, new PathDeserializer());
@@ -231,6 +236,10 @@ public class RewriteRpcProcess extends Thread {
     }
 
     public void shutdown() {
+        if (rssSamplerThread != null) {
+            rssSamplerThread.interrupt();
+            rssSamplerThread = null;
+        }
         if (shutdownHook != null) {
             try {
                 Runtime.getRuntime().removeShutdownHook(shutdownHook);
@@ -270,6 +279,75 @@ public class RewriteRpcProcess extends Thread {
                 Thread.currentThread().interrupt();
             }
             stderrDrainThread = null;
+        }
+    }
+
+    /**
+     * Opt-in RSS profiling ({@code REWRITE_RPC_RSS_MS}): sample the subprocess RSS — which catches
+     * native/off-heap growth the in-process counters miss — into {@code rpc-rss-<pid>.csv}.
+     */
+    private void startRssSampler() {
+        String intervalEnv = System.getenv("REWRITE_RPC_RSS_MS");
+        Path dir = workingDirectory;
+        Process p = process;
+        if (intervalEnv == null || dir == null || p == null) {
+            return;
+        }
+        long intervalMs;
+        try {
+            intervalMs = Long.parseLong(intervalEnv.trim());
+        } catch (NumberFormatException e) {
+            return;
+        }
+        if (intervalMs <= 0) {
+            return;
+        }
+        long pid;
+        try {
+            // Process.pid() is Java 9+, but this module compiles at Java 8 source level.
+            pid = (long) Process.class.getMethod("pid").invoke(p);
+        } catch (Exception e) {
+            return;
+        }
+        Path rssCsv = dir.resolve("rpc-rss-" + pid + ".csv");
+        Thread sampler = new Thread(() -> {
+            try (OutputStream out = Files.newOutputStream(rssCsv,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                out.write("timestamp_ms,rss_kb\n".getBytes());
+                out.flush();
+                while (p.isAlive() && !Thread.currentThread().isInterrupted()) {
+                    long rssKb = readRssKb(pid);
+                    if (rssKb >= 0) {
+                        out.write((System.currentTimeMillis() + "," + rssKb + "\n").getBytes());
+                        out.flush();
+                    }
+                    Thread.sleep(intervalMs);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            } catch (IOException ignored) {
+                // Best-effort profiling; never disturb the run.
+            }
+        }, "rpc-rss-sampler");
+        sampler.setDaemon(true);
+        sampler.start();
+        this.rssSamplerThread = sampler;
+    }
+
+    /** Resident set size of {@code pid} in KiB via {@code ps} (macOS + Linux), or -1 on failure. */
+    private static long readRssKb(long pid) {
+        try {
+            Process ps = new ProcessBuilder("ps", "-o", "rss=", "-p", Long.toString(pid))
+                    .redirectErrorStream(true).start();
+            String out = readFully(ps.getInputStream()).trim();
+            ps.waitFor(2, TimeUnit.SECONDS);
+            if (out.isEmpty()) {
+                return -1;
+            }
+            String[] tokens = out.split("\\s+");
+            return Long.parseLong(tokens[tokens.length - 1]);
+        } catch (Exception e) {
+            return -1;
         }
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/Evict.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/Evict.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.rpc.request;
+
+import lombok.Value;
+
+/**
+ * Drop one source file's tree from the peer's caches after the recipe stack has visited it.
+ * Fire-and-forget notification; see {@link org.openrewrite.rpc.RewriteRpc#evict}.
+ */
+@Value
+public class Evict implements RpcRequest {
+    String id;
+}

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -124,6 +124,8 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         if (isScanningRequired()) {
             return sourceSetEditor.apply(sourceSet, sourceFile -> {
                 BatchState scanBatch = new BatchState();
+                Set<RewriteRpc> touched = newSetFromMap(new IdentityHashMap<>());
+                Map<RewriteRpc, int[]> refCheckpoints = new IdentityHashMap<>();
 
                 SourceFile result = allRecipeStack.reduce(sourceSet, recipe, ctx, (source, recipeStack) -> {
                     Recipe recipe = leaf(recipeStack);
@@ -137,6 +139,10 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                         // Check if this is a batchable RPC scanning recipe
                         RewriteRpc currentRpc = recipe instanceof RpcRecipe ? ((RpcRecipe) recipe).getRpc() : null;
                         String scanVisitorName = recipe instanceof RpcRecipe ? ((RpcRecipe) recipe).getScanVisitor() : null;
+
+                        if (scanVisitorName != null) {
+                            captureRpc(currentRpc, touched, refCheckpoints);
+                        }
 
                         if (currentRpc != null && scanVisitorName != null) {
                             // Flush if switching to a different RPC instance
@@ -198,6 +204,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
                     flushScanBatch(scanBatch, result);
                 }
 
+                evictSourceFile(sourceFile, touched, refCheckpoints);
                 return result;
             });
         }
@@ -220,6 +227,33 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         }
 
         batch.clear();
+    }
+
+    /**
+     * Record a peer this file touched, snapshotting its ref high-water on first sight so
+     * {@link #evictSourceFile} can roll back exactly the refs this file introduced.
+     */
+    private static void captureRpc(@Nullable RewriteRpc rpc, Set<RewriteRpc> touched,
+                                   Map<RewriteRpc, int[]> refCheckpoints) {
+        if (rpc != null && touched.add(rpc)) {
+            refCheckpoints.put(rpc, rpc.refCheckpoint());
+        }
+    }
+
+    /**
+     * Drop this source file's tree from every RPC peer that visited it, rolling each peer's
+     * ref maps back to the pre-file checkpoint. Bounds RPC-server memory to ~one file at a time.
+     */
+    private static void evictSourceFile(@Nullable SourceFile sourceFile, Set<RewriteRpc> touched,
+                                        Map<RewriteRpc, int[]> refCheckpoints) {
+        if (sourceFile == null || touched.isEmpty()) {
+            return;
+        }
+        String id = sourceFile.getId().toString();
+        for (RewriteRpc rpc : touched) {
+            int[] cp = refCheckpoints.get(rpc);
+            rpc.evict(id, cp[0], cp[1]);
+        }
     }
 
     public LSS generateSources(LSS sourceSet) {
@@ -320,6 +354,8 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
     protected @Nullable SourceFile editSource(LSS sourceSet, SourceFile sourceFile) {
         recipeRunStats.recordSourceVisited(sourceFile);
         BatchState batch = new BatchState();
+        Set<RewriteRpc> touched = newSetFromMap(new IdentityHashMap<>());
+        Map<RewriteRpc, int[]> refCheckpoints = new IdentityHashMap<>();
 
         SourceFile result = allRecipeStack.reduce(sourceSet, recipe, ctx, (source, recipeStack) -> {
             Recipe recipe = leaf(recipeStack);
@@ -328,6 +364,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
             }
 
             RewriteRpc currentRpc = recipe instanceof RpcRecipe ? ((RpcRecipe) recipe).getRpc() : null;
+            captureRpc(currentRpc, touched, refCheckpoints);
 
             // Flush batch if switching to a different RPC or non-RPC recipe
             if (batch.rpc != null && batch.rpc != currentRpc) {
@@ -450,6 +487,8 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
             result = flushBatch(batch, result);
         }
 
+        // Recipe errors are handled inside the reduce, so this runs on every normal return.
+        evictSourceFile(sourceFile, touched, refCheckpoints);
         return result;
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -198,6 +198,47 @@ class RewriteRpcTest implements RewriteTest {
         assertThat(result.getText()).isEqualTo("Fixed");
     }
 
+    /**
+     * {@link RewriteRpc#evict} drops the tree from both peers and rolls the client's ref maps
+     * back to the pre-file checkpoint.
+     */
+    @SneakyThrows
+    @Test
+    void evictDropsTreeFromBothPeers() {
+        PlainText original = PlainText.builder()
+          .sourcePath(Path.of("test.txt"))
+          .text("Hello")
+          .build();
+        String id = original.getId().toString();
+        String sourceFileType = PlainText.class.getName();
+
+        // High-water before the client fetches anything, so evict rolls back exactly this exchange.
+        int[] checkpoint = client.refCheckpoint();
+
+        // Server holds the tree; client fetches it → both peers cache it.
+        server.localObjects.put(id, original);
+        client.getObject(id, sourceFileType);
+        assertThat(client.localObjects).containsKey(id);
+        assertThat(client.remoteObjects).containsKey(id);
+        assertThat(server.localObjects).containsKey(id);
+        assertThat(server.remoteObjects).containsKey(id);
+
+        client.evict(id, checkpoint[0], checkpoint[1]);
+
+        // Client cleared synchronously, including refs rolled back to the checkpoint.
+        assertThat(client.localObjects).doesNotContainKey(id);
+        assertThat(client.remoteObjects).doesNotContainKey(id);
+        assertThat(client.remoteRefs.keySet()).allMatch(ref -> ref <= checkpoint[1]);
+
+        // The Evict notification is fire-and-forget; wait for the server to apply it.
+        long deadline = System.currentTimeMillis() + 5_000;
+        while (server.localObjects.containsKey(id) && System.currentTimeMillis() < deadline) {
+            Thread.sleep(10);
+        }
+        assertThat(server.localObjects).doesNotContainKey(id);
+        assertThat(server.remoteObjects).doesNotContainKey(id);
+    }
+
     @DocumentExample
     @Test
     void sendReceiveIdempotence() {

--- a/rewrite-csharp/csharp/OpenRewrite.Tool/Program.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tool/Program.cs
@@ -24,6 +24,9 @@ var logFile = args.FirstOrDefault(a => a.StartsWith("--log-file="))
 var recipeInstallDir = args.FirstOrDefault(a => a.StartsWith("--recipe-install-dir="))
     ?.Substring("--recipe-install-dir=".Length);
 
+var metricsCsv = args.FirstOrDefault(a => a.StartsWith("--metrics-csv="))
+    ?.Substring("--metrics-csv=".Length);
+
 var loggerConfig = new LoggerConfiguration();
 if (logFile != null)
 {
@@ -46,5 +49,5 @@ sw.Stop();
 Log.Debug("<< Parser warmup ({Elapsed})", sw.Elapsed);
 
 Log.Information("Starting RPC server");
-await RewriteRpcServer.RunAsync(recipeInstallDir: recipeInstallDir);
+await RewriteRpcServer.RunAsync(recipeInstallDir: recipeInstallDir, metricsCsv: metricsCsv);
 Log.Information("RPC server exited");

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -85,6 +85,12 @@ public class RewriteRpcServer
     private readonly ConcurrentDictionary<int, object> _remoteRefs = new();
 
     /// <summary>
+    /// Ref high-water per source file (send-side _localRefs count, receive-side max _remoteRefs
+    /// key), captured before first visit so <see cref="Evict"/> rolls back exactly its refs.
+    /// </summary>
+    private readonly ConcurrentDictionary<string, (int LocalRefs, int RemoteRefsMax)> _refCheckpoints = new();
+
+    /// <summary>
     /// Connects this server to a remote JSON-RPC peer. Used by test infrastructure
     /// to wire up an RPC connection to a Java process.
     /// </summary>
@@ -1304,6 +1310,7 @@ public class RewriteRpcServer
         }
 
         // Fetch tree from the remote (Java) process
+        CaptureRefCheckpoint(request.TreeId);
         var tree = await GetObjectFromRemoteAsync(request.TreeId, request.SourceFileType);
 
         if (phase != "scan" && phase != "edit")
@@ -1358,6 +1365,7 @@ public class RewriteRpcServer
         }
 
         var sw = Stopwatch.StartNew();
+        CaptureRefCheckpoint(request.TreeId);
         var tree = await GetObjectFromRemoteAsync(request.TreeId, request.SourceFileType);
         var fetchMs = sw.ElapsedMilliseconds;
 
@@ -1643,9 +1651,62 @@ public class RewriteRpcServer
         _remoteObjects.Clear();
         _localRefs.Clear();
         _remoteRefs.Clear();
+        _refCheckpoints.Clear();
         _preparedRecipes.Clear();
         _recipeAccumulators.Clear();
         _executionContexts.Clear();
+    }
+
+    /// <summary>
+    /// Records the ref high-water before a source file is first visited (first visit wins), so
+    /// <see cref="Evict"/> can roll back exactly the refs that file introduced.
+    /// </summary>
+    private void CaptureRefCheckpoint(string treeId)
+    {
+        _refCheckpoints.GetOrAdd(treeId, _ =>
+        {
+            var remoteMax = -1;
+            foreach (var key in _remoteRefs.Keys)
+            {
+                if (key > remoteMax)
+                {
+                    remoteMax = key;
+                }
+            }
+            return (_localRefs.Count, remoteMax);
+        });
+    }
+
+    /// <summary>
+    /// Drops one source file's tree and rolls back the refs it introduced; recipe/accumulator/
+    /// context state (keyed separately) is preserved. Fire-and-forget, so it returns no response.
+    /// </summary>
+    [JsonRpcMethod("Evict", UseSingleObjectParameterDeserialization = true)]
+    public void Evict(EvictRequest request)
+    {
+        if (string.IsNullOrEmpty(request.Id))
+        {
+            return;
+        }
+        _localObjects.TryRemove(request.Id, out _);
+        _remoteObjects.TryRemove(request.Id, out _);
+        if (_refCheckpoints.TryRemove(request.Id, out var cp))
+        {
+            foreach (var kv in _localRefs)
+            {
+                if (kv.Value > cp.LocalRefs)
+                {
+                    _localRefs.TryRemove(kv.Key, out _);
+                }
+            }
+            foreach (var key in _remoteRefs.Keys)
+            {
+                if (key > cp.RemoteRefsMax)
+                {
+                    _remoteRefs.TryRemove(key, out _);
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -1819,6 +1880,11 @@ public class PrintRequest
     public string? SourcePath { get; set; }
     public string? SourceFileType { get; set; }
     public string? MarkerPrinter { get; set; }
+}
+
+public class EvictRequest
+{
+    public string Id { get; set; } = "";
 }
 
 public class GetMarketplaceResponseRow

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -25,6 +25,7 @@ using OpenRewrite.Core.Rpc;
 using OpenRewrite.Java;
 using Serilog;
 using StreamJsonRpc;
+using StreamJsonRpc.Protocol;
 using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;
 using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 
@@ -1494,6 +1495,7 @@ public class RewriteRpcServer
 
     public static async Task RunAsync(RecipeMarketplace? marketplace = null,
         string? recipeInstallDir = null,
+        string? metricsCsv = null,
         CancellationToken cancellationToken = default)
     {
         marketplace ??= new RecipeMarketplace();
@@ -1521,10 +1523,21 @@ public class RewriteRpcServer
             JsonSerializerOptions = RpcJson.Options,
         };
 
-        var handler = new HeaderDelimitedMessageHandler(outputStream, inputStream, formatter);
-        using var jsonRpc = new StringErrorDataJsonRpc(handler);
-
         var server = new RewriteRpcServer(marketplace, recipeInstallDir);
+
+        // Wrap the handler so each dispatched request records timing + cache residency
+        // (local/remote/refs) — flat with per-file Evict, ramping without.
+        IJsonRpcMessageHandler handler = new HeaderDelimitedMessageHandler(outputStream, inputStream, formatter);
+        RpcMetricsWriter? metrics = null;
+        if (!string.IsNullOrEmpty(metricsCsv))
+        {
+            metrics = new RpcMetricsWriter(metricsCsv, () =>
+                (server._localObjects.Count, server._remoteObjects.Count,
+                    server._localRefs.Count + server._remoteRefs.Count));
+            handler = new MetricsMessageHandler(handler, metrics);
+        }
+
+        using var jsonRpc = new StringErrorDataJsonRpc(handler);
         server._jsonRpc = jsonRpc;
         _current = server;
         // Allow concurrent request dispatch so reentrant callbacks don't deadlock.
@@ -1541,6 +1554,7 @@ public class RewriteRpcServer
         finally
         {
             _current = null;
+            metrics?.Dispose();
         }
     }
 
@@ -1782,6 +1796,126 @@ public class RewriteRpcServer
                 _ => new CSharpReceiver().Visit((J)before, q)!
             };
         }
+    }
+}
+
+/// <summary>
+/// Writes one CSV row per dispatched RPC call: timing, managed-heap memory, and object/ref cache
+/// residency. Same schema as the Go and Python servers. Thread-safe; rows are flushed eagerly.
+/// </summary>
+internal sealed class RpcMetricsWriter : IDisposable
+{
+    private const string Header =
+        "timestamp,method,duration_ms,error,memory_used_bytes,memory_max_bytes,local_objects,remote_objects,refs";
+
+    private readonly StreamWriter _writer;
+    private readonly Func<(int Local, int Remote, int Refs)> _cacheSizes;
+    private readonly object _lock = new();
+    private bool _disposed;
+
+    public RpcMetricsWriter(string path, Func<(int, int, int)> cacheSizes)
+    {
+        _cacheSizes = cacheSizes;
+        _writer = new StreamWriter(new FileStream(path, FileMode.Create, FileAccess.Write, FileShare.Read));
+        _writer.WriteLine(Header);
+        _writer.Flush();
+    }
+
+    public void Record(string method, double durationMs, string? error)
+    {
+        var (local, remote, refs) = _cacheSizes();
+        var used = GC.GetTotalMemory(false);
+        var max = GC.GetGCMemoryInfo().HeapSizeBytes;
+        var timestamp = DateTimeOffset.UtcNow.ToString("O");
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _writer.WriteLine(
+                $"{timestamp},{method},{durationMs:F0},{Escape(error)},{used},{max},{local},{remote},{refs}");
+            _writer.Flush();
+        }
+    }
+
+    // Quote per RFC 4180 only when the field contains a comma, quote, or newline (errors can).
+    private static string Escape(string? field)
+    {
+        if (string.IsNullOrEmpty(field))
+        {
+            return "";
+        }
+        if (field.IndexOfAny([',', '"', '\n', '\r']) < 0)
+        {
+            return field;
+        }
+        return $"\"{field.Replace("\"", "\"\"")}\"";
+    }
+
+    public void Dispose()
+    {
+        lock (_lock)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            _writer.Dispose();
+        }
+    }
+}
+
+/// <summary>
+/// Wraps the message handler to record a metrics row when each inbound request's response is
+/// written. Notifications (Evict) get no response and aren't recorded; outbound requests are ignored.
+/// </summary>
+internal sealed class MetricsMessageHandler : IJsonRpcMessageHandler, IDisposable
+{
+    private readonly IJsonRpcMessageHandler _inner;
+    private readonly RpcMetricsWriter _metrics;
+    private readonly ConcurrentDictionary<RequestId, (string Method, long Start)> _inflight = new();
+
+    public MetricsMessageHandler(IJsonRpcMessageHandler inner, RpcMetricsWriter metrics)
+    {
+        _inner = inner;
+        _metrics = metrics;
+    }
+
+    public bool CanRead => _inner.CanRead;
+    public bool CanWrite => _inner.CanWrite;
+    public IJsonRpcMessageFormatter Formatter => _inner.Formatter;
+
+    public async ValueTask<JsonRpcMessage?> ReadAsync(CancellationToken cancellationToken)
+    {
+        var message = await _inner.ReadAsync(cancellationToken).ConfigureAwait(false);
+        if (message is JsonRpcRequest { IsResponseExpected: true } request)
+        {
+            _inflight[request.RequestId] = (request.Method ?? "", Stopwatch.GetTimestamp());
+        }
+        return message;
+    }
+
+    public async ValueTask WriteAsync(JsonRpcMessage message, CancellationToken cancellationToken)
+    {
+        await _inner.WriteAsync(message, cancellationToken).ConfigureAwait(false);
+        // Only responses to inbound requests carry an id we put in _inflight; outbound requests we
+        // send to Java are JsonRpcRequest and never match, so their ids can't collide here.
+        if (message is JsonRpcResult or JsonRpcError &&
+            message is IJsonRpcMessageWithId withId &&
+            _inflight.TryRemove(withId.RequestId, out var entry))
+        {
+            var durationMs = Stopwatch.GetElapsedTime(entry.Start).TotalMilliseconds;
+            var error = (message as JsonRpcError)?.Error?.Message;
+            _metrics.Record(entry.Method, durationMs, error);
+        }
+    }
+
+    public void Dispose()
+    {
+        (_inner as IDisposable)?.Dispose();
+        _metrics.Dispose();
     }
 }
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -204,6 +204,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
         private Supplier<@Nullable Path> dotnetPathSupplier = () -> DEFAULT_DOTNET_PATH;
         private @Nullable Path csharpServerEntry;
         private @Nullable Path log;
+        private @Nullable Path metricsCsv;
         private Duration timeout = Duration.ofSeconds(60);
         private boolean traceRpcMessages;
         private @Nullable Path workingDirectory;
@@ -268,6 +269,11 @@ public class CSharpRewriteRpc extends RewriteRpc {
 
         public Builder log(@Nullable Path log) {
             this.log = log;
+            return this;
+        }
+
+        public Builder metricsCsv(@Nullable Path metricsCsv) {
+            this.metricsCsv = metricsCsv;
             return this;
         }
 
@@ -360,6 +366,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
                             dotnetPath.toString(),
                             serverEntry.toAbsolutePath().normalize().toString(),
                             log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
+                            metricsCsv == null ? null : "--metrics-csv=" + metricsCsv.toAbsolutePath().normalize(),
                             traceRpcMessages ? "--trace-rpc-messages" : null,
                             recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()
                     );
@@ -485,6 +492,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
                     // ("Non-default ID required"). --no-build also implies --no-restore.
                     "--no-build",
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
+                    metricsCsv == null ? null : "--metrics-csv=" + metricsCsv.toAbsolutePath().normalize(),
                     traceRpcMessages ? "--trace-rpc-messages" : null,
                     recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()
             );
@@ -513,6 +521,7 @@ public class CSharpRewriteRpc extends RewriteRpc {
             return Stream.of(
                     toolExecutable.toAbsolutePath().normalize().toString(),
                     log == null ? null : "--log-file=" + log.toAbsolutePath().normalize(),
+                    metricsCsv == null ? null : "--metrics-csv=" + metricsCsv.toAbsolutePath().normalize(),
                     traceRpcMessages ? "--trace-rpc-messages" : null,
                     recipeInstallDir == null ? null : "--recipe-install-dir=" + recipeInstallDir.toAbsolutePath().normalize()
             );

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -72,6 +72,13 @@ type rpcError struct {
 	Data    string `json:"data,omitempty"`
 }
 
+// evictCheckpoint is a peer's ref high-water before a file is visited: localRefsNext (send,
+// Go→Java) and reverseRemoteRefsMax (receive, Java→Go), so evict rolls back exactly its refs.
+type evictCheckpoint struct {
+	localRefsNext        int
+	reverseRemoteRefsMax int
+}
+
 type server struct {
 	localObjects  map[string]any
 	remoteObjects map[string]any    // forward direction: tracks what Java has from Go
@@ -86,6 +93,10 @@ type server struct {
 	reverseRemoteRefs    map[int]any
 
 	reverseTypePool map[string]java.JavaType
+
+	// Ref high-water marks captured before a source file is first visited, keyed by tree id,
+	// so handleEvict can roll back exactly the refs that file introduced (see handleEvict).
+	refCheckpoints map[string]evictCheckpoint
 
 	// Prepared recipe instances keyed by unique ID
 	preparedRecipes map[string]recipe.Recipe
@@ -211,6 +222,7 @@ func newServer(cfg serverConfig) *server {
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
 		reverseTypePool:         make(map[string]java.JavaType),
+		refCheckpoints:          make(map[string]evictCheckpoint),
 		preparedRecipes:         make(map[string]recipe.Recipe),
 		preparedRecipeNames:     make(map[string]string),
 		preparedEditorOverrides: make(map[string]recipe.TreeVisitor),
@@ -236,7 +248,7 @@ func newServer(cfg serverConfig) *server {
 		} else {
 			s.metricsFile = f
 			s.metricsWriter = csv.NewWriter(f)
-			if err := s.metricsWriter.Write([]string{"timestamp", "method", "duration_ms", "error", "memory_used_bytes", "memory_max_bytes"}); err != nil {
+			if err := s.metricsWriter.Write([]string{"timestamp", "method", "duration_ms", "error", "memory_used_bytes", "memory_max_bytes", "local_objects", "remote_objects", "refs"}); err != nil {
 				logger.Printf("metrics-csv: cannot write header: %v", err)
 			}
 			s.metricsWriter.Flush()
@@ -288,6 +300,9 @@ func (s *server) recordMetric(method string, duration time.Duration, rpcErr *rpc
 		errMsg,
 		strconv.FormatUint(mem.HeapAlloc, 10),
 		strconv.FormatUint(mem.Sys, 10),
+		strconv.Itoa(len(s.localObjects)),
+		strconv.Itoa(len(s.remoteObjects)),
+		strconv.Itoa(s.localRefs.Len() + len(s.reverseRemoteRefs)),
 	}
 	if err := s.metricsWriter.Write(row); err != nil {
 		s.logger.Printf("metrics-csv: write row failed: %v", err)
@@ -349,6 +364,11 @@ func main() {
 		}
 
 		resp := s.safeHandleRequest(req)
+		// Notifications (no id, e.g. Evict) get no reply — a null-id response would fail
+		// every in-flight request on the Java reader.
+		if isNotification(req.ID) {
+			continue
+		}
 		if err := s.writeMessage(resp); err != nil {
 			s.logger.Printf("Error writing response: %v", err)
 			break
@@ -406,6 +426,12 @@ func (s *server) writeMessage(resp *jsonRPCResponse) error {
 // safeHandleRequest wraps handleRequest with panic recovery and per-RPC
 // metrics capture. The metric row is written exactly once per request,
 // after the response is determined (panic-recovered or not).
+// isNotification reports whether a request has no id (a JSON-RPC notification, e.g. Evict).
+func isNotification(id json.RawMessage) bool {
+	trimmed := bytes.TrimSpace(id)
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
 func (s *server) safeHandleRequest(req *jsonRPCRequest) (resp *jsonRPCResponse) {
 	start := time.Now()
 	defer func() {
@@ -444,6 +470,8 @@ func (s *server) handleRequest(req *jsonRPCRequest) *jsonRPCResponse {
 		result, rpcErr = s.handleInstallRecipes(req.Params)
 	case "Reset":
 		result = s.handleReset()
+	case "Evict":
+		result = s.handleEvict(req.Params)
 	case "GetMarketplace":
 		result, rpcErr = s.handleGetMarketplace(req.Params)
 	case "PrepareRecipe":
@@ -1139,11 +1167,58 @@ func (s *server) handleReset() bool {
 	s.reverseRemoteObjects = make(map[string]any)
 	s.reverseRemoteRefs = make(map[int]any)
 	s.reverseTypePool = make(map[string]java.JavaType)
+	s.refCheckpoints = make(map[string]evictCheckpoint)
 	s.preparedRecipes = make(map[string]recipe.Recipe)
 	s.preparedRecipeNames = make(map[string]string)
 	s.preparedEditorOverrides = make(map[string]recipe.TreeVisitor)
 	s.preparedAccumulators = make(map[string]any)
 	s.preparedContexts = make(map[string]*recipe.ExecutionContext)
+	s.refCheckpoints = make(map[string]evictCheckpoint)
+	return true
+}
+
+// captureRefCheckpoint records the ref high-water before a file is first visited (first visit
+// wins), keyed by tree id, so handleEvict rolls back exactly the refs that file introduced.
+func (s *server) captureRefCheckpoint(treeID string) {
+	if _, ok := s.refCheckpoints[treeID]; ok {
+		return
+	}
+	maxKey := -1
+	for k := range s.reverseRemoteRefs {
+		if k > maxKey {
+			maxKey = k
+		}
+	}
+	s.refCheckpoints[treeID] = evictCheckpoint{
+		localRefsNext:        s.localRefs.NextID(),
+		reverseRemoteRefsMax: maxKey,
+	}
+}
+
+// handleEvict drops one source file's tree and rolls back the refs it introduced. Recipe/
+// accumulator/context state (keyed separately) is preserved. Fire-and-forget, so it never errors.
+func (s *server) handleEvict(params json.RawMessage) bool {
+	var req struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(params, &req); err != nil || req.ID == "" {
+		return true
+	}
+	if t, ok := s.inProgressGetObjects[req.ID]; ok {
+		t.stop()
+		delete(s.inProgressGetObjects, req.ID)
+	}
+	delete(s.localObjects, req.ID)
+	delete(s.remoteObjects, req.ID)
+	if cp, ok := s.refCheckpoints[req.ID]; ok {
+		s.localRefs.RollbackTo(cp.localRefsNext)
+		for k := range s.reverseRemoteRefs {
+			if k > cp.reverseRemoteRefsMax {
+				delete(s.reverseRemoteRefs, k)
+			}
+		}
+		delete(s.refCheckpoints, req.ID)
+	}
 	return true
 }
 
@@ -1829,6 +1904,7 @@ func (s *server) handleVisit(params json.RawMessage) (any, *rpcError) {
 	}
 
 	// Get the tree from Java via bidirectional RPC
+	s.captureRefCheckpoint(req.TreeID)
 	treeObj := s.getObjectFromJava(req.TreeID, req.SourceFileType)
 	if treeObj == nil {
 		return &visitResponse{Modified: false}, nil
@@ -1995,6 +2071,7 @@ func (s *server) handleBatchVisit(params json.RawMessage) (any, *rpcError) {
 
 	ctx := s.resolveExecutionContext(req.PID)
 
+	s.captureRefCheckpoint(req.TreeID)
 	treeObj := s.getObjectFromJava(req.TreeID, req.SourceFileType)
 	current, _ := treeObj.(java.Tree)
 	if current == nil {

--- a/rewrite-go/pkg/rpc/reference.go
+++ b/rewrite-go/pkg/rpc/reference.go
@@ -61,6 +61,28 @@ func (m *ReferenceMap) Len() int {
 	return len(m.refs)
 }
 
+// NextID returns the id that will be assigned to the next new reference. Capture it
+// before a source file is visited to use as a rollback checkpoint (see RollbackTo).
+func (m *ReferenceMap) NextID() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.nextID
+}
+
+// RollbackTo drops every reference assigned at or after the checkpoint and resets the id
+// counter so the next file re-allocates the same ids. Unlike DiscardNewReferences, this is
+// safe only because the remote receiver rolls back in lockstep (per-source-file evict).
+func (m *ReferenceMap) RollbackTo(checkpoint int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for obj, ref := range m.refs {
+		if ref >= checkpoint {
+			delete(m.refs, obj)
+		}
+	}
+	m.nextID = checkpoint
+}
+
 func (m *ReferenceMap) deleteIfMatches(obj any, ref int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/rewrite-javascript/rewrite/src/reference.ts
+++ b/rewrite-javascript/rewrite/src/reference.ts
@@ -89,6 +89,10 @@ export class ReferenceMap {
         return this.refCount;
     }
 
+    get size(): number {
+        return this.refsById.size;
+    }
+
     rollbackTo(savedRefCount: number): void {
         for (let i = savedRefCount; i < this.refCount; i++) {
             const obj = this.refsById.get(i);

--- a/rewrite-javascript/rewrite/src/rpc/request/batch-visit.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/batch-visit.ts
@@ -68,6 +68,7 @@ export class BatchVisit {
                   preparedRecipes: Map<String, Recipe>,
                   recipeCursors: WeakMap<Recipe, Cursor>,
                   getObject: (id: string, sourceFileType?: string) => any,
+                  captureRefCheckpoint: (treeId: string) => void,
                   getCursor: (cursorIds: string[] | undefined, sourceFileType?: string) => Promise<Cursor>,
                   dataTableStore: () => DataTableStore | undefined,
                   metricsCsv?: string): void {
@@ -82,6 +83,7 @@ export class BatchVisit {
                     if (store && p instanceof ExecutionContext) {
                         p.messages[DATA_TABLE_STORE] = store;
                     }
+                    captureRefCheckpoint(request.treeId);
                     let tree: Tree = await getObject(request.treeId, request.sourceFileType);
                     const cursor = await getCursor(request.cursor, request.sourceFileType);
 

--- a/rewrite-javascript/rewrite/src/rpc/request/metrics.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/metrics.ts
@@ -17,7 +17,15 @@ import * as fs from 'fs';
 import * as rpc from "vscode-jsonrpc/node";
 import {Cursor, isSourceFile, SourceFile} from "../../tree";
 
-const CSV_HEADER = 'request,target,durationMs,memoryUsedBytes,memoryMaxBytes';
+const CSV_HEADER = 'request,target,durationMs,memoryUsedBytes,memoryMaxBytes,localObjects,remoteObjects,refs';
+
+// Optional provider of current RPC cache sizes, appended to each metrics row so a profile
+// shows cache residency (flat with per-file Evict, monotonic without). Set by RewriteRpc.
+let cacheSizeProvider: (() => { local: number; remote: number; refs: number }) | undefined;
+
+export function setCacheSizeProvider(provider: () => { local: number; remote: number; refs: number }): void {
+    cacheSizeProvider = provider;
+}
 
 /**
  * Extracts the sourcePath from a tree object, either directly from a SourceFile
@@ -162,8 +170,9 @@ function recordMetrics(
 
     const memoryUsedBytes = memEnd.heapUsed;
     const memoryMaxBytes = memEnd.heapTotal;
+    const cache = cacheSizeProvider?.() ?? {local: 0, remote: 0, refs: 0};
 
-    const csvRow = `${request},${target},${durationMs},${memoryUsedBytes},${memoryMaxBytes}\n`;
+    const csvRow = `${request},${target},${durationMs},${memoryUsedBytes},${memoryMaxBytes},${cache.local},${cache.remote},${cache.refs}\n`;
 
     try {
         fs.appendFileSync(metricsCsv, csvRow);

--- a/rewrite-javascript/rewrite/src/rpc/request/visit.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/visit.ts
@@ -44,6 +44,7 @@ export class Visit {
                   preparedRecipes: Map<String, Recipe>,
                   recipeCursors: WeakMap<Recipe, Cursor>,
                   getObject: (id: string, sourceFileType?: string) => any,
+                  captureRefCheckpoint: (treeId: string) => void,
                   getCursor: (cursorIds: string[] | undefined, sourceFileType?: string) => Promise<Cursor>,
                   dataTableStore: () => DataTableStore | undefined,
                   metricsCsv?: string): void {
@@ -58,6 +59,7 @@ export class Visit {
                     if (store && p instanceof ExecutionContext) {
                         p.messages[DATA_TABLE_STORE] = store;
                     }
+                    captureRefCheckpoint(request.treeId);
                     const before: Tree = await getObject(request.treeId, request.sourceFileType);
                     const cursor = await getCursor(request.cursor, request.sourceFileType);
                     context.target = extractSourcePath(before, cursor);

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -38,7 +38,7 @@ import {
 } from "./request";
 import {DataTableStore} from "../data-table";
 import {RecipeMarketplace} from "../marketplace";
-import {initializeMetricsCsv} from "./request/metrics";
+import {initializeMetricsCsv, setCacheSizeProvider} from "./request/metrics";
 import {RpcObjectData, RpcObjectState, RpcReceiveQueue} from "./queue";
 import {RpcRecipe} from "./recipe";
 import {ExecutionContext} from "../execution";
@@ -74,6 +74,10 @@ export class RewriteRpc {
     readonly remoteRefs: Map<number, any> = new Map();
     readonly localRefs: ReferenceMap = new ReferenceMap();
 
+    // Ref high-water per source file, captured before it is first visited so an Evict rolls
+    // back exactly the refs it introduced. `send` = localRefs snapshot, `recvMax` = max remoteRefs key.
+    readonly refCheckpoints: Map<string, { send: number, recvMax: number }> = new Map();
+
     private remoteLanguages?: string[];
     private readonly logger?: rpc.Logger;
     private traceGetObject: TraceGetObject = {receive: false, send: false};
@@ -93,6 +97,11 @@ export class RewriteRpc {
                 }) {
         // Initialize metrics CSV file if configured
         initializeMetricsCsv(options.metricsCsv, options.logger);
+        setCacheSizeProvider(() => ({
+            local: this.localObjects.size,
+            remote: this.remoteObjects.size,
+            refs: this.remoteRefs.size + this.localRefs.size,
+        }));
         this.logger = options.logger;
 
         const preparedRecipes: Map<String, Recipe> = new Map();
@@ -101,6 +110,19 @@ export class RewriteRpc {
         // Need this indirection, otherwise `this` will be undefined when executed in the handlers.
         const getObject = (id: string, sourceFileType?: string) => this.getObject(id, sourceFileType);
         const getCursor = (cursorIds: string[] | undefined, sourceFileType?: string) => this.getCursor(cursorIds, sourceFileType);
+        // First visit of the file wins.
+        const captureRefCheckpoint = (treeId: string) => {
+            if (this.refCheckpoints.has(treeId)) {
+                return;
+            }
+            let recvMax = -1;
+            for (const k of this.remoteRefs.keys()) {
+                if (k > recvMax) {
+                    recvMax = k;
+                }
+            }
+            this.refCheckpoints.set(treeId, {send: this.localRefs.snapshot(), recvMax});
+        };
         const traceGetObject = () => this.traceGetObject.send;
         const dataTableStore = () => this.configuredDataTableStore;
 
@@ -109,8 +131,8 @@ export class RewriteRpc {
         // GetMarketplace builds rows so the host can attribute each recipe to its own bundle.
         const recipeOrigin: Map<string, string> = new Map();
 
-        Visit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, dataTableStore, options.metricsCsv);
-        BatchVisit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, getCursor, dataTableStore, options.metricsCsv);
+        Visit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, captureRefCheckpoint, getCursor, dataTableStore, options.metricsCsv);
+        BatchVisit.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, captureRefCheckpoint, getCursor, dataTableStore, options.metricsCsv);
         Generate.handle(this.connection, this.localObjects, preparedRecipes, recipeCursors, getObject, dataTableStore, options.metricsCsv);
         SetDataTableStore.handle(this.connection, store => this.configuredDataTableStore = store, options.metricsCsv);
         GetObject.handle(this.connection, this.remoteObjects, this.localObjects,
@@ -140,6 +162,7 @@ export class RewriteRpc {
             this.remoteObjects.clear();
             this.remoteRefs.clear();
             this.localRefs.clear();
+            this.refCheckpoints.clear();
             preparedRecipes.clear();
             this.remoteLanguages = undefined;
         };
@@ -153,6 +176,27 @@ export class RewriteRpc {
                 // RewriteRpc.java around line 222.
                 clearLocalState();
                 return true;
+            }
+        )
+
+        // Drop one source file's tree + roll back the refs it introduced. Fire-and-forget
+        // notification (no reply), so recipe/accumulator/context state is left intact.
+        this.connection.onNotification(
+            new rpc.NotificationType<{ id: string }>("Evict"),
+            (params) => {
+                const id = params.id;
+                this.localObjects.delete(id);
+                this.remoteObjects.delete(id);
+                const cp = this.refCheckpoints.get(id);
+                if (cp !== undefined) {
+                    this.localRefs.rollbackTo(cp.send);
+                    for (const k of [...this.remoteRefs.keys()]) {
+                        if (k > cp.recvMax) {
+                            this.remoteRefs.delete(k);
+                        }
+                    }
+                    this.refCheckpoints.delete(id);
+                }
             }
         )
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -59,6 +59,9 @@ local_objects: Dict[str, Any] = {}
 remote_objects: Dict[str, Any] = {}
 # Remote refs - maps reference IDs to objects for cyclic graph handling
 remote_refs: Dict[int, Any] = {}
+# Per-source-file remote_refs high-water, captured before a file is first visited so
+# handle_evict can roll back exactly the refs that file introduced. Keyed by tree id.
+_ref_checkpoints: Dict[str, int] = {}
 
 # Request ID counter for outgoing requests
 _request_id_counter = 0
@@ -673,8 +676,26 @@ def handle_reset(params: dict) -> bool:
     _execution_contexts.clear()
     _recipe_accumulators.clear()
     _recipe_phases.clear()
+    _ref_checkpoints.clear()
 
     logger.info("Reset: cleared all cached state")
+    return True
+
+
+def handle_evict(params: dict) -> bool:
+    """Handle an Evict RPC notification - drop one source file's tree and roll back the
+    refs it introduced, bounding memory to roughly one source file at a time. Recipe,
+    accumulator, and execution-context state (keyed separately) is left intact.
+    """
+    obj_id = params.get('id')
+    if obj_id is None:
+        return True
+    local_objects.pop(obj_id, None)
+    remote_objects.pop(obj_id, None)
+    checkpoint = _ref_checkpoints.pop(obj_id, None)
+    if checkpoint is not None:
+        for ref_id in [k for k in remote_refs if k > checkpoint]:
+            del remote_refs[ref_id]
     return True
 
 
@@ -1580,6 +1601,9 @@ def handle_visit(params: dict) -> dict:
 
     _install_data_table_store(ctx)
 
+    # Snapshot the remote_refs high-water for this file before fetching its tree (first visit wins).
+    _ref_checkpoints.setdefault(tree_id, max(remote_refs.keys(), default=-1))
+
     # Always fetch the tree from Java to ensure we have the latest version.
     # Java may have modified the tree (e.g., via a Java-side recipe) since our last sync.
     tree = get_object_from_java(tree_id, source_file_type)
@@ -1653,6 +1677,9 @@ def handle_batch_visit(params: dict) -> dict:
             local_objects[p_id] = ctx
 
     _install_data_table_store(ctx)
+
+    # Snapshot the remote_refs high-water for this file before fetching its tree.
+    _ref_checkpoints.setdefault(tree_id, max(remote_refs.keys(), default=-1))
 
     # Fetch tree once from Java
     tree = get_object_from_java(tree_id, source_file_type)
@@ -1872,6 +1899,7 @@ def handle_request(method: str, params: dict) -> Any:
         'GetLanguages': handle_get_languages,
         'Print': handle_print,
         'Reset': handle_reset,
+        'Evict': handle_evict,
         'InstallRecipes': handle_install_recipes,
         'GetMarketplace': handle_get_marketplace,
         'PrepareRecipe': handle_prepare_recipe,
@@ -2152,7 +2180,10 @@ def main():
             if args.trace_rpc_messages:
                 logger.debug(f"Sending: {json.dumps(response)}")
 
-            write_message(response)
+            # Notifications (no id, e.g. Evict) get no reply — a null-id response would
+            # fail every in-flight request on the Java reader.
+            if request_id is not None:
+                write_message(response)
 
         except Exception as e:
             logger.exception(f"Fatal error: {e}")

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -22,6 +22,7 @@ Bidirectional RPC:
 
 import argparse
 import ast
+import csv
 import json
 import logging
 import os
@@ -32,9 +33,15 @@ import time
 import traceback
 import threading
 
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, Any, Optional, List, Callable, Set
 from uuid import uuid4
+
+try:
+    import resource
+except ImportError:  # not available on Windows
+    resource = None
 
 from rewrite.discovery import RecipeAttribution, RecipeName
 
@@ -62,6 +69,11 @@ remote_refs: Dict[int, Any] = {}
 # Per-source-file remote_refs high-water, captured before a file is first visited so
 # handle_evict can roll back exactly the refs that file introduced. Keyed by tree id.
 _ref_checkpoints: Dict[str, int] = {}
+
+# Per-call metrics CSV (--metrics-csv), same schema as Go: cache-size ramp vs per-file-Evict sawtooth.
+_metrics_file = None
+_metrics_writer = None
+_metrics_lock = threading.Lock()
 
 # Request ID counter for outgoing requests
 _request_id_counter = 0
@@ -2111,6 +2123,73 @@ def _init_pyroscope() -> None:
     )
 
 
+_METRICS_HEADER = ['timestamp', 'method', 'duration_ms', 'error', 'memory_used_bytes',
+                   'memory_max_bytes', 'local_objects', 'remote_objects', 'refs']
+
+
+def _init_metrics_csv(path: str) -> None:
+    """Open the per-call metrics CSV and write its header. Best-effort: a failure here
+    disables metrics but never blocks the server."""
+    global _metrics_file, _metrics_writer
+    try:
+        _metrics_file = open(path, 'w', newline='')
+        _metrics_writer = csv.writer(_metrics_file)
+        _metrics_writer.writerow(_METRICS_HEADER)
+        _metrics_file.flush()
+    except OSError as e:
+        logger.warning(f"metrics-csv: cannot open {path!r}: {e} - metrics disabled")
+        _metrics_file = _metrics_writer = None
+
+
+def _rss_bytes():
+    """Best-effort (current, peak) RSS in bytes; blank without /proc or the resource module (Windows).
+    The RewriteRpcProcess RSS sampler is the source of truth; these columns just annotate each row."""
+    current = ''
+    peak = ''
+    try:
+        with open('/proc/self/statm') as f:
+            current = int(f.read().split()[1]) * os.sysconf('SC_PAGE_SIZE')
+    except (OSError, ValueError, IndexError):
+        pass
+    if resource is not None:
+        maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # macOS reports ru_maxrss in bytes; Linux and most others in kilobytes.
+        peak = maxrss if sys.platform == 'darwin' else maxrss * 1024
+        if current == '':
+            current = peak
+    return current, peak
+
+
+def _record_metric(method: str, duration_ms: float, error: str) -> None:
+    """Append one row of timing + cache residency. refs counts remote_refs only: Python's send-side
+    refs live on a per-call RpcSendQueue, the only cross-call ref cache handle_evict rolls back."""
+    if _metrics_writer is None:
+        return
+    used, peak = _rss_bytes()
+    with _metrics_lock:
+        if _metrics_writer is None:
+            return
+        try:
+            _metrics_writer.writerow([
+                datetime.now(timezone.utc).isoformat(), method, f"{duration_ms:.0f}", error,
+                used, peak, len(local_objects), len(remote_objects), len(remote_refs)])
+            _metrics_file.flush()
+        except OSError as e:
+            logger.warning(f"metrics-csv: write failed: {e}")
+
+
+def _close_metrics() -> None:
+    global _metrics_file, _metrics_writer
+    with _metrics_lock:
+        if _metrics_file is not None:
+            try:
+                _metrics_file.flush()
+                _metrics_file.close()
+            except OSError:
+                pass
+        _metrics_file = _metrics_writer = None
+
+
 def main():
     """Main entry point for the RPC server."""
     global _trace_rpc
@@ -2123,6 +2202,9 @@ def main():
     args = parser.parse_args()
 
     _init_pyroscope()
+
+    if args.metrics_csv:
+        _init_metrics_csv(args.metrics_csv)
 
     if args.recipe_install_dir:
         global _recipe_install_dir
@@ -2156,6 +2238,8 @@ def main():
                 logger.error("Missing 'method' in request")
                 continue
 
+            metric_start = time.monotonic()
+            metric_error = ''
             try:
                 result = handle_request(method, params)
                 response = {
@@ -2167,6 +2251,7 @@ def main():
                 logger.exception(f"Error handling request: {e}")
                 # Include full stack trace in error response for debugging
                 tb_str = traceback.format_exc()
+                metric_error = str(e)
                 response = {
                     'jsonrpc': '2.0',
                     'id': request_id,
@@ -2176,6 +2261,7 @@ def main():
                         'data': tb_str
                     }
                 }
+            _record_metric(method, (time.monotonic() - metric_start) * 1000.0, metric_error)
 
             if args.trace_rpc_messages:
                 logger.debug(f"Sending: {json.dumps(response)}")
@@ -2191,6 +2277,7 @@ def main():
 
     # No ty-types cleanup needed here — clients are scoped per parse batch
 
+    _close_metrics()
     logger.info("Python RPC server shutting down...")
 
 


### PR DESCRIPTION
## Summary

Bounds the memory of the polyglot `RewriteRpc` servers (Java/JS/Python/Go/C#), whose object + ref caches previously grew insert-only for the whole process lifetime, and adds the Phase-0 profiling instrumentation to measure it. Two commits:

1. `perf(rpc): evict each source file from RPC caches after the recipe stack visits it` — the eviction primitive.
2. `perf(rpc): emit per-call metrics CSV for the Python and C# RPC servers` — profiling parity across all four servers.

## Problem

Every RewriteRpc peer keyed visited `SourceFile`s into `localObjects`/`remoteObjects` + ref maps and never self-evicted; only an explicit `Reset` cleared them. Within a repo, every file stayed resident across every recipe cycle, so peak memory scaled with file count and was only reclaimed when the subprocess was killed per repo.

## Fix — per-source-file `Evict`

`RecipeRunCycle` iterates source-outer / recipe-inner (`editSource` runs the whole recipe stack over one file before the next), so the end of `editSource` (and the scan lambda) is a clean per-file boundary. A new `Evict{id}` primitive drops that file's tree and rolls each touched peer's ref maps back to a pre-file checkpoint:

- Fire-and-forget JSON-RPC **notification** (NON_NULL serialization omits the null id, so it is a true notification everywhere); handlers are total, and the Go/Python read loops skip replying to a null-id request so an errored notification can't fail in-flight requests.
- Ref rollback is symmetric/lockstep: dropping the send-side ref forces the next file to re-ADD the interned `JavaType` (shared across files), so the receiver never sees a dangling `REF_USE`. Send-side rollback = protocol correctness; receive-side = the memory bound.
- Handlers in all five peers (Java, JS `onNotification`, Python, Go via `ReferenceMap.RollbackTo`, C#). Recipe/accumulator/execution-context state is keyed separately and preserved, so a scanning recipe's accumulator survives across files within a cycle.

Eviction is unconditional (no config flag).

## Profiling (Phase 0)

- Per-call metrics CSVs now carry `local_objects,remote_objects,refs` residency columns for **all four** language servers (Go/JS in commit 1; Python + C# in commit 2), so a run shows the cache-size **ramp** (evict off) vs **sawtooth** (evict on). Python's `--metrics-csv` was previously a no-op stub; C# had no metrics CSV at all. C# records via a message-handler wrapper since StreamJsonRpc dispatches by attribute and has no central loop.
- `RewriteRpcProcess` gains an opt-in subprocess RSS sampler (`REWRITE_RPC_RSS_MS` -> `rpc-rss-<pid>.csv`) that uniformly covers all four languages, including native/off-heap growth the in-process counters miss.

## Measured

Same-binary A/B on the Python server (per-repo peak subprocess RSS, evict off -> on): flask 133->94 MB (-30%), poetry 285->86 MB (-70%), scrapy 374->68 MB (-82%). The "before" curve climbs monotonically with file count; "after" is bounded and does not scale with repo size. Cost: ~30% longer wall-clock from the per-file evict notifications.

## Testing

Full `RewriteRpcTest` (19 tests; loopback recipe runs exercise the hook + client rollback + inbound `Evict`) passes, including a new `evictDropsTreeFromBothPeers`. The metrics commit is additive and does not touch the Java loopback test path; it is verified to compile via `py_compile`, `dotnet build`, and `:rewrite-csharp:compileJava`.

## Follow-up (separate repo)

The Moderne CLI already wires each server's `metricsCsv`; C# (`csharp-rpc.csv`) needs a one-line CLI change to pass the path, which lands after this releases.
