### PR TITLE
Restore class loader aware `JavaParser.runtimeClasspath()`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -32,6 +32,8 @@ import org.openrewrite.test.RewriteTest;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -182,6 +184,27 @@ class JavaParserTest implements RewriteTest {
         ctx.setParserClasspathDownloadTarget(updatedTemp.toFile());
         ctx.getParserClasspathDownloadTarget();
         assertThat(updatedTemp.toFile().exists()).isTrue();
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8334")
+    @Test
+    void runtimeClasspathIncludesIsolatedClassLoaderEntries(@TempDir Path temp) throws Exception {
+        // Build tools load recipe artifacts into a class loader of their own, which is never reflected in `java.class.path`
+        Path recipeJar = Files.createFile(temp.resolve("recipe-artifact-1.0.jar"));
+        ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
+        Thread.currentThread().setContextClassLoader(
+          new URLClassLoader(new URL[]{recipeJar.toUri().toURL()}, originalTccl));
+        try {
+            assertThat(JavaParser.runtimeClasspath())
+              .contains(recipeJar)
+              .containsAll(Stream.of(System.getProperty("java.class.path").split(System.getProperty("path.separator")))
+                .map(Paths::get)
+                .filter(Files::exists)
+                .toList());
+            assertThat(JavaParser.dependenciesFromClasspath("recipe-artifact")).containsExactly(recipeJar);
+        } finally {
+            Thread.currentThread().setContextClassLoader(originalTccl);
+        }
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/3222")

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaParserTest.java
@@ -189,7 +189,7 @@ class JavaParserTest implements RewriteTest {
     @Issue("https://github.com/openrewrite/rewrite/issues/8334")
     @Test
     void runtimeClasspathIncludesIsolatedClassLoaderEntries(@TempDir Path temp) throws Exception {
-        // Build tools load recipe artifacts into a class loader of their own, which is never reflected in `java.class.path`
+        // Build tools load recipe artifacts into their own class loader, never reflected in `java.class.path`
         Path recipeJar = Files.createFile(temp.resolve("recipe-artifact-1.0.jar"));
         ClassLoader originalTccl = Thread.currentThread().getContextClassLoader();
         Thread.currentThread().setContextClassLoader(

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -31,6 +31,8 @@ import org.openrewrite.style.NamedStyles;
 import java.io.ByteArrayInputStream;
 import java.lang.reflect.Method;
 import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,6 +46,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
@@ -418,25 +421,64 @@ public interface JavaParser extends Parser {
 
 @UtilityClass
 class RuntimeClasspathCache {
-    @Nullable
-    private static volatile List<Path> runtimeClasspath = null;
+    private static final Map<ClassLoader, List<Path>> runtimeClasspaths = new WeakHashMap<>();
 
     static List<Path> getRuntimeClasspath() {
-        List<Path> paths = runtimeClasspath;
-        if (paths == null) {
-            synchronized (RuntimeClasspathCache.class) {
-                paths = runtimeClasspath;
-                if (paths == null) {
-                    String cp = System.getProperty("java.class.path");
-                    runtimeClasspath = paths = cp == null ? Collections.emptyList() :
-                            Arrays.stream(cp.split(System.getProperty("path.separator")))
-                                    .map(Paths::get)
-                                    .filter(Files::exists)
-                                    .collect(toList());
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        ClassLoader key = contextClassLoader == null ? RuntimeClasspathCache.class.getClassLoader() : contextClassLoader;
+        synchronized (RuntimeClasspathCache.class) {
+            List<Path> paths = runtimeClasspaths.get(key);
+            if (paths == null) {
+                paths = discover(contextClassLoader);
+                runtimeClasspaths.put(key, paths);
+            }
+            return paths;
+        }
+    }
+
+    private static List<Path> discover(@Nullable ClassLoader contextClassLoader) {
+        Set<Path> paths = new LinkedHashSet<>();
+
+        // On Java 9+ the application class loader is not a URLClassLoader, so its entries are
+        // only reachable through this system property.
+        String cp = System.getProperty("java.class.path");
+        if (cp != null) {
+            for (String entry : cp.split(System.getProperty("path.separator"))) {
+                addIfExists(paths, Paths.get(entry));
+            }
+        }
+
+        // Build tools load their plugins, and any recipe artifacts those plugins resolve, into
+        // isolated class loaders whose entries never appear on `java.class.path`.
+        addClassLoaderEntries(paths, contextClassLoader);
+        addClassLoaderEntries(paths, RuntimeClasspathCache.class.getClassLoader());
+
+        return unmodifiableList(new ArrayList<>(paths));
+    }
+
+    private static void addClassLoaderEntries(Set<Path> paths, @Nullable ClassLoader classLoader) {
+        Deque<ClassLoader> hierarchy = new ArrayDeque<>();
+        for (ClassLoader cl = classLoader; cl != null; cl = cl.getParent()) {
+            hierarchy.addFirst(cl);
+        }
+        for (ClassLoader cl : hierarchy) {
+            if (cl instanceof URLClassLoader) {
+                for (URL url : ((URLClassLoader) cl).getURLs()) {
+                    if ("file".equals(url.getProtocol())) {
+                        try {
+                            addIfExists(paths, Paths.get(url.toURI()));
+                        } catch (Exception ignored) {
+                        }
+                    }
                 }
             }
         }
-        return paths;
+    }
+
+    private static void addIfExists(Set<Path> paths, Path path) {
+        if (Files.exists(path)) {
+            paths.add(path);
+        }
     }
 }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaParser.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.style.NamedStyles;
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URL;
@@ -46,6 +47,7 @@ import java.util.stream.Stream;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Collections.synchronizedMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
@@ -421,19 +423,21 @@ public interface JavaParser extends Parser {
 
 @UtilityClass
 class RuntimeClasspathCache {
-    private static final Map<ClassLoader, List<Path>> runtimeClasspaths = new WeakHashMap<>();
+    private static final Map<ClassLoader, List<Path>> runtimeClasspaths = synchronizedMap(new WeakHashMap<>());
 
     static List<Path> getRuntimeClasspath() {
         ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
-        ClassLoader key = contextClassLoader == null ? RuntimeClasspathCache.class.getClassLoader() : contextClassLoader;
-        synchronized (RuntimeClasspathCache.class) {
-            List<Path> paths = runtimeClasspaths.get(key);
-            if (paths == null) {
-                paths = discover(contextClassLoader);
-                runtimeClasspaths.put(key, paths);
+        ClassLoader key = contextClassLoader == null ?
+                RuntimeClasspathCache.class.getClassLoader() : contextClassLoader;
+        List<Path> paths = runtimeClasspaths.get(key);
+        if (paths == null) {
+            paths = discover(contextClassLoader);
+            List<Path> raced = runtimeClasspaths.putIfAbsent(key, paths);
+            if (raced != null) {
+                paths = raced;
             }
-            return paths;
         }
+        return paths;
     }
 
     private static List<Path> discover(@Nullable ClassLoader contextClassLoader) {
@@ -443,7 +447,7 @@ class RuntimeClasspathCache {
         // only reachable through this system property.
         String cp = System.getProperty("java.class.path");
         if (cp != null) {
-            for (String entry : cp.split(System.getProperty("path.separator"))) {
+            for (String entry : cp.split(File.pathSeparator)) {
                 addIfExists(paths, Paths.get(entry));
             }
         }


### PR DESCRIPTION
- Fixes #8334

### Problem

- Since #7338 (`8.80.0`) `JavaParser.runtimeClasspath()` derived the classpath solely from the `java.class.path` system property. That property only holds the JVM's *initial* classpath. Inside a Maven JVM that is a single jar:

```
java.class.path=.../plexus-classworlds-2.11.0.jar
```

Everything Maven loads — the plugin, its dependencies, and the recipe artifacts `rewrite-maven-plugin` resolves from `rewrite.recipeArtifactCoordinates` and merges into its `ClassRealm` — lives in a `URLClassLoader` that is invisible to that property.

rewrite-templating emits this for every Refaster `@BeforeTemplate`:

```java
JavaTemplate.builder("com.acme.FooBarUtils.isEmpty(#{value:any(java.lang.String)})")
        .javaParser(JavaParser.fromJavaVersion().classpath(JavaParser.runtimeClasspath()))
        .build();
```

With an empty classpath the stub fails type attribution, `matcher.find()` never matches, and the recipe **silently no-ops**. Paired with a `RemoveDependency` in the same recipe list, the user gets a tree that no longer declares the dependency but still calls into it — output that does not compile, with nothing logged.

### Fix

`RuntimeClasspathCache` now walks the class loader hierarchy of both the thread context class loader and the class loader that loaded `JavaParser`, collecting `file:` URLs from every `URLClassLoader` (plexus' `ClassRealm` and Gradle's loaders both qualify), in addition to `java.class.path` — which is still needed because the application class loader is not a `URLClassLoader` on Java 9+. This restores the pre-`8.80.0` reach of the ClassGraph based discovery without reintroducing the dependency.

Entries are cached per class loader rather than in a single static field, since the context class loader varies across recipe runs.

### Test

`JavaParserTest#runtimeClasspathIncludesIsolatedClassLoaderEntries` puts a jar behind a `URLClassLoader` that is not on `java.class.path` and asserts it shows up in `runtimeClasspath()` and `dependenciesFromClasspath(...)`. Verified red before the change, green after; the rest of `:rewrite-java-test:test` stays green.

Not addressed here: the issue's secondary suggestion to warn when a `JavaTemplate` stub fails to type-attribute, so this class of failure is loud rather than silent.