### PR TITLE
Kotlin recipe DSL: support non-literal displayName/description

### DIFF
--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirDslCheckers.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeFirDslCheckers.kt
@@ -29,8 +29,12 @@ import org.jetbrains.kotlin.fir.analysis.extensions.FirAdditionalCheckersExtensi
 import org.jetbrains.kotlin.fir.declarations.FirProperty
 import org.jetbrains.kotlin.fir.expressions.FirAnonymousFunctionExpression
 import org.jetbrains.kotlin.fir.expressions.FirBlock
+import org.jetbrains.kotlin.fir.expressions.FirExpression
 import org.jetbrains.kotlin.fir.expressions.FirFunctionCall
+import org.jetbrains.kotlin.fir.expressions.FirLiteralExpression
 import org.jetbrains.kotlin.fir.expressions.FirStatement
+import org.jetbrains.kotlin.fir.expressions.FirStringConcatenationCall
+import org.jetbrains.kotlin.fir.expressions.impl.FirResolvedArgumentList
 import org.jetbrains.kotlin.fir.references.toResolvedCallableSymbol
 import org.jetbrains.kotlin.name.CallableId
 import org.jetbrains.kotlin.name.FqName
@@ -80,6 +84,10 @@ import org.jetbrains.kotlin.name.Name
 internal object RecipeFirDslCheckers : FirPropertyChecker(MppCheckerKind.Common) {
 
     private val RECIPE_FQN = CallableId(FqName("org.openrewrite"), Name.identifier("recipe"))
+    private val RECIPES_FQN = CallableId(FqName("org.openrewrite"), Name.identifier("recipes"))
+
+    private val NAME_DISPLAY_NAME = Name.identifier("displayName")
+    private val NAME_DESCRIPTION = Name.identifier("description")
 
     private val NAME_TO = Name.identifier("to")
     private val NAME_SCAN = Name.identifier("scan")
@@ -119,7 +127,11 @@ internal object RecipeFirDslCheckers : FirPropertyChecker(MppCheckerKind.Common)
     context(@Suppress("unused") context: CheckerContext, reporter: DiagnosticReporter)
     override fun check(declaration: FirProperty) {
         val initializer = declaration.initializer as? FirFunctionCall ?: return
-        if (!initializer.callsRecipeBuilder()) return
+        val calleeId = initializer.calleeReference.toResolvedCallableSymbol()?.callableId
+        if (calleeId != RECIPE_FQN && calleeId != RECIPES_FQN) return
+
+        checkConstantMetadata(initializer, declaration)
+        if (calleeId != RECIPE_FQN) return // remaining rules are specific to the trailing-lambda form
 
         val body = initializer.findTrailingLambdaBody() ?: return
 
@@ -221,6 +233,44 @@ internal object RecipeFirDslCheckers : FirPropertyChecker(MppCheckerKind.Common)
     }
 
     /**
+     * `displayName` / `description` that aren't compile-time constant are
+     * silently dropped by `RecipeIrGenerationExtension` (it can't fold them);
+     * report a compile error instead of losing the recipe with no diagnostic.
+     */
+    context(@Suppress("unused") context: CheckerContext, reporter: DiagnosticReporter)
+    private fun checkConstantMetadata(call: FirFunctionCall, declaration: FirProperty) {
+        val mapping = (call.argumentList as? FirResolvedArgumentList)?.mapping ?: return
+        for ((argExpr, param) in mapping) {
+            if (param.name != NAME_DISPLAY_NAME && param.name != NAME_DESCRIPTION) continue
+            if (!isConstantString(argExpr)) {
+                reportError(
+                    argExpr.source ?: declaration.source ?: return,
+                    "Recipe `${param.name}` must be a compile-time constant String — " +
+                        "a literal, a concatenation of literals (`\"a\" + \"b\"`), or a text " +
+                        "block with `trimIndent()`. A non-constant value (a `val`, parameter, " +
+                        "or `const val` reference) is silently dropped by the recipe code generator.",
+                )
+            }
+        }
+    }
+
+    /** Must accept at least what `RecipeIrGenerationExtension.evalConstString` folds, or this rejects valid metadata. */
+    private fun isConstantString(expr: FirExpression?): Boolean = when (expr) {
+        null -> false
+        is FirLiteralExpression -> true
+        is FirStringConcatenationCall -> expr.argumentList.arguments.all { isConstantString(it) }
+        is FirFunctionCall -> when (expr.callableSimpleName()?.asString()) {
+            "plus" -> isConstantString(expr.explicitReceiver) &&
+                expr.argumentList.arguments.all { isConstantString(it) }
+            "trimIndent" -> isConstantString(expr.explicitReceiver)
+            "trimMargin" -> isConstantString(expr.explicitReceiver) &&
+                expr.argumentList.arguments.all { isConstantString(it) }
+            else -> false
+        }
+        else -> false
+    }
+
+    /**
      * Classify a top-level statement of the recipe block by walking the
      * outermost call's simple-name chain. Only the structural shape matters;
      * we never recurse into argument lambdas, so user code inside an `edit`
@@ -288,11 +338,6 @@ internal object RecipeFirDslCheckers : FirPropertyChecker(MppCheckerKind.Common)
             cursor = receiver
         }
         return ChainInfo(outermost = call, head = cursor, tailNames = tail)
-    }
-
-    private fun FirFunctionCall.callsRecipeBuilder(): Boolean {
-        val symbol = calleeReference.toResolvedCallableSymbol() ?: return false
-        return symbol.callableId == RECIPE_FQN
     }
 
     private fun FirFunctionCall.findTrailingLambdaBody(): FirBlock? {

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeIrGenerationExtension.kt
@@ -60,6 +60,7 @@ import org.jetbrains.kotlin.ir.expressions.IrFunctionExpression
 import org.jetbrains.kotlin.ir.expressions.IrGetValue
 import org.jetbrains.kotlin.ir.expressions.IrReturn
 import org.jetbrains.kotlin.ir.expressions.IrSpreadElement
+import org.jetbrains.kotlin.ir.expressions.IrStringConcatenation
 import org.jetbrains.kotlin.ir.expressions.IrVararg
 import org.jetbrains.kotlin.ir.expressions.IrVarargElement
 import org.jetbrains.kotlin.ir.symbols.IrClassSymbol
@@ -430,8 +431,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val displayNameIdx = params.indexOfFirst { it.name == Name.identifier("displayName") }
         val descriptionIdx = params.indexOfFirst { it.name == Name.identifier("description") }
         if (displayNameIdx < 0 || descriptionIdx < 0) return null
-        val displayName = (call.arguments[displayNameIdx] as? IrConst)?.value as? String ?: return null
-        val description = (call.arguments[descriptionIdx] as? IrConst)?.value as? String ?: return null
+        val displayName = evalConstString(call.arguments[displayNameIdx]) ?: return null
+        val description = evalConstString(call.arguments[descriptionIdx]) ?: return null
 
         val tagsIdx = params.indexOfFirst { it.name == Name.identifier("tags") }
         val tagsArg = if (tagsIdx >= 0) substantiveArgOrNull(call.arguments[tagsIdx]) else null
@@ -455,8 +456,8 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
         val descriptionIdx = params.indexOfFirst { it.name == Name.identifier("description") }
         val recipesIdx = params.indexOfFirst { it.name == Name.identifier("recipes") }
         if (displayNameIdx < 0 || descriptionIdx < 0 || recipesIdx < 0) return null
-        val displayName = (call.arguments[displayNameIdx] as? IrConst)?.value as? String ?: return null
-        val description = (call.arguments[descriptionIdx] as? IrConst)?.value as? String ?: return null
+        val displayName = evalConstString(call.arguments[displayNameIdx]) ?: return null
+        val description = evalConstString(call.arguments[descriptionIdx]) ?: return null
         val recipesVararg = call.arguments[recipesIdx] as? org.jetbrains.kotlin.ir.expressions.IrVararg ?: return null
         return CompositeRecipeMetadata(displayName, description, recipesVararg)
     }
@@ -478,6 +479,38 @@ internal class RecipeIrGenerationExtension : IrGenerationExtension {
             }
         }
         return arg
+    }
+
+    /**
+     * Fold a `displayName` / `description` argument to a compile-time constant
+     * String. This runs BEFORE the IR const-evaluation lowering, so even a
+     * literal `"a" + "b"` is still an unlowered `IrCall`/`IrStringConcatenation`
+     * here — a plain `as? IrConst` would miss it and silently drop the recipe.
+     */
+    private fun evalConstString(expr: IrExpression?): String? {
+        return when (expr) {
+            null -> null
+            is IrConst -> expr.value?.toString()
+            is IrStringConcatenation -> buildString {
+                for (part in expr.arguments) append(evalConstString(part) ?: return null)
+            }
+            is IrCall -> when (expr.symbol.owner.kotlinFqName.asString()) {
+                "kotlin.String.plus" -> {
+                    val left = evalConstString(expr.arguments.getOrNull(0)) ?: return null
+                    val right = evalConstString(expr.arguments.getOrNull(1)) ?: return null
+                    left + right
+                }
+                "kotlin.text.trimIndent" -> evalConstString(expr.arguments.getOrNull(0))?.trimIndent()
+                "kotlin.text.trimMargin" -> {
+                    val receiver = evalConstString(expr.arguments.getOrNull(0)) ?: return null
+                    val marginArg = expr.arguments.getOrNull(1)
+                    if (marginArg == null) receiver.trimMargin()
+                    else receiver.trimMargin(evalConstString(marginArg) ?: return null)
+                }
+                else -> null
+            }
+            else -> null
+        }
     }
 
     // ------------------------------------------------------------------

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipeDslCheckerTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipeDslCheckerTest.kt
@@ -150,4 +150,71 @@ class RecipeDslCheckerTest {
         assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
         assertThat(result.messages).contains("without a trailing `to { ... }`")
     }
+
+    @Test
+    fun `concatenated metadata compiles cleanly`() {
+        val result = RecipePluginCompileFixture.compile(
+            """
+            import org.openrewrite.recipe
+            val r = recipe("Use " + "uppercase", "d" + "esc") { edit { java { } } }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `text-block metadata with trimIndent compiles cleanly`() {
+        val tq = "\"\"\""
+        val result = RecipePluginCompileFixture.compile(
+            """
+            import org.openrewrite.recipe
+            val r = recipe("d", $tq
+                A
+                B
+            $tq.trimIndent()) { edit { java { } } }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+
+    @Test
+    fun `non-constant displayName fails with a constant-metadata diagnostic`() {
+        val result = RecipePluginCompileFixture.compile(
+            """
+            import org.openrewrite.recipe
+            val name: String = "computed"
+            val r = recipe(name, "desc") { edit { java { } } }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains("must be a compile-time constant String")
+    }
+
+    @Test
+    fun `non-constant description fails with a constant-metadata diagnostic`() {
+        val result = RecipePluginCompileFixture.compile(
+            """
+            import org.openrewrite.recipe
+            fun describe(): String = "computed"
+            val r = recipe("d", describe()) { edit { java { } } }
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains("must be a compile-time constant String")
+    }
+
+    @Test
+    fun `non-constant composite recipes displayName fails`() {
+        val result = RecipePluginCompileFixture.compile(
+            """
+            import org.openrewrite.recipe
+            import org.openrewrite.recipes
+            val name: String = "computed"
+            val A = recipe("A", "first") { edit { java { } } }
+            val Combo = recipes(name, "desc", A)
+            """.trimIndent(),
+        )
+        assertThat(result.exitCode).isEqualTo(KotlinCompilation.ExitCode.COMPILATION_ERROR)
+        assertThat(result.messages).contains("must be a compile-time constant String")
+    }
 }

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/RecipePluginRewriteTest.kt
@@ -1136,6 +1136,66 @@ class RecipePluginRewriteTest : RewriteTest {
     }
 
     @Test
+    fun `concatenated displayName and description fold to constants`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val MyRecipe = recipe(
+                    displayName = "Replace " + "lowercase",
+                    description = "Uses " + "uppercase" + " instead",
+                ) {
+                    edit {
+                        rewrite { s: String -> s.lowercase() } to { s -> s.uppercase() }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "MyRecipe",
+        )
+        assertThat(r.displayName).isEqualTo("Replace lowercase")
+        assertThat(r.description).isEqualTo("Uses uppercase instead")
+    }
+
+    @Test
+    fun `text-block description with trimIndent folds to a constant`() {
+        val tq = "\"\"\""
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                val MyRecipe = recipe(
+                    displayName = "d",
+                    description = $tq
+                        Alpha
+                        Beta
+                    $tq.trimIndent(),
+                ) {
+                    edit {
+                        rewrite { s: String -> s.lowercase() } to { s -> s.uppercase() }
+                    }
+                }
+            """.trimIndent(),
+            propertyName = "MyRecipe",
+        )
+        assertThat(r.displayName).isEqualTo("d")
+        assertThat(r.description).isEqualTo("Alpha\nBeta")
+    }
+
+    @Test
+    fun `composite recipes metadata folds concatenation`() {
+        val r = loadCompiledRecipe(
+            source = """
+                import org.openrewrite.recipe
+                import org.openrewrite.recipes
+                val A = recipe("A", "first") { edit { kotlin { visitClassDeclaration { it } } } }
+                val Combo = recipes("Co" + "mbo", "A" + " only", A)
+            """.trimIndent(),
+            propertyName = "Combo",
+        )
+        assertThat(r.displayName).isEqualTo("Combo")
+        assertThat(r.description).isEqualTo("A only")
+        assertThat(r.recipeList).hasSize(1)
+    }
+
+    @Test
     fun `variadic by-example — asList to List_of matches any arity`() {
         // The author writes a representative 3-arg shape; because `asList` is a
         // varargs method the recipe generalizes to ANY arity (2, 4, even 0).


### PR DESCRIPTION
The rewrite-kotlin recipe DSL compiler plugin only extracted a recipe's `displayName`/`description` when they were a single string literal (`as? IrConst`), silently dropping the entire recipe for any concatenation, string template, or text block — because `IrGenerationExtension`s run before IR const-folding, so even `"a" + "b"` is still an unlowered call at extraction time.

This adds an `evalConstString` folder in `RecipeIrGenerationExtension` that handles literals, `+`/template concatenation, and text blocks with `trimIndent()`/`trimMargin()`, used for both `recipe(...)` and the `recipes(...)` composite. It also adds a `RecipeFirDslCheckers` rule that turns genuinely non-constant metadata (a `val`, parameter, or `const val` reference) into a clear compile error instead of a vanished recipe. New tests cover the folded shapes end-to-end and the loud-error/clean-compile checker paths.