### PR TITLE
Delegate the three-arg generate overload through precondition decorators and the RPC Generate handler

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -399,6 +399,11 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
         }
 
         @Override
+        public Collection<? extends SourceFile> generate(T acc, Collection<SourceFile> generatedInThisCycle, ExecutionContext ctx) {
+            return delegate.generate(acc, generatedInThisCycle, ctx);
+        }
+
+        @Override
         public Collection<? extends SourceFile> generate(T acc, ExecutionContext ctx) {
             return delegate.generate(acc, ctx);
         }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/Generate.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/Generate.java
@@ -70,7 +70,7 @@ public class Generate implements RpcRequest {
                 ScanningRecipe<Object> scanningRecipe = (ScanningRecipe<Object>) recipe;
                 Object acc = scanningRecipe.getAccumulator(preparedRecipes.getRecipeCursors().computeIfAbsent(recipe,
                         r -> new Cursor(null, Cursor.ROOT_VALUE)), ctx);
-                Collection<? extends SourceFile> generated = scanningRecipe.generate(acc, ctx);
+                Collection<? extends SourceFile> generated = scanningRecipe.generate(acc, emptyList(), ctx);
 
                 GenerateResponse response = new GenerateResponse(
                         new ArrayList<>(generated.size()),

--- a/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/DeclarativeRecipeTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptyList;
@@ -292,6 +293,84 @@ class DeclarativeRecipeTest implements RewriteTest {
             ))
             .expectedCyclesThatMakeChanges(1),
           text("1")
+        );
+    }
+
+    @Test
+    void yamlPreconditionWithScanningRecipeOverridingThreeArgGenerate() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: org.openrewrite.PreconditionTest
+              description: Test.
+              preconditions:
+                - org.openrewrite.text.Find:
+                    find: 1
+              recipeList:
+                - org.openrewrite.text.AppendToTextFile:
+                   relativeFileName: file.txt
+                   content: content
+              """, "org.openrewrite.PreconditionTest"),
+          text("1", spec -> spec.path("trigger.txt")),
+          text(
+            null,
+            """
+              content
+              """,
+            spec -> spec.path("file.txt")
+          )
+        );
+    }
+
+    @Test
+    void yamlPreconditionNotMetStillGeneratesSources() {
+        rewriteRun(
+          spec -> spec.recipeFromYaml("""
+              ---
+              type: specs.openrewrite.org/v1beta/recipe
+              name: org.openrewrite.PreconditionTest
+              description: Test.
+              preconditions:
+                - org.openrewrite.text.Find:
+                    find: 1
+              recipeList:
+                - org.openrewrite.text.AppendToTextFile:
+                   relativeFileName: file.txt
+                   content: content
+              """, "org.openrewrite.PreconditionTest"),
+          text("2", spec -> spec.path("trigger.txt")),
+          text(
+            null,
+            """
+              content
+              """,
+            spec -> spec.path("file.txt")
+          )
+        );
+    }
+
+    @Test
+    void preconditionDecoratorDelegatesThreeArgGenerate() {
+        rewriteRun(
+          spec -> {
+              spec.validateRecipeSerialization(false);
+              var dr = new DeclarativeRecipe("test", "test", "test", emptySet(),
+                null, URI.create("null"), false, emptyList());
+              dr.addPrecondition(
+                toRecipe(() -> new PlainTextVisitor<>() {
+                    @Override
+                    public PlainText visitText(PlainText text, ExecutionContext ctx) {
+                        return SearchResult.found(text);
+                    }
+                })
+              );
+              dr.addUninitialized(new ThreeArgGenerateRecipe());
+              dr.initialize(List.of());
+              spec.recipe(dr);
+          },
+          text("trigger", spec -> spec.path("trigger.txt")),
+          text(null, "generated", spec -> spec.path("generated.txt"))
         );
     }
 
@@ -906,6 +985,47 @@ class DeclarativeRecipeTest implements RewriteTest {
           .hasSize(1)
           .first()
           .satisfies(r -> assertThat(r.getName()).isEqualTo("leaf"));
+    }
+
+    static class ThreeArgGenerateRecipe extends ScanningRecipe<AtomicBoolean> {
+        @Override
+        public String getDisplayName() {
+            return "Three-arg generate recipe";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Generates a file by overriding only the three-arg generate overload.";
+        }
+
+        @Override
+        public AtomicBoolean getInitialValue(ExecutionContext ctx) {
+            return new AtomicBoolean(false);
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getScanner(AtomicBoolean fileExists) {
+            return new PlainTextVisitor<>() {
+                @Override
+                public PlainText visitText(PlainText text, ExecutionContext ctx) {
+                    if (Path.of("generated.txt").equals(text.getSourcePath())) {
+                        fileExists.set(true);
+                    }
+                    return text;
+                }
+            };
+        }
+
+        @Override
+        public Collection<SourceFile> generate(AtomicBoolean fileExists, Collection<SourceFile> generatedInThisCycle, ExecutionContext ctx) {
+            if (fileExists.get()) {
+                return emptyList();
+            }
+            return List.of(PlainText.builder()
+              .sourcePath(Path.of("generated.txt"))
+              .text("generated")
+              .build());
+        }
     }
 
     static class CountingRecipe extends ScanningRecipe<List<String>> {


### PR DESCRIPTION
## What's changed?
- `DeclarativeRecipe.BellwetherDecoratedScanningRecipe` now overrides the three-arg `generate(acc, generatedInThisCycle, ctx)` and forwards it to the delegate; the single-arg override is retained for direct callers.
- The RPC `Generate.Handler` now invokes the three-arg overload with an empty `generatedInThisCycle` instead of calling the single-arg overload directly. The three-arg default falls back to the single-arg form, so recipes implementing only that overload are unaffected.

Enables: https://github.com/moderneinc/rewrite-spring/pull/396

## What's your motivation?
`RecipeRunCycle.generateSources` invokes the three-arg `generate`, but the precondition decorator only overrode the single-arg form. For a delegate that overrides only the three-arg form — e.g. `org.openrewrite.text.AppendToTextFile`, which needs `generatedInThisCycle` to avoid double-creation — the dispatch chain fell through `ScanningRecipe`'s defaults to `emptyList()`: any file-generating recipe under a declarative recipe's `preconditions:` silently generated nothing, while the identical recipe without preconditions worked. The RPC `Generate` handler had the same fall-through on the server path.

```yaml
type: specs.openrewrite.org/v1beta/recipe
name: com.example.Repro
preconditions:
  - org.openrewrite.FindSourceFiles:
      filePattern: "**/*"
recipeList:
  - org.openrewrite.text.AppendToTextFile:
      relativeFileName: .mvn/jvm.config
      content: hello
```

## Anything in particular you'd like reviewers to focus on?
Source generation is intentionally **not** gated by the precondition: the generation phase runs before the edit phase in which the bellwether evaluates the precondition, so no verdict exists at generate time. `yamlPreconditionNotMetStillGeneratesSources` pins that contract; `preconditionDecoratorDelegatesThreeArgGenerate` pins the delegation independently of `AppendToTextFile`'s choice of overload.

- Fixes moderneinc/customer-requests#2759