### PR TITLE
Migrate Develocity publishing to the OSS Community Develocity Instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 [![ci](https://github.com/openrewrite/rewrite/actions/workflows/ci.yml/badge.svg)](https://github.com/openrewrite/rewrite/actions/workflows/ci.yml)
 [![Apache 2.0](https://img.shields.io/github/license/openrewrite/rewrite.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Maven Central](https://img.shields.io/maven-central/v/org.openrewrite/rewrite-java.svg)](https://mvnrepository.com/artifact/org.openrewrite/rewrite-java)
-[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://ge.openrewrite.org/scans)
+[![Revved up by Develocity](https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A)](https://community.develocity.cloud/scans?search.rootProjectNames=rewrite)
 [![Contributing Guide](https://img.shields.io/badge/Contributing-Guide-informational)](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md)
 </div>
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -85,7 +85,8 @@ plugins {
 
 develocity {
     val isCiServer = System.getenv("CI")?.equals("true") ?: false
-    server = "https://ge.openrewrite.org/"
+    server = "https://community.develocity.cloud"
+    projectId = "openrewrite"
     val accessKey = System.getenv("GRADLE_ENTERPRISE_ACCESS_KEY")
     val authenticated = !accessKey.isNullOrBlank()
     buildCache {


### PR DESCRIPTION
# Migrate Develocity publishing to the OSS Community Develocity Instance

This migrates the project's Build Scan® and Build Cache publishing from the dedicated `ge.openrewrite.org` instance to the shared, Gradle-managed **OSS Community Develocity Instance** at <https://community.develocity.cloud> (project `openrewrite`).

## Changes
- `settings.gradle.kts` — point `server` at `https://community.develocity.cloud` and set `projectId = "openrewrite"`.
- `README.md` — update the "Revved up by Develocity" badge to link to the community instance.

## Action required: update the CI access-key secret
CI already passes `GRADLE_ENTERPRISE_ACCESS_KEY`; only its **value** needs to change to the new host:

```
community.develocity.cloud=<the CI access key shared with you>
```

The `community.develocity.cloud=` prefix is required — without the host, the key is silently ignored.

## Local builds (optional)
Contributors can provision a personal key for the new instance:

```
./gradlew provisionDevelocityAccessKey
```

## Note on this PR's own CI run
This PR is from a fork, so its CI run can't read the repository secret and won't publish a scan. After merge, CI on this repository will publish to <https://community.develocity.cloud>.

---

ℹ️ **This is one example PR.** The same change applies to every OpenRewrite repo currently publishing to `ge.openrewrite.org`. Rather than opening a PR per repo, we can share a small OpenRewrite recipe that makes this exact edit, so you can run it org-wide through your own tooling. Details to follow by email.
