### PR TITLE
Don't throw when RemoveAnnotation is used from a nested visitor

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveAnnotationTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveAnnotationTest.java
@@ -17,7 +17,11 @@ package org.openrewrite.java;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
@@ -53,6 +57,60 @@ class RemoveAnnotationTest implements RewriteTest {
               """
           )
         );
+    }
+
+    /**
+     * {@link RemoveAnnotationVisitor} runs blank-line cleanup that needs an enclosing
+     * {@link org.openrewrite.java.tree.JavaSourceFile} on the cursor. Nested composition
+     * that calls {@code visitCompilationUnit} directly (or visits a subtree without a
+     * parent cursor) must still remove the annotation rather than throw.
+     */
+    @Issue("https://github.com/openrewrite/rewrite/issues/8130")
+    @Test
+    void removeAnnotationWhenInvokedFromNestedVisitor() {
+        rewriteRun(
+          spec -> spec.recipe(new NestedRemoveAnnotation()),
+          java(
+            """
+              @Deprecated
+              class FooBar {
+              }
+              """,
+            """
+              class FooBar {
+              }
+              """
+          )
+        );
+    }
+
+    /**
+     * Mirrors the composition pattern from issue 8130: invoke
+     * {@link RemoveAnnotationVisitor#visitCompilationUnit} from another visitor so the
+     * nested visitor's cursor has no enclosing {@code JavaSourceFile}.
+     */
+    static class NestedRemoveAnnotation extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Remove annotation via nested visitor";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Invokes RemoveAnnotationVisitor from within another visitor.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public J.CompilationUnit visitCompilationUnit(J.CompilationUnit cu, ExecutionContext ctx) {
+                    cu = super.visitCompilationUnit(cu, ctx);
+                    return new RemoveAnnotationVisitor(new AnnotationMatcher("@java.lang.Deprecated"))
+                            .visitCompilationUnit(cu, ctx);
+                }
+            };
+        }
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/861")

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -110,7 +110,11 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
      * formatting in the surrounding source.
      *
      * <p>If {@code before == after} (no change), returns {@code after}
-     * unchanged.
+     * unchanged. If no enclosing {@link JavaSourceFile} is available on the
+     * cursor (for example when a visitor is invoked on a subtree without a
+     * parent cursor, or {@code visitCompilationUnit} is called directly),
+     * returns {@code after} unchanged rather than throwing — blank-line
+     * cleanup is best-effort polish and must not fail nested recipe composition.
      */
     public <J2 extends J> J2 maybeRemoveBlankLines(J2 before, J2 after, P p) {
         return maybeRemoveBlankLines(before, after, p, getCursor().getParentTreeCursor());
@@ -123,7 +127,10 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         }
         JavaSourceFile cu = (after instanceof JavaSourceFile) ?
                 (JavaSourceFile) after :
-                getCursor().firstEnclosingOrThrow(JavaSourceFile.class);
+                getCursor().firstEnclosing(JavaSourceFile.class);
+        if (cu == null) {
+            return after;
+        }
         AutoFormatService service = cu.service(AutoFormatService.class);
         J2 result = (J2) service.normalizeFormatVisitor(null).visit(after, p, parent);
         return (J2) service.blankLinesVisitor(cu, null).visit(result, p, parent);


### PR DESCRIPTION
## What changed

`maybeRemoveBlankLines` used to throw if there was no enclosing `JavaSourceFile` on the cursor. That breaks a pretty common composition pattern: calling `RemoveAnnotationVisitor` from another recipe's visitor (especially via `visitCompilationUnit` directly).

Blank-line cleanup is best-effort, so if we can't find a source file we just skip it and leave the tree as-is. Annotation removal still works.

- Also added a regression test for #8130.

## Why

- Fixes #8130 — `IllegalStateException: Expected to find enclosing JavaSourceFile` when nesting `RemoveAnnotation` inside another recipe.