### PR TITLE
Add DirCache overload to GitIgnore to avoid re-reading the index per file

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/internal/GitIgnore.java
+++ b/rewrite-core/src/main/java/org/openrewrite/internal/GitIgnore.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.internal;
 
+import org.openrewrite.jgit.dircache.DirCache;
 import org.openrewrite.jgit.dircache.DirCacheIterator;
 import org.openrewrite.jgit.lib.FileMode;
 import org.openrewrite.jgit.lib.Repository;
@@ -51,6 +52,28 @@ public final class GitIgnore {
      * @return {@code true} if the path should be treated as ignored
      */
     public static boolean isIgnoredAndUntracked(Repository repository, String repoRelativePath) {
+        try {
+            return isIgnoredAndUntracked(repository, repository.readDirCache(), repoRelativePath);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Returns {@code true} if the given path is matched by a {@code .gitignore}
+     * rule and is <b>not</b> tracked in the given git index.
+     * <p>
+     * This overload accepts a pre-read {@link DirCache} so callers that check many
+     * paths against the same index can read it once (via {@link Repository#readDirCache()})
+     * and reuse it, rather than re-parsing {@code .git/index} on every invocation.
+     *
+     * @param repository       the JGit repository
+     * @param dirCache         the git index, typically obtained from {@link Repository#readDirCache()}
+     * @param repoRelativePath path relative to the repository root, using forward slashes
+     *                         (e.g. {@code "src/main/java/Foo.java"})
+     * @return {@code true} if the path should be treated as ignored
+     */
+    public static boolean isIgnoredAndUntracked(Repository repository, DirCache dirCache, String repoRelativePath) {
         if (repoRelativePath.isEmpty()) {
             return false;
         }
@@ -64,7 +87,7 @@ public final class GitIgnore {
 
         try (TreeWalk walk = new TreeWalk(repository)) {
             walk.addTree(new FileTreeIterator(repository));
-            walk.addTree(new DirCacheIterator(repository.readDirCache()));
+            walk.addTree(new DirCacheIterator(dirCache));
             walk.setFilter(PathFilterGroup.createFromStrings(repoRelativePath));
             while (walk.next()) {
                 WorkingTreeIterator workingTreeIterator = walk.getTree(0, WorkingTreeIterator.class);
@@ -103,5 +126,19 @@ public final class GitIgnore {
      */
     public static boolean isIgnoredAndUntracked(Repository repository, java.nio.file.Path platformPath) {
         return isIgnoredAndUntracked(repository, separatorsToUnix(platformPath.toString()));
+    }
+
+    /**
+     * Convenience overload that normalizes a platform path to a
+     * forward-slash-separated, repository-relative path, using a pre-read index.
+     *
+     * @param repository the JGit repository
+     * @param dirCache the git index, typically obtained from {@link Repository#readDirCache()}
+     * @param platformPath path that may use platform separators
+     * @return {@code true} if the path should be treated as ignored
+     * @see #isIgnoredAndUntracked(Repository, DirCache, String)
+     */
+    public static boolean isIgnoredAndUntracked(Repository repository, DirCache dirCache, java.nio.file.Path platformPath) {
+        return isIgnoredAndUntracked(repository, dirCache, separatorsToUnix(platformPath.toString()));
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/internal/GitIgnoreTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/internal/GitIgnoreTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.internal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.jgit.api.Git;
+import org.openrewrite.jgit.dircache.DirCache;
 import org.openrewrite.jgit.lib.Repository;
 
 import java.nio.charset.StandardCharsets;
@@ -163,6 +164,43 @@ class GitIgnoreTest {
 
             assertThat(GitIgnore.isIgnoredAndUntracked(repo, "")).isFalse();
             assertThat(GitIgnore.isIgnoredAndUntracked(repo, "/")).isFalse();
+        }
+    }
+
+    @Test
+    void dirCacheOverloadMatchesTwoArgOverload(@TempDir Path tempDir) throws Exception {
+        try (Git git = Git.init().setDirectory(tempDir.toFile()).call()) {
+            Repository repo = git.getRepository();
+
+            writeFile(tempDir.resolve("generated.txt"), "untracked content");
+
+            writeFile(tempDir.resolve("tracked-ignored.txt"), "content");
+            git.add().addFilepattern("tracked-ignored.txt").call();
+
+            writeFile(tempDir.resolve("normal.txt"), "content");
+            git.add().addFilepattern("normal.txt").call();
+            git.commit().setMessage("initial").call();
+
+            writeFile(tempDir.resolve(".gitignore"), "generated.txt\ntracked-ignored.txt\n");
+            git.add().addFilepattern(".gitignore").call();
+            git.commit().setMessage("add gitignore").call();
+
+            DirCache dirCache = repo.readDirCache();
+
+            assertThat(GitIgnore.isIgnoredAndUntracked(repo, dirCache, "generated.txt"))
+                    .as("ignored + untracked file should be ignored via DirCache overload")
+                    .isTrue()
+                    .isEqualTo(GitIgnore.isIgnoredAndUntracked(repo, "generated.txt"));
+
+            assertThat(GitIgnore.isIgnoredAndUntracked(repo, dirCache, "tracked-ignored.txt"))
+                    .as("ignored but tracked file should NOT be ignored via DirCache overload")
+                    .isFalse()
+                    .isEqualTo(GitIgnore.isIgnoredAndUntracked(repo, "tracked-ignored.txt"));
+
+            assertThat(GitIgnore.isIgnoredAndUntracked(repo, dirCache, "normal.txt"))
+                    .as("non-ignored file should NOT be ignored via DirCache overload")
+                    .isFalse()
+                    .isEqualTo(GitIgnore.isIgnoredAndUntracked(repo, "normal.txt"));
         }
     }
 


### PR DESCRIPTION
- `GitIgnore.isIgnoredAndUntracked(Repository, String)` calls `repository.readDirCache()` on every invocation, re-parsing the entire `.git/index` from disk each time; build-tool plugins that check one file at a time incur O(sources × index-size) cost on large repos (see openrewrite/rewrite-maven-plugin#1176).

This adds `isIgnoredAndUntracked(Repository, DirCache, String)` (and a symmetric `Path` overload) so callers can read the index once and reuse it, with the existing two-arg and `Path` overloads delegating so their behavior is unchanged. A new test asserts the `DirCache` overload matches the two-arg method for ignored+untracked, ignored-but-tracked, and non-ignored files.