### PR TITLE
Fully link the resolved-dependency graph after lock-file overlay

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/LockFileParser.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/LockFileParser.java
@@ -17,6 +17,8 @@ package org.openrewrite.javascript.internal;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Validated;
@@ -47,10 +49,9 @@ import java.util.Map;
  * {@code name@version} and indexes it by lock-file path; pass two populates the
  * dependency lists, resolving each request Node-style (nearest
  * {@code node_modules} walking up from the dependent's path) with a semver
- * fallback for paths the walk cannot reach. The dependency lists are mutable
- * {@link ArrayList}s populated after construction, which is what allows cyclic
- * graphs to be represented with an otherwise immutable model; instances never
- * escape this class until fully linked.
+ * fallback for paths the walk cannot reach. The lists are filled in place after
+ * construction, per the linkage contract on {@link ResolvedDependency};
+ * instances never escape this class until fully linked.
  */
 public final class LockFileParser {
 
@@ -64,7 +65,11 @@ public final class LockFileParser {
     public static class ParseResult {
         List<ResolvedDependency> all;
         Map<String, ResolvedDependency> topLevel;
+
+        @Getter(AccessLevel.NONE)
         Map<String, ResolvedDependency> byPath;
+
+        @Getter(AccessLevel.NONE)
         Map<String, List<ResolvedDependency>> byName;
 
         /**
@@ -73,7 +78,60 @@ public final class LockFileParser {
          * transitive links inside {@link #getAll()}.
          */
         public @Nullable ResolvedDependency resolve(String name, String versionConstraint) {
-            return LockFileParser.resolve(name, versionConstraint, "", byPath, byName);
+            return resolve(name, versionConstraint, "");
+        }
+
+        /**
+         * Resolves a dependency name from a given path context using Node.js-style
+         * resolution: nearest {@code node_modules} first, then walking up to parent
+         * directories. Falls back to semver matching among all versions of the name
+         * for paths the walk cannot reach (the yarn/pnpm adapters park duplicate
+         * versions under synthetic paths that are not on any walk-up chain).
+         */
+        @Nullable ResolvedDependency resolve(String name, String versionConstraint, String contextPath) {
+            String currentPath = contextPath;
+            while (true) {
+                String candidatePath = currentPath.isEmpty()
+                        ? "node_modules/" + name
+                        : currentPath + "/node_modules/" + name;
+                ResolvedDependency resolved = byPath.get(candidatePath);
+                if (resolved != null) {
+                    return resolved;
+                }
+                if (currentPath.isEmpty()) {
+                    break;
+                }
+                int lastNodeModules = currentPath.lastIndexOf("/node_modules/");
+                currentPath = lastNodeModules < 0 ? "" : currentPath.substring(0, lastNodeModules);
+            }
+
+            List<ResolvedDependency> candidates = byName.get(name);
+            if (candidates == null || candidates.isEmpty()) {
+                return null;
+            }
+            if (candidates.size() == 1) {
+                return candidates.get(0);
+            }
+            Validated<VersionComparator> constraint =
+                    Semver.validate(versionConstraint, null, Semver.Ecosystem.NODE);
+            if (constraint.isValid()) {
+                for (ResolvedDependency candidate : candidates) {
+                    if (candidate.getVersion() != null &&
+                            constraint.getValue().isValid(null, candidate.getVersion())) {
+                        return candidate;
+                    }
+                }
+            }
+            // No version satisfies the constraint: fall back to the highest version.
+            ResolvedDependency max = candidates.get(0);
+            for (int i = 1; i < candidates.size(); i++) {
+                ResolvedDependency candidate = candidates.get(i);
+                if (candidate.getVersion() != null && (max.getVersion() == null ||
+                        VERSION_PRECEDENCE.compare(null, candidate.getVersion(), max.getVersion()) > 0)) {
+                    max = candidate;
+                }
+            }
+            return max;
         }
     }
 
@@ -111,7 +169,8 @@ public final class LockFileParser {
             JsonNode body = entry.getValue();
             String version = body.path("version").asText(null);
 
-            ResolvedDependency dep = byNameAndVersion.get(name + "@" + version);
+            String nameAndVersion = name + "@" + version;
+            ResolvedDependency dep = byNameAndVersion.get(nameAndVersion);
             if (dep == null) {
                 dep = new ResolvedDependency(
                         name, version,
@@ -121,7 +180,7 @@ public final class LockFileParser {
                         emptyListIfPresent(body.get("optionalDependencies")),
                         readStringMap(body.get("engines")),
                         body.path("license").asText(null));
-                byNameAndVersion.put(name + "@" + version, dep);
+                byNameAndVersion.put(nameAndVersion, dep);
                 byName.computeIfAbsent(name, k -> new ArrayList<>()).add(dep);
                 all.add(dep);
                 creatorEntries.add(entry);
@@ -132,6 +191,8 @@ public final class LockFileParser {
             }
         });
 
+        ParseResult result = new ParseResult(all, topLevel, byPath, byName);
+
         // Pass 2: populate the dependency lists, linking each request to its
         // resolution from the dependent's own path context.
         Map<String, Dependency> dependencyCache = new HashMap<>();
@@ -139,16 +200,12 @@ public final class LockFileParser {
             String pathKey = entry.getKey();
             JsonNode body = entry.getValue();
             ResolvedDependency dep = byPath.get(pathKey);
-            fillDependencies(dep.getDependencies(), body.get("dependencies"),
-                    pathKey, byPath, byName, dependencyCache);
-            fillDependencies(dep.getDevDependencies(), body.get("devDependencies"),
-                    pathKey, byPath, byName, dependencyCache);
-            fillDependencies(dep.getPeerDependencies(), body.get("peerDependencies"),
-                    pathKey, byPath, byName, dependencyCache);
-            fillDependencies(dep.getOptionalDependencies(), body.get("optionalDependencies"),
-                    pathKey, byPath, byName, dependencyCache);
+            fillDependencies(dep.getDependencies(), body.get("dependencies"), pathKey, result, dependencyCache);
+            fillDependencies(dep.getDevDependencies(), body.get("devDependencies"), pathKey, result, dependencyCache);
+            fillDependencies(dep.getPeerDependencies(), body.get("peerDependencies"), pathKey, result, dependencyCache);
+            fillDependencies(dep.getOptionalDependencies(), body.get("optionalDependencies"), pathKey, result, dependencyCache);
         }
-        return new ParseResult(all, topLevel, byPath, byName);
+        return result;
     }
 
     /**
@@ -186,8 +243,7 @@ public final class LockFileParser {
     private static void fillDependencies(@Nullable List<Dependency> target,
                                          @Nullable JsonNode node,
                                          String contextPath,
-                                         Map<String, ResolvedDependency> byPath,
-                                         Map<String, List<ResolvedDependency>> byName,
+                                         ParseResult result,
                                          Map<String, Dependency> dependencyCache) {
         if (target == null || node == null || !node.isObject()) {
             return;
@@ -195,7 +251,7 @@ public final class LockFileParser {
         node.fields().forEachRemaining(e -> {
             String name = e.getKey();
             String constraint = e.getValue().asText("");
-            ResolvedDependency resolved = resolve(name, constraint, contextPath, byPath, byName);
+            ResolvedDependency resolved = result.resolve(name, constraint, contextPath);
             // Reuse Dependency instances (see the @JsonIdentityInfo contract on
             // Dependency): identical requests resolving identically share one object.
             String cacheKey = name + '@' + constraint + '@' +
@@ -203,63 +259,6 @@ public final class LockFileParser {
             target.add(dependencyCache.computeIfAbsent(cacheKey,
                     k -> new Dependency(name, constraint, resolved)));
         });
-    }
-
-    /**
-     * Resolves a dependency name from a given path context using Node.js-style
-     * resolution: nearest {@code node_modules} first, then walking up to parent
-     * directories. Falls back to semver matching among all versions of the name
-     * for paths the walk cannot reach (the yarn/pnpm adapters park duplicate
-     * versions under synthetic paths that are not on any walk-up chain).
-     */
-    private static @Nullable ResolvedDependency resolve(String name,
-                                                        String versionConstraint,
-                                                        String contextPath,
-                                                        Map<String, ResolvedDependency> byPath,
-                                                        Map<String, List<ResolvedDependency>> byName) {
-        String currentPath = contextPath;
-        while (true) {
-            String candidatePath = currentPath.isEmpty()
-                    ? "node_modules/" + name
-                    : currentPath + "/node_modules/" + name;
-            ResolvedDependency resolved = byPath.get(candidatePath);
-            if (resolved != null) {
-                return resolved;
-            }
-            if (currentPath.isEmpty()) {
-                break;
-            }
-            int lastNodeModules = currentPath.lastIndexOf("/node_modules/");
-            currentPath = lastNodeModules < 0 ? "" : currentPath.substring(0, lastNodeModules);
-        }
-
-        List<ResolvedDependency> candidates = byName.get(name);
-        if (candidates == null || candidates.isEmpty()) {
-            return null;
-        }
-        if (candidates.size() == 1) {
-            return candidates.get(0);
-        }
-        Validated<VersionComparator> constraint =
-                Semver.validate(versionConstraint, null, Semver.Ecosystem.NODE);
-        if (constraint.isValid()) {
-            for (ResolvedDependency candidate : candidates) {
-                if (candidate.getVersion() != null &&
-                        constraint.getValue().isValid(null, candidate.getVersion())) {
-                    return candidate;
-                }
-            }
-        }
-        // No version satisfies the constraint: fall back to the highest version.
-        ResolvedDependency max = candidates.get(0);
-        for (int i = 1; i < candidates.size(); i++) {
-            ResolvedDependency candidate = candidates.get(i);
-            if (candidate.getVersion() != null && (max.getVersion() == null ||
-                    VERSION_PRECEDENCE.compare(null, candidate.getVersion(), max.getVersion()) > 0)) {
-                max = candidate;
-            }
-        }
-        return max;
     }
 
     private static @Nullable Map<String, String> readStringMap(@Nullable JsonNode node) {

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/LockFileParser.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/LockFileParser.java
@@ -18,24 +18,45 @@ package org.openrewrite.javascript.internal;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Validated;
 import org.openrewrite.javascript.marker.NodeResolutionResult;
+import org.openrewrite.javascript.marker.NodeResolutionResult.Dependency;
 import org.openrewrite.javascript.marker.NodeResolutionResult.ResolvedDependency;
+import org.openrewrite.semver.LatestRelease;
+import org.openrewrite.semver.Semver;
+import org.openrewrite.semver.VersionComparator;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * Parses an npm {@code package-lock.json} v3-format string into structured
- * {@link ResolvedDependency} instances. The Bun lock format is reduced
- * to the same npm v3 shape upstream by {@link BunLockAdapter}, so this
- * parser handles both PMs.
+ * Parses an npm {@code package-lock.json} v3-format string into a fully linked
+ * graph of {@link ResolvedDependency} instances: each nested {@link Dependency}
+ * request carries a {@code resolved} pointer, so the graph is navigable to
+ * arbitrary depth via {@link Dependency#getResolved()}. The Bun, yarn, and pnpm
+ * lock formats are reduced to the same npm v3 shape upstream by their
+ * respective adapters, so this parser handles all PMs.
+ * <p>
+ * Linking mirrors the TypeScript-side {@code parseResolutions} two-pass
+ * approach: pass one creates one {@link ResolvedDependency} per distinct
+ * {@code name@version} and indexes it by lock-file path; pass two populates the
+ * dependency lists, resolving each request Node-style (nearest
+ * {@code node_modules} walking up from the dependent's path) with a semver
+ * fallback for paths the walk cannot reach. The dependency lists are mutable
+ * {@link ArrayList}s populated after construction, which is what allows cyclic
+ * graphs to be represented with an otherwise immutable model; instances never
+ * escape this class until fully linked.
  */
 public final class LockFileParser {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final LatestRelease VERSION_PRECEDENCE = new LatestRelease(null);
 
     private LockFileParser() {}
 
@@ -43,6 +64,17 @@ public final class LockFileParser {
     public static class ParseResult {
         List<ResolvedDependency> all;
         Map<String, ResolvedDependency> topLevel;
+        Map<String, ResolvedDependency> byPath;
+        Map<String, List<ResolvedDependency>> byName;
+
+        /**
+         * Resolve a dependency request made from the project root (a declared
+         * dependency in package.json), using the same semantics as the
+         * transitive links inside {@link #getAll()}.
+         */
+        public @Nullable ResolvedDependency resolve(String name, String versionConstraint) {
+            return LockFileParser.resolve(name, versionConstraint, "", byPath, byName);
+        }
     }
 
     public static ParseResult parse(String npmV3Json) {
@@ -58,8 +90,15 @@ public final class LockFileParser {
         }
 
         List<ResolvedDependency> all = new ArrayList<>();
+        Map<String, ResolvedDependency> byNameAndVersion = new LinkedHashMap<>();
+        Map<String, ResolvedDependency> byPath = new LinkedHashMap<>();
+        Map<String, List<ResolvedDependency>> byName = new LinkedHashMap<>();
         Map<String, ResolvedDependency> topLevel = new LinkedHashMap<>();
+        // Only the entry that created a ResolvedDependency populates its lists,
+        // so the same name@version appearing at several paths isn't filled twice.
+        List<Map.Entry<String, JsonNode>> creatorEntries = new ArrayList<>();
 
+        // Pass 1: create all ResolvedDependency instances and index them by path.
         packages.fields().forEachRemaining(entry -> {
             String pathKey = entry.getKey();
             if (pathKey.isEmpty()) {
@@ -72,27 +111,44 @@ public final class LockFileParser {
             JsonNode body = entry.getValue();
             String version = body.path("version").asText(null);
 
-            List<NodeResolutionResult.Dependency> deps =
-                    readDepObject(body.get("dependencies"));
-            List<NodeResolutionResult.Dependency> devDeps =
-                    readDepObject(body.get("devDependencies"));
-            List<NodeResolutionResult.Dependency> peerDeps =
-                    readDepObject(body.get("peerDependencies"));
-            List<NodeResolutionResult.Dependency> optionalDeps =
-                    readDepObject(body.get("optionalDependencies"));
-            Map<String, String> engines = readStringMap(body.get("engines"));
-            String license = body.path("license").asText(null);
-
-            ResolvedDependency dep = new ResolvedDependency(
-                    name, version,
-                    deps, devDeps, peerDeps, optionalDeps,
-                    engines, license);
-            all.add(dep);
+            ResolvedDependency dep = byNameAndVersion.get(name + "@" + version);
+            if (dep == null) {
+                dep = new ResolvedDependency(
+                        name, version,
+                        emptyListIfPresent(body.get("dependencies")),
+                        emptyListIfPresent(body.get("devDependencies")),
+                        emptyListIfPresent(body.get("peerDependencies")),
+                        emptyListIfPresent(body.get("optionalDependencies")),
+                        readStringMap(body.get("engines")),
+                        body.path("license").asText(null));
+                byNameAndVersion.put(name + "@" + version, dep);
+                byName.computeIfAbsent(name, k -> new ArrayList<>()).add(dep);
+                all.add(dep);
+                creatorEntries.add(entry);
+            }
+            byPath.put(pathKey, dep);
             if (isTopLevel(pathKey)) {
                 topLevel.put(name, dep);
             }
         });
-        return new ParseResult(all, topLevel);
+
+        // Pass 2: populate the dependency lists, linking each request to its
+        // resolution from the dependent's own path context.
+        Map<String, Dependency> dependencyCache = new HashMap<>();
+        for (Map.Entry<String, JsonNode> entry : creatorEntries) {
+            String pathKey = entry.getKey();
+            JsonNode body = entry.getValue();
+            ResolvedDependency dep = byPath.get(pathKey);
+            fillDependencies(dep.getDependencies(), body.get("dependencies"),
+                    pathKey, byPath, byName, dependencyCache);
+            fillDependencies(dep.getDevDependencies(), body.get("devDependencies"),
+                    pathKey, byPath, byName, dependencyCache);
+            fillDependencies(dep.getPeerDependencies(), body.get("peerDependencies"),
+                    pathKey, byPath, byName, dependencyCache);
+            fillDependencies(dep.getOptionalDependencies(), body.get("optionalDependencies"),
+                    pathKey, byPath, byName, dependencyCache);
+        }
+        return new ParseResult(all, topLevel, byPath, byName);
     }
 
     /**
@@ -101,7 +157,7 @@ public final class LockFileParser {
      * The name is whatever comes after the LAST {@code node_modules/} segment,
      * which handles top-level deps, nested deps, and scoped packages uniformly.
      */
-    private static String nameFromPathKey(String pathKey) {
+    private static @Nullable String nameFromPathKey(String pathKey) {
         int marker = pathKey.lastIndexOf("node_modules/");
         if (marker < 0) {
             return null;
@@ -116,18 +172,97 @@ public final class LockFileParser {
                 && pathKey.indexOf("/node_modules/", "node_modules/".length()) < 0;
     }
 
-    private static List<NodeResolutionResult.Dependency> readDepObject(JsonNode node) {
-        if (node == null || !node.isObject()) {
+    /**
+     * A mutable list to be populated in pass 2, or null when the entry does not
+     * declare this scope (the model uses null, not an empty list, for absent scopes).
+     */
+    private static @Nullable List<Dependency> emptyListIfPresent(@Nullable JsonNode node) {
+        if (node == null || !node.isObject() || node.isEmpty()) {
             return null;
         }
-        List<NodeResolutionResult.Dependency> out = new ArrayList<>();
-        node.fields().forEachRemaining(e ->
-                out.add(new NodeResolutionResult.Dependency(
-                        e.getKey(), e.getValue().asText(""), null)));
-        return out.isEmpty() ? null : out;
+        return new ArrayList<>();
     }
 
-    private static Map<String, String> readStringMap(JsonNode node) {
+    private static void fillDependencies(@Nullable List<Dependency> target,
+                                         @Nullable JsonNode node,
+                                         String contextPath,
+                                         Map<String, ResolvedDependency> byPath,
+                                         Map<String, List<ResolvedDependency>> byName,
+                                         Map<String, Dependency> dependencyCache) {
+        if (target == null || node == null || !node.isObject()) {
+            return;
+        }
+        node.fields().forEachRemaining(e -> {
+            String name = e.getKey();
+            String constraint = e.getValue().asText("");
+            ResolvedDependency resolved = resolve(name, constraint, contextPath, byPath, byName);
+            // Reuse Dependency instances (see the @JsonIdentityInfo contract on
+            // Dependency): identical requests resolving identically share one object.
+            String cacheKey = name + '@' + constraint + '@' +
+                    (resolved == null ? "unresolved" : resolved.getName() + '@' + resolved.getVersion());
+            target.add(dependencyCache.computeIfAbsent(cacheKey,
+                    k -> new Dependency(name, constraint, resolved)));
+        });
+    }
+
+    /**
+     * Resolves a dependency name from a given path context using Node.js-style
+     * resolution: nearest {@code node_modules} first, then walking up to parent
+     * directories. Falls back to semver matching among all versions of the name
+     * for paths the walk cannot reach (the yarn/pnpm adapters park duplicate
+     * versions under synthetic paths that are not on any walk-up chain).
+     */
+    private static @Nullable ResolvedDependency resolve(String name,
+                                                        String versionConstraint,
+                                                        String contextPath,
+                                                        Map<String, ResolvedDependency> byPath,
+                                                        Map<String, List<ResolvedDependency>> byName) {
+        String currentPath = contextPath;
+        while (true) {
+            String candidatePath = currentPath.isEmpty()
+                    ? "node_modules/" + name
+                    : currentPath + "/node_modules/" + name;
+            ResolvedDependency resolved = byPath.get(candidatePath);
+            if (resolved != null) {
+                return resolved;
+            }
+            if (currentPath.isEmpty()) {
+                break;
+            }
+            int lastNodeModules = currentPath.lastIndexOf("/node_modules/");
+            currentPath = lastNodeModules < 0 ? "" : currentPath.substring(0, lastNodeModules);
+        }
+
+        List<ResolvedDependency> candidates = byName.get(name);
+        if (candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+        if (candidates.size() == 1) {
+            return candidates.get(0);
+        }
+        Validated<VersionComparator> constraint =
+                Semver.validate(versionConstraint, null, Semver.Ecosystem.NODE);
+        if (constraint.isValid()) {
+            for (ResolvedDependency candidate : candidates) {
+                if (candidate.getVersion() != null &&
+                        constraint.getValue().isValid(null, candidate.getVersion())) {
+                    return candidate;
+                }
+            }
+        }
+        // No version satisfies the constraint: fall back to the highest version.
+        ResolvedDependency max = candidates.get(0);
+        for (int i = 1; i < candidates.size(); i++) {
+            ResolvedDependency candidate = candidates.get(i);
+            if (candidate.getVersion() != null && (max.getVersion() == null ||
+                    VERSION_PRECEDENCE.compare(null, candidate.getVersion(), max.getVersion()) > 0)) {
+                max = candidate;
+            }
+        }
+        return max;
+    }
+
+    private static @Nullable Map<String, String> readStringMap(@Nullable JsonNode node) {
         if (node == null || !node.isObject()) {
             return null;
         }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/LockFileParser.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/LockFileParser.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Validated;
-import org.openrewrite.javascript.marker.NodeResolutionResult;
 import org.openrewrite.javascript.marker.NodeResolutionResult.Dependency;
 import org.openrewrite.javascript.marker.NodeResolutionResult.ResolvedDependency;
 import org.openrewrite.semver.LatestRelease;
@@ -38,20 +37,9 @@ import java.util.Map;
 
 /**
  * Parses an npm {@code package-lock.json} v3-format string into a fully linked
- * graph of {@link ResolvedDependency} instances: each nested {@link Dependency}
- * request carries a {@code resolved} pointer, so the graph is navigable to
- * arbitrary depth via {@link Dependency#getResolved()}. The Bun, yarn, and pnpm
- * lock formats are reduced to the same npm v3 shape upstream by their
- * respective adapters, so this parser handles all PMs.
- * <p>
- * Linking mirrors the TypeScript-side {@code parseResolutions} two-pass
- * approach: pass one creates one {@link ResolvedDependency} per distinct
- * {@code name@version} and indexes it by lock-file path; pass two populates the
- * dependency lists, resolving each request Node-style (nearest
- * {@code node_modules} walking up from the dependent's path) with a semver
- * fallback for paths the walk cannot reach. The lists are filled in place after
- * construction, per the linkage contract on {@link ResolvedDependency};
- * instances never escape this class until fully linked.
+ * graph of {@link ResolvedDependency} instances, navigable to arbitrary depth.
+ * The Bun, yarn, and pnpm lock formats are reduced to the same npm v3 shape
+ * upstream by their respective adapters, so this parser handles all PMs.
  */
 public final class LockFileParser {
 
@@ -74,20 +62,17 @@ public final class LockFileParser {
 
         /**
          * Resolve a dependency request made from the project root (a declared
-         * dependency in package.json), using the same semantics as the
-         * transitive links inside {@link #getAll()}.
+         * dependency in package.json), with the same semantics as the transitive
+         * links inside the graph.
          */
         public @Nullable ResolvedDependency resolve(String name, String versionConstraint) {
             return resolve(name, versionConstraint, "");
         }
 
-        /**
-         * Resolves a dependency name from a given path context using Node.js-style
-         * resolution: nearest {@code node_modules} first, then walking up to parent
-         * directories. Falls back to semver matching among all versions of the name
-         * for paths the walk cannot reach (the yarn/pnpm adapters park duplicate
-         * versions under synthetic paths that are not on any walk-up chain).
-         */
+        // Node-style resolution: nearest node_modules first, then walking up. Falls back
+        // to semver matching among all versions of the name for paths the walk cannot
+        // reach, since the yarn/pnpm adapters park duplicate versions under synthetic
+        // paths that are not on any walk-up chain.
         @Nullable ResolvedDependency resolve(String name, String versionConstraint, String contextPath) {
             String currentPath = contextPath;
             while (true) {
@@ -229,10 +214,8 @@ public final class LockFileParser {
                 && pathKey.indexOf("/node_modules/", "node_modules/".length()) < 0;
     }
 
-    /**
-     * A mutable list to be populated in pass 2, or null when the entry does not
-     * declare this scope (the model uses null, not an empty list, for absent scopes).
-     */
+    // A mutable list to be populated in pass 2, or null when the entry does not declare
+    // this scope (the model uses null, not an empty list, for absent scopes).
     private static @Nullable List<Dependency> emptyListIfPresent(@Nullable JsonNode node) {
         if (node == null || !node.isObject() || node.isEmpty()) {
             return null;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageJsonHelper.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageJsonHelper.java
@@ -717,9 +717,8 @@ public class PackageJsonHelper {
 
     /**
      * Apply a recipe-specific edit to a package.json, refresh its declared-deps
-     * marker, and (when the marker carries a {@link NodeResolutionResult#getPackageManager()
-     * package manager} and a lock was captured at scan time) regenerate the lock
-     * file content via {@link LockFileRegeneration}.
+     * marker, and (when the marker carries a package manager and a lock was captured
+     * at scan time) regenerate the lock file content via {@link LockFileRegeneration}.
      */
     public static EditAndRegenerateResult editAndRegenerate(
             SourceFile packageJson,

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageJsonHelper.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/PackageJsonHelper.java
@@ -282,35 +282,15 @@ public class PackageJsonHelper {
         }
         LockFileParser.ParseResult parsed = LockFileParser.parse(npmV3);
 
-        // Relink declared deps.
-        List<NodeResolutionResult.Dependency> deps =
-                relink(marker.getDependencies(), parsed.getTopLevel());
-        List<NodeResolutionResult.Dependency> devDeps =
-                relink(marker.getDevDependencies(), parsed.getTopLevel());
-        List<NodeResolutionResult.Dependency> peerDeps =
-                relink(marker.getPeerDependencies(), parsed.getTopLevel());
-        List<NodeResolutionResult.Dependency> optionalDeps =
-                relink(marker.getOptionalDependencies(), parsed.getTopLevel());
-        List<NodeResolutionResult.Dependency> bundledDeps =
-                relink(marker.getBundledDependencies(), parsed.getTopLevel());
-
-        // Relink transitive deps inside each ResolvedDependency.
-        List<NodeResolutionResult.ResolvedDependency> all = new ArrayList<>();
-        for (NodeResolutionResult.ResolvedDependency r : parsed.getAll()) {
-            all.add(r
-                    .withDependencies(relink(r.getDependencies(), parsed.getTopLevel()))
-                    .withDevDependencies(relink(r.getDevDependencies(), parsed.getTopLevel()))
-                    .withPeerDependencies(relink(r.getPeerDependencies(), parsed.getTopLevel()))
-                    .withOptionalDependencies(relink(r.getOptionalDependencies(), parsed.getTopLevel())));
-        }
-
+        // Relink declared deps into the parsed graph; the graph itself is
+        // already fully linked (transitive deps included) by LockFileParser.
         NodeResolutionResult updated = marker
-                .withDependencies(deps)
-                .withDevDependencies(devDeps)
-                .withPeerDependencies(peerDeps)
-                .withOptionalDependencies(optionalDeps)
-                .withBundledDependencies(bundledDeps)
-                .withResolvedDependencies(all);
+                .withDependencies(relink(marker.getDependencies(), parsed))
+                .withDevDependencies(relink(marker.getDevDependencies(), parsed))
+                .withPeerDependencies(relink(marker.getPeerDependencies(), parsed))
+                .withOptionalDependencies(relink(marker.getOptionalDependencies(), parsed))
+                .withBundledDependencies(relink(marker.getBundledDependencies(), parsed))
+                .withResolvedDependencies(parsed.getAll());
         return pkg.withMarkers(pkg.getMarkers().setByType(updated));
     }
 
@@ -329,13 +309,13 @@ public class PackageJsonHelper {
 
     private static @Nullable List<NodeResolutionResult.Dependency> relink(
             @Nullable List<NodeResolutionResult.Dependency> deps,
-            Map<String, NodeResolutionResult.ResolvedDependency> topLevel) {
+            LockFileParser.ParseResult parsed) {
         if (deps == null) {
             return null;
         }
         List<NodeResolutionResult.Dependency> out = new ArrayList<>(deps.size());
         for (NodeResolutionResult.Dependency d : deps) {
-            out.add(d.withResolved(topLevel.get(d.getName())));
+            out.add(d.withResolved(parsed.resolve(d.getName(), d.getVersionConstraint())));
         }
         return out;
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
@@ -202,10 +202,10 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
      * This is what was actually installed (name + resolved version + its own dependencies).
      * <p>
      * Each ResolvedDependency's dependency arrays contain Dependency objects (requests)
-     * whose {@link Dependency#getResolved()} pointers reference other ResolvedDependency
-     * instances of the same graph, so the graph is navigable to arbitrary depth and may
-     * contain cycles. Producers uphold this by filling each instance's lists in place
-     * after construction rather than replacing instances with copies.
+     * whose {@code resolved} pointers reference other ResolvedDependency instances of the
+     * same graph, so the graph is navigable to arbitrary depth and may contain cycles.
+     * Producers uphold this by filling each instance's lists in place after construction
+     * rather than replacing instances with copies.
      */
     @Value
     @With

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
@@ -201,8 +201,11 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
      * Represents a resolved dependency from package-lock.json.
      * This is what was actually installed (name + resolved version + its own dependencies).
      * <p>
-     * Each ResolvedDependency's dependency arrays contain Dependency objects (requests),
-     * which can be looked up in NodeResolutionResult.resolvedDependencies to find their resolved versions.
+     * Each ResolvedDependency's dependency arrays contain Dependency objects (requests)
+     * whose {@link Dependency#getResolved()} pointers reference other ResolvedDependency
+     * instances of the same graph, so the graph is navigable to arbitrary depth and may
+     * contain cycles. Producers uphold this by filling each instance's lists in place
+     * after construction rather than replacing instances with copies.
      */
     @Value
     @With

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/LockFileParserTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/LockFileParserTest.java
@@ -123,9 +123,85 @@ class LockFileParserTest {
                 .extracting(NodeResolutionResult.Dependency::getName).containsExactly("react");
         assertThat(express.getOptionalDependencies())
                 .extracting(NodeResolutionResult.Dependency::getName).containsExactly("fsevents");
-        // resolved is null at parse time; the relinking pass populates it.
+        // None of these deps have their own entry in this lock, so they stay unresolved.
         assertThat(express.getDependencies()).allSatisfy(d ->
                 assertThat(d.getResolved()).isNull());
+    }
+
+    @Test
+    void linksTransitiveDependencies() {
+        String lock = "{\n" +
+                "  \"packages\": {\n" +
+                "    \"\": { },\n" +
+                "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/b\": { \"version\": \"1.0.0\", \"dependencies\": { \"c\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/c\": { \"version\": \"1.0.0\" }\n" +
+                "  }\n" +
+                "}";
+        LockFileParser.ParseResult result = LockFileParser.parse(lock);
+
+        ResolvedDependency a = result.getTopLevel().get("a");
+        NodeResolutionResult.Dependency bRequest = a.getDependencies().get(0);
+        assertThat(bRequest.getResolved()).isSameAs(result.getTopLevel().get("b"));
+        NodeResolutionResult.Dependency cRequest = bRequest.getResolved().getDependencies().get(0);
+        assertThat(cRequest.getResolved()).isSameAs(result.getTopLevel().get("c"));
+    }
+
+    @Test
+    void resolvesNestedShadowedVersion() {
+        String lock = "{\n" +
+                "  \"packages\": {\n" +
+                "    \"\": { },\n" +
+                "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/b\": { \"version\": \"2.0.0\" },\n" +
+                "    \"node_modules/a/node_modules/b\": { \"version\": \"1.5.0\" }\n" +
+                "  }\n" +
+                "}";
+        LockFileParser.ParseResult result = LockFileParser.parse(lock);
+
+        // Top-level b is 2.0.0, but a's nested node_modules shadow it with 1.5.0.
+        assertThat(result.getTopLevel().get("b").getVersion()).isEqualTo("2.0.0");
+        ResolvedDependency a = result.getTopLevel().get("a");
+        NodeResolutionResult.Dependency bRequest = a.getDependencies().get(0);
+        assertThat(bRequest.getResolved()).isNotNull();
+        assertThat(bRequest.getResolved().getVersion()).isEqualTo("1.5.0");
+    }
+
+    @Test
+    void fallsBackToSemverMatchForPathsOutsideTheWalk() {
+        // b exists only under a synthetic path (the shape the yarn/pnpm adapters
+        // emit for duplicate versions) that no node_modules walk-up can reach.
+        String lock = "{\n" +
+                "  \"packages\": {\n" +
+                "    \"\": { },\n" +
+                "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/.pnpm/0/node_modules/b\": { \"version\": \"1.5.0\" },\n" +
+                "    \"node_modules/.pnpm/1/node_modules/b\": { \"version\": \"2.0.0\" }\n" +
+                "  }\n" +
+                "}";
+        LockFileParser.ParseResult result = LockFileParser.parse(lock);
+
+        ResolvedDependency a = result.getTopLevel().get("a");
+        NodeResolutionResult.Dependency bRequest = a.getDependencies().get(0);
+        assertThat(bRequest.getResolved()).isNotNull();
+        assertThat(bRequest.getResolved().getVersion()).isEqualTo("1.5.0");
+    }
+
+    @Test
+    void linksCyclicDependencies() {
+        String lock = "{\n" +
+                "  \"packages\": {\n" +
+                "    \"\": { },\n" +
+                "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/b\": { \"version\": \"1.0.0\", \"dependencies\": { \"a\": \"^1.0.0\" } }\n" +
+                "  }\n" +
+                "}";
+        LockFileParser.ParseResult result = LockFileParser.parse(lock);
+
+        ResolvedDependency a = result.getTopLevel().get("a");
+        ResolvedDependency b = result.getTopLevel().get("b");
+        assertThat(a.getDependencies().get(0).getResolved()).isSameAs(b);
+        assertThat(b.getDependencies().get(0).getResolved()).isSameAs(a);
     }
 
     @Test

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PackageJsonHelperTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/PackageJsonHelperTest.java
@@ -263,6 +263,93 @@ class PackageJsonHelperTest {
     }
 
     @Test
+    void overlayResolvedDepsLinksTransitiveDependencies() {
+        String json = "{\n" +
+                "  \"name\": \"x\",\n" +
+                "  \"dependencies\": { \"a\": \"^1.0.0\" }\n" +
+                "}\n";
+        Json.Document doc = parsePackageJson(json);
+        NodeResolutionResult marker = new NodeResolutionResult(
+                UUID.randomUUID(), "x", null, null, ".",
+                null,
+                asList(new Dependency("a", "^1.0.0", null)),
+                Collections.<Dependency>emptyList(),
+                Collections.<Dependency>emptyList(),
+                Collections.<Dependency>emptyList(),
+                Collections.<Dependency>emptyList(),
+                Collections.<NodeResolutionResult.ResolvedDependency>emptyList(),
+                NodeResolutionResult.PackageManager.Npm,
+                null, null);
+        Json.Document withMarker = doc.withMarkers(doc.getMarkers().add(marker));
+
+        String lock = "{\n" +
+                "  \"packages\": {\n" +
+                "    \"\": { },\n" +
+                "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/b\": { \"version\": \"1.0.0\", \"dependencies\": { \"c\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/c\": { \"version\": \"1.0.0\" }\n" +
+                "  }\n" +
+                "}";
+        SourceFile result = PackageJsonHelper.overlayResolvedDeps(
+                withMarker, lock, NodeResolutionResult.PackageManager.Npm);
+
+        NodeResolutionResult m = result.getMarkers()
+                .findFirst(NodeResolutionResult.class).orElseThrow();
+        Dependency aRequest = m.getDependencies().get(0);
+        // The declared dep must point into the same graph as resolvedDependencies…
+        assertThat(aRequest.getResolved()).isSameAs(m.getResolvedDependency("a"));
+        // …and the graph must be navigable to arbitrary depth via getResolved().
+        Dependency bRequest = aRequest.getResolved().getDependencies().get(0);
+        assertThat(bRequest.getResolved()).isNotNull();
+        assertThat(bRequest.getResolved().getName()).isEqualTo("b");
+        Dependency cRequest = bRequest.getResolved().getDependencies().get(0);
+        assertThat(cRequest.getResolved()).isNotNull();
+        assertThat(cRequest.getResolved().getName()).isEqualTo("c");
+        assertThat(cRequest.getResolved().getVersion()).isEqualTo("1.0.0");
+    }
+
+    @Test
+    void overlayResolvedDepsResolvesShadowedNestedVersion() {
+        String json = "{\n" +
+                "  \"name\": \"x\",\n" +
+                "  \"dependencies\": { \"a\": \"^1.0.0\", \"b\": \"^2.0.0\" }\n" +
+                "}\n";
+        Json.Document doc = parsePackageJson(json);
+        NodeResolutionResult marker = new NodeResolutionResult(
+                UUID.randomUUID(), "x", null, null, ".",
+                null,
+                asList(new Dependency("a", "^1.0.0", null), new Dependency("b", "^2.0.0", null)),
+                Collections.<Dependency>emptyList(),
+                Collections.<Dependency>emptyList(),
+                Collections.<Dependency>emptyList(),
+                Collections.<Dependency>emptyList(),
+                Collections.<NodeResolutionResult.ResolvedDependency>emptyList(),
+                NodeResolutionResult.PackageManager.Npm,
+                null, null);
+        Json.Document withMarker = doc.withMarkers(doc.getMarkers().add(marker));
+
+        String lock = "{\n" +
+                "  \"packages\": {\n" +
+                "    \"\": { },\n" +
+                "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                "    \"node_modules/b\": { \"version\": \"2.0.0\" },\n" +
+                "    \"node_modules/a/node_modules/b\": { \"version\": \"1.5.0\" }\n" +
+                "  }\n" +
+                "}";
+        SourceFile result = PackageJsonHelper.overlayResolvedDeps(
+                withMarker, lock, NodeResolutionResult.PackageManager.Npm);
+
+        NodeResolutionResult m = result.getMarkers()
+                .findFirst(NodeResolutionResult.class).orElseThrow();
+        // The root-level declared dep on b resolves to the top-level 2.0.0…
+        assertThat(m.getDependencies().get(1).getResolved().getVersion()).isEqualTo("2.0.0");
+        // …while a's own dep on b resolves to the shadowing nested 1.5.0.
+        Dependency nestedB = m.getDependencies().get(0).getResolved().getDependencies().get(0);
+        assertThat(nestedB.getResolved()).isNotNull();
+        assertThat(nestedB.getResolved().getVersion()).isEqualTo("1.5.0");
+    }
+
+    @Test
     void overlayResolvedDepsReturnsUnchangedWhenNoMarker() {
         Json.Document doc = parsePackageJson("{\"name\":\"x\"}");
         SourceFile result = PackageJsonHelper.overlayResolvedDeps(


### PR DESCRIPTION
## Motivation

After a dependency-modifying recipe (`UpgradeDependencyVersion`, `AddDependency`, …) regenerates the lock file, `PackageJsonHelper.overlayResolvedDeps` re-derives the `NodeResolutionResult` marker from the new lock content. The resulting resolved-dependency graph was only navigable one level deep: `relink()` pointed declared deps at the original parsed instances (whose nested `Dependency.resolved` were all null, as `LockFileParser` created them), while the one-hop-relinked copies went into `resolvedDependencies` — so pointer-chasing via `dep.getResolved()` stopped after one hop, and the declared dep's target was not even the same instance as the one in the `resolvedDependencies` list. Nested deps also resolved by name against the top-level map only, linking to the wrong version whenever a nested `node_modules` entry shadowed the top-level one. The initial parse on the TypeScript side (`parseResolutions`) produces a fully linked graph, so the overlay left the marker in a degraded state relative to a fresh parse.

## Summary

- `LockFileParser` now produces a fully linked graph itself, mirroring the TypeScript-side `parseResolutions` two-pass approach: pass one creates one `ResolvedDependency` per distinct `name@version` (deduplicated, as on the TypeScript side) indexed by lock-file path; pass two populates the dependency lists, resolving each request Node-style — nearest `node_modules` walking up from the dependent's path — with an npm-semver fallback (`Semver.Ecosystem.NODE`) for paths the walk cannot reach, e.g. the synthetic paths the yarn/pnpm adapters emit for duplicate versions.
- Cyclic dependency graphs are representable: the dependency lists are mutable lists populated after construction, before any instance escapes the parser. `Dependency` instances are shared per identical request (matching the `@JsonIdentityInfo` contract), which also keeps RPC serialization of cyclic graphs terminating.
- `overlayResolvedDeps` now relinks the marker's declared deps via `ParseResult.resolve(name, constraint)` (root-context resolution with the same semantics as the transitive links) and uses the parsed graph as-is; the copy-and-relink loop that broke instance identity is gone.

## Test plan

- [x] New `LockFileParserTest` cases: deep `a→b→c` linkage with instance identity, nested shadowed version (`node_modules/a/node_modules/b`), semver fallback for off-walk paths, cyclic linkage — all written first and observed failing against the previous implementation
- [x] New `PackageJsonHelperTest` cases: post-overlay deep navigation via `getResolved()` plus declared-dep/`resolvedDependencies` graph consistency, and the shadowed-version scenario end-to-end
- [x] Full `./gradlew :rewrite-javascript:test` suite passes
- [x] npm-backed integTests pass with nothing skipped: `AddDependencyResolvedOverlayTest` (real lock regeneration + overlay) and `LockFileParserParityTest` (Java↔TypeScript marker parity over RPC for npm/yarn/pnpm)