### PR TITLE
Test RPC composites keep distinct options for same-type children

### DIFF
--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -365,6 +365,75 @@ class RewriteRpcTest implements RewriteTest {
     }
 
     /**
+     * A composite whose recipe list yields multiple instances of the same recipe class with
+     * different option values must keep each prepared child a distinct instance with its own
+     * options, rather than collapsing them.
+     */
+    @Test
+    void compositeWithSameTypeChildrenPreservesDistinctOptions() {
+        Recipe composite = client.prepareRecipe(
+          "org.openrewrite.rpc.RewriteRpcTest$RecipeWithSameTypeChildren", Map.of());
+
+        List<Recipe> children = composite.getRecipeList();
+        assertThat(children).hasSize(3);
+
+        assertThat(children.stream().map(System::identityHashCode).distinct().count())
+          .describedAs("Each prepared child must be its own instance, not a shared/collapsed one")
+          .isEqualTo(3);
+
+        List<String> toTexts = children.stream()
+          .map(child -> child.getDescriptor().getOptions().stream()
+            .filter(o -> "toText".equals(o.getName()))
+            .map(OptionDescriptor::getValue)
+            .map(String::valueOf)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("Child is missing its toText option")))
+          .toList();
+        assertThat(toTexts)
+          .describedAs("Each same-type child must retain its own distinct option value")
+          .containsExactly("a", "b", "c");
+    }
+
+    /**
+     * Each same-type child must actually run with its own option, so all of "a", "b", "c"
+     * appear among the recipes that made changes (a collapse would leave the later
+     * applications as no-ops and attribute only one).
+     */
+    @Test
+    void compositeWithSameTypeChildrenAppliesEachDistinctOption() {
+        rewriteRun(
+          spec -> spec
+            .recipe(client.prepareRecipe(
+              "org.openrewrite.rpc.RewriteRpcTest$RecipeWithSameTypeChildren", Map.of()))
+            .validateRecipeSerialization(false)
+            .cycles(1).expectedCyclesThatMakeChanges(1),
+          text(
+            "hello",
+            "c",
+            spec -> spec.afterRecipe(result -> {
+                RecipesThatMadeChanges marker = result.getMarkers()
+                  .findFirst(RecipesThatMadeChanges.class)
+                  .orElseThrow(() -> new AssertionError("Expected RecipesThatMadeChanges marker"));
+
+                List<String> executedToTexts = marker.getRecipes().stream()
+                  .map(stack -> stack.get(stack.size() - 1))
+                  .filter(leaf -> "org.openrewrite.text.ChangeText".equals(leaf.getName()))
+                  .map(leaf -> leaf.getDescriptor().getOptions().stream()
+                    .filter(o -> "toText".equals(o.getName()))
+                    .map(OptionDescriptor::getValue)
+                    .map(String::valueOf)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Executed ChangeText is missing its toText option")))
+                  .toList();
+                assertThat(executedToTexts)
+                  .describedAs("All three same-type children must execute, each with its own distinct option")
+                  .containsExactlyInAnyOrder("a", "b", "c");
+            })
+          )
+        );
+    }
+
+    /**
      * When a composite recipe has consecutive sub-recipes that are all RpcRecipes
      * bound to the same RewriteRpc instance, the scheduler batches them into a
      * single BatchVisit RPC call. The remote runs all visitors in sequence and
@@ -606,6 +675,26 @@ class RewriteRpcTest implements RewriteTest {
         @Override
         public void buildRecipeList(RecipeList recipes) {
             recipes.recipe(new org.openrewrite.text.ChangeText("hello"));
+        }
+    }
+
+    @SuppressWarnings("unused")
+    static class RecipeWithSameTypeChildren extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "A recipe with same-type children carrying distinct options";
+        }
+
+        @Override
+        public String getDescription() {
+            return "To verify each RPC-prepared child of the same recipe type keeps its own options.";
+        }
+
+        @Override
+        public void buildRecipeList(RecipeList recipes) {
+            recipes.recipe(new org.openrewrite.text.ChangeText("a"));
+            recipes.recipe(new org.openrewrite.text.ChangeText("b"));
+            recipes.recipe(new org.openrewrite.text.ChangeText("c"));
         }
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/PrepareRecipeTreeTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/PrepareRecipeTreeTest.cs
@@ -76,4 +76,48 @@ public class PrepareRecipeTreeTest
         Assert.Contains("RequiredThing", ex.Message);
         Assert.Contains("Missing required option", ex.Message);
     }
+
+    private sealed class SetsText : global::OpenRewrite.Core.Recipe
+    {
+        [global::OpenRewrite.Core.Option(DisplayName = "Text", Description = "Text value.")]
+        public string? Text { get; set; }
+
+        public override string DisplayName => "Sets text";
+        public override string Description => "A recipe with a text option.";
+        public override JavaVisitor<ExecutionContext> GetVisitor() => new CSharpVisitor<ExecutionContext>();
+    }
+
+    private sealed class CompositeSameType : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Composite with same-type children";
+        public override string Description => "A composite with distinct-option children of one type.";
+        public override List<global::OpenRewrite.Core.Recipe> GetRecipeList() =>
+            [new SetsText { Text = "a" }, new SetsText { Text = "b" }, new SetsText { Text = "c" }];
+    }
+
+    /// <summary>
+    /// A composite whose GetRecipeList() yields multiple instances of the same recipe class with
+    /// different option values must keep each prepared child a distinct instance with its own
+    /// options, rather than collapsing them.
+    /// </summary>
+    [Fact]
+    public void PrepareRecipe_SameTypeChildrenPreserveDistinctOptions()
+    {
+        var marketplace = new global::OpenRewrite.Core.RecipeMarketplace();
+        marketplace.Install(new CompositeSameType(), new global::OpenRewrite.Core.CategoryDescriptor("Test"));
+        var server = new RewriteRpcServer(marketplace);
+
+        var parent = server.PrepareRecipe(new PrepareRecipeRequest
+        {
+            Id = typeof(CompositeSameType).FullName!
+        }).GetAwaiter().GetResult();
+
+        Assert.Equal(3, parent.RecipeList.Count);
+        Assert.Equal(3, parent.RecipeList.Select(c => c.Id).Distinct().Count());
+        Assert.All(parent.RecipeList, c => Assert.Equal(typeof(SetsText).FullName, c.Descriptor.Name));
+        var texts = parent.RecipeList
+            .Select(c => c.Descriptor.Options.Single(o => o.Name == "Text").Value)
+            .ToList();
+        Assert.Equal(new object?[] { "a", "b", "c" }, texts);
+    }
 }

--- a/rewrite-go/cmd/rpc/whole_tree_test.go
+++ b/rewrite-go/cmd/rpc/whole_tree_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -116,5 +117,78 @@ func TestPrepareRecipeReturnsWholeChildTree(t *testing.T) {
 	}
 	if got := pr.RecipeList[0].Descriptor.Name; got != "org.openrewrite.go.test.Leaf" {
 		t.Errorf("expected child Leaf, got %q", got)
+	}
+}
+
+// goSetsText carries a text option value; distinct instances hold distinct values.
+type goSetsText struct {
+	recipe.Base
+	Text string
+}
+
+func (*goSetsText) Name() string        { return "org.openrewrite.go.test.SetsText" }
+func (*goSetsText) DisplayName() string { return "Sets text" }
+func (*goSetsText) Description() string { return "A recipe with a text option." }
+func (r *goSetsText) Options() []recipe.OptionDescriptor {
+	return []recipe.OptionDescriptor{recipe.Option("text", "Text", "Text value.").WithValue(r.Text)}
+}
+
+type goCompositeSameType struct{ recipe.Base }
+
+func (*goCompositeSameType) Name() string        { return "org.openrewrite.go.test.CompositeSameType" }
+func (*goCompositeSameType) DisplayName() string { return "Composite with same-type children" }
+func (*goCompositeSameType) Description() string {
+	return "A composite with distinct-option children of one type."
+}
+func (*goCompositeSameType) RecipeList() []recipe.Recipe {
+	return []recipe.Recipe{
+		&goSetsText{Text: "a"},
+		&goSetsText{Text: "b"},
+		&goSetsText{Text: "c"},
+	}
+}
+
+// A composite whose RecipeList() yields multiple instances of the same recipe class with different
+// option values must keep each prepared child's own id and options, rather than collapsing them.
+func TestPrepareRecipeSameTypeChildrenPreserveDistinctOptions(t *testing.T) {
+	s, _ := newTestServer(t)
+	s.registry.Register(&goCompositeSameType{})
+
+	params, err := json.Marshal(prepareRecipeRequest{ID: "org.openrewrite.go.test.CompositeSameType"})
+	if err != nil {
+		t.Fatalf("marshal prepare request: %v", err)
+	}
+	resp, rpcErr := s.handlePrepareRecipe(params)
+	if rpcErr != nil {
+		t.Fatalf("handlePrepareRecipe error: %+v", rpcErr)
+	}
+
+	pr := resp.(prepareRecipeResponse)
+	if len(pr.RecipeList) != 3 {
+		t.Fatalf("expected 3 prepared children, got %d", len(pr.RecipeList))
+	}
+
+	ids := map[string]bool{}
+	var texts []any
+	for _, child := range pr.RecipeList {
+		if got := child.Descriptor.Name; got != "org.openrewrite.go.test.SetsText" {
+			t.Errorf("expected child SetsText, got %q", got)
+		}
+		ids[child.ID] = true
+		for _, opt := range child.Descriptor.Options {
+			if opt.Name == "text" {
+				texts = append(texts, opt.Value)
+			}
+		}
+	}
+
+	// Each child is prepared as its own instance (distinct id)...
+	if len(ids) != 3 {
+		t.Errorf("expected 3 distinct child ids, got %d", len(ids))
+	}
+	// ...retaining its own distinct option value, in the order the composite declared them.
+	want := []any{"a", "b", "c"}
+	if !reflect.DeepEqual(texts, want) {
+		t.Errorf("expected child option values %v, got %v", want, texts)
 	}
 }

--- a/rewrite-javascript/rewrite/fixtures/example-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/example-recipe.ts
@@ -20,6 +20,7 @@ import {ChangeText} from "./change-text";
 import {ChangeVersion} from "./change-version";
 import {RecipeWithRecipeList} from "./recipe-with-recipe-list";
 import {RecipeWithRpcSubRecipe} from "./recipe-with-rpc-sub-recipe";
+import {RecipeWithSameTypeChildren} from "./recipe-with-same-type-children";
 import {ReplaceId} from "./replace-id";
 import {FindIdentifierWithRemotePathPrecondition} from "./remote-path-precondition";
 import {FindIdentifierWithPathPrecondition} from "./path-precondition";
@@ -38,6 +39,7 @@ export async function activate(marketplace: RecipeMarketplace): Promise<void> {
     await marketplace.install(ChangeVersion, JavaScript);
     await marketplace.install(RecipeWithRecipeList, JavaScript);
     await marketplace.install(RecipeWithRpcSubRecipe, JavaScript);
+    await marketplace.install(RecipeWithSameTypeChildren, JavaScript);
     await marketplace.install(ReplaceId, JavaScript);
     await marketplace.install(FindIdentifier, JavaScript);
     await marketplace.install(FindIdentifierWithRemotePathPrecondition, JavaScript);

--- a/rewrite-javascript/rewrite/fixtures/recipe-with-same-type-children.ts
+++ b/rewrite-javascript/rewrite/fixtures/recipe-with-same-type-children.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ChangeText} from "./change-text";
+import {Recipe} from "@openrewrite/rewrite";
+
+export class RecipeWithSameTypeChildren extends Recipe {
+    name = "org.openrewrite.example.text.same-type-children";
+    displayName = "A recipe with same-type children carrying distinct options";
+    description = "To verify each RPC-prepared child of the same recipe type keeps its own options.";
+
+    async recipeList() {
+        return [
+            new ChangeText({text: "a"}),
+            new ChangeText({text: "b"}),
+            new ChangeText({text: "c"})
+        ];
+    }
+}

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -280,6 +280,25 @@ describe("Rewrite RPC", () => {
         );
     });
 
+    test("sameTypeChildrenPreserveDistinctOptions", async () => {
+        // A composite whose recipeList() yields multiple instances of the same recipe class with
+        // different option values must keep each prepared child its own options, rather than
+        // collapsing them.
+        const recipe = await client.prepareRecipe("org.openrewrite.example.text.same-type-children");
+        const descriptor = await recipe.descriptor();
+
+        expect(descriptor.recipeList.map(r => r.name)).toEqual([
+            "org.openrewrite.example.text.change-text",
+            "org.openrewrite.example.text.change-text",
+            "org.openrewrite.example.text.change-text"
+        ]);
+
+        const texts = descriptor.recipeList.map(
+            r => r.options.find(o => o.name === "text")?.value
+        );
+        expect(texts).toEqual(["a", "b", "c"]);
+    });
+
     test("preparing an unknown recipe id delegates to the host instead of failing", async () => {
         // When the host builds RpcRecipe.getRecipeList() it re-prepares every child by
         // id over RPC. A child that delegates to a Java recipe (e.g. Angular's

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -475,6 +475,56 @@ def test_prepare_recipe_returns_whole_child_tree(monkeypatch):
     assert [c["descriptor"]["name"] for c in response["recipeList"]] == ["org.example.Leaf"]
 
 
+def test_prepare_recipe_same_type_children_preserve_distinct_options(monkeypatch):
+    """A composite whose recipe_list() yields multiple instances of the same recipe class with
+    different option values must keep each prepared child's own id and options, rather than
+    collapsing them."""
+    import rewrite.rpc.server as server
+    from rewrite.marketplace import RecipeMarketplace
+    from rewrite import Recipe, CategoryDescriptor
+    from rewrite.recipe import option
+    from dataclasses import dataclass, field
+
+    @dataclass
+    class _SetsText(Recipe):
+        text: str = field(default=None, metadata=option(
+            display_name="Text", description="Text value."))
+
+        @property
+        def name(self): return "org.example.SetsText"
+        @property
+        def display_name(self): return "Sets text"
+        @property
+        def description(self): return "A recipe with a text option."
+
+    class _CompositeSameType(Recipe):
+        @property
+        def name(self): return "org.example.CompositeSameType"
+        @property
+        def display_name(self): return "Composite with same-type children"
+        @property
+        def description(self): return "A composite with distinct-option children of one type."
+
+        def recipe_list(self):
+            return [_SetsText(text="a"), _SetsText(text="b"), _SetsText(text="c")]
+
+    marketplace = RecipeMarketplace()
+    marketplace.install(_CompositeSameType, [CategoryDescriptor(display_name="Test")])
+    monkeypatch.setattr(server, "_marketplace", marketplace)
+
+    response = server.handle_prepare_recipe({"id": "org.example.CompositeSameType"})
+
+    children = response["recipeList"]
+    assert [c["descriptor"]["name"] for c in children] == ["org.example.SetsText"] * 3
+
+    ids = [c["id"] for c in children]
+    assert len(set(ids)) == 3
+
+    def text_of(child):
+        return next(o["value"] for o in child["descriptor"]["options"] if o["name"] == "text")
+    assert [text_of(c) for c in children] == ["a", "b", "c"]
+
+
 def test_hub_release_rewinds_send_refs_in_lockstep_with_the_child():
     """A child drops its receive refs for a file when the broadcast Evict reaches it, so the facade
     must return its send-ref numbering to exactly the pre-file value. If the facade kept advancing,


### PR DESCRIPTION
## The problem

On the RPC side, a composite recipe whose child list contained multiple instances of the **same** recipe class with **different** option values could collapse: the children were reconstructed **by name**, so their per-instance options were lost and every instance behaved like a single one.

This surfaced with the Python version-migration recipes — a composite meant to step a project through several Python versions (e.g. 3.10, then 3.11, then 3.12) only ever applied one of them, because the same-named sub-recipe resolved to a single set of options rather than one set per child.

## Already fixed

The underlying defect was resolved in the meantime by the whole-tree `PrepareRecipe` work:

- **#8134** — `PrepareRecipe` returns the entire prepared child tree (`recipeList`), so composites build their children from the server-prepared instances (each with its own id and options) instead of cross-referencing by name.
- **#8139** — removed the by-name fallback entirely now that every RPC server (Java, C#, npm, Python, Go) returns the whole tree; a missing child tree now fails loudly rather than silently re-preparing by name.

## This PR

This PR adds **no production changes** — it adds tests to guard against a future regression of this behavior across **all ecosystems**. Each server's `PrepareRecipe` is exercised with a composite that lists three instances of the same recipe type carrying distinct options, asserting each prepared child keeps its own id and its own option values (and, in Java, that all three actually execute with their distinct options):

- **Java** — `RewriteRpcTest`: prepare-level + an execution-level companion (via the `RecipesThatMadeChanges` marker).
- **Python** — `test_server.py`
- **JavaScript** — `rewrite-rpc.test.ts` (+ `recipe-with-same-type-children.ts` fixture)
- **C#** — `PrepareRecipeTreeTest.cs`
- **Go** — `whole_tree_test.go`
