### PR TITLE
Preserve XML comments that auto-format or content removal used to drop

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveContentVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/RemoveContentVisitor.java
@@ -44,7 +44,13 @@ public class RemoveContentVisitor<P> extends XmlVisitor<P> {
                     int indexOf = contents.indexOf(content);
                     contents.remove(indexOf);
 
-                    if (removePrecedingComment && 0 < indexOf && contents.get(indexOf - 1) instanceof Xml.Comment) {
+                    if (indexOf < contents.size() && content.getPrefix().contains("\n") &&
+                        !contents.get(indexOf).getPrefix().contains("\n")) {
+                        contents.set(indexOf, (Content) contents.get(indexOf).withPrefix(content.getPrefix()));
+                    }
+
+                    if (removePrecedingComment && 0 < indexOf && contents.get(indexOf - 1) instanceof Xml.Comment &&
+                        !isTrailingComment(contents, indexOf - 1)) {
                         doAfterVisit(new RemoveContentVisitor<>(contents.get(indexOf - 1), true, removePrecedingComment));
                     }
 
@@ -62,5 +68,12 @@ public class RemoveContentVisitor<P> extends XmlVisitor<P> {
         }
 
         return t;
+    }
+
+    /**
+     * A comment that shares a line with the sibling before it documents that sibling, not the one after it.
+     */
+    private static boolean isTrailingComment(List<Content> contents, int index) {
+        return 0 < index && !contents.get(index).getPrefix().contains("\n");
     }
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/RemoveTrailingWhitespaceVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/RemoveTrailingWhitespaceVisitor.java
@@ -20,7 +20,11 @@ import org.openrewrite.Tree;
 import org.openrewrite.xml.XmlIsoVisitor;
 import org.openrewrite.xml.tree.Xml;
 
+import java.util.regex.Pattern;
+
 public class RemoveTrailingWhitespaceVisitor<P> extends XmlIsoVisitor<P> {
+    private static final Pattern TRAILING_WHITESPACE = Pattern.compile("[ \\t]+(?=[\\r\\n]|$)");
+
     @Nullable
     private final Tree stopAfter;
 
@@ -34,10 +38,8 @@ public class RemoveTrailingWhitespaceVisitor<P> extends XmlIsoVisitor<P> {
 
     @Override
     public Xml.Document visitDocument(Xml.Document doc, P p) {
-        String eof = doc.getEof();
-        eof = eof.chars().filter(c -> c == '\n' || c == '\r')
-                .collect(StringBuilder::new, StringBuilder::appendCodePoint, StringBuilder::append)
-                .toString();
+        // `eof` holds everything after the root element, comments and processing instructions included
+        String eof = TRAILING_WHITESPACE.matcher(doc.getEof()).replaceAll("");
 
         Xml.Document d = super.visitDocument(doc, p);
         return d.withEof(eof);

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/RemoveContentTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/RemoveContentTest.java
@@ -112,4 +112,84 @@ class RemoveContentTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void trailingCommentKeepsItsOwnLine() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
+              @Override
+              public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
+                  doAfterVisit(new RemoveContentVisitor<>(requireNonNull(x.getRoot().getContent()).get(1), false, false));
+                  return super.visitDocument(x, ctx);
+              }
+          }).withMaxCycles(1)),
+          xml(
+            """
+              <dependency>
+                  <groupId>group</groupId>
+                  <version/><!-- why version -->
+              </dependency>
+              """,
+            """
+              <dependency>
+                  <groupId>group</groupId>
+                  <!-- why version -->
+              </dependency>
+              """
+          )
+        );
+    }
+
+    @Test
+    void precedingCommentOnTheLineOfAnEarlierSiblingIsRetained() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
+              @Override
+              public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
+                  doAfterVisit(new RemoveContentVisitor<>(requireNonNull(x.getRoot().getContent()).get(2), false, true));
+                  return super.visitDocument(x, ctx);
+              }
+          }).withMaxCycles(1)),
+          xml(
+            """
+              <dependency>
+                  <groupId>group</groupId> <!-- why group -->
+                  <version/>
+              </dependency>
+              """,
+            """
+              <dependency>
+                  <groupId>group</groupId> <!-- why group -->
+              </dependency>
+              """
+          )
+        );
+    }
+
+    @Test
+    void precedingCommentOnItsOwnLineIsRemoved() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new XmlVisitor<>() {
+              @Override
+              public Xml visitDocument(Xml.Document x, ExecutionContext ctx) {
+                  doAfterVisit(new RemoveContentVisitor<>(requireNonNull(x.getRoot().getContent()).get(2), false, true));
+                  return super.visitDocument(x, ctx);
+              }
+          }).withMaxCycles(1)),
+          xml(
+            """
+              <dependency>
+                  <groupId>group</groupId>
+                  <!-- why version -->
+                  <version/>
+              </dependency>
+              """,
+            """
+              <dependency>
+                  <groupId>group</groupId>
+              </dependency>
+              """
+          )
+        );
+    }
 }

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
@@ -173,4 +173,53 @@ class AutoFormatTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void commentAfterRootElementIsRetained() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes/>
+              </project>
+              <!--why project-->
+              """
+          )
+        );
+    }
+
+    @Test
+    void commentTrailingRootElementIsRetained() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes/>
+              </project> <!--why project-->
+              """
+          )
+        );
+    }
+
+    @Test
+    void trailingWhitespaceAfterRootElementIsRemoved() {
+        rewriteRun(
+          xml(
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes/>
+              </project>   \s
+              """,
+            """
+              <?xml version="1.0" encoding="UTF-8"?>
+              <project>
+                <excludes/>
+              </project>
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Follow-up to #8353. That PR made a trailing comment's prefix authoritative by dropping the unconditional line break in `LineBreaksVisitor`. That line break had also been acting as an accidental *repair* for visitors that destroy a comment's spacing, so three latent defects are now user-visible. All three are reproduced by tests that fail on `main`.

## 1. Auto-format silently deletes anything after the root element

`Xml.Document` has no trailing-misc list — a comment or processing instruction after `</project>` is stored verbatim in the `eof` String. `RemoveTrailingWhitespaceVisitor.visitDocument` filtered `eof` down to its `\n`/`\r` characters, so every recipe that auto-formats dropped it:

```diff
 <project>
   <excludes/>
 </project>
-<!--why project-->
```

- This is data loss rather than reflow, and it predates #8353 (the own-line case fails there too); an identity parse/print round-trips the comment fine, so it is the formatter. Now only horizontal whitespace at line ends is stripped, which is equivalent to the old filter for the whitespace-only `eof` that is the common case.

## 2. `RemoveContentVisitor` collapses an orphaned trailing comment

- Called out as a known follow-up in openrewrite/rewrite-migrate-java#1180. The removed element's prefix carried the line break, so the comment that trailed it has none left to inherit:

```diff
 <dependency>
     <groupId>group</groupId>
-    <version/><!-- why version -->
+<!-- why version -->
 </dependency>
```

The removed content's prefix is now transferred to the following sibling when that sibling has no line break of its own. This one is independent of auto-format — it reproduces with `RemoveContentVisitor` alone.

## 3. `removePrecedingComment` eats the *previous* sibling's trailing comment

- Under #8353's semantics `<!-- why group -->` below documents `<groupId>`, but removing `<version/>` with `removePrecedingComment = true` deleted it:

```diff
 <dependency>
-    <groupId>group</groupId> <!-- why group -->
+    <groupId>group</groupId>
 </dependency>
```

Gated on the same predicate `LineBreaksVisitor` uses: a comment sharing a line with an earlier sibling is that sibling's. A comment on its own line, or one that is the first content of its tag, is still removed.

## Tests

New, each failing on `main`:
- `AutoFormatTest#commentAfterRootElementIsRetained`, `#commentTrailingRootElementIsRetained`
- `RemoveContentTest#trailingCommentKeepsItsOwnLine`, `#precedingCommentOnTheLineOfAnEarlierSiblingIsRetained`

New regression guards for the behavior that must not change:
- `AutoFormatTest#trailingWhitespaceAfterRootElementIsRemoved`
- `RemoveContentTest#precedingCommentOnItsOwnLineIsRemoved`

`:rewrite-xml:test`, `:rewrite-maven:test` and `:rewrite-gradle:test` are green.

## Not covered here

- A comment trailing the prolog (`<?xml version="1.0"?> <!--generated-->`) is still moved onto its own line, because #8353's predicate bails when the parent is not an `Xml.Tag`. Consistent with that PR's stated scope, inconsistent as a rule; worth a separate look if anyone hits it.