### PR TITLE
Handle anonymous class overrides in RemoveMethodThrows

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveMethodThrows.java
@@ -29,6 +29,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.TypeUtils;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 @EqualsAndHashCode(callSuper = false)
@@ -78,10 +79,17 @@ public class RemoveMethodThrows extends Recipe {
         return Preconditions.check(precondition, new JavaIsoVisitor<ExecutionContext>() {
                     @Override
                     public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
-                        J.ClassDeclaration enclosingClass = getCursor().firstEnclosing(J.ClassDeclaration.class);
-                        boolean matches = enclosingClass != null ?
-                                methodMatcher.matches(method, enclosingClass) :
-                                methodMatcher.matches(method.getMethodType());
+                        Iterator<Object> enclosingPath = getCursor().getPath(o ->
+                                o instanceof J.ClassDeclaration || o instanceof J.NewClass);
+                        Object enclosing = enclosingPath.hasNext() ? enclosingPath.next() : null;
+                        boolean matches;
+                        if (enclosing instanceof J.NewClass) {
+                            matches = methodMatcher.matches(method, (J.NewClass) enclosing);
+                        } else if (enclosing instanceof J.ClassDeclaration) {
+                            matches = methodMatcher.matches(method, (J.ClassDeclaration) enclosing);
+                        } else {
+                            matches = methodMatcher.matches(method.getMethodType());
+                        }
                         getCursor().putMessage(METHOD_MATCHES_KEY, matches);
 
                         J.MethodDeclaration m = super.visitMethodDeclaration(method, ctx);
@@ -89,7 +97,7 @@ public class RemoveMethodThrows extends Recipe {
                         List<J.Annotation> originalAnnotations = method.getLeadingAnnotations();
                         if (removedAnnotation != null && originalAnnotations.size() == 1 &&
                                 originalAnnotations.get(0) == removedAnnotation) {
-                            m = collapseBlankLineLeftByRemovedAnnotation(m, enclosingClass == null);
+                            m = collapseBlankLineLeftByRemovedAnnotation(m, enclosing == null);
                         }
                         if (!matches || m.getThrows() == null) {
                             return m;

--- a/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodThrowsTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/RemoveMethodThrowsTest.java
@@ -205,6 +205,46 @@ class RemoveMethodThrowsTest implements RewriteTest {
     }
 
     @Test
+    void removeSingleExceptionAnonymousClassOverride() {
+        rewriteRun(
+          spec -> spec.recipe(new RemoveMethodThrows("Itf foo(..)", true, "java.io.IOException")),
+          //language=java
+          java(
+            """
+              import java.io.IOException;
+
+              interface Itf {
+                  void foo();
+              }
+
+              class Holder {
+                  Itf itf = new Itf() {
+                      @Override
+                      public void foo() throws IOException {
+                          // no-op
+                      }
+                  };
+              }
+              """,
+            """
+              interface Itf {
+                  void foo();
+              }
+
+              class Holder {
+                  Itf itf = new Itf() {
+                      @Override
+                      public void foo() {
+                          // no-op
+                      }
+                  };
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void removeExceptionWithMultipleExceptions() {
         rewriteRun(
           //language=java


### PR DESCRIPTION
## What

`RemoveMethodThrows` did not strip the exception from an overriding method declared inside an anonymous class body.

For a method inside `new Itf() { ... }`, `getCursor().firstEnclosing(J.ClassDeclaration.class)` returns the *outer* declared class (not the anonymous class), so `MethodMatcher.matches(method, outerClass)` rejects the override and the `throws` clause is left in place.

## Fix

Walk up to the nearest enclosing `J.NewClass` or `J.ClassDeclaration`, whichever comes first, and dispatch to the corresponding `MethodMatcher.matches` overload — the `J.NewClass` overload already exists and correctly resolves overrides against the anonymous class's supertype.

## Test

Added `removeSingleExceptionAnonymousClassOverride` which mirrors the existing `removeSingleExceptionOverrides` case but places the override in an anonymous class field initializer.