### PR TITLE
Publish rewrite-bom snapshots to the Code Genome Project

### DIFF
--- a/rewrite-bom/build.gradle.kts
+++ b/rewrite-bom/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     `java-platform`
     id("org.openrewrite.build.publish")
+    id("org.openrewrite.build.publish-cgp")
     id("org.openrewrite.build.metadata")
 }
 


### PR DESCRIPTION
### What's changed?

`rewrite-bom` now applies `org.openrewrite.build.publish-cgp` in addition to `org.openrewrite.build.publish`.

### What's your motivation?

`org.openrewrite:rewrite-bom` was the only module in this repository absent from the Code Genome Project's Maven repository. CGP's gateway distinguishes "exists but needs auth" (401) from "not published" (422):

```
$ curl -s -o /dev/null -w "%{http_code}\n" \
    https://artifacts.codegenomeproject.org/maven/org/openrewrite/<artifact>/8.89.0-SNAPSHOT/maven-metadata.xml
rewrite-core   -> 401 (present)
rewrite-java   -> 401 (present)
rewrite-maven  -> 401 (present)
rewrite-bom    -> 422 (absent)
```

Root cause: every other publishing module here applies `org.openrewrite.build.language-library`, and [`RewriteLanguageLibraryPlugin`](https://github.com/openrewrite/rewrite-build-gradle-plugin/blob/main/src/main/java/org/openrewrite/gradle/RewriteLanguageLibraryPlugin.java) applies `RewriteCgpPublishPlugin`, which registers CGP's S3 bucket as a publishing repository. `rewrite-bom` is a `java-platform` that applies `org.openrewrite.build.publish` directly, and `RewritePublishPlugin` does *not* apply the CGP plugin — so the BOM only ever went to Sonatype.

- The missing BOM makes consumers that resolve `org.openrewrite` from CGP fall back to Central, which Maven logs as a warning. openrewrite/rewrite-maven-plugin#1183 adds CGP as a dependency source, and 7 of its integration tests (`RewriteDiscoverIT`, `BasicIT`) assert that nested builds emit no warnings; that PR is blocked until `rewrite-bom` resolves from CGP.

### Anything in particular you'd like reviewers to focus on?

Verified locally that the platform publication is actually covered by the added repository:

```
$ AWS_ACCESS_KEY_ID=test-key AWS_SECRET_ACCESS_KEY=test-secret AWS_REGION=us-west-2 \
    ./gradlew :rewrite-bom:publish --dry-run
:rewrite-bom:publishNebulaPublicationToCgpRepository SKIPPED
:rewrite-bom:publishNebulaPublicationToSonatypeRepository SKIPPED
```

Without AWS credentials the plugin stays inert (only the Sonatype task is registered), so local builds and forks are unaffected. Pom-only artifacts index fine on the CGP side — `rewrite-recipe-bom` already returns 401 there — so no gateway change is needed.

After this merges to `main` and a snapshot publishes, `rewrite-bom` should return 401 rather than 422.