### PR TITLE
Fix OneDependencyDeclarationPerStatement mangling DependencyHandler.add() calls

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatement.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatement.java
@@ -95,6 +95,12 @@ public class OneDependencyDeclarationPerStatement extends Recipe {
                     if (m.getSelect() != null) {
                         return s;
                     }
+                    // `DependencyHandler.add(configuration, notation)` and its provider variants take the
+                    // configuration name as their first argument, so their arguments are not all coordinates
+                    String methodName = m.getSimpleName();
+                    if ("add".equals(methodName) || "addProvider".equals(methodName) || "addProviderConvertible".equals(methodName)) {
+                        return s;
+                    }
                     List<Expression> args = m.getArguments();
                     if (args.size() < 2) {
                         return s;
@@ -122,13 +128,15 @@ public class OneDependencyDeclarationPerStatement extends Recipe {
                     List<Statement> split = new ArrayList<>(args.size());
                     for (int i = 0; i < args.size(); i++) {
                         Expression coord = args.get(i).withPrefix(Space.format(" "));
+                        // Every split beyond the first needs its own id; reusing the original invocation's
+                        // id leaves duplicate ids in the enclosing block, which later recipes choke on.
+                        J.MethodInvocation mi = (i == 0 ? m : m.withId(Tree.randomId()))
+                                .withArguments(singletonList(coord));
                         boolean isLast = i == args.size() - 1;
                         if (isLast && wrappedInReturn) {
-                            J.MethodInvocation innerMi = m.withArguments(singletonList(coord));
-                            split.add(((J.Return) s).withPrefix(subsequentPrefix).withExpression(innerMi));
+                            split.add(((J.Return) s).withPrefix(subsequentPrefix).withExpression(mi));
                         } else {
-                            Space prefix = i == 0 ? stmtPrefix : subsequentPrefix;
-                            split.add(m.withPrefix(prefix).withArguments(singletonList(coord)));
+                            split.add(mi.withPrefix(i == 0 ? stmtPrefix : subsequentPrefix));
                         }
                     }
                     return split;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatement.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatement.java
@@ -44,23 +44,17 @@ import static java.util.Collections.singletonList;
 @EqualsAndHashCode(callSuper = false)
 public class OneDependencyDeclarationPerStatement extends Recipe {
 
-    @Override
-    public String getDisplayName() {
-        return "Use one dependency declaration per statement";
-    }
+    final String displayName = "Use one dependency declaration per statement";
 
-    @Override
-    public String getDescription() {
-        return "The Gradle Groovy DSL accepts multiple coordinates in a single configuration call " +
-                "(e.g. `implementation 'a:b:1.0', 'c:d:2.0'`), but the Kotlin DSL does not. " +
-                "Gradle's best practices recommend declaring a single dependency per statement; " +
-                "see the [Gradle dependency best practices](https://docs.gradle.org/current/userguide/best_practices_dependencies.html). " +
-                "This recipe splits multi-coordinate Groovy DSL configuration calls into one call per coordinate. " +
-                "Run this as a cleanup pass before other dependency-aware recipes (e.g. `UpgradeDependencyVersion`, " +
-                "`ChangeDependency`, `RemoveDependency`): those recipes use the `GradleDependency` trait, which only " +
-                "inspects the first argument of a configuration call. Coordinates in later positions are invisible " +
-                "to them until this recipe reshapes the source into one declaration per statement.";
-    }
+    final String description = "The Gradle Groovy DSL accepts multiple coordinates in a single configuration call " +
+            "(e.g. `implementation 'a:b:1.0', 'c:d:2.0'`), but the Kotlin DSL does not. " +
+            "Gradle's best practices recommend declaring a single dependency per statement; " +
+            "see the [Gradle dependency best practices](https://docs.gradle.org/current/userguide/best_practices_dependencies.html). " +
+            "This recipe splits multi-coordinate Groovy DSL configuration calls into one call per coordinate. " +
+            "Run this as a cleanup pass before other dependency-aware recipes (e.g. `UpgradeDependencyVersion`, " +
+            "`ChangeDependency`, `RemoveDependency`): those recipes use the `GradleDependency` trait, which only " +
+            "inspects the first argument of a configuration call. Coordinates in later positions are invisible " +
+            "to them until this recipe reshapes the source into one declaration per statement.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -125,9 +119,13 @@ public class OneDependencyDeclarationPerStatement extends Recipe {
                     Space stmtPrefix = s.getPrefix();
                     Space subsequentPrefix = Space.build(stmtPrefix.getLastWhitespace(), emptyList());
 
+                    // The space-delimited form separates the coordinate from the method name, but the
+                    // parenthesized form does not; reusing the original first argument's prefix keeps both right
+                    Space argPrefix = args.get(0).getPrefix();
+
                     List<Statement> split = new ArrayList<>(args.size());
                     for (int i = 0; i < args.size(); i++) {
-                        Expression coord = args.get(i).withPrefix(Space.format(" "));
+                        Expression coord = args.get(i).withPrefix(argPrefix);
                         // Every split beyond the first needs its own id; reusing the original invocation's
                         // id leaves duplicate ids in the enclosing block, which later recipes choke on.
                         J.MethodInvocation mi = (i == 0 ? m : m.withId(Tree.randomId()))

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
@@ -77,8 +77,11 @@ public class UseJavaExtensionBlock extends Recipe {
                 // Top-level `sourceCompatibility` / `targetCompatibility` assignments delegate to the removed
                 // `JavaPluginConvention`; move them into a `java { }` block at the root of the build script.
                 G.CompilationUnit cu = (G.CompilationUnit) visited;
-                List<Statement> mapped = moveCompatibility(cu.getStatements(), ctx);
-                return mapped == cu.getStatements() ? cu : cu.withStatements(mapped);
+                // Hold onto the list; each `getStatements()` call builds a new one, so comparing
+                // against a second call would never detect the unchanged case.
+                List<Statement> statements = cu.getStatements();
+                List<Statement> mapped = moveCompatibility(statements, ctx);
+                return mapped == statements ? cu : cu.withStatements(mapped);
             }
 
             @Override
@@ -92,8 +95,9 @@ public class UseJavaExtensionBlock extends Recipe {
                 }
                 J.Lambda lambda = (J.Lambda) m.getArguments().get(0);
                 J.Block body = (J.Block) lambda.getBody();
-                List<Statement> mapped = moveCompatibility(body.getStatements(), ctx);
-                if (mapped == body.getStatements()) {
+                List<Statement> statements = body.getStatements();
+                List<Statement> mapped = moveCompatibility(statements, ctx);
+                if (mapped == statements) {
                     return m;
                 }
                 return autoFormat(m.withArguments(singletonList(lambda.withBody(body.withStatements(mapped)))),

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
@@ -50,19 +50,13 @@ public class UseJavaExtensionBlock extends Recipe {
     private static final String SOURCE = "sourceCompatibility";
     private static final String TARGET = "targetCompatibility";
 
-    @Override
-    public String getDisplayName() {
-        return "Move `sourceCompatibility` and `targetCompatibility` into the `java { }` extension block";
-    }
+    final String displayName = "Move `sourceCompatibility` and `targetCompatibility` into the `java { }` extension block";
 
-    @Override
-    public String getDescription() {
-        return "Gradle 9 removed the `JavaPluginConvention` (deprecated in 8.2). Top-level `sourceCompatibility` and " +
-                "`targetCompatibility` assignments in a Groovy build script previously delegated to that convention object " +
-                "and stop working in Gradle 9. Move them into the `java { }` extension block, normalizing values to " +
-                "`JavaVersion.VERSION_<n>` and adding the missing counterpart so both properties are set explicitly. " +
-                "See the [Gradle upgrade guide](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html) for more information.";
-    }
+    final String description = "Gradle 9 removed the `JavaPluginConvention` (deprecated in 8.2). Top-level `sourceCompatibility` and " +
+            "`targetCompatibility` assignments in a Groovy build script previously delegated to that convention object " +
+            "and stop working in Gradle 9. Move them into the `java { }` extension block, normalizing values to " +
+            "`JavaVersion.VERSION_<n>` and adding the missing counterpart so both properties are set explicitly. " +
+            "See the [Gradle upgrade guide](https://docs.gradle.org/9.0.0/userguide/upgrading_major_version_9.html) for more information.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
@@ -71,11 +71,7 @@ public class UseJavaExtensionBlock extends Recipe {
                 // Top-level `sourceCompatibility` / `targetCompatibility` assignments delegate to the removed
                 // `JavaPluginConvention`; move them into a `java { }` block at the root of the build script.
                 G.CompilationUnit cu = (G.CompilationUnit) visited;
-                // Hold onto the list; each `getStatements()` call builds a new one, so comparing
-                // against a second call would never detect the unchanged case.
-                List<Statement> statements = cu.getStatements();
-                List<Statement> mapped = moveCompatibility(statements, ctx);
-                return mapped == statements ? cu : cu.withStatements(mapped);
+                return cu.withStatements(moveCompatibility(cu.getStatements(), ctx));
             }
 
             @Override

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleBestPracticesTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/GradleBestPracticesTest.java
@@ -195,4 +195,32 @@ class GradleBestPracticesTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void noChangeToDependencyHandlerAddCalls() {
+        rewriteRun(
+          buildGradle(
+            """
+              subprojects {
+                 plugins.withId('java') {
+                     dependencies {
+                         add('testImplementation', platform("org.junit:junit-bom:6.1.2"))
+                         add('testImplementation', platform("org.mockito:mockito-bom:5.23.0"))
+                     }
+                  }
+              }
+              """),
+          properties(
+            //language=properties
+            """
+              """,
+            //language=properties
+            """
+              org.gradle.caching=true
+              org.gradle.parallel=true
+              """,
+            spec -> spec.path("gradle.properties")
+          )
+        );
+    }
 }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatementTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatementTest.java
@@ -152,6 +152,24 @@ class OneDependencyDeclarationPerStatementTest implements RewriteTest {
     }
 
     @Test
+    void leavesDependencyHandlerAddAlone() {
+        rewriteRun(
+          buildGradle(
+            """
+              subprojects {
+                 plugins.withId('java') {
+                     dependencies {
+                         add('testImplementation', platform("org.junit:junit-bom:6.1.2"))
+                         add('testImplementation', platform("org.mockito:mockito-bom:5.23.0"))
+                     }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void leavesCallWithTrailingClosureAlone() {
         rewriteRun(
           buildGradle(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatementTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/gradle9/OneDependencyDeclarationPerStatementTest.java
@@ -67,6 +67,41 @@ class OneDependencyDeclarationPerStatementTest implements RewriteTest {
     }
 
     @Test
+    void splitsParenthesizedCall() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation('com.google.guava:guava:30.0-jre', 'org.apache.commons:commons-lang3:3.12.0')
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation('com.google.guava:guava:30.0-jre')
+                  implementation('org.apache.commons:commons-lang3:3.12.0')
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void splitsWhenSecondCoordinateUsesVersionVariable() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
## What's changed

Three fixes in the Gradle 9 best-practice recipes.

### `OneDependencyDeclarationPerStatement` corrupted `DependencyHandler.add(...)` calls

`add(configuration, notation)` (and the `addProvider` / `addProviderConvertible` variants) take the *configuration name* as their first argument, not a coordinate. The recipe treated every argument as a coordinate and split the call, turning:

```groovy
dependencies {
    add('testImplementation', platform("org.junit:junit-bom:6.1.2"))
}
```

into two broken statements. These method names are now skipped.

### Duplicate LST ids when splitting a multi-coordinate declaration

Every split statement reused the original `J.MethodInvocation`'s id, leaving duplicate ids in the enclosing block that downstream recipes choke on. Each statement after the first now gets a fresh `Tree.randomId()`.

### `UseJavaExtensionBlock` unchanged-detection never fired

`getStatements()` builds a new list on each call, so `mapped == cu.getStatements()` compared against a freshly-allocated list and was always false. The original list is now held in a local and compared against that.

## Testing

Added `leavesDependencyHandlerAddAlone` to `OneDependencyDeclarationPerStatementTest` and `noChangeToDependencyHandlerAddCalls` to `GradleBestPracticesTest`. `./gradlew :rewrite-gradle:test` passes for both classes.