### PR TITLE
Stop `getRequestedVersion()` falling back to the resolved version

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
@@ -25,24 +25,15 @@ import org.openrewrite.rpc.request.RpcRequest;
 public class RecipeBundle implements RpcRequest {
     String packageEcosystem;
     String packageName;
-    @Nullable String requestedVersion;
-    @Nullable String version;
-    @Nullable String team;
 
     /**
-     * A requested version could be a dynamic constraint like LATEST or 0.2.0-SNAPSHOT. The way
-     * in which a dynamic constraint is resolved is {@link RecipeBundleResolver} specific, but
-     * the possibility of dynamic version constraints is a concept that several resolvers share.
-     * <br>
-     * To prevent subtle bugs where, for example, version is set but requested version is not and
-     * a resolver is attempting to read the version on this bundle, we fall back on the version
-     * if a bundle has been constructed with a version but no requested version.
-     *
-     * @return The requested version, or {@link #getVersion()} if no requested version has been set.
+     * May be a dynamic constraint like LATEST or 0.2.0-SNAPSHOT, resolved in a way that is
+     * {@link RecipeBundleResolver} specific. Null when no constraint was requested.
      */
-    public @Nullable String getRequestedVersion() {
-        return requestedVersion == null ? version : requestedVersion;
-    }
+    @Nullable String requestedVersion;
+
+    @Nullable String version;
+    @Nullable String team;
 
     /**
      * This may seem a bit backwards here, but the intent is for resolution to be repeatable.


### PR DESCRIPTION
`RecipeBundle.getRequestedVersion()` returned `version` whenever `requestedVersion` was null. `RecipeMarketplaceWriter` persists that column through the accessor, so a bundle installed without a version constraint was written back carrying the resolved version as its requested version. Reading that CSV produced an exactly pinned bundle, and the pin then survived every subsequent write of the marketplace.

Deleting the hand-written accessor lets `@Data` generate one that returns the field, so null keeps meaning "no constraint was requested". Callers already handle null, and ecosystems with no version concept — `yaml`, `ide`, and runtime-classpath bundles — depend on it.

`getVersion()` keeps its fallback. Resolvers read it on a bundle where only `requestedVersion` is populated in order to decide what to install, so removing that one would make a pinned request install unpinned.

### Test plan

- `:rewrite-core:test --tests '*marketplace*' --tests '*GetMarketplaceResponse*'` passes, including `nullLiteralVersionIsTreatedAsNull` and `roundTripPreservesNullVersions`.
- Verified by hand that a bundle resolved from an unconstrained request now round-trips through `RecipeMarketplaceWriter`/`RecipeMarketplaceReader` with the `requestedVersion` column blank, where previously the second write recorded the resolved version as an exact pin.

No existing test pinned the removed fallback: `GetMarketplaceResponseTest` constructs a bundle with `requestedVersion == null` and a set `version`, but asserts only on `getVersion()`.