### PR TITLE
Do not treat missing type attribution as proof of semantic equality

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/search/SemanticallyEqualTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/search/SemanticallyEqualTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.search;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Issue;
+import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.search.SemanticallyEqual;
+import org.openrewrite.java.tree.J;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Groovy parser does not attribute {@link J.Identifier#getFieldType()} on references, so these cases exercise
+ * what {@code SemanticallyEqual} may conclude when type information is systemically absent rather than merely missing.
+ */
+class SemanticallyEqualTest {
+
+    @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+    @Test
+    void fieldNotEqualToShadowedNameVariable() {
+        J.Assignment assignment = firstAssignment("""
+          class A {
+              private final boolean readOnly
+              A(boolean readOnly) {
+                  this.readOnly = readOnly
+              }
+          }
+          """);
+        assertThat(SemanticallyEqual.areEqual(assignment.getVariable(), assignment.getAssignment())).isFalse();
+        assertThat(SemanticallyEqual.areEqual(assignment.getAssignment(), assignment.getVariable())).isFalse();
+    }
+
+    @Test
+    void identifiersWithSameNameRemainEqual() {
+        J.Assignment assignment = firstAssignment("""
+          class A {
+              void m(boolean readOnly) {
+                  readOnly = readOnly
+              }
+          }
+          """);
+        assertThat(SemanticallyEqual.areEqual(assignment.getVariable(), assignment.getAssignment())).isTrue();
+    }
+
+    private J.Assignment firstAssignment(String source) {
+        G.CompilationUnit cu = GroovyParser.builder().build()
+          .parse(new InMemoryExecutionContext(), source)
+          .findFirst()
+          .map(G.CompilationUnit.class::cast)
+          .orElseThrow();
+        J.ClassDeclaration clazz = (J.ClassDeclaration) cu.getStatements().getFirst();
+        J.MethodDeclaration method = (J.MethodDeclaration) clazz.getBody().getStatements().stream()
+          .filter(J.MethodDeclaration.class::isInstance)
+          .findFirst()
+          .orElseThrow();
+        return (J.Assignment) method.getBody().getStatements().getFirst();
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/SemanticallyEqualTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.ExpectedToFail;
 import org.junitpioneer.jupiter.cartesian.CartesianTest;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.java.tree.J;
@@ -434,6 +435,33 @@ class SemanticallyEqualTest {
             J.Assignment a = (J.Assignment) m.getBody().getStatements().getFirst();
             assertFalse(SemanticallyEqual.areEqual(a.getVariable(), a.getAssignment()));
             assertFalse(SemanticallyEqual.areEqual(((J.FieldAccess) a.getVariable()).getName(), a.getAssignment()));
+        }
+
+        @Issue("https://github.com/openrewrite/rewrite-static-analysis/issues/953")
+        @Test
+        void fieldNotEqualToShadowedNameVariableWithoutTypeAttribution() {
+            J.CompilationUnit cu = javaParser.parse(
+                """
+                  class T {
+                      int a = 1;
+                      void m(int a) {
+                          this.a = a;
+                      }
+                  }
+                  """
+              ).findFirst()
+              .map(J.CompilationUnit.class::cast)
+              .get();
+            J.CompilationUnit unattributed = (J.CompilationUnit) new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.Identifier visitIdentifier(J.Identifier identifier, Integer p) {
+                    return identifier.withFieldType(null).withType(null);
+                }
+            }.visitNonNull(cu, 0);
+            J.MethodDeclaration m = (J.MethodDeclaration) unattributed.getClasses().getFirst().getBody().getStatements().get(1);
+            J.Assignment a = (J.Assignment) m.getBody().getStatements().getFirst();
+            assertFalse(SemanticallyEqual.areEqual(a.getVariable(), a.getAssignment()));
+            assertFalse(SemanticallyEqual.areEqual(a.getAssignment(), a.getVariable()));
         }
 
         @Test

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/SemanticallyEqual.java
@@ -608,10 +608,14 @@ public class SemanticallyEqual {
                         !isOfType(fieldType, ((J.Identifier) j).getFieldType()) ||
                         !fieldAccess.getSimpleName().equals(((J.Identifier) j).getSimpleName())) {
                         isEqual.set(false);
-                    } else {
-                        if (fieldType != null && !fieldType.hasFlags(Flag.Static)) {
+                    } else if (fieldType == null) {
+                        // A null field type is either a type reference (`java.util.regex.Pattern` vs `Pattern`)
+                        // or a variable whose type attribution is missing; only the former is safe to compare by name.
+                        if (!isTypeReference(fieldAccess.getName()) || !isTypeReference((J.Identifier) j)) {
                             isEqual.set(false);
                         }
+                    } else if (!fieldType.hasFlags(Flag.Static)) {
+                        isEqual.set(false);
                     }
                     return fieldAccess;
                 }
@@ -710,6 +714,10 @@ public class SemanticallyEqual {
                     // Consider implicit-this "a" equivalent to "this.a"
                     // Definitely does not account for every possible edge case around "this", but handles the common case
                     if (fieldTarget instanceof J.Identifier && "this".equals(((J.Identifier) fieldTarget).getSimpleName())) {
+                        if (identifier.getFieldType() == null || field.getName().getFieldType() == null) {
+                            isEqual.set(false);
+                            return identifier;
+                        }
                         visit(identifier, field.getName());
                         return identifier;
                     }
@@ -1559,6 +1567,12 @@ public class SemanticallyEqual {
                 }
             }
             return firstTypeName;
+        }
+
+        private static boolean isTypeReference(J.Identifier identifier) {
+            return identifier.getFieldType() == null &&
+                   identifier.getType() instanceof JavaType.FullyQualified &&
+                   !(identifier.getType() instanceof JavaType.Unknown);
         }
 
         protected boolean isOfType(JavaType target, JavaType source) {


### PR DESCRIPTION
- Fixes the `SemanticallyEqual` half of openrewrite/rewrite-static-analysis#953.

### Problem

`SemanticallyEqual` considered `this.x` and a bare `x` equal whenever both sides lacked a `JavaType.Variable`, because `TypeUtils.isOfType(null, null)` is `true`. On an LST with incomplete type attribution a constructor's `this.x = x` therefore looks like a self-assignment, and `RemoveSelfAssignment` deletes it — 852 files across 83 repositories in the Netflix + Spring + Apache run, and where the field is `private final` the output no longer compiles.

Two paths reach it:

- `visitFieldAccess` (the order `RemoveSelfAssignment` uses) guarded on `fieldType != null && !fieldType.hasFlags(Static)`, so a null field type skipped the guard entirely.
- the implicit-`this` shortcut in `visitIdentifier`, which recurses into an identifier-vs-identifier comparison that distinguishes a field from a parameter only by field type.

### Fix

`this.x` is equivalent to `x` only when `x` resolves to the field rather than to a shadowing parameter or local. That cannot be established without type information *in any language*, so both directions of the `J.FieldAccess` / `J.Identifier` comparison now require a field type on both sides.

The carve-out that matters: a null field type on a `J.FieldAccess` name also means "type reference" (`java.util.regex.Pattern` vs `Pattern`, `java.lang.String.class` vs `String.class`), where null is expected rather than missing. Those keep comparing by name.

Comparisons between two identifiers are untouched and still fall back to name equality — that is what languages which never attribute field types rely on, so this is not a coverage regression for them.

### Why this is not Java-only

The Groovy parser passes `null` for `fieldType` at essentially every reference site (`GroovyParserVisitor` `visitVariableExpression`, parameters, `visitPropertyExpression`), so Groovy hit this bug unconditionally — a plain `this.readOnly = readOnly` in a Groovy constructor compared equal before this change. The new `rewrite-groovy` test covers both that case and the identifier-vs-identifier fallback that must keep working.

### Tests

- `SemanticallyEqualTest.fieldNotEqualToShadowedNameVariableWithoutTypeAttribution` (rewrite-java-test) — strips `fieldType`/`type` off identifiers to simulate an LST where attribution did not complete, since `JavaParser` in the test harness always attributes fully. This is why the existing `RemoveSelfAssignment` test suite could not reproduce the bug.
- `org.openrewrite.groovy.search.SemanticallyEqualTest` (new) — the natural reproduction, plus the fallback that must stay `true`.

Both fail on `main` and pass here. `:rewrite-java:test`, `:rewrite-java-test:test`, `:rewrite-java-tck:test`, `:rewrite-groovy:test` and `:rewrite-kotlin:test` are green.

### Follow-ups (not in this PR)

Tracked downstream in openrewrite/rewrite-static-analysis#953; none of this belongs in rewrite-java.

- **Verifying `RemoveSelfAssignment` needs a real LST.** Green unit tests are not evidence here — `RewriteTest`/`JavaParser` always attribute fully, which is why the recipe's own `doNotChangeFieldAssignedFromParameter` passed the whole time the bug was live. The check that works is `mod build` over a repo with unresolved dependencies and reading `fix.patch` (`apache/geronimo-specs`: 193 files, expected 0 after this change), or a unit test that strips attribution the way the new test here does.
- **`CombineSemanticallyEqualCatchBlocks$CommentVisitor` does *not* need this change**, despite the "apply bug fixes here too" note on `SemanticallyEqual`'s javadoc. Its `visitFieldAccess`/`visitIdentifier` require both sides to be the same node type, so it has neither the cross-shape branch nor the implicit-`this` shortcut that were unsound here.
- **A residual hole remains that this PR cannot close.** Two bare identifiers with the same name and no type information on either side are genuinely indistinguishable, so a field and a same-named local still compare equal. That is where a `NoMissingTypes` precondition on the deletion-gating recipes would help — 17 recipes in rewrite-static-analysis call `SemanticallyEqual` and none has one. Worth triaging by exposure rather than applying uniformly: `FindMissingTypes` has no language gate, so such a precondition flags Groovy identifiers en masse and silently disables the recipe for Groovy, and for C#/Python LSTs parsed without a semantic model or `ty` server.
- **The real fix for "missing vs systemically absent" is a signal on the LST.** Today there is none: neither `SourceFile` nor `JavaSourceFile` exposes a language id, no parser emits a "types unavailable" marker, and `TreeVisitor#getLanguage()` lives on the visitor (and `JavaScriptVisitor` returns `"org/openrewrite/javascript"`, which looks like a bug). Both the Python and C# parsers already know at parse time that they are degrading to all-null and could record it.
