### PR TITLE
Do not pin plugin version when managed, even when the managed version is upgraded

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradePluginVersion.java
@@ -153,18 +153,6 @@ public class UpgradePluginVersion extends Recipe {
                 return super.visitTag(tag, ctx);
             }
 
-            private boolean hasManagedPluginVersion(ResolvedPom resolvedPom, String groupId, String artifactId) {
-                for (Plugin p : ListUtils.concatAll(resolvedPom.getPluginManagement(),
-                        resolvedPom.getRequested().getPluginManagement())) {
-                    if (p.getGroupId().equals(groupId) &&
-                            p.getArtifactId().equals(artifactId) &&
-                            p.getVersion() != null) {
-                        return true;
-                    }
-                }
-                return false;
-            }
-
             private Optional<String> findNewerDependencyVersion(String groupId, String artifactId,
                                                                 String currentVersion, ExecutionContext ctx) throws MavenDownloadingException {
                 MavenMetadata mavenMetadata = metadataFailures.insertRows(ctx, () -> downloadPluginMetadata(groupId, artifactId, ctx));
@@ -177,6 +165,18 @@ public class UpgradePluginVersion extends Recipe {
                 return versionComparator.upgrade(currentVersion, availableVersions);
             }
         });
+    }
+
+    private static boolean hasManagedPluginVersion(ResolvedPom resolvedPom, String groupId, String artifactId) {
+        for (Plugin p : ListUtils.concatAll(resolvedPom.getPluginManagement(),
+                resolvedPom.getRequested().getPluginManagement())) {
+            if (p.getGroupId().equals(groupId) &&
+                    p.getArtifactId().equals(artifactId) &&
+                    p.getVersion() != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Value
@@ -202,7 +202,7 @@ public class UpgradePluginVersion extends Recipe {
                             doAfterVisit(new ChangeTagValueVisitor<>(versionTag.get(), newVersion));
                         }
                     }
-                } else if (addVersionIfMissing) {
+                } else if (addVersionIfMissing && !hasManagedPluginVersion(getResolutionResult().getPom(), groupId, artifactId)) {
                     Xml.Tag newTag = Xml.Tag.build("<version>" + newVersion + "</version>");
                     doAfterVisit(new AddToTagVisitor<>(tag, newTag, new MavenTagInsertionComparator(tag.getChildren())));
                 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradePluginVersionTest.java
@@ -1025,4 +1025,77 @@ class UpgradePluginVersionTest implements RewriteTest {
           )
         );
     }
+
+    @Issue("https://github.com/openrewrite/rewrite-migrate-java/issues/1173")
+    @Test
+    void shouldNotAddVersionWhenManagedInSamePomEvenWhenManagedVersionUpgraded() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradePluginVersion(
+            "org.apache.maven.plugins",
+            "maven-compiler-plugin",
+            "3.11.0",
+            null,
+            null,
+            true
+          )),
+          pomXml(
+            """
+              <project>
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <pluginManagement>
+                    <plugins>
+                      <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.8.1</version>
+                      </plugin>
+                    </plugins>
+                  </pluginManagement>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                      </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>org.openrewrite.example</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <build>
+                  <pluginManagement>
+                    <plugins>
+                      <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <version>3.11.0</version>
+                      </plugin>
+                    </plugins>
+                  </pluginManagement>
+                  <plugins>
+                    <plugin>
+                      <groupId>org.apache.maven.plugins</groupId>
+                      <artifactId>maven-compiler-plugin</artifactId>
+                      <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                      </configuration>
+                    </plugin>
+                  </plugins>
+                </build>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
### What's changed?

`UpgradePluginVersion` with `addVersionIfMissing: true` would add an explicit `<version>` to a version-less plugin declaration even when that plugin's version is managed by `<pluginManagement>` in the **same** POM — but only when the managed version itself was being upgraded.

The outer visitor already guards against this via `hasManagedPluginVersion(...)`. The problem was the `ChangePluginVersionVisitor` spawned to upgrade the managed version (e.g. `3.8.1` → `3.11.0`): it runs over the same document via `doAfterVisit`, matches the version-less usage under `<build><plugins>`, and its `addVersionIfMissing` branch had no managed-version guard, so it pinned a redundant version there.

This adds the same guard to `ChangePluginVersionVisitor` (extracting `hasManagedPluginVersion` to a shared static helper).

The existing `shouldNotAddVersionWhenManagedByParent` test passed only because it managed the version in a *separate* parent POM — `doAfterVisit` scopes the spawned visitor to the current document, so the child's usage was never touched by `ChangePluginVersionVisitor`. The single-POM case (management + usage in the same POM) was the uncovered gap.

### Anything in particular you'd like reviewers to focus on?

The new guard only affects the `addVersionIfMissing && version-less` path; explicit-version upgrades are unchanged.

### Checklist

- [x] I've added unit tests to cover my changes (`shouldNotAddVersionWhenManagedInSamePomEvenWhenManagedVersionUpgraded`)

- Fixes openrewrite/rewrite-migrate-java#1173