### PR TITLE
Return a new `RecipesThatMadeChanges` when merging recipe credits

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -850,8 +850,9 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         return afterFile.withMarkers(afterFile.getMarkers().computeByType(
                 RecipesThatMadeChanges.create(recipeStack),
                 (r1, r2) -> {
-                    r1.getRecipes().addAll(r2.getRecipes());
-                    return r1;
+                    List<List<Recipe>> merged = new ArrayList<>(r1.getRecipes());
+                    merged.addAll(r2.getRecipes());
+                    return r1.withRecipes(merged);
                 })
         );
     }


### PR DESCRIPTION
`addRecipesThatMadeChanges` merged a new credit by appending to the existing marker's collection in place and returning the same instance:

```java
(r1, r2) -> {
    r1.getRecipes().addAll(r2.getRecipes());
    return r1;
}
```

`r1` is the marker already attached to the tree. Because the merge returns the same instance, `ListUtils.map` inside `computeByType` sees no element change and returns the same list, `Markers.withMarkers` returns `this`, and so does `SourceFile.withMarkers`. The credits list grows while the marker, its `Markers`, and the `SourceFile` all keep their identity.

That change is invisible to any consumer holding a reference — including the reference-identity comparison `LargeSourceSet.edit` relies on to decide whether a source file changed. A consumer that inspects the marker, then sees more credits appear on the same instance later, has no way to observe or react to it.

Building a merged list and returning a new marker restores the identity signal, consistent with how the rest of the codebase treats trees and markers as immutable and uses `ListUtils`' copy-on-write to signal change.

## Notes

- `RecipesThatMadeChanges` is a Lombok `@Value` holding a mutable `Collection`, so it advertises immutability it does not enforce. This was the only site in the repository mutating `getRecipes()`; everything else is `stream()`/`iterator()`/`isEmpty()`. Making the collection unmodifiable would enforce it, at the cost of diverging from the convention-not-enforcement approach `ListUtils` takes — left out deliberately, happy to add.
- `ListUtils.concatAll` would express this more idiomatically and preserve identity for free when nothing is added, but it takes `List<T>, List<? extends T>` while the field is `Collection<List<Recipe>>`. Narrowing the field to `List<List<Recipe>>` would enable it; all three production callers already pass `List`s. Not done here since it is a public API change.
- The merge still appends duplicate lineages rather than deduping. That is pre-existing and unchanged by this commit.
- Verified: `rewrite-core` 972 tests, `rewrite-test` 71 tests, both green. The one `rewrite-java` failure (`JavaSourceSetTest.skipsMetaInfEntriesUnderDirectoryClasspath`, a byte-buddy classpath assertion) reproduces identically on unmodified `main`.
- No regression test accompanies this. `RecipeListTest.declarativeRecipeInCode` covers credit accumulation but not the identity property, so a revert would not fail the suite. I can add a focused test — a recipe captures the marker it observes holding one credit, and asserts a later credit does not retroactively grow that instance to two — if you would like one.