### PR TITLE
JavaTemplate: fail loudly when the coordinates are never matched

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.tree.NameTree;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
@@ -695,5 +696,38 @@ class JavaTemplateTest8Test implements RewriteTest {
               """
           )
         );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8327")
+    @Test
+    void unreachableCoordinatesFailLoudly() {
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build()
+          .parse(
+            """
+              class Test {
+                  void test() {
+                      System.out.println(hashCode());
+                  }
+              }
+              """
+          )
+          .map(J.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        assertThatThrownBy(() -> new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                if ("println".equals(method.getSimpleName())) {
+                    // The argument is nested inside `method`, which the template visitor never descends into
+                    return JavaTemplate.apply("0", getCursor(), method.getArguments().getFirst().getCoordinates().replace());
+                }
+                return super.visitMethodInvocation(method, p);
+            }
+        }.visit(cu, 0))
+          .rootCause()
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("JavaTemplate coordinates were never matched")
+          .hasMessageContaining(J.MethodInvocation.class.getName());
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaTemplate.java
@@ -21,6 +21,7 @@ import lombok.experimental.NonFinal;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Cursor;
 import org.openrewrite.Incubating;
+import org.openrewrite.Tree;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.java.internal.template.JavaTemplateJavaExtension;
 import org.openrewrite.java.internal.template.JavaTemplateParser;
@@ -123,14 +124,31 @@ public class JavaTemplate implements SourceTemplate<J, JavaCoordinates> {
         String substitutedTemplate = substitutions.substitute();
         onAfterVariableSubstitution.accept(substitutedTemplate);
 
+        JavaTemplateJavaExtension extension = new JavaTemplateJavaExtension(templateParser, substitutions,
+                substitutedTemplate, coordinates, autoFormat);
+
         //noinspection ConstantConditions
-        J2 result = (J2) new JavaTemplateJavaExtension(templateParser, substitutions, substitutedTemplate, coordinates, autoFormat)
+        J2 result = (J2) extension
                 .getMixin()
                 .visit(scope.getValue(), 0, scope.getParentOrThrow());
+
+        if (!extension.isSubstituted()) {
+            throw new IllegalStateException(unmatchedCoordinatesMessage(scope, coordinates));
+        }
 
         return result != scope.getValue() && result instanceof Expression ?
                 (J2) ParenthesizeVisitor.maybeParenthesize((Expression) result, scope) :
                 result;
+    }
+
+    private static String unmatchedCoordinatesMessage(Cursor scope, JavaCoordinates coordinates) {
+        Tree target = coordinates.getTree();
+        return "JavaTemplate coordinates were never matched, so the template was not applied: " +
+               target.getClass().getName() + " (id=" + target.getId() + ") at " +
+               coordinates.getSpaceLocation() + " in " + coordinates.getMode() + " mode.\n" +
+               "The `scope` cursor pointed at " + scope.getValue().getClass().getName() + ".\n" +
+               "Either the targeted element is not reachable from `scope`, or it is not dispatched to a visitor " +
+               "method and therefore can never be matched.";
     }
 
     protected Substitutions substitutions(Object[] parameters) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -58,8 +58,6 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
     @Override
     public TreeVisitor<? extends J, Integer> getMixin() {
         return new JavaVisitor<Integer>() {
-            private boolean substituted;
-
             @Override
             public <J2 extends J> J2 autoFormat(J2 j, @Nullable J stopAfter, Integer p, Cursor parent) {
                 return autoFormat ? super.autoFormat(j, stopAfter, p, parent) : j;
@@ -410,6 +408,10 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             public J visitMethodInvocation(J.MethodInvocation method, Integer integer) {
                 if (getCursor().firstEnclosing(Javadoc.DocComment.class) != null) {
                     // We don't have support for changing method references in Javadoc comments (yet), so it's safer not to attempt any changes
+                    if (isScope(method)) {
+                        // Record the deliberate skip, so it isn't reported as a scope that could never be matched
+                        substituted = true;
+                    }
                     return method;
                 }
                 if ((loc == METHOD_INVOCATION_ARGUMENTS || loc == METHOD_INVOCATION_NAME) && isScope(method)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateLanguageExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateLanguageExtension.java
@@ -16,7 +16,9 @@
 package org.openrewrite.java.internal.template;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaTemplate;
@@ -39,6 +41,14 @@ public abstract class JavaTemplateLanguageExtension {
     Tree insertionPoint;
     Space.Location loc;
     JavaCoordinates.Mode mode;
+
+    /**
+     * Whether the mixin visitor found {@link #insertionPoint} and applied the template to it. When this remains
+     * {@code false} after the visit, the template silently made no change, which callers almost never expect.
+     */
+    @Getter
+    @NonFinal
+    boolean substituted;
 
     public JavaTemplateLanguageExtension(JavaTemplateParser templateParser, Substitutions substitutions,
                                          String substitutedTemplate, JavaCoordinates coordinates) {


### PR DESCRIPTION
- Fixes #8327

### Problem

In `JavaCoordinates.Mode.REPLACEMENT`, `JavaTemplate.apply(...)` does its substitution from inside `JavaTemplateJavaExtension`'s `visitStatement` / `visitExpression` / `visitX` hooks, guarded by `isScope(...)`. If the targeted element is never *dispatched* to one of those hooks, nothing matches and `apply()` returns the tree unchanged and without complaint.

Callers then do the idiomatic thing and cast the result, and get a `ClassCastException` in a recipe that has nothing to do with the actual defect:

```
class org.openrewrite.kotlin.tree.K$StatementExpression cannot be cast to
class org.openrewrite.java.tree.J$MethodInvocation
```

- The usual cause is a language-module wrapper LST that is "transparent" — its `acceptX` visits its child directly instead of delegating to a `visitX` hook (`K.StatementExpression` (#8325), `K.ExpressionStatement`, `G.ExpressionStatement`, `S.StatementExpression` / `S.ExpressionStatement`). Each occurrence has cost real diagnosis time to trace back to LST dispatch.

### Change

`JavaTemplateLanguageExtension` now tracks whether the mixin ever substituted (the flag already existed as a private field on the anonymous visitor; it just moved up so `JavaTemplate` can read it). `doApply` throws when it comes back `false`:

```
JavaTemplate coordinates were never matched, so the template was not applied: org.openrewrite.kotlin.tree.K$StatementExpression (id=...) at STATEMENT_PREFIX in REPLACEMENT mode.
The `scope` cursor pointed at org.openrewrite.kotlin.tree.K$StatementExpression.
Either the targeted element is not reachable from `scope`, or it is not dispatched to a visitor method and therefore can never be matched.
```

### On the issue's open question ("are there callers that legitimately rely on the silent no-op?")

Empirically, almost none. Across `rewrite-java-test`, `rewrite-kotlin`, `rewrite-groovy`, `rewrite-scala`, `rewrite-maven`, `rewrite-csharp`, `rewrite-gradle` and `rewrite-android`, exactly **one** legitimate case turned up: method invocations inside Javadoc comments, which `visitMethodInvocation` deliberately skips ("we don't have support for changing method references in Javadoc comments (yet)"). Real recipes hit this — `JavaTemplateJavadocTest` is extracted from `MigrateURLDecoderDecode`, which applies a template unconditionally in `visitMethodInvocation` and meets a `@see java.net.URLDecoder#decode(String)` reference. That branch now records the deliberate skip, so it stays a no-op rather than becoming an error.

`JavaTemplate.matches(...)` is unaffected: `JavaTemplateSemanticallyEqual.matchesTemplate` already catches `RuntimeException` and reports no-match.

Given that, this goes in as the default rather than behind a debug flag. `INSERTION`/`BEFORE`/`AFTER` share the same `unsubstitute` bookkeeping and are covered by the same check.

### Verification

`:rewrite-java-test:test :rewrite-groovy:test :rewrite-kotlin:test :rewrite-gradle:test :rewrite-maven:test :rewrite-scala:test :rewrite-csharp:test :rewrite-android:test` — green apart from 73 `rewrite-gradle` failures that are all Maven Central `HTTP 429` rate limiting (`Unable to download metadata`), unrelated to this change and reproducible on `main`.