### PR TITLE
Recipe bundle identity comes from the resolver, not the CSV payload

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
@@ -42,7 +42,7 @@ public class RecipeBundle implements RpcRequest {
      * will then be set on version so that subsequent installations of the same bundle result
      * in a repeatable outcome.
      */
-    public @Nullable String getVersion() {
+    public @Nullable String getEffectiveVersion() {
         return version == null ? requestedVersion : version;
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
@@ -37,10 +37,8 @@ public class RecipeBundle implements RpcRequest {
     @Nullable String team;
 
     /**
-     * This may seem a bit backwards here, but the intent is for resolution to be repeatable.
-     * Only when version is null do we resolve the requested version. That resolved version
-     * will then be set on version so that subsequent installations of the same bundle result
-     * in a repeatable outcome.
+     * The version to resolve with: an already-resolved version wins over the requested
+     * constraint, which is what makes a repeat install of the same bundle repeatable.
      */
     public @Nullable String getEffectiveVersion() {
         return version == null ? requestedVersion : version;

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
@@ -23,8 +23,8 @@ import org.openrewrite.rpc.request.RpcRequest;
 @Data
 @AllArgsConstructor
 public class RecipeBundle implements RpcRequest {
-    String packageEcosystem;
-    String packageName;
+    @Nullable String packageEcosystem;
+    @Nullable String packageName;
 
     /**
      * May be a dynamic constraint like LATEST or 0.2.0-SNAPSHOT, resolved in a way that is

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeBundle.java
@@ -15,24 +15,25 @@
  */
 package org.openrewrite.marketplace;
 
-import lombok.AllArgsConstructor;
-import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import lombok.With;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.rpc.request.RpcRequest;
 
-@Data
-@AllArgsConstructor
+@Value
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class RecipeBundle implements RpcRequest {
-    @Nullable String packageEcosystem;
-    @Nullable String packageName;
+    @EqualsAndHashCode.Include @Nullable String packageEcosystem;
+    @EqualsAndHashCode.Include @Nullable String packageName;
 
     /**
      * May be a dynamic constraint like LATEST or 0.2.0-SNAPSHOT, resolved in a way that is
      * {@link RecipeBundleResolver} specific. Null when no constraint was requested.
      */
-    @Nullable String requestedVersion;
+    @With @Nullable String requestedVersion;
 
-    @Nullable String version;
+    @With @Nullable String version;
     @Nullable String team;
 
     /**

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -94,9 +94,8 @@ public class RecipeMarketplace {
      * nearest scope first.
      *
      * @return The listings actually added, so callers report what landed rather than what was
-     * offered. Keyed by recipe name, so a recipe filed under several categories counts once --
-     * and so do two bundles declaring one name, which no current caller can produce because
-     * every merge contributes a single bundle.
+     * offered. Keyed by recipe name, so a recipe filed under several categories counts once,
+     * as do two bundles declaring one name.
      */
     public Set<RecipeListing> merge(RecipeMarketplace marketplace) {
         Set<RecipeListing> added = new LinkedHashSet<>();

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -83,8 +83,7 @@ public class RecipeMarketplace {
         RecipeBundle bundle = bundleReader.getBundle();
         bindRecursive(marketplace.getRoot(), bundle);
         uninstall(bundle.getPackageEcosystem(), bundle.getPackageName());
-        root.merge(marketplace.getRoot());
-        return marketplace.getAllRecipes();
+        return root.merge(marketplace.getRoot());
     }
 
     /**
@@ -120,14 +119,22 @@ public class RecipeMarketplace {
         private final List<Category> categories = new ArrayList<>();
         private final List<RecipeListing> recipes = new ArrayList<>();
 
-        public void merge(Category category) {
+        /**
+         * @return The listings actually added to this category (or a subcategory), i.e. excluding
+         * any that lost the first-wins name collision below. Used by {@link RecipeMarketplace#install}
+         * to report only what actually landed, rather than everything the source category offered.
+         */
+        public Set<RecipeListing> merge(Category category) {
+            Set<RecipeListing> added = new LinkedHashSet<>();
             for (RecipeListing recipe : category.recipes) {
                 // First-wins, matching findRecipe/getAllRecipes traversal order and this method's own
                 // subcategory branch, which keeps the existing node. Callers express precedence by
                 // merging the nearest scope first.
                 if (!recipes.contains(recipe)) {
-                    recipes.add(recipe.withMarketplace(RecipeMarketplace.this)
-                            .withBundle(intern(recipe.getBundle())));
+                    RecipeListing installed = recipe.withMarketplace(RecipeMarketplace.this)
+                            .withBundle(intern(recipe.getBundle()));
+                    recipes.add(installed);
+                    added.add(installed);
                 }
             }
             for (Category subCategory : category.categories) {
@@ -139,13 +146,14 @@ public class RecipeMarketplace {
                     }
                 }
                 if (existingSubCategory != null) {
-                    existingSubCategory.merge(subCategory);
+                    added.addAll(existingSubCategory.merge(subCategory));
                 } else {
                     Category copy = new Category(subCategory.displayName, subCategory.description);
-                    copy.merge(subCategory);
+                    added.addAll(copy.merge(subCategory));
                     categories.add(copy);
                 }
             }
+            return added;
         }
 
         public void uninstall(String packageEcosystem, String packageName) {

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -122,9 +122,13 @@ public class RecipeMarketplace {
 
         public void merge(Category category) {
             for (RecipeListing recipe : category.recipes) {
-                recipes.remove(recipe);
-                recipes.add(recipe.withMarketplace(RecipeMarketplace.this)
-                        .withBundle(intern(recipe.getBundle())));
+                // First-wins, matching findRecipe/getAllRecipes traversal order and this method's own
+                // subcategory branch, which keeps the existing node. Callers express precedence by
+                // merging the nearest scope first.
+                if (!recipes.contains(recipe)) {
+                    recipes.add(recipe.withMarketplace(RecipeMarketplace.this)
+                            .withBundle(intern(recipe.getBundle())));
+                }
             }
             for (Category subCategory : category.categories) {
                 Category existingSubCategory = null;

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -32,7 +32,11 @@ public class RecipeMarketplace {
             "When displaying the category hierarchy of a marketplace, " +
             "this is typically not shown.");
 
-    private final Map<BundleKey, RecipeBundle> bundles = new LinkedHashMap<>();
+    private static final Comparator<RecipeBundle> BY_COORDINATE =
+            Comparator.comparing(RecipeBundle::getPackageEcosystem)
+                    .thenComparing(RecipeBundle::getPackageName);
+
+    private final Map<BundleKey, RecipeBundle> bundles = new HashMap<>();
 
     public @Nullable RecipeListing findRecipe(String name) {
         return root.findRecipe(name);
@@ -42,21 +46,17 @@ public class RecipeMarketplace {
         return root.getAllRecipes();
     }
 
-    /** @return Every distinct bundle contributing recipes to this marketplace. */
     public Set<RecipeBundle> getBundles() {
-        return new LinkedHashSet<>(bundles.values());
+        Set<RecipeBundle> sorted = new TreeSet<>(BY_COORDINATE);
+        sorted.addAll(bundles.values());
+        return sorted;
     }
 
     public @Nullable RecipeBundle bundleFor(String packageEcosystem, String packageName) {
         return bundles.get(new BundleKey(packageEcosystem, packageName));
     }
 
-    /**
-     * Canonicalize so every listing from one bundle shares one instance. A bundle with no
-     * identity — an inner CSV that omitted the columns — is not registered; install binds it
-     * to the resolved bundle before it matters.
-     */
-    RecipeBundle intern(RecipeBundle bundle) {
+    private RecipeBundle intern(RecipeBundle bundle) {
         if (bundle.getPackageEcosystem() == null || bundle.getPackageName() == null) {
             return bundle;
         }
@@ -86,12 +86,6 @@ public class RecipeMarketplace {
         return root.merge(marketplace.getRoot());
     }
 
-    /**
-     * A reader contributes only its own bundle's recipes, so whatever identity the payload
-     * claimed is replaced by the bundle that was actually resolved. Walks the tree rather than
-     * getAllRecipes(), which deduplicates by name and would miss a recipe's sibling listings
-     * in other categories.
-     */
     private void bindRecursive(Category category, RecipeBundle bundle) {
         category.getRecipes().replaceAll(listing -> listing.withBundle(bundle));
         for (Category child : category.getCategories()) {
@@ -101,9 +95,6 @@ public class RecipeMarketplace {
 
     public void uninstall(String packageEcosystem, String packageName) {
         root.uninstall(packageEcosystem, packageName);
-        // Once a bundle contributes no listings it must not linger in the registry --
-        // otherwise a later install() of the same (ecosystem, packageName) at a new version
-        // finds the stale key still populated and intern() re-attaches the old instance.
         bundles.remove(new BundleKey(packageEcosystem, packageName));
     }
 
@@ -120,16 +111,12 @@ public class RecipeMarketplace {
         private final List<RecipeListing> recipes = new ArrayList<>();
 
         /**
-         * @return The listings actually added to this category (or a subcategory), i.e. excluding
-         * any that lost the first-wins name collision below. Used by {@link RecipeMarketplace#install}
-         * to report only what actually landed, rather than everything the source category offered.
+         * @return The listings actually added, excluding any that lost a name collision, so that
+         * callers can report what landed rather than what was offered.
          */
         public Set<RecipeListing> merge(Category category) {
             Set<RecipeListing> added = new LinkedHashSet<>();
             for (RecipeListing recipe : category.recipes) {
-                // First-wins, matching findRecipe/getAllRecipes traversal order and this method's own
-                // subcategory branch, which keeps the existing node. Callers express precedence by
-                // merging the nearest scope first.
                 if (!recipes.contains(recipe)) {
                     RecipeListing installed = recipe.withMarketplace(RecipeMarketplace.this)
                             .withBundle(intern(recipe.getBundle()));
@@ -156,7 +143,7 @@ public class RecipeMarketplace {
             return added;
         }
 
-        public void uninstall(String packageEcosystem, String packageName) {
+        private void uninstall(String packageEcosystem, String packageName) {
             recipes.removeIf(r -> Objects.equals(r.getBundle().getPackageName(), packageName) &&
                                   Objects.equals(r.getBundle().getPackageEcosystem(), packageEcosystem));
             for (Category category : categories) {
@@ -200,17 +187,10 @@ public class RecipeMarketplace {
          * @param recipe       The recipe to add
          * @param categoryPath Category path from shallowest to deepest (e.g., "Java", "Search")
          */
-        public void install(RecipeListing recipe, List<CategoryDescriptor> categoryPath) {
-            installInto(recipe.withMarketplace(RecipeMarketplace.this)
-                    .withBundle(intern(recipe.getBundle())), categoryPath);
-        }
+        private void install(RecipeListing recipe, List<CategoryDescriptor> categoryPath) {
+            recipe = recipe.withMarketplace(RecipeMarketplace.this)
+                    .withBundle(intern(recipe.getBundle()));
 
-        /**
-         * Recursive descent for {@link #install}. Takes a recipe that has already been bound
-         * and interned once at the entry point, so it isn't redundantly re-bound/re-interned at
-         * every category depth.
-         */
-        private void installInto(RecipeListing recipe, List<CategoryDescriptor> categoryPath) {
             if (categoryPath.isEmpty()) {
                 recipes.add(recipe);
                 return;
@@ -221,7 +201,7 @@ public class RecipeMarketplace {
             Category targetCategory = findOrCreateCategory(firstCategory);
 
             // Recursively add to the child category
-            targetCategory.installInto(recipe, categoryPath.subList(1, categoryPath.size()));
+            targetCategory.install(recipe, categoryPath.subList(1, categoryPath.size()));
         }
 
         private Category findOrCreateCategory(CategoryDescriptor categoryDescriptor) {

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -78,12 +78,31 @@ public class RecipeMarketplace {
         root.install(recipe, categoryPath);
     }
 
-    public Set<RecipeListing> install(RecipeBundleReader bundleReader) {
+    public List<RecipeListing> install(RecipeBundleReader bundleReader) {
         RecipeMarketplace marketplace = bundleReader.read();
         RecipeBundle bundle = bundleReader.getBundle();
         bindRecursive(marketplace.getRoot(), bundle);
         uninstall(bundle.getPackageEcosystem(), bundle.getPackageName());
-        return root.merge(marketplace.getRoot());
+        return merge(marketplace);
+    }
+
+    /**
+     * Contribute another marketplace's recipes to this one, keeping what is already here. A
+     * bundle coordinate already installed blocks every listing the incoming marketplace offers
+     * for it, whether that is the same version (a duplicate) or a different one (a farther
+     * layer, superseded by the nearer install). Callers express precedence by merging the
+     * nearest scope first.
+     *
+     * @return The listings actually added, so callers report what landed rather than what was
+     * offered. A recipe filed under several categories appears once per category.
+     */
+    public List<RecipeListing> merge(RecipeMarketplace marketplace) {
+        List<RecipeListing> added = new ArrayList<>();
+        // Snapshot, because interning registers each incoming bundle as its first listing lands
+        // and a bundle's recipes span several categories -- a live check would block its own
+        // second category.
+        root.merge(marketplace.getRoot(), new HashSet<>(bundles.keySet()), added);
+        return added;
     }
 
     private void bindRecursive(Category category, RecipeBundle bundle) {
@@ -110,19 +129,20 @@ public class RecipeMarketplace {
         private final List<Category> categories = new ArrayList<>();
         private final List<RecipeListing> recipes = new ArrayList<>();
 
-        /**
-         * @return The listings actually added, excluding any that lost a name collision, so that
-         * callers can report what landed rather than what was offered.
-         */
-        public Set<RecipeListing> merge(Category category) {
-            Set<RecipeListing> added = new LinkedHashSet<>();
+        private void merge(Category category, Set<BundleKey> alreadyInstalled, List<RecipeListing> added) {
             for (RecipeListing recipe : category.recipes) {
-                if (!recipes.contains(recipe)) {
-                    RecipeListing installed = recipe.withMarketplace(RecipeMarketplace.this)
-                            .withBundle(intern(recipe.getBundle()));
-                    recipes.add(installed);
-                    added.add(installed);
+                RecipeBundle bundle = recipe.getBundle();
+                if (bundle.getPackageEcosystem() != null && bundle.getPackageName() != null &&
+                    alreadyInstalled.contains(new BundleKey(bundle.getPackageEcosystem(), bundle.getPackageName()))) {
+                    continue;
                 }
+                // No name check: the coordinate filter above means nothing surviving can already
+                // be here, so a colliding name belongs to another bundle and is stored shadowed --
+                // it resolves as soon as the winner is uninstalled, without reprocessing.
+                RecipeListing installed = recipe.withMarketplace(RecipeMarketplace.this)
+                        .withBundle(intern(bundle));
+                recipes.add(installed);
+                added.add(installed);
             }
             for (Category subCategory : category.categories) {
                 Category existingSubCategory = null;
@@ -133,14 +153,17 @@ public class RecipeMarketplace {
                     }
                 }
                 if (existingSubCategory != null) {
-                    added.addAll(existingSubCategory.merge(subCategory));
+                    existingSubCategory.merge(subCategory, alreadyInstalled, added);
                 } else {
                     Category copy = new Category(subCategory.displayName, subCategory.description);
-                    added.addAll(copy.merge(subCategory));
-                    categories.add(copy);
+                    copy.merge(subCategory, alreadyInstalled, added);
+                    // A wholly blocked subtree contributes nothing; grafting it would leave empty
+                    // categories for a UI to render.
+                    if (!copy.recipes.isEmpty() || !copy.categories.isEmpty()) {
+                        categories.add(copy);
+                    }
                 }
             }
-            return added;
         }
 
         private void uninstall(String packageEcosystem, String packageName) {

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -78,7 +78,7 @@ public class RecipeMarketplace {
         root.install(recipe, categoryPath);
     }
 
-    public List<RecipeListing> install(RecipeBundleReader bundleReader) {
+    public Set<RecipeListing> install(RecipeBundleReader bundleReader) {
         RecipeMarketplace marketplace = bundleReader.read();
         RecipeBundle bundle = bundleReader.getBundle();
         bindRecursive(marketplace.getRoot(), bundle);
@@ -94,10 +94,12 @@ public class RecipeMarketplace {
      * nearest scope first.
      *
      * @return The listings actually added, so callers report what landed rather than what was
-     * offered. A recipe filed under several categories appears once per category.
+     * offered. Keyed by recipe name, so a recipe filed under several categories counts once --
+     * and so do two bundles declaring one name, which no current caller can produce because
+     * every merge contributes a single bundle.
      */
-    public List<RecipeListing> merge(RecipeMarketplace marketplace) {
-        List<RecipeListing> added = new ArrayList<>();
+    public Set<RecipeListing> merge(RecipeMarketplace marketplace) {
+        Set<RecipeListing> added = new LinkedHashSet<>();
         // Snapshot, because interning registers each incoming bundle as its first listing lands
         // and a bundle's recipes span several categories -- a live check would block its own
         // second category.
@@ -129,7 +131,7 @@ public class RecipeMarketplace {
         private final List<Category> categories = new ArrayList<>();
         private final List<RecipeListing> recipes = new ArrayList<>();
 
-        private void merge(Category category, Set<BundleKey> alreadyInstalled, List<RecipeListing> added) {
+        private void merge(Category category, Set<BundleKey> alreadyInstalled, Set<RecipeListing> added) {
             for (RecipeListing recipe : category.recipes) {
                 RecipeBundle bundle = recipe.getBundle();
                 if (bundle.getPackageEcosystem() != null && bundle.getPackageName() != null &&

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -17,6 +17,7 @@ package org.openrewrite.marketplace;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Incubating;
 import org.openrewrite.NlsRewrite;
@@ -31,12 +32,42 @@ public class RecipeMarketplace {
             "When displaying the category hierarchy of a marketplace, " +
             "this is typically not shown.");
 
+    private final Map<BundleKey, RecipeBundle> bundles = new LinkedHashMap<>();
+
     public @Nullable RecipeListing findRecipe(String name) {
         return root.findRecipe(name);
     }
 
     public Set<RecipeListing> getAllRecipes() {
         return root.getAllRecipes();
+    }
+
+    /** @return Every distinct bundle contributing recipes to this marketplace. */
+    public Set<RecipeBundle> getBundles() {
+        return new LinkedHashSet<>(bundles.values());
+    }
+
+    public @Nullable RecipeBundle bundleFor(String packageEcosystem, String packageName) {
+        return bundles.get(new BundleKey(packageEcosystem, packageName));
+    }
+
+    /**
+     * Canonicalize so every listing from one bundle shares one instance. A bundle with no
+     * identity — an inner CSV that omitted the columns — is not registered; install binds it
+     * to the resolved bundle before it matters.
+     */
+    RecipeBundle intern(RecipeBundle bundle) {
+        if (bundle.getPackageEcosystem() == null || bundle.getPackageName() == null) {
+            return bundle;
+        }
+        return bundles.computeIfAbsent(
+                new BundleKey(bundle.getPackageEcosystem(), bundle.getPackageName()), k -> bundle);
+    }
+
+    @Value
+    private static class BundleKey {
+        String packageEcosystem;
+        String packageName;
     }
 
     public List<Category> getCategories() {
@@ -71,6 +102,10 @@ public class RecipeMarketplace {
 
     public void uninstall(String packageEcosystem, String packageName) {
         root.uninstall(packageEcosystem, packageName);
+        // Once a bundle contributes no listings it must not linger in the registry --
+        // otherwise a later install() of the same (ecosystem, packageName) at a new version
+        // finds the stale key still populated and intern() re-attaches the old instance.
+        bundles.remove(new BundleKey(packageEcosystem, packageName));
     }
 
     @Getter
@@ -88,7 +123,8 @@ public class RecipeMarketplace {
         public void merge(Category category) {
             for (RecipeListing recipe : category.recipes) {
                 recipes.remove(recipe);
-                recipes.add(recipe.withMarketplace(RecipeMarketplace.this));
+                recipes.add(recipe.withMarketplace(RecipeMarketplace.this)
+                        .withBundle(intern(recipe.getBundle())));
             }
             for (Category subCategory : category.categories) {
                 Category existingSubCategory = null;
@@ -109,8 +145,8 @@ public class RecipeMarketplace {
         }
 
         public void uninstall(String packageEcosystem, String packageName) {
-            recipes.removeIf(r -> r.getBundle().getPackageName().equals(packageName) &&
-                                  r.getBundle().getPackageEcosystem().equals(packageEcosystem));
+            recipes.removeIf(r -> Objects.equals(r.getBundle().getPackageName(), packageName) &&
+                                  Objects.equals(r.getBundle().getPackageEcosystem(), packageEcosystem));
             for (Category category : categories) {
                 category.uninstall(packageEcosystem, packageName);
             }
@@ -153,8 +189,16 @@ public class RecipeMarketplace {
          * @param categoryPath Category path from shallowest to deepest (e.g., "Java", "Search")
          */
         public void install(RecipeListing recipe, List<CategoryDescriptor> categoryPath) {
-            recipe = recipe.withMarketplace(RecipeMarketplace.this);
+            installInto(recipe.withMarketplace(RecipeMarketplace.this)
+                    .withBundle(intern(recipe.getBundle())), categoryPath);
+        }
 
+        /**
+         * Recursive descent for {@link #install}. Takes a recipe that has already been bound
+         * and interned once at the entry point, so it isn't redundantly re-bound/re-interned at
+         * every category depth.
+         */
+        private void installInto(RecipeListing recipe, List<CategoryDescriptor> categoryPath) {
             if (categoryPath.isEmpty()) {
                 recipes.add(recipe);
                 return;
@@ -165,7 +209,7 @@ public class RecipeMarketplace {
             Category targetCategory = findOrCreateCategory(firstCategory);
 
             // Recursively add to the child category
-            targetCategory.install(recipe, categoryPath.subList(1, categoryPath.size()));
+            targetCategory.installInto(recipe, categoryPath.subList(1, categoryPath.size()));
         }
 
         private Category findOrCreateCategory(CategoryDescriptor categoryDescriptor) {

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -50,9 +50,23 @@ public class RecipeMarketplace {
     public Set<RecipeListing> install(RecipeBundleReader bundleReader) {
         RecipeMarketplace marketplace = bundleReader.read();
         RecipeBundle bundle = bundleReader.getBundle();
+        bindRecursive(marketplace.getRoot(), bundle);
         uninstall(bundle.getPackageEcosystem(), bundle.getPackageName());
         root.merge(marketplace.getRoot());
         return marketplace.getAllRecipes();
+    }
+
+    /**
+     * A reader contributes only its own bundle's recipes, so whatever identity the payload
+     * claimed is replaced by the bundle that was actually resolved. Walks the tree rather than
+     * getAllRecipes(), which deduplicates by name and would miss a recipe's sibling listings
+     * in other categories.
+     */
+    private void bindRecursive(Category category, RecipeBundle bundle) {
+        category.getRecipes().replaceAll(listing -> listing.withBundle(bundle));
+        for (Category child : category.getCategories()) {
+            bindRecursive(child, bundle);
+        }
     }
 
     public void uninstall(String packageEcosystem, String packageName) {

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -136,9 +136,6 @@ public class RecipeMarketplace {
                     alreadyInstalled.contains(new BundleKey(bundle.getPackageEcosystem(), bundle.getPackageName()))) {
                     continue;
                 }
-                // No name check: the coordinate filter above means nothing surviving can already
-                // be here, so a colliding name belongs to another bundle and is stored shadowed --
-                // it resolves as soon as the winner is uninstalled, without reprocessing.
                 RecipeListing installed = recipe.withMarketplace(RecipeMarketplace.this)
                         .withBundle(intern(bundle));
                 recipes.add(installed);
@@ -157,8 +154,6 @@ public class RecipeMarketplace {
                 } else {
                     Category copy = new Category(subCategory.displayName, subCategory.description);
                     copy.merge(subCategory, alreadyInstalled, added);
-                    // A wholly blocked subtree contributes nothing; grafting it would leave empty
-                    // categories for a UI to render.
                     if (!copy.recipes.isEmpty() || !copy.categories.isEmpty()) {
                         categories.add(copy);
                     }

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.Incubating;
 import org.openrewrite.NlsRewrite;
 import org.openrewrite.config.CategoryDescriptor;
+import org.openrewrite.internal.StringUtils;
 
 import java.util.*;
 
@@ -79,10 +80,17 @@ public class RecipeMarketplace {
     }
 
     public Set<RecipeListing> install(RecipeBundleReader bundleReader) {
-        RecipeMarketplace marketplace = bundleReader.read();
         RecipeBundle bundle = bundleReader.getBundle();
+        String packageEcosystem = bundle.getPackageEcosystem();
+        String packageName = bundle.getPackageName();
+        if (StringUtils.isBlank(packageEcosystem) || StringUtils.isBlank(packageName)) {
+            throw new IllegalArgumentException("A bundle must be resolved to an ecosystem and package name " +
+                                               "before it can be installed, but got ecosystem '" + packageEcosystem +
+                                               "' and package name '" + packageName + "'");
+        }
+        RecipeMarketplace marketplace = bundleReader.read();
         bindRecursive(marketplace.getRoot(), bundle);
-        uninstall(bundle.getPackageEcosystem(), bundle.getPackageName());
+        uninstall(packageEcosystem, packageName);
         return merge(marketplace);
     }
 
@@ -133,8 +141,14 @@ public class RecipeMarketplace {
         private void merge(Category category, Set<BundleKey> alreadyInstalled, Set<RecipeListing> added) {
             for (RecipeListing recipe : category.recipes) {
                 RecipeBundle bundle = recipe.getBundle();
-                if (bundle.getPackageEcosystem() != null && bundle.getPackageName() != null &&
-                    alreadyInstalled.contains(new BundleKey(bundle.getPackageEcosystem(), bundle.getPackageName()))) {
+                String packageEcosystem = bundle.getPackageEcosystem();
+                String packageName = bundle.getPackageName();
+                if (StringUtils.isBlank(packageEcosystem) || StringUtils.isBlank(packageName)) {
+                    throw new IllegalArgumentException("Cannot merge '" + recipe.getName() + "' because its bundle " +
+                                                       "has no ecosystem and package name. A marketplace read from " +
+                                                       "an inner CSV must be bound to a resolved bundle first.");
+                }
+                if (alreadyInstalled.contains(new BundleKey(packageEcosystem, packageName))) {
                     continue;
                 }
                 RecipeListing installed = recipe.withMarketplace(RecipeMarketplace.this)

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -115,8 +115,8 @@ public class RecipeMarketplace {
     }
 
     private void bindRecursive(Category category, RecipeBundle bundle) {
-        category.getRecipes().replaceAll(listing -> listing.withBundle(bundle));
-        for (Category child : category.getCategories()) {
+        category.recipes.replaceAll(listing -> listing.withBundle(bundle));
+        for (Category child : category.categories) {
             bindRecursive(child, bundle);
         }
     }
@@ -137,6 +137,21 @@ public class RecipeMarketplace {
 
         private final List<Category> categories = new ArrayList<>();
         private final List<RecipeListing> recipes = new ArrayList<>();
+
+        /**
+         * A view, not a copy. Structural change goes through {@link #install} and
+         * {@link #uninstall}, which keep the bundle registry in step with the tree.
+         */
+        public List<Category> getCategories() {
+            return Collections.unmodifiableList(categories);
+        }
+
+        /**
+         * @see #getCategories()
+         */
+        public List<RecipeListing> getRecipes() {
+            return Collections.unmodifiableList(recipes);
+        }
 
         private void merge(Category category, Set<BundleKey> alreadyInstalled, Set<RecipeListing> added) {
             for (RecipeListing recipe : category.recipes) {

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceReader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceReader.java
@@ -239,10 +239,13 @@ public class RecipeMarketplaceReader {
             throw new IllegalArgumentException("CSV file must contain a column named 'name' and each row must have a value for it");
         }
 
-        // ecosystem and packageName are optional: an inner (single-bundle) CSV need not carry
-        // identity, because RecipeMarketplace.install binds every listing to the resolved bundle.
+        if ((ecosystem == null) != (packageName == null)) {
+            throw new IllegalArgumentException("A recipe row must have both 'ecosystem' and 'packageName' or neither, but '" +
+                                               name + "' has only '" + (ecosystem == null ? "packageName" : "ecosystem") + "'");
+        }
+
         RecipeBundle bundle = new RecipeBundle(
-                ecosystem == null ? null : ecosystem.toLowerCase(),
+                ecosystem == null ? null : ecosystem.toLowerCase(Locale.ROOT),
                 packageName, requestedVersion, version, team);
 
         RecipeListing listing = new RecipeListing(

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceReader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceReader.java
@@ -237,14 +237,13 @@ public class RecipeMarketplaceReader {
 
         if (name == null) {
             throw new IllegalArgumentException("CSV file must contain a column named 'name' and each row must have a value for it");
-        } else if (packageName == null) {
-            throw new IllegalArgumentException("CSV file must contain a column named 'packageName' and each row must have a value for it");
-        } else if (ecosystem == null) {
-            throw new IllegalArgumentException("CSV file must contain a column named 'ecosystem' and each row must have a value for it");
         }
 
-        // Create bundle if ecosystem information is present
-        RecipeBundle bundle = new RecipeBundle(ecosystem.toLowerCase(), packageName, requestedVersion, version, team);
+        // ecosystem and packageName are optional: an inner (single-bundle) CSV need not carry
+        // identity, because RecipeMarketplace.install binds every listing to the resolved bundle.
+        RecipeBundle bundle = new RecipeBundle(
+                ecosystem == null ? null : ecosystem.toLowerCase(),
+                packageName, requestedVersion, version, team);
 
         RecipeListing listing = new RecipeListing(
                 marketplace,

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceWriter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceWriter.java
@@ -69,7 +69,6 @@ public class RecipeMarketplaceWriter {
             int maxCategoryDepth = calculateMaxCategoryDepth(marketplace.getRoot(), -1) + 1;
             boolean hasOptions = hasAnyOptions(marketplace.getRoot());
             boolean hasDataTables = hasAnyDataTables(marketplace.getRoot());
-            boolean hasVersion = hasAnyVersion(marketplace);
             boolean hasTeam = hasAnyTeam(marketplace);
             boolean hasCategoryDescription = hasAnyCategoryDescription(marketplace.getRoot());
             List<String> metadataKeys = collectMetadataKeys(marketplace);
@@ -77,10 +76,8 @@ public class RecipeMarketplaceWriter {
             List<String> headers = new ArrayList<>();
             headers.add("ecosystem");
             headers.add("packageName");
-            if (hasVersion) {
-                headers.add("requestedVersion");
-                headers.add("version");
-            }
+            headers.add("requestedVersion");
+            headers.add("version");
             headers.add("name");
             headers.add("displayName");
             headers.add("description");
@@ -117,7 +114,7 @@ public class RecipeMarketplaceWriter {
             csv.writeHeaders(headers);
             List<List<String>> rows = new ArrayList<>();
             collectRowsRecursive(rows, marketplace.getRoot(), emptyList(), emptyList(),
-                    maxCategoryDepth, hasOptions, hasDataTables, hasTeam, hasVersion, hasCategoryDescription, metadataKeys);
+                    maxCategoryDepth, hasOptions, hasDataTables, hasTeam, hasCategoryDescription, metadataKeys);
             rows.sort(CSV_ROW_COMPARATOR);
             for (List<String> row : rows) {
                 csv.writeRow(row.toArray(new String[0]));
@@ -130,17 +127,15 @@ public class RecipeMarketplaceWriter {
     private void collectRowsRecursive(List<List<String>> rows, RecipeMarketplace.Category category,
                                       List<String> categoryPath, List<String> categoryDescriptionPath,
                                       int maxCategoryDepth, boolean hasOptions, boolean hasDataTables, boolean hasTeam,
-                                      boolean hasVersion, boolean hasCategoryDescription,
+                                      boolean hasCategoryDescription,
                                       List<String> metadataKeys) {
         for (RecipeListing recipe : category.getRecipes()) {
             List<String> row = new ArrayList<>();
             RecipeBundle bundle = recipe.getBundle();
-            row.add(bundle.getPackageEcosystem());
-            row.add(bundle.getPackageName());
-            if (hasVersion) {
-                row.add(StringUtils.isBlank(bundle.getRequestedVersion()) ? "" : bundle.getRequestedVersion());
-                row.add(StringUtils.isBlank(bundle.getVersion()) ? "" : bundle.getVersion());
-            }
+            row.add(StringUtils.isBlank(bundle.getPackageEcosystem()) ? "" : bundle.getPackageEcosystem());
+            row.add(StringUtils.isBlank(bundle.getPackageName()) ? "" : bundle.getPackageName());
+            row.add(StringUtils.isBlank(bundle.getRequestedVersion()) ? "" : bundle.getRequestedVersion());
+            row.add(StringUtils.isBlank(bundle.getVersion()) ? "" : bundle.getVersion());
             row.add(recipe.getName());
             row.add(recipe.getDisplayName());
             row.add(recipe.getDescription());
@@ -197,7 +192,7 @@ public class RecipeMarketplaceWriter {
             List<String> childDescriptionPath = new ArrayList<>(categoryDescriptionPath);
             childDescriptionPath.add(0, child.getDescription());
             collectRowsRecursive(rows, child, childPath, childDescriptionPath, maxCategoryDepth, hasOptions, hasDataTables,
-                    hasTeam, hasVersion, hasCategoryDescription, metadataKeys);
+                    hasTeam, hasCategoryDescription, metadataKeys);
         }
     }
 
@@ -283,16 +278,6 @@ public class RecipeMarketplaceWriter {
         for (RecipeListing recipe : marketplace.getAllRecipes()) {
             RecipeBundle bundle = recipe.getBundle();
             if (StringUtils.isNotBlank(bundle.getTeam())) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private boolean hasAnyVersion(RecipeMarketplace marketplace) {
-        for (RecipeListing recipe : marketplace.getAllRecipes()) {
-            RecipeBundle bundle = recipe.getBundle();
-            if (StringUtils.isNotBlank(bundle.getVersion())) {
                 return true;
             }
         }

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceWriter.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplaceWriter.java
@@ -71,13 +71,16 @@ public class RecipeMarketplaceWriter {
             boolean hasDataTables = hasAnyDataTables(marketplace.getRoot());
             boolean hasTeam = hasAnyTeam(marketplace);
             boolean hasCategoryDescription = hasAnyCategoryDescription(marketplace.getRoot());
+            boolean hasVersion = hasAnyVersion(marketplace.getRoot());
             List<String> metadataKeys = collectMetadataKeys(marketplace);
 
             List<String> headers = new ArrayList<>();
             headers.add("ecosystem");
             headers.add("packageName");
-            headers.add("requestedVersion");
-            headers.add("version");
+            if (hasVersion) {
+                headers.add("requestedVersion");
+                headers.add("version");
+            }
             headers.add("name");
             headers.add("displayName");
             headers.add("description");
@@ -114,7 +117,8 @@ public class RecipeMarketplaceWriter {
             csv.writeHeaders(headers);
             List<List<String>> rows = new ArrayList<>();
             collectRowsRecursive(rows, marketplace.getRoot(), emptyList(), emptyList(),
-                    maxCategoryDepth, hasOptions, hasDataTables, hasTeam, hasCategoryDescription, metadataKeys);
+                    maxCategoryDepth, hasOptions, hasDataTables, hasTeam, hasCategoryDescription,
+                    hasVersion, metadataKeys);
             rows.sort(CSV_ROW_COMPARATOR);
             for (List<String> row : rows) {
                 csv.writeRow(row.toArray(new String[0]));
@@ -127,15 +131,17 @@ public class RecipeMarketplaceWriter {
     private void collectRowsRecursive(List<List<String>> rows, RecipeMarketplace.Category category,
                                       List<String> categoryPath, List<String> categoryDescriptionPath,
                                       int maxCategoryDepth, boolean hasOptions, boolean hasDataTables, boolean hasTeam,
-                                      boolean hasCategoryDescription,
+                                      boolean hasCategoryDescription, boolean hasVersion,
                                       List<String> metadataKeys) {
         for (RecipeListing recipe : category.getRecipes()) {
             List<String> row = new ArrayList<>();
             RecipeBundle bundle = recipe.getBundle();
             row.add(StringUtils.isBlank(bundle.getPackageEcosystem()) ? "" : bundle.getPackageEcosystem());
             row.add(StringUtils.isBlank(bundle.getPackageName()) ? "" : bundle.getPackageName());
-            row.add(StringUtils.isBlank(bundle.getRequestedVersion()) ? "" : bundle.getRequestedVersion());
-            row.add(StringUtils.isBlank(bundle.getVersion()) ? "" : bundle.getVersion());
+            if (hasVersion) {
+                row.add(StringUtils.isBlank(bundle.getRequestedVersion()) ? "" : bundle.getRequestedVersion());
+                row.add(StringUtils.isBlank(bundle.getVersion()) ? "" : bundle.getVersion());
+            }
             row.add(recipe.getName());
             row.add(recipe.getDisplayName());
             row.add(recipe.getDescription());
@@ -192,7 +198,7 @@ public class RecipeMarketplaceWriter {
             List<String> childDescriptionPath = new ArrayList<>(categoryDescriptionPath);
             childDescriptionPath.add(0, child.getDescription());
             collectRowsRecursive(rows, child, childPath, childDescriptionPath, maxCategoryDepth, hasOptions, hasDataTables,
-                    hasTeam, hasCategoryDescription, metadataKeys);
+                    hasTeam, hasCategoryDescription, hasVersion, metadataKeys);
         }
     }
 
@@ -268,6 +274,27 @@ public class RecipeMarketplaceWriter {
         }
         for (RecipeMarketplace.Category child : category.getCategories()) {
             if (hasAnyDataTables(child)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Walks the tree rather than {@link RecipeMarketplace#getAllRecipes()}, which is keyed by
+     * recipe name: a bundle whose every listing lost that dedup would have its version invisible
+     * here, making the file's schema depend on which duplicate won a traversal.
+     */
+    private boolean hasAnyVersion(RecipeMarketplace.Category category) {
+        for (RecipeListing recipe : category.getRecipes()) {
+            RecipeBundle bundle = recipe.getBundle();
+            if (StringUtils.isNotBlank(bundle.getVersion()) ||
+                StringUtils.isNotBlank(bundle.getRequestedVersion())) {
+                return true;
+            }
+        }
+        for (RecipeMarketplace.Category child : category.getCategories()) {
+            if (hasAnyVersion(child)) {
                 return true;
             }
         }

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleReader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleReader.java
@@ -33,9 +33,20 @@ public class YamlRecipeBundleReader implements RecipeBundleReader {
     private final @Getter RecipeBundle bundle;
     private final YamlResourceLoader yamlLoader;
 
+    /**
+     * Category path to file every recipe under, shallowest to deepest. When empty each recipe
+     * takes the path inferred from its own name.
+     */
+    private final List<CategoryDescriptor> categoryOverride;
+
     public YamlRecipeBundleReader(RecipeBundle bundle, InputStream yamlLoader, URI source, Properties properties, RecipeMarketplace marketplace, Collection<RecipeBundleResolver> resolvers) {
+        this(bundle, yamlLoader, source, properties, marketplace, resolvers, emptyList());
+    }
+
+    public YamlRecipeBundleReader(RecipeBundle bundle, InputStream yamlLoader, URI source, Properties properties, RecipeMarketplace marketplace, Collection<RecipeBundleResolver> resolvers, List<CategoryDescriptor> categoryOverride) {
         this.yamlLoader = new YamlResourceLoader(yamlLoader, source, properties, marketplace, resolvers);
         this.bundle = bundle;
+        this.categoryOverride = categoryOverride;
     }
 
     @Override
@@ -46,7 +57,9 @@ public class YamlRecipeBundleReader implements RecipeBundleReader {
 
         RecipeMarketplace marketplace = new RecipeMarketplace();
         for (RecipeListing listing : yamlLoader.listRecipeListings(bundle)) {
-            marketplace.install(listing, inferCategoriesFromName(env, listing.getName()));
+            marketplace.install(listing, categoryOverride.isEmpty() ?
+                    inferCategoriesFromName(env, listing.getName()) :
+                    categoryOverride);
         }
 
         return marketplace;

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleReader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleReader.java
@@ -32,11 +32,6 @@ import static java.util.Collections.*;
 public class YamlRecipeBundleReader implements RecipeBundleReader {
     private final @Getter RecipeBundle bundle;
     private final YamlResourceLoader yamlLoader;
-
-    /**
-     * Category path to file every recipe under, shallowest to deepest. When empty each recipe
-     * takes the path inferred from its own name.
-     */
     private final List<CategoryDescriptor> categoryOverride;
 
     public YamlRecipeBundleReader(RecipeBundle bundle, InputStream yamlLoader, URI source, Properties properties, RecipeMarketplace marketplace, Collection<RecipeBundleResolver> resolvers) {

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
@@ -34,11 +34,6 @@ public class YamlRecipeBundleResolver implements RecipeBundleResolver {
     private final Properties properties;
     private final RecipeMarketplace marketplace;
     private final Collection<RecipeBundleResolver> resolvers;
-
-    /**
-     * Category path to file every recipe under, shallowest to deepest. When empty each recipe
-     * takes the path inferred from its own name.
-     */
     private final List<CategoryDescriptor> categoryOverride;
 
     public YamlRecipeBundleResolver(Properties properties, RecipeMarketplace marketplace,

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/YamlRecipeBundleResolver.java
@@ -16,6 +16,7 @@
 package org.openrewrite.marketplace;
 
 import lombok.RequiredArgsConstructor;
+import org.openrewrite.config.CategoryDescriptor;
 
 import java.io.InputStream;
 import java.net.URI;
@@ -23,13 +24,27 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
+
+import static java.util.Collections.emptyList;
 
 @RequiredArgsConstructor
 public class YamlRecipeBundleResolver implements RecipeBundleResolver {
     private final Properties properties;
     private final RecipeMarketplace marketplace;
     private final Collection<RecipeBundleResolver> resolvers;
+
+    /**
+     * Category path to file every recipe under, shallowest to deepest. When empty each recipe
+     * takes the path inferred from its own name.
+     */
+    private final List<CategoryDescriptor> categoryOverride;
+
+    public YamlRecipeBundleResolver(Properties properties, RecipeMarketplace marketplace,
+                                    Collection<RecipeBundleResolver> resolvers) {
+        this(properties, marketplace, resolvers, emptyList());
+    }
 
     @Override
     public String getEcosystem() {
@@ -42,7 +57,7 @@ public class YamlRecipeBundleResolver implements RecipeBundleResolver {
             Path path = Paths.get(bundle.getPackageName());
             if (Files.exists(path)) {
                 try (InputStream is = Files.newInputStream(path)) {
-                    return new YamlRecipeBundleReader(bundle, is, path.toUri(), properties, marketplace, resolvers);
+                    return new YamlRecipeBundleReader(bundle, is, path.toUri(), properties, marketplace, resolvers, categoryOverride);
                 }
             }
         } catch (Exception ignored) {
@@ -51,7 +66,7 @@ public class YamlRecipeBundleResolver implements RecipeBundleResolver {
         try {
             URI resource = URI.create(bundle.getPackageName());
             try (InputStream is = resource.toURL().openStream()) {
-                return new YamlRecipeBundleReader(bundle, is, resource, properties, marketplace, resolvers);
+                return new YamlRecipeBundleReader(bundle, is, resource, properties, marketplace, resolvers, categoryOverride);
             }
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.marketplace;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Recipe;
+import org.openrewrite.config.CategoryDescriptor;
+import org.openrewrite.config.RecipeDescriptor;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RecipeMarketplaceInstallTest {
+
+    /** Returns listings whose bundles claim a different package than the one being installed. */
+    private static RecipeBundleReader driftingReader(RecipeBundle requested, RecipeBundle claimed) {
+        return new RecipeBundleReader() {
+            @Override
+            public RecipeBundle getBundle() {
+                return requested;
+            }
+
+            @Override
+            public RecipeMarketplace read() {
+                RecipeMarketplace m = new RecipeMarketplace();
+                RecipeListing listing = new RecipeListing(null, "com.foo.Bar", "Bar", "Bar.",
+                        null, emptyList(), emptyList(), 1, claimed);
+                m.install(listing, List.of(category("Java")));
+                m.install(listing, List.of(category("JavaScript")));
+                return m;
+            }
+
+            @Override
+            public RecipeDescriptor describe(RecipeListing listing) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    private static CategoryDescriptor category(String name) {
+        return new CategoryDescriptor(name, "", "", emptySet(), false, 0, false);
+    }
+
+    @Test
+    void installBindsEveryListingToTheRequestedBundle() {
+        RecipeBundle requested = new RecipeBundle("maven", "co.uk.acme:recipes", "LATEST", "1.2.3", null);
+        RecipeBundle claimed = new RecipeBundle("maven", "com.yourorg:starter", null, null, null);
+
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+        marketplace.install(driftingReader(requested, claimed));
+
+        // Walk the tree, not getAllRecipes() — both category copies must be bound.
+        assertThat(allListings(marketplace.getRoot()))
+                .hasSize(2)
+                .allSatisfy(l -> {
+                    assertThat(l.getBundle().getPackageName()).isEqualTo("co.uk.acme:recipes");
+                    assertThat(l.getBundle().getVersion()).isEqualTo("1.2.3");
+                });
+    }
+
+    private static List<RecipeListing> allListings(RecipeMarketplace.Category category) {
+        List<RecipeListing> out = new java.util.ArrayList<>(category.getRecipes());
+        for (RecipeMarketplace.Category child : category.getCategories()) {
+            out.addAll(allListings(child));
+        }
+        return out;
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.config.RecipeDescriptor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -106,5 +107,68 @@ class RecipeMarketplaceInstallTest {
             out.addAll(allListings(child));
         }
         return out;
+    }
+
+    /** A reader whose sole listing is {@code recipeName}, bound to {@code bundle}. */
+    private static RecipeBundleReader singleRecipeReader(RecipeBundle bundle, String recipeName) {
+        return new RecipeBundleReader() {
+            @Override
+            public RecipeBundle getBundle() {
+                return bundle;
+            }
+
+            @Override
+            public RecipeMarketplace read() {
+                RecipeMarketplace m = new RecipeMarketplace();
+                RecipeListing listing = new RecipeListing(null, recipeName, recipeName, recipeName + ".",
+                        null, emptyList(), emptyList(), 1, bundle);
+                m.install(listing, List.of(category("Java")));
+                return m;
+            }
+
+            @Override
+            public RecipeDescriptor describe(RecipeListing listing) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+
+    @Test
+    void installReportsOnlyListingsThatActuallyLanded() {
+        RecipeBundle bundleA = new RecipeBundle("maven", "org.example:a", "1.0.0", "1.0.0", null);
+        RecipeBundle bundleB = new RecipeBundle("maven", "org.example:b", "1.0.0", "1.0.0", null);
+
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+
+        Set<RecipeListing> installedA = marketplace.install(singleRecipeReader(bundleA, "com.foo.Bar"));
+        assertThat(installedA)
+                .as("bundle a is the first to claim com.foo.Bar, so it lands")
+                .extracting(RecipeListing::getName)
+                .containsExactly("com.foo.Bar");
+
+        // bundle b also declares com.foo.Bar, but a already owns that name -- Category.merge's
+        // first-wins tie-break skips it. install() must not report a listing it didn't add.
+        Set<RecipeListing> installedB = marketplace.install(singleRecipeReader(bundleB, "com.foo.Bar"));
+        assertThat(installedB)
+                .as("install() must report nothing when every listing lost the name collision")
+                .isEmpty();
+
+        // The marketplace itself is unaffected: com.foo.Bar is still owned by bundle a.
+        assertThat(marketplace.findRecipe("com.foo.Bar"))
+                .isNotNull()
+                .extracting(l -> l.getBundle().getPackageName())
+                .isEqualTo("org.example:a");
+
+        // A bundle that contributed no listings must not appear as installed.
+        assertThat(marketplace.getBundles())
+                .as("bundle b never interned a listing, so it must not be reported as installed")
+                .extracting(RecipeBundle::getPackageName)
+                .containsExactly("org.example:a");
+        assertThat(marketplace.bundleFor("maven", "org.example:b")).isNull();
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.config.RecipeDescriptor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -144,7 +145,7 @@ class RecipeMarketplaceInstallTest {
 
         RecipeMarketplace marketplace = new RecipeMarketplace();
 
-        List<RecipeListing> installedA = marketplace.install(singleRecipeReader(bundleA, "com.foo.Bar"));
+        Set<RecipeListing> installedA = marketplace.install(singleRecipeReader(bundleA, "com.foo.Bar"));
         assertThat(installedA)
                 .as("bundle a is the first to claim com.foo.Bar, so it resolves")
                 .extracting(RecipeListing::getName)
@@ -152,7 +153,7 @@ class RecipeMarketplaceInstallTest {
 
         // bundle b declares the same name from a different coordinate, so it is stored behind a
         // rather than dropped -- otherwise revealing it later would mean reprocessing bundle b.
-        List<RecipeListing> installedB = marketplace.install(singleRecipeReader(bundleB, "com.foo.Bar"));
+        Set<RecipeListing> installedB = marketplace.install(singleRecipeReader(bundleB, "com.foo.Bar"));
         assertThat(installedB)
                 .extracting(RecipeListing::getName)
                 .containsExactly("com.foo.Bar");

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RecipeMarketplaceInstallTest {
 
@@ -139,6 +140,16 @@ class RecipeMarketplaceInstallTest {
     }
 
     @Test
+    void installRejectsABundleThatWasNeverResolvedToACoordinate() {
+        RecipeBundle unidentified = new RecipeBundle("maven", "", "1.0.0", "1.0.0", null);
+
+        assertThatThrownBy(() -> new RecipeMarketplace()
+                .install(singleRecipeReader(unidentified, "com.foo.Bar")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must be resolved to an ecosystem and package name");
+    }
+
+    @Test
     void installStoresACollidingNameShadowedRatherThanDroppingIt() {
         RecipeBundle bundleA = new RecipeBundle("maven", "org.example:a", "1.0.0", "1.0.0", null);
         RecipeBundle bundleB = new RecipeBundle("maven", "org.example:b", "1.0.0", "1.0.0", null);
@@ -151,8 +162,7 @@ class RecipeMarketplaceInstallTest {
                 .extracting(RecipeListing::getName)
                 .containsExactly("com.foo.Bar");
 
-        // bundle b declares the same name from a different coordinate, so it is stored behind a
-        // rather than dropped -- otherwise revealing it later would mean reprocessing bundle b.
+        // Dropping b's listing instead would make revealing it later a reprocess of bundle b.
         Set<RecipeListing> installedB = marketplace.install(singleRecipeReader(bundleB, "com.foo.Bar"));
         assertThat(installedB)
                 .extracting(RecipeListing::getName)

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -22,7 +22,6 @@ import org.openrewrite.config.RecipeDescriptor;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
@@ -139,36 +138,40 @@ class RecipeMarketplaceInstallTest {
     }
 
     @Test
-    void installReportsOnlyListingsThatActuallyLanded() {
+    void installStoresACollidingNameShadowedRatherThanDroppingIt() {
         RecipeBundle bundleA = new RecipeBundle("maven", "org.example:a", "1.0.0", "1.0.0", null);
         RecipeBundle bundleB = new RecipeBundle("maven", "org.example:b", "1.0.0", "1.0.0", null);
 
         RecipeMarketplace marketplace = new RecipeMarketplace();
 
-        Set<RecipeListing> installedA = marketplace.install(singleRecipeReader(bundleA, "com.foo.Bar"));
+        List<RecipeListing> installedA = marketplace.install(singleRecipeReader(bundleA, "com.foo.Bar"));
         assertThat(installedA)
-                .as("bundle a is the first to claim com.foo.Bar, so it lands")
+                .as("bundle a is the first to claim com.foo.Bar, so it resolves")
                 .extracting(RecipeListing::getName)
                 .containsExactly("com.foo.Bar");
 
-        // bundle b also declares com.foo.Bar, but a already owns that name -- Category.merge's
-        // first-wins tie-break skips it. install() must not report a listing it didn't add.
-        Set<RecipeListing> installedB = marketplace.install(singleRecipeReader(bundleB, "com.foo.Bar"));
+        // bundle b declares the same name from a different coordinate, so it is stored behind a
+        // rather than dropped -- otherwise revealing it later would mean reprocessing bundle b.
+        List<RecipeListing> installedB = marketplace.install(singleRecipeReader(bundleB, "com.foo.Bar"));
         assertThat(installedB)
-                .as("install() must report nothing when every listing lost the name collision")
-                .isEmpty();
+                .extracting(RecipeListing::getName)
+                .containsExactly("com.foo.Bar");
 
-        // The marketplace itself is unaffected: com.foo.Bar is still owned by bundle a.
         assertThat(marketplace.findRecipe("com.foo.Bar"))
                 .isNotNull()
                 .extracting(l -> l.getBundle().getPackageName())
+                .as("first-wins: a still resolves while b is shadowed")
                 .isEqualTo("org.example:a");
 
-        // A bundle that contributed no listings must not appear as installed.
         assertThat(marketplace.getBundles())
-                .as("bundle b never interned a listing, so it must not be reported as installed")
                 .extracting(RecipeBundle::getPackageName)
-                .containsExactly("org.example:a");
-        assertThat(marketplace.bundleFor("maven", "org.example:b")).isNull();
+                .containsExactly("org.example:a", "org.example:b");
+
+        marketplace.uninstall("maven", "org.example:a");
+
+        assertThat(marketplace.findRecipe("com.foo.Bar"))
+                .isNotNull()
+                .extracting(l -> l.getBundle().getPackageName())
+                .isEqualTo("org.example:b");
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -102,6 +102,25 @@ class RecipeMarketplaceInstallTest {
                 .isEqualTo("2.0.0");
     }
 
+    @Test
+    void theCategoryTreeCannotBeEditedThroughItsGetters() {
+        RecipeBundle bundle = new RecipeBundle("maven", "org.example:a", "LATEST", "1.0.0", null);
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+        marketplace.install(singleRecipeReader(bundle, "com.foo.Bar"));
+
+        RecipeMarketplace.Category root = marketplace.getRoot();
+        RecipeListing listing = marketplace.findRecipe("com.foo.Bar");
+
+        // Editing the tree directly would leave the bundle registry describing a marketplace
+        // that no longer exists, and can silently mutate a marketplace that is shared or cached.
+        assertThatThrownBy(() -> root.getRecipes().add(listing))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> root.getCategories().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> marketplace.getCategories().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
     private static List<RecipeListing> allListings(RecipeMarketplace.Category category) {
         List<RecipeListing> out = new java.util.ArrayList<>(category.getRecipes());
         for (RecipeMarketplace.Category child : category.getCategories()) {

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -80,6 +80,26 @@ class RecipeMarketplaceInstallTest {
                 });
     }
 
+    @Test
+    void reinstallAtNewVersionReplacesTheInternedBundle() {
+        RecipeBundle v1 = new RecipeBundle("maven", "co.uk.acme:recipes", "LATEST", "1.0.0", null);
+        RecipeBundle v2 = new RecipeBundle("maven", "co.uk.acme:recipes", "LATEST", "2.0.0", null);
+
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+        marketplace.install(driftingReader(v1, v1));
+        marketplace.install(driftingReader(v2, v2));
+
+        // Every listing must report the new version -- not a stale interned v1 bundle.
+        assertThat(allListings(marketplace.getRoot()))
+                .hasSize(2)
+                .allSatisfy(l -> assertThat(l.getBundle().getVersion()).isEqualTo("2.0.0"));
+
+        assertThat(marketplace.bundleFor("maven", "co.uk.acme:recipes"))
+                .isNotNull()
+                .extracting(RecipeBundle::getVersion)
+                .isEqualTo("2.0.0");
+    }
+
     private static List<RecipeListing> allListings(RecipeMarketplace.Category category) {
         List<RecipeListing> out = new java.util.ArrayList<>(category.getRecipes());
         for (RecipeMarketplace.Category child : category.getCategories()) {

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -309,10 +309,11 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
-    void recipeInMultipleCategoriesHasSeparateBundleInstances() {
+    void recipeInMultipleCategoriesHasSeparateListingInstances() {
         // This tests the scenario where a recipe appears in multiple categories
-        // (e.g., Java recipes that also work for JavaScript). Each listing should
-        // have its own RecipeBundle instance that needs to be updated independently.
+        // (e.g., Java recipes that also work for JavaScript). Each listing is a
+        // distinct instance -- that's what encodes multi-category membership --
+        // but they share one interned RecipeBundle per marketplace.
         RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
           name,displayName,category1,category2,ecosystem,packageName
           org.openrewrite.java.ChangeMethodName,Change method name,ChangeMethodName,Java,maven,org.openrewrite:rewrite-java
@@ -332,9 +333,30 @@ class RecipeMarketplaceReaderTest {
         RecipeListing javaListing = findCategory(java, "ChangeMethodName").getRecipes().getFirst();
         RecipeListing jsListing = findCategory(javascript, "ChangeMethodName").getRecipes().getFirst();
 
-        // These are DIFFERENT RecipeListing instances with DIFFERENT RecipeBundle instances
+        // These are DIFFERENT RecipeListing instances, but they share ONE interned RecipeBundle
         assertThat(javaListing).isNotSameAs(jsListing);
-        assertThat(javaListing.getBundle()).isNotSameAs(jsListing.getBundle());
+        assertThat(javaListing.getBundle()).isSameAs(jsListing.getBundle());
+    }
+
+    @Test
+    void bundlesAreInternedPerEcosystemAndPackage() {
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1,category2
+          maven,org.openrewrite:rewrite-java,LATEST,8.70.0,org.openrewrite.java.ChangeMethodName,Change method name,ChangeMethodName,Java
+          maven,org.openrewrite:rewrite-java,LATEST,8.70.0,org.openrewrite.java.ChangeMethodName,Change method name,ChangeMethodName,JavaScript
+          """);
+
+        RecipeMarketplace.Category java = findCategory(marketplace.getRoot(), "Java");
+        RecipeMarketplace.Category js = findCategory(marketplace.getRoot(), "JavaScript");
+        RecipeListing javaListing = findCategory(java, "ChangeMethodName").getRecipes().getFirst();
+        RecipeListing jsListing = findCategory(js, "ChangeMethodName").getRecipes().getFirst();
+
+        assertThat(javaListing).isNotSameAs(jsListing);
+        assertThat(javaListing.getBundle()).isSameAs(jsListing.getBundle());
+
+        assertThat(marketplace.getBundles()).hasSize(1);
+        assertThat(marketplace.bundleFor("maven", "org.openrewrite:rewrite-java"))
+                .isSameAs(javaListing.getBundle());
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -612,7 +612,8 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
-    void versionColumnsAreAlwaysEmitted() {
+    void versionColumnsAreOmittedWhenNoListingHasAVersion() {
+        // The shape of a generated inner recipes.csv: identity, but nothing resolved yet.
         RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
           ecosystem,packageName,name,displayName,category1
           yaml,recipes/team.yml,com.foo.Bar,Bar,Java
@@ -621,7 +622,53 @@ class RecipeMarketplaceReaderTest {
         String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
 
         assertThat(csv.lines().findFirst().orElseThrow())
-                .startsWith("ecosystem,packageName,requestedVersion,version,");
+                .startsWith("ecosystem,packageName,name,");
+    }
+
+    @Test
+    void aGeneratedInnerCsvCarriesNoVersionColumns() {
+        // MavenRecipeMarketplaceGenerator stamps "" rather than null for both versions, so the
+        // contract has to hold for blank as well as absent.
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+        marketplace.install(new RecipeListing(marketplace, "com.foo.Bar", "Bar", "Bar does a thing.",
+                null, List.of(), List.of(), 1,
+                new RecipeBundle("maven", "org.example:a", "", "", null)), List.of());
+
+        String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
+
+        assertThat(csv.lines().findFirst().orElseThrow())
+                .startsWith("ecosystem,packageName,name,");
+        assertThat(csv.lines().skip(1).findFirst().orElseThrow())
+                .startsWith("maven,org.example:a,com.foo.Bar,");
+    }
+
+    @Test
+    void versionColumnsAreEmittedWhenAnyListingHasAVersion() {
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:a,LATEST,1.0.0,com.foo.Bar,Bar,Java
+          """);
+
+        String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
+
+        assertThat(csv.lines().findFirst().orElseThrow())
+                .startsWith("ecosystem,packageName,requestedVersion,version,name,");
+    }
+
+    @Test
+    void aRequestedVersionAloneStillEmitsTheVersionColumns() {
+        // Gating on the resolved version alone would silently drop this row's requestedVersion.
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:a,LATEST,,com.foo.Bar,Bar,Java
+          """);
+
+        String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
+
+        assertThat(csv.lines().findFirst().orElseThrow())
+                .startsWith("ecosystem,packageName,requestedVersion,version,name,");
+        assertThat(csv.lines().skip(1).findFirst().orElseThrow())
+                .startsWith("maven,org.example:a,LATEST,,com.foo.Bar,");
     }
 
     @Test
@@ -634,7 +681,7 @@ class RecipeMarketplaceReaderTest {
         String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
 
         assertThat(csv).doesNotContain("null");
-        assertThat(csv.lines().skip(1).findFirst().orElseThrow()).startsWith(",,,,com.foo.Bar,");
+        assertThat(csv.lines().skip(1).findFirst().orElseThrow()).startsWith(",,com.foo.Bar,");
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -335,39 +335,6 @@ class RecipeMarketplaceReaderTest {
         // These are DIFFERENT RecipeListing instances with DIFFERENT RecipeBundle instances
         assertThat(javaListing).isNotSameAs(jsListing);
         assertThat(javaListing.getBundle()).isNotSameAs(jsListing.getBundle());
-
-        // Simulate what MavenRecipeBundleReader needs to do - update version on ALL bundles.
-        // If we only use getAllRecipes(), we'd only update one of them.
-        // The fix uses setVersionRecursive to walk the full tree.
-        String resolvedVersion = "8.70.0";
-        String requestedVersion = "LATEST";
-
-        // Walk the full tree and update all bundles matching the package
-        setVersionRecursive(marketplace.getRoot(), "org.openrewrite:rewrite-java", requestedVersion, resolvedVersion);
-
-        // Both listings should now have the version set
-        assertThat(javaListing.getBundle().getVersion()).isEqualTo(resolvedVersion);
-        assertThat(javaListing.getBundle().getRequestedVersion()).isEqualTo(requestedVersion);
-        assertThat(jsListing.getBundle().getVersion()).isEqualTo(resolvedVersion);
-        assertThat(jsListing.getBundle().getRequestedVersion()).isEqualTo(requestedVersion);
-
-        // Round-trip through CSV writer to verify versions are preserved
-        String writtenCsv = new RecipeMarketplaceWriter().toCsv(marketplace);
-        assertThat(writtenCsv).contains("LATEST");
-        assertThat(writtenCsv).contains("8.70.0");
-
-        // Verify the written CSV has versions for ALL rows, not just some
-        RecipeMarketplace roundTripped = new RecipeMarketplaceReader().fromCsv(writtenCsv);
-        RecipeMarketplace.Category rtJava = findCategory(roundTripped.getRoot(), "Java");
-        RecipeMarketplace.Category rtJs = findCategory(roundTripped.getRoot(), "JavaScript");
-
-        RecipeListing rtJavaListing = findCategory(rtJava, "ChangeMethodName").getRecipes().getFirst();
-        RecipeListing rtJsListing = findCategory(rtJs, "ChangeMethodName").getRecipes().getFirst();
-
-        assertThat(rtJavaListing.getBundle().getVersion()).isEqualTo(resolvedVersion);
-        assertThat(rtJavaListing.getBundle().getRequestedVersion()).isEqualTo(requestedVersion);
-        assertThat(rtJsListing.getBundle().getVersion()).isEqualTo(resolvedVersion);
-        assertThat(rtJsListing.getBundle().getRequestedVersion()).isEqualTo(requestedVersion);
     }
 
     @Test
@@ -406,20 +373,6 @@ class RecipeMarketplaceReaderTest {
         RecipeListing rtListing = roundTripped.getAllRecipes().iterator().next();
         assertThat(rtListing.getBundle().getVersion()).isNull();
         assertThat(rtListing.getBundle().getRequestedVersion()).isNull();
-    }
-
-    private void setVersionRecursive(RecipeMarketplace.Category category, String packageName,
-                                     String requestedVersion, String version) {
-        for (RecipeListing recipe : category.getRecipes()) {
-            RecipeBundle bundle = recipe.getBundle();
-            if (packageName.equals(bundle.getPackageName())) {
-                bundle.setVersion(version);
-                bundle.setRequestedVersion(requestedVersion);
-            }
-        }
-        for (RecipeMarketplace.Category child : category.getCategories()) {
-            setVersionRecursive(child, packageName, requestedVersion, version);
-        }
     }
 
     @Test
@@ -576,6 +529,26 @@ class RecipeMarketplaceReaderTest {
         assertThat(listing).isNotNull();
         assertThat(listing.getBundle().getPackageEcosystem()).isNull();
         assertThat(listing.getBundle().getPackageName()).isNull();
+    }
+
+    @Test
+    void equalityIsIdentityOnly() {
+        RecipeBundle a = new RecipeBundle("maven", "org.example:lib", "LATEST", "1.0.0", null);
+        RecipeBundle b = new RecipeBundle("maven", "org.example:lib", null, "2.0.0", "team");
+
+        assertThat(a).isEqualTo(b);
+        assertThat(a.hashCode()).isEqualTo(b.hashCode());
+        assertThat(a).isNotEqualTo(new RecipeBundle("pip", "org.example:lib", null, "1.0.0", null));
+    }
+
+    @Test
+    void withVersionReturnsACopy() {
+        RecipeBundle a = new RecipeBundle("maven", "org.example:lib", "LATEST", null, null);
+        RecipeBundle b = a.withVersion("1.0.0");
+
+        assertThat(b).isNotSameAs(a);
+        assertThat(a.getVersion()).isEqualTo("LATEST");   // getVersion() falls back to requestedVersion
+        assertThat(b.getVersion()).isEqualTo("1.0.0");
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -540,6 +540,32 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
+    void versionColumnsAreAlwaysEmitted() {
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,name,displayName,category1
+          yaml,recipes/team.yml,com.foo.Bar,Bar,Java
+          """);
+
+        String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
+
+        assertThat(csv.lines().findFirst().orElseThrow())
+                .startsWith("ecosystem,packageName,requestedVersion,version,");
+    }
+
+    @Test
+    void nullIdentityWritesEmptyCellsNotNullLiterals() {
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          name,displayName,category1
+          com.foo.Bar,Bar,Java
+          """);
+
+        String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
+
+        assertThat(csv).doesNotContain("null");
+        assertThat(csv.lines().skip(1).findFirst().orElseThrow()).startsWith(",,,,com.foo.Bar,");
+    }
+
+    @Test
     void identityColumnsAreOptional() {
         RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
           name,displayName,description,category1

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.config.DataTableDescriptor;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RecipeMarketplaceReaderTest {
 
@@ -536,6 +537,29 @@ class RecipeMarketplaceReaderTest {
         assertThat(marketplace.getRoot().getCategories().getFirst().getRecipes()).hasSize(2);
         // The first-seen casing wins
         assertThat(marketplace.getRoot().getCategories().getFirst().getDisplayName()).isEqualTo("AI");
+    }
+
+    @Test
+    void identityColumnsAreOptional() {
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          name,displayName,description,category1
+          com.foo.Bar,Bar,Bar does a thing.,Java
+          """);
+
+        RecipeListing listing = marketplace.findRecipe("com.foo.Bar");
+        assertThat(listing).isNotNull();
+        assertThat(listing.getBundle().getPackageEcosystem()).isNull();
+        assertThat(listing.getBundle().getPackageName()).isNull();
+    }
+
+    @Test
+    void nameIsStillRequired() {
+        assertThatThrownBy(() -> new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,displayName
+          maven,org.example:lib,Bar
+          """))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("name");
     }
 
     private static RecipeMarketplace.Category findCategory(RecipeMarketplace.Category category, String name) {

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -487,6 +487,31 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
+    void mergeLandsEveryCategoryOfABundleNotOnlyTheFirst() {
+        // Interning registers a bundle as its first listing lands, so the already-installed
+        // check has to read a snapshot: a live one would block the bundle's own later
+        // categories. A generated marketplace is exactly this shape -- one bundle, many
+        // categories, and one recipe filed under two of them.
+        RecipeMarketplace source = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:lib,1.0.0,1.0.0,com.foo.Bar,Bar,Java
+          maven,org.example:lib,1.0.0,1.0.0,com.foo.Baz,Baz,JavaScript
+          maven,org.example:lib,1.0.0,1.0.0,com.foo.Bar,Bar,JavaScript
+          """);
+        RecipeMarketplace target = new RecipeMarketplace();
+
+        target.merge(source);
+
+        assertThat(target.getCategories()).extracting("displayName")
+                .containsExactlyInAnyOrder("Java", "JavaScript");
+        assertThat(findCategory(target.getRoot(), "Java").getRecipes())
+                .extracting(RecipeListing::getName).containsExactly("com.foo.Bar");
+        assertThat(findCategory(target.getRoot(), "JavaScript").getRecipes())
+                .extracting(RecipeListing::getName)
+                .containsExactlyInAnyOrder("com.foo.Bar", "com.foo.Baz");
+    }
+
+    @Test
     void aWhollyBlockedSubtreeGraftsNoEmptyCategories() {
         RecipeMarketplace target = new RecipeMarketplaceReader().fromCsv("""
           ecosystem,packageName,requestedVersion,version,name,displayName,category1

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -417,7 +417,7 @@ class RecipeMarketplaceReaderTest {
 
         // Merge source into target — both have "Java" category so this exercises
         // the recursive merge path where withMarketplace() is called
-        target.getRoot().merge(source.getRoot());
+        target.merge(source);
 
         // Verify both recipes exist and metadata is preserved
         RecipeListing mergedTest = target.findRecipe("org.example.TestRecipe");
@@ -432,7 +432,7 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
-    void mergeKeepsTheIncumbent() {
+    void mergeShadowsACollidingNameRatherThanDroppingIt() {
         RecipeMarketplace nearest = new RecipeMarketplaceReader().fromCsv("""
           ecosystem,packageName,requestedVersion,version,name,displayName,category1
           maven,org.example:near,1.0.0,1.0.0,com.foo.Bar,Near,Java
@@ -442,11 +442,93 @@ class RecipeMarketplaceReaderTest {
           maven,org.example:far,2.0.0,2.0.0,com.foo.Bar,Far,Java
           """);
 
-        nearest.getRoot().merge(farther.getRoot());
+        nearest.merge(farther);
 
         assertThat(nearest.findRecipe("com.foo.Bar").getBundle().getPackageName())
                 .isEqualTo("org.example:near");
-        assertThat(nearest.getAllRecipes()).hasSize(1);
+        assertThat(nearest.getAllRecipes())
+                .as("The projection resolves one listing per name")
+                .hasSize(1);
+
+        nearest.uninstall("maven", "org.example:near");
+
+        assertThat(nearest.findRecipe("com.foo.Bar").getBundle().getPackageName())
+                .as("The shadowed listing was stored, so it resolves without reinstalling its bundle")
+                .isEqualTo("org.example:far");
+    }
+
+    @Test
+    void anInstalledCoordinateBlocksEveryListingAFartherVersionOffers() {
+        RecipeMarketplace nearest = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:lib,2.0.0,2.0.0,com.foo.Kept,Kept,Java
+          """);
+        RecipeMarketplace farther = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:lib,1.0.0,1.0.0,com.foo.Kept,Kept,Java
+          maven,org.example:lib,1.0.0,1.0.0,com.foo.Dropped,Dropped,Java
+          """);
+
+        assertThat(nearest.merge(farther)).isEmpty();
+        assertThat(nearest.findRecipe("com.foo.Dropped"))
+                .as("A recipe the nearer version removed stays removed; the older version does not resurrect it")
+                .isNull();
+        assertThat(nearest.bundleFor("maven", "org.example:lib").getVersion()).isEqualTo("2.0.0");
+    }
+
+    @Test
+    void mergingTheSameMarketplaceTwiceAddsNothing() {
+        RecipeMarketplace source = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:lib,1.0.0,1.0.0,com.foo.Bar,Bar,Java
+          """);
+        RecipeMarketplace target = new RecipeMarketplace();
+
+        assertThat(target.merge(source)).hasSize(1);
+        assertThat(target.merge(source)).isEmpty();
+        assertThat(target.getAllRecipes()).hasSize(1);
+    }
+
+    @Test
+    void aWhollyBlockedSubtreeGraftsNoEmptyCategories() {
+        RecipeMarketplace target = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:lib,2.0.0,2.0.0,com.foo.Bar,Bar,Java
+          """);
+        RecipeMarketplace farther = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:lib,1.0.0,1.0.0,com.foo.Baz,Baz,Python
+          """);
+
+        target.merge(farther);
+
+        assertThat(target.getRoot().getCategories())
+                .extracting(RecipeMarketplace.Category::getDisplayName)
+                .containsExactly("Java");
+    }
+
+    @Test
+    void aShadowedListingSurvivesACsvRoundTrip() {
+        RecipeMarketplace nearest = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:near,1.0.0,1.0.0,com.foo.Bar,Near,Java
+          """);
+        RecipeMarketplace farther = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:far,2.0.0,2.0.0,com.foo.Bar,Far,Java
+          """);
+        nearest.merge(farther);
+
+        RecipeMarketplace reloaded = new RecipeMarketplaceReader()
+                .fromCsv(new RecipeMarketplaceWriter().toCsv(nearest));
+
+        assertThat(reloaded.getBundles())
+                .extracting(RecipeBundle::getPackageName)
+                .containsExactly("org.example:far", "org.example:near");
+        assertThat(reloaded.findRecipe("com.foo.Bar").getBundle().getPackageName())
+                .as("The writer sorts rows by coordinate, so precedence within one marketplace " +
+                    "survives reload as a property of the coordinate rather than of install order")
+                .isEqualTo("org.example:far");
     }
 
     @Test
@@ -465,7 +547,7 @@ class RecipeMarketplaceReaderTest {
           io.moderne.ai.FindLibrariesInUse,ai,maven,io.moderne.recipe:rewrite-ai
           """);
 
-        marketplace1.getRoot().merge(marketplace2.getRoot());
+        marketplace1.merge(marketplace2);
 
         assertThat(marketplace1.getRoot().getCategories())
           .as("AI and ai should merge into a single category")
@@ -489,7 +571,7 @@ class RecipeMarketplaceReaderTest {
           """);
         RecipeMarketplace target = new RecipeMarketplace();
 
-        target.getRoot().merge(source.getRoot());
+        target.merge(source);
 
         RecipeMarketplace.Category sourceOuter = findCategory(source.getRoot(), "Outer");
         RecipeMarketplace.Category targetOuter = findCategory(target.getRoot(), "Outer");
@@ -502,7 +584,7 @@ class RecipeMarketplaceReaderTest {
           name,category1,category2,ecosystem,packageName
           org.example.OverlayRecipe,Inner,Outer,maven,org.example:overlay
           """);
-        target.getRoot().merge(overlay.getRoot());
+        target.merge(overlay);
 
         assertThat(findCategory(sourceOuter, "Inner").getRecipes())
           .as("Source category must not be mutated by changes to merge target")

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -310,10 +310,8 @@ class RecipeMarketplaceReaderTest {
 
     @Test
     void recipeInMultipleCategoriesHasSeparateListingInstances() {
-        // This tests the scenario where a recipe appears in multiple categories
-        // (e.g., Java recipes that also work for JavaScript). Each listing is a
-        // distinct instance -- that's what encodes multi-category membership --
-        // but they share one interned RecipeBundle per marketplace.
+        // Distinct listing instances are what encode multi-category membership, so a recipe
+        // that works for two languages is filed under both.
         RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
           name,displayName,category1,category2,ecosystem,packageName
           org.openrewrite.java.ChangeMethodName,Change method name,ChangeMethodName,Java,maven,org.openrewrite:rewrite-java
@@ -333,7 +331,6 @@ class RecipeMarketplaceReaderTest {
         RecipeListing javaListing = findCategory(java, "ChangeMethodName").getRecipes().getFirst();
         RecipeListing jsListing = findCategory(javascript, "ChangeMethodName").getRecipes().getFirst();
 
-        // These are DIFFERENT RecipeListing instances, but they share ONE interned RecipeBundle
         assertThat(javaListing).isNotSameAs(jsListing);
         assertThat(javaListing.getBundle()).isSameAs(jsListing.getBundle());
     }
@@ -654,6 +651,19 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
+    void mergeRejectsAMarketplaceWhoseBundlesAreUnidentified() {
+        RecipeMarketplace inner = new RecipeMarketplaceReader().fromCsv("""
+          name,displayName,description,category1
+          com.foo.Bar,Bar,Bar does a thing.,Java
+          """);
+
+        assertThatThrownBy(() -> new RecipeMarketplace().merge(inner))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("com.foo.Bar")
+          .hasMessageContaining("bound to a resolved bundle");
+    }
+
+    @Test
     void identityColumnsAreAllOrNothing() {
         assertThatThrownBy(() -> new RecipeMarketplaceReader().fromCsv("""
           ecosystem,name,displayName,category1
@@ -725,12 +735,9 @@ class RecipeMarketplaceReaderTest {
         RecipeBundle unresolved = new RecipeBundle("maven", "org.example:lib", "LATEST", null, null);
         RecipeBundle resolved = unresolved.withVersion("1.0.0");
 
-        // getVersion() is the raw field: null until resolution sets it, then exactly what was set.
         assertThat(unresolved.getVersion()).isNull();
         assertThat(resolved.getVersion()).isEqualTo("1.0.0");
 
-        // getEffectiveVersion() is the resolution decision: falls back to requestedVersion when
-        // version is unset, and otherwise matches the resolved version.
         assertThat(unresolved.getEffectiveVersion()).isEqualTo("LATEST");
         assertThat(resolved.getEffectiveVersion()).isEqualTo("1.0.0");
     }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -572,6 +572,23 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
+    void writerPersistsRawVersionNotEffectiveVersion() {
+        // An unresolved bundle (version=null, requestedVersion=">=1.0") must write an empty
+        // version cell. The writer must not persist getEffectiveVersion()'s fallback -- doing so
+        // would make a read-back bundle's "resolved" version look like a dynamic constraint.
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          name,displayName,category1,ecosystem,packageName,requestedVersion
+          com.foo.Bar,Bar,Java,maven,org.example:lib,>=1.0
+          """);
+
+        String csv = new RecipeMarketplaceWriter().toCsv(marketplace);
+        String[] columns = csv.lines().skip(1).findFirst().orElseThrow().split(",", -1);
+
+        assertThat(columns[2]).as("requestedVersion column").isEqualTo(">=1.0");
+        assertThat(columns[3]).as("version column").isEmpty();
+    }
+
+    @Test
     void equalityIsIdentityOnly() {
         RecipeBundle a = new RecipeBundle("maven", "org.example:lib", "LATEST", "1.0.0", null);
         RecipeBundle b = new RecipeBundle("maven", "org.example:lib", null, "2.0.0", "team");
@@ -587,8 +604,42 @@ class RecipeMarketplaceReaderTest {
         RecipeBundle b = a.withVersion("1.0.0");
 
         assertThat(b).isNotSameAs(a);
-        assertThat(a.getVersion()).isEqualTo("LATEST");   // getVersion() falls back to requestedVersion
+        assertThat(a.getVersion()).isNull();
         assertThat(b.getVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void effectiveVersionFallsBackToRequestedVersionButVersionDoesNot() {
+        RecipeBundle unresolved = new RecipeBundle("maven", "org.example:lib", "LATEST", null, null);
+        RecipeBundle resolved = unresolved.withVersion("1.0.0");
+
+        // getVersion() is the raw field: null until resolution sets it, then exactly what was set.
+        assertThat(unresolved.getVersion()).isNull();
+        assertThat(resolved.getVersion()).isEqualTo("1.0.0");
+
+        // getEffectiveVersion() is the resolution decision: falls back to requestedVersion when
+        // version is unset, and otherwise matches the resolved version.
+        assertThat(unresolved.getEffectiveVersion()).isEqualTo("LATEST");
+        assertThat(resolved.getEffectiveVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void roundTripDoesNotMigrateRequestedVersionIntoVersionColumn() {
+        // An unresolved bundle (version=null, requestedVersion set) must survive
+        // read -> write -> read without the constraint leaking into the version column.
+        RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv("""
+          name,displayName,category1,ecosystem,packageName,requestedVersion
+          com.foo.Bar,Bar,Java,maven,org.example:lib,>=1.0
+          """);
+
+        String firstCsv = new RecipeMarketplaceWriter().toCsv(marketplace);
+        RecipeMarketplace roundTripped = new RecipeMarketplaceReader().fromCsv(firstCsv);
+        String secondCsv = new RecipeMarketplaceWriter().toCsv(roundTripped);
+
+        RecipeBundle bundle = roundTripped.findRecipe("com.foo.Bar").getBundle();
+        assertThat(bundle.getRequestedVersion()).isEqualTo(">=1.0");
+        assertThat(bundle.getVersion()).isNull();
+        assertThat(secondCsv).isEqualTo(firstCsv);
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -432,6 +432,24 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
+    void mergeKeepsTheIncumbent() {
+        RecipeMarketplace nearest = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:near,1.0.0,1.0.0,com.foo.Bar,Near,Java
+          """);
+        RecipeMarketplace farther = new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,requestedVersion,version,name,displayName,category1
+          maven,org.example:far,2.0.0,2.0.0,com.foo.Bar,Far,Java
+          """);
+
+        nearest.getRoot().merge(farther.getRoot());
+
+        assertThat(nearest.findRecipe("com.foo.Bar").getBundle().getPackageName())
+                .isEqualTo("org.example:near");
+        assertThat(nearest.getAllRecipes()).hasSize(1);
+    }
+
+    @Test
     void mergeCategoriesCaseInsensitive() {
         // Simulates the real-world scenario where rewrite-java defines category "AI"
         // and rewrite-ai defines category "ai" -- these should merge into one category

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceReaderTest.java
@@ -572,6 +572,36 @@ class RecipeMarketplaceReaderTest {
     }
 
     @Test
+    void identityColumnsAreAllOrNothing() {
+        assertThatThrownBy(() -> new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,name,displayName,category1
+          maven,com.foo.Bar,Bar,Java
+          """))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("com.foo.Bar")
+          .hasMessageContaining("only 'ecosystem'");
+
+        assertThatThrownBy(() -> new RecipeMarketplaceReader().fromCsv("""
+          packageName,name,displayName,category1
+          org.example:lib,com.foo.Bar,Bar,Java
+          """))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("only 'packageName'");
+    }
+
+    @Test
+    void blankIdentityCellCountsAsAbsent() {
+        // The reader normalizes a blank cell to null, so a populated ecosystem beside an empty
+        // packageName is exactly-one, not both.
+        assertThatThrownBy(() -> new RecipeMarketplaceReader().fromCsv("""
+          ecosystem,packageName,name,displayName,category1
+          maven,,com.foo.Bar,Bar,Java
+          """))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("only 'ecosystem'");
+    }
+
+    @Test
     void writerPersistsRawVersionNotEffectiveVersion() {
         // An unresolved bundle (version=null, requestedVersion=">=1.0") must write an empty
         // version cell. The writer must not persist getEffectiveVersion()'s fallback -- doing so

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/YamlRecipeBundleReaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/YamlRecipeBundleReaderTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.marketplace;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.CategoryDescriptor;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Properties;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class YamlRecipeBundleReaderTest {
+    private static final String YAML = """
+      type: specs.openrewrite.org/v1beta/recipe
+      name: com.example.text.FindAndReplace
+      displayName: Find and replace
+      description: Finds and replaces.
+      recipeList:
+        - org.openrewrite.text.Find:
+            find: hello
+      """;
+
+    private static RecipeMarketplace read(List<CategoryDescriptor> categoryOverride) {
+        RecipeBundle bundle = new RecipeBundle("yaml", "/recipes/example.yml", null, null, null);
+        return new YamlRecipeBundleReader(bundle,
+                new ByteArrayInputStream(YAML.getBytes(StandardCharsets.UTF_8)),
+                URI.create("file:///recipes/example.yml"),
+                new Properties(), new RecipeMarketplace(), emptyList(), categoryOverride).read();
+    }
+
+    private static CategoryDescriptor category(String name) {
+        return new CategoryDescriptor(name, "", "", emptySet(), false, 0, false);
+    }
+
+    private static List<String> pathTo(RecipeMarketplace marketplace, String recipeName) {
+        return pathTo(marketplace.getRoot(), recipeName, emptyList());
+    }
+
+    private static List<String> pathTo(RecipeMarketplace.Category category, String recipeName, List<String> soFar) {
+        for (RecipeListing listing : category.getRecipes()) {
+            if (listing.getName().equals(recipeName)) {
+                return soFar;
+            }
+        }
+        for (RecipeMarketplace.Category child : category.getCategories()) {
+            List<String> deeper = new java.util.ArrayList<>(soFar);
+            deeper.add(child.getDisplayName());
+            List<String> found = pathTo(child, recipeName, deeper);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void withoutAnOverrideTheCategoryIsInferredFromTheRecipeName() {
+        RecipeMarketplace marketplace = read(emptyList());
+
+        assertThat(marketplace.findRecipe("com.example.text.FindAndReplace")).isNotNull();
+        assertThat(pathTo(marketplace, "com.example.text.FindAndReplace"))
+                .as("the path comes from the recipe's own package, not from the caller")
+                .isNotEmpty();
+    }
+
+    @Test
+    void anOverrideReplacesTheInferredCategoryPath() {
+        RecipeMarketplace marketplace = read(List.of(category("Custom"), category("Nested")));
+
+        assertThat(pathTo(marketplace, "com.example.text.FindAndReplace"))
+                .as("the override is a path, shallowest to deepest, and supersedes the inferred one")
+                .containsExactly("Custom", "Nested");
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -882,7 +882,9 @@ public class RewriteRpcServer
     {
         var stagingCsproj = EnsureRecipesProject(packageName, ".staging");
         var addArgs = $"add \"{stagingCsproj}\" package {packageName}";
-        if (requestedVersion != null)
+        // Empty is the same statement as absent — no constraint requested. Appending an empty
+        // --version emits a dangling flag and fails the restore instead of resolving latest.
+        if (!string.IsNullOrWhiteSpace(requestedVersion))
             addArgs += $" --version {requestedVersion}";
         RunDotnet(addArgs);
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -882,8 +882,6 @@ public class RewriteRpcServer
     {
         var stagingCsproj = EnsureRecipesProject(packageName, ".staging");
         var addArgs = $"add \"{stagingCsproj}\" package {packageName}";
-        // Empty is the same statement as absent — no constraint requested. Appending an empty
-        // --version emits a dangling flag and fails the restore instead of resolving latest.
         if (!string.IsNullOrWhiteSpace(requestedVersion))
             addArgs += $" --version {requestedVersion}";
         RunDotnet(addArgs);

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
@@ -48,9 +48,9 @@ public class NuGetRecipeBundleResolver implements RecipeBundleResolver {
             String absolutePath = pkgPath.toAbsolutePath().normalize().toString();
             resolved = new RecipeBundle(bundle.getPackageEcosystem(), absolutePath,
                     bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
-            response = rpc.installRecipes(absolutePath, bundle.getVersion());
+            response = rpc.installRecipes(absolutePath, bundle.getEffectiveVersion());
         } else {
-            response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
+            response = rpc.installRecipes(bundle.getPackageName(), bundle.getEffectiveVersion());
         }
         if (response.getVersion() != null) {
             resolved = resolved.withVersion(response.getVersion());

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marketplace/NuGetRecipeBundleResolver.java
@@ -39,20 +39,22 @@ public class NuGetRecipeBundleResolver implements RecipeBundleResolver {
     public RecipeBundleReader resolve(RecipeBundle bundle) {
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
+        RecipeBundle resolved = bundle;
         if (Files.exists(pkgPath)) {
             // Local file: send (and record on the bundle) the absolute path. The server's working
             // directory may differ from ours, so it needs the absolute form to load the assembly —
             // and aligning the bundle's packageName with it keeps the install origin the server
             // records and the marketplace filter key (the bundle's packageName) the same value.
             String absolutePath = pkgPath.toAbsolutePath().normalize().toString();
-            bundle.setPackageName(absolutePath);
+            resolved = new RecipeBundle(bundle.getPackageEcosystem(), absolutePath,
+                    bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
             response = rpc.installRecipes(absolutePath, bundle.getVersion());
         } else {
             response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
         }
         if (response.getVersion() != null) {
-            bundle.setVersion(response.getVersion());
+            resolved = resolved.withVersion(response.getVersion());
         }
-        return new NuGetRecipeBundleReader(bundle, rpc);
+        return new NuGetRecipeBundleReader(resolved, rpc);
     }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marketplace/GolangRecipeBundleResolver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marketplace/GolangRecipeBundleResolver.java
@@ -59,7 +59,7 @@ public class GolangRecipeBundleResolver implements RecipeBundleResolver {
                     bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
             response = rpc.installRecipes(absolute.toFile());
         } else {
-            response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
+            response = rpc.installRecipes(bundle.getPackageName(), bundle.getEffectiveVersion());
         }
         this.lastResponse = response;
         if (response.getVersion() != null) {

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marketplace/GolangRecipeBundleResolver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marketplace/GolangRecipeBundleResolver.java
@@ -51,18 +51,20 @@ public class GolangRecipeBundleResolver implements RecipeBundleResolver {
     public RecipeBundleReader resolve(RecipeBundle bundle) {
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
+        RecipeBundle resolved = bundle;
         if (Files.exists(pkgPath)) {
-            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
             Path absolute = pkgPath.toAbsolutePath().normalize();
-            bundle.setPackageName(absolute.toString());
+            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
+            resolved = new RecipeBundle(bundle.getPackageEcosystem(), absolute.toString(),
+                    bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
             response = rpc.installRecipes(absolute.toFile());
         } else {
             response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
         }
         this.lastResponse = response;
         if (response.getVersion() != null) {
-            bundle.setVersion(response.getVersion());
+            resolved = resolved.withVersion(response.getVersion());
         }
-        return new GolangRecipeBundleReader(bundle, rpc);
+        return new GolangRecipeBundleReader(resolved, rpc);
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
@@ -39,17 +39,19 @@ public class NpmRecipeBundleResolver implements RecipeBundleResolver {
     public RecipeBundleReader resolve(RecipeBundle bundle) {
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
+        RecipeBundle resolved = bundle;
         if (Files.exists(pkgPath)) {
-            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
             Path absolute = pkgPath.toAbsolutePath().normalize();
-            bundle.setPackageName(absolute.toString());
+            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
+            resolved = new RecipeBundle(bundle.getPackageEcosystem(), absolute.toString(),
+                    bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
             response = rpc.installRecipes(absolute.toFile());
         } else {
             response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
         }
         if (response.getVersion() != null) {
-            bundle.setVersion(response.getVersion());
+            resolved = resolved.withVersion(response.getVersion());
         }
-        return new NpmRecipeBundleReader(bundle, rpc);
+        return new NpmRecipeBundleReader(resolved, rpc);
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marketplace/NpmRecipeBundleResolver.java
@@ -47,7 +47,7 @@ public class NpmRecipeBundleResolver implements RecipeBundleResolver {
                     bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
             response = rpc.installRecipes(absolute.toFile());
         } else {
-            response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
+            response = rpc.installRecipes(bundle.getPackageName(), bundle.getEffectiveVersion());
         }
         if (response.getVersion() != null) {
             resolved = resolved.withVersion(response.getVersion());

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
@@ -102,7 +102,7 @@ public class MavenRecipeBundleReader implements RecipeBundleReader {
                     classLoader
             ).build();
 
-            GroupArtifactVersion gav = new GroupArtifactVersion(ga[0], ga[1], bundle.getVersion());
+            GroupArtifactVersion gav = new GroupArtifactVersion(ga[0], ga[1], bundle.getEffectiveVersion());
 
             for (RecipeDescriptor descriptor : env.listRecipeDescriptors()) {
                 marketplace.install(

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
@@ -71,18 +71,9 @@ public class MavenRecipeBundleReader implements RecipeBundleReader {
                     JarEntry entry = jarFile.getJarEntry("META-INF/rewrite/recipes.csv");
                     if (entry != null) {
                         try (InputStream recipesCsv = jarFile.getInputStream(entry)) {
-                            RecipeMarketplace marketplace = new RecipeMarketplaceReader().fromCsv(recipesCsv);
-                            // The recipes.csv inside a JAR may be generated without a version,
-                            // since the version of a published Maven artifact is determined at
-                            // publish time if the artifact is a snapshot. Having resolved the
-                            // JAR containing the recipes.csv, we now know the version.
-                            //
-                            // We must walk the full tree structure rather than using getAllRecipes()
-                            // because getAllRecipes() returns a deduplicated set (by recipe name).
-                            // When a recipe appears in multiple categories, each category has its
-                            // own RecipeListing with its own RecipeBundle that needs updating.
-                            setVersionRecursive(marketplace.getRoot());
-                            return marketplace;
+                            // Identity and version are applied by RecipeMarketplace.install, which binds every
+                            // listing to the resolved bundle. Nothing here may trust the CSV's own columns.
+                            return new RecipeMarketplaceReader().fromCsv(recipesCsv);
                         }
                     }
                 } catch (IOException e) {
@@ -198,19 +189,5 @@ public class MavenRecipeBundleReader implements RecipeBundleReader {
     private boolean isResolvedBundle(ResolvedDependency resolvedDependency) {
         return resolvedDependency.isDirect() && bundle.getPackageName()
                 .equals(resolvedDependency.getGroupId() + ":" + resolvedDependency.getArtifactId());
-    }
-
-    private void setVersionRecursive(RecipeMarketplace.Category category) {
-        for (RecipeListing recipe : category.getRecipes()) {
-            RecipeBundle recipeBundle = recipe.getBundle();
-            // Only update bundles from the same package as the bundle we're reading
-            if (bundle.getPackageName().equals(recipeBundle.getPackageName())) {
-                recipeBundle.setVersion(bundle.getVersion());
-                recipeBundle.setRequestedVersion(bundle.getRequestedVersion());
-            }
-        }
-        for (RecipeMarketplace.Category child : category.getCategories()) {
-            setVersionRecursive(child);
-        }
     }
 }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReader.java
@@ -71,8 +71,8 @@ public class MavenRecipeBundleReader implements RecipeBundleReader {
                     JarEntry entry = jarFile.getJarEntry("META-INF/rewrite/recipes.csv");
                     if (entry != null) {
                         try (InputStream recipesCsv = jarFile.getInputStream(entry)) {
-                            // Identity and version are applied by RecipeMarketplace.install, which binds every
-                            // listing to the resolved bundle. Nothing here may trust the CSV's own columns.
+                            // The CSV's own bundle columns are not trusted; RecipeMarketplace.install
+                            // binds every listing to the resolved bundle.
                             return new RecipeMarketplaceReader().fromCsv(recipesCsv);
                         }
                     }
@@ -108,8 +108,7 @@ public class MavenRecipeBundleReader implements RecipeBundleReader {
                 marketplace.install(
                         RecipeListing.fromDescriptor(descriptor, new RecipeBundle(
                                 "maven", gav.getGroupId() + ":" + gav.getArtifactId(),
-                                bundle.getRequestedVersion() == null ? gav.getVersion() : bundle.getRequestedVersion(),
-                                gav.getVersion(), null)),
+                                bundle.getRequestedVersion(), bundle.getVersion(), null)),
                         descriptor.inferCategoriesFromName(env)
                 );
             }

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
@@ -57,11 +57,12 @@ public class MavenRecipeBundleResolver implements RecipeBundleResolver {
             GroupArtifactVersion gav = new GroupArtifactVersion(ga[0], ga[1], bundle.getVersion());
             return resolveDependencies(gav)
                     .map(mrr -> {
-                        ResolvedDependency resolvedDependency = mrr.getDependencies().get(Scope.Runtime).stream().filter(ResolvedDependency::isDirect)
+                        ResolvedDependency resolvedDependency = mrr.getDependencies().get(Scope.Runtime).stream()
+                                .filter(ResolvedDependency::isDirect)
                                 .findFirst().orElseThrow(() -> new IllegalStateException("Failed to find direct dependency for " + gav));
-                        bundle.setVersion(resolvedDependency.getDatedSnapshotVersion() == null ?
+                        RecipeBundle resolved = bundle.withVersion(resolvedDependency.getDatedSnapshotVersion() == null ?
                                 resolvedDependency.getVersion() : resolvedDependency.getDatedSnapshotVersion());
-                        reader = new MavenRecipeBundleReader(bundle, mrr, downloader, classLoaderFactory);
+                        reader = new MavenRecipeBundleReader(resolved, mrr, downloader, classLoaderFactory);
                         return (RecipeBundleReader) reader;
                     })
                     .orElseGet(() -> new ThrowingRecipeBundleReader(bundle, new IllegalStateException("Unable to resolve recipe " + gav)));

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
@@ -54,7 +54,7 @@ public class MavenRecipeBundleResolver implements RecipeBundleResolver {
             // RELEASE rather than LATEST: DynamicVersion.matches treats LATEST as snapshot-eligible, and an
             // unexpressed preference should not opt a caller into pre-release artifacts. This is a
             // resolver-boundary translation only — the stored column stays blank.
-            String requested = StringUtils.isBlank(bundle.getVersion()) ? "RELEASE" : bundle.getVersion();
+            String requested = StringUtils.isBlank(bundle.getEffectiveVersion()) ? "RELEASE" : bundle.getEffectiveVersion();
             String[] ga = bundle.getPackageName().split(":");
             GroupArtifactVersion gav = new GroupArtifactVersion(ga[0], ga[1], requested);
             return resolveDependencies(gav)

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
@@ -50,10 +50,9 @@ public class MavenRecipeBundleResolver implements RecipeBundleResolver {
     @Override
     public RecipeBundleReader resolve(RecipeBundle bundle) {
         if (reader == null) {
-            // Blank means "no constraint requested", which every other ecosystem resolves as latest.
-            // RELEASE rather than LATEST: DynamicVersion.matches treats LATEST as snapshot-eligible, and an
-            // unexpressed preference should not opt a caller into pre-release artifacts. This is a
-            // resolver-boundary translation only — the stored column stays blank.
+            // Blank means no constraint requested, which every other ecosystem resolves as latest.
+            // RELEASE rather than LATEST because LATEST is snapshot-eligible, and an unexpressed
+            // preference should not opt a caller into pre-release artifacts.
             String requested = StringUtils.isBlank(bundle.getEffectiveVersion()) ? "RELEASE" : bundle.getEffectiveVersion();
             String[] ga = bundle.getPackageName().split(":");
             GroupArtifactVersion gav = new GroupArtifactVersion(ga[0], ga[1], requested);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/marketplace/MavenRecipeBundleResolver.java
@@ -50,11 +50,13 @@ public class MavenRecipeBundleResolver implements RecipeBundleResolver {
     @Override
     public RecipeBundleReader resolve(RecipeBundle bundle) {
         if (reader == null) {
-            if (StringUtils.isBlank(bundle.getVersion())) {
-                return new ThrowingRecipeBundleReader(bundle, new IllegalStateException("Unable to read a Maven recipe bundle that has no version"));
-            }
+            // Blank means "no constraint requested", which every other ecosystem resolves as latest.
+            // RELEASE rather than LATEST: DynamicVersion.matches treats LATEST as snapshot-eligible, and an
+            // unexpressed preference should not opt a caller into pre-release artifacts. This is a
+            // resolver-boundary translation only — the stored column stays blank.
+            String requested = StringUtils.isBlank(bundle.getVersion()) ? "RELEASE" : bundle.getVersion();
             String[] ga = bundle.getPackageName().split(":");
-            GroupArtifactVersion gav = new GroupArtifactVersion(ga[0], ga[1], bundle.getVersion());
+            GroupArtifactVersion gav = new GroupArtifactVersion(ga[0], ga[1], requested);
             return resolveDependencies(gav)
                     .map(mrr -> {
                         ResolvedDependency resolvedDependency = mrr.getDependencies().get(Scope.Runtime).stream()

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
@@ -186,7 +186,7 @@ class MavenRecipeBundleReaderTest {
 
         assertThat(reader).isNotInstanceOf(ThrowingRecipeBundleReader.class);
         assertThat(reader.getBundle().getVersion())
-                .as("RELEASE excludes snapshots")
-                .doesNotContain("-SNAPSHOT");
+                .as("a blank version should resolve to a concrete release, not the literal RELEASE constraint")
+                .matches("\\d+\\.\\d+\\.\\d+");
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/marketplace/MavenRecipeBundleReaderTest.java
@@ -30,6 +30,7 @@ import org.openrewrite.marketplace.RecipeBundleReader;
 import org.openrewrite.marketplace.RecipeClassLoader;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.marketplace.ThrowingRecipeBundleReader;
 import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.maven.MavenSettings;
 import org.openrewrite.maven.cache.LocalMavenArtifactCache;
@@ -175,5 +176,17 @@ class MavenRecipeBundleReaderTest {
                 .anyMatch(r -> r.getName().contains(org.openrewrite.text.Find.class.getName()));
 
         dirReader.close();
+    }
+
+    @Test
+    void blankVersionResolvesLatestRelease() {
+        RecipeBundle bundle = new RecipeBundle("maven", "org.openrewrite:rewrite-core", null, null, null);
+
+        RecipeBundleReader reader = resolver.resolve(bundle);
+
+        assertThat(reader).isNotInstanceOf(ThrowingRecipeBundleReader.class);
+        assertThat(reader.getBundle().getVersion())
+                .as("RELEASE excludes snapshots")
+                .doesNotContain("-SNAPSHOT");
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
@@ -39,17 +39,19 @@ public class PipRecipeBundleResolver implements RecipeBundleResolver {
     public RecipeBundleReader resolve(RecipeBundle bundle) {
         Path pkgPath = Paths.get(bundle.getPackageName());
         InstallRecipesResponse response;
+        RecipeBundle resolved = bundle;
         if (Files.exists(pkgPath)) {
-            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
             Path absolute = pkgPath.toAbsolutePath().normalize();
-            bundle.setPackageName(absolute.toString());
+            // Key the bundle on the absolute, normalized path so it matches the origin the server records for it.
+            resolved = new RecipeBundle(bundle.getPackageEcosystem(), absolute.toString(),
+                    bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
             response = rpc.installRecipes(absolute.toFile());
         } else {
             response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
         }
         if (response.getVersion() != null) {
-            bundle.setVersion(response.getVersion());
+            resolved = resolved.withVersion(response.getVersion());
         }
-        return new PipRecipeBundleReader(bundle, rpc);
+        return new PipRecipeBundleReader(resolved, rpc);
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marketplace/PipRecipeBundleResolver.java
@@ -47,7 +47,7 @@ public class PipRecipeBundleResolver implements RecipeBundleResolver {
                     bundle.getRequestedVersion(), bundle.getVersion(), bundle.getTeam());
             response = rpc.installRecipes(absolute.toFile());
         } else {
-            response = rpc.installRecipes(bundle.getPackageName(), bundle.getVersion());
+            response = rpc.installRecipes(bundle.getPackageName(), bundle.getEffectiveVersion());
         }
         if (response.getVersion() != null) {
             resolved = resolved.withVersion(response.getVersion());


### PR DESCRIPTION
A recipe bundle's identity — `(packageEcosystem, packageName)` and its version — was taken from
whatever the `recipes.csv` inside a jar happened to claim. That payload is untrustworthy in
practice: CSVs get hand-edited, a project's group/artifact can diverge from its publication
coordinates, a relocation produces two publications, and a single curated jar can be made to
claim a bundle it isn't. The observable symptom was a listing landing in a marketplace with a
blank version, which no supported flow should be able to produce.

Identity now comes from the resolver that fetched the artifact.

## What changed

**Bind on install.** `RecipeMarketplace.install(RecipeBundleReader)` rebinds every listing in
the reader's marketplace to the bundle that was actually resolved, walking the tree rather than
the name-deduplicated `getAllRecipes()` so a recipe filed under several categories is bound in
each. Whatever the payload claimed is irrelevant.

**The inner CSV no longer needs identity columns.** Since the bind supplies it, `ecosystem` and
`packageName` are optional when reading — but all-or-nothing: a row carrying one and not the
other is a malformed row and is rejected, because it would otherwise parse into a half-identified
bundle that never interns and cannot be uninstalled. The aggregated `recipes-v5.csv` keeps
requiring both, and now always emits the version columns so an unresolved bundle round-trips as
an empty cell instead of vanishing.

**`RecipeBundle` is immutable**, with equality on the coordinate alone. Version is resolution
state, not identity. Fifteen mutation sites across this repo, the CLI and saas became
construction; `getEffectiveVersion()` expresses the resolution fallback so `getVersion()` can
stay the raw field.

**One bundle instance per coordinate per marketplace.** The marketplace interns them, which
makes `getBundles()` and `bundleFor(ecosystem, packageName)` answer "what is installed here"
directly rather than through a hand-rolled index, and guarantees a reinstall at a new version
cannot leave listings pointing at a stale instance.

**Merge shadows rather than drops.** A colliding recipe name from a *different* coordinate is
stored behind the incumbent instead of being discarded, so uninstalling the winner reveals the
runner-up without reprocessing its bundle. First-wins is expressed by position, and the
projection — `findRecipe` and `getAllRecipes` — resolves exactly one, so a name-addressed
`mod run` cannot reach a shadowed listing. An already-installed coordinate blocks every listing
an incoming marketplace offers for it, same version or older, so a recipe a newer version removed
stays removed. That decision is taken once per merge from a snapshot of installed coordinates,
because a bundle's recipes span several categories and the registry fills as the first lands.

**A blank Maven version means latest.** Every other ecosystem treats an unexpressed version as
"newest"; Maven alone rejected it. It now resolves as `RELEASE` rather than `LATEST`, since
`LATEST` is snapshot-eligible and an unexpressed preference should not opt anyone into
pre-release artifacts. The stored column stays blank — this is a resolver-boundary translation.
The C# RPC server likewise treats an empty version like a missing one instead of emitting a
dangling `--version`.

## Breaking changes

`RecipeBundle` loses its setters. `Category.merge`, `Category.install` and `Category.uninstall`
become private — every external caller was bypassing a marketplace invariant, including the
intern registry — with `RecipeMarketplace.merge(RecipeMarketplace)` replacing the
`getRoot().merge(getRoot())` reach. `Category.getAllRecipes` and `findRecipe` stay public; they
back UI traversals.

moderne-cli and moderne-saas both need updating and will not compile against this as-is.

## Testing

`rewrite-core` and `rewrite-maven` suites pass; the four RPC resolver modules compile. One
pre-existing failure on Windows only, `closeDoesNotCloseHandedOutClassLoaders`, which fails
identically on the base commit — the test holds classloaders open by design, so the OS still
locks the jars when `@TempDir` tries to delete them.

Draft while the downstream work lands.