### PR TITLE
Emit listing-weight GetMarketplace rows instead of full descriptors

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -176,7 +176,7 @@ public class RewriteRpc {
         jsonRpc.rpc("GetMarketplace", new JsonRpcMethod<Void>() {
             @Override
             protected Object handle(Void noParams) {
-                return GetMarketplaceResponse.fromMarketplace(marketplace, RewriteRpc.this.resolvers);
+                return GetMarketplaceResponse.fromMarketplace(marketplace);
             }
         });
         jsonRpc.rpc("TraceGetObject", new JsonRpcMethod<TraceGetObject>() {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetMarketplaceResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetMarketplaceResponse.java
@@ -17,24 +17,58 @@ package org.openrewrite.rpc.request;
 
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.NlsRewrite;
 import org.openrewrite.config.CategoryDescriptor;
+import org.openrewrite.config.DataTableDescriptor;
+import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleResolver;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 
 public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row> {
     @Value
     public static class Row {
-        RecipeDescriptor descriptor;
+        /**
+         * Listing-weight fields. Emitters populate these and leave {@link #descriptor} null; the full
+         * descriptor is fetched lazily via {@code PrepareRecipe}.
+         */
+        @Nullable String name;
+
+        @Nullable @NlsRewrite.DisplayName String displayName;
+
+        @Nullable @NlsRewrite.Description String description;
+
+        @Nullable Duration estimatedEffortPerOccurrence;
+
+        @Nullable List<OptionDescriptor> options;
+
+        @Nullable List<DataTableDescriptor> dataTables;
+
+        /**
+         * The count of this recipe plus all of its transitive sub-recipes. Emitters must compute it
+         * as {@code 1 + all transitive recipeList entries}; the host uses it as a sort key (see
+         * {@link RecipeListing#getRecipeCount()}).
+         */
+        int recipeCount;
+
+        /**
+         * The full, recursive recipe descriptor. Retained for backward compatibility with peers that
+         * still emit it, but nullable and no longer emitted by up-to-date engines — prefer the
+         * lightweight fields above. Will be removed once nothing emits it.
+         */
+        @Nullable RecipeDescriptor descriptor;
+
         List<List<CategoryDescriptor>> categoryPaths;
 
         /**
@@ -57,25 +91,50 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
                     !recipe.getPackageName().equals(bundle.getPackageName())) {
                 continue;
             }
+            RecipeListing listing = toListing(recipe, bundle);
             for (List<CategoryDescriptor> categoryPath : recipe.getCategoryPaths()) {
-                marketplace.install(RecipeListing.fromDescriptor(recipe.getDescriptor(), bundle), categoryPath);
+                marketplace.install(listing, categoryPath);
             }
         }
         return marketplace;
     }
 
-    public static GetMarketplaceResponse fromMarketplace(RecipeMarketplace marketplace, List<RecipeBundleResolver> resolvers) {
+    /**
+     * The {@link RecipeListing} a row represents, attributed to {@code bundle}. Prefers the
+     * lightweight fields; a null {@link Row#name} means an older peer sent only {@link Row#descriptor},
+     * so fall back to deriving the listing from it.
+     */
+    private static RecipeListing toListing(Row row, RecipeBundle bundle) {
+        return row.getName() != null ?
+                new RecipeListing(null, row.getName(), row.getDisplayName(), row.getDescription(),
+                        row.getEstimatedEffortPerOccurrence(),
+                        row.getOptions() != null ? row.getOptions() : emptyList(),
+                        row.getDataTables() != null ? row.getDataTables() : emptyList(),
+                        row.getRecipeCount(), bundle) :
+                RecipeListing.fromDescriptor(row.getDescriptor(), bundle);
+    }
+
+    public static GetMarketplaceResponse fromMarketplace(RecipeMarketplace marketplace) {
         Map<String, Row> rowByRecipeId = new LinkedHashMap<>();
         for (RecipeMarketplace.Category category : marketplace.getCategories()) {
-            fromCategory(resolvers, rowByRecipeId, category, new ArrayList<>());
+            fromCategory(rowByRecipeId, category, new ArrayList<>());
         }
         GetMarketplaceResponse response = new GetMarketplaceResponse();
         response.addAll(rowByRecipeId.values());
         return response;
     }
 
-    private static void fromCategory(List<RecipeBundleResolver> resolvers,
-                                     Map<String, Row> rowByRecipeId,
+    /**
+     * @deprecated Use {@link #fromMarketplace(RecipeMarketplace)}. The {@code resolvers} argument is
+     * no longer needed: rows are emitted listing-weight straight off each {@link RecipeListing}, so no
+     * recipe is resolved or described here.
+     */
+    @Deprecated
+    public static GetMarketplaceResponse fromMarketplace(RecipeMarketplace marketplace, List<RecipeBundleResolver> resolvers) {
+        return fromMarketplace(marketplace);
+    }
+
+    private static void fromCategory(Map<String, Row> rowByRecipeId,
                                      RecipeMarketplace.Category category,
                                      List<CategoryDescriptor> parentCategory) {
         List<CategoryDescriptor> categoryPath = new ArrayList<>(parentCategory);
@@ -83,11 +142,13 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
                 category.getDescription(), emptySet(), false, 0, false));
         for (RecipeListing recipe : category.getRecipes()) {
             rowByRecipeId.computeIfAbsent(recipe.getName(), recipeId ->
-                    new Row(recipe.describe(resolvers), new ArrayList<>(),
-                            recipe.getBundle().getPackageName())).categoryPaths.add(categoryPath);
+                    new Row(recipe.getName(), recipe.getDisplayName(), recipe.getDescription(),
+                            recipe.getEstimatedEffortPerOccurrence(), recipe.getOptions(),
+                            recipe.getDataTables(), recipe.getRecipeCount(), null,
+                            new ArrayList<>(), recipe.getBundle().getPackageName())).categoryPaths.add(categoryPath);
         }
         for (RecipeMarketplace.Category child : category.getCategories()) {
-            fromCategory(resolvers, rowByRecipeId, child, categoryPath);
+            fromCategory(rowByRecipeId, child, categoryPath);
         }
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetMarketplaceResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/GetMarketplaceResponse.java
@@ -21,7 +21,6 @@ import org.openrewrite.NlsRewrite;
 import org.openrewrite.config.CategoryDescriptor;
 import org.openrewrite.config.DataTableDescriptor;
 import org.openrewrite.config.OptionDescriptor;
-import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeBundleResolver;
 import org.openrewrite.marketplace.RecipeListing;
@@ -40,8 +39,8 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
     @Value
     public static class Row {
         /**
-         * Listing-weight fields. Emitters populate these and leave {@link #descriptor} null; the full
-         * descriptor is fetched lazily via {@code PrepareRecipe}.
+         * Listing-weight fields the host builds a {@link RecipeListing} from. The full descriptor is
+         * fetched lazily per recipe via {@code PrepareRecipe} when detail or execution is needed.
          */
         @Nullable String name;
 
@@ -61,13 +60,6 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
          * {@link RecipeListing#getRecipeCount()}).
          */
         int recipeCount;
-
-        /**
-         * The full, recursive recipe descriptor. Retained for backward compatibility with peers that
-         * still emit it, but nullable and no longer emitted by up-to-date engines — prefer the
-         * lightweight fields above. Will be removed once nothing emits it.
-         */
-        @Nullable RecipeDescriptor descriptor;
 
         List<List<CategoryDescriptor>> categoryPaths;
 
@@ -100,18 +92,15 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
     }
 
     /**
-     * The {@link RecipeListing} a row represents, attributed to {@code bundle}. Prefers the
-     * lightweight fields; a null {@link Row#name} means an older peer sent only {@link Row#descriptor},
-     * so fall back to deriving the listing from it.
+     * The {@link RecipeListing} a row represents, attributed to {@code bundle}, built from its
+     * listing-weight fields.
      */
     private static RecipeListing toListing(Row row, RecipeBundle bundle) {
-        return row.getName() != null ?
-                new RecipeListing(null, row.getName(), row.getDisplayName(), row.getDescription(),
-                        row.getEstimatedEffortPerOccurrence(),
-                        row.getOptions() != null ? row.getOptions() : emptyList(),
-                        row.getDataTables() != null ? row.getDataTables() : emptyList(),
-                        row.getRecipeCount(), bundle) :
-                RecipeListing.fromDescriptor(row.getDescriptor(), bundle);
+        return new RecipeListing(null, row.getName(), row.getDisplayName(), row.getDescription(),
+                row.getEstimatedEffortPerOccurrence(),
+                row.getOptions() != null ? row.getOptions() : emptyList(),
+                row.getDataTables() != null ? row.getDataTables() : emptyList(),
+                row.getRecipeCount(), bundle);
     }
 
     public static GetMarketplaceResponse fromMarketplace(RecipeMarketplace marketplace) {
@@ -144,7 +133,7 @@ public class GetMarketplaceResponse extends ArrayList<GetMarketplaceResponse.Row
             rowByRecipeId.computeIfAbsent(recipe.getName(), recipeId ->
                     new Row(recipe.getName(), recipe.getDisplayName(), recipe.getDescription(),
                             recipe.getEstimatedEffortPerOccurrence(), recipe.getOptions(),
-                            recipe.getDataTables(), recipe.getRecipeCount(), null,
+                            recipe.getDataTables(), recipe.getRecipeCount(),
                             new ArrayList<>(), recipe.getBundle().getPackageName())).categoryPaths.add(categoryPath);
         }
         for (RecipeMarketplace.Category child : category.getCategories()) {

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/GetMarketplaceResponseTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/GetMarketplaceResponseTest.java
@@ -15,8 +15,10 @@
  */
 package org.openrewrite.rpc;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.CategoryDescriptor;
+import org.openrewrite.config.OptionDescriptor;
 import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeListing;
@@ -24,6 +26,7 @@ import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.rpc.request.GetMarketplaceResponse;
 
 import java.net.URI;
+import java.time.Duration;
 import java.util.List;
 
 import static java.util.Collections.emptyList;
@@ -37,23 +40,53 @@ class GetMarketplaceResponseTest {
                 emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://example.com"));
     }
 
+    private static List<List<CategoryDescriptor>> path() {
+        return List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false)));
+    }
+
+    /**
+     * A lightweight row: null descriptor, listing fields populated.
+     */
+    private static GetMarketplaceResponse.Row lightweightRow(String name, int recipeCount, @Nullable String packageName) {
+        return new GetMarketplaceResponse.Row(name, name, name, null, emptyList(), emptyList(),
+                recipeCount, null, path(), packageName);
+    }
+
+    /**
+     * A legacy descriptor-only row: null name signals the fallback path.
+     */
+    private static GetMarketplaceResponse.Row descriptorRow(String name, @Nullable String packageName) {
+        return new GetMarketplaceResponse.Row(null, null, null, null, null, null,
+                0, descriptor(name), path(), packageName);
+    }
+
+    /**
+     * A marketplace holding a single listing-weight recipe under one category, for emitter tests.
+     */
+    private static RecipeMarketplace marketplaceWith(RecipeListing listing) {
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+        marketplace.install(listing, List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false)));
+        return marketplace;
+    }
+
+    private static RecipeListing compositeListing(RecipeBundle bundle) {
+        return new RecipeListing(null, "recipe.Composite", "Composite Display", "Composite Description",
+                Duration.ofMinutes(3),
+                List.of(new OptionDescriptor("opt", "String", "Opt", "Opt description", null, null, false, null)),
+                emptyList(), 5, bundle);
+    }
+
     @Test
     void filtersForeignOriginAndAttributesTheRestToRequestedBundle() {
         GetMarketplaceResponse response = new GetMarketplaceResponse();
         // Row from a different package than the one requested: it belongs to that bundle's own reader,
         // so this read must filter it out.
-        response.add(new GetMarketplaceResponse.Row(descriptor("recipe.FromCore"),
-                List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false))),
-                "Core"));
+        response.add(lightweightRow("recipe.FromCore", 1, "Core"));
         // Row with no origin: must fall back to the requested bundle.
-        response.add(new GetMarketplaceResponse.Row(descriptor("recipe.Unattributed"),
-                List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false))),
-                null));
+        response.add(lightweightRow("recipe.Unattributed", 1, null));
         // Row whose origin equals the requested bundle's packageName: attributed to the requested
         // bundle (with its version preserved).
-        response.add(new GetMarketplaceResponse.Row(descriptor("recipe.OwnPinned"),
-                List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false))),
-                "Migration"));
+        response.add(lightweightRow("recipe.OwnPinned", 1, "Migration"));
 
         RecipeBundle requested = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
         RecipeMarketplace marketplace = response.toMarketplace(requested);
@@ -71,5 +104,81 @@ class GetMarketplaceResponseTest {
         assertThat(ownPinned).isNotNull();
         assertThat(ownPinned.getBundle().getPackageName()).isEqualTo("Migration");
         assertThat(ownPinned.getBundle().getVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void prefersLightweightFieldsOverDescriptor() {
+        GetMarketplaceResponse response = new GetMarketplaceResponse();
+        response.add(new GetMarketplaceResponse.Row(
+                "recipe.Light", "Light Display", "Light Description",
+                Duration.ofMinutes(5),
+                List.of(new OptionDescriptor("opt", "String", "Opt", "Opt description", null, null, false, null)),
+                emptyList(), 7, null, path(), null));
+
+        RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
+        RecipeListing listing = response.toMarketplace(bundle).findRecipe("recipe.Light");
+
+        assertThat(listing).isNotNull();
+        assertThat(listing.getDisplayName()).isEqualTo("Light Display");
+        assertThat(listing.getDescription()).isEqualTo("Light Description");
+        assertThat(listing.getEstimatedEffortPerOccurrence()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(listing.getOptions()).hasSize(1);
+        assertThat(listing.getRecipeCount()).isEqualTo(7);
+    }
+
+    @Test
+    void fallsBackToDescriptorWhenNameIsNull() {
+        GetMarketplaceResponse response = new GetMarketplaceResponse();
+        response.add(descriptorRow("recipe.Legacy", null));
+
+        RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
+        RecipeListing listing = response.toMarketplace(bundle).findRecipe("recipe.Legacy");
+
+        assertThat(listing).isNotNull();
+        assertThat(listing.getName()).isEqualTo("recipe.Legacy");
+        // The descriptor-derived metadata is what the listing carries, not just the name.
+        assertThat(listing.getDisplayName()).isEqualTo("recipe.Legacy");
+        assertThat(listing.getDescription()).isEqualTo("recipe.Legacy");
+        assertThat(listing.getRecipeCount()).isEqualTo(1);
+    }
+
+    @SuppressWarnings("deprecation") // deliberately exercises the deprecated fromMarketplace overload
+    @Test
+    void emitsOptimizedRowsWithoutDescriptor() {
+        RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
+        RecipeMarketplace marketplace = marketplaceWith(compositeListing(bundle));
+
+        GetMarketplaceResponse response = GetMarketplaceResponse.fromMarketplace(marketplace);
+
+        assertThat(response).hasSize(1);
+        GetMarketplaceResponse.Row row = response.get(0);
+        // The optimization: listing-weight fields are emitted and the heavyweight descriptor is not.
+        assertThat(row.getDescriptor()).isNull();
+        assertThat(row.getName()).isEqualTo("recipe.Composite");
+        assertThat(row.getDisplayName()).isEqualTo("Composite Display");
+        assertThat(row.getDescription()).isEqualTo("Composite Description");
+        assertThat(row.getEstimatedEffortPerOccurrence()).isEqualTo(Duration.ofMinutes(3));
+        assertThat(row.getOptions()).hasSize(1);
+        assertThat(row.getRecipeCount()).isEqualTo(5);
+        assertThat(row.getPackageName()).isEqualTo("Migration");
+
+        // The deprecated overload is a pure shim: same optimized output, still no descriptor.
+        assertThat(GetMarketplaceResponse.fromMarketplace(marketplace, emptyList()).get(0).getDescriptor()).isNull();
+    }
+
+    @Test
+    void roundTripsOptimizedRows() {
+        RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
+        RecipeMarketplace source = marketplaceWith(compositeListing(bundle));
+
+        RecipeListing round = GetMarketplaceResponse.fromMarketplace(source)
+                .toMarketplace(bundle).findRecipe("recipe.Composite");
+
+        assertThat(round).isNotNull();
+        assertThat(round.getDisplayName()).isEqualTo("Composite Display");
+        assertThat(round.getDescription()).isEqualTo("Composite Description");
+        assertThat(round.getEstimatedEffortPerOccurrence()).isEqualTo(Duration.ofMinutes(3));
+        assertThat(round.getOptions()).hasSize(1);
+        assertThat(round.getRecipeCount()).isEqualTo(5);
     }
 }

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/GetMarketplaceResponseTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/GetMarketplaceResponseTest.java
@@ -19,13 +19,11 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.config.CategoryDescriptor;
 import org.openrewrite.config.OptionDescriptor;
-import org.openrewrite.config.RecipeDescriptor;
 import org.openrewrite.marketplace.RecipeBundle;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.rpc.request.GetMarketplaceResponse;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 
@@ -35,29 +33,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class GetMarketplaceResponseTest {
 
-    private static RecipeDescriptor descriptor(String name) {
-        return new RecipeDescriptor(name, name, name, name, emptySet(), null,
-                emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), URI.create("https://example.com"));
-    }
-
     private static List<List<CategoryDescriptor>> path() {
         return List.of(List.of(new CategoryDescriptor("Cat", "", "", emptySet(), false, 0, false)));
     }
 
-    /**
-     * A lightweight row: null descriptor, listing fields populated.
-     */
     private static GetMarketplaceResponse.Row lightweightRow(String name, int recipeCount, @Nullable String packageName) {
         return new GetMarketplaceResponse.Row(name, name, name, null, emptyList(), emptyList(),
-                recipeCount, null, path(), packageName);
-    }
-
-    /**
-     * A legacy descriptor-only row: null name signals the fallback path.
-     */
-    private static GetMarketplaceResponse.Row descriptorRow(String name, @Nullable String packageName) {
-        return new GetMarketplaceResponse.Row(null, null, null, null, null, null,
-                0, descriptor(name), path(), packageName);
+                recipeCount, path(), packageName);
     }
 
     /**
@@ -107,13 +89,13 @@ class GetMarketplaceResponseTest {
     }
 
     @Test
-    void prefersLightweightFieldsOverDescriptor() {
+    void buildsListingFromLightweightFields() {
         GetMarketplaceResponse response = new GetMarketplaceResponse();
         response.add(new GetMarketplaceResponse.Row(
                 "recipe.Light", "Light Display", "Light Description",
                 Duration.ofMinutes(5),
                 List.of(new OptionDescriptor("opt", "String", "Opt", "Opt description", null, null, false, null)),
-                emptyList(), 7, null, path(), null));
+                emptyList(), 7, path(), null));
 
         RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
         RecipeListing listing = response.toMarketplace(bundle).findRecipe("recipe.Light");
@@ -127,24 +109,7 @@ class GetMarketplaceResponseTest {
     }
 
     @Test
-    void fallsBackToDescriptorWhenNameIsNull() {
-        GetMarketplaceResponse response = new GetMarketplaceResponse();
-        response.add(descriptorRow("recipe.Legacy", null));
-
-        RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
-        RecipeListing listing = response.toMarketplace(bundle).findRecipe("recipe.Legacy");
-
-        assertThat(listing).isNotNull();
-        assertThat(listing.getName()).isEqualTo("recipe.Legacy");
-        // The descriptor-derived metadata is what the listing carries, not just the name.
-        assertThat(listing.getDisplayName()).isEqualTo("recipe.Legacy");
-        assertThat(listing.getDescription()).isEqualTo("recipe.Legacy");
-        assertThat(listing.getRecipeCount()).isEqualTo(1);
-    }
-
-    @SuppressWarnings("deprecation") // deliberately exercises the deprecated fromMarketplace overload
-    @Test
-    void emitsOptimizedRowsWithoutDescriptor() {
+    void emitsListingWeightRows() {
         RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
         RecipeMarketplace marketplace = marketplaceWith(compositeListing(bundle));
 
@@ -152,8 +117,6 @@ class GetMarketplaceResponseTest {
 
         assertThat(response).hasSize(1);
         GetMarketplaceResponse.Row row = response.get(0);
-        // The optimization: listing-weight fields are emitted and the heavyweight descriptor is not.
-        assertThat(row.getDescriptor()).isNull();
         assertThat(row.getName()).isEqualTo("recipe.Composite");
         assertThat(row.getDisplayName()).isEqualTo("Composite Display");
         assertThat(row.getDescription()).isEqualTo("Composite Description");
@@ -161,13 +124,10 @@ class GetMarketplaceResponseTest {
         assertThat(row.getOptions()).hasSize(1);
         assertThat(row.getRecipeCount()).isEqualTo(5);
         assertThat(row.getPackageName()).isEqualTo("Migration");
-
-        // The deprecated overload is a pure shim: same optimized output, still no descriptor.
-        assertThat(GetMarketplaceResponse.fromMarketplace(marketplace, emptyList()).get(0).getDescriptor()).isNull();
     }
 
     @Test
-    void roundTripsOptimizedRows() {
+    void roundTripsListingWeightRows() {
         RecipeBundle bundle = new RecipeBundle("nuget", "Migration", null, "1.0.0", null);
         RecipeMarketplace source = marketplaceWith(compositeListing(bundle));
 

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/DataTableDescriptorDtoTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/DataTableDescriptorDtoTest.cs
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Verifies the marketplace row carries data tables (name, display metadata, and columns), bringing
+/// the C# emitter in line with the other ecosystems rather than emitting an empty list.
+/// </summary>
+public class DataTableDescriptorDtoTest
+{
+    [Fact]
+    public void FromDescriptor_MapsDataTableAndColumns()
+    {
+        var descriptor = new DataTableDescriptor(
+            "my.table", "My Table", "A table.",
+            [new ColumnDescriptor("col", "Column", "A column.")]);
+
+        var dto = DataTableDescriptorDto.FromDescriptor(descriptor);
+
+        Assert.Equal("my.table", dto.Name);
+        Assert.Equal("My Table", dto.DisplayName);
+        Assert.Equal("A table.", dto.Description);
+
+        var column = Assert.Single(dto.Columns);
+        Assert.Equal("col", column.Name);
+        Assert.Equal("Column", column.DisplayName);
+        Assert.Equal("A column.", column.Description);
+        // C#'s ColumnDescriptor carries no type; the wire field is present but empty.
+        Assert.Equal("", column.Type);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceOriginAttributionTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceOriginAttributionTest.cs
@@ -101,8 +101,8 @@ public class MarketplaceOriginAttributionTest : IDisposable
 
         var rows = server.GetMarketplace().GetAwaiter().GetResult();
 
-        var alpha = rows.Single(r => r.Descriptor.Name == "AlphaPlugin.AlphaRecipe");
-        var beta = rows.Single(r => r.Descriptor.Name == "BetaPlugin.BetaRecipe");
+        var alpha = rows.Single(r => r.Name == "AlphaPlugin.AlphaRecipe");
+        var beta = rows.Single(r => r.Name == "BetaPlugin.BetaRecipe");
 
         Assert.Equal(_alphaDll, alpha.PackageName);
         Assert.Equal(_betaDll, beta.PackageName);

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceRecipeCountTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceRecipeCountTest.cs
@@ -58,5 +58,9 @@ public class MarketplaceRecipeCountTest
         var root = rows.Single(r => r.DisplayName == "Root");
 
         Assert.Equal(3, root.RecipeCount); // root + middle + leaf
+
+        // Guard: the marketplace holds a RecipeListing (with the precomputed count), not a descriptor.
+        global::OpenRewrite.Core.RecipeListing held = marketplace.FindRecipe(typeof(RootRecipe).FullName!)!.Value.Listing;
+        Assert.Equal(3, held.RecipeCount);
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceRecipeCountTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/MarketplaceRecipeCountTest.cs
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.CSharp;
+using OpenRewrite.CSharp.Rpc;
+using OpenRewrite.Java;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Verifies the marketplace row's RecipeCount is 1 + every transitive sub-recipe, not just the
+/// direct children — the host uses it as a marketplace sort key.
+/// </summary>
+public class MarketplaceRecipeCountTest
+{
+    private sealed class LeafRecipe : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Leaf";
+        public override string Description => "Leaf recipe.";
+        public override JavaVisitor<ExecutionContext> GetVisitor() => new CSharpVisitor<ExecutionContext>();
+    }
+
+    private sealed class MiddleRecipe : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Middle";
+        public override string Description => "Middle composite.";
+        public override List<global::OpenRewrite.Core.Recipe> GetRecipeList() => [new LeafRecipe()];
+    }
+
+    private sealed class RootRecipe : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Root";
+        public override string Description => "Root composite.";
+        public override List<global::OpenRewrite.Core.Recipe> GetRecipeList() => [new MiddleRecipe()];
+    }
+
+    [Fact]
+    public void GetMarketplace_RecipeCountIncludesTransitiveSubRecipes()
+    {
+        var marketplace = new global::OpenRewrite.Core.RecipeMarketplace();
+        marketplace.Install(new RootRecipe(), new global::OpenRewrite.Core.CategoryDescriptor("Test"));
+        var server = new RewriteRpcServer(marketplace);
+
+        var rows = server.GetMarketplace().GetAwaiter().GetResult();
+        var root = rows.Single(r => r.DisplayName == "Root");
+
+        Assert.Equal(3, root.RecipeCount); // root + middle + leaf
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -700,28 +700,28 @@ public class RewriteRpcServer
             new() { DisplayName = category.Descriptor.DisplayName, Description = category.Descriptor.Description }
         };
 
-        foreach (var (descriptor, _) in category.Recipes)
+        foreach (var (_, (listing, _)) in category.Recipes)
         {
-            if (!rowByRecipeId.TryGetValue(descriptor.Name, out var row))
+            if (!rowByRecipeId.TryGetValue(listing.Name, out var row))
             {
-                // Emit listing-weight fields only: the host builds its marketplace from these without
-                // the full recursive descriptor, which it fetches lazily per recipe via PrepareRecipe.
-                // RecipeCount collapses the transitive RecipeList the host would otherwise only count.
+                // Serve the RecipeListing the marketplace already holds: RecipeCount was computed once
+                // at install, so listing never walks the descriptor tree. The host fetches the full
+                // descriptor lazily per recipe via PrepareRecipe.
                 row = new GetMarketplaceResponseRow
                 {
-                    Name = descriptor.Name,
-                    DisplayName = descriptor.DisplayName,
-                    Description = descriptor.Description,
-                    EstimatedEffortPerOccurrence = descriptor.EstimatedEffortPerOccurrence is { } ts
+                    Name = listing.Name,
+                    DisplayName = listing.DisplayName,
+                    Description = listing.Description,
+                    EstimatedEffortPerOccurrence = listing.EstimatedEffortPerOccurrence is { } ts
                         ? System.Xml.XmlConvert.ToString(ts) // ISO-8601 duration (e.g. "PT5M")
                         : null,
-                    Options = descriptor.Options.Select(OptionDescriptorDto.FromDescriptor).ToList(),
-                    DataTables = descriptor.DataTables.Select(DataTableDescriptorDto.FromDescriptor).ToList(),
-                    RecipeCount = CountRecipes(descriptor),
+                    Options = listing.Options.Select(OptionDescriptorDto.FromDescriptor).ToList(),
+                    DataTables = listing.DataTables.Select(DataTableDescriptorDto.FromDescriptor).ToList(),
+                    RecipeCount = listing.RecipeCount,
                     CategoryPaths = [],
-                    PackageName = _recipeOrigin.GetValueOrDefault(descriptor.Name)
+                    PackageName = _recipeOrigin.GetValueOrDefault(listing.Name)
                 };
-                rowByRecipeId[descriptor.Name] = row;
+                rowByRecipeId[listing.Name] = row;
             }
             row.CategoryPaths.Add(new List<CategoryDescriptorDto>(currentPath));
         }
@@ -730,18 +730,6 @@ public class RewriteRpcServer
         {
             CollectRecipes(rowByRecipeId, child, currentPath);
         }
-    }
-
-    // Returns 1 (this recipe) plus every transitive entry in its RecipeList. The host uses this as a
-    // sort key in place of the recursive RecipeList it would otherwise walk to compute it.
-    private static int CountRecipes(RecipeDescriptor descriptor)
-    {
-        var count = 1;
-        foreach (var sub in descriptor.RecipeList)
-        {
-            count += CountRecipes(sub);
-        }
-        return count;
     }
 
     [JsonRpcMethod("InstallRecipes", UseSingleObjectParameterDeserialization = true)]
@@ -1238,7 +1226,7 @@ public class RewriteRpcServer
             });
         }
 
-        var (descriptor, recipe) = found.Value;
+        var (_, recipe) = found.Value;
         if (recipe == null)
         {
             throw new InvalidOperationException($"Recipe {request.Id} has no live instance (installed without constructor)");
@@ -2213,9 +2201,6 @@ public class GetMarketplaceResponseRow
     // 1 + every transitive RecipeList entry; the host uses it as a sort key.
     public int RecipeCount { get; set; }
 
-    // Retained for backward compatibility with peers that still emit the full recursive descriptor,
-    // but nullable and no longer emitted here — prefer the lightweight fields above.
-    public RecipeDescriptorDto? Descriptor { get; set; }
     public List<List<CategoryDescriptorDto>> CategoryPaths { get; set; } = [];
     public string? PackageName { get; set; }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -704,9 +704,20 @@ public class RewriteRpcServer
         {
             if (!rowByRecipeId.TryGetValue(descriptor.Name, out var row))
             {
+                // Emit listing-weight fields only: the host builds its marketplace from these without
+                // the full recursive descriptor, which it fetches lazily per recipe via PrepareRecipe.
+                // RecipeCount collapses the transitive RecipeList the host would otherwise only count.
                 row = new GetMarketplaceResponseRow
                 {
-                    Descriptor = RecipeDescriptorDto.FromDescriptor(descriptor),
+                    Name = descriptor.Name,
+                    DisplayName = descriptor.DisplayName,
+                    Description = descriptor.Description,
+                    EstimatedEffortPerOccurrence = descriptor.EstimatedEffortPerOccurrence is { } ts
+                        ? System.Xml.XmlConvert.ToString(ts) // ISO-8601 duration (e.g. "PT5M")
+                        : null,
+                    Options = descriptor.Options.Select(OptionDescriptorDto.FromDescriptor).ToList(),
+                    DataTables = descriptor.DataTables.Select(DataTableDescriptorDto.FromDescriptor).ToList(),
+                    RecipeCount = CountRecipes(descriptor),
                     CategoryPaths = [],
                     PackageName = _recipeOrigin.GetValueOrDefault(descriptor.Name)
                 };
@@ -719,6 +730,18 @@ public class RewriteRpcServer
         {
             CollectRecipes(rowByRecipeId, child, currentPath);
         }
+    }
+
+    // Returns 1 (this recipe) plus every transitive entry in its RecipeList. The host uses this as a
+    // sort key in place of the recursive RecipeList it would otherwise walk to compute it.
+    private static int CountRecipes(RecipeDescriptor descriptor)
+    {
+        var count = 1;
+        foreach (var sub in descriptor.RecipeList)
+        {
+            count += CountRecipes(sub);
+        }
+        return count;
     }
 
     [JsonRpcMethod("InstallRecipes", UseSingleObjectParameterDeserialization = true)]
@@ -2176,7 +2199,23 @@ public class EvictRequest
 
 public class GetMarketplaceResponseRow
 {
-    public RecipeDescriptorDto Descriptor { get; set; } = null!;
+    // Listing-weight fields (Name through RecipeCount) carry everything the host needs to list the
+    // marketplace without materializing recipes. Up-to-date engines populate these and leave
+    // Descriptor null; the host fetches the full descriptor lazily per recipe via PrepareRecipe.
+    public string? Name { get; set; }
+    public string? DisplayName { get; set; }
+    public string? Description { get; set; }
+
+    [JsonConverter(typeof(DurationWireConverter))]
+    public string? EstimatedEffortPerOccurrence { get; set; }
+    public List<OptionDescriptorDto> Options { get; set; } = [];
+    public List<DataTableDescriptorDto> DataTables { get; set; } = [];
+    // 1 + every transitive RecipeList entry; the host uses it as a sort key.
+    public int RecipeCount { get; set; }
+
+    // Retained for backward compatibility with peers that still emit the full recursive descriptor,
+    // but nullable and no longer emitted here — prefer the lightweight fields above.
+    public RecipeDescriptorDto? Descriptor { get; set; }
     public List<List<CategoryDescriptorDto>> CategoryPaths { get; set; } = [];
     public string? PackageName { get; set; }
 }
@@ -2283,6 +2322,45 @@ public class OptionDescriptorDto
             Valid = d.Valid?.ToList(),
             Required = d.Required,
             Value = d.Value
+        };
+    }
+}
+
+public class DataTableDescriptorDto
+{
+    public string Name { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    public string Description { get; set; } = "";
+    public List<ColumnDescriptorDto> Columns { get; set; } = [];
+
+    public static DataTableDescriptorDto FromDescriptor(DataTableDescriptor d)
+    {
+        return new DataTableDescriptorDto
+        {
+            Name = d.Name,
+            DisplayName = d.DisplayName,
+            Description = d.Description,
+            Columns = d.Columns.Select(ColumnDescriptorDto.FromDescriptor).ToList()
+        };
+    }
+}
+
+public class ColumnDescriptorDto
+{
+    public string Name { get; set; } = "";
+    // C#'s ColumnDescriptor carries no column type; emit an empty string so the wire field
+    // (which the Java peer's ColumnDescriptor treats as non-null) is present.
+    public string Type { get; set; } = "";
+    public string DisplayName { get; set; } = "";
+    public string Description { get; set; } = "";
+
+    public static ColumnDescriptorDto FromDescriptor(ColumnDescriptor d)
+    {
+        return new ColumnDescriptorDto
+        {
+            Name = d.Name,
+            DisplayName = d.DisplayName,
+            Description = d.Description
         };
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeListing.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeListing.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace OpenRewrite.Core;
+
+/// <summary>
+/// Listing-weight view the marketplace holds and serves for the InstallRecipes and GetMarketplace
+/// RPC commands, so listing never materializes the full recursive descriptor. The full tree is built
+/// lazily per recipe by PrepareRecipe. <see cref="RecipeCount"/> is 1 + every transitive RecipeList
+/// entry, computed once at install time (the host uses it as a sort key).
+/// </summary>
+public sealed record RecipeListing(
+    string Name,
+    string DisplayName,
+    string Description,
+    TimeSpan? EstimatedEffortPerOccurrence,
+    IReadOnlyList<OptionDescriptor> Options,
+    IReadOnlyList<DataTableDescriptor> DataTables,
+    int RecipeCount)
+{
+    /// <summary>
+    /// Derives the listing-weight view from a full descriptor, collapsing its recursive RecipeList
+    /// to a count.
+    /// </summary>
+    public static RecipeListing From(RecipeDescriptor descriptor) => new(
+        descriptor.Name,
+        descriptor.DisplayName,
+        descriptor.Description,
+        descriptor.EstimatedEffortPerOccurrence,
+        descriptor.Options,
+        descriptor.DataTables,
+        CountRecipes(descriptor));
+
+    private static int CountRecipes(RecipeDescriptor descriptor)
+    {
+        var count = 1;
+        foreach (var sub in descriptor.RecipeList)
+        {
+            count += CountRecipes(sub);
+        }
+        return count;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeMarketplace.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeMarketplace.cs
@@ -159,17 +159,17 @@ public class RecipeMarketplace
     public IReadOnlyList<Category> Categories => _root.SubCategories;
 
     /// <summary>
-    /// Find a recipe by its fully qualified name. Returns the descriptor and optionally the live recipe instance.
+    /// Find a recipe by its fully qualified name. Returns the listing and optionally the live recipe instance.
     /// </summary>
-    public (RecipeDescriptor Descriptor, Recipe? Recipe)? FindRecipe(string name)
+    public (RecipeListing Listing, Recipe? Recipe)? FindRecipe(string name)
     {
         return _root.FindRecipe(name);
     }
 
     /// <summary>
-    /// Recursively collect all recipe descriptors in the marketplace.
+    /// Recursively collect all recipe listings in the marketplace.
     /// </summary>
-    public List<RecipeDescriptor> AllRecipes()
+    public List<RecipeListing> AllRecipes()
     {
         return _root.AllRecipes();
     }
@@ -181,7 +181,9 @@ public class RecipeMarketplace
     {
         public CategoryDescriptor Descriptor { get; }
         private readonly List<Category> _categories = [];
-        private readonly Dictionary<RecipeDescriptor, Recipe?> _recipes = new();
+        // Keyed by recipe name, holding the listing-weight view and (when installed from a class) the
+        // live recipe instance PrepareRecipe uses to build the full tree.
+        private readonly Dictionary<string, (RecipeListing Listing, Recipe? Recipe)> _recipes = new();
 
         public Category(CategoryDescriptor descriptor)
         {
@@ -189,13 +191,15 @@ public class RecipeMarketplace
         }
 
         public IReadOnlyList<Category> SubCategories => _categories;
-        public IReadOnlyDictionary<RecipeDescriptor, Recipe?> Recipes => _recipes;
+        public IReadOnlyDictionary<string, (RecipeListing Listing, Recipe? Recipe)> Recipes => _recipes;
 
         internal void Install(Recipe recipe, ReadOnlySpan<CategoryDescriptor> categoryPath)
         {
             if (categoryPath.IsEmpty)
             {
-                _recipes[recipe.GetDescriptor()] = recipe;
+                // Derive the listing once at install; retain the instance for PrepareRecipe.
+                var descriptor = recipe.GetDescriptor();
+                _recipes[descriptor.Name] = (RecipeListing.From(descriptor), recipe);
                 return;
             }
 
@@ -207,7 +211,7 @@ public class RecipeMarketplace
         {
             if (categoryPath.IsEmpty)
             {
-                _recipes[descriptor] = null;
+                _recipes[descriptor.Name] = (RecipeListing.From(descriptor), null);
                 return;
             }
 
@@ -228,13 +232,10 @@ public class RecipeMarketplace
             return newCategory;
         }
 
-        public (RecipeDescriptor Descriptor, Recipe? Recipe)? FindRecipe(string name)
+        public (RecipeListing Listing, Recipe? Recipe)? FindRecipe(string name)
         {
-            foreach (var (descriptor, recipe) in _recipes)
-            {
-                if (descriptor.Name == name)
-                    return (descriptor, recipe);
-            }
+            if (_recipes.TryGetValue(name, out var entry))
+                return entry;
 
             foreach (var category in _categories)
             {
@@ -246,9 +247,13 @@ public class RecipeMarketplace
             return null;
         }
 
-        public List<RecipeDescriptor> AllRecipes()
+        public List<RecipeListing> AllRecipes()
         {
-            var result = new List<RecipeDescriptor>(_recipes.Keys);
+            var result = new List<RecipeListing>();
+            foreach (var (listing, _) in _recipes.Values)
+            {
+                result.Add(listing);
+            }
             foreach (var category in _categories)
             {
                 result.AddRange(category.AllRecipes());

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1408,8 +1408,19 @@ func parseOrderedColumns(raw json.RawMessage) ([]recipe.ColumnValue, error) {
 	return cols, nil
 }
 
+// marketplaceRow carries listing-weight metadata only: the host builds a RecipeListing from these
+// fields without materializing recipes. The full recursive descriptor is deliberately not shipped —
+// the host fetches it lazily per recipe via the separate PrepareRecipe RPC. RecipeCount collapses
+// the transitive recipeList the host would otherwise only count.
 type marketplaceRow struct {
-	Descriptor    marketplaceDescriptor   `json:"descriptor"`
+	Name                         string                  `json:"name"`
+	DisplayName                  string                  `json:"displayName"`
+	Description                  string                  `json:"description"`
+	EstimatedEffortPerOccurrence *string                 `json:"estimatedEffortPerOccurrence"`
+	Options                      []marketplaceOption     `json:"options"`
+	DataTables                   []any                   `json:"dataTables"`
+	// RecipeCount is 1 + every transitive recipeList entry; the host uses it as a sort key.
+	RecipeCount   int                     `json:"recipeCount"`
 	CategoryPaths [][]marketplaceCategory `json:"categoryPaths"`
 	// PackageName is the package that contributed this recipe (nil when unattributed, e.g. a
 	// local-path install), so the host attributes each row to its own bundle.
@@ -1477,7 +1488,12 @@ func (s *server) handleGetMarketplace(params json.RawMessage) (any, *rpcError) {
 			packageName = &origin
 		}
 		rows = append(rows, marketplaceRow{
-			Descriptor:    marketplaceDescriptorFromRecipe(desc),
+			Name:          desc.Name,
+			DisplayName:   desc.DisplayName,
+			Description:   desc.Description,
+			Options:       marketplaceOptionsFromRecipe(desc),
+			DataTables:    marketplaceDataTablesFromRecipe(desc),
+			RecipeCount:   countRecipes(desc),
 			CategoryPaths: [][]marketplaceCategory{categoryPath},
 			PackageName:   packageName,
 		})
@@ -1512,7 +1528,18 @@ func delegateDescriptor(name string) marketplaceDescriptor {
 	}
 }
 
-func marketplaceDescriptorFromRecipe(desc recipe.RecipeDescriptor) marketplaceDescriptor {
+// countRecipes returns 1 (this recipe) plus every transitive entry in its recipeList. The host uses
+// this as a sort key in place of the recursive recipeList it would otherwise walk to compute it.
+func countRecipes(desc recipe.RecipeDescriptor) int {
+	count := 1
+	for _, sub := range desc.RecipeList {
+		count += countRecipes(sub)
+	}
+	return count
+}
+
+// marketplaceOptionsFromRecipe converts a recipe's own (non-recursive) options to wire format.
+func marketplaceOptionsFromRecipe(desc recipe.RecipeDescriptor) []marketplaceOption {
 	options := make([]marketplaceOption, 0, len(desc.Options))
 	for _, opt := range desc.Options {
 		var example *string
@@ -1534,6 +1561,25 @@ func marketplaceDescriptorFromRecipe(desc recipe.RecipeDescriptor) marketplaceDe
 			Valid:       valid,
 		})
 	}
+	return options
+}
+
+// marketplaceDataTablesFromRecipe converts a recipe's own (non-recursive) data tables to wire format.
+func marketplaceDataTablesFromRecipe(desc recipe.RecipeDescriptor) []any {
+	dataTables := make([]any, 0, len(desc.DataTables))
+	for _, dt := range desc.DataTables {
+		dataTables = append(dataTables, marketplaceDataTable{
+			Name:        dt.Name,
+			DisplayName: dt.DisplayName,
+			Description: dt.Description,
+			Columns:     marketplaceColumns(dt.Columns),
+		})
+	}
+	return dataTables
+}
+
+func marketplaceDescriptorFromRecipe(desc recipe.RecipeDescriptor) marketplaceDescriptor {
+	options := marketplaceOptionsFromRecipe(desc)
 
 	recipeList := make([]marketplaceDescriptor, 0, len(desc.RecipeList))
 	for _, sub := range desc.RecipeList {
@@ -1545,15 +1591,7 @@ func marketplaceDescriptorFromRecipe(desc recipe.RecipeDescriptor) marketplaceDe
 		preconditions = append(preconditions, marketplaceDescriptorFromRecipe(pre))
 	}
 
-	dataTables := make([]any, 0, len(desc.DataTables))
-	for _, dt := range desc.DataTables {
-		dataTables = append(dataTables, marketplaceDataTable{
-			Name:        dt.Name,
-			DisplayName: dt.DisplayName,
-			Description: dt.Description,
-			Columns:     marketplaceColumns(dt.Columns),
-		})
-	}
+	dataTables := marketplaceDataTablesFromRecipe(desc)
 
 	maintainers := make([]any, 0, len(desc.Maintainers))
 	for _, m := range desc.Maintainers {

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1469,7 +1469,10 @@ type marketplaceCategory struct {
 func (s *server) handleGetMarketplace(params json.RawMessage) (any, *rpcError) {
 	var rows []marketplaceRow
 	for _, reg := range s.registry.AllRegistrations() {
-		desc := reg.Descriptor
+		// Serve the RecipeListing the registry already holds: RecipeCount was computed once at
+		// registration, so listing never walks the descriptor tree. The full descriptor is fetched
+		// lazily per recipe via PrepareRecipe.
+		listing := reg.Listing
 
 		var categoryPath []marketplaceCategory
 		for _, cat := range reg.Categories {
@@ -1484,16 +1487,16 @@ func (s *server) handleGetMarketplace(params json.RawMessage) (any, *rpcError) {
 		}
 
 		var packageName *string
-		if origin, ok := s.recipeOrigin[desc.Name]; ok {
+		if origin, ok := s.recipeOrigin[listing.Name]; ok {
 			packageName = &origin
 		}
 		rows = append(rows, marketplaceRow{
-			Name:          desc.Name,
-			DisplayName:   desc.DisplayName,
-			Description:   desc.Description,
-			Options:       marketplaceOptionsFromRecipe(desc),
-			DataTables:    marketplaceDataTablesFromRecipe(desc),
-			RecipeCount:   countRecipes(desc),
+			Name:          listing.Name,
+			DisplayName:   listing.DisplayName,
+			Description:   listing.Description,
+			Options:       marketplaceOptions(listing.Options),
+			DataTables:    marketplaceDataTables(listing.DataTables),
+			RecipeCount:   listing.RecipeCount,
 			CategoryPaths: [][]marketplaceCategory{categoryPath},
 			PackageName:   packageName,
 		})
@@ -1528,20 +1531,10 @@ func delegateDescriptor(name string) marketplaceDescriptor {
 	}
 }
 
-// countRecipes returns 1 (this recipe) plus every transitive entry in its recipeList. The host uses
-// this as a sort key in place of the recursive recipeList it would otherwise walk to compute it.
-func countRecipes(desc recipe.RecipeDescriptor) int {
-	count := 1
-	for _, sub := range desc.RecipeList {
-		count += countRecipes(sub)
-	}
-	return count
-}
-
-// marketplaceOptionsFromRecipe converts a recipe's own (non-recursive) options to wire format.
-func marketplaceOptionsFromRecipe(desc recipe.RecipeDescriptor) []marketplaceOption {
-	options := make([]marketplaceOption, 0, len(desc.Options))
-	for _, opt := range desc.Options {
+// marketplaceOptions converts a recipe's own (non-recursive) options to wire format.
+func marketplaceOptions(opts []recipe.OptionDescriptor) []marketplaceOption {
+	options := make([]marketplaceOption, 0, len(opts))
+	for _, opt := range opts {
 		var example *string
 		if opt.Example != "" {
 			example = &opt.Example
@@ -1564,10 +1557,10 @@ func marketplaceOptionsFromRecipe(desc recipe.RecipeDescriptor) []marketplaceOpt
 	return options
 }
 
-// marketplaceDataTablesFromRecipe converts a recipe's own (non-recursive) data tables to wire format.
-func marketplaceDataTablesFromRecipe(desc recipe.RecipeDescriptor) []any {
-	dataTables := make([]any, 0, len(desc.DataTables))
-	for _, dt := range desc.DataTables {
+// marketplaceDataTables converts a recipe's own (non-recursive) data tables to wire format.
+func marketplaceDataTables(dts []recipe.DataTableDescriptor) []any {
+	dataTables := make([]any, 0, len(dts))
+	for _, dt := range dts {
 		dataTables = append(dataTables, marketplaceDataTable{
 			Name:        dt.Name,
 			DisplayName: dt.DisplayName,
@@ -1579,7 +1572,7 @@ func marketplaceDataTablesFromRecipe(desc recipe.RecipeDescriptor) []any {
 }
 
 func marketplaceDescriptorFromRecipe(desc recipe.RecipeDescriptor) marketplaceDescriptor {
-	options := marketplaceOptionsFromRecipe(desc)
+	options := marketplaceOptions(desc.Options)
 
 	recipeList := make([]marketplaceDescriptor, 0, len(desc.RecipeList))
 	for _, sub := range desc.RecipeList {
@@ -1591,7 +1584,7 @@ func marketplaceDescriptorFromRecipe(desc recipe.RecipeDescriptor) marketplaceDe
 		preconditions = append(preconditions, marketplaceDescriptorFromRecipe(pre))
 	}
 
-	dataTables := marketplaceDataTablesFromRecipe(desc)
+	dataTables := marketplaceDataTables(desc.DataTables)
 
 	maintainers := make([]any, 0, len(desc.Maintainers))
 	for _, m := range desc.Maintainers {
@@ -1765,9 +1758,15 @@ func (s *server) handlePrepareRecipe(params json.RawMessage) (any, *rpcError) {
 		// (stale/missing CLI-built binary) instead of "Unknown recipe: <uuid>".
 		s.preparedRecipes[recipeID] = instance
 		s.preparedRecipeNames[recipeID] = req.ID
+		// A constructor-less registration always carries its descriptor; fall back to a name-only
+		// stand-in for the (broken-binary) edge case where it doesn't.
+		descriptor := delegateDescriptor(req.ID)
+		if reg.Descriptor != nil {
+			descriptor = marketplaceDescriptorFromRecipe(*reg.Descriptor)
+		}
 		return prepareRecipeResponse{
 			ID:                recipeID,
-			Descriptor:        marketplaceDescriptorFromRecipe(reg.Descriptor),
+			Descriptor:        descriptor,
 			EditVisitor:       "edit:" + recipeID,
 			EditPreconditions: []any{},
 			ScanPreconditions: []any{},

--- a/rewrite-go/cmd/rpc/marketplace_test.go
+++ b/rewrite-go/cmd/rpc/marketplace_test.go
@@ -21,9 +21,9 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 )
 
-// countRecipes must count a recipe plus every transitive entry in its RecipeList,
+// ToListing must count a recipe plus every transitive entry in its RecipeList,
 // not just its direct children — the host uses the value as a marketplace sort key.
-func TestCountRecipesIncludesTransitiveSubRecipes(t *testing.T) {
+func TestToListingCountsTransitiveSubRecipes(t *testing.T) {
 	desc := recipe.RecipeDescriptor{
 		Name: "root",
 		RecipeList: []recipe.RecipeDescriptor{
@@ -35,7 +35,7 @@ func TestCountRecipesIncludesTransitiveSubRecipes(t *testing.T) {
 			},
 		},
 	}
-	if got := countRecipes(desc); got != 3 {
-		t.Errorf("countRecipes = %d, want 3 (root + middle + leaf)", got)
+	if got := recipe.ToListing(desc).RecipeCount; got != 3 {
+		t.Errorf("ToListing(desc).RecipeCount = %d, want 3 (root + middle + leaf)", got)
 	}
 }

--- a/rewrite-go/cmd/rpc/marketplace_test.go
+++ b/rewrite-go/cmd/rpc/marketplace_test.go
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package main
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+)
+
+// countRecipes must count a recipe plus every transitive entry in its RecipeList,
+// not just its direct children — the host uses the value as a marketplace sort key.
+func TestCountRecipesIncludesTransitiveSubRecipes(t *testing.T) {
+	desc := recipe.RecipeDescriptor{
+		Name: "root",
+		RecipeList: []recipe.RecipeDescriptor{
+			{
+				Name: "middle",
+				RecipeList: []recipe.RecipeDescriptor{
+					{Name: "leaf"},
+				},
+			},
+		},
+	}
+	if got := countRecipes(desc); got != 3 {
+		t.Errorf("countRecipes = %d, want 3 (root + middle + leaf)", got)
+	}
+}

--- a/rewrite-go/pkg/recipe/registry.go
+++ b/rewrite-go/pkg/recipe/registry.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 )
 
 type CategoryDescriptor struct {
@@ -29,9 +30,52 @@ type CategoryDescriptor struct {
 
 type RecipeConstructor func(options map[string]any) Recipe
 
+// RecipeListing is the listing-weight view the registry holds and serves for the InstallRecipes and
+// GetMarketplace RPC commands, so listing never materializes the full recursive descriptor. The full
+// tree is built lazily per recipe by PrepareRecipe. RecipeCount is 1 + every transitive RecipeList
+// entry, computed once at registration (the host uses it as a sort key).
+type RecipeListing struct {
+	Name                         string
+	DisplayName                  string
+	Description                  string
+	EstimatedEffortPerOccurrence time.Duration
+	Options                      []OptionDescriptor
+	DataTables                   []DataTableDescriptor
+	RecipeCount                  int
+}
+
+// ToListing derives the listing-weight view from a full descriptor, collapsing its recursive
+// RecipeList to a count.
+func ToListing(desc RecipeDescriptor) RecipeListing {
+	return RecipeListing{
+		Name:                         desc.Name,
+		DisplayName:                  desc.DisplayName,
+		Description:                  desc.Description,
+		EstimatedEffortPerOccurrence: desc.EstimatedEffortPerOccurrence,
+		Options:                      desc.Options,
+		DataTables:                   desc.DataTables,
+		RecipeCount:                  countRecipes(desc),
+	}
+}
+
+func countRecipes(desc RecipeDescriptor) int {
+	count := 1
+	for _, sub := range desc.RecipeList {
+		count += countRecipes(sub)
+	}
+	return count
+}
+
 type Registration struct {
-	Descriptor  RecipeDescriptor
+	// Listing is the listing-weight view served for GetMarketplace, computed once at registration.
+	Listing     RecipeListing
 	Constructor RecipeConstructor
+
+	// Descriptor is retained only for descriptor-only registrations that lack a runnable Constructor
+	// (the installer's bootstrap listing binary); PrepareRecipe returns it when the recipe can't be
+	// instantiated here. Nil for normal registrations, which rebuild the full descriptor from
+	// Constructor on PrepareRecipe.
+	Descriptor *RecipeDescriptor
 
 	// Categories is the category path from shallowest to deepest
 	// (e.g., []CategoryDescriptor{{DisplayName: "Go"}, {DisplayName: "Cleanup"}}).
@@ -98,7 +142,7 @@ func (r *Registry) Register(prototype Recipe, categories ...CategoryDescriptor) 
 	constructor := newReflectConstructor(prototype)
 
 	reg := &Registration{
-		Descriptor:  desc,
+		Listing:     ToListing(desc),
 		Constructor: constructor,
 		Categories:  categories,
 	}
@@ -130,8 +174,10 @@ func (r *Registry) registerSubRecipes(rec Recipe) {
 			// A child that is also registered as a top-level recipe is
 			// already resolvable via byName; FindRecipe checks byName first.
 			child := sub
+			// Sub-recipes are resolved by name only to be prepared (via Constructor); they never
+			// surface in GetMarketplace, so they need no Listing, and PrepareRecipe describes the
+			// instance rather than a stored descriptor.
 			r.subByName[name] = &Registration{
-				Descriptor:  Describe(child),
 				Constructor: func(map[string]any) Recipe { return child },
 			}
 			r.registerSubRecipes(child)
@@ -161,9 +207,11 @@ func (r *Registry) RegisterWithCategories(desc RecipeDescriptor, categories []Ca
 			return
 		}
 	}
+	descCopy := desc
 	reg := &Registration{
-		Descriptor:  desc,
+		Listing:     ToListing(desc),
 		Constructor: func(options map[string]any) Recipe { return nil },
+		Descriptor:  &descCopy,
 		Categories:  categories,
 	}
 	r.byName[desc.Name] = reg
@@ -181,12 +229,12 @@ func (r *Registry) FindRecipe(name string) (*Registration, bool) {
 	return reg, ok
 }
 
-func (r *Registry) AllRecipes() []RecipeDescriptor {
+func (r *Registry) AllRecipes() []RecipeListing {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	result := make([]RecipeDescriptor, 0, len(r.byName))
+	result := make([]RecipeListing, 0, len(r.byName))
 	for _, reg := range r.byName {
-		result = append(result, reg.Descriptor)
+		result = append(result, reg.Listing)
 	}
 	return result
 }

--- a/rewrite-go/pkg/recipe/registry_test.go
+++ b/rewrite-go/pkg/recipe/registry_test.go
@@ -90,8 +90,8 @@ func TestCompositeChildrenNotInMarketplace(t *testing.T) {
 	}
 
 	for _, reg := range r.AllRegistrations() {
-		if childNames[reg.Descriptor.Name] {
-			t.Errorf("child recipe %q must not appear in AllRegistrations (marketplace)", reg.Descriptor.Name)
+		if childNames[reg.Listing.Name] {
+			t.Errorf("child recipe %q must not appear in AllRegistrations (marketplace)", reg.Listing.Name)
 		}
 	}
 	for _, desc := range r.AllRecipes() {
@@ -104,8 +104,8 @@ func TestCompositeChildrenNotInMarketplace(t *testing.T) {
 	var walk func(c *Category)
 	walk = func(c *Category) {
 		for _, reg := range c.Recipes {
-			if childNames[reg.Descriptor.Name] {
-				t.Errorf("child recipe %q must not appear in the category tree", reg.Descriptor.Name)
+			if childNames[reg.Listing.Name] {
+				t.Errorf("child recipe %q must not appear in the category tree", reg.Listing.Name)
 			}
 		}
 		for _, sub := range c.Subcategories {
@@ -114,5 +114,23 @@ func TestCompositeChildrenNotInMarketplace(t *testing.T) {
 	}
 	for _, cat := range r.Categories() {
 		walk(cat)
+	}
+}
+
+// TestRegistryHoldsListingNotDescriptor verifies the registry holds a listing-weight view (with the
+// transitive count precomputed) rather than the full recursive descriptor for executable recipes.
+func TestRegistryHoldsListingNotDescriptor(t *testing.T) {
+	r := NewRegistry()
+	r.Register(newComposite(), CategoryDescriptor{DisplayName: "Example"})
+
+	reg, ok := r.FindRecipe("com.example.Composite")
+	if !ok {
+		t.Fatal("expected to find the composite recipe")
+	}
+	if reg.Descriptor != nil {
+		t.Error("an executable registration must not hold a resident descriptor")
+	}
+	if reg.Listing.RecipeCount != 3 {
+		t.Errorf("Listing.RecipeCount = %d, want 3 (composite + Keep + Negate)", reg.Listing.RecipeCount)
 	}
 }

--- a/rewrite-go/test/recipe_test.go
+++ b/rewrite-go/test/recipe_test.go
@@ -204,8 +204,8 @@ func TestRegistryActivate(t *testing.T) {
 	if !ok {
 		t.Fatal("expected to find FindFoo recipe")
 	}
-	if found.Descriptor.DisplayName != "Find foo identifiers" {
-		t.Errorf("expected displayName %q, got %q", "Find foo identifiers", found.Descriptor.DisplayName)
+	if found.Listing.DisplayName != "Find foo identifiers" {
+		t.Errorf("expected displayName %q, got %q", "Find foo identifiers", found.Listing.DisplayName)
 	}
 
 	// All recipes

--- a/rewrite-javascript/rewrite/src/marketplace.ts
+++ b/rewrite-javascript/rewrite/src/marketplace.ts
@@ -13,12 +13,56 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Recipe, RecipeDescriptor} from "./recipe";
+import {Minutes, OptionDescriptor, Recipe, RecipeDescriptor} from "./recipe";
+import {DataTableDescriptor} from "./data-table";
 
 export type RecipeConstructor = new (options?: any) => Recipe;
 
-function isRecipeConstructor(recipe: RecipeConstructor | RecipeDescriptor): recipe is RecipeConstructor {
+/**
+ * Listing-weight view of a recipe: everything the marketplace needs to answer InstallRecipes and
+ * GetMarketplace without holding the full recursive descriptor. The full tree is materialized lazily
+ * per recipe by PrepareRecipe. recipeCount is 1 + every transitive recipeList entry, computed once at
+ * install time (the host uses it as a sort key).
+ */
+export interface RecipeListing {
+    readonly name: string
+    readonly displayName: string
+    readonly description: string
+    readonly estimatedEffortPerOccurrence?: Minutes
+    readonly options?: ({ name: string, value?: any } & OptionDescriptor)[]
+    readonly dataTables?: DataTableDescriptor[]
+    readonly recipeCount: number
+}
+
+function isRecipeConstructor(recipe: RecipeConstructor | RecipeListing): recipe is RecipeConstructor {
     return typeof recipe === 'function';
+}
+
+/**
+ * The count of this recipe and all recipes nested transitively in its recipeList.
+ */
+function countRecipes(descriptor: RecipeDescriptor): number {
+    let count = 1;
+    for (const sub of descriptor.recipeList ?? []) {
+        count += countRecipes(sub);
+    }
+    return count;
+}
+
+/**
+ * Derives the listing-weight view from a full descriptor, collapsing its recursive recipeList to a
+ * count. Called once at install time so the marketplace never re-walks the tree to list.
+ */
+export function toRecipeListing(descriptor: RecipeDescriptor): RecipeListing {
+    return {
+        name: descriptor.name,
+        displayName: descriptor.displayName ?? descriptor.name,
+        description: descriptor.description ?? "",
+        estimatedEffortPerOccurrence: descriptor.estimatedEffortPerOccurrence,
+        options: descriptor.options,
+        dataTables: descriptor.dataTables,
+        recipeCount: countRecipes(descriptor),
+    };
 }
 
 export class RecipeMarketplace {
@@ -29,16 +73,16 @@ export class RecipeMarketplace {
 
     /**
      * Install a recipe into the marketplace under the specified category path.
-     * If a RecipeConstructor is provided, it is instantiated to extract its descriptor.
-     * If a RecipeDescriptor is provided, it is used directly (for client-side hydration).
-     * Categories are specified top-down (shallowest to deepest).
-     * Intermediate categories are created as needed.
+     * A RecipeConstructor is instantiated once to derive its {@link RecipeListing} (and the
+     * constructor is retained so PrepareRecipe can later build the full tree). A RecipeListing is
+     * stored directly (for client-side hydration). Categories are specified top-down (shallowest to
+     * deepest); intermediate categories are created as needed.
      *
-     * @param recipe The recipe class or descriptor to install
+     * @param recipe The recipe class or listing to install
      * @param categoryPath Category path from shallowest to deepest (e.g., ["Java", "Search"])
      */
     public async install(
-        recipe: RecipeConstructor | RecipeDescriptor,
+        recipe: RecipeConstructor | RecipeListing,
         categoryPath: CategoryDescriptor[]
     ): Promise<void> {
         await this.root.install(recipe, categoryPath);
@@ -48,11 +92,11 @@ export class RecipeMarketplace {
         return this.root.categories;
     }
 
-    public findRecipe(name: string): [RecipeDescriptor, RecipeConstructor | undefined] | undefined {
+    public findRecipe(name: string): [RecipeListing, RecipeConstructor | undefined] | undefined {
         return this.root.findRecipe(name)
     }
 
-    public allRecipes(): RecipeDescriptor[] {
+    public allRecipes(): RecipeListing[] {
         return this.root.allRecipes()
     }
 }
@@ -60,7 +104,7 @@ export class RecipeMarketplace {
 export namespace RecipeMarketplace {
     export class Category {
         readonly categories: Category[] = [];
-        readonly recipes: Map<RecipeDescriptor, RecipeConstructor | undefined> = new Map();
+        readonly recipes: Map<RecipeListing, RecipeConstructor | undefined> = new Map();
 
         constructor(
             readonly descriptor: CategoryDescriptor,
@@ -69,23 +113,23 @@ export namespace RecipeMarketplace {
 
         /**
          * Install a recipe into this category or a subcategory.
-         * If a RecipeConstructor is provided, it is instantiated to extract its descriptor.
-         * If a RecipeDescriptor is provided, it is used directly (for client-side hydration).
-         * Categories are specified top-down (shallowest to deepest).
-         * Intermediate categories are created as needed.
+         * A RecipeConstructor is instantiated once to derive its {@link RecipeListing} (the
+         * constructor is retained for PrepareRecipe). A RecipeListing is stored directly (for
+         * client-side hydration). Categories are specified top-down (shallowest to deepest);
+         * intermediate categories are created as needed.
          *
-         * @param recipe The recipe class or descriptor to install
+         * @param recipe The recipe class or listing to install
          * @param categoryPath Category path from shallowest to deepest
          */
         public async install(
-            recipe: RecipeConstructor | RecipeDescriptor,
+            recipe: RecipeConstructor | RecipeListing,
             categoryPath: CategoryDescriptor[]
         ): Promise<void> {
             if (categoryPath.length === 0) {
                 if (isRecipeConstructor(recipe)) {
                     try {
                         const recipeInst = new recipe({});
-                        this.recipes.set(await recipeInst.descriptor(), recipe);
+                        this.recipes.set(toRecipeListing(await recipeInst.descriptor()), recipe);
                     } catch (e) {
                         // Surface the underlying cause inline: it is dropped at the
                         // JSON-RPC serialization boundary (only `message` survives), so
@@ -123,7 +167,7 @@ export namespace RecipeMarketplace {
             return newCategory;
         }
 
-        public findRecipe(name: string): [RecipeDescriptor, RecipeConstructor | undefined] | undefined {
+        public findRecipe(name: string): [RecipeListing, RecipeConstructor | undefined] | undefined {
             for (const [recipe, ctor] of this.recipes.entries()) {
                 if (recipe.name === name) {
                     return [recipe, ctor];
@@ -138,8 +182,8 @@ export namespace RecipeMarketplace {
             return undefined;
         }
 
-        public allRecipes(): RecipeDescriptor[] {
-            const result: RecipeDescriptor[] = [...this.recipes.keys()];
+        public allRecipes(): RecipeListing[] {
+            const result: RecipeListing[] = [...this.recipes.keys()];
             for (const category of this.categories) {
                 result.push(...category.allRecipes());
             }

--- a/rewrite-javascript/rewrite/src/rpc/request/get-marketplace.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/get-marketplace.ts
@@ -15,17 +15,14 @@
  */
 import * as rpc from "vscode-jsonrpc/node";
 import {withMetrics0} from "./metrics";
-import {CategoryDescriptor, RecipeMarketplace} from "../../marketplace";
-import {Minutes, OptionDescriptor, RecipeDescriptor} from "../../recipe";
+import {CategoryDescriptor, RecipeListing, RecipeMarketplace} from "../../marketplace";
+import {Minutes, OptionDescriptor} from "../../recipe";
 import {DataTableDescriptor} from "../../data-table";
 
 export interface GetMarketplaceResponseRow {
     /**
-     * Listing-weight fields ({@link name} through {@link recipeCount}) carry everything the host
-     * needs to list the marketplace without materializing recipes. Up-to-date engines populate
-     * these and leave {@link descriptor} undefined; the full descriptor is fetched lazily per recipe
-     * via the separate PrepareRecipe RPC. A defined {@link name} selects this path in
-     * {@link toMarketplace}.
+     * Listing-weight fields the host builds a RecipeListing from. The full descriptor is fetched
+     * lazily per recipe via the separate PrepareRecipe RPC when detail or execution is needed.
      */
     readonly name?: string
     readonly displayName?: string
@@ -35,11 +32,6 @@ export interface GetMarketplaceResponseRow {
     readonly dataTables?: DataTableDescriptor[]
     /** 1 + every transitive recipeList entry; the host uses it as a sort key. */
     readonly recipeCount?: number
-    /**
-     * The full, recursive descriptor. Retained for backward compatibility with peers that still
-     * emit it, but no longer emitted by up-to-date engines — prefer the lightweight fields above.
-     */
-    readonly descriptor?: RecipeDescriptor
     readonly categoryPaths: CategoryDescriptor[][]
     /**
      * The package this recipe was contributed by, recorded at install time. Lets the host attribute
@@ -50,54 +42,31 @@ export interface GetMarketplaceResponseRow {
 }
 
 /**
- * 1 (this recipe) plus every transitive entry in its recipeList. The host uses this as a sort key
- * in place of the recursive recipeList it would otherwise walk to compute it.
+ * The {@link RecipeListing} a row stands for, built from its listing-weight fields.
  */
-function countRecipes(descriptor: RecipeDescriptor): number {
-    let count = 1;
-    for (const sub of descriptor.recipeList ?? []) {
-        count += countRecipes(sub);
-    }
-    return count;
+function rowToListing(row: GetMarketplaceResponseRow): RecipeListing {
+    const name = row.name ?? "";
+    return {
+        name,
+        displayName: row.displayName ?? name,
+        description: row.description ?? "",
+        estimatedEffortPerOccurrence: row.estimatedEffortPerOccurrence,
+        options: row.options,
+        dataTables: row.dataTables,
+        recipeCount: row.recipeCount ?? 1,
+    };
 }
 
 /**
- * Reconstructs the RecipeDescriptor a row stands for. Prefers the listing-weight fields (empty
- * recipeList/preconditions — detail is fetched lazily via PrepareRecipe); falls back to a
- * legacy peer's full {@link GetMarketplaceResponseRow.descriptor} when {@link name} is absent.
- */
-function rowToDescriptor(row: GetMarketplaceResponseRow): RecipeDescriptor {
-    if (row.name != null) {
-        const displayName = row.displayName ?? row.name;
-        return {
-            name: row.name,
-            displayName,
-            instanceName: displayName,
-            description: row.description ?? "",
-            tags: [],
-            estimatedEffortPerOccurrence: row.estimatedEffortPerOccurrence ?? 5,
-            options: row.options ?? [],
-            preconditions: [],
-            recipeList: [],
-            dataTables: row.dataTables ?? [],
-            maintainers: [],
-            contributors: [],
-            examples: [],
-        };
-    }
-    return row.descriptor!;
-}
-
-/**
- * Converts GetMarketplace response rows into a hydrated RecipeMarketplace.
+ * Converts GetMarketplace response rows into a hydrated RecipeMarketplace of {@link RecipeListing}s.
  * This is used by the RPC client to reconstruct the marketplace structure.
  */
 export async function toMarketplace(rows: GetMarketplaceResponseRow[]): Promise<RecipeMarketplace> {
     const marketplace = new RecipeMarketplace();
     for (const row of rows) {
-        const descriptor = rowToDescriptor(row);
+        const listing = rowToListing(row);
         for (const categoryPath of row.categoryPaths) {
-            await marketplace.root.install(descriptor, categoryPath);
+            await marketplace.root.install(listing, categoryPath);
         }
     }
     return marketplace;
@@ -112,10 +81,9 @@ export class GetMarketplace {
                 "GetMarketplace",
                 metricsCsv,
                 (context) => async () => {
-                    // Group recipes by name, collecting all category paths for each. Emit
-                    // listing-weight fields only: the host builds its marketplace from these
-                    // without the full recursive descriptor, which it fetches lazily per recipe
-                    // via PrepareRecipe. recipeCount collapses the transitive recipeList.
+                    // Serve the RecipeListings the marketplace already holds, grouping by name and
+                    // collecting each recipe's category paths. recipeCount was computed once at
+                    // install time; the full descriptor is fetched lazily per recipe via PrepareRecipe.
                     const rowByRecipeId = new Map<string, GetMarketplaceResponseRow & { categoryPaths: CategoryDescriptor[][] }>();
 
                     function collectRecipes(category: RecipeMarketplace.Category, categoryPath: CategoryDescriptor[]): void {
@@ -134,7 +102,7 @@ export class GetMarketplace {
                                     estimatedEffortPerOccurrence: recipe.estimatedEffortPerOccurrence,
                                     options: recipe.options,
                                     dataTables: recipe.dataTables,
-                                    recipeCount: countRecipes(recipe),
+                                    recipeCount: recipe.recipeCount,
                                     categoryPaths: [currentPath],
                                     packageName: recipeOrigin.get(recipe.name)
                                 });

--- a/rewrite-javascript/rewrite/src/rpc/request/get-marketplace.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/get-marketplace.ts
@@ -16,10 +16,30 @@
 import * as rpc from "vscode-jsonrpc/node";
 import {withMetrics0} from "./metrics";
 import {CategoryDescriptor, RecipeMarketplace} from "../../marketplace";
-import {RecipeDescriptor} from "../../recipe";
+import {Minutes, OptionDescriptor, RecipeDescriptor} from "../../recipe";
+import {DataTableDescriptor} from "../../data-table";
 
 export interface GetMarketplaceResponseRow {
-    readonly descriptor: RecipeDescriptor
+    /**
+     * Listing-weight fields ({@link name} through {@link recipeCount}) carry everything the host
+     * needs to list the marketplace without materializing recipes. Up-to-date engines populate
+     * these and leave {@link descriptor} undefined; the full descriptor is fetched lazily per recipe
+     * via the separate PrepareRecipe RPC. A defined {@link name} selects this path in
+     * {@link toMarketplace}.
+     */
+    readonly name?: string
+    readonly displayName?: string
+    readonly description?: string
+    readonly estimatedEffortPerOccurrence?: Minutes
+    readonly options?: ({ name: string, value?: any } & OptionDescriptor)[]
+    readonly dataTables?: DataTableDescriptor[]
+    /** 1 + every transitive recipeList entry; the host uses it as a sort key. */
+    readonly recipeCount?: number
+    /**
+     * The full, recursive descriptor. Retained for backward compatibility with peers that still
+     * emit it, but no longer emitted by up-to-date engines — prefer the lightweight fields above.
+     */
+    readonly descriptor?: RecipeDescriptor
     readonly categoryPaths: CategoryDescriptor[][]
     /**
      * The package this recipe was contributed by, recorded at install time. Lets the host attribute
@@ -30,14 +50,54 @@ export interface GetMarketplaceResponseRow {
 }
 
 /**
+ * 1 (this recipe) plus every transitive entry in its recipeList. The host uses this as a sort key
+ * in place of the recursive recipeList it would otherwise walk to compute it.
+ */
+function countRecipes(descriptor: RecipeDescriptor): number {
+    let count = 1;
+    for (const sub of descriptor.recipeList ?? []) {
+        count += countRecipes(sub);
+    }
+    return count;
+}
+
+/**
+ * Reconstructs the RecipeDescriptor a row stands for. Prefers the listing-weight fields (empty
+ * recipeList/preconditions — detail is fetched lazily via PrepareRecipe); falls back to a
+ * legacy peer's full {@link GetMarketplaceResponseRow.descriptor} when {@link name} is absent.
+ */
+function rowToDescriptor(row: GetMarketplaceResponseRow): RecipeDescriptor {
+    if (row.name != null) {
+        const displayName = row.displayName ?? row.name;
+        return {
+            name: row.name,
+            displayName,
+            instanceName: displayName,
+            description: row.description ?? "",
+            tags: [],
+            estimatedEffortPerOccurrence: row.estimatedEffortPerOccurrence ?? 5,
+            options: row.options ?? [],
+            preconditions: [],
+            recipeList: [],
+            dataTables: row.dataTables ?? [],
+            maintainers: [],
+            contributors: [],
+            examples: [],
+        };
+    }
+    return row.descriptor!;
+}
+
+/**
  * Converts GetMarketplace response rows into a hydrated RecipeMarketplace.
  * This is used by the RPC client to reconstruct the marketplace structure.
  */
 export async function toMarketplace(rows: GetMarketplaceResponseRow[]): Promise<RecipeMarketplace> {
     const marketplace = new RecipeMarketplace();
     for (const row of rows) {
+        const descriptor = rowToDescriptor(row);
         for (const categoryPath of row.categoryPaths) {
-            await marketplace.root.install(row.descriptor, categoryPath);
+            await marketplace.root.install(descriptor, categoryPath);
         }
     }
     return marketplace;
@@ -52,8 +112,11 @@ export class GetMarketplace {
                 "GetMarketplace",
                 metricsCsv,
                 (context) => async () => {
-                    // Group recipes by name, collecting all category paths for each
-                    const rowByRecipeId = new Map<string, { descriptor: RecipeDescriptor, categoryPaths: CategoryDescriptor[][], packageName?: string }>();
+                    // Group recipes by name, collecting all category paths for each. Emit
+                    // listing-weight fields only: the host builds its marketplace from these
+                    // without the full recursive descriptor, which it fetches lazily per recipe
+                    // via PrepareRecipe. recipeCount collapses the transitive recipeList.
+                    const rowByRecipeId = new Map<string, GetMarketplaceResponseRow & { categoryPaths: CategoryDescriptor[][] }>();
 
                     function collectRecipes(category: RecipeMarketplace.Category, categoryPath: CategoryDescriptor[]): void {
                         const currentPath = [...categoryPath, category.descriptor];
@@ -65,7 +128,13 @@ export class GetMarketplace {
                                 existing.categoryPaths.push(currentPath);
                             } else {
                                 rowByRecipeId.set(recipe.name, {
-                                    descriptor: recipe,
+                                    name: recipe.name,
+                                    displayName: recipe.displayName,
+                                    description: recipe.description,
+                                    estimatedEffortPerOccurrence: recipe.estimatedEffortPerOccurrence,
+                                    options: recipe.options,
+                                    dataTables: recipe.dataTables,
+                                    recipeCount: countRecipes(recipe),
                                     categoryPaths: [currentPath],
                                     packageName: recipeOrigin.get(recipe.name)
                                 });

--- a/rewrite-javascript/rewrite/test/recipe.test.ts
+++ b/rewrite-javascript/rewrite/test/recipe.test.ts
@@ -45,14 +45,14 @@ describe("recipes", () => {
         await activate(marketplace);
         const result = marketplace.findRecipe("org.openrewrite.example.text.change-text");
         expect(result).toBeDefined();
-        const [descriptor, RecipeClass] = result!;
+        const [listing, RecipeClass] = result!;
         expect(RecipeClass).toBeDefined();
         expect(new RecipeClass!()).toBeInstanceOf(ChangeText);
 
-        expect(descriptor).toEqual({
+        // The marketplace holds a listing-weight view; the full descriptor is fetched via PrepareRecipe.
+        expect(listing).toEqual({
             name: "org.openrewrite.example.text.change-text",
             displayName: "Change text",
-            instanceName: "Change text to 'undefined'",
             description: "Change the text of a file.",
             estimatedEffortPerOccurrence: 5,
             options: [
@@ -64,13 +64,11 @@ describe("recipes", () => {
                     value: undefined
                 }
             ],
-            preconditions: [],
-            recipeList: [],
-            tags: [],
             dataTables: [],
-            maintainers: [],
-            contributors: [],
-            examples: []
+            recipeCount: 1
         });
+        // Guard: the marketplace holds a listing, not the full descriptor.
+        expect(listing).not.toHaveProperty("recipeList");
+        expect(listing).not.toHaveProperty("instanceName");
     });
 });

--- a/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
@@ -16,7 +16,7 @@
 import {withDir} from "tmp-promise";
 import * as fs from "fs";
 import * as path from "path";
-import {RecipeMarketplace} from "../../src";
+import {RecipeDescriptor, RecipeMarketplace} from "../../src";
 import {InstallRecipes, InstallRecipesResponse} from "../../src/rpc/request/install-recipes";
 import {GetMarketplace, GetMarketplaceResponseRow} from "../../src/rpc/request/get-marketplace";
 
@@ -381,18 +381,15 @@ describe("InstallRecipes", () => {
         test("GetMarketplace recipeCount counts transitive sub-recipes", async () => {
             // recipeCount must be 1 + every transitive recipeList entry, not just direct children —
             // the host uses it as a marketplace sort key.
+            const desc = (name: string, recipeList: RecipeDescriptor[] = []): RecipeDescriptor => ({
+                name, displayName: name, instanceName: name, description: "", tags: [],
+                estimatedEffortPerOccurrence: 5, options: [], preconditions: [],
+                recipeList, dataTables: [], maintainers: [], contributors: [], examples: []
+            });
+
             const marketplace = new RecipeMarketplace();
             await marketplace.install(
-                class CompositeRecipe {
-                    async descriptor() {
-                        return {
-                            name: "composite.root", displayName: "Root", description: "",
-                            recipeList: [
-                                {name: "composite.middle", recipeList: [{name: "composite.leaf", recipeList: []}]}
-                            ]
-                        };
-                    }
-                },
+                desc("composite.root", [desc("composite.middle", [desc("composite.leaf")])]),
                 [{displayName: "Composite"}]
             );
 

--- a/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
@@ -372,10 +372,35 @@ describe("InstallRecipes", () => {
                 const getMarketplace = captureGetMarketplace(marketplace, recipeOrigin);
                 const rows = await getMarketplace();
 
-                const row = rows.find(r => r.descriptor.name === "row.recipe");
+                const row = rows.find(r => r.name === "row.recipe");
                 expect(row).toBeDefined();
                 expect(row!.packageName).toBe("@example/recipes");
             }, {unsafeCleanup: true});
+        });
+
+        test("GetMarketplace recipeCount counts transitive sub-recipes", async () => {
+            // recipeCount must be 1 + every transitive recipeList entry, not just direct children —
+            // the host uses it as a marketplace sort key.
+            const marketplace = new RecipeMarketplace();
+            await marketplace.install(
+                class CompositeRecipe {
+                    async descriptor() {
+                        return {
+                            name: "composite.root", displayName: "Root", description: "",
+                            recipeList: [
+                                {name: "composite.middle", recipeList: [{name: "composite.leaf", recipeList: []}]}
+                            ]
+                        };
+                    }
+                },
+                [{displayName: "Composite"}]
+            );
+
+            const getMarketplace = captureGetMarketplace(marketplace, new Map());
+            const rows = await getMarketplace();
+
+            const row = rows.find(r => r.name === "composite.root");
+            expect(row?.recipeCount).toBe(3); // root + middle + leaf
         });
 
         test("attributes npm-installed recipes to their package", async () => {

--- a/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/install-recipes.test.ts
@@ -16,7 +16,7 @@
 import {withDir} from "tmp-promise";
 import * as fs from "fs";
 import * as path from "path";
-import {RecipeDescriptor, RecipeMarketplace} from "../../src";
+import {RecipeDescriptor, RecipeListing, RecipeMarketplace, toRecipeListing} from "../../src";
 import {InstallRecipes, InstallRecipesResponse} from "../../src/rpc/request/install-recipes";
 import {GetMarketplace, GetMarketplaceResponseRow} from "../../src/rpc/request/get-marketplace";
 
@@ -378,26 +378,35 @@ describe("InstallRecipes", () => {
             }, {unsafeCleanup: true});
         });
 
-        test("GetMarketplace recipeCount counts transitive sub-recipes", async () => {
+        test("toRecipeListing counts transitive sub-recipes", () => {
             // recipeCount must be 1 + every transitive recipeList entry, not just direct children —
-            // the host uses it as a marketplace sort key.
+            // computed once at install time; the host uses it as a marketplace sort key.
             const desc = (name: string, recipeList: RecipeDescriptor[] = []): RecipeDescriptor => ({
                 name, displayName: name, instanceName: name, description: "", tags: [],
                 estimatedEffortPerOccurrence: 5, options: [], preconditions: [],
                 recipeList, dataTables: [], maintainers: [], contributors: [], examples: []
             });
 
+            const listing = toRecipeListing(
+                desc("composite.root", [desc("composite.middle", [desc("composite.leaf")])]));
+
+            expect(listing.recipeCount).toBe(3); // root + middle + leaf
+        });
+
+        test("GetMarketplace serves the marketplace's stored RecipeListing", async () => {
+            // The marketplace holds RecipeListings; GetMarketplace serves the precomputed recipeCount
+            // straight off them rather than re-walking a descriptor tree.
             const marketplace = new RecipeMarketplace();
-            await marketplace.install(
-                desc("composite.root", [desc("composite.middle", [desc("composite.leaf")])]),
-                [{displayName: "Composite"}]
-            );
+            const listing: RecipeListing = {
+                name: "composite.root", displayName: "Root", description: "", recipeCount: 3
+            };
+            await marketplace.install(listing, [{displayName: "Composite"}]);
 
             const getMarketplace = captureGetMarketplace(marketplace, new Map());
             const rows = await getMarketplace();
 
             const row = rows.find(r => r.name === "composite.root");
-            expect(row?.recipeCount).toBe(3); // root + middle + leaf
+            expect(row?.recipeCount).toBe(3);
         });
 
         test("attributes npm-installed recipes to their package", async () => {

--- a/rewrite-python/rewrite/src/rewrite/marketplace.py
+++ b/rewrite-python/rewrite/src/rewrite/marketplace.py
@@ -16,13 +16,51 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple, Type, Union, TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, TYPE_CHECKING
 
 from rewrite.category import CategoryDescriptor
 from rewrite.recipe import Recipe, RecipeDescriptor
 
 if TYPE_CHECKING:
     pass
+
+
+@dataclass
+class RecipeListing:
+    """Listing-weight view the marketplace holds and serves for the InstallRecipes and
+    GetMarketplace RPC commands, so listing never materializes the full recursive descriptor.
+    The full tree is built lazily per recipe by PrepareRecipe. ``recipe_count`` is 1 + every
+    transitive recipe_list entry, computed once at install time (the host uses it as a sort key)."""
+    name: str
+    display_name: str
+    description: str
+    estimated_effort_per_occurrence: Any = None
+    options: Any = field(default_factory=list)
+    data_tables: Any = field(default_factory=list)
+    recipe_count: int = 1
+
+
+def _count_recipes(descriptor) -> int:
+    """The count of this recipe and all recipes nested transitively in its recipe_list."""
+    count = 1
+    for sub in descriptor.recipe_list:
+        count += _count_recipes(sub)
+    return count
+
+
+def to_listing(descriptor) -> RecipeListing:
+    """Derive the listing-weight view from a full descriptor, collapsing its recursive
+    recipe_list to a count."""
+    return RecipeListing(
+        name=descriptor.name,
+        display_name=descriptor.display_name,
+        description=descriptor.description,
+        estimated_effort_per_occurrence=descriptor.estimated_effort_per_occurrence,
+        options=descriptor.options,
+        data_tables=descriptor.data_tables,
+        recipe_count=_count_recipes(descriptor),
+    )
 
 
 class RecipeMarketplace:
@@ -45,12 +83,11 @@ class RecipeMarketplace:
         def __init__(self, descriptor: CategoryDescriptor):
             self.descriptor = descriptor
             self.categories: List[RecipeMarketplace.Category] = []
-            # Use recipe name as key since RecipeDescriptor contains unhashable Lists
-            self._recipes: Dict[str, Tuple[RecipeDescriptor, Optional[Type[Recipe]]]] = {}
+            self._recipes: Dict[str, Tuple[RecipeListing, Optional[Type[Recipe]]]] = {}
 
         @property
-        def recipes(self) -> Dict[str, Tuple[RecipeDescriptor, Optional[Type[Recipe]]]]:
-            """Get the recipes dict (name -> (descriptor, class))."""
+        def recipes(self) -> Dict[str, Tuple[RecipeListing, Optional[Type[Recipe]]]]:
+            """Get the recipes dict (name -> (listing, class))."""
             return self._recipes
 
         def install(
@@ -74,21 +111,22 @@ class RecipeMarketplace:
             """
             if len(category_path) == 0:
                 if isinstance(recipe, type) and issubclass(recipe, Recipe):
-                    # It's a Recipe class - instantiate to get descriptor
+                    # It's a Recipe class - instantiate once to derive its listing (the class is
+                    # retained so PrepareRecipe can later build the full tree).
                     try:
                         recipe_inst = recipe()
-                        desc = recipe_inst.descriptor()
+                        listing = to_listing(recipe_inst.descriptor())
                         # First-wins must match the host's name-keyed RecipeListing and
                         # RecipeAttribution.
-                        self._recipes.setdefault(desc.name, (desc, recipe))
+                        self._recipes.setdefault(listing.name, (listing, recipe))
                     except Exception as e:
                         raise RuntimeError(
                             f"Failed to install recipe {recipe}. "
                             f"Ensure the constructor can be called without arguments."
                         ) from e
                 else:
-                    # It's already a RecipeDescriptor
-                    self._recipes.setdefault(recipe.name, (recipe, None))
+                    # It's already a RecipeDescriptor (client-side hydration) - derive its listing.
+                    self._recipes.setdefault(recipe.name, (to_listing(recipe), None))
                 return
 
             # Get the first category in the path
@@ -111,7 +149,7 @@ class RecipeMarketplace:
 
         def find_recipe(
             self, name: str
-        ) -> Optional[Tuple[RecipeDescriptor, Optional[Type[Recipe]]]]:
+        ) -> Optional[Tuple[RecipeListing, Optional[Type[Recipe]]]]:
             """
             Find a recipe by its fully qualified name.
 
@@ -130,9 +168,9 @@ class RecipeMarketplace:
                     return found
             return None
 
-        def all_recipes(self) -> List[RecipeDescriptor]:
+        def all_recipes(self) -> List[RecipeListing]:
             """Get all recipes in this category and subcategories."""
-            result: List[RecipeDescriptor] = [desc for desc, _ in self._recipes.values()]
+            result: List[RecipeListing] = [listing for listing, _ in self._recipes.values()]
             for category in self.categories:
                 result.extend(category.all_recipes())
             return result
@@ -173,7 +211,7 @@ class RecipeMarketplace:
 
     def find_recipe(
         self, name: str
-    ) -> Optional[Tuple[RecipeDescriptor, Optional[Type[Recipe]]]]:
+    ) -> Optional[Tuple[RecipeListing, Optional[Type[Recipe]]]]:
         """
         Find a recipe by its fully qualified name.
 
@@ -185,7 +223,7 @@ class RecipeMarketplace:
         """
         return self.root.find_recipe(name)
 
-    def all_recipes(self) -> List[RecipeDescriptor]:
+    def all_recipes(self) -> List[RecipeListing]:
         """Get all recipes in the marketplace."""
         return self.root.all_recipes()
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
@@ -10,6 +10,14 @@ from rewrite.rpc import venv_manager
 from rewrite.rpc.child_connection import ChildConnection, child_command
 
 
+def _row_name(row: dict) -> str:
+    """The recipe name of a GetMarketplace row. Lightweight rows carry it at the top level;
+    older rows only carried a nested ``descriptor``, so fall back to that."""
+    name = row.get("name")
+    if name is not None:
+        return name
+    return row["descriptor"]["name"]
+
 
 class BundleChildren:
     def __init__(self, python_executable, venvs_root, upstream, *, spawn=None, venv_ops=None):
@@ -69,14 +77,14 @@ class BundleChildren:
         rows = self._ensure_child(bundle_dist).request("GetMarketplace", {})
         self._descriptors[bundle_dist] = rows
         for row in rows:
-            self._owner.setdefault(row["descriptor"]["name"], bundle_dist)  # first-wins
+            self._owner.setdefault(_row_name(row), bundle_dist)  # first-wins
         return rows
 
     def marketplace(self):
         merged, seen = [], set()
         for rows in self._descriptors.values():
             for row in rows:
-                name = row["descriptor"]["name"]
+                name = _row_name(row)
                 if name in seen:
                     continue
                 seen.add(name)

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1440,26 +1440,26 @@ def _collect_marketplace_rows(
     def collect(category, category_path: List[dict]) -> None:
         current_path = [*category_path, _category_descriptor_to_dict(category.descriptor)]
 
-        for _recipe_name, (recipe_desc, _recipe_class) in category.recipes.items():
-            if recipe_filter is not None and recipe_desc.name not in recipe_filter:
+        for _recipe_name, (listing, _recipe_class) in category.recipes.items():
+            if recipe_filter is not None and listing.name not in recipe_filter:
                 continue
-            existing = next((r for r in rows if r['name'] == recipe_desc.name), None)
+            existing = next((r for r in rows if r['name'] == listing.name), None)
             if existing:
                 existing['categoryPaths'].append(current_path)
             else:
-                # Emit listing-weight fields only: the host builds a RecipeListing from these without
-                # materializing recipes, and fetches the full descriptor lazily via PrepareRecipe.
-                # recipeCount collapses the transitive recipeList the host would otherwise only count.
+                # Serve the RecipeListing the marketplace already holds: recipeCount was computed
+                # once at install time, so listing never walks the descriptor tree. The host fetches
+                # the full descriptor lazily via PrepareRecipe.
                 rows.append({
-                    'name': recipe_desc.name,
-                    'displayName': recipe_desc.display_name,
-                    'description': recipe_desc.description,
-                    'estimatedEffortPerOccurrence': recipe_desc.estimated_effort_per_occurrence,
-                    'options': _options_to_dicts(recipe_desc),
-                    'dataTables': recipe_desc.data_tables,
-                    'recipeCount': _count_recipes(recipe_desc),
+                    'name': listing.name,
+                    'displayName': listing.display_name,
+                    'description': listing.description,
+                    'estimatedEffortPerOccurrence': listing.estimated_effort_per_occurrence,
+                    'options': _options_to_dicts(listing),
+                    'dataTables': listing.data_tables,
+                    'recipeCount': listing.recipe_count,
                     'categoryPaths': [current_path],
-                    'packageName': _attribution.package_for(recipe_desc.name),
+                    'packageName': _attribution.package_for(listing.name),
                 })
 
         for subcategory in category.categories:
@@ -1518,18 +1518,6 @@ def _options_to_dicts(descriptor) -> List[dict]:
         }
         for name, value, opt in descriptor.options
     ]
-
-
-def _count_recipes(descriptor) -> int:
-    """Return 1 (this recipe) plus every transitive entry in its recipe_list.
-
-    The host uses this as a sort key in place of the recursive recipeList it would otherwise
-    walk to compute it.
-    """
-    count = 1
-    for sub in descriptor.recipe_list:
-        count += _count_recipes(sub)
-    return count
 
 
 def _recipe_descriptor_to_dict(descriptor) -> dict:

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1443,12 +1443,21 @@ def _collect_marketplace_rows(
         for _recipe_name, (recipe_desc, _recipe_class) in category.recipes.items():
             if recipe_filter is not None and recipe_desc.name not in recipe_filter:
                 continue
-            existing = next((r for r in rows if r['descriptor']['name'] == recipe_desc.name), None)
+            existing = next((r for r in rows if r['name'] == recipe_desc.name), None)
             if existing:
                 existing['categoryPaths'].append(current_path)
             else:
+                # Emit listing-weight fields only: the host builds a RecipeListing from these without
+                # materializing recipes, and fetches the full descriptor lazily via PrepareRecipe.
+                # recipeCount collapses the transitive recipeList the host would otherwise only count.
                 rows.append({
-                    'descriptor': _recipe_descriptor_to_dict(recipe_desc),
+                    'name': recipe_desc.name,
+                    'displayName': recipe_desc.display_name,
+                    'description': recipe_desc.description,
+                    'estimatedEffortPerOccurrence': recipe_desc.estimated_effort_per_occurrence,
+                    'options': _options_to_dicts(recipe_desc),
+                    'dataTables': recipe_desc.data_tables,
+                    'recipeCount': _count_recipes(recipe_desc),
                     'categoryPaths': [current_path],
                     'packageName': _attribution.package_for(recipe_desc.name),
                 })
@@ -1495,6 +1504,34 @@ def _delegate_descriptor(name: str) -> dict:
     }
 
 
+def _options_to_dicts(descriptor) -> List[dict]:
+    """Convert a descriptor's own (non-recursive) options to dicts for JSON serialization."""
+    return [
+        {
+            'name': name,
+            'value': _serialize_value(value),
+            'displayName': opt.display_name,
+            'description': opt.description,
+            'example': opt.example,
+            'required': opt.required,
+            'valid': opt.valid,
+        }
+        for name, value, opt in descriptor.options
+    ]
+
+
+def _count_recipes(descriptor) -> int:
+    """Return 1 (this recipe) plus every transitive entry in its recipe_list.
+
+    The host uses this as a sort key in place of the recursive recipeList it would otherwise
+    walk to compute it.
+    """
+    count = 1
+    for sub in descriptor.recipe_list:
+        count += _count_recipes(sub)
+    return count
+
+
 def _recipe_descriptor_to_dict(descriptor) -> dict:
     """Convert a RecipeDescriptor to a dict for JSON serialization."""
     return {
@@ -1503,18 +1540,7 @@ def _recipe_descriptor_to_dict(descriptor) -> dict:
         'description': descriptor.description,
         'tags': descriptor.tags,
         'estimatedEffortPerOccurrence': descriptor.estimated_effort_per_occurrence,
-        'options': [
-            {
-                'name': name,
-                'value': _serialize_value(value),
-                'displayName': opt.display_name,
-                'description': opt.description,
-                'example': opt.example,
-                'required': opt.required,
-                'valid': opt.valid,
-            }
-            for name, value, opt in descriptor.options
-        ],
+        'options': _options_to_dicts(descriptor),
         'preconditions': [],
         'recipeList': [_recipe_descriptor_to_dict(r) for r in descriptor.recipe_list],
         'dataTables': descriptor.data_tables,

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -251,10 +251,10 @@ def test_handle_install_recipes_local_path_attributes_to_the_supplied_path(monke
 
 
 def test_count_recipes_includes_transitive_sub_recipes():
-    """recipeCount is 1 + every transitive recipe_list entry, not just direct children —
-    the host uses it as a marketplace sort key."""
+    """recipe_count is 1 + every transitive recipe_list entry, not just direct children —
+    computed once at install time; the host uses it as a marketplace sort key."""
     from types import SimpleNamespace
-    from rewrite.rpc.server import _count_recipes
+    from rewrite.marketplace import _count_recipes
 
     leaf = SimpleNamespace(recipe_list=[])
     middle = SimpleNamespace(recipe_list=[leaf])

--- a/rewrite-python/rewrite/tests/rpc/test_server.py
+++ b/rewrite-python/rewrite/tests/rpc/test_server.py
@@ -250,6 +250,19 @@ def test_handle_install_recipes_local_path_attributes_to_the_supplied_path(monke
     assert attribution.package_for("org.local.Sample") == supplied   # the path, not "sample-dist"
 
 
+def test_count_recipes_includes_transitive_sub_recipes():
+    """recipeCount is 1 + every transitive recipe_list entry, not just direct children —
+    the host uses it as a marketplace sort key."""
+    from types import SimpleNamespace
+    from rewrite.rpc.server import _count_recipes
+
+    leaf = SimpleNamespace(recipe_list=[])
+    middle = SimpleNamespace(recipe_list=[leaf])
+    root = SimpleNamespace(recipe_list=[middle])
+
+    assert _count_recipes(root) == 3  # root + middle + leaf
+
+
 def test_recipe_descriptor_to_dict_emits_all_collection_keys():
     from rewrite.recipe import RecipeDescriptor
     from rewrite.rpc.server import _recipe_descriptor_to_dict
@@ -297,7 +310,7 @@ def test_get_marketplace_row_carries_package_name(monkeypatch):
 
     rows = server._collect_marketplace_rows(marketplace)
 
-    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.MyRecipe")
+    row = next(r for r in rows if r["name"] == "org.example.MyRecipe")
     assert row["packageName"] == "my-recipes-package"
 
 
@@ -335,7 +348,7 @@ def test_handle_install_recipes_local_path_attributes_to_the_path(tmp_path, monk
     assert server._attribution.package_for("org.example.MyRecipe") == str(local)
     # And GetMarketplace surfaces that path as the row's origin, so the host keeps the recipe.
     rows = server._collect_marketplace_rows(marketplace)
-    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.MyRecipe")
+    row = next(r for r in rows if r["name"] == "org.example.MyRecipe")
     assert row["packageName"] == str(local)
 
 
@@ -360,7 +373,7 @@ def test_get_marketplace_row_unattributed_has_none_package_name(monkeypatch):
 
     rows = server._collect_marketplace_rows(marketplace)
 
-    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.Unattributed")
+    row = next(r for r in rows if r["name"] == "org.example.Unattributed")
     assert row["packageName"] is None
 
 

--- a/rewrite-python/rewrite/tests/test_marketplace.py
+++ b/rewrite-python/rewrite/tests/test_marketplace.py
@@ -280,7 +280,7 @@ class TestPerPackageAttribution:
 
         # Each row carries its origin packageName, so the host attributes each recipe to the
         # package that actually contributed it instead of the single requested bundle.
-        package_of = {r["descriptor"]["name"]: r["packageName"]
+        package_of = {r["name"]: r["packageName"]
                       for r in server.handle_get_marketplace({})}
 
         assert package_of["org.openrewrite.test.pkga.RecipeA"] == "pkg-a"
@@ -307,7 +307,7 @@ class TestPerPackageAttribution:
         # pkg-b contributed nothing, so no GetMarketplace row is attributed to it, and pkg-a's
         # recipe keeps its own attribution.
         assert b_response["recipesInstalled"] == 0
-        package_of = {r["descriptor"]["name"]: r["packageName"]
+        package_of = {r["name"]: r["packageName"]
                       for r in server.handle_get_marketplace({})}
         assert package_of["org.openrewrite.test.pkga.RecipeA"] == "pkg-a"
         assert "pkg-b" not in package_of.values()
@@ -329,15 +329,15 @@ class TestPerPackageAttribution:
 
         # Filter by pkg-a
         rows_a = server.handle_get_marketplace({"packageName": "pkg-a"})
-        assert {r["descriptor"]["name"] for r in rows_a} == {"org.openrewrite.test.pkga.RecipeA"}
+        assert {r["name"] for r in rows_a} == {"org.openrewrite.test.pkga.RecipeA"}
 
         # Filter by pkg-b
         rows_b = server.handle_get_marketplace({"packageName": "pkg-b"})
-        assert {r["descriptor"]["name"] for r in rows_b} == {"org.openrewrite.test.pkgb.RecipeB"}
+        assert {r["name"] for r in rows_b} == {"org.openrewrite.test.pkgb.RecipeB"}
 
         # No filter still returns everything for callers that want the full marketplace.
         rows_all = server.handle_get_marketplace({})
-        assert {r["descriptor"]["name"] for r in rows_all} == {
+        assert {r["name"] for r in rows_all} == {
             "org.openrewrite.test.pkga.RecipeA",
             "org.openrewrite.test.pkgb.RecipeB",
         }
@@ -357,4 +357,4 @@ class TestPerPackageAttribution:
 
         # Query with underscore form.
         rows = server.handle_get_marketplace({"packageName": "openrewrite_migrate_python"})
-        assert {r["descriptor"]["name"] for r in rows} == {"org.openrewrite.test.pkga.RecipeA"}
+        assert {r["name"] for r in rows} == {"org.openrewrite.test.pkga.RecipeA"}

--- a/rewrite-python/rewrite/tests/test_marketplace.py
+++ b/rewrite-python/rewrite/tests/test_marketplace.py
@@ -87,6 +87,18 @@ class TestRecipeMarketplace:
         assert descriptor.name == "org.openrewrite.python.RemovePass"
         assert recipe_class is RemovePass
 
+    def test_marketplace_holds_listing_not_descriptor(self):
+        """The marketplace holds a listing-weight view (with a precomputed count), not the full
+        descriptor; PrepareRecipe builds the full tree from the retained class."""
+        from rewrite.marketplace import RecipeListing
+        marketplace = RecipeMarketplace()
+        marketplace.install(RemovePass, Cleanup)
+
+        held, _recipe_class = marketplace.find_recipe("org.openrewrite.python.RemovePass")
+        assert isinstance(held, RecipeListing)
+        assert held.recipe_count >= 1
+        assert not hasattr(held, "recipe_list")  # not the full descriptor
+
     def test_find_recipe_not_found(self):
         """Test finding a recipe that doesn't exist."""
         marketplace = RecipeMarketplace()

--- a/rewrite-python/rewrite/tests/test_marketplace_first_wins.py
+++ b/rewrite-python/rewrite/tests/test_marketplace_first_wins.py
@@ -19,5 +19,5 @@ def test_registry_is_first_wins_on_duplicate_name():
     m.install(_recipe("org.example.X", "second"), [CategoryDescriptor(display_name="Test")])
 
     rows = _collect_marketplace_rows(m)
-    row = next(r for r in rows if r["descriptor"]["name"] == "org.example.X")
-    assert row["descriptor"]["description"] == "first"  # first registration wins, not overwritten
+    row = next(r for r in rows if r["name"] == "org.example.X")
+    assert row["description"] == "first"  # first registration wins, not overwritten

--- a/rewrite-python/src/integTest/java/org/openrewrite/python/PythonMarketplaceIntegTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/PythonMarketplaceIntegTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.marketplace.RecipeBundle;
+import org.openrewrite.marketplace.RecipeListing;
+import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end check that the Python RPC server emits listing-weight marketplace rows (no full
+ * descriptor) and that the JVM host reconstructs them into {@link RecipeListing}s over RPC.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class PythonMarketplaceIntegTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder()
+                .log(tempDir.resolve("python-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        PythonRewriteRpc.shutdownCurrent();
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder());
+    }
+
+    @Test
+    void getMarketplaceReturnsLightweightListings() {
+        // Built-in Python recipes are attributed to the "openrewrite" package by the server.
+        RecipeBundle bundle = new RecipeBundle("pip", "openrewrite", null, null, null);
+        RecipeMarketplace marketplace = PythonRewriteRpc.getOrStart().getMarketplace(bundle);
+
+        assertThat(marketplace).isNotNull();
+        assertThat(marketplace.getAllRecipes()).isNotEmpty();
+        // Every listing was built from a lightweight row: name and the transitive recipe count
+        // survive the round-trip, proving the host didn't need the full descriptor.
+        for (RecipeListing listing : marketplace.getAllRecipes()) {
+            assertThat(listing.getName()).isNotBlank();
+            assertThat(listing.getRecipeCount()).isGreaterThanOrEqualTo(1);
+        }
+    }
+}


### PR DESCRIPTION
## Problem

`GetMarketplace` shipped a full, recursive `RecipeDescriptor` for every recipe, but the host only uses lightweight `RecipeListing` metadata. The nested `recipeList` was serialized, transmitted, and held in memory only to be counted into an integer and then discarded — ~82× more nodes than listings (tens of MB vs ~717 KB for an 846-recipe marketplace), hitting the non-JVM engines (Go/Python/JS/C#) hardest. The full descriptor is already fetched lazily via `PrepareRecipe`, so the eager copy was pure redundancy.

## Solution

Emit listing-weight rows — `name`, `displayName`, `description`, `estimatedEffortPerOccurrence`, `options`, `dataTables`, and `recipeCount` (the collapsed transitive `recipeList`) — and stop shipping the descriptor. `describe()`/`prepare()` stay lazy over `PrepareRecipe`.

Backward compatible and additive: `descriptor` is now nullable, `toMarketplace` prefers the lightweight fields and falls back to `fromDescriptor` when `name == null`, and unknown fields are ignored so old/new peers interoperate (host must be at least as new as the engine). Applied in `rewrite-core` plus the `GetMarketplace` handlers for `rewrite-go`, `rewrite-python`, `rewrite-javascript`, and `rewrite-csharp`.

Verified with unit tests (emit/consume, round-trip, descriptor fallback, per-engine transitive count) and cross-process Python→Java and JS→Java round-trips.