### PR TITLE
Prefer PATH over well-known install directories in GoExecutor.find()

### DIFF
--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/GoExecutor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/GoExecutor.java
@@ -112,12 +112,8 @@ public final class GoExecutor {
     }
 
     /**
-     * {@code PATH} is searched ahead of the well-known install directories because callers hand the
-     * resolved binary's {@code GOROOT} to child processes that go on to invoke a bare {@code go} of
-     * their own. Preferring a fixed location such as {@code /usr/bin/go} pairs that child's {@code go}
-     * with a {@code GOROOT} from whichever release happens to sit there, and the toolchain rejects the
-     * mismatch with {@code compile: version "goX" does not match go tool version "goY"}. An explicit
-     * {@code GOROOT} still wins, since child processes inherit it.
+     * {@code PATH} is searched ahead of the well-known install directories so the resolved binary matches the
+     * bare {@code go} that child processes invoke; otherwise the toolchain rejects the {@code GOROOT} mismatch.
      */
     @Nullable String find(@Nullable String goRoot, @Nullable String pathEnv, Predicate<Path> isExecutable) {
         String exe = IS_WINDOWS ? name + ".exe" : name;

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/GoExecutor.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/GoExecutor.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -31,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 
 /**
  * Locates and runs the {@code go} toolchain. Mirrors the Python/JavaScript
@@ -103,15 +105,32 @@ public final class GoExecutor {
      * installed or not on {@code PATH}.
      */
     public @Nullable String find() {
-        if (cachedPath != null) {
-            return cachedPath;
+        if (cachedPath == null) {
+            cachedPath = find(System.getenv("GOROOT"), System.getenv("PATH"), Files::isExecutable);
         }
+        return cachedPath;
+    }
 
+    /**
+     * {@code PATH} is searched ahead of the well-known install directories because callers hand the
+     * resolved binary's {@code GOROOT} to child processes that go on to invoke a bare {@code go} of
+     * their own. Preferring a fixed location such as {@code /usr/bin/go} pairs that child's {@code go}
+     * with a {@code GOROOT} from whichever release happens to sit there, and the toolchain rejects the
+     * mismatch with {@code compile: version "goX" does not match go tool version "goY"}. An explicit
+     * {@code GOROOT} still wins, since child processes inherit it.
+     */
+    @Nullable String find(@Nullable String goRoot, @Nullable String pathEnv, Predicate<Path> isExecutable) {
         String exe = IS_WINDOWS ? name + ".exe" : name;
         List<String> locations = new ArrayList<>();
-        String goRoot = System.getenv("GOROOT");
         if (goRoot != null && !goRoot.trim().isEmpty()) {
-            locations.add(goRoot + (IS_WINDOWS ? "\\bin\\" : "/bin/") + exe);
+            locations.add(goRoot.trim() + (IS_WINDOWS ? "\\bin\\" : "/bin/") + exe);
+        }
+        if (pathEnv != null) {
+            for (String entry : pathEnv.split(File.pathSeparator)) {
+                if (!entry.trim().isEmpty()) {
+                    locations.add(entry.trim() + File.separator + exe);
+                }
+            }
         }
         if (IS_WINDOWS) {
             locations.add("C:\\Program Files\\Go\\bin\\" + exe);
@@ -125,31 +144,9 @@ public final class GoExecutor {
 
         for (String location : locations) {
             Path path = Paths.get(location);
-            if (Files.isExecutable(path)) {
-                cachedPath = path.toAbsolutePath().toString();
-                return cachedPath;
+            if (isExecutable.test(path)) {
+                return path.toAbsolutePath().toString();
             }
-        }
-
-        try {
-            ProcessBuilder pb = new ProcessBuilder(IS_WINDOWS ? "where" : "which", exe);
-            pb.redirectErrorStream(true);
-            Process process = pb.start();
-            String first = null;
-            try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream(), StandardCharsets.UTF_8))) {
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    if (first == null && !line.trim().isEmpty()) {
-                        first = line.trim();
-                    }
-                }
-            }
-            if (process.waitFor() == 0 && first != null) {
-                cachedPath = first;
-                return cachedPath;
-            }
-        } catch (IOException | InterruptedException e) {
-            // Ignore
         }
 
         return null;

--- a/rewrite-go/src/test/java/org/openrewrite/golang/internal/GoExecutorTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/internal/GoExecutorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisabledOnOs(OS.WINDOWS)
+class GoExecutorTest {
+
+    private static final String TOOLCHAIN = "/opt/hostedtoolcache/go/1.25.12/x64";
+
+    private static Predicate<Path> installedAt(String... paths) {
+        Set<String> installed = Set.of(paths);
+        return path -> installed.contains(path.toString());
+    }
+
+    @Test
+    void pathBeatsWellKnownInstallLocations() {
+        // The GitHub Actions layout that broke Go recipe doc generation: the image's default Go is
+        // symlinked into /usr/bin, and actions/setup-go prepends a newer toolchain to PATH.
+        assertThat(GoExecutor.GO.find(null, TOOLCHAIN + "/bin:/usr/local/bin:/usr/bin",
+          installedAt(TOOLCHAIN + "/bin/go", "/usr/bin/go")))
+          .isEqualTo(TOOLCHAIN + "/bin/go");
+    }
+
+    @Test
+    void explicitGoRootBeatsPath() {
+        assertThat(GoExecutor.GO.find(TOOLCHAIN, "/usr/bin",
+          installedAt(TOOLCHAIN + "/bin/go", "/usr/bin/go")))
+          .isEqualTo(TOOLCHAIN + "/bin/go");
+    }
+
+    @Test
+    void wellKnownInstallLocationsAreATailFallback() {
+        assertThat(GoExecutor.GO.find(null, "/usr/local/sbin", installedAt("/usr/local/go/bin/go")))
+          .isEqualTo("/usr/local/go/bin/go");
+    }
+
+    @Test
+    void blankGoRootAndEmptyPathEntriesAreSkipped() {
+        assertThat(GoExecutor.GO.find("  ", "::" + TOOLCHAIN + "/bin:", installedAt(TOOLCHAIN + "/bin/go")))
+          .isEqualTo(TOOLCHAIN + "/bin/go");
+    }
+
+    @Test
+    void nullWhenGoIsNotInstalled() {
+        assertThat(GoExecutor.GO.find(null, "/usr/bin", installedAt())).isNull();
+    }
+}


### PR DESCRIPTION
## Problem

`GoExecutor.find()` resolves `go` by trying fixed absolute paths — `$GOROOT/bin/go`, `/usr/local/go/bin/go`, `/opt/homebrew/bin/go`, `/usr/local/bin/go`, `/usr/bin/go` — and only falls back to `which go` if none exist. On a host with more than one Go install, that picks whichever release happens to sit in a fixed location instead of the one a child process would actually get from `PATH`.

That matters because the resolved path is not just used to run `go`. `GoRewriteRpc.ensureGoRoot` derives `GOROOT` from it and injects it into the `rewrite-go-rpc` child process, and the RPC server's installer then runs a bare `exec.Command("go", "build", ...)` resolved from `PATH`. When the two disagree the toolchain refuses:

```
compile: version "go1.24.13" does not match go tool version "go1.25.12"
```

This is not hypothetical. It silently emptied the Go recipe catalog on docs.moderne.io: GitHub's ubuntu image symlinks its default Go into `/usr/bin`, `actions/setup-go` prepends a newer toolchain to `PATH`, so `find()` returned the 1.24.13 binary while the RPC server built with 1.25.12. Every recipe-module install failed, `GoRecipeLoader` logged a warning and returned an empty list, and the docs job — which replaces the catalog wholesale — deleted all 187 `recipes-go` pages across two green runs before anyone noticed.

## Fix

Reorder to: explicit `GOROOT` → `PATH` → well-known directories.

* `GOROOT` stays first because child processes inherit it, so it is the one setting that keeps parent and child consistent by construction.
* `PATH` now beats the fixed locations, matching what a bare `go` in a child process resolves to.
* The well-known directories remain as a tail fallback, which is what they are actually for — GUI-launched processes (IDE plugins started from Finder or the dock) that have no useful `PATH`.

Scanning `PATH` directly also lets the `which`/`where` subprocess go away, and makes the resolution order a pure function of `(GOROOT, PATH, isExecutable)` so it can be tested.

## Testing

New `GoExecutorTest` covers the ordering with an injected executable-lookup predicate. `pathBeatsWellKnownInstallLocations` reproduces the exact GitHub Actions layout and fails against the previous ordering — I verified that by temporarily restoring the old precedence:

```
GoExecutorTest > pathBeatsWellKnownInstallLocations() FAILED
5 tests completed, 1 failed
```

`:rewrite-go:test --tests "org.openrewrite.golang.internal.*"` and `:rewrite-go:license` pass.

## Risk

Behavior only changes on hosts where `go` resolves differently through `PATH` than through the fixed locations — precisely the case that is broken today. Single-install hosts resolve to the same binary either way. Dropping `which` is not a behavior change: `which` scans `PATH` and does not expand shell aliases or functions.