### PR TITLE
Python: transfer removed import's prefix in `ChangeImport`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
@@ -29,7 +29,7 @@ from rewrite.python.import_utils import get_qualid_name, get_name_string, get_al
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
 from rewrite.python.add_import import AddImportOptions, maybe_add_import
-from rewrite.python.remove_import import RemoveImportOptions, maybe_remove_import
+from rewrite.python.remove_import import RemoveImportOptions, maybe_remove_import, prefix_to_inherit
 
 
 _Imports = [*Python, CategoryDescriptor(display_name="Imports")]
@@ -185,6 +185,8 @@ class ChangeImport(Recipe):
                 result = super().visit_compilation_unit(cu, p)
                 if not isinstance(result, CompilationUnit):
                     return result
+
+                result = self._transfer_removed_prefixes(cu, result)
 
                 # Schedule adding the new import (only for direct import changes)
                 if self.has_old_import:
@@ -342,6 +344,39 @@ class ChangeImport(Recipe):
                     new_name_ident = result.name.replace(_simple_name=new_name)
                     result = result.padding.replace(_name=result.padding.name.replace(_element=new_name_ident))
                 return result
+
+            def _transfer_removed_prefixes(self, before: CompilationUnit, after: CompilationUnit) -> CompilationUnit:
+                """Dropping a statement discards its prefix; when it is worth rescuing
+                (see prefix_to_inherit) hand it to the next surviving statement,
+                mirroring RemoveImport._remove_import."""
+                removed_ids = ({p.element.id for p in before.padding.statements}
+                               - {p.element.id for p in after.padding.statements})
+                if not removed_ids:
+                    return after
+                inherited = None
+                prefix_by_id = {}
+                for index, padded in enumerate(before.padding.statements):
+                    stmt = padded.element
+                    if stmt.id in removed_ids:
+                        prefix = prefix_to_inherit(stmt, index)
+                        if prefix is not None:
+                            inherited = prefix
+                    elif inherited is not None:
+                        # A whitespace-only prefix is handed only to a following
+                        # import: a following plain statement keeps its own
+                        # separation, which AddImport's front insertion relies on
+                        # when it places the replacement import before it.
+                        if inherited.comments or isinstance(stmt, (Import, MultiImport)):
+                            prefix_by_id[stmt.id] = inherited
+                        inherited = None
+                if not prefix_by_id:
+                    return after
+                new_padded = [
+                    p.replace(_element=p.element.replace(prefix=prefix_by_id[p.element.id]))
+                    if p.element.id in prefix_by_id else p
+                    for p in after.padding.statements
+                ]
+                return after.padding.replace(_statements=new_padded)
 
             def _get_new_module_type(self) -> JavaType.Class:
                 if self.new_module_type is None:

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -39,6 +39,12 @@ class RemoveImportOptions:
     only_if_unused: bool = True
 
 
+def prefix_to_inherit(stmt, index: int) -> Optional[Space]:
+    """The removed statement's prefix only when worth rescuing (comments, or the file's leading
+    prefix), since otherwise it is blank-line separation the next statement already carries."""
+    return stmt.prefix if (index == 0 or stmt.prefix.comments) else None
+
+
 def maybe_remove_import(visitor: PythonVisitor, options: RemoveImportOptions) -> None:
     """Register a RemoveImport visitor to remove an import statement.
 
@@ -170,12 +176,6 @@ class RemoveImport(PythonVisitor):
         collector.visit(cu, None)
         return used
 
-    @staticmethod
-    def _prefix_to_inherit(stmt, index: int) -> Optional[Space]:
-        """The removed statement's prefix only when worth rescuing (comments, or the file's leading
-        prefix), since otherwise it is blank-line separation the next statement already carries."""
-        return stmt.prefix if (index == 0 or stmt.prefix.comments) else None
-
     def _remove_import(self, cu: CompilationUnit) -> CompilationUnit:
         """Remove the import from the compilation unit."""
         new_padded_stmts = []
@@ -187,7 +187,7 @@ class RemoveImport(PythonVisitor):
             if isinstance(stmt, Import) and not isinstance(stmt, MultiImport):
                 result = self._process_single_import(stmt)
                 if result is None:
-                    removed_prefix = self._prefix_to_inherit(stmt, index)
+                    removed_prefix = prefix_to_inherit(stmt, index)
                     changed = True
                 else:
                     if removed_prefix is not None:
@@ -203,7 +203,7 @@ class RemoveImport(PythonVisitor):
                 if result is None:
                     # Remove the entire statement; remember its prefix
                     # so the next statement can inherit it if needed
-                    removed_prefix = self._prefix_to_inherit(stmt, index)
+                    removed_prefix = prefix_to_inherit(stmt, index)
                     changed = True
                 else:
                     if result is not stmt:

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -504,6 +504,71 @@ class TestChangeImport:
             )
         )
 
+    def test_emptied_first_import_no_leading_blank_line(self):
+        """Emptying the file's first import must not leave a leading blank line."""
+        spec = RecipeSpec(recipe=ChangeImport(
+            old_module='collections',
+            old_name='Mapping',
+            new_module='collections.abc',
+        ))
+        spec.rewrite_run(
+            python(
+                """
+                from collections import Mapping
+                from collections.abc import Callable
+                d: Mapping = {}
+                """,
+                """
+                from collections.abc import Callable, Mapping
+                d: Mapping = {}
+                """,
+            )
+        )
+
+    def test_incrementally_emptied_import_no_leading_blank_line(self):
+        """Successive ChangeImports that empty a multi-name import one name at a
+        time must not leave a leading blank line."""
+        spec = RecipeSpec().with_recipes(
+            ChangeImport(old_module='collections', old_name='Callable', new_module='collections.abc'),
+            ChangeImport(old_module='collections', old_name='Mapping', new_module='collections.abc'),
+            ChangeImport(old_module='collections', old_name='Sequence', new_module='collections.abc'),
+        )
+        spec.rewrite_run(
+            python(
+                """
+                from collections import Callable, Mapping, Sequence
+                d: Mapping = {}
+                """,
+                """
+                from collections.abc import Callable, Mapping, Sequence
+                d: Mapping = {}
+                """,
+            )
+        )
+
+    def test_emptied_import_preserves_leading_comment(self):
+        """A comment in the removed import's prefix moves to the next statement."""
+        spec = RecipeSpec(recipe=ChangeImport(
+            old_module='collections',
+            old_name='Mapping',
+            new_module='collections.abc',
+        ))
+        spec.rewrite_run(
+            python(
+                """
+                # comment
+                from collections import Mapping
+                from collections.abc import Callable
+                d: Mapping = {}
+                """,
+                """
+                # comment
+                from collections.abc import Callable, Mapping
+                d: Mapping = {}
+                """,
+            )
+        )
+
     def test_both_from_import_and_direct_import(self):
         """When a file has both 'from X import name' and 'import X', handle without duplicates."""
         spec = RecipeSpec(recipe=ChangeImport(
@@ -522,7 +587,11 @@ class TestChangeImport:
                 """,
                 # The old from-import is removed and new one added after
                 # existing imports; import fractions is preserved.
-                # Leading newline is inherited from the removed from-import's prefix.
-                "\n\nimport fractions\nfrom math import gcd\n\nresult = gcd(12, 8)\n",
+                """
+                import fractions
+                from math import gcd
+
+                result = gcd(12, 8)
+                """,
             )
         )


### PR DESCRIPTION
## Motivation

When `ChangeImport` removes the last remaining name from a `from X import a, b, ...` statement, `visit_multi_import` drops the whole statement — but its prefix was discarded instead of being handed to the following statement. The next statement kept its own `"\n"` prefix, so when the emptied import was the file's first statement the output started with a spurious blank line, and any comments in the removed statement's prefix were lost. This surfaced when composing many per-name `ChangeImport`s (e.g. PEP 585 typing/collections migrations), where a multi-name import is emptied incrementally:

```python
# before
from collections import Callable, Mapping, Sequence
d: Mapping = {}

# after three ChangeImports (collections -> collections.abc) — note the leading blank line
\nfrom collections.abc import Callable, Mapping, Sequence
d: Mapping = {}
```

`RemoveImport` already solves exactly this by transferring the removed statement's prefix to the next surviving statement; `ChangeImport` now gets the same behavior.

## Summary

- `ChangeImport.visit_compilation_unit` runs a post-visit `_transfer_removed_prefixes` pass: statements dropped by the import visitors are detected by diffing statement ids before/after the visit, and each removed statement's prefix is handed to the next surviving statement when worth rescuing (file-leading position, or comments — preserving them).
- The rescue rule is promoted from `RemoveImport._prefix_to_inherit` (private static) to a module-level `prefix_to_inherit` in `remove_import.py`, now shared by both visitors.
- A whitespace-only prefix is handed only to a following import statement: a following plain statement keeps its own separation, which `AddImport`'s front insertion relies on when it places the replacement import before it.
- Corrected `test_both_from_import_and_direct_import`'s expectation, which had encoded the buggy leading blank line.

## Test plan

- [x] New tests (all watched failing first): `test_emptied_first_import_no_leading_blank_line`, `test_incrementally_emptied_import_no_leading_blank_line` (three `ChangeImport`s in sequence), `test_emptied_import_preserves_leading_comment`
- [x] Full rewrite-python suite (excluding `tests/rpc`): 1826 passed, 7 skipped