### PR TITLE
Run nested ScanningRecipe scanners in the TypeScript scheduler

### DIFF
--- a/rewrite-javascript/rewrite/src/run.ts
+++ b/rewrite-javascript/rewrite/src/run.ts
@@ -49,12 +49,12 @@ export class Result {
 type RecipeLists = WeakMap<Recipe, Recipe[]>;
 
 async function subRecipes(recipe: Recipe, recipeLists: RecipeLists): Promise<Recipe[]> {
-    let subRecipes = recipeLists.get(recipe);
-    if (subRecipes === undefined) {
-        subRecipes = await recipe.recipeList();
-        recipeLists.set(recipe, subRecipes);
+    let resolved = recipeLists.get(recipe);
+    if (resolved === undefined) {
+        resolved = await recipe.recipeList();
+        recipeLists.set(recipe, resolved);
     }
-    return subRecipes;
+    return resolved;
 }
 
 async function hasScanningRecipe(recipe: Recipe, recipeLists: RecipeLists): Promise<boolean> {
@@ -115,17 +115,16 @@ export async function* scheduleRunStreaming(
     const cursor = rootCursor();
     const recipeLists: RecipeLists = new WeakMap();
     const isScanning = await hasScanningRecipe(recipe, recipeLists);
+    const knownTotal = Array.isArray(before) ? before.length : -1; // -1 = unknown total
 
     if (isScanning) {
         // For scanning recipes, pull files from the generator and scan them immediately.
         // Files are stored for the later edit phase.
         const files: SourceFile[] = [];
-        const iterable = Array.isArray(before) ? before : before;
-        const knownTotal = Array.isArray(before) ? before.length : -1; // -1 = unknown total
 
         // Phase 1: Pull files from generator and scan each immediately
         let scanCount = 0;
-        for await (const b of iterable) {
+        for await (const b of before) {
             files.push(b);
             scanCount++;
             onProgress?.('scanning', scanCount, knownTotal, b.sourcePath);
@@ -172,10 +171,8 @@ export async function* scheduleRunStreaming(
         }
     } else {
         // For non-scanning recipes, process files immediately as they come in
-        const iterable = Array.isArray(before) ? before : before;
-        const knownTotal = Array.isArray(before) ? before.length : -1; // -1 = unknown total
         let processCount = 0;
-        for await (const b of iterable) {
+        for await (const b of before) {
             processCount++;
             onProgress?.('processing', processCount, knownTotal, b.sourcePath);
             const editedB = await recurseRecipeList(recipe, b, recipeLists, async (recipe, b2) => (await recipe.editor()).visit(b2, ctx, cursor));

--- a/rewrite-javascript/rewrite/src/run.ts
+++ b/rewrite-javascript/rewrite/src/run.ts
@@ -40,28 +40,47 @@ export class Result {
     }
 }
 
-async function hasScanningRecipe(recipe: Recipe): Promise<boolean> {
+/**
+ * Recipes commonly instantiate their sub-recipes inside `recipeList()`, so calling it more
+ * than once yields different instances. A scanning sub-recipe would then hold a different
+ * accumulator in every phase and for every source file. Resolving each recipe list once per
+ * run keeps sub-recipe identity, and therefore accumulator identity, stable.
+ */
+type RecipeLists = WeakMap<Recipe, Recipe[]>;
+
+async function subRecipes(recipe: Recipe, recipeLists: RecipeLists): Promise<Recipe[]> {
+    let subRecipes = recipeLists.get(recipe);
+    if (subRecipes === undefined) {
+        subRecipes = await recipe.recipeList();
+        recipeLists.set(recipe, subRecipes);
+    }
+    return subRecipes;
+}
+
+async function hasScanningRecipe(recipe: Recipe, recipeLists: RecipeLists): Promise<boolean> {
     if (recipe instanceof ScanningRecipe) return true;
-    for (const item of (await recipe.recipeList())) {
-        if (await hasScanningRecipe(item)) return true;
+    for (const item of (await subRecipes(recipe, recipeLists))) {
+        if (await hasScanningRecipe(item, recipeLists)) return true;
     }
     return false;
 }
 
-async function recurseRecipeList<T>(recipe: Recipe, initial: T, fn: (recipe: Recipe, t: T) => Promise<T | undefined>): Promise<T | undefined> {
+async function recurseRecipeList<T>(recipe: Recipe, initial: T, recipeLists: RecipeLists, fn: (recipe: Recipe, t: T) => Promise<T | undefined>): Promise<T | undefined> {
     let t: T | undefined = await fn(recipe, initial);
-    for (const subRecipe of await recipe.recipeList()) {
+    for (const subRecipe of await subRecipes(recipe, recipeLists)) {
         if (t === undefined) {
             return undefined;
         }
-        t = await recurseRecipeList(subRecipe, t, fn);
+        t = await recurseRecipeList(subRecipe, t, recipeLists, fn);
     }
     return t;
 }
 
-async function recursiveOnComplete(recipe: Recipe, ctx: ExecutionContext): Promise<void> {
+async function recursiveOnComplete(recipe: Recipe, ctx: ExecutionContext, recipeLists: RecipeLists): Promise<void> {
     await recipe.onComplete(ctx);
-    (await recipe.recipeList()).forEach(r => recursiveOnComplete(r, ctx));
+    for (const subRecipe of await subRecipes(recipe, recipeLists)) {
+        await recursiveOnComplete(subRecipe, ctx, recipeLists);
+    }
 }
 
 export async function scheduleRun(recipe: Recipe, before: SourceFile[], ctx: ExecutionContext): Promise<RecipeRun> {
@@ -94,7 +113,8 @@ export async function* scheduleRunStreaming(
     onProgress?: ProgressCallback
 ): AsyncGenerator<Result, void, undefined> {
     const cursor = rootCursor();
-    const isScanning = await hasScanningRecipe(recipe);
+    const recipeLists: RecipeLists = new WeakMap();
+    const isScanning = await hasScanningRecipe(recipe, recipeLists);
 
     if (isScanning) {
         // For scanning recipes, pull files from the generator and scan them immediately.
@@ -110,18 +130,22 @@ export async function* scheduleRunStreaming(
             scanCount++;
             onProgress?.('scanning', scanCount, knownTotal, b.sourcePath);
 
-            // Scan this file immediately
-            await recurseRecipeList(recipe, b, async (recipe, b2) => {
+            // Scan this file immediately. Scanning must not modify the tree, so the visit
+            // result is discarded and the original file is passed on to the next recipe in
+            // the list. Returning `undefined` here would abort traversal of the remainder
+            // of the recipe list, leaving nested scanners unrun.
+            await recurseRecipeList(recipe, b, recipeLists, async (recipe, b2) => {
                 if (recipe instanceof ScanningRecipe) {
-                    return (await recipe.scanner(recipe.accumulator(cursor, ctx))).visit(b2, ctx, cursor)
+                    await (await recipe.scanner(recipe.accumulator(cursor, ctx))).visit(b2, ctx, cursor);
                 }
+                return b2;
             });
         }
 
         const totalFiles = files.length;
 
         // Phase 2: Collect generated files
-        const generated = (await recurseRecipeList(recipe, [] as SourceFile[], async (recipe, generated) => {
+        const generated = (await recurseRecipeList(recipe, [] as SourceFile[], recipeLists, async (recipe, generated) => {
             if (recipe instanceof ScanningRecipe) {
                 generated.push(...await recipe.generate(recipe.accumulator(cursor, ctx), ctx));
             }
@@ -132,7 +156,7 @@ export async function* scheduleRunStreaming(
         for (let i = 0; i < files.length; i++) {
             const b = files[i];
             onProgress?.('processing', i + 1, totalFiles, b.sourcePath);
-            const editedB = await recurseRecipeList(recipe, b, async (recipe, b2) => (await recipe.editor()).visit(b2, ctx, cursor));
+            const editedB = await recurseRecipeList(recipe, b, recipeLists, async (recipe, b2) => (await recipe.editor()).visit(b2, ctx, cursor));
             // Always yield a result so the caller knows when each file is processed
             yield new Result(b, editedB !== b ? editedB : b);
             // Clear array entry to allow GC to free memory for this file
@@ -141,7 +165,7 @@ export async function* scheduleRunStreaming(
 
         // Phase 4: Edit generated files and yield results
         for (const g of generated) {
-            const editedG = await recurseRecipeList(recipe, g, async (recipe, g2) => (await recipe.editor()).visit(g2, ctx, cursor));
+            const editedG = await recurseRecipeList(recipe, g, recipeLists, async (recipe, g2) => (await recipe.editor()).visit(g2, ctx, cursor));
             if (editedG) {
                 yield new Result(undefined, editedG);
             }
@@ -154,11 +178,11 @@ export async function* scheduleRunStreaming(
         for await (const b of iterable) {
             processCount++;
             onProgress?.('processing', processCount, knownTotal, b.sourcePath);
-            const editedB = await recurseRecipeList(recipe, b, async (recipe, b2) => (await recipe.editor()).visit(b2, ctx, cursor));
+            const editedB = await recurseRecipeList(recipe, b, recipeLists, async (recipe, b2) => (await recipe.editor()).visit(b2, ctx, cursor));
             // Always yield a result so the caller knows when each file is processed
             yield new Result(b, editedB !== b ? editedB : b);
         }
     }
 
-    await recursiveOnComplete(recipe, ctx);
+    await recursiveOnComplete(recipe, ctx, recipeLists);
 }

--- a/rewrite-javascript/rewrite/test/run.test.ts
+++ b/rewrite-javascript/rewrite/test/run.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {ExecutionContext, Recipe, ScanningRecipe, SourceFile, TreeVisitor} from "../src";
+import {scheduleRun} from "../src/run";
+import {PlainText, PlainTextParser, PlainTextVisitor, text} from "../src/text";
+import {RecipeSpec} from "../src/test";
+import {ScanningEditor} from "../fixtures/scanning-editor";
+
+class Composite extends Recipe {
+    name = "org.openrewrite.test.composite";
+    displayName = "Composite";
+    description = "A plain composite recipe that only contributes a recipe list.";
+
+    constructor(private readonly children: Recipe[]) {
+        super();
+    }
+
+    async recipeList(): Promise<Recipe[]> {
+        return this.children;
+    }
+}
+
+class InliningComposite extends Recipe {
+    name = "org.openrewrite.test.inlining-composite";
+    displayName = "Inlining composite";
+    description = "A plain composite that instantiates its sub-recipes inside recipeList().";
+
+    async recipeList(): Promise<Recipe[]> {
+        return [new ScanningEditor()];
+    }
+}
+
+class Exclaim extends Recipe {
+    name = "org.openrewrite.test.exclaim";
+    displayName = "Exclaim";
+    description = "Appends an exclamation mark to each text file.";
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        return new class extends PlainTextVisitor<ExecutionContext> {
+            override async visitText(t: PlainText): Promise<PlainText | undefined> {
+                return {...t, text: t.text + "!"};
+            }
+        };
+    }
+}
+
+class DeleteFile extends Recipe {
+    name = "org.openrewrite.test.delete-file";
+    displayName = "Delete file";
+    description = "Deletes every text file it visits.";
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        return new class extends PlainTextVisitor<ExecutionContext> {
+            override async visitText(): Promise<PlainText | undefined> {
+                return undefined;
+            }
+        };
+    }
+}
+
+async function parse(...sources: string[]): Promise<SourceFile[]> {
+    const parsed: SourceFile[] = [];
+    for await (const sourceFile of new PlainTextParser().parse(
+        ...sources.map((text, i) => ({text, sourcePath: `file${i}.txt`})))) {
+        parsed.push(sourceFile);
+    }
+    return parsed;
+}
+
+describe("scheduleRun", () => {
+    describe("scanning phase traversal", () => {
+        test("scanning recipe one level under a plain composite", async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = new Composite([new ScanningEditor()]);
+            await spec.rewriteRun(
+                text("hello", "hello (count: 1)")
+            );
+        });
+
+        test("scanning recipe several levels deep", async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = new Composite([new Composite([new Composite([new ScanningEditor()])])]);
+            await spec.rewriteRun(
+                text("hello", "hello (count: 1)")
+            );
+        });
+
+        test("scanning recipe positioned after a plain sibling", async () => {
+            // The root is itself a scanning recipe, so traversal starts out fine. The plain
+            // sibling in front of the scanning recipe is what used to abort the recipe list.
+            class ScanningRoot extends ScanningRecipe<{}> {
+                name = "org.openrewrite.test.scanning-root";
+                displayName = "Scanning root";
+                description = "A scanning recipe that contributes a recipe list.";
+
+                initialValue(): {} {
+                    return {};
+                }
+
+                async recipeList(): Promise<Recipe[]> {
+                    return [new Composite([]), new ScanningEditor()];
+                }
+            }
+
+            const spec = new RecipeSpec();
+            spec.recipe = new ScanningRoot();
+            await spec.rewriteRun(
+                text("hello", "hello (count: 1)")
+            );
+        });
+
+        test("scanning recipe instantiated inside recipeList()", async () => {
+            // The recipe list is resolved once per run, so the scan phase and the edit phase
+            // see the same sub-recipe instance and therefore the same accumulator.
+            const spec = new RecipeSpec();
+            spec.recipe = new InliningComposite();
+            await spec.rewriteRun(
+                text("alpha", "alpha (count: 2)"),
+                text("beta", "beta (count: 2)")
+            );
+        });
+
+        test("accumulator sees every file before any file is edited", async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = new Composite([new ScanningEditor()]);
+            await spec.rewriteRun(
+                text("alpha", "alpha (count: 3)"),
+                text("beta", "beta (count: 3)"),
+                text("gamma", "gamma (count: 3)")
+            );
+        });
+
+        test("a scanner that returns undefined does not halt the run", async () => {
+            // Scanning must not modify the tree, so the visit result is discarded entirely,
+            // matching the Java RecipeRunCycle, which keeps the original source file.
+            class DeletingScanner extends ScanningRecipe<{}> {
+                name = "org.openrewrite.test.deleting-scanner";
+                displayName = "Deleting scanner";
+                description = "A scanner whose visitor returns undefined.";
+
+                initialValue(): {} {
+                    return {};
+                }
+
+                async scanner(): Promise<TreeVisitor<any, ExecutionContext>> {
+                    return new class extends PlainTextVisitor<ExecutionContext> {
+                        override async visitText(): Promise<PlainText | undefined> {
+                            return undefined;
+                        }
+                    };
+                }
+            }
+
+            const spec = new RecipeSpec();
+            spec.recipe = new Composite([new DeletingScanner(), new ScanningEditor()]);
+            await spec.rewriteRun(
+                text("hello", "hello (count: 1)")
+            );
+        });
+    });
+
+    test("onComplete of a nested recipe finishes before the run returns", async () => {
+        const completed: string[] = [];
+
+        class Completing extends Recipe {
+            name = "org.openrewrite.test.completing";
+            displayName = "Completing";
+            description = "Records an asynchronous onComplete.";
+
+            constructor(private readonly label: string) {
+                super();
+            }
+
+            override async onComplete(): Promise<void> {
+                await new Promise(resolve => setTimeout(resolve, 0));
+                completed.push(this.label);
+            }
+        }
+
+        await scheduleRun(
+            new Composite([new Completing("child"), new Composite([new Completing("grandchild")])]),
+            await parse("hello"),
+            new ExecutionContext()
+        );
+
+        expect(completed).toEqual(["child", "grandchild"]);
+    });
+
+    describe("edit phase short-circuit", () => {
+        test("a deleted file stops being visited", async () => {
+            const before = await parse("hello");
+            const {changeset} = await scheduleRun(
+                new Composite([new DeleteFile(), new Exclaim()]),
+                before,
+                new ExecutionContext()
+            );
+
+            expect(changeset).toHaveLength(1);
+            expect(changeset[0].before).toBe(before[0]);
+            expect(changeset[0].after).toBeUndefined();
+        });
+
+        test("a deleted file stops being visited when the run also scans", async () => {
+            const before = await parse("hello");
+            const {changeset} = await scheduleRun(
+                new Composite([new ScanningEditor(), new DeleteFile(), new Exclaim()]),
+                before,
+                new ExecutionContext()
+            );
+
+            expect(changeset).toHaveLength(1);
+            expect(changeset[0].before).toBe(before[0]);
+            expect(changeset[0].after).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
- Fixes #8385

A `ScanningRecipe` nested anywhere inside a plain composite `Recipe` never had its scanner run under `scheduleRun`, so its accumulator stayed at `initialValue(...)` and the edit phase silently produced no changes. Two independent causes, both in `rewrite-javascript/rewrite/src/run.ts`:

**The scan phase aborted the recipe list.** `recurseRecipeList` treats an `undefined` callback result as "stop traversing", and the scan callback returned `undefined` for every recipe that was not itself a `ScanningRecipe`. A plain composite root therefore aborted before its first child, and a plain sibling aborted everything after it. Scanning must not modify the tree and its visit result is discarded anyway, so the scanner now runs for its side effects and the source file is always passed through. This matches [`RecipeRunCycle.scanSources`](https://github.com/openrewrite/rewrite/blob/main/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java#L174-L199), which keeps `after = source` regardless of what the scanner returns and asserts the scanner did not mutate the tree.

The `undefined` short-circuit is left intact for the edit phase, where it is how a deleted file stops being visited.

**Sub-recipe instances were not stable across phases.** `recipeList()` was re-invoked once per file while scanning, again while generating, and again per file while editing. Recipes overwhelmingly construct their sub-recipes inline (`return [new SomeScanningRecipe()]`), so each call returned new instances, and `ScanningRecipe.accumulator` keys off a per-instance `Symbol` — the edit phase read a fresh `initialValue(...)` even when the scan phase had run correctly. Each recipe's list is now resolved once per run through a `WeakMap`, mirroring Java's cached `getRecipeList()`. This also stops `RpcRecipe.recipeList()` from re-issuing a `prepareRecipe` RPC call per child per file per phase.

While threading that through, `recursiveOnComplete` was firing its recursive calls without awaiting them, so nested recipes' `onComplete` could still be in flight after `scheduleRun` returned. Awaited now.

### Tests

New `test/run.test.ts`, 9 tests:

- `ScanningRecipe` one level under a plain composite, and three levels deep
- `ScanningRecipe` positioned after a plain sibling under a `ScanningRecipe` root
- `ScanningRecipe` instantiated inside `recipeList()` rather than held in a field
- a cross-file scan: the accumulator sees every file before any file is edited
- a scanner whose visitor returns `undefined` does not halt the run
- nested `onComplete` finishes before the run returns
- two edit-phase deletion tests asserting the short-circuit still yields `after === undefined`

Reverting `src/run.ts` to `main` fails 7 of the 9; the two that still pass are exactly the deletion short-circuit tests, i.e. the behavior this change leaves alone.
