### PR TITLE
C#: type numeric literals consistently with their values

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/LiteralTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/LiteralTests.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using OpenRewrite.CSharp;
 using OpenRewrite.Java;
 using OpenRewrite.Test;
 
@@ -122,5 +123,27 @@ public class LiteralTests : RewriteTest
         Assert.NotNull(lit.Type);
         Assert.IsType<JavaType.Primitive>(lit.Type);
         Assert.Equal(expectedKind, ((JavaType.Primitive)lit.Type).Kind);
+    }
+
+    [Theory]
+    [InlineData("234.7m", JavaType.PrimitiveKind.Double, 234.7d)]
+    [InlineData("42u", JavaType.PrimitiveKind.Long, 42L)]
+    [InlineData("42UL", JavaType.PrimitiveKind.Long, 42L)]
+    [InlineData("18446744073709551615UL", JavaType.PrimitiveKind.Long, -1L)] // ulong bits reinterpreted as signed
+    [InlineData("4.5f", JavaType.PrimitiveKind.Float, 4.5f)]
+    [InlineData("5L", JavaType.PrimitiveKind.Long, 5L)]
+    [InlineData("1_000_000", JavaType.PrimitiveKind.Int, 1_000_000)]
+    public void NumericLiteralValueMatchesDeclaredType(string literal, JavaType.PrimitiveKind expectedKind, object expectedValue)
+    {
+        var cu = Parse($"{literal};");
+        var lit = FindFirst<Literal>(cu);
+        Assert.NotNull(lit);
+        var primitive = Assert.IsType<JavaType.Primitive>(lit.Type);
+        Assert.Equal(expectedKind, primitive.Kind);
+        Assert.NotNull(lit.Value);
+        Assert.Equal(expectedValue.GetType(), lit.Value!.GetType());
+        Assert.Equal(expectedValue, lit.Value);
+        Assert.Equal(literal, lit.ValueSource);
+        Assert.Equal($"{literal};", new CSharpPrinter<object>().Print(cu));
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -4592,9 +4592,17 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // Skip past the literal token
         _cursor = node.Token.Span.End;
 
-        var type = node.Kind() == SyntaxKind.NumericLiteralExpression
-            ? _typeMapping?.Type(node) as JavaType.Primitive ?? GetPrimitiveType(node.Kind())
-            : GetPrimitiveType(node.Kind());
+        JavaType.Primitive? type;
+        if (node.Kind() == SyntaxKind.NumericLiteralExpression)
+        {
+            // Derive value and type together from the constant's runtime type so
+            // they cannot disagree (e.g. 234.7m must not be typed Int).
+            (value, type) = NormalizeNumericLiteral(value);
+        }
+        else
+        {
+            type = GetPrimitiveType(node.Kind());
+        }
 
         return new Literal(
             Guid.NewGuid(),
@@ -10250,6 +10258,28 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             callingConvention, unmanagedConventionTypes,
             new JContainer<TypeTree>(angleBracketSpace, paramTypes, Markers.Empty), null);
     }
+
+    /// <summary>
+    /// Maps a numeric literal constant to a (value, type) pair whose runtime type matches
+    /// the declared primitive. decimal/uint/ulong have no Java equivalent: decimal narrows
+    /// to double, uint widens to long, and ulong reinterprets its bits as a signed long;
+    /// the original text is preserved in ValueSource so printing is unaffected.
+    /// </summary>
+    private static (object? Value, JavaType.Primitive Type) NormalizeNumericLiteral(object? value) => value switch
+    {
+        int i => (i, JavaType.Primitive.Of(JavaType.PrimitiveKind.Int)),
+        long l => (l, JavaType.Primitive.Of(JavaType.PrimitiveKind.Long)),
+        float f => (f, JavaType.Primitive.Of(JavaType.PrimitiveKind.Float)),
+        double d => (d, JavaType.Primitive.Of(JavaType.PrimitiveKind.Double)),
+        decimal m => ((double)m, JavaType.Primitive.Of(JavaType.PrimitiveKind.Double)),
+        uint u => ((long)u, JavaType.Primitive.Of(JavaType.PrimitiveKind.Long)),
+        ulong ul => (unchecked((long)ul), JavaType.Primitive.Of(JavaType.PrimitiveKind.Long)),
+        short s => (s, JavaType.Primitive.Of(JavaType.PrimitiveKind.Short)),
+        sbyte sb => (sb, JavaType.Primitive.Of(JavaType.PrimitiveKind.Byte)),
+        ushort us => ((int)us, JavaType.Primitive.Of(JavaType.PrimitiveKind.Int)),
+        byte b => ((short)b, JavaType.Primitive.Of(JavaType.PrimitiveKind.Short)), // Java byte cannot hold 128-255
+        _ => (value, JavaType.Primitive.Of(JavaType.PrimitiveKind.Int))
+    };
 
     private static JavaType.Primitive? GetPrimitiveType(SyntaxKind kind)
     {


### PR DESCRIPTION
## What's changed

The C# parser derives a numeric `J.Literal`'s value and its `JavaType.Primitive` together from the Roslyn constant's runtime type, so the two can never disagree:

- `int`/`long`/`float`/`double` map to `Int`/`Long`/`Float`/`Double` as before
- `decimal` (`234.7m`) narrows to `Double` — Java has no decimal primitive; the source text is preserved in `ValueSource` so printing is unaffected
- `uint` widens to `Long`
- `ulong` reinterprets its bits as a signed `long` (`unchecked((long)v)`) typed `Long`

Previously `GetPrimitiveType` fell back to `Int` for any `NumericLiteralExpression` whose semantic type had no primitive mapping, so `234.7m` produced a literal typed `Int` carrying a non-integer value — and without a semantic model even `5L`/`4.5` were typed `Int`.

## Why

Consumers rely on the invariant that a literal's value runtime class matches its declared primitive. In particular it lets the Moderne CLI's V3 LST serializer normalize/enforce the type/value invariant at write time instead of failing (previously `NumberFormatException`) when re-boxing `"234.7"` as `Int` at read time.

## Tests

`LiteralTests.NumericLiteralValueMatchesDeclaredType` asserts for `234.7m`, `42u`, `42UL`, `18446744073709551615UL`, `4.5f`, `5L`, `1_000_000` that the parsed literal's primitive kind and value runtime type agree per the mapping and that printing round-trips the original source text.