### PR TITLE
C#: drop MSBuildLocator; evaluate restore graphs via the SDK's own msbuild

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/OpenRewrite.Tests.csproj
@@ -16,11 +16,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <!-- Keep MSBuild assemblies out of the output so MSBuildLocator can load the SDK's copies
-         for in-process restore-graph evaluation (NuGetResolver). A stale app-base copy of
-         Microsoft.Build.Framework causes MissingMethodException at MSBuild load time. -->
-    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" />
     <!-- Test-only: fixtures build throwaway git repos with LibGit2Sharp. The production
          tool resolves git through the host `git` CLI (see GitCli) and ships no native libs. -->
     <PackageReference Include="LibGit2Sharp" Version="0.31.0" />

--- a/rewrite-csharp/csharp/OpenRewrite.Tool/OpenRewrite.Tool.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite.Tool/OpenRewrite.Tool.csproj
@@ -29,11 +29,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Keep MSBuild assemblies out of the output so MSBuildLocator can load the SDK's copies
-         for in-process restore-graph evaluation (NuGetResolver). A stale app-base copy of
-         Microsoft.Build.Framework causes MissingMethodException at MSBuild load time. -->
-    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" />
   </ItemGroup>
 
 </Project>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
@@ -14,11 +14,9 @@
  * limitations under the License.
  */
 using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Xml.Linq;
 using Microsoft.Build.Construction;
-using Microsoft.Build.Evaluation;
-using Microsoft.Build.Execution;
-using Microsoft.Build.Locator;
 using NuGet.Commands;
 using NuGet.Common;
 using NuGet.Configuration;
@@ -35,30 +33,6 @@ using Serilog;
 using ILogger = NuGet.Common.ILogger;
 
 namespace OpenRewrite.CSharp.NuGet;
-
-/// <summary>
-/// Ensures MSBuildLocator registration happens exactly once per process, shared by
-/// <see cref="SolutionParser"/> (MSBuildWorkspace) and <see cref="NuGetResolver"/>
-/// (in-process restore-graph evaluation).
-/// </summary>
-internal static class MSBuildRegistration
-{
-    private static readonly object Lock = new();
-    private static bool _registered;
-
-    public static void Ensure()
-    {
-        lock (Lock)
-        {
-            if (!_registered)
-            {
-                if (!MSBuildLocator.IsRegistered)
-                    MSBuildLocator.RegisterDefaults();
-                _registered = true;
-            }
-        }
-    }
-}
 
 /// <summary>
 /// In-process NuGet engine replacing all child-process package operations
@@ -122,28 +96,6 @@ public static class NuGetResolver
         }
     }
 
-    /// <summary>MSBuild logger forwarding errors/warnings to Serilog at Debug level.</summary>
-    private sealed class SerilogMSBuildLogger : Microsoft.Build.Framework.ILogger
-    {
-        public Microsoft.Build.Framework.LoggerVerbosity Verbosity { get; set; } =
-            Microsoft.Build.Framework.LoggerVerbosity.Quiet;
-
-        public string? Parameters { get; set; }
-
-        public void Initialize(Microsoft.Build.Framework.IEventSource eventSource)
-        {
-            eventSource.ErrorRaised += (_, e) =>
-                Log.Debug("MSBuild error {Code} at {File}({Line}): {Message}",
-                    e.Code, e.File, e.LineNumber, e.Message);
-            eventSource.WarningRaised += (_, e) =>
-                Log.Debug("MSBuild warning {Code}: {Message}", e.Code, e.Message);
-        }
-
-        public void Shutdown()
-        {
-        }
-    }
-
     public static ILogger Logger => SerilogNuGetLogger.Instance;
 
     public static ISettings LoadSettings(string startDirectory) =>
@@ -160,8 +112,6 @@ public static class NuGetResolver
         string path,
         IDictionary<string, string>? extraGlobalProperties = null)
     {
-        MSBuildRegistration.Ensure();
-
         var projects = EnumerateProjects(path).ToList();
         if (projects.Count == 0)
         {
@@ -242,18 +192,21 @@ public static class NuGetResolver
         }
     }
 
-    // BuildManager.DefaultBuildManager.Build is not safe for concurrent invocations.
+    // Serialize graph generation: concurrent SDK msbuild processes contend on obj/ and
+    // the NuGet http cache without adding throughput for our one-at-a-time callers.
     private static readonly object BuildGate = new();
 
+    private static readonly TimeSpan GraphGenTimeout = TimeSpan.FromMinutes(5);
+
     /// <summary>
-    /// Runs the <c>GenerateRestoreGraphFile</c> target for a single project and loads the
-    /// resulting <see cref="DependencyGraphSpec"/>. The target executes in an out-of-process
-    /// MSBuild worker node (<see cref="BuildParameters.DisableInProcNode"/>) so the SDK's own
-    /// NuGet task assemblies never load into this process, where they would collide with the
-    /// NuGet client libraries used for the in-process restore. Only graph *evaluation* happens
-    /// in the worker; dependency resolution and downloads run in-process via
-    /// <see cref="RestoreRunner"/>. Returns null on evaluation/target failure
-    /// (e.g. a legacy project whose imports cannot be resolved).
+    /// Runs the <c>GenerateRestoreGraphFile</c> target for a single project via the .NET SDK's
+    /// own <c>dotnet msbuild</c> and loads the resulting <see cref="DependencyGraphSpec"/>.
+    /// Evaluation deliberately runs in the SDK's process, never ours: loading Microsoft.Build
+    /// into this process (MSBuildLocator-style) is fragile — any MSBuild assembly in the app
+    /// base defeats the redirection, and the SDK's restore tasks bind their own NuGet assembly
+    /// versions. Only *evaluation* happens in the child; dependency resolution and downloads
+    /// run in-process via <see cref="RestoreRunner"/>. Returns null on evaluation/target
+    /// failure (e.g. a legacy project whose imports cannot be resolved).
     /// </summary>
     private static DependencyGraphSpec? GenerateRestoreGraph(
         string projectPath,
@@ -272,7 +225,7 @@ public static class NuGetResolver
                 // NuGet.targets' internal default already discovers the closure per entry.
                 ["NuGetAudit"] = "false",
                 ["RestoreIgnoreFailedSources"] = "true",
-                ["RestoreAdditionalProjectSources"] = string.Join(";", AdditionalNuGetSources),
+                ["RestoreAdditionalProjectSources"] = string.Join("%3B", AdditionalNuGetSources),
                 // Avoid restore-time package imports polluting evaluation
                 ["ExcludeRestorePackageImports"] = "true",
             };
@@ -282,27 +235,46 @@ public static class NuGetResolver
                     globalProps[k] = v;
             }
 
+            var psi = new ProcessStartInfo("dotnet")
+            {
+                WorkingDirectory = Path.GetDirectoryName(projectPath) ?? ".",
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+            psi.ArgumentList.Add("msbuild");
+            psi.ArgumentList.Add(projectPath);
+            psi.ArgumentList.Add("-t:GenerateRestoreGraphFile");
+            psi.ArgumentList.Add("-nologo");
+            psi.ArgumentList.Add("-v:quiet");
+            psi.ArgumentList.Add("-nodeReuse:false");
+            foreach (var (k, v) in globalProps)
+                psi.ArgumentList.Add($"-p:{k}={v}");
+
             lock (BuildGate)
             {
-                using var projectCollection = new ProjectCollection(globalProps);
-                var parameters = new BuildParameters(projectCollection)
+                using var process = Process.Start(psi);
+                if (process == null)
                 {
-                    DisableInProcNode = true,
-                    EnableNodeReuse = false,
-                    MaxNodeCount = 1,
-                    Loggers = new Microsoft.Build.Framework.ILogger[] { new SerilogMSBuildLogger() },
-                };
-                var requestData = new BuildRequestData(
-                    projectPath,
-                    globalProps,
-                    null,
-                    new[] { "GenerateRestoreGraphFile" },
-                    null);
-                var result = BuildManager.DefaultBuildManager.Build(parameters, requestData);
-                if (result.OverallResult != BuildResultCode.Success || !File.Exists(outputPath))
+                    Log.Debug("NuGetResolver: failed to start dotnet msbuild for {Project}", projectPath);
+                    return null;
+                }
+
+                // Read both streams before waiting to avoid pipe-buffer deadlock.
+                var stdoutTask = process.StandardOutput.ReadToEndAsync();
+                var stderrTask = process.StandardError.ReadToEndAsync();
+                if (!process.WaitForExit((int)GraphGenTimeout.TotalMilliseconds))
                 {
-                    Log.Debug("NuGetResolver: GenerateRestoreGraphFile failed for {Project}: {Exception}",
-                        projectPath, result.Exception?.Message);
+                    try { process.Kill(entireProcessTree: true); } catch { /* best effort */ }
+                    Log.Debug("NuGetResolver: GenerateRestoreGraphFile timed out for {Project}", projectPath);
+                    return null;
+                }
+
+                if (process.ExitCode != 0 || !File.Exists(outputPath))
+                {
+                    Log.Debug("NuGetResolver: GenerateRestoreGraphFile failed for {Project} (exit {Exit}):\n{Out}\n{Err}",
+                        projectPath, process.ExitCode, stdoutTask.Result.Trim(), stderrTask.Result.Trim());
                     return null;
                 }
             }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -220,7 +220,6 @@ public class SolutionParser
     public async Task<Solution> LoadAsync(string path, CancellationToken ct = default)
     {
         Log.Debug("LoadAsync: starting for {Path}", path);
-        MSBuildRegistration.Ensure();
 
         // Legacy non-SDK projects use packages.config: they need the solution-local packages/
         // folder materialized and get their attestation graph from a synthesized PackageSpec.

--- a/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
+++ b/rewrite-csharp/csharp/OpenRewrite/OpenRewrite.csproj
@@ -36,17 +36,14 @@
     <!-- In-process NuGet restore (PackageSpec/DependencyGraphSpec -> RestoreRunner -> LockFile).
          Commands transitively supplies ProjectModel, Protocol, Packaging, Configuration, Common. -->
     <PackageReference Include="NuGet.Commands" Version="7.6.0" />
+    <!-- Plain runtime dependency, used only for managed .sln parsing (SolutionFile.Parse).
+         No MSBuildLocator: project evaluation happens in the SDK's own `dotnet msbuild`
+         (NuGetResolver) or Roslyn's out-of-process BuildHost (MSBuildWorkspace). -->
+    <PackageReference Include="Microsoft.Build" Version="18.8.2" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.3.0" PrivateAssets="none" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.7.8" />
-    <!-- Compile-time only: at runtime MSBuildLocator redirects these to the located SDK's MSBuild.
-         PrivateAssets=all keeps the runtime assets from flowing to consuming projects too — a
-         stale Microsoft.Build*.dll in any consumer's output directory would break the SDK
-         assembly redirection (MissingMethodException/FileLoadException at MSBuild load time). -->
-    <PackageReference Include="Microsoft.Build" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" PrivateAssets="none" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="5.6.0" PrivateAssets="none" />
     <PackageReference Include="Serilog" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.25.29" />


### PR DESCRIPTION
## Context / Problem Being Solved

The in-process NuGet resolver (#8286) evaluated restore graphs by loading MSBuild into our own process via MSBuildLocator. That pattern is fragile: any MSBuild assembly reachable in the app base — including transitive runtime assets from other packages — silently defeats the locator's redirect and fails at runtime (`MissingMethodException`/`FileLoadException`), and every consumer of the published OpenRewrite.CSharp package had to carry compile-only `Microsoft.Build` pins to stay functional. Modern Roslyn `Workspaces.MSBuild` no longer needs the locator at all (out-of-process BuildHost).

## Solution

Removes MSBuildLocator entirely. Restore-graph generation now runs the .NET SDK's own `dotnet msbuild -t:GenerateRestoreGraphFile` as a short-lived child process (evaluation only — dependency resolution and downloads stay in-process via `RestoreRunner`), so no MSBuild assemblies are ever loaded into our process and consumers need no pins. `Microsoft.Build` remains a plain runtime dependency solely for managed `SolutionFile.Parse`. Also upgrades `Microsoft.CodeAnalysis.*` to 5.6.0.

## Related

Follow-up to #8286 (in-process NuGet resolution). Supersedes the second commit of #8296, which is closed as a duplicate of already-merged work.

## Release Notes

C# LST builds no longer load MSBuild into the parser process, eliminating a class of assembly-conflict failures for consumers of the OpenRewrite.CSharp package.
