### PR TITLE
KotlinTemplate: attribute members selected on substituted placeholders

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
@@ -20,6 +20,8 @@ import org.openrewrite.java.internal.template.Substitutions;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypedTree;
 
+import java.util.Collections;
+
 import static java.util.Collections.emptySet;
 
 public class KotlinSubstitutions extends Substitutions {
@@ -40,7 +42,7 @@ public class KotlinSubstitutions extends Substitutions {
     // and render arrays as kotlin.Array<T> / primitive array types.
     private String toKotlinTypeSyntax(String fqn, int index, boolean starProjectRaw) {
         if (fqn.endsWith("[]")) {
-            return toKotlinArrayType(fqn.substring(0, fqn.length() - "[]".length()), index);
+            return toKotlinArrayType(fqn.substring(0, fqn.length() - 2), index);
         }
         String kotlinType = fqn
                 .replace("? extends ", "out ")
@@ -49,14 +51,7 @@ public class KotlinSubstitutions extends Substitutions {
         if (starProjectRaw && kotlinType.indexOf('<') < 0) {
             int arity = genericArity(index);
             if (arity > 0) {
-                StringBuilder sb = new StringBuilder(kotlinType).append('<');
-                for (int i = 0; i < arity; i++) {
-                    if (i > 0) {
-                        sb.append(", ");
-                    }
-                    sb.append('*');
-                }
-                return sb.append('>').toString();
+                return kotlinType + "<" + String.join(", ", Collections.nCopies(arity, "*")) + ">";
             }
         }
         return kotlinType;

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
@@ -15,26 +15,105 @@
  */
 package org.openrewrite.kotlin.internal.template;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.java.internal.template.Substitutions;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.java.tree.TypedTree;
 
 import static java.util.Collections.emptySet;
 
 public class KotlinSubstitutions extends Substitutions {
+    private final Object[] parameters;
+
     public KotlinSubstitutions(String code, Object[] parameters) {
         super(code, emptySet(), parameters);
+        this.parameters = parameters;
     }
 
     @Override
     protected String newObjectParameter(String fqn, int index) {
-        return "__P__./*__p" + index + "__*/p<" + toKotlinTypeSyntax(fqn) + ">()";
+        return "__P__./*__p" + index + "__*/p<" + toKotlinTypeSyntax(fqn, index, true) + ">()";
     }
 
-    // Wildcards are rendered in Java syntax; a `?` cannot occur in a type name, so plain replacement is unambiguous
-    private static String toKotlinTypeSyntax(String fqn) {
-        return fqn
+    /**
+     * Render a Java type name emitted by {@link Substitutions} as a Kotlin type so that the Kotlin
+     * parser can resolve members accessed on the substituted placeholder.
+     * <ul>
+     *     <li>Wildcards ({@code ? extends}, {@code ? super}, {@code ?}) become Kotlin variance/projection syntax.</li>
+     *     <li>Arrays ({@code T[]}) become {@code kotlin.Array<T>} or a primitive array type, since Kotlin has no
+     *     {@code T[]} syntax.</li>
+     *     <li>A top-level generic type named without type arguments (a raw type) gets star projections, since Kotlin
+     *     has no raw types and a bare generic name resolves to an error type — which suppresses attribution of any
+     *     member selected on it. Star projection only applies to the substituted type itself, whose arity is recovered
+     *     from the actual argument; nested type arguments (e.g. array elements) are rendered structurally only.</li>
+     * </ul>
+     */
+    private String toKotlinTypeSyntax(String fqn, int index, boolean starProjectRaw) {
+        if (fqn.endsWith("[]")) {
+            return toKotlinArrayType(fqn.substring(0, fqn.length() - "[]".length()), index);
+        }
+        String kotlinType = fqn
                 .replace("? extends ", "out ")
                 .replace("? super ", "in ")
                 .replace("?", "*");
+        if (starProjectRaw && kotlinType.indexOf('<') < 0) {
+            int arity = genericArity(index);
+            if (arity > 0) {
+                StringBuilder sb = new StringBuilder(kotlinType).append('<');
+                for (int i = 0; i < arity; i++) {
+                    if (i > 0) {
+                        sb.append(", ");
+                    }
+                    sb.append('*');
+                }
+                return sb.append('>').toString();
+            }
+        }
+        return kotlinType;
+    }
+
+    private String toKotlinArrayType(String elementFqn, int index) {
+        switch (elementFqn) {
+            case "boolean":
+                return "kotlin.BooleanArray";
+            case "byte":
+                return "kotlin.ByteArray";
+            case "char":
+                return "kotlin.CharArray";
+            case "double":
+                return "kotlin.DoubleArray";
+            case "float":
+                return "kotlin.FloatArray";
+            case "int":
+                return "kotlin.IntArray";
+            case "long":
+                return "kotlin.LongArray";
+            case "short":
+                return "kotlin.ShortArray";
+            case "java.lang.Object":
+                return "kotlin.Array<*>";
+            default:
+                return "kotlin.Array<" + toKotlinTypeSyntax(elementFqn, index, false) + ">";
+        }
+    }
+
+    /**
+     * The number of type parameters the substituted parameter's own type carries, used to star-project a
+     * template-declared raw generic type. The declared type (from the template text) is a shallow class with no
+     * type parameters, so the arity is recovered from the actual argument instead.
+     */
+    private int genericArity(int index) {
+        if (index < 0 || index >= parameters.length || !(parameters[index] instanceof TypedTree)) {
+            return 0;
+        }
+        JavaType type = ((TypedTree) parameters[index]).getType();
+        if (type instanceof JavaType.Parameterized) {
+            return ((JavaType.Parameterized) type).getTypeParameters().size();
+        }
+        if (type instanceof JavaType.FullyQualified) {
+            return ((JavaType.FullyQualified) type).getTypeParameters().size();
+        }
+        return 0;
     }
 
     @Override

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/template/KotlinSubstitutions.java
@@ -35,19 +35,9 @@ public class KotlinSubstitutions extends Substitutions {
         return "__P__./*__p" + index + "__*/p<" + toKotlinTypeSyntax(fqn, index, true) + ">()";
     }
 
-    /**
-     * Render a Java type name emitted by {@link Substitutions} as a Kotlin type so that the Kotlin
-     * parser can resolve members accessed on the substituted placeholder.
-     * <ul>
-     *     <li>Wildcards ({@code ? extends}, {@code ? super}, {@code ?}) become Kotlin variance/projection syntax.</li>
-     *     <li>Arrays ({@code T[]}) become {@code kotlin.Array<T>} or a primitive array type, since Kotlin has no
-     *     {@code T[]} syntax.</li>
-     *     <li>A top-level generic type named without type arguments (a raw type) gets star projections, since Kotlin
-     *     has no raw types and a bare generic name resolves to an error type — which suppresses attribution of any
-     *     member selected on it. Star projection only applies to the substituted type itself, whose arity is recovered
-     *     from the actual argument; nested type arguments (e.g. array elements) are rendered structurally only.</li>
-     * </ul>
-     */
+    // Kotlin has no `T[]` syntax and no raw types: a bare generic name resolves to an error type, which
+    // suppresses attribution of members selected on the placeholder. Star-project raw types (top-level only)
+    // and render arrays as kotlin.Array<T> / primitive array types.
     private String toKotlinTypeSyntax(String fqn, int index, boolean starProjectRaw) {
         if (fqn.endsWith("[]")) {
             return toKotlinArrayType(fqn.substring(0, fqn.length() - "[]".length()), index);
@@ -97,11 +87,8 @@ public class KotlinSubstitutions extends Substitutions {
         }
     }
 
-    /**
-     * The number of type parameters the substituted parameter's own type carries, used to star-project a
-     * template-declared raw generic type. The declared type (from the template text) is a shallow class with no
-     * type parameters, so the arity is recovered from the actual argument instead.
-     */
+    // The template-declared type is a shallow class with no type parameters, so a raw type's arity is
+    // recovered from the actual argument instead.
     private int genericArity(int index) {
         if (index < 0 || index >= parameters.length || !(parameters[index] instanceof TypedTree)) {
             return 0;

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -878,6 +878,110 @@ class KotlinTemplateTest implements RewriteTest {
     }
 
     @Test
+    void attributesMemberCallOnSubstitutedPlaceholder() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if ("placeholder".equals(method.getSimpleName())) {
+                      J.MethodInvocation applied = KotlinTemplate.builder("require(#{any(java.util.Collection)}.isEmpty())")
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
+                      J.MethodInvocation inner = (J.MethodInvocation) applied.getArguments().get(0);
+                      assertThat(inner.getMethodType()).as("inner isEmpty() methodType").isNotNull();
+                      assertThat(inner.getName().getType()).as("inner isEmpty() name type").isSameAs(inner.getMethodType());
+                      assertThat(applied.getMethodType()).as("enclosing require() methodType").isNotNull();
+                      return applied;
+                  }
+                  return super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          kotlin(
+            """
+              fun placeholder(c: java.util.Collection<Int>) {}
+              fun test(c: java.util.Collection<Int>) {
+                  placeholder(c)
+              }
+              """,
+            """
+              fun placeholder(c: java.util.Collection<Int>) {}
+              fun test(c: java.util.Collection<Int>) {
+                  require(c.isEmpty())
+              }
+              """
+          ));
+    }
+
+    @Test
+    void attributesPropertyAccessOnSubstitutedPlaceholder() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if ("placeholder".equals(method.getSimpleName())) {
+                      J.MethodInvocation applied = KotlinTemplate.builder("require(#{any(java.util.Collection)}.size == 0)")
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
+                      J.Binary binary = (J.Binary) applied.getArguments().get(0);
+                      assertThat(binary.getLeft().getType()).as(".size property access type").isNotNull();
+                      return applied;
+                  }
+                  return super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          kotlin(
+            """
+              fun placeholder(c: java.util.Collection<Int>) {}
+              fun test(c: java.util.Collection<Int>) {
+                  placeholder(c)
+              }
+              """,
+            """
+              fun placeholder(c: java.util.Collection<Int>) {}
+              fun test(c: java.util.Collection<Int>) {
+                  require(c.size == 0)
+              }
+              """
+          ));
+    }
+
+    @Test
+    void attributesAnyArrayPlaceholder() {
+        List<String> stubs = new ArrayList<>();
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new KotlinVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if ("placeholder".equals(method.getSimpleName())) {
+                      J.MethodInvocation applied = KotlinTemplate.builder("require(#{anyArray(kotlin.String)}.isEmpty())")
+                        .doBeforeParseTemplate(stubs::add)
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
+                      J.MethodInvocation inner = (J.MethodInvocation) applied.getArguments().get(0);
+                      assertThat(inner.getMethodType()).as("inner isEmpty() methodType").isNotNull();
+                      return applied;
+                  }
+                  return super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          kotlin(
+            """
+              fun placeholder(a: Array<String>) {}
+              fun test(a: Array<String>) {
+                  placeholder(a)
+              }
+              """,
+            """
+              fun placeholder(a: Array<String>) {}
+              fun test(a: Array<String>) {
+                  require(a.isEmpty())
+              }
+              """
+          ));
+        assertThat(stubs).anyMatch(stub -> stub.contains("p<kotlin.Array<kotlin.String>>()"));
+    }
+
+    @Test
     void addAnnotationToMethod() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new KotlinIsoVisitor<>() {


### PR DESCRIPTION
- `KotlinTemplate` wraps a typed placeholder `#{any(FQN)}` as `__P__.p<FQN>()`, but Kotlin has no raw generic types, so `p<java.util.Collection>()` resolved to an error type and left members selected on the placeholder (`isEmpty()`, `.size`) — and the enclosing call — untyped. `KotlinSubstitutions` now star-projects a top-level raw generic using the actual argument's arity (`java.util.Collection<*>`) and renders array placeholders as `kotlin.Array<T>` / primitive-array types instead of the unparseable `T[]`, so member/property accesses resolve through the Kotlin type system and the `MethodInvocation#getName().getType() == methodType` invariant holds. Three new `KotlinTemplateTest` cases cover member calls, property access, and `#{anyArray(...)}`; the full `rewrite-kotlin` suite (1299 tests) passes. This unblocks removing the `HamcrestMatcherToJUnit5.attributeTypes(...)` workaround in rewrite-testing-frameworks (PR #1058) once released.