### PR TITLE
Route addToRootPom=true pins to the reactor root in UpgradeTransitiveDependencyVersion

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -29,8 +29,11 @@ import org.openrewrite.semver.VersionComparator;
 import org.openrewrite.xml.tree.Xml;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -182,6 +185,10 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
     public static class Scanned {
         boolean usingType;
         List<SourceFile> rootPoms = new ArrayList<>();
+        // Populated by callers (e.g. UpgradeTransitiveDependencyVersion.getScanner) when
+        // addToRootPom=true and a transitive was found in a non-root pom under a reactor root.
+        // Keyed by the reactor root's GAV; values are the coordinates the writer should pin there.
+        Map<ResolvedGroupArtifactVersion, Set<GroupArtifact>> reactorRootTransitives = new HashMap<>();
     }
 
     @Override

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersion.java
@@ -21,8 +21,10 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.maven.table.MavenMetadataFailures;
+import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.xml.tree.Xml;
 
@@ -169,7 +171,37 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<AddManage
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(AddManagedDependency.Scanned acc) {
-        return addManagedDependency().getScanner(acc);
+        TreeVisitor<?, ExecutionContext> addManagedDependencyScanner = addManagedDependency().getScanner(acc);
+        if (!Boolean.TRUE.equals(addToRootPom)) {
+            return addManagedDependencyScanner;
+        }
+        // When adding to the reactor root, record for each root the coordinates any pom under it
+        // holds transitively. The visitor phase reads this map to write the pins in one place
+        // instead of the pom that happens to hold each transitive.
+        return new MavenIsoVisitor<ExecutionContext>() {
+            @Override
+            public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+                addManagedDependencyScanner.visit(document, ctx);
+                MavenResolutionResult mrr = getResolutionResult();
+                Set<ResolvedDependency> matchingDependencies = mrr.findDependencies(groupId, artifactId, null)
+                        .stream()
+                        .filter(ResolvedDependency::isTransitive)
+                        .collect(toCollection(LinkedHashSet::new));
+                if (matchingDependencies.isEmpty()) {
+                    return document;
+                }
+                MavenResolutionResult current = mrr;
+                while (current.parentPomIsProjectPom()) {
+                    current = current.getParent();
+                }
+                ResolvedGroupArtifactVersion rootGav = current.getPom().getGav();
+                Set<GroupArtifact> coords = acc.reactorRootTransitives.computeIfAbsent(rootGav, k -> new LinkedHashSet<>());
+                for (ResolvedDependency dep : matchingDependencies) {
+                    coords.add(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()));
+                }
+                return document;
+            }
+        };
     }
 
     @Override
@@ -177,6 +209,27 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<AddManage
         return new MavenIsoVisitor<ExecutionContext>() {
             @Override
             public Xml.Document visitDocument(Xml.Document document, ExecutionContext ctx) {
+                if (Boolean.TRUE.equals(addToRootPom)) {
+                    // Only fire on the reactor root; write every coordinate recorded against it by
+                    // the scanner. Skip non-root poms even if they hold the transitive - the point
+                    // of addToRootPom is to centralize the pin.
+                    MavenResolutionResult mrr = getResolutionResult();
+                    if (mrr.parentPomIsProjectPom()) {
+                        return document;
+                    }
+                    Set<GroupArtifact> coords = acc.reactorRootTransitives.get(mrr.getPom().getGav());
+                    if (coords == null || coords.isEmpty()) {
+                        return document;
+                    }
+                    Xml.Document d = document;
+                    for (GroupArtifact coord : coords) {
+                        d = (Xml.Document) addManagedDependency(coord.getGroupId(), coord.getArtifactId())
+                                .getVisitor(acc)
+                                .visitNonNull(d, ctx);
+                    }
+                    return d;
+                }
+
                 Set<ResolvedDependency> matchingDependencies = getResolutionResult().findDependencies(groupId, artifactId, null)
                         .stream()
                         .filter(ResolvedDependency::isTransitive)

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeTransitiveDependencyVersionTest.java
@@ -381,4 +381,71 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void addsManagedDependencyToReactorRootWhenAddToRootPomAndOnlyChildHoldsTheTransitive() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeTransitiveDependencyVersion(
+            "com.fasterxml*", "jackson-core", "2.12.5", null, null, null, null, null, null, true, null)),
+          mavenProject("parent",
+            pomXml(
+              """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                      <module>child</module>
+                  </modules>
+              </project>
+              """,
+              """
+              <project>
+                  <modelVersion>4.0.0</modelVersion>
+                  <groupId>com.example</groupId>
+                  <artifactId>parent</artifactId>
+                  <version>1.0.0</version>
+                  <packaging>pom</packaging>
+                  <modules>
+                      <module>child</module>
+                  </modules>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.fasterxml.jackson.core</groupId>
+                              <artifactId>jackson-core</artifactId>
+                              <version>2.12.5</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+            ),
+            mavenProject("child",
+              pomXml(
+                """
+                <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <parent>
+                        <groupId>com.example</groupId>
+                        <artifactId>parent</artifactId>
+                        <version>1.0.0</version>
+                    </parent>
+                    <artifactId>child</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.openrewrite</groupId>
+                            <artifactId>rewrite-java</artifactId>
+                            <version>7.0.0</version>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+              )
+            )
+          )
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`UpgradeTransitiveDependencyVersion(..., addToRootPom=true)` silently dropped every pin in a multi-module reactor whenever the vulnerable transitive was held only by a child module. Two things combined to hide the write:

1. `UpgradeTransitiveDependencyVersion.visitDocument` returned early on the reactor root because the root itself has no matching transitive of its own (`matchingDependencies.isEmpty()`).
2. `AddManagedDependency.visitDocument`'s write gate (`!Boolean.TRUE.equals(addToRootPom) || acc.rootPoms.contains(document)`) refused to write on the child pom because only reactor-root poms are in `acc.rootPoms`.

Result: the recipe produced no changes at all, even though a child module clearly held the transitive.

## Change

Give `UpgradeTransitiveDependencyVersion` a real scanner: for every pom that holds a matching transitive, walk up `parentPomIsProjectPom()` to find the reactor root's GAV and record the coordinate against it in a new `AddManagedDependency.Scanned#reactorRootTransitives` map.

In the visitor phase, branch on `addToRootPom`:
- `true` — fire only on reactor roots (`!parentPomIsProjectPom()`) and pin every coordinate the scanner collected against that root's GAV.
- `null`/`false` — existing behavior unchanged (per-pom matching with parent-preference dedup).

`AddManagedDependency.visitDocument`'s guard already routes correctly when the root pom is visited (root is in `acc.rootPoms`), so no changes needed there.

## Behavior change

Only the `addToRootPom=true` path is affected. The `null`/`false` path — the common case, including everything `UpgradeTransitiveDependencyVersionTest` covered before — is unchanged.

Callers that were relying on `addToRootPom=true` silently no-op-ing in reactors will now see the recipe produce edits.

## Known scope limitation

If a child has its own competing `<dependencyManagement>` entry for the same coordinate, Maven's inheritance rule means the child's local entry shadows the parent's — the root-scoped pin won't take effect for that specific module until the child entry is removed. This PR does not touch child poms. Filed as follow-up.

## Test plan

- [x] New `addsManagedDependencyToReactorRootWhenAddToRootPomAndOnlyChildHoldsTheTransitive` in `UpgradeTransitiveDependencyVersionTest` covers the reactor-root write.
- [x] Full `UpgradeTransitiveDependencyVersionTest` and `AddManagedDependencyTest` suites pass.
- [x] Full `rewrite-maven:test` module passes.

Draft — soliciting feedback on the accumulator shape and the child-cleanup boundary before finalizing.