### PR TITLE
Fix `ChangeType` and `ChangePackage` crashing on Kotlin functions with `where` clauses

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1335,7 +1335,7 @@ public interface K extends J {
 
         @Override
         public <T extends J> T withType(@Nullable JavaType type) {
-            return (T) withMethodDeclaration(methodDeclaration.withType(type));
+            return (T) this; // type must be changed on method declaration
         }
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangePackageTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangePackageTest.java
@@ -200,4 +200,36 @@ class ChangePackageTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void methodDeclarationWithTypeConstraints() {
+        rewriteRun(
+          kotlin(
+            """
+              package a.b
+              class Original
+              """,
+            """
+              package x.y
+              class Original
+              """
+          ),
+          kotlin(
+            """
+              import a.b.Original
+
+              class A {
+                  fun <T> foo(t: T): Original where T : CharSequence = Original()
+              }
+              """,
+            """
+              import x.y.Original
+
+              class A {
+                  fun <T> foo(t: T): Original where T : CharSequence = Original()
+              }
+              """
+          )
+        );
+    }
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -529,4 +529,32 @@ class ChangeTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void methodDeclarationWithTypeConstraints() {
+        rewriteRun(
+          kotlin(
+            """
+              package a.b
+              class Original
+              """
+          ),
+          kotlin(
+            """
+              import a.b.Original
+
+              class A {
+                  fun <T> foo(t: T): Original where T : CharSequence = Original()
+              }
+              """,
+            """
+              import x.y.Target
+
+              class A {
+                  fun <T> foo(t: T): Target where T : CharSequence = Target()
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
## The bug

`ChangeType` and `ChangePackage` abort outright on any Kotlin function that carries a `where` type-constraint clause and references the type being renamed:

```
java.lang.UnsupportedOperationException: To change the return type of this method declaration, use withMethodType(..)
  org.openrewrite.java.tree.J$MethodDeclaration.withType(J.java:4073)
  org.openrewrite.kotlin.tree.K$MethodDeclaration.withType(K.java:1344)
  org.openrewrite.java.ChangeType$JavaChangeTypeVisitor.postVisit(ChangeType.java:241)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:245)
  org.openrewrite.kotlin.KotlinVisitor.visitCompilationUnit(KotlinVisitor.java:56)
  ...
```

The whole run fails rather than degrading, so a single such function blocks the migration for the entire repository.

## Why it happens

`K.MethodDeclaration` wraps a `J.MethodDeclaration` and implements `TypedTree`, but is **not** itself a `J.MethodDeclaration`. The type-updating cascades in `ChangeType.postVisit` and `ChangePackage.postVisit` test for `J.MethodDeclaration` first — the branch that would correctly call `withMethodType(..)` — so the Kotlin wrapper misses it and falls through to the generic `TypedTree` branch:

```java
} else if (j instanceof TypedTree) {                                  // K.MethodDeclaration lands here
    return ((TypedTree) j).withType(updateType(((TypedTree) j).getType()));
}
```

`K.MethodDeclaration.withType(..)` then delegated straight into `J.MethodDeclaration.withType(..)`, which throws unconditionally to redirect callers to `withMethodType(..)`.

`K.MethodDeclaration` is only constructed when a function has a `where` clause (`KotlinTreeParserVisitor:2784`):

```java
return (typeConstraints == null) ? methodDeclaration : new K.MethodDeclaration(randomId(), Markers.EMPTY, methodDeclaration, typeConstraints);
```

which is why this went unnoticed for so long — but it is not specific to these two recipes. Every recipe that reaches the `TypedTree` fallback with a `K.MethodDeclaration` hits the same throw.

## The fix

`KotlinVisitor.visitMethodDeclaration` already visits the wrapped node:

```java
m = m.withMethodDeclaration(visitAndCast(m.getMethodDeclaration(), p));
```

so by the time the wrapper is post-visited the delegate has already had `withMethodType(..)` correctly applied. The wrapper's `withType(..)` is redundant work that exists only to crash.

`K.Constructor` — same file, wrapping the same `J.MethodDeclaration`, with an identical `getType()` — already carries exactly this guard:

```java
@Override
public Constructor withType(@Nullable JavaType type) {
    return this; // type must be changed on method declaration
}
```

This makes `K.MethodDeclaration` consistent with its sibling.

Worth being explicit about the trade-off: `withType(..)` becomes a silent no-op rather than a loud error. That is deliberate. `TypedTree.getType()` on a method declaration returns only `methodType.getReturnType()`, so a `withType` round-trip can never express the full update that `updateType(m.getMethodType())` performs across `declaringType`, `parameterTypes`, `thrownExceptions` and `returnType`. Having the wrapper attempt a return-type-only update would produce a half-updated `JavaType.Method` — which is what the unconditional throw in `J.MethodDeclaration` exists to prevent. Dropping the call is the honest behaviour; the correct call site is `withMethodType(..)` on the delegate.

## Tests

Added a reproducer to both `ChangeTypeTest` and `ChangePackageTest` in `rewrite-kotlin`. Verified they fail on `main` with the reported exception:

```
ChangeTypeTest > methodDeclarationWithTypeConstraints() FAILED
    org.openrewrite.internal.RecipeRunException: java.lang.UnsupportedOperationException:
        To change the return type of this method declaration, use withMethodType(..)
ChangePackageTest > methodDeclarationWithTypeConstraints() FAILED
    org.openrewrite.internal.RecipeRunException: java.lang.UnsupportedOperationException:
        To change the return type of this method declaration, use withMethodType(..)
2 tests completed, 2 failed
```

and pass with the fix. The full `:rewrite-kotlin:test` suite is green locally.

## Follow-up

Draft for discussion on the approach. A more structural fix would be a declaration-side counterpart to `org.openrewrite.java.tree.MethodCall` — `ChangeType.postVisit` already branches on `instanceof MethodCall` — implemented by `J.MethodDeclaration`, `K.MethodDeclaration` and `K.Constructor`, and matched ahead of the `TypedTree` fallback. That would let type-updating recipes handle method declarations polymorphically across languages instead of relying on each wrapper to opt out. It is a public API addition and worth doing separately; it should not hold up unblocking users hitting the crash.

Reported by a customer running `ChangePackage` and `ChangeType` over a mixed Java/Kotlin codebase.
