### PR TITLE
Preserve the file's line separator when adding a properties comment

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/service/PropertiesCommentService.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/service/PropertiesCommentService.java
@@ -83,14 +83,12 @@ public class PropertiesCommentService extends CommentService {
             return file;
         }
         Properties.Content element = content.get(idx);
-        // The first line of a file carries no leading newline; every later line is separated from the
-        // previous one by the newline rendered as its own prefix.
-        String commentPrefix = idx == 0 ? "" : "\n";
-        Properties.Comment comment = new Properties.Comment(randomId(), commentPrefix, Markers.EMPTY,
+        // The comment takes over the element's prefix, so it lands exactly where the element was.
+        String prefix = element.getPrefix();
+        Properties.Comment comment = new Properties.Comment(randomId(), prefix, Markers.EMPTY,
                 Properties.Comment.Delimiter.HASH_TAG, NEWLINE.matcher(text).replaceAll(" "));
-        // Push the element onto the line below the comment when it shared the comment's line.
-        Properties.Content newElement = element.getPrefix().contains("\n") ?
-                element : (Properties.Content) element.withPrefix("\n" + element.getPrefix());
+        String indent = prefix.substring(prefix.lastIndexOf('\n') + 1);
+        Properties.Content newElement = (Properties.Content) element.withPrefix(lineSeparator(file) + indent);
         List<Properties.Content> newContent = new ArrayList<>(content);
         newContent.set(idx, newElement);
         newContent.add(idx, comment);
@@ -142,6 +140,21 @@ public class PropertiesCommentService extends CommentService {
             }
         }
         return file.withContent(newContent);
+    }
+
+    private static String lineSeparator(Properties.File file) {
+        if (file.getEof().indexOf('\r') >= 0) {
+            return "\r\n";
+        }
+        // The parser splits on '\n', so a comment line's trailing CR lands in its message rather than
+        // in the next element's prefix.
+        for (Properties.Content c : file.getContent()) {
+            if (c.getPrefix().indexOf('\r') >= 0 ||
+                    c instanceof Properties.Comment && ((Properties.Comment) c).getMessage().indexOf('\r') >= 0) {
+                return "\r\n";
+            }
+        }
+        return "\n";
     }
 
     private static Properties.@Nullable File parentFile(Cursor cursor) {

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyCommentTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/AddPropertyCommentTest.java
@@ -199,6 +199,118 @@ class AddPropertyCommentTest implements RewriteTest {
     }
 
     @Test
+    void shouldAddCommentBeforeFirstPropertyOfCrlfFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPropertyComment(
+            "cucumber.publish.quiet",
+            "myComment",
+            false
+          )),
+          properties(
+            "cucumber.publish.quiet=true\r\n" +
+            "cucumber.options=--format pretty",
+            "# myComment\r\n" +
+            "cucumber.publish.quiet=true\r\n" +
+            "cucumber.options=--format pretty"
+          )
+        );
+    }
+
+    @Test
+    void shouldAddCommentBeforeLaterPropertyOfCrlfFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPropertyComment(
+            "cucumber.options",
+            "myComment",
+            false
+          )),
+          properties(
+            "cucumber.publish.quiet=true\r\n" +
+            "cucumber.options=--format pretty\r\n",
+            "cucumber.publish.quiet=true\r\n" +
+            "# myComment\r\n" +
+            "cucumber.options=--format pretty\r\n"
+          )
+        );
+    }
+
+    @Test
+    void shouldAddCommentAfterExistingCommentOfCrlfFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPropertyComment(
+            "cucumber.options",
+            "myComment",
+            false
+          )),
+          properties(
+            "# existing\r\n" +
+            "cucumber.options=--format pretty",
+            "# existing\r\n" +
+            "# myComment\r\n" +
+            "cucumber.options=--format pretty"
+          )
+        );
+    }
+
+    @Test
+    void shouldUseCrlfWhenAddingToMixedEndingsFile() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPropertyComment(
+            "yyy",
+            "myComment",
+            false
+          )),
+          properties(
+            "xxx=true\r\n" +
+            "yyy=true\n" +
+            "zzz=true\r\n",
+            "xxx=true\r\n" +
+            "# myComment\r\n" +
+            "yyy=true\n" +
+            "zzz=true\r\n"
+          )
+        );
+    }
+
+    @Test
+    void shouldKeepBlankLineAboveComment() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPropertyComment(
+            "yyy",
+            "myComment",
+            false
+          )),
+          properties(
+            "xxx=true\n" +
+            "\n" +
+            "yyy=true\n",
+            "xxx=true\n" +
+            "\n" +
+            "# myComment\n" +
+            "yyy=true\n"
+          )
+        );
+    }
+
+    @Test
+    void shouldKeepIndentationOfCommentedProperty() {
+        rewriteRun(
+          spec -> spec.recipe(new AddPropertyComment(
+            "yyy",
+            "myComment",
+            false
+          )),
+          properties(
+            "xxx=true\n" +
+            "  yyy=true\n",
+            "xxx=true\n" +
+            "  # myComment\n" +
+            "  yyy=true\n"
+          )
+        );
+    }
+
+    @Test
     void shouldASkipCommentOutProperty() {
         rewriteRun(
           spec -> spec.recipe(new AddPropertyComment(


### PR DESCRIPTION
`PropertiesCommentService.addComment` hardcoded `"\n"` both for the inserted comment's prefix and for pushing the element onto the next line, so in a CRLF `.properties` file it emitted a bare LF that silently flipped the *preceding* line's terminator from CRLF to LF.

This mirrors `XmlCommentService.addBefore` instead: the comment takes over the element's prefix and the element moves down one line, keeping only its own indentation after a line separator derived from the file (CRLF when the eof, any content prefix, or any comment message contains a CR — the parser splits on `\n`, so a comment line's trailing CR ends up inside its message rather than in the next element's prefix). That also fixes two latent issues, where an element prefix containing a blank line left that blank line *between* the comment and the property it annotates, and where an indented property got a non-indented comment.

Existing behaviour is preserved: the `CommentService` referential-equality contract, the idempotency check scoped to the insertion point, and the flattening of multi-line comment text. Five tests were added covering CRLF before the first entry, before a later entry, after an existing comment, mixed endings, blank lines, and indentation; the existing LF tests pass unchanged.

Found while using the `Comments` trait from `CucumberOptionsPropertyToIndividualProperties` in rewrite-cucumber-jvm, which still hand-rolls its comment insertion because of this.