### PR TITLE
Use generous HTTP timeouts in UpdateGradleWrapperTest to avoid CI flakiness

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateGradleWrapperTest.java
@@ -73,8 +73,13 @@ class UpdateGradleWrapperTest implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
+        // Resolving versions fetches checksums from downloads.gradle.org; the 1s default connect timeout flakes on CI.
+        HttpUrlConnectionSender sender = new HttpUrlConnectionSender(Duration.ofSeconds(30), Duration.ofMinutes(1));
         spec.recipe(new UpdateGradleWrapper("7.4.2", null, null, null, null))
-          .beforeRecipe(withToolingApi());
+          .beforeRecipe(withToolingApi())
+          .executionContext(HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+            .setHttpSender(sender)
+            .setLargeFileHttpSender(sender));
     }
 
     @DocumentExample("Update existing Gradle wrapper")


### PR DESCRIPTION
## What's wrong

The `main` CI build [failed](https://github.com/openrewrite/rewrite/actions/runs/29869474205) on `:rewrite-gradle:test` with four failing tests in `UpdateGradleWrapperTest`:

- `defaultsToLatestRelease`
- `updateWrapperVersionAndDistributionTypeInKotlinDSL`
- `updateWrapperVersionViaTasksPropertyAccessInKotlinDSL`
- `updateWrapperDistributionURLInGroovyDsl`

All four failed with the same error — `java.net.SocketTimeoutException: Connect timed out` — while the recipe fetched a `.sha256` distribution checksum from `downloads.gradle.org` (`DistributionInfos.fetchChecksum` → `Checksum.fromUri`).

This is environmental flakiness, not a code regression: the commit CI ran on was an unrelated Python/Pipfile change, and only four of eight structurally near-identical wrapper tests failed.

## Root cause

The version-resolving tests inherit the execution context's **default** `HttpSender` (`new HttpUrlConnectionSender()`), which uses a **1-second connect timeout** and no retry. On a busy CI runner, a TLS handshake to `downloads.gradle.org` that takes longer than 1s fails the entire recipe run. The sibling `DistributionInfosTest` already avoids this by using generous 30s/60s timeouts and does not flake.

## Fix

Set the same generous 30s connect / 60s read timeouts once in the class-level `defaults()`, rather than changing the production 1s default (which fast-fails intentionally). Tests that set their own `executionContext` (the offline custom-distribution cases) override the class default and are unaffected.

## Verification

- All four previously-failing tests pass.
- Full `UpdateGradleWrapperTest` class: **37 tests, 0 skipped, 0 failures, 0 errors** — no regressions, nothing silently skipped.