### PR TITLE
Represent oversize source files as Quarks in the RPC project parsers

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -311,6 +311,19 @@ public class RewriteRpcServer
                 });
             }
 
+            // Oversize source files skipped during parsing are emitted as Quarks; the Java
+            // side builds each Quark from SourcePath locally, so they carry no content and
+            // are deliberately not registered in _localObjects (no GetObject round-trip).
+            foreach (var relPath in solutionParser.LastOversizePaths)
+            {
+                response.Items.Add(new ParseSolutionResponseItem
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    SourceFileType = "org.openrewrite.quark.Quark",
+                    SourcePath = relPath
+                });
+            }
+
             // Parse the .csproj file itself as an Xml.Document LST with MSBuildProject marker.
             // The in-process restore during solution loading produced the in-memory LockFile
             // for each project; fall back to a fresh in-process resolve when absent.
@@ -1960,6 +1973,10 @@ public class ParseSolutionResponseItem
 {
     public string Id { get; set; } = "";
     public string SourceFileType { get; set; } = "";
+
+    // Relative source path; only populated for Quark items, from which the Java
+    // side builds the Quark locally. Null for normal items (fetched via GetObject).
+    public string? SourcePath { get; set; }
 }
 
 public class GetObjectRequest

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -290,10 +290,19 @@ public class SolutionParser
     /// is true, each successfully parsed file is printed and compared against the original
     /// source; mismatches are also returned as <see cref="ParseError"/>.
     /// </summary>
+    // Files larger than this are recorded as Quarks rather than parsed into a
+    // Roslyn tree/LST. Matches the 1 MB cap in the other RPC engines.
+    private const long MaxParseableSizeBytes = 1024 * 1024;
+
+    // Relative paths of source files skipped by the most recent ParseProject call
+    // because they exceed MaxParseableSizeBytes; the RPC layer emits these as Quarks.
+    public readonly List<string> LastOversizePaths = new();
+
     public List<SourceFile> ParseProject(
         Solution solution, string projectPath, string rootDir,
         bool requirePrintEqualsInput = true)
     {
+        LastOversizePaths.Clear();
         var projectName = Path.GetFileNameWithoutExtension(projectPath);
         Log.Debug("ParseProject: starting {ProjectName}", projectName);
 
@@ -347,6 +356,17 @@ public class SolutionParser
         foreach (var doc in userDocs)
         {
             fileIndex++;
+
+            // Files too large to parse into a Roslyn tree/LST are recorded as Quarks
+            // (path only) by the RPC layer; skip the expensive parse entirely.
+            long docSize;
+            try { docSize = new FileInfo(doc.FilePath!).Length; } catch { docSize = 0; }
+            if (docSize > MaxParseableSizeBytes)
+            {
+                LastOversizePaths.Add(Path.GetRelativePath(rootDir, doc.FilePath!).Replace('\\', '/'));
+                continue;
+            }
+
             var source = doc.GetTextAsync().Result?.ToString();
             if (source == null) continue;
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/CSharpRewriteRpc.java
@@ -20,11 +20,15 @@ import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.DataTableStore;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.FileAttributes;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.marketplace.RecipeBundleResolver;
 import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.quark.Quark;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RewriteRpcProcess;
 import org.openrewrite.rpc.RewriteRpcProcessManager;
@@ -150,6 +154,15 @@ public class CSharpRewriteRpc extends RewriteRpc {
 
                 ParseSolutionResponse.Item item = response.getItems().get(index);
                 index++;
+
+                if (Quark.class.getName().equals(item.getSourceFileType())) {
+                    // Oversize file the C# side declined to parse; build the Quark locally
+                    // from its path (plus file attributes) — no content on the wire.
+                    Path sourcePath = Paths.get(Objects.requireNonNull(item.getSourcePath()));
+                    action.accept(new Quark(Tree.randomId(), sourcePath, Markers.EMPTY, null,
+                            FileAttributes.fromPath(rootDir.resolve(sourcePath))));
+                    return true;
+                }
 
                 SourceFile sourceFile = getObject(item.getId(), item.getSourceFileType());
 

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/ParseSolutionResponse.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/rpc/ParseSolutionResponse.java
@@ -16,6 +16,7 @@
 package org.openrewrite.csharp.rpc;
 
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,5 +51,12 @@ class ParseSolutionResponse {
          * Example: org.openrewrite.csharp.tree.Cs$CompilationUnit
          */
         String sourceFileType;
+
+        /**
+         * The relative source path; populated only for Quark items, from which the
+         * Java side builds the Quark locally. Null for normal items.
+         */
+        @Nullable
+        String sourcePath;
     }
 }

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2247,6 +2247,10 @@ type parseProjectResponseItem struct {
 // Multi-module repos (root go.mod plus nested submodules) are honored:
 // each .go file resolves against its closest-ancestor go.mod, not the
 // project root's.
+// Files larger than this are recorded as Quarks rather than parsed into an AST.
+// Matches the 1 MB cap in the JVM JavaScriptParser and the other RPC engines.
+const maxParseableSizeBytes = 1 << 20
+
 func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 	var req parseProjectRequest
 	if err := json.Unmarshal(params, &req); err != nil {
@@ -2257,8 +2261,9 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 
 	// Discover all .go files AND every go.mod in the project tree.
 	type discovered struct {
-		goFiles []string
-		goMods  []string
+		goFiles       []string
+		oversizeFiles []string
+		goMods        []string
 	}
 	var disc discovered
 	err := filepath.Walk(req.ProjectPath, func(path string, info os.FileInfo, err error) error {
@@ -2284,7 +2289,12 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		case filepath.Base(path) == "go.mod":
 			disc.goMods = append(disc.goMods, path)
 		case strings.HasSuffix(path, ".go"):
-			disc.goFiles = append(disc.goFiles, path)
+			// Files too large to parse into an AST are recorded as Quarks below.
+			if info.Size() > maxParseableSizeBytes {
+				disc.oversizeFiles = append(disc.oversizeFiles, path)
+			} else {
+				disc.goFiles = append(disc.goFiles, path)
+			}
 		}
 		return nil
 	})
@@ -2515,6 +2525,22 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 			ID:             id,
 			SourceFileType: "org.openrewrite.golang.tree.Go$CompilationUnit",
 			SourcePath:     o.sourcePath,
+		})
+	}
+
+	// Oversize .go files aren't parsed; emit each as a Quark the Java side
+	// builds locally from its path (no content over the wire, no localObjects entry).
+	for _, goFile := range disc.oversizeFiles {
+		sourcePath := goFile
+		if req.RelativeTo != nil && *req.RelativeTo != "" {
+			if rel, err := filepath.Rel(*req.RelativeTo, goFile); err == nil {
+				sourcePath = rel
+			}
+		}
+		items = append(items, parseProjectResponseItem{
+			ID:             uuid.New().String(),
+			SourceFileType: "org.openrewrite.quark.Quark",
+			SourcePath:     sourcePath,
 		})
 	}
 

--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
@@ -19,12 +19,16 @@ import lombok.Getter;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.DataTableStore;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.FileAttributes;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.golang.GolangParser;
 import org.openrewrite.golang.internal.GoExecutor;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.marketplace.RecipeBundleResolver;
 import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.quark.Quark;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RewriteRpcProcess;
 import org.openrewrite.rpc.RewriteRpcProcessManager;
@@ -261,6 +265,16 @@ public class GoRewriteRpc extends RewriteRpc {
 
                 ParseProjectResponse.Item item = response.get(index);
                 index++;
+
+                if (Quark.class.getName().equals(item.getSourceFileType())) {
+                    // Oversize file the Go side declined to parse; build the Quark
+                    // locally from its path (plus file attributes) — no content on the wire.
+                    Path base = relativeTo != null ? relativeTo : projectPath;
+                    Path sourcePath = Paths.get(Objects.requireNonNull(item.getSourcePath()));
+                    action.accept(new Quark(Tree.randomId(), sourcePath, Markers.EMPTY, null,
+                            FileAttributes.fromPath(base.resolve(sourcePath))));
+                    return true;
+                }
 
                 SourceFile sourceFile;
                 try {

--- a/rewrite-javascript/rewrite/src/javascript/project-parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/project-parser.ts
@@ -101,6 +101,12 @@ export interface DiscoveredFiles {
     };
     /** JavaScript/TypeScript files (includes .prettierrc.js, prettier.config.js) */
     jsFiles: string[];
+    /**
+     * JS/TS files that won't be parsed into an AST and are instead recorded as
+     * Quarks (path only, no content). Currently only files over
+     * {@link MAX_PARSEABLE_SIZE_BYTES}; other unparseable cases may join later.
+     */
+    unparseableFiles: string[];
     /** JSON files (tsconfig.json, .prettierrc.json, other .json) */
     jsonFiles: string[];
     /** YAML files (.prettierrc.yaml, other .yaml/.yml) */
@@ -128,6 +134,14 @@ export const DEFAULT_EXCLUSIONS = [
 const SOURCE_EXTENSIONS = new Set([
     ".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"
 ]);
+
+/**
+ * JS/TS files larger than this are recorded as Quarks rather than parsed into a
+ * full AST. Matches the 1 MB default in the JVM {@code JavaScriptParser}, which
+ * likewise diverts oversize files off the parse path. A ~20 MB JSON-like `.js`
+ * otherwise balloons the TypeScript parser to multi-GB / OOM.
+ */
+const MAX_PARSEABLE_SIZE_BYTES = 1024 * 1024;
 
 /**
  * All lock file names for quick lookup.
@@ -412,6 +426,7 @@ export class ProjectParser {
                 text: []
             },
             jsFiles: [],
+            unparseableFiles: [],
             jsonFiles: [],
             yamlFiles: [],
             textFiles: []
@@ -434,7 +449,7 @@ export class ProjectParser {
             if (basename === "package.json") {
                 discovered.packageJsonFiles.push(file);
             } else if (SOURCE_EXTENSIONS.has(ext)) {
-                discovered.jsFiles.push(file);
+                (this.isOversize(file) ? discovered.unparseableFiles : discovered.jsFiles).push(file);
             } else if ((JSON_LOCK_FILE_NAMES as readonly string[]).includes(basename)) {
                 discovered.lockFiles.json.push(file);
             } else if (basename === "yarn.lock") {
@@ -605,6 +620,19 @@ export class ProjectParser {
     }
 
     /**
+     * Whether a source file exceeds {@link MAX_PARSEABLE_SIZE_BYTES}. A stat
+     * failure returns false so the file follows the normal parse path (which
+     * surfaces a real read error as a ParseError) rather than being quarked.
+     */
+    private isOversize(filePath: string): boolean {
+        try {
+            return fs.statSync(filePath).size > MAX_PARSEABLE_SIZE_BYTES;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
      * Classifies a yarn.lock file as YAML (Berry) or text (Classic).
      */
     private async classifyYarnLockFile(filePath: string): Promise<"yaml" | "text"> {
@@ -633,6 +661,7 @@ export class ProjectParser {
             discovered.lockFiles.yaml.length +
             discovered.lockFiles.text.length +
             discovered.jsFiles.length +
+            discovered.unparseableFiles.length +
             discovered.jsonFiles.length +
             discovered.yamlFiles.length +
             discovered.textFiles.length
@@ -652,6 +681,7 @@ export class ProjectParser {
                 text: discovered.lockFiles.text.filter(filter)
             },
             jsFiles: discovered.jsFiles.filter(filter),
+            unparseableFiles: discovered.unparseableFiles.filter(filter),
             jsonFiles: discovered.jsonFiles.filter(filter),
             yamlFiles: discovered.yamlFiles.filter(filter),
             textFiles: discovered.textFiles.filter(filter)

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -232,6 +232,17 @@ export class ParseProject {
                         }
                     }
 
+                    // Unparseable JS/TS files (currently: too large) are recorded as
+                    // Quarks. The Java side builds the Quark locally from sourcePath,
+                    // so no GetObject round-trip and no content crosses the wire.
+                    for (const filePath of discovered.unparseableFiles) {
+                        resultItems.push({
+                            id: randomId(),
+                            sourceFileType: "org.openrewrite.quark.Quark", // break cycle
+                            sourcePath: path.relative(relativeTo, filePath)
+                        });
+                    }
+
                     // Parse other YAML files
                     if (discovered.yamlFiles.length > 0) {
                         const parser = Parsers.createParser("yaml", {ctx, relativeTo});

--- a/rewrite-javascript/rewrite/test/rpc/project-parser-unparseable.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/project-parser-unparseable.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import {dir} from "tmp-promise";
+import {ProjectParser} from "../../src/javascript/project-parser";
+
+describe("ProjectParser unparseable file discovery", () => {
+    it("routes JS/TS files over the size cap to unparseableFiles, keeps small ones in jsFiles", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            fs.writeFileSync(path.join(tmpDir.path, "small.js"), "export const x = 1;\n");
+            // 2 MB > the 1 MB cap; a JSON-like blob rather than a minified single line.
+            fs.writeFileSync(path.join(tmpDir.path, "big.js"),
+                "export default {\n" + "  a: 1,\n".repeat(300_000) + "};\n");
+
+            const discovered = await new ProjectParser(tmpDir.path, {useGit: false}).discoverFiles();
+
+            expect(discovered.jsFiles.map(f => path.basename(f))).toEqual(["small.js"]);
+            expect(discovered.unparseableFiles.map(f => path.basename(f))).toEqual(["big.js"]);
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+});

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -28,6 +28,7 @@ import org.openrewrite.marker.Markers;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.marketplace.RecipeBundleResolver;
 import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.quark.Quark;
 import org.openrewrite.rpc.DynamicDispatchRpcCodec;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RewriteRpcProcess;
@@ -183,6 +184,16 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
 
                 ParseProjectResponse.Item item = response.get(index);
                 index++;
+
+                if (Quark.class.getName().equals(item.getSourceFileType())) {
+                    // Oversize file the TypeScript side declined to parse; build the Quark
+                    // locally from its path (plus file attributes) — no content on the wire.
+                    Path base = relativeTo != null ? relativeTo : projectPath;
+                    Path sourcePath = Paths.get(item.getSourcePath());
+                    action.accept(new Quark(Tree.randomId(), sourcePath, Markers.EMPTY, null,
+                            FileAttributes.fromPath(base.resolve(sourcePath))));
+                    return true;
+                }
 
                 SourceFile sourceFile;
                 try {

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -402,6 +402,31 @@ def _create_parse_error(path: str, message: str, source: str = '') -> dict:
     return {'id': obj_id, 'sourceFileType': 'org.openrewrite.tree.ParseError', 'sourcePath': path}
 
 
+# Files larger than this are recorded as Quarks rather than parsed into an AST.
+# Matches the 1 MB cap in the JVM JavaScriptParser and the other RPC engines.
+MAX_PARSEABLE_SIZE_BYTES = 1024 * 1024
+
+
+def _create_quark(path: str, relative_to: Optional[str]) -> dict:
+    """Represent a file that won't be parsed (currently: too large) as a Quark.
+
+    No object is registered in ``local_objects``: the Java side builds the Quark
+    from ``sourcePath`` locally, so no content crosses the wire.
+    """
+    from rewrite import random_id
+    source_path = Path(path)
+    if relative_to is not None:
+        try:
+            source_path = source_path.relative_to(relative_to)
+        except ValueError:
+            pass  # path is not under relative_to, keep absolute
+    return {
+        'id': str(random_id()),
+        'sourceFileType': 'org.openrewrite.quark.Quark',
+        'sourcePath': str(source_path),
+    }
+
+
 def _infer_project_root(inputs: list) -> Optional[str]:
     """Infer the project root from input paths.
 
@@ -555,6 +580,13 @@ def handle_parse_project(params: dict) -> List[dict]:
             for file in files:
                 if file.endswith('.py'):
                     path = os.path.join(root, file)
+                    try:
+                        oversize = os.path.getsize(path) > MAX_PARSEABLE_SIZE_BYTES
+                    except OSError:
+                        oversize = False  # let the normal path surface the read error
+                    if oversize:
+                        results.append(_create_quark(path, relative_to))
+                        continue
                     try:
                         result = parse_python_file(path, relative_to, ty_client,
                                                    language_level=language_level,

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -29,6 +29,7 @@ import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.python.marker.PythonResolutionResult.Dependency;
 import org.openrewrite.python.marker.PythonResolutionResult.ResolvedDependency;
 import org.openrewrite.python.tree.Py;
+import org.openrewrite.quark.Quark;
 import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.RewriteRpcProcess;
 import org.openrewrite.rpc.RewriteRpcProcessManager;
@@ -218,6 +219,16 @@ public class PythonRewriteRpc extends RewriteRpc {
 
                 ParseProjectResponse.Item item = response.get(index);
                 index++;
+
+                if (Quark.class.getName().equals(item.getSourceFileType())) {
+                    // Oversize file the Python side declined to parse; build the Quark
+                    // locally from its path (plus file attributes) — no content on the wire.
+                    Path base = relativeTo != null ? relativeTo : projectPath;
+                    Path sourcePath = Paths.get(item.getSourcePath());
+                    action.accept(new Quark(Tree.randomId(), sourcePath, Markers.EMPTY, null,
+                            FileAttributes.fromPath(base.resolve(sourcePath))));
+                    return true;
+                }
 
                 SourceFile sourceFile;
                 try {


### PR DESCRIPTION
## What
Large source files can drive the RPC language engines' `parseProject` to multi-GB memory use or OOM, because every discovered file is parsed regardless of size. This caps each RPC project parser at **1 MB** (matching the JVM `JavaScriptParser` default): files over the cap are diverted off the parse path at discovery and represented as a content-less `org.openrewrite.quark.Quark` instead of being parsed or silently dropped.

## How
Each engine (JavaScript/TypeScript, Python, Go, C#) diverts oversize source files during discovery and emits a response item tagged `org.openrewrite.quark.Quark` with only the relative path — no engine-side object, no content. The Java client (`*RewriteRpc.parseProject`) short-circuits that tag and builds the `Quark` locally from the path + `FileAttributes`, so there's no `GetObject` round-trip and no content over the wire. The file is still represented in the LST, just as a stub.

For C# (MSBuild/Roslyn — no file walk) the size gate sits at the per-`Document` loop before the Roslyn tree is built; the `ParseSolution` response item gains a `sourcePath` field for the Quark case.

## Testing
- **rewrite-javascript**: new unit test asserting a >1 MB file lands in the new `unparseableFiles` bucket while a small file stays parseable; existing parse-project discovery tests still pass; `tsc` + Java compile clean.
- **Python / Go / C#**: `py_compile`, `go build`, `dotnet build`, and all four Java clients compile.
- **End-to-end**: building a JS project containing a 20 MB `.js` data file now records it as a `Quark` (LST manifest `data.js,Quark`) with the neighboring small file still parsed to a full AST — previously the engine OOM'd on that file.