### PR TITLE
Gradle FindDependency: match against resolved version, not declared

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/search/FindDependency.java
@@ -120,7 +120,10 @@ public class FindDependency extends Recipe {
         if (desiredVersion == null) {
             return true;
         }
-        String actualVersion = gradleDependency.getDeclaredVersion();
+        String actualVersion = gradleDependency.getVersion();
+        if (actualVersion == null) {
+            actualVersion = gradleDependency.getDeclaredVersion();
+        }
         if (actualVersion == null) {
             return false;
         }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/search/FindDependencyTest.java
@@ -17,6 +17,8 @@ package org.openrewrite.gradle.search;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.maven.table.DependenciesDeclared;
@@ -450,6 +452,63 @@ class FindDependencyTest implements RewriteTest {
               }
               dependencies {
                   /*~~>*/api("org.openrewrite:rewrite-core:latest.release")
+              }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2.7.18", "2.7.x"})
+    void findDependencyWhenVersionComesFromBuildscriptExtProperty(String versionSelector) {
+        rewriteRun(
+          spec -> spec
+            .beforeRecipe(withToolingApi())
+            .recipe(new FindDependency("org.springframework.boot", "spring-boot-starter", null, versionSelector, null)),
+          buildGradle(
+            //language=gradle
+            """
+              buildscript {
+                  ext {
+                      springBootVersion = '2.7.18'
+                  }
+                  repositories {
+                      mavenCentral()
+                  }
+              }
+
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation "org.springframework.boot:spring-boot-starter:${springBootVersion}"
+              }
+              """,
+            """
+              buildscript {
+                  ext {
+                      springBootVersion = '2.7.18'
+                  }
+                  repositories {
+                      mavenCentral()
+                  }
+              }
+
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  /*~~>*/implementation "org.springframework.boot:spring-boot-starter:${springBootVersion}"
               }
               """
           )


### PR DESCRIPTION
## What

`FindDependency` with a `version` option now compares against the dependency's resolved concrete version instead of the raw declared version. This means a version declared via a Gradle property — including one sourced from a `buildscript { ext { } }` block — matches correctly.

## Why

`FindDependency.versionIsValid` was calling `GradleDependency.getDeclaredVersion()`, which returns the literal text from the build script. When the version was interpolated (e.g. `"org.springframework.boot:spring-boot-starter:${springBootVersion}"`), the placeholder was handed to `Semver.validate` and never matched the caller's requested version — the recipe reported no match even when the effective version did match.

`ModuleHasDependency` handles this correctly because it reads from `GradleDependencyConfiguration.getDirectResolved()`, and the `GradleDependency` trait already exposes the equivalent resolved value via `getVersion()`. `FindDependency` simply wasn't using it.

The change prefers the resolved value and falls back to the declared value when resolution hasn't run (e.g. when the trait constructed a synthetic `ResolvedDependency`).

## Test plan

- [x] New `FindDependencyTest#findDependencyWhenVersionComesFromBuildscriptExtProperty` reproduces the issue verbatim; fails on `main`, passes with the fix
- [x] Full `:rewrite-gradle:test` green