### PR TITLE
Python: scope native lock regeneration to a recipe's changed dependencies

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/LockFileRegeneration.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/LockFileRegeneration.java
@@ -136,7 +136,13 @@ public abstract class LockFileRegeneration {
     }
 
     public final Result regenerate(String dependenciesContent, @Nullable String existingLockContent, ExecutionContext ctx) {
-        return regenerate(dependenciesContent, existingLockContent, Collections.emptyMap(), ctx);
+        return regenerate(dependenciesContent, null, existingLockContent, Collections.emptyMap(), ctx);
+    }
+
+    public final Result regenerate(String dependenciesContent, @Nullable String originalDependenciesContent,
+                                   @Nullable String existingLockContent, ExecutionContext ctx) {
+        return regenerate(dependenciesContent, originalDependenciesContent, existingLockContent,
+                Collections.emptyMap(), ctx);
     }
 
     /**
@@ -144,50 +150,62 @@ public abstract class LockFileRegeneration {
      * When an existing lock file is provided a minimal update is performed
      * rather than re-resolving every dependency from scratch.
      *
-     * @param dependenciesContent the dependencies-file content to lock
-     * @param existingLockContent the current lock file content, or {@code null}
-     * @param environment         ignored; retained for API compatibility with the
-     *                            former shell-out implementation. Environment-style
-     *                            proxy/index configuration has no effect on the
-     *                            native engines; use {@code ctx} instead
-     * @param ctx                 supplies the HTTP transport (proxy included) via
-     *                            {@link org.openrewrite.HttpSenderExecutionContextView}
-     *                            and host-configured package indexes/credentials via
-     *                            {@link org.openrewrite.python.PythonExecutionContextView}
+     * @param dependenciesContent         the dependencies-file content to lock
+     * @param originalDependenciesContent the pre-edit dependencies-file content, or {@code null}.
+     *                                    When provided, engines that support it reconcile only the
+     *                                    packages the edit actually changed, leaving pre-existing
+     *                                    drift in untouched packages as-is instead of aborting
+     * @param existingLockContent         the current lock file content, or {@code null}
+     * @param environment                 ignored; retained for API compatibility with the
+     *                                    former shell-out implementation. Environment-style
+     *                                    proxy/index configuration has no effect on the
+     *                                    native engines; use {@code ctx} instead
+     * @param ctx                         supplies the HTTP transport (proxy included) via
+     *                                    {@link org.openrewrite.HttpSenderExecutionContextView}
+     *                                    and host-configured package indexes/credentials via
+     *                                    {@link org.openrewrite.python.PythonExecutionContextView}
      * @return a result containing the new lock file content, or a failure
      */
-    public abstract Result regenerate(String dependenciesContent, @Nullable String existingLockContent,
-                                      Map<String, String> environment, ExecutionContext ctx);
+    public abstract Result regenerate(String dependenciesContent, @Nullable String originalDependenciesContent,
+                                      @Nullable String existingLockContent, Map<String, String> environment,
+                                      ExecutionContext ctx);
 
     private static final class NativePipenv extends LockFileRegeneration {
         @Override
-        public Result regenerate(String dependenciesContent, @Nullable String existingLockContent,
-                                 Map<String, String> environment, ExecutionContext ctx) {
-            return PipenvLockEngine.regenerate(dependenciesContent, existingLockContent, ctx);
+        public Result regenerate(String dependenciesContent, @Nullable String originalDependenciesContent,
+                                 @Nullable String existingLockContent, Map<String, String> environment,
+                                 ExecutionContext ctx) {
+            return PipenvLockEngine.regenerate(dependenciesContent, originalDependenciesContent,
+                    existingLockContent, ctx);
         }
     }
 
     private static final class NativeUv extends LockFileRegeneration {
         @Override
-        public Result regenerate(String dependenciesContent, @Nullable String existingLockContent,
-                                 Map<String, String> environment, ExecutionContext ctx) {
+        public Result regenerate(String dependenciesContent, @Nullable String originalDependenciesContent,
+                                 @Nullable String existingLockContent, Map<String, String> environment,
+                                 ExecutionContext ctx) {
             return UvLockEngine.regenerate(dependenciesContent, existingLockContent, ctx);
         }
     }
 
     private static final class NativePoetry extends LockFileRegeneration {
         @Override
-        public Result regenerate(String dependenciesContent, @Nullable String existingLockContent,
-                                 Map<String, String> environment, ExecutionContext ctx) {
-            return PoetryLockEngine.regenerate(dependenciesContent, existingLockContent, ctx);
+        public Result regenerate(String dependenciesContent, @Nullable String originalDependenciesContent,
+                                 @Nullable String existingLockContent, Map<String, String> environment,
+                                 ExecutionContext ctx) {
+            return PoetryLockEngine.regenerate(dependenciesContent, originalDependenciesContent,
+                    existingLockContent, ctx);
         }
     }
 
     private static final class NativePdm extends LockFileRegeneration {
         @Override
-        public Result regenerate(String dependenciesContent, @Nullable String existingLockContent,
-                                 Map<String, String> environment, ExecutionContext ctx) {
-            return PdmLockEngine.regenerate(dependenciesContent, existingLockContent, ctx);
+        public Result regenerate(String dependenciesContent, @Nullable String originalDependenciesContent,
+                                 @Nullable String existingLockContent, Map<String, String> environment,
+                                 ExecutionContext ctx) {
+            return PdmLockEngine.regenerate(dependenciesContent, originalDependenciesContent,
+                    existingLockContent, ctx);
         }
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PyProjectHelper.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PyProjectHelper.java
@@ -291,8 +291,9 @@ public class PyProjectHelper {
             return EditAndRegenerateResult.unchanged();
         }
         SourceFile modified = refreshMarker((SourceFile) updated.getTree());
+        String originalDepsContent = ((SourceFile) trait.getTree()).printAll();
         LockFileRegeneration.Result regen = capturedLockContent == null ? null
-                : regenerateLockContent(modified, capturedLockContent, ctx);
+                : regenerateLockContent(modified, originalDepsContent, capturedLockContent, ctx);
         if (regen != null && regen.isSuccess() && regen.getLockFileContent() != null) {
             modified = applyResolvedDependencies(modified, regen.getLockFileContent());
         }
@@ -331,6 +332,17 @@ public class PyProjectHelper {
 
     public static LockFileRegeneration.@Nullable Result regenerateLockContent(
             SourceFile depsFile, @Nullable String capturedLockContent, ExecutionContext ctx) {
+        return regenerateLockContent(depsFile, null, capturedLockContent, ctx);
+    }
+
+    /**
+     * @param originalDepsContent the pre-edit dependencies-file content, or {@code null}; lets the
+     *                            engine reconcile only the packages the edit changed (see
+     *                            {@link LockFileRegeneration#regenerate}).
+     */
+    public static LockFileRegeneration.@Nullable Result regenerateLockContent(
+            SourceFile depsFile, @Nullable String originalDepsContent,
+            @Nullable String capturedLockContent, ExecutionContext ctx) {
         PythonResolutionResult marker = depsFile.getMarkers()
                 .findFirst(PythonResolutionResult.class).orElse(null);
         if (marker == null) {
@@ -340,7 +352,7 @@ public class PyProjectHelper {
         if (regen == null) {
             return null;
         }
-        return regen.regenerate(depsFile.printAll(), capturedLockContent, ctx);
+        return regen.regenerate(depsFile.printAll(), originalDepsContent, capturedLockContent, ctx);
     }
 
     /**

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/pdmlock/PdmLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/pdmlock/PdmLockEngine.java
@@ -52,6 +52,11 @@ public final class PdmLockEngine {
     }
 
     public static Result regenerate(String pyprojectContent, @Nullable String oldLockContent, ExecutionContext ctx) {
+        return regenerate(pyprojectContent, null, oldLockContent, ctx);
+    }
+
+    public static Result regenerate(String pyprojectContent, @Nullable String originalPyprojectContent,
+                                    @Nullable String oldLockContent, ExecutionContext ctx) {
         if (oldLockContent == null) {
             return Result.failure(new Failure(Reason.RESOLUTION_REQUIRED, null, null,
                     "No existing pdm.lock; locking from scratch requires full dependency resolution, " +
@@ -69,8 +74,10 @@ public final class PdmLockEngine {
             return Result.failure(new Failure(Reason.MALFORMED_MANIFEST, null, null,
                     "Edited pyproject.toml could not be parsed as TOML"));
         }
+        // Best-effort: a null or unparseable original falls back to whole-pyproject reconciliation.
+        Toml.Document originalPyproject = originalPyprojectContent == null ? null : parseToml(originalPyprojectContent);
         try {
-            return new Run(pyproject, lock, ctx).regenerate();
+            return new Run(pyproject, originalPyproject, lock, ctx).regenerate();
         } catch (PythonIndexException e) {
             return Result.failure(indexFailure(null, e));
         } catch (PdmLockFormatException e) {
@@ -125,6 +132,7 @@ public final class PdmLockEngine {
 
     private static final class Run {
         private final Toml.Document pyproject;
+        private final Toml.@Nullable Document originalPyproject;
         private final PdmLock lock;
         private final HttpSender http;
         private final SimpleIndexClient simpleClient;
@@ -133,8 +141,9 @@ public final class PdmLockEngine {
 
         private List<PdmLockPackage> packages;
 
-        Run(Toml.Document pyproject, PdmLock lock, ExecutionContext ctx) {
+        Run(Toml.Document pyproject, Toml.@Nullable Document originalPyproject, PdmLock lock, ExecutionContext ctx) {
             this.pyproject = pyproject;
+            this.originalPyproject = originalPyproject;
             this.lock = lock;
             this.http = HttpSenderExecutionContextView.view(ctx).getHttpSender();
             this.simpleClient = new SimpleIndexClient(http);
@@ -154,7 +163,10 @@ public final class PdmLockEngine {
             packages = new ArrayList<>(lock.getPackages());
             String newHash = PdmContentHash.hash(pyproject);
 
-            Map<String, @Nullable PythonVersionSpecifierSet> declared = collectDirectDeps();
+            Map<String, @Nullable PythonVersionSpecifierSet> declared = collectDirectDeps(pyproject);
+            Map<String, @Nullable PythonVersionSpecifierSet> originalDeclared =
+                    originalPyproject == null ? null : collectDirectDeps(originalPyproject);
+            Set<String> changedPackages = changedNames(originalDeclared, declared);
 
             Map<String, Integer> byName = new HashMap<>();
             for (int i = 0; i < packages.size(); i++) {
@@ -163,6 +175,10 @@ public final class PdmLockEngine {
 
             List<Change> changes = new ArrayList<>();
             for (Map.Entry<String, @Nullable PythonVersionSpecifierSet> dep : declared.entrySet()) {
+                // Leave pre-existing drift in a dependency the recipe never touched exactly as-is.
+                if (changedPackages != null && !changedPackages.contains(dep.getKey())) {
+                    continue;
+                }
                 Integer idx = byName.get(dep.getKey());
                 if (idx == null) {
                     throw new EngineFailure(Reason.RESOLUTION_REQUIRED, dep.getKey(),
@@ -179,7 +195,11 @@ public final class PdmLockEngine {
                 }
             }
 
-            requireNoOrphans(declared.keySet(), byName);
+            // Tolerate orphans that already existed under the original declarations; only fail loud
+            // on packages this edit orphaned (a removal or closure-shrinking change).
+            Set<String> tolerated = originalDeclared == null ?
+                    Collections.emptySet() : orphansUnder(originalDeclared.keySet(), byName);
+            requireNoOrphans(declared.keySet(), byName, tolerated);
 
             for (Change change : changes) {
                 applyLeafChange(change);
@@ -189,7 +209,48 @@ public final class PdmLockEngine {
             return Result.success(PdmLockWriter.write(updated));
         }
 
-        private void requireNoOrphans(Set<String> roots, Map<String, Integer> byName) {
+        private static @Nullable Set<String> changedNames(
+                @Nullable Map<String, @Nullable PythonVersionSpecifierSet> original,
+                Map<String, @Nullable PythonVersionSpecifierSet> edited) {
+            if (original == null) {
+                return null;
+            }
+            Set<String> changed = new HashSet<>();
+            Set<String> names = new HashSet<>(original.keySet());
+            names.addAll(edited.keySet());
+            for (String name : names) {
+                if (!Objects.equals(original.get(name), edited.get(name))) {
+                    changed.add(name);
+                }
+            }
+            return changed;
+        }
+
+        private void requireNoOrphans(Set<String> roots, Map<String, Integer> byName, Set<String> tolerated) {
+            Set<String> reachable = reachableFrom(roots, byName);
+            for (PdmLockPackage pkg : packages) {
+                String canonical = Pep508Requirement.canonicalize(pkg.getName());
+                if (!reachable.contains(canonical) && !tolerated.contains(canonical)) {
+                    throw new EngineFailure(Reason.RESOLUTION_REQUIRED, pkg.getName(),
+                            "Locked package " + pkg.getName() + " is not reachable from the declared " +
+                                    "dependencies; pruning or adding a dependency requires resolution");
+                }
+            }
+        }
+
+        private Set<String> orphansUnder(Set<String> roots, Map<String, Integer> byName) {
+            Set<String> reachable = reachableFrom(roots, byName);
+            Set<String> orphans = new HashSet<>();
+            for (PdmLockPackage pkg : packages) {
+                String canonical = Pep508Requirement.canonicalize(pkg.getName());
+                if (!reachable.contains(canonical)) {
+                    orphans.add(canonical);
+                }
+            }
+            return orphans;
+        }
+
+        private Set<String> reachableFrom(Set<String> roots, Map<String, Integer> byName) {
             Set<String> reachable = new HashSet<>();
             Deque<String> queue = new ArrayDeque<>();
             for (String root : roots) {
@@ -209,13 +270,7 @@ public final class PdmLockEngine {
                     }
                 }
             }
-            for (PdmLockPackage pkg : packages) {
-                if (!reachable.contains(Pep508Requirement.canonicalize(pkg.getName()))) {
-                    throw new EngineFailure(Reason.RESOLUTION_REQUIRED, pkg.getName(),
-                            "Locked package " + pkg.getName() + " is not reachable from the declared " +
-                                    "dependencies; pruning or adding a dependency requires resolution");
-                }
-            }
+            return reachable;
         }
 
         private void applyLeafChange(Change change) {
@@ -408,7 +463,7 @@ public final class PdmLockEngine {
 
         // ---- manifest reading ----
 
-        private Map<String, @Nullable PythonVersionSpecifierSet> collectDirectDeps() {
+        private Map<String, @Nullable PythonVersionSpecifierSet> collectDirectDeps(Toml.Document pyproject) {
             Map<String, Object> root = PyprojectData.toNestedMap(pyproject);
             Map<String, @Nullable PythonVersionSpecifierSet> deps = new LinkedHashMap<>();
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngine.java
@@ -57,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.TreeSet;
 
 import static java.util.Collections.emptyList;
@@ -83,6 +84,11 @@ public final class PipenvLockEngine {
     }
 
     public static Result regenerate(String pipfileContent, @Nullable String oldLockContent, ExecutionContext ctx) {
+        return regenerate(pipfileContent, null, oldLockContent, ctx);
+    }
+
+    public static Result regenerate(String pipfileContent, @Nullable String originalPipfileContent,
+                                    @Nullable String oldLockContent, ExecutionContext ctx) {
         if (oldLockContent == null) {
             return Result.failure(new Failure(Reason.RESOLUTION_REQUIRED, null, null,
                     "No existing Pipfile.lock; locking from scratch requires full dependency resolution, " +
@@ -107,8 +113,13 @@ public final class PipenvLockEngine {
             return Result.failure(new Failure(Reason.MALFORMED_MANIFEST, null, null, detail));
         }
 
+        // Parsed best-effort: a null or unparseable original falls back to whole-Pipfile
+        // reconciliation. The edited Pipfile already parsed above, so this rarely fails.
+        Toml.Document originalPipfile = originalPipfileContent == null ? null :
+                parsePipfile(originalPipfileContent, new String[1]);
+
         try {
-            return new Run(pipfile, lock, oldLockContent, ctx).regenerate();
+            return new Run(pipfile, originalPipfile, lock, oldLockContent, ctx).regenerate();
         } catch (PythonIndexException e) {
             return Result.failure(indexFailure(null, e));
         }
@@ -196,9 +207,16 @@ public final class PipenvLockEngine {
         private final MarkerEnvironment env;
         private final @Nullable PythonVersion lockPython;
 
+        // Canonical names of packages the recipe actually changed, or null to reconcile the
+        // whole Pipfile. When non-null, entries the recipe left untouched are preserved as-is
+        // so pre-existing Pipfile/lock drift in an unrelated package can't abort the edit.
+        private final @Nullable Set<String> changedPackages;
+
         @SuppressWarnings("unchecked")
-        Run(Toml.Document pipfile, Map<String, Object> lock, String oldLockContent, ExecutionContext ctx) {
+        Run(Toml.Document pipfile, Toml.@Nullable Document originalPipfile, Map<String, Object> lock,
+            String oldLockContent, ExecutionContext ctx) {
             this.pipfile = pipfile;
+            this.changedPackages = changedPackages(originalPipfile, pipfile);
             this.lock = lock;
             this.newline = oldLockContent.contains("\r\n") ? "\r\n" : "\n";
             this.http = HttpSenderExecutionContextView.view(ctx).getHttpSender();
@@ -225,7 +243,7 @@ public final class PipenvLockEngine {
         }
 
         Result regenerate() {
-            Map<String, Map<String, PipfileEntry>> pipfileCategories = readPipfileCategories();
+            Map<String, Map<String, PipfileEntry>> pipfileCategories = readPipfileCategories(pipfile);
             if (pipfileCategories == null) {
                 return Result.failure(new Failure(Reason.UNSUPPORTED_ENTRY_TYPE, null, null,
                         "Pipfile contains a dependency entry the native engine cannot represent"));
@@ -270,7 +288,7 @@ public final class PipenvLockEngine {
          * Reads [packages]/[dev-packages]/custom category tables keyed by lock category name.
          * Returns null when an entry value cannot be interpreted.
          */
-        private @Nullable Map<String, Map<String, PipfileEntry>> readPipfileCategories() {
+        private static @Nullable Map<String, Map<String, PipfileEntry>> readPipfileCategories(Toml.Document pipfile) {
             Map<String, Map<String, PipfileEntry>> categories = new LinkedHashMap<>();
             for (TomlValue value : pipfile.getValues()) {
                 if (!(value instanceof Toml.Table)) {
@@ -303,6 +321,63 @@ public final class PipenvLockEngine {
             return categories;
         }
 
+        /**
+         * Canonical names of packages whose Pipfile declaration differs between the original
+         * (pre-edit) and edited Pipfile — the ones the recipe actually touched. Returns null
+         * when the original is unavailable or unrepresentable, in which case the whole Pipfile
+         * is reconciled against the lock (the historical behavior).
+         */
+        private static @Nullable Set<String> changedPackages(Toml.@Nullable Document original, Toml.Document edited) {
+            if (original == null) {
+                return null;
+            }
+            Map<String, String> before = declarationSignatures(original);
+            Map<String, String> after = declarationSignatures(edited);
+            if (before == null || after == null) {
+                return null;
+            }
+            Set<String> changed = new HashSet<>();
+            Set<String> names = new HashSet<>(before.keySet());
+            names.addAll(after.keySet());
+            for (String canonical : names) {
+                if (!Objects.equals(before.get(canonical), after.get(canonical))) {
+                    changed.add(canonical);
+                }
+            }
+            return changed;
+        }
+
+        /**
+         * Each declared package (by canonical name) mapped to a signature aggregating every field
+         * that affects locking across every category it appears in: category, version constraint,
+         * extras, markers, and index. Aggregating (rather than last-category-wins) matters because
+         * {@code computeEdits} reconciles per category, so a change in any one must mark the package.
+         */
+        private static @Nullable Map<String, String> declarationSignatures(Toml.Document pipfile) {
+            Map<String, Map<String, PipfileEntry>> categories = readPipfileCategories(pipfile);
+            if (categories == null) {
+                return null;
+            }
+            Map<String, TreeSet<String>> byCanonical = new LinkedHashMap<>();
+            for (Map.Entry<String, Map<String, PipfileEntry>> category : categories.entrySet()) {
+                for (PipfileEntry entry : category.getValue().values()) {
+                    String canonical = Pep508Requirement.canonicalize(entry.keyAsWritten);
+                    byCanonical.computeIfAbsent(canonical, k -> new TreeSet<>()).add(category.getKey() + '|' +
+                            entry.constraint + '|' +
+                            new TreeSet<>(entry.extras) + '|' +
+                            entry.markers + '|' +
+                            new TreeMap<>(entry.markerKeys) + '|' +
+                            entry.indexName + '|' +
+                            entry.unsupported);
+                }
+            }
+            Map<String, String> signatures = new LinkedHashMap<>();
+            for (Map.Entry<String, TreeSet<String>> e : byCanonical.entrySet()) {
+                signatures.put(e.getKey(), e.getValue().toString());
+            }
+            return signatures;
+        }
+
         private static String lockCategoryName(String pipfileTable) {
             if ("packages".equals(pipfileTable)) {
                 return "default";
@@ -313,7 +388,7 @@ public final class PipenvLockEngine {
             return pipfileTable;
         }
 
-        private @Nullable PipfileEntry readEntry(String key, Toml value) {
+        private static @Nullable PipfileEntry readEntry(String key, Toml value) {
             PipfileEntry entry = new PipfileEntry(key);
             if (value instanceof Toml.Literal) {
                 Object v = ((Toml.Literal) value).getValue();
@@ -376,6 +451,11 @@ public final class PipenvLockEngine {
 
                 for (PipfileEntry entry : category.getValue().values()) {
                     String canonical = Pep508Requirement.canonicalize(entry.keyAsWritten);
+                    // Preserve entries the recipe did not touch: pre-existing Pipfile/lock drift
+                    // in an unrelated package must not add an edit or abort this regeneration.
+                    if (changedPackages != null && !changedPackages.contains(canonical)) {
+                        continue;
+                    }
                     String lockKey = lockKeysByCanonical.get(canonical);
                     if (lockKey == null) {
                         if (entry.unsupported) {
@@ -426,8 +506,11 @@ public final class PipenvLockEngine {
                 }
                 for (Map.Entry<String, Object> lockEntry : lockEntries.entrySet()) {
                     Map<String, Object> e = entryMap(lockEntry.getValue());
-                    if (e.containsKey("index") &&
-                            !pipfileCanonical.contains(Pep508Requirement.canonicalize(lockEntry.getKey()))) {
+                    String canonical = Pep508Requirement.canonicalize(lockEntry.getKey());
+                    if (changedPackages != null && !changedPackages.contains(canonical)) {
+                        continue; // only remove a package the recipe actually removed
+                    }
+                    if (e.containsKey("index") && !pipfileCanonical.contains(canonical)) {
                         edits.add(new Edit(lockCategory, new PipfileEntry(lockEntry.getKey()),
                                 lockEntry.getKey(), Edit.Kind.REMOVAL));
                     }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/poetrylock/PoetryLockEngine.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/poetrylock/PoetryLockEngine.java
@@ -53,6 +53,11 @@ public final class PoetryLockEngine {
     }
 
     public static Result regenerate(String pyprojectContent, @Nullable String oldLockContent, ExecutionContext ctx) {
+        return regenerate(pyprojectContent, null, oldLockContent, ctx);
+    }
+
+    public static Result regenerate(String pyprojectContent, @Nullable String originalPyprojectContent,
+                                    @Nullable String oldLockContent, ExecutionContext ctx) {
         if (oldLockContent == null) {
             return Result.failure(new Failure(Reason.RESOLUTION_REQUIRED, null, null,
                     "No existing poetry.lock; locking from scratch requires full dependency resolution, " +
@@ -70,8 +75,10 @@ public final class PoetryLockEngine {
             return Result.failure(new Failure(Reason.MALFORMED_MANIFEST, null, null,
                     "Edited pyproject.toml could not be parsed as TOML"));
         }
+        // Best-effort: a null or unparseable original falls back to whole-pyproject reconciliation.
+        Toml.Document originalPyproject = originalPyprojectContent == null ? null : parseToml(originalPyprojectContent);
         try {
-            return new Run(pyproject, lock, ctx).regenerate();
+            return new Run(pyproject, originalPyproject, lock, ctx).regenerate();
         } catch (PythonIndexException e) {
             return Result.failure(indexFailure(null, e));
         } catch (PoetryLockFormatException e) {
@@ -126,6 +133,7 @@ public final class PoetryLockEngine {
 
     private static final class Run {
         private final Toml.Document pyproject;
+        private final Toml.@Nullable Document originalPyproject;
         private final PoetryLock lock;
         private final HttpSender http;
         private final SimpleIndexClient simpleClient;
@@ -135,8 +143,9 @@ public final class PoetryLockEngine {
 
         private List<PoetryLockPackage> packages;
 
-        Run(Toml.Document pyproject, PoetryLock lock, ExecutionContext ctx) {
+        Run(Toml.Document pyproject, Toml.@Nullable Document originalPyproject, PoetryLock lock, ExecutionContext ctx) {
             this.pyproject = pyproject;
+            this.originalPyproject = originalPyproject;
             this.lock = lock;
             this.http = HttpSenderExecutionContextView.view(ctx).getHttpSender();
             this.simpleClient = new SimpleIndexClient(http);
@@ -157,7 +166,10 @@ public final class PoetryLockEngine {
             packages = new ArrayList<>(lock.getPackages());
             String newHash = PoetryContentHash.hash(pyproject);
 
-            Map<String, @Nullable PythonVersionSpecifierSet> declared = collectDirectDeps();
+            Map<String, @Nullable PythonVersionSpecifierSet> declared = collectDirectDeps(pyproject);
+            Map<String, @Nullable PythonVersionSpecifierSet> originalDeclared =
+                    originalPyproject == null ? null : collectDirectDeps(originalPyproject);
+            Set<String> changedPackages = changedNames(originalDeclared, declared);
 
             Map<String, Integer> byName = new HashMap<>();
             for (int i = 0; i < packages.size(); i++) {
@@ -166,6 +178,10 @@ public final class PoetryLockEngine {
 
             List<Change> changes = new ArrayList<>();
             for (Map.Entry<String, @Nullable PythonVersionSpecifierSet> dep : declared.entrySet()) {
+                // Leave pre-existing drift in a dependency the recipe never touched exactly as-is.
+                if (changedPackages != null && !changedPackages.contains(dep.getKey())) {
+                    continue;
+                }
                 Integer idx = byName.get(dep.getKey());
                 if (idx == null) {
                     throw new EngineFailure(Reason.RESOLUTION_REQUIRED, dep.getKey(),
@@ -182,7 +198,11 @@ public final class PoetryLockEngine {
                 }
             }
 
-            requireNoOrphans(declared.keySet(), byName);
+            // Tolerate orphans that already existed under the original declarations; only fail loud
+            // on packages this edit orphaned (a removal or closure-shrinking change).
+            Set<String> tolerated = originalDeclared == null ?
+                    Collections.emptySet() : orphansUnder(originalDeclared.keySet(), byName);
+            requireNoOrphans(declared.keySet(), byName, tolerated);
 
             for (Change change : changes) {
                 applyLeafChange(change);
@@ -192,12 +212,53 @@ public final class PoetryLockEngine {
             return Result.success(PoetryLockWriter.write(updated));
         }
 
+        private static @Nullable Set<String> changedNames(
+                @Nullable Map<String, @Nullable PythonVersionSpecifierSet> original,
+                Map<String, @Nullable PythonVersionSpecifierSet> edited) {
+            if (original == null) {
+                return null;
+            }
+            Set<String> changed = new HashSet<>();
+            Set<String> names = new HashSet<>(original.keySet());
+            names.addAll(edited.keySet());
+            for (String name : names) {
+                if (!Objects.equals(original.get(name), edited.get(name))) {
+                    changed.add(name);
+                }
+            }
+            return changed;
+        }
+
         /**
          * Every locked package must be reachable by name from a declared direct dependency, so a
          * pure version change leaves no orphan. A removed dependency (or one pruned by an upgrade)
          * shows up as an orphan and defers to a real relock.
          */
-        private void requireNoOrphans(Set<String> roots, Map<String, Integer> byName) {
+        private void requireNoOrphans(Set<String> roots, Map<String, Integer> byName, Set<String> tolerated) {
+            Set<String> reachable = reachableFrom(roots, byName);
+            for (PoetryLockPackage pkg : packages) {
+                String canonical = Pep508Requirement.canonicalize(pkg.getName());
+                if (!reachable.contains(canonical) && !tolerated.contains(canonical)) {
+                    throw new EngineFailure(Reason.RESOLUTION_REQUIRED, pkg.getName(),
+                            "Locked package " + pkg.getName() + " is not reachable from the declared " +
+                                    "dependencies; pruning or adding a dependency requires resolution");
+                }
+            }
+        }
+
+        private Set<String> orphansUnder(Set<String> roots, Map<String, Integer> byName) {
+            Set<String> reachable = reachableFrom(roots, byName);
+            Set<String> orphans = new HashSet<>();
+            for (PoetryLockPackage pkg : packages) {
+                String canonical = Pep508Requirement.canonicalize(pkg.getName());
+                if (!reachable.contains(canonical)) {
+                    orphans.add(canonical);
+                }
+            }
+            return orphans;
+        }
+
+        private Set<String> reachableFrom(Set<String> roots, Map<String, Integer> byName) {
             Set<String> reachable = new HashSet<>();
             Deque<String> queue = new ArrayDeque<>();
             for (String root : roots) {
@@ -217,13 +278,7 @@ public final class PoetryLockEngine {
                     }
                 }
             }
-            for (PoetryLockPackage pkg : packages) {
-                if (!reachable.contains(Pep508Requirement.canonicalize(pkg.getName()))) {
-                    throw new EngineFailure(Reason.RESOLUTION_REQUIRED, pkg.getName(),
-                            "Locked package " + pkg.getName() + " is not reachable from the declared " +
-                                    "dependencies; pruning or adding a dependency requires resolution");
-                }
-            }
+            return reachable;
         }
 
         private void applyLeafChange(Change change) {
@@ -418,7 +473,7 @@ public final class PoetryLockEngine {
         // ---- manifest reading ----
 
         @SuppressWarnings("unchecked")
-        private Map<String, @Nullable PythonVersionSpecifierSet> collectDirectDeps() {
+        private Map<String, @Nullable PythonVersionSpecifierSet> collectDirectDeps(Toml.Document pyproject) {
             Map<String, Object> root = PyprojectData.toNestedMap(pyproject);
             Map<String, @Nullable PythonVersionSpecifierSet> deps = new LinkedHashMap<>();
 

--- a/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionPipfileLockTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/UpgradeDependencyVersionPipfileLockTest.java
@@ -199,6 +199,75 @@ class UpgradeDependencyVersionPipfileLockTest implements RewriteTest {
 
     @Test
     @Timeout(120)
+    void unrelatedStaleDependencyDoesNotBlockUpgrade() {
+        // The Pipfile declares click, but it predates the lock (absent from it) — a pre-existing
+        // inconsistency the recipe never touched. Upgrading requests must still succeed, leaving
+        // click alone rather than aborting with "click is not in the existing lock".
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("requests", ">=2.32.0", null, null))
+            .executionContext(ctx),
+          pipfile(
+            """
+              [packages]
+              requests = ">=2.28.0"
+              click = ">=8.3.2"
+              """,
+            s -> s.after(actual -> {
+                assertThat(actual).contains("requests = \">=2.32.0\"");
+                return actual;
+            }).afterRecipe(doc -> assertThat(doc.getMarkers().findFirst(Markup.Warn.class))
+              .as("upgrade should not warn about the unrelated stale dependency")
+              .isEmpty())
+          ),
+          json(
+            """
+              {
+                  "_meta": {
+                      "hash": {
+                          "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+                      },
+                      "pipfile-spec": 6,
+                      "requires": {},
+                      "sources": [
+                          {
+                              "name": "pypi",
+                              "url": "https://pypi.org/simple",
+                              "verify_ssl": true
+                          }
+                      ]
+                  },
+                  "default": {
+                      "certifi": {
+                          "hashes": [
+                              "sha256:%s"
+                          ],
+                          "markers": "python_version >= '3.6'",
+                          "version": "==2024.2.2"
+                      },
+                      "requests": {
+                          "hashes": [
+                              "sha256:%s",
+                              "sha256:%s"
+                          ],
+                          "index": "pypi",
+                          "markers": "python_version >= '3.7'",
+                          "version": "==2.31.0"
+                      }
+                  },
+                  "develop": {}
+              }
+              """.formatted(CERTIFI, WHEEL_2310, SDIST_2310),
+            spec -> spec.path("Pipfile.lock").noTrim().after(actual -> {
+                assertThat(actual).contains("\"version\": \"==2.32.4\"");
+                assertThat(actual).doesNotContain("click");
+                return actual;
+            })
+          )
+        );
+    }
+
+    @Test
+    @Timeout(120)
     void recordsStructuredFailureInDataTableAndWarns() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("requests", "==9.9.9", null, null))

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/pdmlock/PdmLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/pdmlock/PdmLockEngineTest.java
@@ -92,6 +92,33 @@ class PdmLockEngineTest {
         assertThat(http.requests).isEmpty();
     }
 
+    @Test
+    void unrelatedMissingDependencyDoesNotBlockScopedUpgrade() {
+        stubPypiSix();
+        // attrs is declared but absent from the lock (pre-existing drift). Bumping six — which the
+        // recipe actually changed — must succeed and leave attrs alone, not abort on it.
+        String original = resource("g-upgrade/pyproject.toml.before")
+                .replace("dependencies = [\"six==1.16.0\"]", "dependencies = [\"six==1.16.0\", \"attrs==25.1.0\"]");
+        String edited = resource("g-upgrade/pyproject.toml.after")
+                .replace("dependencies = [\"six==1.17.0\"]", "dependencies = [\"six==1.17.0\", \"attrs==25.1.0\"]");
+        Result result = PdmLockEngine.regenerate(edited, original, resource("g-upgrade/pdm.lock.before"), ctx);
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("version = \"1.17.0\"");
+        assertThat(result.getLockFileContent()).doesNotContain("attrs");
+    }
+
+    @Test
+    void newlyAddedDependencyStillDefersUnderScoping() {
+        // With the original supplied, adding attrs IS the change, so it still defers to resolution.
+        String original = resource("a-minimal/pyproject.toml");
+        String edited = original.replace("dependencies = [\"six==1.16.0\"]", "dependencies = [\"six==1.16.0\", \"attrs==25.1.0\"]");
+        Result result = PdmLockEngine.regenerate(edited, original, resource("a-minimal/pdm.lock"), ctx);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getFailure().getReason()).isEqualTo(Reason.RESOLUTION_REQUIRED);
+        assertThat(result.getFailure().getPackageName()).isEqualTo("attrs");
+    }
+
     static final class RoutedHttp implements HttpSender {
         final Map<String, byte[]> routes = new LinkedHashMap<>();
         final List<String> requests = new ArrayList<>();

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/pipfilelock/PipenvLockEngineTest.java
@@ -462,6 +462,165 @@ class PipenvLockEngineTest {
     }
 
     @Test
+    void preExistingDriftInUntouchedPackageDoesNotBlockScopedUpgrade() {
+        stubRequestsBaseline();
+        // click is declared in the Pipfile but predates the lock (absent from it): a pre-existing
+        // Pipfile/lock inconsistency the recipe never touched. Upgrading requests must not abort on it.
+        String original = """
+          [[source]]
+          url = "https://pypi.org/simple"
+          verify_ssl = true
+          name = "pypi"
+
+          [packages]
+          requests = ">=2.31.0"
+          click = ">=8.3.2"
+
+          [requires]
+          python_version = "3.11"
+          """;
+        String edited = original.replace(">=2.31.0", ">=2.32.0");
+
+        Result result = PipenvLockEngine.regenerate(edited, original, baseLock(), ctx);
+
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("\"version\": \"==2.32.4\"");
+        assertThat(result.getLockFileContent()).doesNotContain("click");
+    }
+
+    @Test
+    void staleLockVersionInUntouchedPackageIsLeftAsIs() {
+        stubRequestsBaseline();
+        // The Pipfile constraint (>=8.3.2) drifted above the locked click version (8.3.1). Because
+        // the recipe only upgrades requests, click is left exactly as the lock had it.
+        String original = """
+          [[source]]
+          url = "https://pypi.org/simple"
+          verify_ssl = true
+          name = "pypi"
+
+          [packages]
+          requests = ">=2.31.0"
+          click = ">=8.3.2"
+
+          [requires]
+          python_version = "3.11"
+          """;
+        String edited = original.replace(">=2.31.0", ">=2.32.0");
+        // JSON is whitespace-insensitive on read, so the input lock is written plainly here.
+        String lock = """
+          {
+              "_meta": {
+                  "hash": {"sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
+                  "pipfile-spec": 6,
+                  "requires": {"python_version": "3.11"},
+                  "sources": [{"name": "pypi", "url": "https://pypi.org/simple", "verify_ssl": true}]
+              },
+              "default": {
+                  "certifi": {"hashes": ["sha256:%s"], "markers": "python_version >= '3.6'", "version": "==2024.2.2"},
+                  "click": {"hashes": ["sha256:%s"], "index": "pypi", "version": "==8.3.1"},
+                  "idna": {"hashes": ["sha256:%s"], "markers": "python_version >= '3.5'", "version": "==3.7"},
+                  "requests": {"hashes": ["sha256:%s", "sha256:%s"], "index": "pypi", "markers": "python_version >= '3.7'", "version": "==2.31.0"}
+              },
+              "develop": {}
+          }
+          """.formatted(CERTIFI, "1".repeat(64), IDNA, WHEEL_2310, SDIST_2310);
+
+        Result result = PipenvLockEngine.regenerate(edited, original, lock, ctx);
+
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("\"version\": \"==2.32.4\"");
+        assertThat(result.getLockFileContent()).contains("\"version\": \"==8.3.1\"");
+    }
+
+    @Test
+    void packageDeclaredInTwoCategoriesReLocksWhenOneChanges() {
+        stubRequestsBaseline();
+        // requests is declared in BOTH [packages] and [dev-packages]. The recipe bumps only the
+        // default one; scoping must re-lock it and not collapse the two declarations to "unchanged".
+        String original = """
+          [[source]]
+          url = "https://pypi.org/simple"
+          verify_ssl = true
+          name = "pypi"
+
+          [packages]
+          requests = ">=2.31.0"
+
+          [dev-packages]
+          requests = ">=2.31.0"
+
+          [requires]
+          python_version = "3.11"
+          """;
+        String edited = original.replaceFirst("requests = \">=2.31.0\"", "requests = \">=2.32.0\"");
+        String lock = """
+          {
+              "_meta": {
+                  "hash": {"sha256": "0000000000000000000000000000000000000000000000000000000000000000"},
+                  "pipfile-spec": 6,
+                  "requires": {"python_version": "3.11"},
+                  "sources": [{"name": "pypi", "url": "https://pypi.org/simple", "verify_ssl": true}]
+              },
+              "default": {
+                  "certifi": {"hashes": ["sha256:%s"], "markers": "python_version >= '3.6'", "version": "==2024.2.2"},
+                  "idna": {"hashes": ["sha256:%s"], "markers": "python_version >= '3.5'", "version": "==3.7"},
+                  "requests": {"hashes": ["sha256:%s", "sha256:%s"], "index": "pypi", "markers": "python_version >= '3.7'", "version": "==2.31.0"}
+              },
+              "develop": {
+                  "requests": {"hashes": ["sha256:%s", "sha256:%s"], "index": "pypi", "markers": "python_version >= '3.7'", "version": "==2.31.0"}
+              }
+          }
+          """.formatted(CERTIFI, IDNA, WHEEL_2310, SDIST_2310, WHEEL_2310, SDIST_2310);
+
+        Result result = PipenvLockEngine.regenerate(edited, original, lock, ctx);
+
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("==2.32.4"); // default re-locked, not skipped
+        assertThat(result.getLockFileContent()).contains("==2.31.0"); // develop left as-is
+    }
+
+    @Test
+    void newlyAddedAbsentPackageStillFailsLoudUnderScoping() {
+        // With the original supplied, an ADD (flask absent from lock and freshly declared) IS in
+        // scope, so the native engine still fails loud rather than emit a lock missing the dependency.
+        String original = """
+          [[source]]
+          url = "https://pypi.org/simple"
+          verify_ssl = true
+          name = "pypi"
+
+          [packages]
+          requests = ">=2.31.0"
+
+          [requires]
+          python_version = "3.11"
+          """;
+        String edited = """
+          [[source]]
+          url = "https://pypi.org/simple"
+          verify_ssl = true
+          name = "pypi"
+
+          [packages]
+          requests = ">=2.31.0"
+          flask = "*"
+
+          [requires]
+          python_version = "3.11"
+          """;
+
+        Result result = PipenvLockEngine.regenerate(edited, original, baseLock(), ctx);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getFailure().getReason()).isEqualTo(Reason.RESOLUTION_REQUIRED);
+        assertThat(result.getFailure().getPackageName()).isEqualTo("flask");
+    }
+
+    @Test
     void untouchedVcsEntryPassesThrough() {
         String pipfile = """
           [[source]]

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/poetrylock/PoetryLockEngineTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/poetrylock/PoetryLockEngineTest.java
@@ -101,6 +101,33 @@ class PoetryLockEngineTest {
         assertThat(result.getFailure().getReason()).isEqualTo(Reason.RESOLUTION_REQUIRED);
     }
 
+    @Test
+    void unrelatedMissingDependencyDoesNotBlockScopedUpgrade() {
+        stubPypiSix();
+        // attrs is declared but absent from the lock (pre-existing drift). Bumping six — which the
+        // recipe actually changed — must succeed and leave attrs alone, not abort on it.
+        String original = resource("i-upgrade/pyproject.toml.before")
+                .replace("six = \"1.16.0\"", "six = \"1.16.0\"\nattrs = \"25.1.0\"");
+        String edited = resource("i-upgrade/pyproject.toml.after")
+                .replace("six = \"1.17.0\"", "six = \"1.17.0\"\nattrs = \"25.1.0\"");
+        Result result = PoetryLockEngine.regenerate(edited, original, resource("i-upgrade/poetry.lock.before"), ctx);
+        assertThat(result.getErrorMessage()).isNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getLockFileContent()).contains("version = \"1.17.0\"");
+        assertThat(result.getLockFileContent()).doesNotContain("attrs");
+    }
+
+    @Test
+    void newlyAddedDependencyStillDefersUnderScoping() {
+        // With the original supplied, adding attrs IS the change, so it still defers to resolution.
+        String original = resource("a-minimal/pyproject.toml");
+        String edited = original.replace("six = \"1.16.0\"", "six = \"1.16.0\"\nattrs = \"25.1.0\"");
+        Result result = PoetryLockEngine.regenerate(edited, original, resource("a-minimal/poetry.lock"), ctx);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getFailure().getReason()).isEqualTo(Reason.RESOLUTION_REQUIRED);
+        assertThat(result.getFailure().getPackageName()).isEqualTo("attrs");
+    }
+
     static final class RoutedHttp implements HttpSender {
         final Map<String, byte[]> routes = new LinkedHashMap<>();
         final List<String> requests = new ArrayList<>();


### PR DESCRIPTION
## What's changed

The native `Pipfile.lock` / `poetry.lock` / `pdm.lock` regeneration engines reconciled the **entire** edited manifest against the lock. Any pre-existing manifest/lock drift in a package unrelated to the recipe's change would abort the recipe:

- a declared dependency whose locked version no longer satisfies its constraint (e.g. `Pipfile` wants `click>=8.3.2`, `Pipfile.lock` has `click==8.3.1`), or
- a declared dependency absent from the lock entirely,

- surfaced as `RESOLUTION_REQUIRED [click]: Package is not in the existing lock ...` even when the user was upgrading something else. This is the same class of problem as #8304 (bare-version parsing), one layer down.

## Fix

Thread the pre-edit manifest into each engine and reconcile **only the packages whose declaration changed** between the original and edited manifest. Packages the recipe never touched are left in the lock exactly as-is, so pre-existing drift in an unrelated package can no longer abort an upgrade.

- Plumbing: `LockFileRegeneration.regenerate` gains an optional `originalDependenciesContent`; `PyProjectHelper.editAndRegenerate` passes the pre-edit manifest. The recipes are unchanged.
- When no original manifest is supplied (`changedPackages == null`) the engines fall back to whole-manifest reconciliation, so every existing caller and direct engine test behaves identically.
- Adding a genuinely new dependency is still *in scope* and still fails loud rather than emitting a lock that is missing the dependency.
- For Poetry and PDM, the orphan check now tolerates packages that were already unreachable under the original declarations, failing loud only on orphans the edit itself introduces (a removal or closure-shrinking change).

`uv.lock` is untouched — it has its own delta resolver and ignores the new argument.

### Note on the content hash

The regenerated lock's content hash is still computed over the edited manifest, so a package left drifted won't be flagged by a subsequent `pipenv verify` / `poetry lock --check`. That drift was pre-existing and out of the recipe's scope; the recipe's job is to apply its change without being blocked by unrelated stale state.

## Tests

- `PipenvLockEngineTest` +4: unrelated absent/drifted dependency doesn't block a scoped upgrade, a newly-added absent dependency still fails loud, and a package declared in both `[packages]` and `[dev-packages]` is re-locked when only one changes (guards against per-category vs collapsed-scope divergence).
- `UpgradeDependencyVersionPipfileLockTest` +1: end-to-end reproduction of the reported scenario (upgrade `requests` while `click` sits stale in the `Pipfile`).
- `PoetryLockEngineTest` +2, `PdmLockEngineTest` +2: unrelated missing dependency doesn't block a scoped upgrade; a new dependency still defers to resolution.

All engine golden/byte-for-byte tests still pass unchanged.
