### PR TITLE
Accept Jupyter notebooks (.ipynb) in JsonParser

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/JsonParser.java
@@ -79,7 +79,7 @@ public class JsonParser implements Parser {
     @Override
     public boolean accept(Path path) {
         String fileName = path.getFileName().toString();
-        return fileName.endsWith(".json") || "Pipfile.lock".equals(fileName);
+        return fileName.endsWith(".json") || fileName.endsWith(".ipynb") || "Pipfile.lock".equals(fileName);
     }
 
     @Override

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -374,4 +374,56 @@ class JsonParserTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void acceptsJupyterNotebooks() {
+        JsonParser parser = new JsonParser();
+        assertThat(parser.accept(Paths.get("analysis.ipynb"))).isTrue();
+        assertThat(parser.accept(Paths.get("nested/dir/analysis.ipynb"))).isTrue();
+    }
+
+    @Test
+    void parseJupyterNotebook() {
+        rewriteRun(
+          json(
+            """
+              {
+               "cells": [
+                {
+                 "cell_type": "code",
+                 "execution_count": null,
+                 "metadata": {},
+                 "outputs": [],
+                 "source": [
+                  "import os\\n",
+                  "print(os.getcwd())"
+                 ]
+                },
+                {
+                 "cell_type": "markdown",
+                 "metadata": {},
+                 "source": [
+                  "# Heading"
+                 ]
+                }
+               ],
+               "metadata": {
+                "kernelspec": {
+                 "display_name": "Python 3",
+                 "language": "python",
+                 "name": "python3"
+                },
+                "language_info": {
+                 "name": "python",
+                 "version": "3.11.0"
+                }
+               },
+               "nbformat": 4,
+               "nbformat_minor": 5
+              }
+              """,
+            spec -> spec.path("analysis.ipynb")
+          )
+        );
+    }
 }


### PR DESCRIPTION
Jupyter notebook `.ipynb` files are strict JSON, so `JsonParser` can parse and losslessly round-trip them; this adds `.ipynb` to its accepted extensions alongside `.json` and `Pipfile.lock`. This exposes notebooks to JSON recipes for envelope/metadata work (e.g. stripping outputs, bumping `language_info`, editing `metadata`); it does not parse the Python inside code cells, which remain opaque JSON strings. Adds tests asserting `.ipynb` acceptance and verifying a realistic notebook parses and prints byte-identically.