### PR TITLE
Keep XML comments trailing an element on the same line

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/LineBreaksVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/LineBreaksVisitor.java
@@ -18,8 +18,11 @@ package org.openrewrite.xml.format;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.xml.XmlIsoVisitor;
+import org.openrewrite.xml.tree.Content;
 import org.openrewrite.xml.tree.Misc;
 import org.openrewrite.xml.tree.Xml;
+
+import java.util.List;
 
 public class LineBreaksVisitor<P> extends XmlIsoVisitor<P> {
     @Nullable
@@ -35,8 +38,23 @@ public class LineBreaksVisitor<P> extends XmlIsoVisitor<P> {
 
     @Override
     public Xml.Comment visitComment(Xml.Comment comment, P p) {
+        if (isTrailingComment(comment)) {
+            return super.visitComment(comment, p);
+        }
         return keepMaximumLines(minimumLines(super.visitComment(comment, p),
                 isFirstMisc(comment) ? 0 : 1), 2);
+    }
+
+    private boolean isTrailingComment(Xml.Comment comment) {
+        if (comment.getPrefix().contains("\n")) {
+            return false;
+        }
+        Object parent = getCursor().getParentTreeCursor().getValue();
+        if (!(parent instanceof Xml.Tag)) {
+            return false;
+        }
+        List<? extends Content> content = ((Xml.Tag) parent).getContent();
+        return content != null && !content.isEmpty() && content.get(0) != comment;
     }
 
     @Override

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
@@ -114,4 +114,63 @@ class AutoFormatTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void trailingCommentStaysOnSameLine() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes>
+                  <exclude>com.bol.fin.profit.ProfitFactory.processProfit.1</exclude> <!--tmp logic, test by cucumber-->
+                  <exclude>com.bol.fin.profit.io.ProfitUtils</exclude><!--tmp logic, test by cucumber-->
+                </excludes>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingCommentAfterTagContentStaysOnSameLine() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes>
+                  <exclude>a</exclude> <!--why a-->
+                </excludes> <!--why excludes-->
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
+    void misindentedTrailingCommentIsStillIndented() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes>
+                  <exclude>a</exclude>
+              <!--why a-->
+                </excludes>
+              </project>
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes>
+                  <exclude>a</exclude>
+                  <!--why a-->
+                </excludes>
+              </project>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
@@ -123,8 +123,8 @@ class AutoFormatTest implements RewriteTest {
               <?xml version="1.0" encoding="UTF-8"?>
               <project>
                 <excludes>
-                  <exclude>com.bol.fin.profit.ProfitFactory.processProfit.1</exclude> <!--tmp logic, test by cucumber-->
-                  <exclude>com.bol.fin.profit.io.ProfitUtils</exclude><!--tmp logic, test by cucumber-->
+                  <exclude>com.example.profit.ProfitFactory.processProfit.1</exclude> <!--tmp logic, tested elsewhere-->
+                  <exclude>com.example.profit.io.ProfitUtils</exclude><!--tmp logic, tested elsewhere-->
                 </excludes>
               </project>
               """

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/format/LineBreaksTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/format/LineBreaksTest.java
@@ -74,6 +74,22 @@ class LineBreaksTest implements RewriteTest {
         );
     }
 
+    @Test
+    void trailingCommentsStayOnSameLine() {
+        rewriteRun(
+          xml(
+            """
+              <project>
+                <excludes>
+                  <exclude>a</exclude> <!--comment-->
+                  <exclude>b</exclude><!--comment-->
+                </excludes>
+              </project>
+              """
+          )
+        );
+    }
+
     @SuppressWarnings("CheckTagEmptyBody")
     @Test
     void docTypeDecl() {


### PR DESCRIPTION
Fixes https://github.com/moderneinc/customer-requests/issues/2926

## What

XML auto-format moved a comment that trailed an element on the same line onto its own following line:

```diff
-  <exclude>com.example.profit.ProfitFactory.processProfit.1</exclude> <!--tmp logic, tested elsewhere-->
-  <exclude>com.example.profit.io.ProfitUtils</exclude><!--tmp logic, tested elsewhere-->
+  <exclude>com.example.profit.ProfitFactory.processProfit.1</exclude>
+  <!--tmp logic, tested elsewhere-->
+  <exclude>com.example.profit.io.ProfitUtils</exclude>
+  <!--tmp logic, tested elsewhere-->
```

Besides being pure review noise on a migration PR, this silently changes what each comment documents: by XML convention the reflowed comment now reads as annotating the *next* `<exclude>`, and the last one dangles with nothing after it.

## Why

The XML LST has no notion of a trailing comment — the whitespace separating it from the preceding sibling lives in the comment's own prefix, so that prefix is the only carrier of the author's intent. `LineBreaksVisitor.visitComment` called `minimumLines(..., 1)` unconditionally, which prepends `"\n"` to any newline-free prefix; `TabsAndIndentsVisitor` then indented the now-multiline prefix. Latent since XML auto-format was written (`0b1efb7706`, 2022), and untested — grepping `rewrite-xml`/`rewrite-maven`/`rewrite-gradle` for `</tag> <!--` returned zero fixtures.

## How

Skip the line break when the comment is on the same line as a preceding sibling — i.e. its prefix contains no newline *and* it is not the first content of its parent tag. Existing behavior is preserved for:

- a comment that is the first content of a tag (`<dependencies><!--comment-->`), which the existing `LineBreaksTest#comments` case asserts should reflow;
- a comment already on its own line, which still gets re-indented;
- prolog/misc comments, which are untouched.

## Tests

- `LineBreaksTest#trailingCommentsStayOnSameLine`
- `AutoFormatTest#trailingCommentStaysOnSameLine` (the reproducer from the issue)
- `AutoFormatTest#trailingCommentAfterTagContentStaysOnSameLine`
- `AutoFormatTest#misindentedTrailingCommentIsStillIndented` (guards the contrast case)

All three new same-line tests fail on `main` and pass with the fix. `:rewrite-xml:test`, `:rewrite-maven:test` and `:rewrite-gradle:test` are green.

## Not covered here

The issue also asks which recipe auto-formatted a scope far wider than it changed (`OrderPomElements`, `AddAnnotationProcessor` over the whole `<plugins>` block are the likely candidates). This fix stops the comment reflow regardless of the caller; the over-wide auto-format scope is a separate question.