### PR TITLE
Surface RPC subprocess stderr instead of discarding it

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -132,7 +132,7 @@ public class RewriteRpcProcess extends Thread {
             // parent-side file handle after process termination, preventing deletion
             // of the log file.  Instead we drain stderr in a daemon thread.
             process = pb.start();
-            stderrDrainThread = drainStderr(process, stderrRedirect, stderrTail);
+            stderrDrainThread = drainStderr(process, stderrRedirect, stderrTail, mirrorStderrToConsole());
         } catch (IOException e) {
             // Record the failure so start() can surface it instead of busy-waiting forever
             // on `process == null`. Throwing here would just kill this thread silently.
@@ -140,7 +140,21 @@ public class RewriteRpcProcess extends Thread {
         }
     }
 
-    private static Thread drainStderr(Process process, @Nullable Path stderrRedirect, StderrTail stderrTail) {
+    /**
+     * Opt-in stderr mirroring ({@code REWRITE_RPC_STDERR=console}): forward everything the
+     * subprocess writes to stderr on to the parent's own stderr, on top of the bounded tail
+     * {@link #getLivenessCheck()} always retains. Use when the tail isn't enough — a server
+     * that fails after logging heavily, or one that misbehaves without ever exiting, so
+     * there is no liveness check to attach the tail to. Set it in CI to capture the full
+     * stream without a code change in the repo under test.
+     */
+    private static boolean mirrorStderrToConsole() {
+        String stderrEnv = System.getenv("REWRITE_RPC_STDERR");
+        return stderrEnv != null && "console".equalsIgnoreCase(stderrEnv.trim());
+    }
+
+    private static Thread drainStderr(Process process, @Nullable Path stderrRedirect, StderrTail stderrTail,
+                                      boolean mirrorToConsole) {
         Thread thread = new Thread(() -> {
             byte[] buf = new byte[8192];
             try (InputStream stderr = process.getErrorStream()) {
@@ -150,6 +164,12 @@ public class RewriteRpcProcess extends Thread {
                     int n;
                     while ((n = stderr.read(buf)) != -1) {
                         stderrTail.append(buf, n);
+                        if (mirrorToConsole) {
+                            // Flush per chunk; an unflushed buffer is lost if the JVM is killed,
+                            // which is exactly when this output matters most.
+                            System.err.write(buf, 0, n);
+                            System.err.flush();
+                        }
                         if (out != null) {
                             out.write(buf, 0, n);
                         }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -52,6 +53,8 @@ import static org.openrewrite.internal.StringUtils.readFully;
  * A client for spawning and communicating with a subprocess that implements Rewrite RPC.
  */
 public class RewriteRpcProcess extends Thread {
+    private static final int STDERR_TAIL_BYTES = 8 * 1024;
+
     private final String[] command;
 
     @Setter
@@ -79,6 +82,8 @@ public class RewriteRpcProcess extends Thread {
 
     @Nullable
     private Thread stderrDrainThread;
+
+    private final StderrTail stderrTail = new StderrTail();
 
     @Nullable
     private Thread rssSamplerThread;
@@ -127,7 +132,7 @@ public class RewriteRpcProcess extends Thread {
             // parent-side file handle after process termination, preventing deletion
             // of the log file.  Instead we drain stderr in a daemon thread.
             process = pb.start();
-            stderrDrainThread = drainStderr(process, stderrRedirect);
+            stderrDrainThread = drainStderr(process, stderrRedirect, stderrTail);
         } catch (IOException e) {
             // Record the failure so start() can surface it instead of busy-waiting forever
             // on `process == null`. Throwing here would just kill this thread silently.
@@ -135,22 +140,23 @@ public class RewriteRpcProcess extends Thread {
         }
     }
 
-    private static Thread drainStderr(Process process, @Nullable Path stderrRedirect) {
+    private static Thread drainStderr(Process process, @Nullable Path stderrRedirect, StderrTail stderrTail) {
         Thread thread = new Thread(() -> {
             byte[] buf = new byte[8192];
             try (InputStream stderr = process.getErrorStream()) {
-                if (stderrRedirect != null) {
-                    try (OutputStream out = Files.newOutputStream(stderrRedirect,
-                            StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
-                        int n;
-                        while ((n = stderr.read(buf)) != -1) {
+                OutputStream out = stderrRedirect == null ? null : Files.newOutputStream(stderrRedirect,
+                        StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+                try {
+                    int n;
+                    while ((n = stderr.read(buf)) != -1) {
+                        stderrTail.append(buf, n);
+                        if (out != null) {
                             out.write(buf, 0, n);
                         }
                     }
-                } else {
-                    //noinspection StatementWithEmptyBody
-                    while (stderr.read(buf) != -1) {
-                        // discard
+                } finally {
+                    if (out != null) {
+                        out.close();
                     }
                 }
             } catch (IOException ignored) {
@@ -178,9 +184,26 @@ public class RewriteRpcProcess extends Thread {
                 // Ignore errors reading final stdout
             }
 
+            // The subprocess is already dead, so stderr is at (or about to reach) EOF.
+            // Give the drain thread a moment to observe it, otherwise the very output
+            // that explains the exit code can still be in flight.
+            Thread drainThread = stderrDrainThread;
+            if (drainThread != null) {
+                try {
+                    drainThread.join(TimeUnit.SECONDS.toMillis(1));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            String stdError = stderrTail.toString();
+
             String message = "RPC process shut down early with exit code " + exitCode;
             if (!stdOutput.isEmpty()) {
                 message += "\nStandard output:\n  " + stdOutput.replace("\n", "\n  ");
+            }
+            if (!stdError.isEmpty()) {
+                message += "\nStandard error (last " + STDERR_TAIL_BYTES + " bytes):\n  " +
+                           stdError.replace("\n", "\n  ");
             }
             if (stderrRedirect != null) {
                 message += "\nSee stderr log: " + stderrRedirect;
@@ -188,6 +211,43 @@ public class RewriteRpcProcess extends Thread {
             return new IllegalStateException(message.trim());
         }
         return null;
+    }
+
+    /**
+     * A fixed-size ring buffer over the tail of the subprocess's stderr. The drain
+     * thread has to consume stderr eagerly to keep the subprocess from blocking on a
+     * full pipe, so without retaining some of it here a crash surfaces as nothing but
+     * an exit code — the diagnostic is read and thrown away. Bounded because stderr is
+     * unbounded and a server that logs steadily would otherwise be retained in full.
+     */
+    private static class StderrTail {
+        private final byte[] buffer = new byte[STDERR_TAIL_BYTES];
+        private int size;
+        private int next;
+
+        synchronized void append(byte[] b, int len) {
+            // Anything before this was already overwritten by the tail of the same chunk.
+            for (int i = Math.max(0, len - buffer.length); i < len; i++) {
+                buffer[next] = b[i];
+                next = (next + 1) % buffer.length;
+                if (size < buffer.length) {
+                    size++;
+                }
+            }
+        }
+
+        @Override
+        public synchronized String toString() {
+            if (size == 0) {
+                return "";
+            }
+            byte[] ordered = new byte[size];
+            int start = size < buffer.length ? 0 : next;
+            for (int i = 0; i < size; i++) {
+                ordered[i] = buffer[(start + i) % buffer.length];
+            }
+            return new String(ordered, StandardCharsets.UTF_8);
+        }
     }
 
     @Override

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -21,6 +21,7 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -164,6 +165,111 @@ class RewriteRpcProcessTest {
                 assertThatThrownBy(process::start)
                         .isInstanceOf(UncheckedIOException.class)
                         .hasMessageContaining(missing));
+    }
+
+    /**
+     * When the subprocess dies, its stderr is the only thing that explains why. The drain
+     * thread has to consume stderr eagerly to keep the subprocess off a full pipe, so
+     * unless a tail is retained the diagnostic is read and discarded and the failure
+     * surfaces as a bare exit code — see the recurring {@code RPC process shut down early
+     * with exit code 217/1/127} failures in rewrite-static-analysis CI, which had no
+     * attributable cause for exactly this reason.
+     */
+    @Test
+    void livenessCheckReportsSubprocessStderr() throws Exception {
+        // given: a subprocess that reports a startup failure on stderr and exits non-zero
+        RewriteRpcProcess process = new RewriteRpcProcess(
+                System.getProperty("java.home") + "/bin/java",
+                "-cp", System.getProperty("java.class.path"),
+                StderrThenExitEntryPoint.class.getName());
+        try {
+            process.start();
+
+            // when: it has exited
+            assertThat(underlyingProcess(process).waitFor(30, TimeUnit.SECONDS))
+                    .as("subprocess should exit on its own")
+                    .isTrue();
+
+            // then: the liveness check explains why, not just that
+            assertThat(process.getLivenessCheck())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("exit code 217")
+                    .hasMessageContaining(StderrThenExitEntryPoint.MESSAGE);
+        } finally {
+            process.shutdown();
+        }
+    }
+
+    /**
+     * The retained stderr is bounded, so a subprocess that logs steadily can't be held in
+     * memory in full. The bytes worth keeping are the last ones — a stack trace or fatal
+     * error lands at the end — so eviction must drop the head, not truncate the tail.
+     */
+    @Test
+    void livenessCheckRetainsTailOfOversizeStderr() throws Exception {
+        // given: a subprocess emitting far more stderr than the retained tail holds
+        RewriteRpcProcess process = new RewriteRpcProcess(
+                System.getProperty("java.home") + "/bin/java",
+                "-cp", System.getProperty("java.class.path"),
+                OversizeStderrEntryPoint.class.getName());
+        try {
+            process.start();
+
+            // when: it has exited
+            assertThat(underlyingProcess(process).waitFor(30, TimeUnit.SECONDS))
+                    .as("subprocess should exit on its own")
+                    .isTrue();
+
+            // then: the last thing it said survives, and the first thing was evicted
+            assertThat(process.getLivenessCheck())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining(OversizeStderrEntryPoint.TAIL)
+                    .hasMessageNotContaining(OversizeStderrEntryPoint.HEAD);
+        } finally {
+            process.shutdown();
+        }
+    }
+
+    private static Process underlyingProcess(RewriteRpcProcess process) throws Exception {
+        Field f = RewriteRpcProcess.class.getDeclaredField("process");
+        f.setAccessible(true);
+        return (Process) f.get(process);
+    }
+
+    /**
+     * Forked entry point that writes a diagnostic to stderr and exits with the same code
+     * observed in CI. Uses {@code halt} so no shutdown hook can add output after it.
+     */
+    public static class StderrThenExitEntryPoint {
+        static final String MESSAGE = "rpc-server: failed to start, ENOENT";
+
+        public static void main(String[] args) {
+            System.err.println(MESSAGE);
+            System.err.flush();
+            Runtime.getRuntime().halt(217);
+        }
+    }
+
+    /**
+     * Forked entry point that brackets far more than the retained tail of filler between
+     * two markers, so the test can tell which end of the buffer survived eviction.
+     */
+    public static class OversizeStderrEntryPoint {
+        static final String HEAD = "HEAD-MARKER-should-be-evicted";
+        static final String TAIL = "TAIL-MARKER-should-survive";
+
+        public static void main(String[] args) {
+            System.err.println(HEAD);
+            byte[] junk = new byte[8192];
+            Arrays.fill(junk, (byte) 'x');
+            String filler = new String(junk, StandardCharsets.UTF_8);
+            for (int i = 0; i < 8; i++) {
+                System.err.print(filler);
+            }
+            System.err.println(TAIL);
+            System.err.flush();
+            Runtime.getRuntime().halt(1);
+        }
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.rpc;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
@@ -227,6 +228,82 @@ class RewriteRpcProcessTest {
                     .hasMessageNotContaining(OversizeStderrEntryPoint.HEAD);
         } finally {
             process.shutdown();
+        }
+    }
+
+    /**
+     * The retained tail only reaches the caller through {@link RewriteRpcProcess#getLivenessCheck()},
+     * so it is no help when the subprocess logs heavily before dying, or misbehaves without exiting
+     * at all. {@code REWRITE_RPC_STDERR=console} mirrors the whole stream to the parent's stderr,
+     * which is settable in CI without touching the repo under test.
+     */
+    @Test
+    void mirrorsSubprocessStderrToConsoleWhenEnvVarSet() throws Exception {
+        assertThat(runForkedSpawner("console"))
+                .as("REWRITE_RPC_STDERR=console should mirror the subprocess's stderr")
+                .contains(StderrThenExitEntryPoint.MESSAGE);
+    }
+
+    /**
+     * Negative control for {@link #mirrorsSubprocessStderrToConsoleWhenEnvVarSet()} — mirroring is
+     * strictly opt-in, so an unset variable must leave the parent's stderr untouched. Without this
+     * the positive test would still pass if stderr were mirrored unconditionally.
+     */
+    @Test
+    void doesNotMirrorSubprocessStderrByDefault() throws Exception {
+        assertThat(runForkedSpawner(null))
+                .as("stderr mirroring should be opt-in")
+                .doesNotContain(StderrThenExitEntryPoint.MESSAGE);
+    }
+
+    /**
+     * Runs {@link SpawnerEntryPoint} in a forked JVM, optionally with {@code REWRITE_RPC_STDERR}
+     * set, and returns everything that JVM wrote to stdout and stderr.
+     */
+    private static String runForkedSpawner(@Nullable String stderrEnv) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(
+                System.getProperty("java.home") + "/bin/java",
+                "-cp", System.getProperty("java.class.path"),
+                SpawnerEntryPoint.class.getName());
+        if (stderrEnv == null) {
+            pb.environment().remove("REWRITE_RPC_STDERR");
+        } else {
+            pb.environment().put("REWRITE_RPC_STDERR", stderrEnv);
+        }
+        pb.redirectErrorStream(true);
+        Process forked = pb.start();
+
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(forked.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append('\n');
+            }
+        }
+        assertThat(forked.waitFor(30, TimeUnit.SECONDS))
+                .as("forked JVM should exit on its own")
+                .isTrue();
+        return output.toString();
+    }
+
+    /**
+     * Runs in the forked JVM. Spawns {@link StderrThenExitEntryPoint} via
+     * {@link RewriteRpcProcess} and waits for it to exit, so whatever the drain thread
+     * did with its stderr has landed by the time the forked JVM exits.
+     */
+    public static class SpawnerEntryPoint {
+        public static void main(String[] args) throws Exception {
+            RewriteRpcProcess proc = new RewriteRpcProcess(
+                    System.getProperty("java.home") + "/bin/java",
+                    "-cp", System.getProperty("java.class.path"),
+                    StderrThenExitEntryPoint.class.getName());
+            proc.start();
+
+            Field f = RewriteRpcProcess.class.getDeclaredField("process");
+            f.setAccessible(true);
+            ((Process) f.get(proc)).waitFor(20, TimeUnit.SECONDS);
+
+            proc.shutdown();
         }
     }
 


### PR DESCRIPTION
## What's changed

When an RPC subprocess dies, `RewriteRpcProcess.getLivenessCheck()` reported only a bare exit code. The stderr that explains *why* it exited was consumed by the drain thread and discarded whenever no `stderrRedirect` was set — which is the default everywhere except the `rewrite-javascript` integration tests that opt in via `JavaScriptRewriteRpc.builder().log(path)`.

Two complementary changes:

1. **Always retain a bounded (8KB) tail** of stderr and append it to the `IllegalStateException` message. The drain thread is briefly joined first, so output still in flight when the process dies isn't missed. No configuration needed — this works everywhere immediately.
2. **`REWRITE_RPC_STDERR=console`** mirrors the full stream to the parent's stderr. The tail only reaches the caller through `getLivenessCheck()`, so it doesn't help when the subprocess logs heavily before dying, or misbehaves without ever exiting. Unlike the existing programmatic `.log(path)` hook, an env var is settable in CI without a code change in the repo under test. Follows the existing `REWRITE_RPC_RSS_MS` opt-in convention.

## Why

This has made a recurring CI failure impossible to attribute. `openrewrite/rewrite-static-analysis` scheduled runs failed on 2026-07-15, 07-16, 07-19 and [07-28](https://github.com/openrewrite/rewrite-static-analysis/actions/runs/30386440190) — 4 of the last 14 days, only on `schedule`, never on push/PR — with ~9 TypeScript tests each reporting:

```
java.lang.IllegalStateException: RPC process shut down early with exit code 217
    at org.openrewrite.rpc.RewriteRpcProcess.getLivenessCheck(RewriteRpcProcess.java:188)
    at org.openrewrite.javascript.rpc.JavaScriptRewriteRpc$Builder$$Lambda/0x…get(Unknown Source)
```

The exit code varies *within a single run* (1, 217, 127), which points at a subprocess startup/environment failure — but the node process's own error message is thrown away, so there is nothing to diagnose from. It does not reproduce locally.

For the record, the obvious suspect was ruled out: this is **not** an npm publish lag. The resolved `rewrite-javascript-8.88.0-20260728.163231-66` jar pins `@openrewrite/rewrite@8.88.0-20260728-114130`, and that version is present on the registry.

This PR doesn't fix the flake — it makes the next occurrence diagnosable instead of a fifth dead end.

## Testing

Four regression tests in `RewriteRpcProcessTest`, all following the existing forked-JVM pattern in that file:

- `livenessCheckReportsSubprocessStderr` — subprocess writes a diagnostic to stderr and halts with 217; the liveness check must surface both.
- `livenessCheckRetainsTailOfOversizeStderr` — subprocess brackets 64KB of filler between two markers; eviction must drop the head and keep the tail, since a stack trace or fatal error lands at the end.
- `mirrorsSubprocessStderrToConsoleWhenEnvVarSet` — forked JVM with the env var set must reproduce the subprocess's stderr on its own.
- `doesNotMirrorSubprocessStderrByDefault` — negative control; without it the previous test would still pass if mirroring were unconditional.

Each fails without its corresponding change and passes with it. The full `org.openrewrite.rpc.*` package passes, including `shutdownWaitsForStderrDrainToComplete`, which covers the Windows file-handle behaviour the restructured drain loop touches.