### PR TITLE
Prevent lock regeneration warnings from corrupting package.json

### DIFF
--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/UpgradeDependencyVersionTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/UpgradeDependencyVersionTest.java
@@ -15,14 +15,24 @@
  */
 package org.openrewrite.javascript;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.javascript.marker.NodeResolutionResult;
+import org.openrewrite.json.tree.Json;
+import org.openrewrite.marker.Markup;
 import org.openrewrite.test.RewriteTest;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.javascript.Assertions.npm;
 import static org.openrewrite.javascript.Assertions.packageJson;
+import static org.openrewrite.test.SourceSpecs.text;
 
 class UpgradeDependencyVersionTest implements RewriteTest {
 
@@ -58,5 +68,66 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                                 "    \"lodash\": \"^4.17.21\"\n" +
                                 "  }\n" +
                                 "}\n")));
+    }
+
+    /**
+     * A chained glob upgrade (as in {@code UpgradeToAngular21}) sets an invalid {@code 8.x} constraint on
+     * {@code @angular/build} before a later step sets a valid {@code 21.x}.
+     */
+    @Test
+    void chainedGlobUpgradeSelfHealsAfterAnIntermediateInvalidVersion(@TempDir Path tempDir) {
+        @Language("json")
+        String packageJson = "{\n" +
+                "  \"name\": \"x\",\n" +
+                "  \"devDependencies\": {\n" +
+                "    \"@angular/build\": \"^20.0.0\"\n" +
+                "  }\n" +
+                "}\n";
+
+        // Materialize the workspace so we can seed each recipe's scanner with a real lock file; without a
+        // captured lock the recipe skips regeneration entirely and neither the bug nor the fix surfaces.
+        Path workspace = DependencyWorkspace.getOrCreateWorkspace(packageJson);
+        String lockFileContent;
+        try {
+            lockFileContent = new String(Files.readAllBytes(workspace.resolve("package-lock.json")));
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not read package-lock.json from workspace", e);
+        }
+
+        AtomicReference<Json.Document> capturedAfter = new AtomicReference<>();
+
+        rewriteRun(
+                spec -> spec.recipes(
+                                new UpgradeDependencyVersion(null, "@angular/*", "8.x"),
+                                new UpgradeDependencyVersion(null, "@angular/*", "21.x"))
+                        .cycles(1)
+                        .expectedCyclesThatMakeChanges(1),
+                npm(tempDir,
+                        packageJson(
+                                packageJson,
+                                "{\n" +
+                                "  \"name\": \"x\",\n" +
+                                "  \"devDependencies\": {\n" +
+                                "    \"@angular/build\": \"21.x\"\n" +
+                                "  }\n" +
+                                "}\n",
+                                s -> s.afterRecipe(capturedAfter::set)),
+                        text(lockFileContent, s -> s.path("package-lock.json").after(actual -> actual).noTrim())));
+
+        Json.Document after = capturedAfter.get();
+        assertThat(after).as("package.json should have been visited").isNotNull();
+
+        // The intermediate 8.x failure left no warning behind (the fix): package.json is clean.
+        assertThat(after.getMarkers().findFirst(Markup.Warn.class))
+                .as("no lock-regeneration warning should survive")
+                .isEmpty();
+
+        // @angular/build resolves to a real 21.x release, proving the final step's regeneration succeeded.
+        NodeResolutionResult marker = after.getMarkers().findFirst(NodeResolutionResult.class).orElse(null);
+        assertThat(marker).isNotNull();
+        assertThat(marker.getResolvedDependency("@angular/build"))
+                .as("@angular/build should resolve to a real 21.x release after regeneration")
+                .isNotNull()
+                .satisfies(d -> assertThat(d.getVersion()).startsWith("21."));
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/AddDependency.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/AddDependency.java
@@ -143,11 +143,11 @@ public class AddDependency extends ScanningRecipe<AddDependency.Accumulator> {
                     }
                     if (ps.modifiedPackageJson != null) {
                         SourceFile out = ps.modifiedPackageJson;
+                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
-                            out = Markup.warn(out, new RuntimeException(
+                            return Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
                         }
-                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         return out;
                     }
                 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/ChangeDependency.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/ChangeDependency.java
@@ -162,11 +162,11 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                     }
                     if (ps.modifiedPackageJson != null) {
                         SourceFile out = ps.modifiedPackageJson;
+                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
-                            out = Markup.warn(out, new RuntimeException(
+                            return Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
                         }
-                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         return out;
                     }
                 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/RemoveDependency.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/RemoveDependency.java
@@ -141,11 +141,11 @@ public class RemoveDependency extends ScanningRecipe<RemoveDependency.Accumulato
                     }
                     if (ps.modifiedPackageJson != null) {
                         SourceFile out = ps.modifiedPackageJson;
+                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
-                            out = Markup.warn(out, new RuntimeException(
+                            return Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
                         }
-                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         return out;
                     }
                 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/UpgradeDependencyVersion.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/UpgradeDependencyVersion.java
@@ -190,11 +190,11 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                     }
                     if (ps.modifiedPackageJson != null) {
                         SourceFile out = ps.modifiedPackageJson;
+                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
-                            out = Markup.warn(out, new RuntimeException(
+                            return Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
                         }
-                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         return out;
                     }
                 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/UpgradeTransitiveDependencyVersion.java
@@ -134,11 +134,11 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                     }
                     if (ps.modifiedPackageJson != null) {
                         SourceFile out = ps.modifiedPackageJson;
+                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         if (ps.regenResult != null && !ps.regenResult.isSuccess()) {
-                            out = Markup.warn(out, new RuntimeException(
+                            return Markup.warn(out, new RuntimeException(
                                     "lock regeneration failed: " + ps.regenResult.getErrorMessage()));
                         }
-                        PackageJsonHelper.putLiveTree(ctx, p, out);
                         return out;
                     }
                 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageJsonHelper.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageJsonHelper.java
@@ -787,6 +787,8 @@ public class PackageJsonHelper {
         if (regen == null) {
             return null;
         }
-        return regen.regenerate(packageJson.printAll(), capturedLockContent, configFiles);
+        String content = packageJson.printAll(
+                new PrintOutputCapture<>(0, PrintOutputCapture.MarkerPrinter.SANITIZED));
+        return regen.regenerate(content, capturedLockContent, configFiles);
     }
 }


### PR DESCRIPTION
## What

When an npm dependency recipe fails to regenerate the lock file, it attaches a `Markup.Warn` marker to the `package.json` tree. Two things then went wrong:

1. **The warning corrupted the JSON fed to the package manager.** `PackageJsonHelper.regenerateLockContent` serialized `package.json` with a bare `printAll()`, which renders markers with the default marker printer — so the warning was emitted as an inline `/*~~(lock regeneration failed: ...)~~>*/` comment. `npm install --package-lock-only` then failed with `EJSONPARSE` because `package.json` must be comment-free JSON.

2. **The warning leaked into the shared tree.** The warned tree was published to the cross-recipe side channel (`livePackageJsonTrees`), so every subsequent recipe in a composite run built on corrupted state and stacked further warnings — one transient failure permanently blocked all later lock regeneration.

## Why it matters

The npm dependency recipes are designed to be chained (e.g. an Angular-style `Upgrade` migration that walks versions step by step). A single legitimate failure — such as an early step setting a version that does not yet exist for a package — should not prevent a later step that sets a valid version from regenerating the lock. Before this change it did: the cascade left `package.json` invalid and `package-lock.json` stale for the rest of the run.

## Changes

- **`PackageJsonHelper.regenerateLockContent`** — print with `MarkerPrinter.SANITIZED` so the content handed to the package manager is always valid, marker-free JSON. This is the load-bearing fix and is shared by all five dependency recipes.
- **`UpgradeDependencyVersion`, `UpgradeTransitiveDependencyVersion`, `AddDependency`, `RemoveDependency`, `ChangeDependency`** — publish the clean (marker-free) tree to the shared side channel and attach the regeneration warning only to the value returned by that step, so it can no longer propagate to later recipes or survive onto the final output.
- **`UpgradeDependencyVersionTest`** — regression test: a two-step composite that sets an invalid version and then a valid one, asserting the chain self-heals (lock regenerated, no warning left behind). Verified to fail before the fix with the exact `EJSONPARSE` cascade and pass after.