### PR TITLE
Make Kotlin's statement/expression wrappers first-class visited nodes

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinIsoVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinIsoVisitor.java
@@ -118,6 +118,11 @@ public class KotlinIsoVisitor<P> extends KotlinVisitor<P> {
     }
 
     @Override
+    public K.StatementExpression visitStatementExpression(K.StatementExpression statementExpression, P p) {
+        return (K.StatementExpression) super.visitStatementExpression(statementExpression, p);
+    }
+
+    @Override
     public K.TypeAlias visitTypeAlias(K.TypeAlias typeAlias, P p) {
         return (K.TypeAlias) super.visitTypeAlias(typeAlias, p);
     }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinIsoVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinIsoVisitor.java
@@ -63,6 +63,11 @@ public class KotlinIsoVisitor<P> extends KotlinVisitor<P> {
     }
 
     @Override
+    public K.ExpressionStatement visitExpressionStatement(K.ExpressionStatement expressionStatement, P p) {
+        return (K.ExpressionStatement) super.visitExpressionStatement(expressionStatement, p);
+    }
+
+    @Override
     public K.FunctionType visitFunctionType(K.FunctionType functionType, P p) {
         return (K.FunctionType) super.visitFunctionType(functionType, p);
     }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinIsoVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinIsoVisitor.java
@@ -28,6 +28,11 @@ public class KotlinIsoVisitor<P> extends KotlinVisitor<P> {
     }
 
     @Override
+    public K.AnnotatedExpression visitAnnotatedExpression(K.AnnotatedExpression annotatedExpression, P p) {
+        return (K.AnnotatedExpression) super.visitAnnotatedExpression(annotatedExpression, p);
+    }
+
+    @Override
     public K.AnnotationType visitAnnotationType(K.AnnotationType annotationType, P p) {
         return (K.AnnotationType) super.visitAnnotationType(annotationType, p);
     }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -274,17 +274,11 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
 
     public J visitStatementExpression(K.StatementExpression statementExpression, P p) {
         K.StatementExpression s = statementExpression;
-        Statement temp = (Statement) visitStatement(s, p);
+        Expression temp = (Expression) visitExpression(s, p);
         if (!(temp instanceof K.StatementExpression)) {
             return temp;
         } else {
             s = (K.StatementExpression) temp;
-        }
-        Expression temp2 = (Expression) visitExpression(s, p);
-        if (!(temp2 instanceof K.StatementExpression)) {
-            return temp2;
-        } else {
-            s = (K.StatementExpression) temp2;
         }
         J statement = visit(s.getStatement(), p);
         if (statement instanceof K.StatementExpression) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -257,9 +257,6 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
 
     public J visitStatementExpression(K.StatementExpression statementExpression, P p) {
         K.StatementExpression s = statementExpression;
-        // Route through visitStatement/visitExpression like every other K statement-expression type
-        // (e.g. K.Return), so scope-based operations such as JavaTemplate replacements can target the
-        // wrapper node itself rather than transparently descending into the statement it wraps.
         Statement temp = (Statement) visitStatement(s, p);
         if (!(temp instanceof K.StatementExpression)) {
             return temp;

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -147,6 +147,23 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         return d.getPadding().withDestructAssignments(visitContainer(d.getPadding().getDestructAssignments(), KContainer.Location.DESTRUCT_ASSIGNMENTS, p));
     }
 
+    public J visitExpressionStatement(K.ExpressionStatement expressionStatement, P p) {
+        K.ExpressionStatement e = expressionStatement;
+        Statement temp = (Statement) visitStatement(e, p);
+        if (!(temp instanceof K.ExpressionStatement)) {
+            return temp;
+        } else {
+            e = (K.ExpressionStatement) temp;
+        }
+        J expression = visit(e.getExpression(), p);
+        if (expression instanceof K.ExpressionStatement) {
+            return expression;
+        } else if (expression instanceof Expression) {
+            return e.withExpression((Expression) expression);
+        }
+        return expression;
+    }
+
     public J visitFunctionType(K.FunctionType functionType, P p) {
         K.FunctionType f = functionType;
         f = f.withPrefix(visitSpace(f.getPrefix(), KSpace.Location.FUNCTION_TYPE_PREFIX, p));

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinVisitor.java
@@ -255,6 +255,32 @@ public class KotlinVisitor<P> extends JavaVisitor<P> {
         return s.withExpression(visitAndCast(s.getExpression(), p));
     }
 
+    public J visitStatementExpression(K.StatementExpression statementExpression, P p) {
+        K.StatementExpression s = statementExpression;
+        // Route through visitStatement/visitExpression like every other K statement-expression type
+        // (e.g. K.Return), so scope-based operations such as JavaTemplate replacements can target the
+        // wrapper node itself rather than transparently descending into the statement it wraps.
+        Statement temp = (Statement) visitStatement(s, p);
+        if (!(temp instanceof K.StatementExpression)) {
+            return temp;
+        } else {
+            s = (K.StatementExpression) temp;
+        }
+        Expression temp2 = (Expression) visitExpression(s, p);
+        if (!(temp2 instanceof K.StatementExpression)) {
+            return temp2;
+        } else {
+            s = (K.StatementExpression) temp2;
+        }
+        J statement = visit(s.getStatement(), p);
+        if (statement instanceof K.StatementExpression) {
+            return statement;
+        } else if (statement instanceof Statement) {
+            return s.withStatement((Statement) statement);
+        }
+        return statement;
+    }
+
     public J visitStringTemplate(K.StringTemplate stringTemplate, P p) {
         K.StringTemplate k = stringTemplate;
         k = k.withPrefix(visitSpace(k.getPrefix(), KSpace.Location.STRING_TEMPLATE_PREFIX, p));

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -995,13 +995,7 @@ public interface K extends J {
 
         @Override
         public <P> J acceptKotlin(KotlinVisitor<P> v, P p) {
-            J j = v.visit(getExpression(), p);
-            if (j instanceof ExpressionStatement) {
-                return j;
-            } else if (j instanceof Expression) {
-                return withExpression((Expression) j);
-            }
-            return j;
+            return v.visitExpressionStatement(this, p);
         }
 
         @Override

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1655,13 +1655,7 @@ public interface K extends J {
 
         @Override
         public <P> J acceptKotlin(KotlinVisitor<P> v, P p) {
-            J j = v.visit(getStatement(), p);
-            if (j instanceof StatementExpression) {
-                return j;
-            } else if (j instanceof Statement) {
-                return withStatement((Statement) j);
-            }
-            return j;
+            return v.visitStatementExpression(this, p);
         }
 
         @Override

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.Expression;
@@ -107,6 +108,38 @@ class KotlinTemplateTest implements RewriteTest {
                       val x = value + 1
                       println("added")
                   }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void replaceExpressionStatementWithTemplate() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public J.Block visitBlock(J.Block block, ExecutionContext ctx) {
+                    J.Block b = super.visitBlock(block, ctx);
+                    return b.withStatements(ListUtils.map(b.getStatements(), s -> {
+                        if (!(s instanceof K.ExpressionStatement)) {
+                            return s;
+                        }
+                        return (J.MethodInvocation) JavaTemplate.builder("#{any()}.hashCode()")
+                          .build()
+                          .apply(new Cursor(getCursor(), s), s.getCoordinates().replace(), s);
+                    }));
+                }
+            })),
+          kotlin(
+            """
+              fun test(a: Int) {
+                  a
+              }
+              """,
+            """
+              fun test(a: Int) {
+                  a.hashCode()
               }
               """
           ));

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -17,12 +17,16 @@ package org.openrewrite.kotlin;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
@@ -103,6 +107,68 @@ class KotlinTemplateTest implements RewriteTest {
                       val x = value + 1
                       println("added")
                   }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void wrapControlFlowReturnExpressionWithBuild() {
+        // A `return if (...) ... else ...` parses the `if` into a K.StatementExpression in the
+        // return's expression slot. Wrapping it with a `#{any(...)}.build()` template (as
+        // rewrite-testing-frameworks' UpdateMockWebServerDispatcher does) previously left the
+        // K.StatementExpression untouched, so callers casting the result to J.MethodInvocation hit a
+        // ClassCastException. The wrapper must be a first-class visited node for the scope-based
+        // template replacement to target it.
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none())
+            .recipe(toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+                @Override
+                public J.Return visitReturn(J.Return aReturn, ExecutionContext ctx) {
+                    J.Return r = super.visitReturn(aReturn, ctx);
+                    Expression expr = r.getExpression();
+                    if (!(expr instanceof K.StatementExpression)) {
+                        return r;
+                    }
+                    J.MethodInvocation wrapped = JavaTemplate.builder("#{any(a.b.Resp)}.build()")
+                      .build()
+                      .apply(new Cursor(getCursor(), expr), expr.getCoordinates().replace(), expr);
+                    return r.withExpression(wrapped);
+                }
+            })),
+          kotlin(
+            """
+              package a.b
+              class Resp {
+                  fun build(): Resp = this
+                  companion object {
+                      fun ok(): Resp = Resp()
+                      fun notFound(): Resp = Resp()
+                  }
+              }
+              fun dispatch(path: String): Resp {
+                  return if (path == "/") {
+                      Resp.ok()
+                  } else {
+                      Resp.notFound()
+                  }
+              }
+              """,
+            """
+              package a.b
+              class Resp {
+                  fun build(): Resp = this
+                  companion object {
+                      fun ok(): Resp = Resp()
+                      fun notFound(): Resp = Resp()
+                  }
+              }
+              fun dispatch(path: String): Resp {
+                  return if (path == "/") {
+                      Resp.ok()
+                  } else {
+                      Resp.notFound()
+                  }.build()
               }
               """
           ));


### PR DESCRIPTION
`ChangePackage` (and other `java.*` recipes/templates) threw `class K$StatementExpression cannot be cast to class J$MethodInvocation` on Kotlin sources, as surfaced by rewrite-testing-frameworks' MockWebServer migration over a `return if (…) … else …` in a `Dispatcher` override.

The root cause: Kotlin's statement/expression wrapper types had an `acceptKotlin` that bypassed `visitStatement`/`visitExpression` and descended straight into the wrapped node, so JavaTemplate's scope-based replacement could never target the wrapper itself and `apply()` returned it unchanged — which callers then cast to `J.MethodInvocation`.

Both Kotlin wrappers are now first-class visited nodes, each routed through the hook matching the role it actually plays:

- **`K.StatementExpression`** wraps a `Statement` so it can occupy an `Expression` slot (`convertToExpression` wraps only when `j instanceof Statement && !(j instanceof Expression)`). New `KotlinVisitor#visitStatementExpression` routes through `visitExpression`; the wrapped statement continues to route through `visitStatement` on its own. `JavaTemplateJavaExtension#visitExpression` handles `STATEMENT_PREFIX` coordinates when the node is also a `Statement` and parses the template as an expression, which is the more accurate treatment for a node in an expression slot.
- **`K.ExpressionStatement`** is the mirror image — it wraps an `Expression` so it can occupy a `Statement` slot — and had the identical defect. It is far more common: a bare `a + b`, `a > b`, or `a` in any block is wrapped, and `convertToStatement` is called from nine sites in `KotlinTreeParserVisitor`. Confirmed by repro: `JavaTemplate.apply(cursor, exprStmt.getCoordinates().replace(), exprStmt)` returned the untouched wrapper, and the caller's cast threw `K$ExpressionStatement cannot be cast to J$MethodInvocation`. New `KotlinVisitor#visitExpressionStatement` routes through `visitStatement` only; routing through `visitExpression` as well would present the wrapper *and* its child to type-matching recipes as two indistinguishable nodes, since the wrapper delegates `getType()`/prefix/markers to the child.

Both get the matching narrowing override in `KotlinIsoVisitor`, which also picks up a missing `visitAnnotatedExpression` override (pre-existing gap, unrelated).

Regression tests `KotlinTemplateTest.wrapControlFlowReturnExpressionWithBuild` and `KotlinTemplateTest.replaceExpressionStatementWithTemplate` each reproduce their exact `ClassCastException`; both were verified to fail without the corresponding fix. Full `rewrite-kotlin` and `rewrite-gradle` suites pass.

Follow-ups, not in this PR:

- #8327 — `JavaTemplate.apply()` silently no-ops when a `REPLACEMENT` scope is never matched, which is what makes this bug family present as a `ClassCastException` far from its cause.
- `G.ExpressionStatement` is still transparent in the same way, and `rewrite-gradle` parses build scripts as Groovy, so it sits on a hotter path than either Kotlin wrapper. Worth its own PR gated on the `rewrite-groovy` and `rewrite-gradle` suites.
