### PR TITLE
Make `ChangeStaticFieldToMethod` work on Kotlin sources

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeStaticFieldToMethod.java
@@ -128,7 +128,6 @@ public class ChangeStaticFieldToMethod extends Recipe {
                 }
                 return JavaTemplate
                         .builder(methodInvocationTemplate)
-                        .contextSensitive()
                         .javaParser(JavaParser.fromJavaVersion().dependsOn(methodStub))
                         .imports(newClass)
                         .build();

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeStaticFieldToMethodTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeStaticFieldToMethodTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
+import org.openrewrite.java.ChangeStaticFieldToMethod;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class ChangeStaticFieldToMethodTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(new ChangeStaticFieldToMethod(
+          "java.util.Collections",
+          "EMPTY_LIST",
+          "java.nio.charset.StandardCharsets",
+          "UTF_8",
+          "name"
+        ));
+    }
+
+    @Test
+    void migratesQualifiedField() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.util.Collections
+
+              class A {
+                  fun test(): Any = Collections.EMPTY_LIST
+              }
+              """,
+            """
+              import java.nio.charset.StandardCharsets
+
+              class A {
+                  fun test(): Any = StandardCharsets.UTF_8.name()
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void migratesStaticImportedField() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.util.Collections.EMPTY_LIST
+
+              class A {
+                  fun test(): Any = EMPTY_LIST
+              }
+              """,
+            """
+              import java.nio.charset.StandardCharsets
+
+              class A {
+                  fun test(): Any = StandardCharsets.UTF_8.name()
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/moderneinc/customer-requests/issues/2924")
+    @Test
+    void migratesArgumentInGenericMethod() {
+        rewriteRun(
+          kotlin(
+            """
+              import java.util.Collections
+
+              open class Base
+
+              class A : Base() {
+                  private val other = A()
+
+                  private fun <T> doGetResponse(clazz: Class<T>): T? {
+                      val result = java.util.Objects.toString(Collections.EMPTY_LIST)
+                      return null
+                  }
+
+                  fun `should do the thing`() {
+                  }
+              }
+              """,
+            """
+              import java.nio.charset.StandardCharsets
+
+              open class Base
+
+              class A : Base() {
+                  private val other = A()
+
+                  private fun <T> doGetResponse(clazz: Class<T>): T? {
+                      val result = java.util.Objects.toString(StandardCharsets.UTF_8.name())
+                      return null
+                  }
+
+                  fun `should do the thing`() {
+                  }
+              }
+              """
+          )
+        );
+    }
+}

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ReplaceConstantWithAnotherConstantTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ReplaceConstantWithAnotherConstantTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.ReplaceConstantWithAnotherConstant;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.kotlin.Assertions.kotlin;
+
+class ReplaceConstantWithAnotherConstantTest implements RewriteTest {
+
+    @Test
+    void replaceConstantOnSameOwner() {
+        rewriteRun(
+          spec -> spec.recipe(new ReplaceConstantWithAnotherConstant("java.io.File.pathSeparator", "java.io.File.separator")),
+          kotlin(
+            """
+              import java.io.File
+
+              class Test {
+                  fun foo() {
+                      println(File.pathSeparator)
+                      println(java.io.File.pathSeparator)
+                  }
+              }
+              """,
+            """
+              import java.io.File
+
+              class Test {
+                  fun foo() {
+                      println(File.separator)
+                      println(File.separator)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceConstantOnAnotherOwner() {
+        rewriteRun(
+          spec -> spec.recipe(new ReplaceConstantWithAnotherConstant("java.io.File.pathSeparator", "java.util.jar.JarFile.MANIFEST_NAME")),
+          kotlin(
+            """
+              import java.io.File
+
+              class Test {
+                  fun foo() {
+                      println(File.pathSeparator)
+                  }
+              }
+              """,
+            """
+              import java.util.jar.JarFile
+
+              class Test {
+                  fun foo() {
+                      println(JarFile.MANIFEST_NAME)
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void replaceImportedConstant() {
+        rewriteRun(
+          spec -> spec.recipe(new ReplaceConstantWithAnotherConstant("java.io.File.pathSeparator", "java.util.jar.JarFile.MANIFEST_NAME")),
+          kotlin(
+            """
+              import java.io.File.pathSeparator
+
+              class Test {
+                  fun foo() {
+                      println(pathSeparator)
+                  }
+              }
+              """,
+            """
+              import java.util.jar.JarFile.MANIFEST_NAME
+
+              class Test {
+                  fun foo() {
+                      println(MANIFEST_NAME)
+                  }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
- Fixes defect **F** from https://github.com/moderneinc/customer-requests/issues/2924.

## What was actually broken

The marker the customer saw was attributed to `org.openrewrite.java.ReplaceConstantWithAnotherConstant`, but that recipe builds no `JavaTemplate` at all, so it cannot produce a "Failed to parse expression template" error. The template in the message — `StandardCharsets.UTF_8.name()` — comes from `org.openrewrite.java.ChangeStaticFieldToMethod`, as used by `org.openrewrite.apache.commons.lang3.UseStandardCharsets` to migrate `CharEncoding.UTF_8`. So F is another instance of the misattribution tracked as defect G.

## The fix

`ChangeStaticFieldToMethod` built its replacement template `contextSensitive()`. The template is a fully qualified static method invocation that references nothing from the surrounding scope, so context sensitivity buys nothing — but it makes `BlockStatementTemplateGenerator` emit the enclosing type printed as Java. For a Kotlin source that stub is not valid Java, it compiles to zero trees, and `JavaTemplateParser#parseExpression` throws.

Dropping `.contextSensitive()` fixes it. As a bonus, the resulting `J.MethodInvocation` now carries type attribution on Kotlin, which it did not before (Kotlin's `assertValidTypes` flagged it even in the cases that did not throw).

## Tests

- `rewrite-kotlin` `ChangeStaticFieldToMethodTest` — a qualified field access, a statically imported one, and the reported shape (argument to a call inside a `val` in a generic function of a subclass with backtick-named members). All three fail on `main`: the first two with `LST contains missing or invalid type information`, the third with the exact `Failed to parse expression template` from the issue.
- `rewrite-kotlin` `ReplaceConstantWithAnotherConstantTest` — added to pin down that this recipe is in fact Kotlin-clean, so the next report of this shape is not chased into the wrong file.

`rewrite-java-test`'s existing `ChangeStaticFieldToMethodTest` still passes unchanged.