### PR TITLE
Run a recipe's own visitor and scanner alongside its recipe list in the C# scheduler

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/RecipeSchedulerTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/RecipeSchedulerTests.cs
@@ -88,6 +88,47 @@ public class RecipeSchedulerTests
     }
 
     [Fact]
+    public void ScannersSeeSourcesBeforeAnySiblingEdits()
+    {
+        // The scan phase runs over the whole recipe tree before any editor runs, so the
+        // scanner observes the class under its original name even though an earlier
+        // sibling renames it.
+        var results = RecipeScheduler.Run(
+            new Composite(new Rename("A", "B"), new AppendScannedNames()),
+            [Parse("class A { }", "a.cs")],
+            new ExecutionContext());
+
+        var result = Assert.Single(results);
+        Assert.Equal("class B_A { }", Print(result.After!));
+    }
+
+    [Fact]
+    public void GeneratedFilesAreVisitedByTheGeneratingRecipesOwnEditor()
+    {
+        var results = RecipeScheduler.Run(
+            new CountingScanningRecipe { GenerateFile = true },
+            [Parse("class C { }", "c.cs")],
+            new ExecutionContext());
+
+        var generated = Assert.Single(results, r => r.Before == null);
+        Assert.Equal("class G1 { }", Print(generated.After!));
+    }
+
+    [Fact]
+    public void SubRecipeInstancesAreStableAcrossPhases()
+    {
+        // GetRecipeList() constructs the child inline; the scan and edit phases must
+        // still share one accumulator.
+        var results = RecipeScheduler.Run(
+            new InliningComposite(),
+            [Parse("class A { }", "a.cs")],
+            new ExecutionContext());
+
+        var result = Assert.Single(results);
+        Assert.Equal("class A1 { }", Print(result.After!));
+    }
+
+    [Fact]
     public void ResultBeforeIsOriginalSourceAfterChainedEdits()
     {
         var original = Parse("class A { }", "a.cs");
@@ -177,6 +218,48 @@ public class RecipeSchedulerTests
                 return cd.WithName(cd.Name.WithSimpleName(cd.Name.SimpleName + acc.Count));
             }
         }
+    }
+
+    /// <summary>
+    /// Collects every class name during the scan phase, then appends the sorted collected
+    /// names to each class name during the edit phase — making it observable which state
+    /// of the sources the scanner saw.
+    /// </summary>
+    private class AppendScannedNames : ScanningRecipe<SortedSet<string>>
+    {
+        public override string DisplayName => "Append scanned names";
+        public override string Description => "Appends the class names collected while scanning to each class name.";
+
+        public override SortedSet<string> GetInitialValue(ExecutionContext ctx) => [];
+
+        public override ITreeVisitor<ExecutionContext> GetScanner(SortedSet<string> acc) => new NameCollector(acc);
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor(SortedSet<string> acc) => new NameAppender(acc);
+
+        private class NameCollector(SortedSet<string> acc) : CSharpVisitor<ExecutionContext>
+        {
+            public override J VisitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx)
+            {
+                acc.Add(cd.Name.SimpleName);
+                return cd;
+            }
+        }
+
+        private class NameAppender(SortedSet<string> acc) : CSharpVisitor<ExecutionContext>
+        {
+            public override J VisitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx)
+            {
+                return cd.WithName(cd.Name.WithSimpleName(cd.Name.SimpleName + "_" + string.Join("", acc)));
+            }
+        }
+    }
+
+    private class InliningComposite : OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Inlining composite";
+        public override string Description => "Instantiates its sub-recipes inside `GetRecipeList()`.";
+
+        public override List<OpenRewrite.Core.Recipe> GetRecipeList() => [new CountingScanningRecipe()];
     }
 
     private class Rename(string from, string to, params OpenRewrite.Core.Recipe[] children) : OpenRewrite.Core.Recipe

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/RecipeSchedulerTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/RecipeSchedulerTests.cs
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Core;
+
+public class RecipeSchedulerTests
+{
+    private static readonly CSharpParser Parser = new();
+    private static readonly CSharpPrinter<object> Printer = new();
+
+    private static SourceFile Parse(string source, string sourcePath) =>
+        Parser.Parse(source, sourcePath: sourcePath);
+
+    private static string Print(SourceFile source) => Printer.Print(source);
+
+    [Fact]
+    public void ScanningRecipeWithRecipeListRunsItsOwnScannerAndEditor()
+    {
+        var original = Parse("class C { }", "c.cs");
+        var results = RecipeScheduler.Run(
+            new CountingScanningRecipe(new Rename("X", "Y")),
+            [original],
+            new ExecutionContext());
+
+        var result = Assert.Single(results);
+        Assert.Same(original, result.Before);
+        Assert.Equal("class C1 { }", Print(result.After!));
+    }
+
+    [Fact]
+    public void ScanningRecipeWithRecipeListGenerates()
+    {
+        var results = RecipeScheduler.Run(
+            new CountingScanningRecipe(new Rename("X", "Y")) { GenerateFile = true },
+            [Parse("class C { }", "c.cs")],
+            new ExecutionContext());
+
+        Assert.Contains(results, r => r.Before == null && r.After?.SourcePath == "generated.cs");
+    }
+
+    [Fact]
+    public void PlainRecipeWithVisitorAndRecipeListRunsBoth()
+    {
+        // The recipe's own visitor runs before its recipe list, so the child sees the
+        // class already renamed to B.
+        var results = RecipeScheduler.Run(
+            new Rename("A", "B", new Rename("B", "C")),
+            [Parse("class A { }", "a.cs")],
+            new ExecutionContext());
+
+        var result = Assert.Single(results);
+        Assert.Equal("class C { }", Print(result.After!));
+    }
+
+    [Fact]
+    public void NestedScannerSeesEveryFileBeforeAnyEdit()
+    {
+        var results = RecipeScheduler.Run(
+            new Composite(new CountingScanningRecipe()),
+            [
+                Parse("class A { }", "a.cs"),
+                Parse("class B { }", "b.cs"),
+                Parse("class D { }", "d.cs")
+            ],
+            new ExecutionContext());
+
+        Assert.Equal(3, results.Count);
+        Assert.Contains(results, r => r.After != null && Print(r.After) == "class A3 { }");
+        Assert.Contains(results, r => r.After != null && Print(r.After) == "class B3 { }");
+        Assert.Contains(results, r => r.After != null && Print(r.After) == "class D3 { }");
+    }
+
+    [Fact]
+    public void ResultBeforeIsOriginalSourceAfterChainedEdits()
+    {
+        var original = Parse("class A { }", "a.cs");
+        var results = RecipeScheduler.Run(
+            new Composite(new Rename("A", "B"), new Rename("B", "C")),
+            [original],
+            new ExecutionContext());
+
+        var result = Assert.Single(results);
+        Assert.Same(original, result.Before);
+        Assert.Equal("class C { }", Print(result.After!));
+    }
+
+    [Fact]
+    public void ResultBeforeIsOriginalSourceWhenEditedThenDeleted()
+    {
+        var original = Parse("class A { }", "a.cs");
+        var results = RecipeScheduler.Run(
+            new Composite(new Rename("A", "B"), new DeleteAll()),
+            [original],
+            new ExecutionContext());
+
+        var result = Assert.Single(results);
+        Assert.Same(original, result.Before);
+        Assert.Null(result.After);
+    }
+
+    [Fact]
+    public void DeletedFileIsNotVisitedByLaterRecipes()
+    {
+        var original = Parse("class A { }", "a.cs");
+        var results = RecipeScheduler.Run(
+            new Composite(new DeleteAll(), new Rename("A", "B")),
+            [original],
+            new ExecutionContext());
+
+        var result = Assert.Single(results);
+        Assert.Same(original, result.Before);
+        Assert.Null(result.After);
+    }
+
+    private class Counter
+    {
+        public int Count;
+    }
+
+    /// <summary>
+    /// Counts the source files during the scan phase, then appends the final count to
+    /// every class name during the edit phase. The count therefore only shows up in the
+    /// output when the scanner actually ran, and its value reveals how many files were
+    /// scanned before editing began.
+    /// </summary>
+    private class CountingScanningRecipe(params OpenRewrite.Core.Recipe[] children) : ScanningRecipe<Counter>
+    {
+        public bool GenerateFile { get; init; }
+
+        public override string DisplayName => "Counting scanner";
+        public override string Description => "Counts source files and appends the count to class names.";
+
+        public override List<OpenRewrite.Core.Recipe> GetRecipeList() => [.. children];
+
+        public override Counter GetInitialValue(ExecutionContext ctx) => new();
+
+        public override ITreeVisitor<ExecutionContext> GetScanner(Counter acc) => new FileCounter(acc);
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor(Counter acc) => new AppendCountToClassName(acc);
+
+        public override IEnumerable<SourceFile> Generate(Counter acc, ExecutionContext ctx) =>
+            GenerateFile ? [Parse("class G { }", "generated.cs")] : [];
+
+        private class FileCounter(Counter acc) : CSharpVisitor<ExecutionContext>
+        {
+            public override J? Visit(OpenRewrite.Core.Tree? tree, ExecutionContext ctx)
+            {
+                if (tree is SourceFile)
+                {
+                    acc.Count++;
+                }
+                return tree as J;
+            }
+        }
+
+        private class AppendCountToClassName(Counter acc) : CSharpVisitor<ExecutionContext>
+        {
+            public override J VisitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx)
+            {
+                return cd.WithName(cd.Name.WithSimpleName(cd.Name.SimpleName + acc.Count));
+            }
+        }
+    }
+
+    private class Rename(string from, string to, params OpenRewrite.Core.Recipe[] children) : OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => $"Rename {from} to {to}";
+        public override string Description => $"Renames class `{from}` to `{to}`.";
+
+        public override List<OpenRewrite.Core.Recipe> GetRecipeList() => [.. children];
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor() => new RenameVisitor(from, to);
+
+        private class RenameVisitor(string from, string to) : CSharpVisitor<ExecutionContext>
+        {
+            public override J VisitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx)
+            {
+                return cd.Name.SimpleName == from ? cd.WithName(cd.Name.WithSimpleName(to)) : cd;
+            }
+        }
+    }
+
+    private class DeleteAll : OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Delete all";
+        public override string Description => "Deletes every source file it visits.";
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor() => new DeletingVisitor();
+
+        private class DeletingVisitor : CSharpVisitor<ExecutionContext>
+        {
+            public override J? Visit(OpenRewrite.Core.Tree? tree, ExecutionContext ctx) => null;
+        }
+    }
+
+    private class Composite(params OpenRewrite.Core.Recipe[] children) : OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Composite";
+        public override string Description => "A plain composite recipe that only contributes a recipe list.";
+
+        public override List<OpenRewrite.Core.Recipe> GetRecipeList() => [.. children];
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
@@ -13,166 +13,170 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using OpenRewrite.Java;
-
 namespace OpenRewrite.Core;
 
 /// <summary>
-/// Runs a recipe (and its sub-recipes) against a set of source files,
-/// collecting before/after results. Handles composite recipes by recursing
-/// through <see cref="Recipe.GetRecipeList"/>.
+/// Runs a recipe (and its sub-recipes) against a set of source files, collecting
+/// before/after results. When any recipe in the tree is an <see cref="IScanningRecipe"/>
+/// the run is phased: every scanner visits every file, then generated files are collected,
+/// and only then do editors run — so scanners observe the source set in its unedited state
+/// and generated files are edited like any other source. Structured after the TypeScript
+/// scheduler (rewrite-javascript/rewrite/src/run.ts) to keep the implementations aligned.
 /// </summary>
 public static class RecipeScheduler
 {
     public static List<Result> Run(Recipe recipe, List<SourceFile> sources, ExecutionContext ctx)
     {
-        var currentSources = new List<SourceFile>(sources);
+        var state = new RunState(ctx);
+        var results = new List<Result>();
 
-        RunRecipe(recipe, currentSources, ctx);
-
-        return BuildResults(sources, currentSources);
-    }
-
-    private static void RunRecipe(
-        Recipe recipe,
-        List<SourceFile> currentSources,
-        ExecutionContext ctx)
-    {
-        // Pre-order traversal, as in Java's RecipeRunCycle/RecipeStack: the recipe's own
-        // visitor (or scan/generate/edit lifecycle) runs first, then its recipe list.
-        ApplyResults(EditSources(recipe, currentSources, ctx), currentSources);
-
-        foreach (var subRecipe in recipe.GetRecipeList())
+        if (HasScanningRecipe(recipe, state))
         {
-            RunRecipe(subRecipe, currentSources, ctx);
-        }
-    }
-
-    private static List<Result> EditSources(
-        Recipe recipe,
-        List<SourceFile> sources,
-        ExecutionContext ctx)
-    {
-        if (recipe is IScanningRecipe scanning)
-        {
-            var acc = scanning.InitialValue(ctx);
-
-            // Phase 1: Scan
-            var scanner = scanning.Scanner(acc);
+            // Phase 1: Scan — every scanner visits every file. Scanning must not modify
+            // the tree, so the visit result is discarded and the original file is passed
+            // on to the next recipe in the list.
             foreach (var source in sources)
             {
-                scanner.Visit(source, ctx);
+                RecurseRecipeList(recipe, source, state, (r, s) =>
+                {
+                    if (r is IScanningRecipe scanning)
+                    {
+                        scanning.Scanner(state.Accumulator(scanning)).Visit(s, ctx);
+                    }
+                    return s;
+                });
             }
 
-            // Phase 2: Generate
-            var generated = scanning.Generate(acc, ctx).ToList();
-
-            // Phase 3: Edit
-            var results = VisitAll(scanning.Editor(acc), sources, ctx);
-
-            foreach (var gen in generated)
+            // Phase 2: Collect generated files
+            var generated = RecurseRecipeList(recipe, new List<SourceFile>(), state, (r, g) =>
             {
-                results.Add(new Result(null, gen));
-            }
+                if (r is IScanningRecipe scanning)
+                {
+                    g.AddRange(scanning.Generate(state.Accumulator(scanning), ctx));
+                }
+                return g;
+            })!;
 
-            return results;
+            // Phase 3: Edit existing files
+            EditAll(recipe, sources, state, results);
+
+            // Phase 4: Edit generated files, including by the generating recipe's own editor
+            foreach (var source in generated)
+            {
+                var after = EditFile(recipe, source, state);
+                if (after != null)
+                {
+                    results.Add(new Result(null, after));
+                }
+            }
         }
-
-        var visitor = recipe.GetVisitor();
-        if (visitor is NoopVisitor<ExecutionContext>)
+        else
         {
-            // The default visitor is a no-op, so recipes that don't override it
-            // (typically composites) need no traversal of the source set.
-            return [];
-        }
-
-        return VisitAll(visitor, sources, ctx);
-    }
-
-    private static List<Result> VisitAll(
-        ITreeVisitor<ExecutionContext> visitor,
-        List<SourceFile> sources,
-        ExecutionContext ctx)
-    {
-        var results = new List<Result>();
-        foreach (var source in sources)
-        {
-            var after = visitor.Visit(source, ctx);
-            if (after == null)
-            {
-                results.Add(new Result(source, null));
-            }
-            else if (after is SourceFile sf && !ReferenceEquals(source, after))
-            {
-                results.Add(new Result(source, sf));
-            }
+            EditAll(recipe, sources, state, results);
         }
 
         return results;
     }
 
-    private static void ApplyResults(List<Result> results, List<SourceFile> currentSources)
+    private static void EditAll(Recipe recipe, List<SourceFile> sources, RunState state, List<Result> results)
     {
-        foreach (var result in results)
+        foreach (var source in sources)
         {
-            var before = result.Before;
-            if (before != null)
+            var after = EditFile(recipe, source, state);
+            if (!ReferenceEquals(source, after))
             {
-                if (result.After != null)
-                {
-                    var i = currentSources.FindIndex(s => s.Id == before.Id);
-                    if (i >= 0)
-                    {
-                        currentSources[i] = result.After;
-                    }
-                }
-                else
-                {
-                    currentSources.RemoveAll(s => s.Id == before.Id);
-                }
-            }
-            else if (result.After != null)
-            {
-                currentSources.Add(result.After);
+                results.Add(new Result(source, after));
             }
         }
+    }
+
+    private static SourceFile? EditFile(Recipe recipe, SourceFile source, RunState state)
+    {
+        return RecurseRecipeList(recipe, source, state, (r, s) =>
+        {
+            var visitor = r is IScanningRecipe scanning
+                ? scanning.Editor(state.Accumulator(scanning))
+                : r.GetVisitor();
+            if (visitor is NoopVisitor<ExecutionContext>)
+            {
+                // The default visitor is a no-op, so recipes that don't override it
+                // (typically composites) need no visit.
+                return s;
+            }
+
+            var after = visitor.Visit(s, state.Ctx);
+            return after == null ? null : after as SourceFile ?? s;
+        });
     }
 
     /// <summary>
-    /// Diffs the source set as parsed against its state after the run, pairing files by id:
-    /// same id with a different tree → changed, id only present before → deleted, id only
-    /// present after → generated. Because only the initial and final states are compared,
-    /// <see cref="Result.Before"/> is always the originally parsed source no matter how many
-    /// recipes edited the file, and a generated file that a later recipe deleted yields no
-    /// result at all. Relies on visitors preserving <see cref="SourceFile.Id"/> across edits.
+    /// Pre-order fold over the recipe tree: the recipe itself is visited first, then its
+    /// recipe list. A null callback result short-circuits the remaining traversal — in the
+    /// edit phase that is how a deleted file stops being visited.
     /// </summary>
-    private static List<Result> BuildResults(List<SourceFile> before, List<SourceFile> after)
+    private static T? RecurseRecipeList<T>(Recipe recipe, T initial, RunState state, Func<Recipe, T, T?> fn)
+        where T : class
     {
-        var results = new List<Result>();
-        var afterById = after.ToDictionary(s => s.Id);
-        foreach (var beforeSource in before)
+        var t = fn(recipe, initial);
+        foreach (var subRecipe in state.SubRecipes(recipe))
         {
-            if (afterById.Remove(beforeSource.Id, out var afterSource))
+            if (t == null)
             {
-                if (!ReferenceEquals(beforeSource, afterSource))
-                {
-                    results.Add(new Result(beforeSource, afterSource));
-                }
+                return null;
             }
-            else
+            t = RecurseRecipeList(subRecipe, t, state, fn);
+        }
+        return t;
+    }
+
+    private static bool HasScanningRecipe(Recipe recipe, RunState state)
+    {
+        if (recipe is IScanningRecipe)
+        {
+            return true;
+        }
+        foreach (var subRecipe in state.SubRecipes(recipe))
+        {
+            if (HasScanningRecipe(subRecipe, state))
             {
-                results.Add(new Result(beforeSource, null));
+                return true;
             }
         }
+        return false;
+    }
 
-        foreach (var afterSource in after)
+    /// <summary>
+    /// Per-run state. Recipes commonly instantiate their sub-recipes inside
+    /// <see cref="Recipe.GetRecipeList"/>, so calling it more than once yields different
+    /// instances, and a scanning sub-recipe would then be handed a different accumulator in
+    /// every phase. Resolving each recipe list once per run keeps sub-recipe identity — and
+    /// therefore accumulator identity — stable.
+    /// </summary>
+    private sealed class RunState(ExecutionContext ctx)
+    {
+        public ExecutionContext Ctx { get; } = ctx;
+
+        private readonly Dictionary<Recipe, List<Recipe>> _recipeLists = new(ReferenceEqualityComparer.Instance);
+        private readonly Dictionary<IScanningRecipe, object> _accumulators = new(ReferenceEqualityComparer.Instance);
+
+        public List<Recipe> SubRecipes(Recipe recipe)
         {
-            if (afterById.ContainsKey(afterSource.Id))
+            if (!_recipeLists.TryGetValue(recipe, out var subRecipes))
             {
-                results.Add(new Result(null, afterSource));
+                subRecipes = recipe.GetRecipeList();
+                _recipeLists[recipe] = subRecipes;
             }
+            return subRecipes;
         }
 
-        return results;
+        public object Accumulator(IScanningRecipe recipe)
+        {
+            if (!_accumulators.TryGetValue(recipe, out var acc))
+            {
+                acc = recipe.InitialValue(Ctx);
+                _accumulators[recipe] = acc;
+            }
+            return acc;
+        }
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
@@ -26,28 +26,25 @@ public static class RecipeScheduler
 {
     public static List<Result> Run(Recipe recipe, List<SourceFile> sources, ExecutionContext ctx)
     {
-        var allResults = new Dictionary<Guid, Result>();
         var currentSources = new List<SourceFile>(sources);
 
-        RunRecipe(recipe, currentSources, allResults, ctx);
+        RunRecipe(recipe, currentSources, ctx);
 
-        return allResults.Values.ToList();
+        return BuildResults(sources, currentSources);
     }
 
     private static void RunRecipe(
         Recipe recipe,
         List<SourceFile> currentSources,
-        Dictionary<Guid, Result> allResults,
         ExecutionContext ctx)
     {
         // Pre-order traversal, as in Java's RecipeRunCycle/RecipeStack: the recipe's own
         // visitor (or scan/generate/edit lifecycle) runs first, then its recipe list.
-        var results = EditSources(recipe, currentSources, ctx);
-        ApplyResults(results, currentSources, allResults);
+        ApplyResults(EditSources(recipe, currentSources, ctx), currentSources);
 
         foreach (var subRecipe in recipe.GetRecipeList())
         {
-            RunRecipe(subRecipe, currentSources, allResults, ctx);
+            RunRecipe(subRecipe, currentSources, ctx);
         }
     }
 
@@ -81,7 +78,15 @@ public static class RecipeScheduler
             return results;
         }
 
-        return VisitAll(recipe.GetVisitor(), sources, ctx);
+        var visitor = recipe.GetVisitor();
+        if (visitor is NoopVisitor<ExecutionContext>)
+        {
+            // The default visitor is a no-op, so recipes that don't override it
+            // (typically composites) need no traversal of the source set.
+            return [];
+        }
+
+        return VisitAll(visitor, sources, ctx);
     }
 
     private static List<Result> VisitAll(
@@ -106,56 +111,68 @@ public static class RecipeScheduler
         return results;
     }
 
-    private static void ApplyResults(
-        List<Result> results,
-        List<SourceFile> currentSources,
-        Dictionary<Guid, Result> allResults)
+    private static void ApplyResults(List<Result> results, List<SourceFile> currentSources)
     {
         foreach (var result in results)
         {
-            if (result.Before != null)
+            var before = result.Before;
+            if (before != null)
             {
-                // An earlier recipe may already have recorded a result for this file, in which
-                // case result.Before is that recipe's after tree. The final result must pair
-                // the file's original state with the latest after.
-                if (allResults.TryGetValue(result.Before.Id, out var existing))
-                {
-                    if (existing.Before == null && result.After == null)
-                    {
-                        // A generated file that a later recipe deleted never existed
-                        allResults.Remove(result.Before.Id);
-                    }
-                    else
-                    {
-                        allResults[result.Before.Id] = new Result(existing.Before, result.After);
-                    }
-                }
-                else
-                {
-                    allResults[result.Before.Id] = result;
-                }
-
                 if (result.After != null)
                 {
-                    for (var i = 0; i < currentSources.Count; i++)
+                    var i = currentSources.FindIndex(s => s.Id == before.Id);
+                    if (i >= 0)
                     {
-                        if (currentSources[i].Id == result.Before.Id)
-                        {
-                            currentSources[i] = result.After;
-                            break;
-                        }
+                        currentSources[i] = result.After;
                     }
                 }
                 else
                 {
-                    currentSources.RemoveAll(s => s.Id == result.Before.Id);
+                    currentSources.RemoveAll(s => s.Id == before.Id);
                 }
             }
             else if (result.After != null)
             {
-                allResults[result.After.Id] = result;
                 currentSources.Add(result.After);
             }
         }
+    }
+
+    /// <summary>
+    /// Diffs the source set as parsed against its state after the run, pairing files by id:
+    /// same id with a different tree → changed, id only present before → deleted, id only
+    /// present after → generated. Because only the initial and final states are compared,
+    /// <see cref="Result.Before"/> is always the originally parsed source no matter how many
+    /// recipes edited the file, and a generated file that a later recipe deleted yields no
+    /// result at all. Relies on visitors preserving <see cref="SourceFile.Id"/> across edits.
+    /// </summary>
+    private static List<Result> BuildResults(List<SourceFile> before, List<SourceFile> after)
+    {
+        var results = new List<Result>();
+        var afterById = after.ToDictionary(s => s.Id);
+        foreach (var beforeSource in before)
+        {
+            if (afterById.Remove(beforeSource.Id, out var afterSource))
+            {
+                if (!ReferenceEquals(beforeSource, afterSource))
+                {
+                    results.Add(new Result(beforeSource, afterSource));
+                }
+            }
+            else
+            {
+                results.Add(new Result(beforeSource, null));
+            }
+        }
+
+        foreach (var afterSource in after)
+        {
+            if (afterById.ContainsKey(afterSource.Id))
+            {
+                results.Add(new Result(null, afterSource));
+            }
+        }
+
+        return results;
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/RecipeScheduler.cs
@@ -40,18 +40,14 @@ public static class RecipeScheduler
         Dictionary<Guid, Result> allResults,
         ExecutionContext ctx)
     {
-        var recipeList = recipe.GetRecipeList();
-        if (recipeList.Count > 0)
+        // Pre-order traversal, as in Java's RecipeRunCycle/RecipeStack: the recipe's own
+        // visitor (or scan/generate/edit lifecycle) runs first, then its recipe list.
+        var results = EditSources(recipe, currentSources, ctx);
+        ApplyResults(results, currentSources, allResults);
+
+        foreach (var subRecipe in recipe.GetRecipeList())
         {
-            foreach (var subRecipe in recipeList)
-            {
-                RunRecipe(subRecipe, currentSources, allResults, ctx);
-            }
-        }
-        else
-        {
-            var results = EditSources(recipe, currentSources, ctx);
-            ApplyResults(results, currentSources, allResults);
+            RunRecipe(subRecipe, currentSources, allResults, ctx);
         }
     }
 
@@ -119,7 +115,26 @@ public static class RecipeScheduler
         {
             if (result.Before != null)
             {
-                allResults[result.Before.Id] = result;
+                // An earlier recipe may already have recorded a result for this file, in which
+                // case result.Before is that recipe's after tree. The final result must pair
+                // the file's original state with the latest after.
+                if (allResults.TryGetValue(result.Before.Id, out var existing))
+                {
+                    if (existing.Before == null && result.After == null)
+                    {
+                        // A generated file that a later recipe deleted never existed
+                        allResults.Remove(result.Before.Id);
+                    }
+                    else
+                    {
+                        allResults[result.Before.Id] = new Result(existing.Before, result.After);
+                    }
+                }
+                else
+                {
+                    allResults[result.Before.Id] = result;
+                }
+
                 if (result.After != null)
                 {
                     for (var i = 0; i < currentSources.Count; i++)


### PR DESCRIPTION
### Motivation

The C# `RecipeScheduler` treated a non-empty recipe list as exclusive: it ran only the children and never the recipe's own visitor or scan/generate/edit lifecycle. An `IScanningRecipe` that also returns a recipe list therefore never scanned, never generated, and never edited itself — the same silent no-op hazard class as #8385 (the TypeScript analog, fixed in #8386) — and a plain recipe with both a visitor and sub-recipes lost its own visitor.

Beyond fixing that, the scheduler is restructured to mirror the TypeScript scheduler (`rewrite-javascript/rewrite/src/run.ts` as of #8386), which is itself the simple subset of Java's `RecipeRunCycle`. Sharing the structure keeps the implementations easy to align, and the phase model fixes two further behaviors the old per-recipe recursion got wrong: sibling scanners observed trees an earlier sibling had already edited, and generated files were never visited by any editor.

### Summary

- The scheduler is now phased, as in the TypeScript scheduler: when any recipe in the tree scans, every scanner visits every file first, then generated files are collected, and only then do editors run — over the existing files and then over the generated files, the latter including the generating recipe's own editor.
- Traversal is a pre-order fold over the recipe tree (`RecurseRecipeList`, the analog of the TS function of the same name): the recipe itself first, then its recipe list. A null result short-circuits the fold, which is how a deleted file stops being visited. Because the edit fold chains all recipes over one file at a time, `Result.Before` is always the originally parsed source no matter how many recipes edited the file.
- Recipe lists and scanning accumulators are resolved once per run and cached by instance (the analog of the TS `WeakMap`), since recipes commonly construct sub-recipes inline in `GetRecipeList()` and the scan and edit phases must observe the same accumulator.
- Deliberate differences from the TS code, for C# idiom: no streaming/progress path (`List<SourceFile>` in, `List<Result>` out), results are only emitted for actual changes rather than for every file, and recipes whose visitor is the default no-op (typically composites) skip the visit entirely.

### Test plan

- [x] New `OpenRewrite.Tests/Core/RecipeSchedulerTests.cs` (xUnit, 10 tests, scenarios adapted from `rewrite-javascript/rewrite/test/run.test.ts` on `tim/reykjavik-v1`): a scanning recipe with a recipe list runs its own scanner/editor and generates; a plain recipe with both a visitor and sub-recipes runs both (own visitor first); a nested scanner sees every file before any edit; scanners see sources before any sibling edits them; generated files are visited by the generating recipe's own editor; sub-recipe instances are stable across phases; `Result.Before` is the originally parsed source after chained edits and after edit-then-delete; a deleted file is not visited by later recipes.
- [x] Each behavioral test was written first and observed failing against the scheduler before the corresponding fix.
- [x] Full C# suite: `dotnet test` — 1972 passed, 0 failed (RPC-fixture tests run with the classpath from `./gradlew :rewrite-csharp:rpcTestClasspath`).