### PR TITLE
Kotlin: render wildcard-typed template parameters as type projections

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -176,8 +176,6 @@ class JavaTemplateAnnotationTest implements RewriteTest {
     @Issue("https://github.com/moderneinc/customer-requests/issues/2824")
     @Test
     void replaceAnnotationArgumentsWithAssignmentShapedSubstitution() {
-        // The substituted expression must keep the space after `=`; annotation argument
-        // replacement does not run autoFormat, so unsubstitution has to restore it
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
               @Override

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateAnnotationTest.java
@@ -173,6 +173,52 @@ class JavaTemplateAnnotationTest implements RewriteTest {
             .isEqualTo(stub.chars().filter(c -> c == '}').count()));
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2824")
+    @Test
+    void replaceAnnotationArgumentsWithAssignmentShapedSubstitution() {
+        // The substituted expression must keep the space after `=`; annotation argument
+        // replacement does not run autoFormat, so unsubstitution has to restore it
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Retry".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null && !annotation.getArguments().isEmpty() &&
+                      annotation.getArguments().getFirst() instanceof J.Assignment assignment &&
+                      assignment.getVariable() instanceof J.Identifier attribute &&
+                      "include".equals(attribute.getSimpleName())) {
+                      return JavaTemplate.builder("includes = #{any()}")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments(),
+                          assignment.getAssignment());
+                  }
+                  return annotation;
+              }
+          })),
+          java(
+            """
+              @interface Retry {
+                  Class<? extends Throwable>[] include() default {};
+                  Class<? extends Throwable>[] includes() default {};
+              }
+              """
+          ),
+          java(
+            """
+              class MyService {
+                  @Retry(include = {IllegalStateException.class})
+                  void doWork() {}
+              }
+              """,
+            """
+              class MyService {
+                  @Retry(includes = {IllegalStateException.class})
+                  void doWork() {}
+              }
+              """
+          ));
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4634")
     @Test
     void replacesInRecordVisitor() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -402,11 +402,7 @@ public class Substitutions {
                 return maybeParameter(j1, j1);
             }
 
-            /**
-             * @param marker   the element whose prefix carries the {@code __pN__} marker comment
-             * @param replaced the element being replaced, whose prefix supplies the whitespace
-             *                 preceding the placeholder
-             */
+            // marker carries the __pN__ comment; replaced supplies the whitespace preceding the placeholder
             private @Nullable J maybeParameter(J marker, J replaced) {
                 Integer param = parameterIndex(marker.getPrefix());
                 if (param != null) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -352,7 +352,7 @@ public class Substitutions {
 
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, Integer integer) {
-                J param = maybeParameter(method.getName());
+                J param = maybeParameter(method.getName(), method);
                 if (param instanceof Expression) {
                     return maybeParenthesize((Expression) param, getCursor());
                 } else if (param != null) {
@@ -399,10 +399,19 @@ public class Substitutions {
             }
 
             private @Nullable J maybeParameter(J j1) {
-                Integer param = parameterIndex(j1.getPrefix());
+                return maybeParameter(j1, j1);
+            }
+
+            /**
+             * @param marker   the element whose prefix carries the {@code __pN__} marker comment
+             * @param replaced the element being replaced, whose prefix supplies the whitespace
+             *                 preceding the placeholder
+             */
+            private @Nullable J maybeParameter(J marker, J replaced) {
+                Integer param = parameterIndex(marker.getPrefix());
                 if (param != null) {
                     J j2 = (J) parameters[param];
-                    return j2.withPrefix(j2.getPrefix().withWhitespace(j1.getPrefix().getWhitespace()));
+                    return j2.withPrefix(j2.getPrefix().withWhitespace(replaced.getPrefix().getWhitespace()));
                 }
                 return null;
             }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
@@ -29,12 +29,7 @@ public class KotlinSubstitutions extends Substitutions {
         return "__P__./*__p" + index + "__*/p<" + toKotlinTypeSyntax(fqn) + ">()";
     }
 
-    /**
-     * Parameter types are rendered in Java syntax, in which wildcards ({@code ? extends X},
-     * {@code ? super X}, {@code ?}) must be converted to Kotlin type projections
-     * ({@code out X}, {@code in X}, {@code *}) to parse as Kotlin. A {@code ?} cannot
-     * occur in a type name, so plain string replacement is unambiguous.
-     */
+    // Wildcards are rendered in Java syntax; a `?` cannot occur in a type name, so plain replacement is unambiguous
     private static String toKotlinTypeSyntax(String fqn) {
         return fqn
                 .replace("? extends ", "out ")

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
@@ -26,7 +26,20 @@ public class KotlinSubstitutions extends Substitutions {
 
     @Override
     protected String newObjectParameter(String fqn, int index) {
-        return "__P__./*__p" + index + "__*/p<" + fqn + ">()";
+        return "__P__./*__p" + index + "__*/p<" + toKotlinTypeSyntax(fqn) + ">()";
+    }
+
+    /**
+     * Parameter types are rendered in Java syntax, in which wildcards ({@code ? extends X},
+     * {@code ? super X}, {@code ?}) must be converted to Kotlin type projections
+     * ({@code out X}, {@code in X}, {@code *}) to parse as Kotlin. A {@code ?} cannot
+     * occur in a type name, so plain string replacement is unambiguous.
+     */
+    private static String toKotlinTypeSyntax(String fqn) {
+        return fqn
+                .replace("? extends ", "out ")
+                .replace("? super ", "in ")
+                .replace("?", "*");
     }
 
     @Override

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 
@@ -586,6 +587,7 @@ class KotlinTemplateTest implements RewriteTest {
     @Issue("https://github.com/moderneinc/customer-requests/issues/2824")
     @Test
     void replaceAnnotationArgumentsWithWildcardTypedSubstitution() {
+        List<String> stubs = new ArrayList<>();
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
               @Override
@@ -595,10 +597,8 @@ class KotlinTemplateTest implements RewriteTest {
                       annotation.getArguments().getFirst() instanceof J.Assignment assignment &&
                       assignment.getVariable() instanceof J.Identifier attribute &&
                       "include".equals(attribute.getSimpleName())) {
-                      // The collection literal is typed by the declared attribute type
-                      // `Array<KClass<out Throwable>>`, whose wildcard must not be rendered
-                      // in Java syntax (`? extends`) in the Kotlin template stub
                       return KotlinTemplate.builder("includes = #{any()}")
+                        .doBeforeParseTemplate(stubs::add)
                         .build()
                         .apply(getCursor(), annotation.getCoordinates().replaceArguments(),
                           assignment.getAssignment());
@@ -630,19 +630,20 @@ class KotlinTemplateTest implements RewriteTest {
               }
               """
           ));
+        assertThat(stubs).anyMatch(stub -> stub.contains("p<kotlin.Array<kotlin.reflect.KClass<out kotlin.Throwable>>>()"));
     }
 
     @Issue("https://github.com/moderneinc/customer-requests/issues/2824")
     @Test
     void contravariantAndStarProjectionTypedSubstitution() {
+        List<String> stubs = new ArrayList<>();
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new KotlinVisitor<>() {
               @Override
               public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
                   if (multiVariable.getVariables().getFirst().getSimpleName().startsWith("x")) {
-                      // The parameter types `Comparator<? super String>` and `KClass<?>` must be
-                      // rendered as `Comparator<in String>` and `KClass<*>` in the template stub
                       return KotlinTemplate.builder("println(#{any()})")
+                        .doBeforeParseTemplate(stubs::add)
                         .build()
                         .apply(getCursor(), multiVariable.getCoordinates().replace(),
                           multiVariable.getVariables().getFirst().getInitializer());
@@ -668,6 +669,8 @@ class KotlinTemplateTest implements RewriteTest {
               }
               """
           ));
+        assertThat(stubs).anyMatch(stub -> stub.contains("Comparator<in kotlin.String>"));
+        assertThat(stubs).anyMatch(stub -> stub.contains("KClass<*>"));
     }
 
     @Test

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -583,6 +583,55 @@ class KotlinTemplateTest implements RewriteTest {
           ));
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2824")
+    @Test
+    void replaceAnnotationArgumentsWithWildcardTypedSubstitution() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {
+              @Override
+              public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext ctx) {
+                  if ("Retry".equals(annotation.getSimpleName()) &&
+                      annotation.getArguments() != null && !annotation.getArguments().isEmpty() &&
+                      annotation.getArguments().getFirst() instanceof J.Assignment assignment &&
+                      assignment.getVariable() instanceof J.Identifier attribute &&
+                      "include".equals(attribute.getSimpleName())) {
+                      // The collection literal is typed by the declared attribute type
+                      // `Array<KClass<out Throwable>>`, whose wildcard must not be rendered
+                      // in Java syntax (`? extends`) in the Kotlin template stub
+                      return KotlinTemplate.builder("includes = #{any()}")
+                        .build()
+                        .apply(getCursor(), annotation.getCoordinates().replaceArguments(),
+                          assignment.getAssignment());
+                  }
+                  return annotation;
+              }
+          })),
+          kotlin(
+            """
+              import kotlin.reflect.KClass
+
+              annotation class Retry(
+                  val include: Array<KClass<out Throwable>> = [],
+                  val includes: Array<KClass<out Throwable>> = []
+              )
+              """
+          ),
+          kotlin(
+            """
+              class MyService {
+                  @Retry(include = [IllegalStateException::class])
+                  fun doWork() {}
+              }
+              """,
+            """
+              class MyService {
+                  @Retry(includes = [IllegalStateException::class])
+                  fun doWork() {}
+              }
+              """
+          ));
+    }
+
     @Test
     void replaceAnnotationArgumentsOnProperty() {
         rewriteRun(

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -632,6 +632,44 @@ class KotlinTemplateTest implements RewriteTest {
           ));
     }
 
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2824")
+    @Test
+    void contravariantAndStarProjectionTypedSubstitution() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinVisitor<>() {
+              @Override
+              public J visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext ctx) {
+                  if (multiVariable.getVariables().getFirst().getSimpleName().startsWith("x")) {
+                      // The parameter types `Comparator<? super String>` and `KClass<?>` must be
+                      // rendered as `Comparator<in String>` and `KClass<*>` in the template stub
+                      return KotlinTemplate.builder("println(#{any()})")
+                        .build()
+                        .apply(getCursor(), multiVariable.getCoordinates().replace(),
+                          multiVariable.getVariables().getFirst().getInitializer());
+                  }
+                  return multiVariable;
+              }
+          })),
+          kotlin(
+            """
+              import kotlin.reflect.KClass
+
+              fun test(c: Comparator<in String>, k: KClass<*>) {
+                  val x1 = c
+                  val x2 = k
+              }
+              """,
+            """
+              import kotlin.reflect.KClass
+
+              fun test(c: Comparator<in String>, k: KClass<*>) {
+                  println(c)
+                  println(k)
+              }
+              """
+          ));
+    }
+
     @Test
     void replaceAnnotationArgumentsOnProperty() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?

Two fixes uncovered by the same reproducer:

1. `KotlinSubstitutions` converts the Java-syntax wildcard rendering of a substituted parameter's type — `? extends X` / `? super X` / `?` — to Kotlin type projections (`out X` / `in X` / `*`) before embedding it in the template stub. A `?` cannot occur in a fully-qualified type name, so literal replacement over the `TypeUtils.toString` output grammar is unambiguous.
2. `Substitutions.unsubstitute` (language-neutral) now takes a replaced placeholder invocation's whitespace from the invocation's own prefix instead of its name's prefix, which is always empty in the generated stub. Whitespace preceding the placeholder now survives, e.g. the space after `=` in `includes = #{any()}`.

## What's your motivation?

Any `KotlinTemplate` substitution whose parameter type contains a wildcard crashed:

```
Could not parse as Java:
class MyService{/*__TEMPLATE_cfcc2025-6662__*/@Example(includes = __P__./*__p0__*/p<kotlin.Array<kotlin.reflect.KClass<? extends kotlin.Throwable>>>())
 fun `$method`() {};}
annotation class `$Placeholder` {}
```

- This surfaces whenever an annotation class-array attribute is bound by name — e.g. spring-retry's `@Retryable(include = [...])` / `retryFor = [...]`, declared `Class<? extends Throwable>[]` — because Kotlin types the collection literal by the declared attribute type (covariant wildcard), while `value = [...]` infers from the elements, which is why simple cases appeared to work. Hit by `MigrateSpringRetryToSpringFramework7` on Kotlin sources (moderneinc/customer-requests#2824; follow-up to #8168/#8208).

The whitespace bug reproduces on pure Java with the same `attr = #{any()}` shape (`@Retry(includes ={...})`): statement templates mask it via autoFormat, but annotation-argument replacement does not autoformat.

## Anything in particular you'd like reviewers to focus on?

- Tests assert the stub content directly (capture via `doBeforeParseTemplate`, assert `out kotlin.Throwable` / `in kotlin.String` / `KClass<*>`), and each fails with the conversion reverted — coverage of all three projections is proven both ways.
- Known gap intentionally left out of scope (pre-existing): array-typed substitutions (`#{anyArray(...)}` or Java-interop `X[]`) still render Java `[]` syntax in Kotlin stubs and fail the same way; a proper fix needs `Array<T>`/`IntArray` rendering at the `JavaType` level. `ScalaSubstitutions` shares the wildcard gap and additionally embeds Java `<>` generics — both left for follow-ups.
- Full suites of `rewrite-java-test`, `rewrite-kotlin`, `rewrite-groovy`, `rewrite-scala` pass.

## Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/recipes/recipes/recipeconventionsandbestpractices)
- [x] I've used the [IntelliJ IDEA auto-formatter](https://docs.openrewrite.org/reference/building-openrewrite-from-source#code-style) on affected files
