### PR TITLE
C#: keep declared PackageReferences visible when in-process NuGet restore fails

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
@@ -225,4 +225,66 @@ public class CsprojParserTests
         Assert.True(newtonsoft.HasXdtTransforms);
         Assert.True(newtonsoft.HasLegacyContentFolder);
     }
+
+    // When an in-process restore is unavailable (offline CI, restore-graph failure), the marker
+    // must still expose declared <PackageReference> items from the XML, or the Find/Upgrade/Remove
+    // NuGet recipes silently no-op.
+    [Fact]
+    public void MarkerExposesDeclaredPackageReferencesWithoutRestore()
+    {
+        var doc = new XmlParser().Parse(
+            """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+                <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
+              </ItemGroup>
+            </Project>
+            """,
+            "project.csproj");
+
+        // No rootDir -> no restore is attempted; the marker is built from the XML alone.
+        var marker = MSBuildProjectHelper.CreateMarker(doc);
+
+        Assert.NotNull(marker);
+        Assert.Equal("Microsoft.NET.Sdk.Web", marker.Sdk);
+        var tfm = Assert.Single(marker.TargetFrameworks);
+        Assert.Equal("net8.0", tfm.TargetFrameworkMoniker);
+        Assert.Equal(2, tfm.PackageReferences.Count);
+        Assert.Contains(tfm.PackageReferences, p => p.Include == "Swashbuckle.AspNetCore" && p.RequestedVersion == "6.4.0");
+        Assert.Contains(tfm.PackageReferences, p => p.Include == "Microsoft.AspNetCore.OpenApi" && p.RequestedVersion == "7.0.0");
+    }
+
+    [Fact]
+    public void MarkerExposesDeclaredPackageReferencesForMultiTargetWithoutRestore()
+    {
+        var doc = new XmlParser().Parse(
+            """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+              </PropertyGroup>
+              <ItemGroup>
+                <PackageReference Include="Newtonsoft.Json">
+                  <Version>13.0.3</Version>
+                </PackageReference>
+              </ItemGroup>
+            </Project>
+            """,
+            "project.csproj");
+
+        var marker = MSBuildProjectHelper.CreateMarker(doc);
+
+        Assert.NotNull(marker);
+        Assert.Equal(2, marker.TargetFrameworks.Count);
+        foreach (var tfm in marker.TargetFrameworks)
+        {
+            var pkgRef = Assert.Single(tfm.PackageReferences);
+            Assert.Equal("Newtonsoft.Json", pkgRef.Include);
+            Assert.Equal("13.0.3", pkgRef.RequestedVersion);
+        }
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -107,11 +107,11 @@ public static class MSBuildProjectHelper
         var sdk = doc.Root.GetAttributeValue("Sdk");
 
         if (rootDir == null)
-            return new MSBuildProject(Guid.NewGuid(), sdk);
+            return CreateFromXml(doc, sdk);
 
         var projectPath = Path.GetFullPath(Path.Combine(rootDir, doc.SourcePath));
         if (!File.Exists(projectPath))
-            return new MSBuildProject(Guid.NewGuid(), sdk);
+            return CreateFromXml(doc, sdk);
 
         try
         {
@@ -119,7 +119,7 @@ public static class MSBuildProjectHelper
                 .ResolveProjectLockFileAsync(projectPath, null, CancellationToken.None)
                 .GetAwaiter().GetResult();
             if (lockFile == null)
-                return new MSBuildProject(Guid.NewGuid(), sdk);
+                return CreateFromXml(doc, sdk);
 
             var projectDir = Path.GetDirectoryName(projectPath)!;
             return CreateFromLockFile(sdk, lockFile, projectDir,
@@ -128,9 +128,72 @@ public static class MSBuildProjectHelper
         catch (Exception ex)
         {
             Log.Debug("Failed to resolve lock file for {Path}: {Error}", projectPath, ex.Message);
-            return new MSBuildProject(Guid.NewGuid(), sdk);
+            return CreateFromXml(doc, sdk);
         }
     }
+
+    /// <summary>
+    ///     Builds a marker from the declared <c>&lt;PackageReference&gt;</c> items and
+    ///     <c>&lt;TargetFramework(s)&gt;</c> read straight from the csproj XML, used whenever an
+    ///     in-process NuGet restore is unavailable (no project on disk, restore-graph evaluation
+    ///     failed, offline, etc.). This keeps the marker's declared package references 1:1 with
+    ///     the csproj — recipes such as FindNuGetPackageReference / UpgradeNuGetPackageVersion /
+    ///     RemoveNuGetPackageReference query the declared references and must not silently no-op
+    ///     just because the transitive graph could not be resolved. Only <see cref="PackageReference.ResolvedVersion"/>
+    ///     (the restore-computed value) is absent in this fallback.
+    /// </summary>
+    private static MSBuildProject CreateFromXml(Document doc, string? sdk)
+    {
+        var tfms = new List<string>();
+        var declared = new List<PackageReference>();
+        foreach (var tag in DescendantTags(doc.Root))
+        {
+            if (string.Equals(tag.Name, "TargetFramework", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(tag.Name, "TargetFrameworks", StringComparison.OrdinalIgnoreCase))
+            {
+                var value = tag.GetValue();
+                if (!string.IsNullOrWhiteSpace(value) && !IsPropertyReference(value))
+                {
+                    foreach (var tfm in value.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+                        if (!tfms.Contains(tfm))
+                            tfms.Add(tfm);
+                }
+            }
+            else if (string.Equals(tag.Name, "PackageReference", StringComparison.OrdinalIgnoreCase))
+            {
+                var include = tag.GetAttributeValue("Include") ?? tag.GetAttributeValue("Update");
+                if (string.IsNullOrWhiteSpace(include))
+                    continue;
+                var version = tag.GetAttributeValue("Version") ?? tag.GetChild("Version")?.GetValue();
+                declared.Add(new PackageReference(include, version));
+            }
+        }
+
+        if (declared.Count == 0)
+            return new MSBuildProject(Guid.NewGuid(), sdk);
+
+        if (tfms.Count == 0)
+            tfms.Add("");
+
+        var tfmList = new List<TargetFramework>(tfms.Count);
+        foreach (var tfm in tfms)
+            tfmList.Add(new TargetFramework(tfm, new List<PackageReference>(declared)));
+
+        return new MSBuildProject(Guid.NewGuid(), sdk, null, null, tfmList);
+    }
+
+    private static IEnumerable<Tag> DescendantTags(Tag tag)
+    {
+        foreach (var child in tag.GetChildren())
+        {
+            yield return child;
+            foreach (var descendant in DescendantTags(child))
+                yield return descendant;
+        }
+    }
+
+    private static bool IsPropertyReference(string value)
+        => value.StartsWith("$(") && value.EndsWith(")");
 
     /// <summary>
     ///     Creates an MSBuildProject marker from a pre-resolved <see cref="LockFile"/>


### PR DESCRIPTION
## What

Adds an XML-based fallback when building the `MSBuildProject` marker: if the in-process NuGet restore yields no lock file, the marker's `TargetFrameworks` and declared `PackageReferences` are now read straight from the parsed csproj XML instead of coming back empty.

## Why

- Since #8286 ("resolve NuGet dependencies in-process"), the marker's declared `<PackageReference>` items are sourced **only** from the restore's `PackageSpec` (`spec.TargetFrameworks[].Dependencies`). When the in-process restore produces no lock file — no project on disk, offline, or `dotnet msbuild -t:GenerateRestoreGraphFile` failing to evaluate (as it does in some CI sandboxes; #8298 moved graph evaluation to that child process) — `MSBuildProjectHelper.CreateMarker` fell back to a bare `new MSBuildProject(Guid, sdk)` with **no** TargetFrameworks and **no** PackageReferences.

Recipes that query declared references then silently no-op even though the `<PackageReference>` items are present verbatim in the csproj XML:

- `FindNuGetPackageReference`
- `UpgradeNuGetPackageVersion`
- `RemoveNuGetPackageReference`

This regressed **moderneinc/recipes-csharp** scheduled CI on 2026-07-20: 15 tests failed with `Recipe was expected to make changes but did not modify the source file` (the whole 85-test suite ran in ~2s — restore-graph generation was failing fast, not producing declared references). The failures were reproduced locally by forcing `GenerateRestoreGraph` to return `null`, which flips the exact same tests to the exact same error; the fix makes them pass again.

## How

`CreateFromXml` walks the document, collects `<TargetFramework(s)>` monikers and every `<PackageReference Include="…">` (version from the `Version` attribute or child element), and attaches them to the marker. The declared references stay 1:1 with the csproj. Only the restore-computed `ResolvedVersion` is absent on this fallback path; the successful-restore path (`CreateFromLockFile`) is untouched, so no behavior change when restore succeeds.

## Testing

- New regression tests in `CsprojParserTests` asserting declared package references (single- and multi-target, attribute- and child-element versions) survive without a restore.
- All `CsprojParserTests` pass locally (existing restore-based tests still green).
- Verified end-to-end against `moderneinc/recipes-csharp` via source-linked build: the 15 previously-failing `FindNuGetPackageReferenceTests` / `UpgradeNuGetPackageVersionTests` pass both with a real restore and with restore forced to fail.