### PR TITLE
Add deep transitive dependency test for JS `DependencyInsight`

### DIFF
--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/search/DependencyInsightTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/search/DependencyInsightTest.java
@@ -207,6 +207,44 @@ class DependencyInsightTest implements RewriteTest {
     }
 
     @Test
+    void findDeepTransitiveDependency(@TempDir Path tempDir) {
+        // is-buffer is reachable only via is-even -> is-odd -> is-number -> kind-of -> is-buffer,
+        // so a match requires recursing well below the direct dependency's own requests.
+        rewriteRun(
+          spec -> spec
+            .recipe(new DependencyInsight("is-buffer", null, null))
+            .dataTable(NodeDependenciesInUse.Row.class, rows -> {
+                assertThat(rows).hasSize(1);
+                NodeDependenciesInUse.Row row = rows.getFirst();
+                assertThat(row.getPackageName()).isEqualTo("is-buffer");
+                assertThat(row.getDirect()).isFalse();
+            }),
+          npm(tempDir,
+            packageJson(
+              """
+                {
+                  "name": "my-app",
+                  "version": "1.0.0",
+                  "dependencies": {
+                    "is-even": "^1.0.0"
+                  }
+                }
+                """,
+              """
+                {
+                  "name": "my-app",
+                  "version": "1.0.0",
+                  "dependencies": {
+                    /*~~>*/"is-even": "^1.0.0"
+                  }
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
     void onlyDirectExcludesTransitiveDependencies(@TempDir Path tempDir) {
         // With onlyDirect=true, should not find chalk (transitive dependency of jest)
         rewriteRun(


### PR DESCRIPTION
## Motivation

The Node.js `DependencyInsight` predecessor only identified direct dependencies, and transitive detection was the key enhancement requested for it. The current test suite covers transitive matching only via chalk under jest, which sits just one hop below a direct dependency — a regression that truncated recursion below the first level would still pass. This adds a test where the match is unambiguously several hops deep.

## Summary

- Added `findDeepTransitiveDependency` to `DependencyInsightTest`, using the version-frozen `is-even -> is-odd -> is-number -> kind-of -> is-buffer` chain so matching `is-buffer` requires recursing well below the direct dependency's own requests
- Asserts both the search marker on the `is-even` key in `package.json` and the data table row (`direct=false`)

## Test plan

- [x] `./gradlew :rewrite-javascript:integTest --tests "org.openrewrite.javascript.search.DependencyInsightTest"` — all 9 tests pass