### PR TITLE
Python: fix match-statement parse desync that corrupts trees over RPC

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -1156,9 +1156,32 @@ class ParserVisitor(ast.NodeVisitor):
 
         # Use __convert_match_pattern to handle parentheses (GROUP patterns)
         pattern = self.__convert_match_pattern(node.pattern)
-        if isinstance(pattern, py.MatchCase) and node.guard:
+        if node.guard:
+            # The guard source (`if <cond>`) must be consumed whenever a guard is present, or the
+            # cursor drifts and every subsequent node is parsed against misaligned text. Value and
+            # capture patterns are returned bare (not wrapped in py.MatchCase), so wrap them here to
+            # give the guard a home — the printer emits LITERAL/VALUE/CAPTURE as the inner element.
             guard = self.__pad_left(self.__source_before('if'), self.__convert(node.guard))
-            pattern = pattern.padding.replace(guard=guard)
+            if isinstance(pattern, py.MatchCase):
+                pattern = pattern.padding.replace(guard=guard)
+            else:
+                kind = (py.MatchCase.Pattern.Kind.CAPTURE if isinstance(node.pattern, ast.MatchAs)
+                        else py.MatchCase.Pattern.Kind.VALUE)
+                pattern = py.MatchCase(
+                    random_id(),
+                    Space.EMPTY,
+                    Markers.EMPTY,
+                    py.MatchCase.Pattern(
+                        random_id(),
+                        Space.EMPTY,
+                        Markers.EMPTY,
+                        kind,
+                        JContainer(Space.EMPTY, [self.__pad_right(pattern, Space.EMPTY)], Markers.EMPTY),
+                        None
+                    ),
+                    guard,
+                    None
+                )
 
         return j.Case(
             random_id(),
@@ -1403,7 +1426,10 @@ class ParserVisitor(ast.NodeVisitor):
                             Markers.EMPTY,
                             cast(j.Identifier, self.__convert_name(kwd)),
                             _EMPTY_LIST,
-                            self.__pad_left(self.__source_before('='), self.__convert(node.kwd_patterns[i])),
+                            # __convert_match_pattern (not __convert) so a parenthesized GROUP value
+                            # like `k=(A() | B())` has its parens consumed — matching positional
+                            # patterns above; __convert alone leaves the parens and drifts the cursor.
+                            self.__pad_left(self.__source_before('='), self.__convert_match_pattern(node.kwd_patterns[i])),
                             None
                         ), Space.EMPTY)
                     ]

--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -1157,10 +1157,6 @@ class ParserVisitor(ast.NodeVisitor):
         # Use __convert_match_pattern to handle parentheses (GROUP patterns)
         pattern = self.__convert_match_pattern(node.pattern)
         if node.guard:
-            # The guard source (`if <cond>`) must be consumed whenever a guard is present, or the
-            # cursor drifts and every subsequent node is parsed against misaligned text. Value and
-            # capture patterns are returned bare (not wrapped in py.MatchCase), so wrap them here to
-            # give the guard a home — the printer emits LITERAL/VALUE/CAPTURE as the inner element.
             guard = self.__pad_left(self.__source_before('if'), self.__convert(node.guard))
             if isinstance(pattern, py.MatchCase):
                 pattern = pattern.padding.replace(guard=guard)
@@ -1426,9 +1422,6 @@ class ParserVisitor(ast.NodeVisitor):
                             Markers.EMPTY,
                             cast(j.Identifier, self.__convert_name(kwd)),
                             _EMPTY_LIST,
-                            # __convert_match_pattern (not __convert) so a parenthesized GROUP value
-                            # like `k=(A() | B())` has its parens consumed — matching positional
-                            # patterns above; __convert alone leaves the parens and drifts the cursor.
                             self.__pad_left(self.__source_before('='), self.__convert_match_pattern(node.kwd_patterns[i])),
                             None
                         ), Space.EMPTY)

--- a/rewrite-python/rewrite/tests/rpc/test_match_guard_desync.py
+++ b/rewrite-python/rewrite/tests/rpc/test_match_guard_desync.py
@@ -1,0 +1,112 @@
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A `case` guard on a value/capture pattern desyncs the parser's source cursor.
+
+Value patterns (`case 1`, `case Enum.X`) and capture patterns (`case v`) are returned bare, so
+visit_match_case never consumed their guard's ` if <cond>` source: the cursor drifted and every
+later node parsed against misaligned text, yielding children with `_id = None`. RpcSendQueue then
+crashes at `el.element._id` on the None child, so the tree transfer fails. `case Enum.X if cond:`
+is idiomatic 3.10+ code, absent from older corpora — which is why it went unnoticed.
+"""
+import ast
+from dataclasses import fields, is_dataclass
+
+from rewrite.python._parser_visitor import ParserVisitor
+from rewrite.python.printer import PythonPrinter
+from rewrite.rpc.python_receiver import PythonRpcReceiver
+from rewrite.rpc.receive_queue import RpcReceiveQueue
+from rewrite.rpc.send_queue import RpcSendQueue
+
+_CU_TYPE = "org.openrewrite.python.tree.Py$CompilationUnit"
+
+# A guarded value pattern (matching the home-assistant / customer construct), then any later node
+# whose children the cursor desync would null out.
+GUARDED = '''\
+def f(x):
+    match x:
+        case 1 if x > 0:
+            pass
+
+def g(y):
+    return y in ("a", "b", "c", "d")
+'''
+
+
+def _parse(src):
+    return ParserVisitor(src, "<m>", None).visit_Module(ast.parse(src))
+
+
+def test_guarded_value_pattern_has_no_null_padded_elements():
+    """No JRightPadded/JLeftPadded may wrap a None element — that is the cursor-desync signature.
+    Walks the raw dataclass tree (padding wrappers aren't visited by the LST visitor)."""
+    cu = _parse(GUARDED)
+
+    bad = []
+    seen = set()
+    stack = [cu]
+    while stack:
+        o = stack.pop()
+        if id(o) in seen:
+            continue
+        seen.add(id(o))
+        if is_dataclass(o):
+            cls = type(o).__name__
+            if cls in ("JRightPadded", "JLeftPadded") and getattr(o, "_element", "x") is None:
+                bad.append(cls)
+            stack.extend(getattr(o, f.name, None) for f in fields(o))
+        elif isinstance(o, (list, tuple)):
+            stack.extend(o)
+    assert not bad, f"cursor desync produced padded wrappers with a None element: {bad}"
+
+
+def test_guarded_value_pattern_round_trips_over_rpc():
+    """The tree must serialise and rebuild — a None child crashes RpcSendQueue at el.element._id."""
+    cu = _parse(GUARDED)
+    data = list(RpcSendQueue(_CU_TYPE).generate(cu, None))
+
+    def pull():
+        out = data[:]
+        data.clear()
+        return out
+
+    rebuilt = PythonRpcReceiver().receive(None, RpcReceiveQueue({}, _CU_TYPE, pull))
+    assert PythonPrinter().print(rebuilt) == PythonPrinter().print(cu)
+
+
+# A parenthesized (GROUP) sub-pattern as a class keyword-argument value. visit_MatchClass used
+# __convert for kwarg values (unlike positional patterns), which doesn't consume the parens — same
+# cursor-drift class as the guard bug, but guard-independent.
+PAREN_KWARG = '''\
+def f(x):
+    match x:
+        case Foo(k=(A() | B())):
+            pass
+
+def g(y):
+    return y in ("a", "b", "c", "d")
+'''
+
+
+def test_parenthesized_class_kwarg_round_trips_over_rpc():
+    cu = _parse(PAREN_KWARG)
+    data = list(RpcSendQueue(_CU_TYPE).generate(cu, None))
+
+    def pull():
+        out = data[:]
+        data.clear()
+        return out
+
+    rebuilt = PythonRpcReceiver().receive(None, RpcReceiveQueue({}, _CU_TYPE, pull))
+    assert PythonPrinter().print(rebuilt) == PythonPrinter().print(cu)


### PR DESCRIPTION
Two spots in the Python `match`-case parser left source unconsumed, drifting the source cursor so every later node parsed against misaligned text and came out with `None` children. `RpcSendQueue` then crashes at `el.element._id` on the `None` child, failing the tree transfer (`handle_get_object` returns a degenerate `[END_OF_OBJECT]`). Because `match`/`case` is Python 3.10+ and absent from older codebases, the defect only surfaces on modernized code.

## Fixes (both in `_parser_visitor.py`)

- **Guards on value/capture patterns** (`case 1 if x:`, `case Enum.X if x:`, `case v if x:`): the guard source (`if <cond>`) was consumed only when the pattern wrapped as `py.MatchCase`. Value and capture patterns are returned bare, so the guard text stayed in the buffer. Consume it unconditionally and wrap the bare pattern in `py.MatchCase(VALUE/CAPTURE)` so the guard has a home. The existing `py.MatchCase` codec (Python and Java) and printer already handle these kinds — no model or codec change needed.
- **Parenthesized GROUP as a class keyword value** (`case Foo(k=(A() | B())):`): keyword patterns used `__convert` (which does not consume parens) while positional patterns used `__convert_match_pattern`. Use the latter for both, consistent with positional handling.

## Verification

- New regression tests (`tests/rpc/test_match_guard_desync.py`) cover both shapes end-to-end (parse → `RpcSendQueue` → `RpcReceiveQueue` → print), asserting no `None`-element padding and a clean round-trip.
- Serialize→deserialize→print round-trip run over 20,635 real files (numpy, home-assistant, ansible, botocore): **3 crashing files → 0**, no regressions, existing `match`/pattern suite green.