### PR TITLE
Python: enumerate module-level functions and constants in DependencyTypes

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -28,7 +28,7 @@ import ast
 import os
 import tempfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from ..java import JavaType
 
@@ -97,6 +97,36 @@ _PRIMITIVE_TO_PYTHON: Dict[JavaType.Primitive, str] = {
     JavaType.Primitive.Boolean: 'bool',
     JavaType.Primitive.None_: 'None',
 }
+
+# ty-types descriptor kinds that map to JavaType.Method
+_FUNCTION_KINDS = frozenset(('function', 'boundMethod', 'callable', 'wrapperDescriptor'))
+
+
+def _module_all_names(tree: ast.Module) -> Optional[Set[str]]:
+    """The names ``__all__`` declares via top-level literal list/tuple assignments
+    (plain, annotated, or augmented), or None when the module has no such ``__all__``."""
+    names: Optional[Set[str]] = None
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Assign):
+            targets, value = stmt.targets, stmt.value
+        elif isinstance(stmt, (ast.AnnAssign, ast.AugAssign)):
+            targets, value = [stmt.target], stmt.value
+        else:
+            continue
+        if not isinstance(value, (ast.List, ast.Tuple)):
+            continue
+        if any(isinstance(t, ast.Name) and t.id == '__all__' for t in targets):
+            if names is None:
+                names = set()
+            names.update(elt.value for elt in value.elts
+                         if isinstance(elt, ast.Constant) and isinstance(elt.value, str))
+    return names
+
+
+def _is_public(name: str, all_names: Optional[Set[str]]) -> bool:
+    """Whether ``name`` is part of the module's public surface: membership in
+    ``__all__`` when declared, else the non-underscore convention."""
+    return name in all_names if all_names is not None else not name.startswith('_')
 
 
 class PythonTypeMapping:
@@ -477,7 +507,7 @@ class PythonTypeMapping:
             module_name = descriptor.get('moduleName', '')
             return self._create_class_type(module_name)
 
-        elif kind in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
+        elif kind in _FUNCTION_KINDS:
             # Use structured return type if available
             return_type_id = descriptor.get('returnType')
             if return_type_id is not None:
@@ -552,7 +582,7 @@ class PythonTypeMapping:
                     if member_type_id is None:
                         continue
                     member_desc = self._type_registry.get(member_type_id)
-                    if member_desc and member_desc.get('kind') in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
+                    if member_desc and member_desc.get('kind') in _FUNCTION_KINDS:
                         method = self._create_method_from_descriptor(member_desc, class_type)
                         if method:
                             methods.append(method)
@@ -781,7 +811,7 @@ class PythonTypeMapping:
     def _is_variable_descriptor(self, descriptor: Dict[str, Any]) -> bool:
         """Check if a type descriptor represents a variable (not a function, class, or module)."""
         kind = descriptor.get('kind')
-        return kind not in ('function', 'boundMethod', 'callable', 'wrapperDescriptor', 'module', 'classLiteral')
+        return kind not in _FUNCTION_KINDS and kind not in ('module', 'classLiteral')
 
     def name_type_info(self, node: ast.Name) -> Tuple[Optional[JavaType], Optional[JavaType.Variable]]:
         """Get expression type and variable type for a name reference.
@@ -842,7 +872,7 @@ class PythonTypeMapping:
         type_id = self._lookup_type_id(node)
         if type_id is not None:
             descriptor = self._type_registry.get(type_id)
-            if descriptor and descriptor.get('kind') in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
+            if descriptor and descriptor.get('kind') in _FUNCTION_KINDS:
                 # If the descriptor has parameters/returnType, use them directly
                 params = descriptor.get('parameters')
                 ret_id = descriptor.get('returnType')
@@ -909,6 +939,75 @@ class PythonTypeMapping:
             _parameter_types=param_types if param_types else None,
             _declared_formal_type_names=type_param_names if type_param_names else None,
         )
+
+    def module_type(self, module_fqn: str) -> Optional[JavaType.Class]:
+        """A JavaType.Class for the module itself: FQN = the module name, public
+        top-level functions as methods, public top-level constants as members.
+
+        This is the definition half of how the type model represents module-level
+        API — attribution declares a reference like ``click.echo`` or ``os.sep``
+        under a class named after the module (see
+        ``_declaring_type_from_descriptor``), so an enumeration of the module's
+        public types must define that class for such references to resolve.
+        Re-exported bindings (``from .utils import echo`` in ``__init__.py``) are
+        included under their binding name, since attribution names them the same
+        way; re-exported classes are not — a class reference keeps its defining
+        FQN. The public surface is ``__all__`` when declared, else the
+        non-underscore names. Returns None when the module has no public
+        module-level symbols.
+        """
+        try:
+            tree = ast.parse(self._source)
+        except SyntaxError:
+            return None
+
+        all_names = _module_all_names(tree)
+        # Shallow until a body is found: promotion would advertise a defined
+        # (rather than merely referenced) class even for an empty module.
+        module_class = self._create_class_type(module_fqn)
+        methods: Dict[str, JavaType.Method] = {}
+        members: Dict[str, JavaType.Variable] = {}
+
+        def add_binding(name: str, node: ast.AST) -> None:
+            if not _is_public(name, all_names) or name in methods or name in members:
+                return
+            type_id = self._lookup_type_id(node)
+            descriptor = self._type_registry.get(type_id)
+            if descriptor is None:
+                return
+            if descriptor.get('kind') in _FUNCTION_KINDS:
+                method = self._create_method_from_descriptor(descriptor, module_class, name=name)
+                if method is not None:
+                    methods[name] = method
+            elif self._is_variable_descriptor(descriptor):
+                member_type = self._resolve_type(type_id)
+                if member_type is not None:
+                    members[name] = JavaType.Variable(
+                        _name=name, _type=member_type, _owner=module_class)
+            # classLiteral / module bindings keep their own FQN — not module members.
+
+        for stmt in tree.body:
+            if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                add_binding(stmt.name, stmt)
+            elif isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name):
+                        add_binding(target.id, target)
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                add_binding(stmt.target.id, stmt.target)
+            elif isinstance(stmt, ast.ImportFrom):
+                for alias in stmt.names:
+                    if alias.name != '*':
+                        add_binding(alias.asname or alias.name, alias)
+            # plain `import x` binds a module object, never module-level API
+
+        if not methods and not members:
+            return None
+        # Promote in place, so references minted earlier from this file share the instance.
+        module_class = self._create_class_type(module_fqn, shallow=False)
+        module_class._methods = list(methods.values()) or None
+        module_class._members = list(members.values()) or None
+        return module_class
 
     def method_invocation_type(self, node: ast.Call) -> Optional[JavaType.Method]:
         """Get the method type for a function/method call.
@@ -1105,7 +1204,7 @@ class PythonTypeMapping:
                     kind = descriptor.get('kind')
                     if kind == 'module':
                         return self._create_class_type(descriptor.get('moduleName', ''))
-                    elif kind in ('function', 'boundMethod', 'callable', 'wrapperDescriptor'):
+                    elif kind in _FUNCTION_KINDS:
                         # boundMethod has className — use it for declaring type
                         if descriptor.get('className'):
                             return self._class_reference(descriptor)
@@ -1366,9 +1465,11 @@ class PythonTypeMapping:
         return None
 
     def _create_method_from_descriptor(self, descriptor: Dict[str, Any],
-                                        declaring_type: JavaType.FullyQualified) -> Optional[JavaType.Method]:
-        """Create a JavaType.Method from a ty-types function/boundMethod descriptor."""
-        name = descriptor.get('name', '')
+                                        declaring_type: JavaType.FullyQualified,
+                                        name: Optional[str] = None) -> Optional[JavaType.Method]:
+        """Create a JavaType.Method from a ty-types function/boundMethod descriptor.
+        ``name`` overrides the descriptor's own name (e.g. for aliased re-exports)."""
+        name = name or descriptor.get('name', '')
         if not name:
             return None
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -674,7 +674,9 @@ def _module_name(fp: str, root: str) -> str:
 
 def _enumerate_artifact(artifact: str, root: str, client, by_fqn: Dict[str, Any],
                         processed_ids: Set[int]) -> None:
-    """Collect the complete JavaType.Class for every class one package defines.
+    """Collect the complete JavaType.Class for every class one package defines,
+    plus a synthetic per-module class carrying its module-level functions and
+    constants (see ``PythonTypeMapping.module_type``).
 
     ty has no module enumeration, so walk the package's own .py/.pyi, run the
     per-file type extraction, and keep the classLiteral descriptors whose module
@@ -740,6 +742,12 @@ def _enumerate_artifact(artifact: str, root: str, client, by_fqn: Dict[str, Any]
             existing = by_fqn.get(fqn)
             if existing is None or _richness(java_type) > _richness(existing):
                 by_fqn[fqn] = java_type
+        # One module type per module FQN: the first file defines it, which the
+        # stub-first file ordering makes the .pyi when one exists.
+        if own_module not in by_fqn:
+            module_type = mapping.module_type(own_module)
+            if module_type is not None:
+                by_fqn[own_module] = module_type
 
 
 # DependencyTypes pages its (potentially hundreds-of-MB) response: the full list is

--- a/rewrite-python/rewrite/tests/rpc/test_dependency_types.py
+++ b/rewrite-python/rewrite/tests/rpc/test_dependency_types.py
@@ -320,6 +320,16 @@ class TestExportedTypes:
             f.write(FIXTURE)
         return pkg
 
+    def _enumerate(self, root, artifact) -> dict:
+        client = TyTypesClient()
+        assert client.initialize(str(root))
+        by_fqn: dict = {}
+        try:
+            _enumerate_artifact(str(artifact), str(root), client, by_fqn, set())
+        finally:
+            client.shutdown()
+        return by_fqn
+
     def test_enumerates_own_types_with_methods(self):
         root = tempfile.mkdtemp(prefix="rewrite-exported-types-")
         try:
@@ -342,6 +352,98 @@ class TestExportedTypes:
             assert {"find", "save"} <= repo_methods
         finally:
             shutil.rmtree(root, ignore_errors=True)
+
+    def test_enumerates_module_level_functions_and_constants(self, tmp_path):
+        # A dependency's public API includes module-level functions (click.echo)
+        # and constants (os.sep), not just classes. Parse-time attribution gives
+        # such a reference the *module* as its declaring type (a JavaType.Class
+        # named after the module), so the enumeration must define that module
+        # type — with the function as a method and the constant as a member —
+        # for the consumer's defined-FQN set to cover it.
+        pkg = tmp_path / "toplib"
+        pkg.mkdir()
+        (pkg / "__init__.py").write_text(
+            'GREETING = "hello"\n'
+            "TIMEOUT: float\n\n"
+            "def shout(text: str) -> str:\n"
+            "    return text.upper()\n\n"
+            "class Thing:\n"
+            "    def run(self) -> None:\n        ...\n")
+
+        by_fqn = self._enumerate(tmp_path, pkg)
+
+        assert "toplib.Thing" in by_fqn
+
+        module_type = by_fqn.get("toplib")
+        assert isinstance(module_type, JavaType.Class), \
+            "module-level symbols lost: no type defined for module 'toplib'"
+        assert "shout" in {m._name for m in (module_type._methods or [])}
+        member_names = {v._name for v in (module_type._members or [])}
+        assert "GREETING" in member_names
+        assert "TIMEOUT" in member_names  # annotation-only, stub-style declaration
+        # The class stays under its own FQN, not on the module type.
+        assert "Thing" not in {m._name for m in (module_type._methods or [])}
+
+    def test_module_type_includes_reexports_under_binding_names(self, tmp_path):
+        # click-style layout: the API is defined in a submodule and re-exported by
+        # the package __init__. Parse-time attribution declares `relib.echo(...)`
+        # under the *package* module type, so the enumeration must surface the
+        # re-exported bindings there (under the imported-as name), while a
+        # re-exported class keeps its defining FQN.
+        pkg = tmp_path / "relib"
+        pkg.mkdir()
+        (pkg / "utils.py").write_text(
+            'SEP = "/"\n\n'
+            "def echo(message: str) -> None:\n"
+            "    print(message)\n\n"
+            "class Widget:\n"
+            "    def draw(self) -> None:\n        ...\n")
+        (pkg / "__init__.py").write_text(
+            "from relib.utils import echo, SEP, Widget\n"
+            "from relib.utils import echo as shout\n")
+
+        by_fqn = self._enumerate(tmp_path, pkg)
+
+        package_type = by_fqn.get("relib")
+        assert isinstance(package_type, JavaType.Class)
+        method_names = {m._name for m in (package_type._methods or [])}
+        assert "echo" in method_names
+        assert "shout" in method_names  # aliased re-export binds under its alias
+        assert "Widget" not in method_names
+        assert "SEP" in {v._name for v in (package_type._members or [])}
+
+        # The defining submodule gets its own module type; the class its own FQN.
+        utils_type = by_fqn.get("relib.utils")
+        assert isinstance(utils_type, JavaType.Class)
+        assert "echo" in {m._name for m in (utils_type._methods or [])}
+        assert "relib.utils.Widget" in by_fqn
+
+    def test_module_type_respects_public_api_convention(self, tmp_path):
+        # Without __all__, underscore names are private; with __all__, it is the
+        # public surface — even for names the underscore rule would hide.
+        pkg = tmp_path / "conv"
+        pkg.mkdir()
+        (pkg / "__init__.py").touch()
+        (pkg / "noall.py").write_text(
+            "VISIBLE = 1\n_HIDDEN = 2\n\n"
+            "def visible() -> None:\n    ...\n\n"
+            "def _hidden() -> None:\n    ...\n")
+        (pkg / "withall.py").write_text(
+            '__all__ = ["_special"]\n\n'
+            "def _special() -> None:\n    ...\n\n"
+            "def other() -> None:\n    ...\n")
+
+        by_fqn = self._enumerate(tmp_path, pkg)
+
+        noall = by_fqn.get("conv.noall")
+        assert isinstance(noall, JavaType.Class)
+        assert {m._name for m in (noall._methods or [])} == {"visible"}
+        assert {v._name for v in (noall._members or [])} == {"VISIBLE"}
+
+        withall = by_fqn.get("conv.withall")
+        assert isinstance(withall, JavaType.Class)
+        assert {m._name for m in (withall._methods or [])} == {"_special"}
+        assert not withall._members  # __all__ itself is not public API
 
     def test_own_module_filter_excludes_sibling(self):
         # "clickhouse" shares the "click" prefix but not the "click." boundary,


### PR DESCRIPTION
## Motivation

- The `DependencyTypes` RPC (#8360) enumerates a pip dependency's (or stdlib module's) public API so the Moderne CLI can serialize it into a shared per-coordinate type table. The enumeration harvested only `classLiteral` descriptors, so module-level functions (`click.echo`) and constants (`os.sep`) never reached the table. Parse-time attribution declares such references under a `JavaType.Class` named after the module (the declaring type of `click.echo` is a class with FQN `click`), but the enumeration never defined that class — so those references could never be resolved against the dependency's table and stayed shallow in every consumer, and the module-level half of a dependency's API was simply missing from the shared table.

## Examples

For a distribution containing:

```python
# toplib/__init__.py
GREETING = "hello"
TIMEOUT: float

def shout(text: str) -> str:
    return text.upper()

class Thing:
    def run(self) -> None: ...
```

the enumeration now defines `toplib.Thing` (as before) plus a `toplib` class whose methods include `shout` and whose members include `GREETING` and `TIMEOUT`. Re-exports are attributed to the re-exporting package: with `click/__init__.py` doing `from click.utils import echo`, the `click` module type carries `echo` as a method (under its binding name, so `from x import echo as shout` binds `shout`), while a re-exported class keeps its defining FQN.

## Summary

- `PythonTypeMapping.module_type(fqn)` synthesizes a `JavaType.Class` for a module: public top-level functions as methods, public top-level constants (including annotation-only, stub-style declarations) as members, and re-exported bindings under their binding names. The public surface is `__all__` when declared, else the non-underscore names. ty emits no descriptor for a file's own module and its registry cannot distinguish module-level functions from methods (both carry only `moduleName`), so the harvest walks the file's top-level AST and resolves each binding through the node index.
- `_enumerate_artifact` emits that module type per file; the first file defines a module's type, which the stub-first ordering makes the `.pyi` when one exists.
- `_FUNCTION_KINDS` replaces the six copies of the function-kind tuple, and `_create_method_from_descriptor` takes an optional `name` override for aliased re-exports.

## Test plan

- [x] New test: module-level function, constants (assigned and annotation-only), and class all enumerated; the class stays off the module type
- [x] New test: re-exports surface on the package module type under their binding names (including aliases); re-exported classes keep their defining FQN; submodules get their own module type
- [x] New test: underscore convention without `__all__`; `__all__` as the public surface when declared
- [x] `pytest tests/rpc/test_dependency_types.py` — 26 passed
- [x] `pytest tests/python/test_type_attribution.py` — 151 passed, 4 skipped (type-attribution regression check for the shared `type_mapping.py` changes)