### PR TITLE
Deep-link the remaining Python resolved-dependency graph paths

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/RequirementsTxtParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/RequirementsTxtParser.java
@@ -20,8 +20,8 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.ParseExceptionResult;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
+import org.openrewrite.python.internal.InstalledEnvParser;
 import org.openrewrite.python.internal.PyProjectHelper;
-import org.openrewrite.python.internal.PythonResolutionLinker;
 import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.python.marker.PythonResolutionResult.Dependency;
 import org.openrewrite.python.marker.PythonResolutionResult.PackageManager;
@@ -29,10 +29,6 @@ import org.openrewrite.python.marker.PythonResolutionResult.ResolvedDependency;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextParser;
 
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -50,8 +46,6 @@ public class RequirementsTxtParser implements Parser {
     private static final Pattern FILENAME_PATTERN = Pattern.compile(
             "requirements(-[\\w-]+)?\\.(txt|in)"
     );
-
-    private static final Pattern EXTRA_MARKER_PATTERN = Pattern.compile("\\bextra\\s*==");
 
     private final PlainTextParser plainTextParser = new PlainTextParser();
     private final Map<String, String> subprocessEnvironment;
@@ -190,138 +184,18 @@ public class RequirementsTxtParser implements Parser {
     }
 
     /**
-     * Link transitive dependencies by reading installed package METADATA files from site-packages.
-     * Uses a two-pass approach: first builds a name→entry map, then reads each package's
-     * {@code Requires-Dist} entries to link the graph.
+     * Link transitive dependencies from the workspace's {@code .venv} site-packages.
      *
      * @param resolved  flat list of resolved dependencies from freeze output
      * @param workspace workspace directory containing {@code .venv/}
      * @return new list with dependencies linked (or original list if site-packages not found)
      */
     static List<ResolvedDependency> linkDependenciesFromMetadata(List<ResolvedDependency> resolved, Path workspace) {
-        Path sitePackages = findSitePackages(workspace);
+        Path sitePackages = InstalledEnvParser.findSitePackages(workspace.resolve(".venv"));
         if (sitePackages == null) {
             return resolved;
         }
-
-        List<PythonResolutionLinker.UnlinkedPackage> packages = new ArrayList<>(resolved.size());
-        for (ResolvedDependency r : resolved) {
-            packages.add(new PythonResolutionLinker.UnlinkedPackage(
-                    r.getName(), r.getVersion(), r.getSource(),
-                    readRequiresDist(sitePackages, r.getName(), r.getVersion())));
-        }
-        return PythonResolutionLinker.buildGraph(packages);
-    }
-
-    private static @Nullable Path findSitePackages(Path workspace) {
-        // Windows: .venv/Lib/site-packages (no python* subdirectory)
-        Path windowsSitePackages = workspace.resolve(".venv/Lib/site-packages");
-        if (Files.isDirectory(windowsSitePackages)) {
-            return windowsSitePackages;
-        }
-        // Unix: .venv/lib/python*/site-packages
-        Path lib = workspace.resolve(".venv/lib");
-        if (!Files.isDirectory(lib)) {
-            return null;
-        }
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(lib, "python*")) {
-            for (Path pythonDir : stream) {
-                Path sp = pythonDir.resolve("site-packages");
-                if (Files.isDirectory(sp)) {
-                    return sp;
-                }
-            }
-        } catch (IOException e) {
-            // fall through
-        }
-        return null;
-    }
-
-    private static List<String> readRequiresDist(Path sitePackages, String packageName, String version) {
-        Path metadataFile = findMetadataFile(sitePackages, packageName, version);
-        if (metadataFile == null) {
-            return Collections.emptyList();
-        }
-        try {
-            String content = new String(Files.readAllBytes(metadataFile), StandardCharsets.UTF_8);
-            return parseRequiresDist(content);
-        } catch (IOException e) {
-            return Collections.emptyList();
-        }
-    }
-
-    private static @Nullable Path findMetadataFile(Path sitePackages, String packageName, String version) {
-        // Try common naming conventions: package_name-version.dist-info
-        // The directory name uses the package's canonical form which may differ from freeze output
-        String normalized = packageName.replace('-', '_');
-        Path direct = sitePackages.resolve(normalized + "-" + version + ".dist-info/METADATA");
-        if (Files.exists(direct)) {
-            return direct;
-        }
-        // Try with original name (dashes preserved)
-        direct = sitePackages.resolve(packageName + "-" + version + ".dist-info/METADATA");
-        if (Files.exists(direct)) {
-            return direct;
-        }
-        // Fallback: glob for matching dist-info directory (must also match version)
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(sitePackages, "*.dist-info")) {
-            String normalizedLower = PythonResolutionResult.normalizeName(packageName);
-            String expectedSuffix = "-" + version + ".dist-info";
-            for (Path distInfo : stream) {
-                String dirName = distInfo.getFileName().toString();
-                if (!dirName.endsWith(expectedSuffix)) {
-                    continue;
-                }
-                String dirPkgName = dirName.substring(0, dirName.length() - expectedSuffix.length());
-                if (PythonResolutionResult.normalizeName(dirPkgName).equals(normalizedLower)) {
-                    Path metadata = distInfo.resolve("METADATA");
-                    if (Files.exists(metadata)) {
-                        return metadata;
-                    }
-                }
-            }
-        } catch (IOException e) {
-            // fall through
-        }
-        return null;
-    }
-
-    /**
-     * Parse {@code Requires-Dist} entries from package METADATA content.
-     * Filters out entries gated by {@code extra ==} markers (optional extras).
-     *
-     * @return list of required package names (not normalized)
-     */
-    static List<String> parseRequiresDist(String metadataContent) {
-        List<String> names = new ArrayList<>();
-        for (String line : metadataContent.split("\n")) {
-            String trimmed = line.trim();
-            if (!trimmed.startsWith("Requires-Dist:")) {
-                continue;
-            }
-            String value = trimmed.substring("Requires-Dist:".length()).trim();
-
-            // Skip entries with "extra ==" markers (optional extras, not always installed)
-            if (EXTRA_MARKER_PATTERN.matcher(value).find()) {
-                continue;
-            }
-
-            // Extract package name: everything before the first version specifier or marker
-            // PEP 508: name followed by optional extras [..], version specs, or ; markers
-            int end = value.length();
-            for (int i = 0; i < value.length(); i++) {
-                char c = value.charAt(i);
-                if (c == '<' || c == '>' || c == '=' || c == '!' || c == ';' || c == '[' || c == ' ') {
-                    end = i;
-                    break;
-                }
-            }
-            String name = value.substring(0, end).trim();
-            if (!name.isEmpty()) {
-                names.add(name);
-            }
-        }
-        return names;
+        return InstalledEnvParser.linkDependenciesFromMetadata(resolved, sitePackages);
     }
 
     @Override

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
@@ -16,6 +16,8 @@
 package org.openrewrite.python.internal;
 
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.python.internal.metadata.MetadataParser;
+import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.python.marker.PythonResolutionResult.ResolvedDependency;
 
 import java.io.IOException;
@@ -25,6 +27,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
 
@@ -35,33 +38,37 @@ import static java.util.Collections.emptyList;
  */
 public final class InstalledEnvParser {
 
+    private static final Pattern EXTRA_MARKER_PATTERN = Pattern.compile("\\bextra\\s*==");
+
     private InstalledEnvParser() {
     }
 
     public static List<ResolvedDependency> parse(Path env) {
-        Path sitePackages = sitePackages(env);
+        Path sitePackages = findSitePackages(env);
         if (sitePackages == null) {
             return emptyList();
         }
-        List<ResolvedDependency> resolved = new ArrayList<>();
+        List<PythonResolutionLinker.UnlinkedPackage> packages = new ArrayList<>();
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(sitePackages, "*.dist-info")) {
             for (Path distInfo : ds) {
                 String dir = distInfo.getFileName().toString();
                 String base = dir.substring(0, dir.length() - ".dist-info".length());
                 int dash = base.lastIndexOf('-');
                 if (dash > 0) {
-                    resolved.add(new ResolvedDependency(base.substring(0, dash), base.substring(dash + 1), null, null));
+                    packages.add(new PythonResolutionLinker.UnlinkedPackage(
+                            base.substring(0, dash), base.substring(dash + 1), null,
+                            readRequiresDist(distInfo.resolve("METADATA"))));
                 }
             }
         } catch (IOException e) {
             return emptyList();
         }
-        resolved.sort(Comparator.comparing(ResolvedDependency::getName));
-        return resolved;
+        packages.sort(Comparator.comparing(PythonResolutionLinker.UnlinkedPackage::getName));
+        return PythonResolutionLinker.buildGraph(packages);
     }
 
     /** {@code <env>/lib/pythonX.Y/site-packages} (POSIX) or {@code <env>/Lib/site-packages} (Windows). */
-    private static @Nullable Path sitePackages(Path env) {
+    public static @Nullable Path findSitePackages(Path env) {
         Path lib = env.resolve("lib");
         if (Files.isDirectory(lib)) {
             try (DirectoryStream<Path> ds = Files.newDirectoryStream(lib, "python*")) {
@@ -76,5 +83,87 @@ public final class InstalledEnvParser {
         }
         Path winSp = env.resolve("Lib").resolve("site-packages");
         return Files.isDirectory(winSp) ? winSp : null;
+    }
+
+    /**
+     * Link transitive dependencies by reading each package's {@code dist-info/METADATA}
+     * ({@code Requires-Dist} entries) from {@code sitePackages}, building the graph via
+     * {@link PythonResolutionLinker#buildGraph}.
+     *
+     * @param resolved flat list of resolved dependencies installed in {@code sitePackages}
+     * @return new list with dependencies linked
+     */
+    public static List<ResolvedDependency> linkDependenciesFromMetadata(List<ResolvedDependency> resolved, Path sitePackages) {
+        List<PythonResolutionLinker.UnlinkedPackage> packages = new ArrayList<>(resolved.size());
+        for (ResolvedDependency r : resolved) {
+            Path metadataFile = findMetadataFile(sitePackages, r.getName(), r.getVersion());
+            packages.add(new PythonResolutionLinker.UnlinkedPackage(
+                    r.getName(), r.getVersion(), r.getSource(),
+                    metadataFile == null ? emptyList() : readRequiresDist(metadataFile)));
+        }
+        return PythonResolutionLinker.buildGraph(packages);
+    }
+
+    private static @Nullable Path findMetadataFile(Path sitePackages, String packageName, String version) {
+        // Try common naming conventions: package_name-version.dist-info
+        // The directory name uses the package's canonical form which may differ from freeze output
+        String normalized = packageName.replace('-', '_');
+        Path direct = sitePackages.resolve(normalized + "-" + version + ".dist-info/METADATA");
+        if (Files.exists(direct)) {
+            return direct;
+        }
+        // Try with original name (dashes preserved)
+        direct = sitePackages.resolve(packageName + "-" + version + ".dist-info/METADATA");
+        if (Files.exists(direct)) {
+            return direct;
+        }
+        // Fallback: glob for matching dist-info directory (must also match version)
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(sitePackages, "*.dist-info")) {
+            String normalizedLower = PythonResolutionResult.normalizeName(packageName);
+            String expectedSuffix = "-" + version + ".dist-info";
+            for (Path distInfo : stream) {
+                String dirName = distInfo.getFileName().toString();
+                if (!dirName.endsWith(expectedSuffix)) {
+                    continue;
+                }
+                String dirPkgName = dirName.substring(0, dirName.length() - expectedSuffix.length());
+                if (PythonResolutionResult.normalizeName(dirPkgName).equals(normalizedLower)) {
+                    Path metadata = distInfo.resolve("METADATA");
+                    if (Files.exists(metadata)) {
+                        return metadata;
+                    }
+                }
+            }
+        } catch (IOException e) {
+            // fall through
+        }
+        return null;
+    }
+
+    /**
+     * Read the names of a package's required (non-extra) dependencies: the
+     * {@code Requires-Dist} headers of its METADATA file, minus entries gated by
+     * {@code extra ==} markers (optional extras, not always installed).
+     *
+     * @return list of required package names (not normalized)
+     */
+    private static List<String> readRequiresDist(Path metadataFile) {
+        List<String> requiresDist;
+        try {
+            requiresDist = MetadataParser.parse(Files.readAllBytes(metadataFile)).getRequiresDist();
+        } catch (IOException e) {
+            return emptyList();
+        }
+        List<String> names = new ArrayList<>();
+        for (String value : requiresDist) {
+            if (EXTRA_MARKER_PATTERN.matcher(value).find()) {
+                continue;
+            }
+            String name = PyProjectHelper.extractPackageName(value);
+            if (name != null) {
+                names.add(name);
+            }
+        }
+        return names;
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
@@ -26,7 +26,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;
@@ -48,6 +50,16 @@ public final class InstalledEnvParser {
         if (sitePackages == null) {
             return emptyList();
         }
+        List<PythonResolutionLinker.UnlinkedPackage> packages = scanDistInfos(sitePackages);
+        packages.sort(Comparator.comparing(PythonResolutionLinker.UnlinkedPackage::getName));
+        return PythonResolutionLinker.buildGraph(packages);
+    }
+
+    /**
+     * One package per {@code site-packages/*.dist-info}: name and version from the
+     * directory name, dependency names from its METADATA.
+     */
+    private static List<PythonResolutionLinker.UnlinkedPackage> scanDistInfos(Path sitePackages) {
         List<PythonResolutionLinker.UnlinkedPackage> packages = new ArrayList<>();
         try (DirectoryStream<Path> ds = Files.newDirectoryStream(sitePackages, "*.dist-info")) {
             for (Path distInfo : ds) {
@@ -61,10 +73,9 @@ public final class InstalledEnvParser {
                 }
             }
         } catch (IOException e) {
-            return emptyList();
+            return new ArrayList<>();
         }
-        packages.sort(Comparator.comparing(PythonResolutionLinker.UnlinkedPackage::getName));
-        return PythonResolutionLinker.buildGraph(packages);
+        return packages;
     }
 
     /** {@code <env>/lib/pythonX.Y/site-packages} (POSIX) or {@code <env>/Lib/site-packages} (Windows). */
@@ -88,56 +99,28 @@ public final class InstalledEnvParser {
     /**
      * Link transitive dependencies by reading each package's {@code dist-info/METADATA}
      * ({@code Requires-Dist} entries) from {@code sitePackages}, building the graph via
-     * {@link PythonResolutionLinker#buildGraph}.
+     * {@link PythonResolutionLinker#buildGraph}. Packages are matched to dist-info
+     * directories by normalized name and exact version, so freeze-output spellings
+     * that differ from the canonical directory name still resolve.
      *
      * @param resolved flat list of resolved dependencies installed in {@code sitePackages}
      * @return new list with dependencies linked
      */
     public static List<ResolvedDependency> linkDependenciesFromMetadata(List<ResolvedDependency> resolved, Path sitePackages) {
+        Map<String, List<String>> requiresDistByPackage = new HashMap<>();
+        for (PythonResolutionLinker.UnlinkedPackage pkg : scanDistInfos(sitePackages)) {
+            requiresDistByPackage.putIfAbsent(
+                    PythonResolutionResult.normalizeName(pkg.getName()) + "@" + pkg.getVersion(),
+                    pkg.getDependencyNames());
+        }
         List<PythonResolutionLinker.UnlinkedPackage> packages = new ArrayList<>(resolved.size());
         for (ResolvedDependency r : resolved) {
-            Path metadataFile = findMetadataFile(sitePackages, r.getName(), r.getVersion());
+            List<String> requiresDist = requiresDistByPackage.getOrDefault(
+                    PythonResolutionResult.normalizeName(r.getName()) + "@" + r.getVersion(), emptyList());
             packages.add(new PythonResolutionLinker.UnlinkedPackage(
-                    r.getName(), r.getVersion(), r.getSource(),
-                    metadataFile == null ? emptyList() : readRequiresDist(metadataFile)));
+                    r.getName(), r.getVersion(), r.getSource(), requiresDist));
         }
         return PythonResolutionLinker.buildGraph(packages);
-    }
-
-    private static @Nullable Path findMetadataFile(Path sitePackages, String packageName, String version) {
-        // Try common naming conventions: package_name-version.dist-info
-        // The directory name uses the package's canonical form which may differ from freeze output
-        String normalized = packageName.replace('-', '_');
-        Path direct = sitePackages.resolve(normalized + "-" + version + ".dist-info/METADATA");
-        if (Files.exists(direct)) {
-            return direct;
-        }
-        // Try with original name (dashes preserved)
-        direct = sitePackages.resolve(packageName + "-" + version + ".dist-info/METADATA");
-        if (Files.exists(direct)) {
-            return direct;
-        }
-        // Fallback: glob for matching dist-info directory (must also match version)
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(sitePackages, "*.dist-info")) {
-            String normalizedLower = PythonResolutionResult.normalizeName(packageName);
-            String expectedSuffix = "-" + version + ".dist-info";
-            for (Path distInfo : stream) {
-                String dirName = distInfo.getFileName().toString();
-                if (!dirName.endsWith(expectedSuffix)) {
-                    continue;
-                }
-                String dirPkgName = dirName.substring(0, dirName.length() - expectedSuffix.length());
-                if (PythonResolutionResult.normalizeName(dirPkgName).equals(normalizedLower)) {
-                    Path metadata = distInfo.resolve("METADATA");
-                    if (Files.exists(metadata)) {
-                        return metadata;
-                    }
-                }
-            }
-        } catch (IOException e) {
-            // fall through
-        }
-        return null;
     }
 
     /**

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonResolutionLinker.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonResolutionLinker.java
@@ -86,22 +86,24 @@ public final class PythonResolutionLinker {
     public static PythonResolutionResult updateResolvedVersions(PythonResolutionResult marker,
                                                                 Map<String, String> versionUpdates) {
         List<ResolvedDependency> resolved = marker.getResolvedDependencies();
-        boolean changed = resolved.stream().anyMatch(dep -> {
-            String newVersion = versionUpdates.get(PythonResolutionResult.normalizeName(dep.getName()));
-            return newVersion != null && !newVersion.equals(dep.getVersion());
-        });
-        if (!changed) {
+        if (resolved.stream().noneMatch(dep -> updatedVersion(dep, versionUpdates) != null)) {
             return marker;
         }
         List<UnlinkedPackage> packages = new ArrayList<>(resolved.size());
         for (ResolvedDependency dep : resolved) {
-            String newVersion = versionUpdates.get(PythonResolutionResult.normalizeName(dep.getName()));
+            String newVersion = updatedVersion(dep, versionUpdates);
             List<String> depNames = dep.getDependencies() == null ? emptyList() :
                     dep.getDependencies().stream().map(ResolvedDependency::getName).collect(Collectors.toList());
             packages.add(new UnlinkedPackage(dep.getName(),
                     newVersion != null ? newVersion : dep.getVersion(), dep.getSource(), depNames));
         }
         return relink(marker, buildGraph(packages));
+    }
+
+    /** The updated version for {@code dep}, or null when {@code versionUpdates} leaves it unchanged. */
+    private static @Nullable String updatedVersion(ResolvedDependency dep, Map<String, String> versionUpdates) {
+        String newVersion = versionUpdates.get(PythonResolutionResult.normalizeName(dep.getName()));
+        return newVersion == null || newVersion.equals(dep.getVersion()) ? null : newVersion;
     }
 
     public static List<Dependency> link(List<Dependency> deps, List<ResolvedDependency> resolved) {

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonResolutionLinker.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonResolutionLinker.java
@@ -30,10 +30,12 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static java.util.Collections.emptyList;
+
 /**
  * Overlays resolved-dependency information from a parsed lock file onto a
- * {@link PythonResolutionResult} marker. Pyproject and Pipfile have different
- * sets of declared-dependency fields, so two entry points are exposed.
+ * {@link PythonResolutionResult} marker. The pyproject and pipfile entry points
+ * differ only in package-manager handling.
  */
 public final class PythonResolutionLinker {
 
@@ -41,16 +43,32 @@ public final class PythonResolutionLinker {
     }
 
     /**
-     * Apply pyproject-shaped resolution: link dependencies, build-requires,
-     * optional-dependencies, dependency-groups, constraint-dependencies, and
-     * override-dependencies. Sets the package manager to {@code pm}, the resolver
-     * whose lock this overlay came from.
+     * Apply pyproject-shaped resolution and set the package manager to {@code pm},
+     * the resolver whose lock this overlay came from.
      */
     public static PythonResolutionResult applyPyproject(PythonResolutionResult marker,
                                                         List<ResolvedDependency> resolvedDeps,
                                                         PackageManager pm) {
+        return relink(marker, resolvedDeps).withPackageManager(pm);
+    }
+
+    /**
+     * Apply pipfile-shaped resolution. The package manager is left unchanged
+     * ({@code createMarker} already sets it to {@link PackageManager#Pipenv}).
+     */
+    public static PythonResolutionResult applyPipfile(PythonResolutionResult marker,
+                                                      List<ResolvedDependency> resolvedDeps) {
+        return relink(marker, resolvedDeps);
+    }
+
+    /**
+     * Replace the marker's resolved graph and relink every declared-dependency
+     * field against it; linking an empty field is a no-op, so this covers all
+     * marker shapes.
+     */
+    private static PythonResolutionResult relink(PythonResolutionResult marker,
+                                                 List<ResolvedDependency> resolvedDeps) {
         marker = marker.withResolvedDependencies(resolvedDeps);
-        marker = marker.withPackageManager(pm);
         marker = marker.withDependencies(link(marker.getDependencies(), resolvedDeps));
         marker = marker.withBuildRequires(link(marker.getBuildRequires(), resolvedDeps));
         marker = marker.withOptionalDependencies(linkMap(marker.getOptionalDependencies(), resolvedDeps));
@@ -61,16 +79,29 @@ public final class PythonResolutionLinker {
     }
 
     /**
-     * Apply pipfile-shaped resolution: link {@code [packages]} and
-     * {@code [dev-packages]}. The package manager is left unchanged ({@code createMarker}
-     * already sets it to {@link PackageManager#Pipenv}).
+     * Rebuild the resolved graph with updated versions via {@link #buildGraph} and relink
+     * all declared-dependency {@code resolved} pointers. Keys of {@code versionUpdates} are
+     * normalized package names. Returns the same marker when no version changes.
      */
-    public static PythonResolutionResult applyPipfile(PythonResolutionResult marker,
-                                                      List<ResolvedDependency> resolvedDeps) {
-        marker = marker.withResolvedDependencies(resolvedDeps);
-        marker = marker.withDependencies(link(marker.getDependencies(), resolvedDeps));
-        marker = marker.withOptionalDependencies(linkMap(marker.getOptionalDependencies(), resolvedDeps));
-        return marker;
+    public static PythonResolutionResult updateResolvedVersions(PythonResolutionResult marker,
+                                                                Map<String, String> versionUpdates) {
+        List<ResolvedDependency> resolved = marker.getResolvedDependencies();
+        boolean changed = resolved.stream().anyMatch(dep -> {
+            String newVersion = versionUpdates.get(PythonResolutionResult.normalizeName(dep.getName()));
+            return newVersion != null && !newVersion.equals(dep.getVersion());
+        });
+        if (!changed) {
+            return marker;
+        }
+        List<UnlinkedPackage> packages = new ArrayList<>(resolved.size());
+        for (ResolvedDependency dep : resolved) {
+            String newVersion = versionUpdates.get(PythonResolutionResult.normalizeName(dep.getName()));
+            List<String> depNames = dep.getDependencies() == null ? emptyList() :
+                    dep.getDependencies().stream().map(ResolvedDependency::getName).collect(Collectors.toList());
+            packages.add(new UnlinkedPackage(dep.getName(),
+                    newVersion != null ? newVersion : dep.getVersion(), dep.getSource(), depNames));
+        }
+        return relink(marker, buildGraph(packages));
     }
 
     public static List<Dependency> link(List<Dependency> deps, List<ResolvedDependency> resolved) {

--- a/rewrite-python/src/main/java/org/openrewrite/python/trait/PythonDependencyFile.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/trait/PythonDependencyFile.java
@@ -10,14 +10,13 @@ import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.python.internal.PyProjectHelper;
+import org.openrewrite.python.internal.PythonResolutionLinker;
 import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.trait.SimpleTraitMatcher;
 import org.openrewrite.trait.Trait;
 
 import java.util.*;
 import java.util.regex.Pattern;
-
-import static org.openrewrite.internal.ListUtils.map;
 
 /**
  * Trait for Python dependency files (pyproject.toml, requirements.txt, etc.).
@@ -160,21 +159,12 @@ public interface PythonDependencyFile extends Trait<SourceFile> {
     }
 
     /**
-     * Update the resolved dependency versions in a marker to reflect version changes.
-     * Returns the same marker if no changes were needed.
+     * Update the resolved dependency versions in a marker; see
+     * {@link PythonResolutionLinker#updateResolvedVersions} for the contract.
      */
     static PythonResolutionResult updateResolvedVersions(
             PythonResolutionResult marker, Map<String, String> versionUpdates) {
-        List<PythonResolutionResult.ResolvedDependency> resolved = marker.getResolvedDependencies();
-        List<PythonResolutionResult.ResolvedDependency> updated = map(resolved, dep -> {
-            String normalizedName = PythonResolutionResult.normalizeName(dep.getName());
-            String newVersion = versionUpdates.get(normalizedName);
-            if (newVersion != null && !newVersion.equals(dep.getVersion())) {
-                return dep.withVersion(newVersion);
-            }
-            return dep;
-        });
-        return updated == resolved ? marker : marker.withResolvedDependencies(updated);
+        return PythonResolutionLinker.updateResolvedVersions(marker, versionUpdates);
     }
 
     class Matcher extends SimpleTraitMatcher<PythonDependencyFile> {

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/InstalledEnvParserTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/InstalledEnvParserTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.internal;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.python.marker.PythonResolutionResult.ResolvedDependency;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InstalledEnvParserTest {
+
+    private static void writeDistInfo(Path sitePackages, String name, String version, String metadata) throws IOException {
+        Path distInfo = sitePackages.resolve(name + "-" + version + ".dist-info");
+        Files.createDirectories(distInfo);
+        Files.write(distInfo.resolve("METADATA"), metadata.getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    void linksTransitiveDependenciesDeeply(@TempDir Path env) throws IOException {
+        Path sitePackages = env.resolve("lib/python3.12/site-packages");
+        writeDistInfo(sitePackages, "a", "1.0.0", """
+          Metadata-Version: 2.4
+          Name: a
+          Version: 1.0.0
+          Requires-Dist: b>=1.0
+          """);
+        writeDistInfo(sitePackages, "b", "1.0.0", """
+          Metadata-Version: 2.4
+          Name: b
+          Version: 1.0.0
+          Requires-Dist: c>=1.0
+          """);
+        writeDistInfo(sitePackages, "c", "1.0.0", """
+          Metadata-Version: 2.4
+          Name: c
+          Version: 1.0.0
+          """);
+
+        List<ResolvedDependency> resolved = InstalledEnvParser.parse(env);
+
+        assertThat(resolved).hasSize(3);
+        ResolvedDependency a = resolved.get(0);
+        ResolvedDependency b = resolved.get(1);
+        ResolvedDependency c = resolved.get(2);
+        assertThat(a.getDependencies().get(0)).isSameAs(b);
+        assertThat(b.getDependencies().get(0)).isSameAs(c);
+        assertThat(a.getDependencies().get(0).getDependencies().get(0)).isSameAs(c);
+        assertThat(c.getDependencies()).isNull();
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/trait/PythonDependencyFileTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/trait/PythonDependencyFileTest.java
@@ -162,6 +162,25 @@ class PythonDependencyFileTest implements RewriteTest {
         }
 
         @Test
+        void relinksGraphAndDeclaredPointersAfterUpdate() {
+            ResolvedDependency certifi = new ResolvedDependency("certifi", "2024.2.2", null, null);
+            ResolvedDependency requests = new ResolvedDependency("requests", "2.28.0", null,
+              singletonList(certifi));
+            Dependency declared = new Dependency("requests", ">=2.28.0", null, null, requests);
+            PythonResolutionResult marker = createMarker(singletonList(declared), Arrays.asList(requests, certifi));
+
+            Map<String, String> updates = Map.of("requests", "2.31.0", "certifi", "2025.1.31");
+            PythonResolutionResult updated = PythonDependencyFile.updateResolvedVersions(marker, updates);
+
+            ResolvedDependency newRequests = updated.getResolvedDependency("requests");
+            ResolvedDependency newCertifi = updated.getResolvedDependency("certifi");
+            assertThat(newRequests.getVersion()).isEqualTo("2.31.0");
+            assertThat(newCertifi.getVersion()).isEqualTo("2025.1.31");
+            assertThat(newRequests.getDependencies().get(0)).isSameAs(newCertifi);
+            assertThat(updated.getDependencies().get(0).getResolved()).isSameAs(newRequests);
+        }
+
+        @Test
         void returnsOriginalWhenNoChanges() {
             ResolvedDependency requests = new ResolvedDependency("requests", "2.28.0", null, null);
             PythonResolutionResult marker = createMarker(emptyList(), singletonList(requests));


### PR DESCRIPTION
## Motivation

#8373 fully linked the resolved-dependency graph in the four Python lock-file parsers, but two paths still produced or broke shallow graphs. `InstalledEnvParser` created every `ResolvedDependency` with `dependencies = null`, so the no-lock-file + installed-env path offered no transitive navigation even though the `Requires-Dist` data sits in the very `dist-info/METADATA` files it enumerates. And `PythonDependencyFile.updateResolvedVersions` replaced flat-list entries with `withVersion(...)` copies after dependency upgrades, while every parent's `dependencies` list and every declared `Dependency.resolved` pointer kept the stale instance — after one upgrade, deep navigation reported pre-upgrade versions, the same bug class #8372/#8373 fixed elsewhere.

## Examples

Deep navigation now works for an installed environment and stays consistent through version updates:

```java
List<ResolvedDependency> resolved = InstalledEnvParser.parse(venv);
// a -> b -> c linked to the graph's own instances
assertThat(a.getDependencies().get(0)).isSameAs(b);
assertThat(a.getDependencies().get(0).getDependencies().get(0)).isSameAs(c);

PythonResolutionResult updated = PythonResolutionLinker.updateResolvedVersions(marker, Map.of("certifi", "2025.1.31"));
// parents and declared dependencies point at the rebuilt graph's instances
assertThat(newRequests.getDependencies().get(0)).isSameAs(newCertifi);
assertThat(updated.getDependencies().get(0).getResolved()).isSameAs(newRequests);
```

## Summary

- `InstalledEnvParser.parse` now builds the linked graph in one pass: it reads each package's `Requires-Dist` from the `dist-info/METADATA` it is already enumerating and links via `PythonResolutionLinker.buildGraph`.
- The METADATA-based linking is hoisted from `RequirementsTxtParser` into `InstalledEnvParser`; both consumers share one dist-info scan, the freeze-output path matches packages by normalized name and exact version, and site-packages discovery is unified on `InstalledEnvParser.findSitePackages`.
- The hoisted parsing reuses existing helpers instead of hand-rolled scanning: `MetadataParser` for headers (handles folded headers, stops at the body) and `PyProjectHelper.extractPackageName` for requirement names (handles `~=` and `name @ url`).
- New `PythonResolutionLinker.updateResolvedVersions` rebuilds the graph from the old one with updated versions and relinks all declared-dependency `resolved` pointers; `PythonDependencyFile.updateResolvedVersions` delegates to it.
- `applyPyproject`/`applyPipfile` now share a shape-agnostic `relink()`; the two entry points differ only in package-manager handling.

## Test plan

- [x] New `InstalledEnvParserTest.linksTransitiveDependenciesDeeply` (written failing first against the shallow graph)
- [x] New `PythonDependencyFileTest.relinksGraphAndDeclaredPointersAfterUpdate` (written failing first against the stale-instance graph)
- [x] Full `./gradlew :rewrite-python:test` suite green