### PR TITLE
Java 25: recover the method invocation type when an argument type is unresolvable

### DIFF
--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -425,6 +425,15 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             } catch (Exception e) {
                 // ignore
             }
+
+            // On JDK 24+ an unresolvable argument leaves the select as a plain ErrorType even though
+            // the callee resolved; recover the invocation type javac computed (kept in the error's
+            // original type), falling back to the symbol's declared type, to keep the JavaType.Method.
+            if (symbol instanceof Symbol.MethodSymbol && symbol.kind != Kinds.Kind.ERR &&
+                symbol.type != null && !(symbol.type instanceof Type.ErrorType) && !isUnknownType(symbol.type)) {
+                Type originalType = selectType.getOriginalType();
+                return methodInvocationType(originalType instanceof Type.MethodType ? originalType : symbol.type, symbol);
+            }
         }
 
         if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR ||
@@ -703,7 +712,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
     }
 
     /**
-     * Check for the `UnknownType` which existed up until JDK 22; starting with JDK 23 only the `ErrorType` is used.
+     * Check for the `UnknownType` which existed up until JDK 23; starting with JDK 24 only the `ErrorType` is used.
      * Uses reflection to avoid compile-time dependency on the class, which was removed in JDK 24.
      */
     public static boolean isUnknownType(@Nullable Type type) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21TypeMapping.java
@@ -425,15 +425,6 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
             } catch (Exception e) {
                 // ignore
             }
-
-            // On JDK 24+ an unresolvable argument leaves the select as a plain ErrorType even though
-            // the callee resolved; recover the invocation type javac computed (kept in the error's
-            // original type), falling back to the symbol's declared type, to keep the JavaType.Method.
-            if (symbol instanceof Symbol.MethodSymbol && symbol.kind != Kinds.Kind.ERR &&
-                symbol.type != null && !(symbol.type instanceof Type.ErrorType) && !isUnknownType(symbol.type)) {
-                Type originalType = selectType.getOriginalType();
-                return methodInvocationType(originalType instanceof Type.MethodType ? originalType : symbol.type, symbol);
-            }
         }
 
         if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR ||
@@ -712,7 +703,7 @@ class ReloadableJava21TypeMapping implements JavaTypeMapping<Tree> {
     }
 
     /**
-     * Check for the `UnknownType` which existed up until JDK 23; starting with JDK 24 only the `ErrorType` is used.
+     * Check for the `UnknownType` which existed up until JDK 22; starting with JDK 23 only the `ErrorType` is used.
      * Uses reflection to avoid compile-time dependency on the class, which was removed in JDK 24.
      */
     public static boolean isUnknownType(@Nullable Type type) {

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
@@ -430,11 +430,13 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
                 // ignore
             }
 
-            // An unresolvable argument can leave the select as a plain ErrorType while the callee
-            // still resolved; fall back to the symbol's own type to keep the JavaType.Method.
+            // An unresolvable argument leaves the select as a plain ErrorType even though the callee
+            // resolved; recover the invocation type javac computed (kept in the error's original
+            // type), falling back to the symbol's declared type, to keep the JavaType.Method.
             if (symbol instanceof Symbol.MethodSymbol && symbol.kind != Kinds.Kind.ERR &&
                 symbol.type != null && !(symbol.type instanceof Type.ErrorType)) {
-                return methodInvocationType(symbol.type, symbol);
+                Type originalType = selectType.getOriginalType();
+                return methodInvocationType(originalType instanceof Type.MethodType ? originalType : symbol.type, symbol);
             }
         }
 

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25TypeMapping.java
@@ -429,6 +429,13 @@ class ReloadableJava25TypeMapping implements JavaTypeMapping<Tree> {
             } catch (Exception e) {
                 // ignore
             }
+
+            // An unresolvable argument can leave the select as a plain ErrorType while the callee
+            // still resolved; fall back to the symbol's own type to keep the JavaType.Method.
+            if (symbol instanceof Symbol.MethodSymbol && symbol.kind != Kinds.Kind.ERR &&
+                symbol.type != null && !(symbol.type instanceof Type.ErrorType)) {
+                return methodInvocationType(symbol.type, symbol);
+            }
         }
 
         if (selectType == null || selectType instanceof Type.ErrorType || symbol == null || symbol.kind == Kinds.Kind.ERR) {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
@@ -462,8 +462,87 @@ class JavaParserTypeMappingTest implements JavaTypeMappingTest, RewriteTest {
                     public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer n) {
                         if ("requireNonNull".equals(method.getSimpleName())) {
                             assertThat(method.getMethodType()).isNotNull();
+                            assertThat(method.getMethodType().getName()).isEqualTo("requireNonNull");
                             assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName())
                                     .isEqualTo("java.util.Objects");
+                            asserted.set(true);
+                        }
+                        return super.visitMethodInvocation(method, n);
+                    }
+                }.visit(cu, 0);
+                assertThat(asserted.get()).isTrue();
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/pull/8318")
+    @MinimumJava25
+    @Test
+    void methodInvocationTypeResolvedFromRecoveredInvocationTypeWhenArgumentTypeUnresolvable() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().identifiers(false).methodInvocations(false).build()),
+          java(
+            """
+              import static java.util.Objects.requireNonNull;
+              class MyTest {
+                  void test() {
+                      requireNonNull(UnknownType.unknownMethod());
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicBoolean asserted = new AtomicBoolean(false);
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer n) {
+                        if ("requireNonNull".equals(method.getSimpleName())) {
+                            JavaType.Method methodType = method.getMethodType();
+                            assertThat(methodType).isNotNull();
+                            assertThat(TypeUtils.asFullyQualified(methodType.getReturnType()).getFullyQualifiedName())
+                                    .isEqualTo("java.lang.Object");
+                            assertThat(methodType.getParameterTypes()).hasSize(1);
+                            assertThat(TypeUtils.asFullyQualified(methodType.getParameterTypes().get(0)).getFullyQualifiedName())
+                                    .isEqualTo("java.lang.Object");
+                            asserted.set(true);
+                        }
+                        return super.visitMethodInvocation(method, n);
+                    }
+                }.visit(cu, 0);
+                assertThat(asserted.get()).isTrue();
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/pull/8318")
+    @MinimumJava11
+    @Test
+    void methodInvocationTypeBoundOnOverloadedCalleeWithUnresolvableArgument() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().identifiers(false).methodInvocations(false).build()),
+          java(
+            """
+              class MyTest {
+                  Object test() {
+                      return String.valueOf(UnknownType.unknownMethod());
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicBoolean asserted = new AtomicBoolean(false);
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer n) {
+                        if ("valueOf".equals(method.getSimpleName())) {
+                            // With an unresolvable argument, overload resolution cannot pick a
+                            // principled winner; we bind javac's recovery candidate rather than
+                            // leaving the method type null, so only name and declaring type are
+                            // stable across JDKs.
+                            assertThat(method.getMethodType()).isNotNull();
+                            assertThat(method.getMethodType().getName()).isEqualTo("valueOf");
+                            assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName())
+                                    .isEqualTo("java.lang.String");
                             asserted.set(true);
                         }
                         return super.visitMethodInvocation(method, n);

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/JavaParserTypeMappingTest.java
@@ -439,4 +439,39 @@ class JavaParserTypeMappingTest implements JavaTypeMappingTest, RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-testing-frameworks/issues/1061")
+    @MinimumJava11
+    @Test
+    void methodInvocationTypeBoundWhenArgumentTypeUnresolvable() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.builder().identifiers(false).methodInvocations(false).build()),
+          java(
+            """
+              import static java.util.Objects.requireNonNull;
+              class MyTest {
+                  void test() {
+                      requireNonNull(UnknownType.unknownMethod());
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                AtomicBoolean asserted = new AtomicBoolean(false);
+                new JavaIsoVisitor<Integer>() {
+                    @Override
+                    public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer n) {
+                        if ("requireNonNull".equals(method.getSimpleName())) {
+                            assertThat(method.getMethodType()).isNotNull();
+                            assertThat(method.getMethodType().getDeclaringType().getFullyQualifiedName())
+                                    .isEqualTo("java.util.Objects");
+                            asserted.set(true);
+                        }
+                        return super.visitMethodInvocation(method, n);
+                    }
+                }.visit(cu, 0);
+                assertThat(asserted.get()).isTrue();
+            })
+          )
+        );
+    }
 }


### PR DESCRIPTION
On JDK 25, javac's error recovery leaves a method invocation's select as a plain `ErrorType` when one of its arguments fails to resolve, even though the callee symbol resolved cleanly — so `rewrite-java-25` left the invocation's `getMethodType()` null (java-21 bound it). This surfaced as type-driven `MethodMatcher`s silently not firing and `RemoveUnusedImports` dropping still-used static imports, yielding non-compiling output (observed migrating rewrite-testing-frameworks to java-25, openrewrite/rewrite-testing-frameworks#1061).

### Root cause

Two JDK 24 javac changes ended the recovery shape the older parsers rely on:
- [JDK-8328536](https://bugs.openjdk.org/browse/JDK-8328536): `Attr.checkIdInternal` no longer early-returns on an erroneous expected type; it now fully instantiates the method type and stores it on the tree wrapped as a plain `ErrorType`, while the symbol stays a cleanly resolved `MethodSymbol`. Previously the select's type was left null and our `should-stop.ifError=GENERATE` pipeline had `postAttr` fill it with `Type$UnknownType` — the shape the java-11/17/21 mappings bind through their `UnknownType` branches.
- [JDK-8339296](https://bugs.openjdk.org/browse/JDK-8339296): removed `Type$UnknownType` entirely.

The existing `AttrRecover$RecoveryErrorType` reflection cannot rescue this case: javac only attaches it when resolution itself fails (arity/return-context mismatches), never for a resolved callee with an erroneous argument.

### Fix

In `ReloadableJava25TypeMapping.methodInvocationType`, when the select is a plain `ErrorType` but the callee is a cleanly-resolved `MethodSymbol`, recurse with the invocation type javac computed and kept in the error's original type (a resolved `Type.MethodType`, e.g. `(Object)Object` for `requireNonNull` — the same shape a non-erroneous call produces), falling back to the symbol's declared type otherwise.

### Tests

Three tests added to the shared TCK (`JavaParserTypeMappingTest`):
- the regression scenario, gated `@MinimumJava11` since JDK 8's javac predates this error recovery and never bound it; java-11/17/21 pass it via their pre-existing `UnknownType` branches
- a `@MinimumJava25` test pinning the resolved `java.lang.Object` parameter/return shape produced by the new fallback
- an overloaded-callee case (`String.valueOf(<unresolvable>)`) documenting the deliberate trade-off: with an unresolvable argument javac's recovery commits to an arbitrary candidate among the overloads, so we bind that candidate rather than leaving the method type null, and only name and declaring type are pinned

Verified locally: `JavaParserTypeMappingTest` green on the java-8/11/17/21/25 `compatibilityTest` suites, and the full `:rewrite-java-25:compatibilityTest` and `:rewrite-java-21:compatibilityTest` suites pass (648 tests each).

### Out of scope

On JDK 24 runtimes the java-21 parser hits the same plain-`ErrorType` recovery and still returns a null method type (its `UnknownType` branch is unreachable there since JDK-8339296 removed the class). This PR is deliberately scoped to the java-25 parser; porting the fallback to `ReloadableJava21TypeMapping` is left for a follow-up.
