### PR TITLE
Keep relocated YAML property at the indentation of its new siblings

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/format/IndentsVisitor.java
@@ -61,9 +61,11 @@ public class IndentsVisitor<P> extends YamlIsoVisitor<P> {
                 }
             }
         }
-        Iterator<Object> path = parent.getPath(Yaml.class::isInstance);
-        if (path.hasNext()) {
-            preVisit((Yaml) path.next(), p);
+        if (parent.getMessage("lastIndent") == null) {
+            Iterator<Object> path = parent.getPath(Yaml.class::isInstance);
+            if (path.hasNext()) {
+                preVisit((Yaml) path.next(), p);
+            }
         }
         return visit(tree, p);
     }

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/ChangePropertyKeyTest.java
@@ -523,7 +523,30 @@ class ChangePropertyKeyTest implements RewriteTest {
             """
               spring:
                 elasticsearch:
-                    restclient.sniffer.interval: 1
+                  restclient.sniffer.interval: 1
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-spring/issues/353")
+    @Test
+    void relocatedPropertyKeepsIndentationOfSiblings() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangePropertyKey("a.b.c.d", "a.b.c2.d", true, null, null)),
+          yaml(
+            """
+              a:
+                b:
+                  c:
+                    d: 1
+                  e: 2
+              """,
+            """
+              a:
+                b:
+                  e: 2
+                  c2.d: 1
               """
           )
         );


### PR DESCRIPTION
## What's changed?

`ChangePropertyKey` over-indents the relocated key whenever the rename happens three or more levels deep:

```yaml
# before
a:
  b:
    c:
      d: 1
    e: 2

# after (current)
a:
  b:
      c2.d: 1
    e: 2
```

Root cause is in `IndentsVisitor.visit(tree, p, parent)`. It first walks the parent cursor chain and seeds `lastIndent` from each Yaml ancestor's actual prefix, and then *also* calls `preVisit` on the nearest Yaml ancestor. When that ancestor is a `Yaml.Mapping.Entry` whose prefix contains a line break, `preVisit` puts `lastIndent + indentSize` on the very same cursor the loop just seeded, so the value is one level too deep. Nothing formatted relative to that cursor lands where it should.

The `preVisit` seeding is still needed when the loop found nothing (an ancestor whose prefix has no line break, e.g. a root-level entry), so it is now skipped only when the loop already established `lastIndent` for that cursor.

`relocatesPropertyWithSamePrefix` was asserting the over-indented output; its expectation is updated along with a new test for the sibling case.

## Anything in particular you'd like reviewers to focus on?

This touches shared YAML formatting rather than `ChangePropertyKey` itself. The full `rewrite-yaml` suite passes, and `IndentsVisitor` has no users outside that module in this repo, but it is worth a second pair of eyes on whether any downstream recipe relies on the current cursor-relative behaviour.

- Needed by openrewrite/rewrite-spring#353 — `ChangeSpringPropertyKey` renames of deeply nested Spring properties are visibly mis-indented for a customer today.