### PR TITLE
Python: treat bare Pipfile version as an exact pin during lock regeneration

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
@@ -1352,10 +1352,17 @@ public final class PipenvLockEngine {
             return stringOrNull(lockEntry.get("index"));
         }
 
+        private static final List<String> VERSION_OPERATORS =
+                Arrays.asList("===", "==", "~=", "!=", "<=", ">=", "<", ">");
+
         private static @Nullable PythonVersionSpecifierSet parseConstraint(String constraint) {
             String trimmed = constraint.trim();
             if (trimmed.isEmpty() || "*".equals(trimmed)) {
                 return PythonVersionSpecifierSet.parse("");
+            }
+            // pipenv treats a bare version like "2.33.0" as an exact pin; normalize to "==2.33.0".
+            if (VERSION_OPERATORS.stream().noneMatch(trimmed::startsWith)) {
+                trimmed = "==" + trimmed;
             }
             return PythonVersionSpecifierSet.parse(trimmed);
         }

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
@@ -255,6 +255,52 @@ class PipenvLockEngineTest {
     }
 
     @Test
+    void bareVersionIsTreatedAsExactPin() {
+        stubRequestsBaseline();
+        String pipfile = """
+          [[source]]
+          url = "https://pypi.org/simple"
+          verify_ssl = true
+          name = "pypi"
+
+          [packages]
+          requests = "2.32.4"
+
+          [requires]
+          python_version = "3.11"
+          """;
+
+        Result result = PipenvLockEngine.regenerate(pipfile, baseLock(), ctx);
+
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("\"version\": \"==2.32.4\"");
+    }
+
+    @Test
+    void bareVersionMatchingExistingPinRegeneratesWithoutError() {
+        stubRequestsBaseline();
+        String pipfile = """
+          [[source]]
+          url = "https://pypi.org/simple"
+          verify_ssl = true
+          name = "pypi"
+
+          [packages]
+          requests = "2.31.0"
+
+          [requires]
+          python_version = "3.11"
+          """;
+
+        Result result = PipenvLockEngine.regenerate(pipfile, baseLock(), ctx);
+
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("\"version\": \"==2.31.0\"");
+    }
+
+    @Test
     void requiresBumpRevalidatesEveryPinAndRewritesMeta() {
         listing("requests",
           wheel("requests-2.31.0-py3-none-any.whl", WHEEL_2310, ">=3.7"),


### PR DESCRIPTION
## What's changed

A Pipfile dependency written with a bare version and no comparison operator — e.g. `marshmallow = "4.1.2"` or `requests = "2.33.0"` — is a pipenv **exact pin**, equivalent to `==4.1.2`. Pipenv normalizes it that way and `pipenv install` accepts it.

The native `PipenvLockEngine` did not. `parseConstraint` passed the bare string straight to `PythonVersionSpecifierSet.parse`, which correctly rejects it (a PEP 440 specifier set requires an operator) and returns `null`, so lock regeneration aborted with:

```
RESOLUTION_REQUIRED [marshmallow]: Unparseable version constraint: 4.1.2
```

Because `computeEdits` parses **every** Pipfile entry's constraint before checking anything else, a single bare-version entry broke regeneration regardless of which package the recipe was actually upgrading. Supplying `==` in the recipe options couldn't help — the offending entries were other packages in the Pipfile.

## Fix

In `parseConstraint`, mirror pipenv's own normalization: if the constraint doesn't start with a PEP 440 operator, prepend `==`. The raw `entry.constraint` is left untouched so error messages still reflect what the user wrote.

## Tests

Added two regression tests to `PipenvLockEngineTest`:
- `bareVersionIsTreatedAsExactPin` — a bare `requests = "2.32.4"` upgrades the existing `==2.31.0` pin, proving the bare version is honored as exact `==`.
- `bareVersionMatchingExistingPinRegeneratesWithoutError` — a bare version equal to its existing pin regenerates cleanly instead of aborting (the reported `marshmallow` scenario).