### PR TITLE
Implement the scan/generate/edit lifecycle in the Python-native recipe scheduler

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/execution.py
+++ b/rewrite-python/rewrite/src/rewrite/execution.py
@@ -67,6 +67,10 @@ class LargeSourceSet(ABC):
         ...
 
     @abstractmethod
+    def generate(self, ls: List[SourceFile]) -> LargeSourceSet:
+        ...
+
+    @abstractmethod
     def get_changeset(self) -> List[Result]:
         ...
 
@@ -89,11 +93,17 @@ class InMemoryLargeSourceSet(LargeSourceSet):
             mapped_source = map(source)
             if mapped_source is not None:
                 mapped.append(mapped_source)
-                changed = mapped_source is not source
+                if mapped_source is not source:
+                    changed = True
             else:
                 deleted.append(source)
                 changed = True
         return self if not changed else InMemoryLargeSourceSet(mapped, deleted, self._initial_state or self)
+
+    def generate(self, ls: List[SourceFile]) -> LargeSourceSet:
+        if not ls:
+            return self
+        return InMemoryLargeSourceSet(self._sources + ls, list(self._deletions), self._initial_state or self)
 
     def get_changeset(self) -> List[Result]:
         source_file_by_id = {sf.id: sf for sf in (self._initial_state or self)._sources}

--- a/rewrite-python/rewrite/src/rewrite/recipe.py
+++ b/rewrite-python/rewrite/src/rewrite/recipe.py
@@ -20,6 +20,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, fields, is_dataclass
 from typing import (
     Any,
+    Callable,
     List,
     Optional,
     TYPE_CHECKING,
@@ -263,6 +264,10 @@ class Recipe(ABC):
         """
         Run this recipe on a set of source files.
 
+        Executes the scan/generate/edit lifecycle: every source file is
+        scanned by every ScanningRecipe in the recipe tree, then new files
+        are generated, then all files (including generated ones) are edited.
+
         Args:
             before: The source files to transform
             ctx: The execution context
@@ -272,7 +277,39 @@ class Recipe(ABC):
         """
         from rewrite.visitor import Cursor
 
-        return _RecipeRun(ctx, Cursor(None, Cursor.ROOT_VALUE)).run(self, before).get_changeset()
+        cursor = Cursor(None, Cursor.ROOT_VALUE)
+        recipe_lists: _RecipeLists = {}
+
+        after = before
+        if _has_scanning_recipe(self, recipe_lists):
+            # Phase 1: scan each file. Scanning must not modify the tree, so the
+            # visit result is discarded and the original file is passed on to the
+            # next recipe in the list. Returning None here would abort traversal
+            # of the remainder of the recipe list, leaving nested scanners unrun.
+            def scan_one(recipe: Recipe, b: SourceFile) -> SourceFile:
+                if isinstance(recipe, ScanningRecipe):
+                    recipe.scanner(recipe.accumulator(cursor, ctx)).visit(b, ctx, cursor)
+                return b
+
+            # edit() is used only to iterate the source files; scan_one returns
+            # each file unchanged, so the returned source set is the same
+            after.edit(lambda b: _recurse_recipe_list(self, b, recipe_lists, scan_one))
+
+            # Phase 2: collect generated files
+            def generate_one(recipe: Recipe, generated: List[SourceFile]) -> List[SourceFile]:
+                if isinstance(recipe, ScanningRecipe):
+                    generated.extend(recipe.generate(recipe.accumulator(cursor, ctx), ctx))
+                return generated
+
+            after = after.generate(_recurse_recipe_list(self, [], recipe_lists, generate_one))
+
+        # Phase 3: edit all files, including generated ones. An editor returning
+        # None deletes the file and stops later recipes from visiting it.
+        def edit_one(recipe: Recipe, b: SourceFile) -> Optional[SourceFile]:
+            return recipe.editor().visit(b, ctx, cursor)
+
+        after = after.edit(lambda b: _recurse_recipe_list(self, b, recipe_lists, edit_one))
+        return after.get_changeset()
 
 
 T = TypeVar("T")
@@ -385,76 +422,44 @@ class ScanningRecipe(Recipe, Generic[T], ABC):
         return _AccumulatorEditor()
 
 
-class _RecipeRun:
+# Recipes commonly instantiate their sub-recipes inside recipe_list(), so calling it more
+# than once yields different instances. A scanning sub-recipe would then hold a different
+# accumulator in every phase and for every source file. Resolving each recipe list once per
+# run keeps sub-recipe identity, and therefore accumulator identity, stable. Keyed by id()
+# rather than by recipe (dataclass-based recipes are unhashable); every keyed recipe stays
+# referenced through the cached lists (the root through the caller), so ids cannot be
+# recycled during the run.
+_RecipeLists = dict[int, List[Recipe]]
+
+
+def _sub_recipes(recipe: Recipe, recipe_lists: _RecipeLists) -> List[Recipe]:
+    resolved = recipe_lists.get(id(recipe))
+    if resolved is None:
+        resolved = recipe.recipe_list()
+        recipe_lists[id(recipe)] = resolved
+    return resolved
+
+
+def _has_scanning_recipe(recipe: Recipe, recipe_lists: _RecipeLists) -> bool:
+    if isinstance(recipe, ScanningRecipe):
+        return True
+    return any(_has_scanning_recipe(r, recipe_lists) for r in _sub_recipes(recipe, recipe_lists))
+
+
+def _recurse_recipe_list(
+    recipe: Recipe,
+    initial: T,
+    recipe_lists: _RecipeLists,
+    fn: Callable[[Recipe, T], Optional[T]],
+) -> Optional[T]:
+    """Apply fn to every recipe in the tree in pre-order, threading the value through.
+
+    A None result short-circuits the remaining traversal (a deleted file
+    stops being visited).
     """
-    A single scheduled run of a recipe over a set of source files.
-
-    Mirrors the Java ``RecipeRunCycle`` lifecycle: every source file is
-    scanned by every ``ScanningRecipe`` in the recipe tree, then new files
-    are generated, then all files (including generated ones) are edited.
-    """
-
-    def __init__(self, ctx: ExecutionContext, root: Cursor):
-        self._ctx = ctx
-        self._root = root
-        # Recipes commonly instantiate their sub-recipes inline in recipe_list(),
-        # so each call yields new instances. Resolving each recipe's list once per
-        # run keeps sub-recipe identity — and therefore scanning-recipe accumulator
-        # identity — stable across the scan, generate, and edit phases. Keyed by
-        # id() because dataclass-based recipes are unhashable; every keyed recipe
-        # stays referenced through the cached lists (the root through the caller),
-        # so ids cannot be recycled during the run.
-        self._recipe_lists: dict[int, List[Recipe]] = {}
-
-    def run(self, recipe: Recipe, before: LargeSourceSet) -> LargeSourceSet:
-        after = before
-        if self._has_scanning_recipe(recipe):
-            # edit() is used only to iterate the source files; _scan returns
-            # each file unchanged, so the returned source set is the same
-            after.edit(lambda source: self._scan(recipe, source))
-            generated = self._recurse(recipe, [], self._generate_one)
-            after = after.generate(generated)
-        return after.edit(lambda source: self._recurse(recipe, source, self._edit_one))
-
-    def _scan(self, recipe: Recipe, source: SourceFile) -> SourceFile:
-        return self._recurse(recipe, source, self._scan_one)
-
-    def _scan_one(self, recipe: Recipe, source: SourceFile) -> SourceFile:
-        if isinstance(recipe, ScanningRecipe):
-            scanner = recipe.scanner(recipe.accumulator(self._root, self._ctx))
-            # Scanning must not modify the tree, so the visit result is discarded
-            # and the original file is passed on to the next recipe; in particular
-            # a scanner returning None must not halt the traversal.
-            scanner.visit(source, self._ctx, self._root)
-        return source
-
-    def _generate_one(self, recipe: Recipe, generated: List[SourceFile]) -> List[SourceFile]:
-        if isinstance(recipe, ScanningRecipe):
-            generated.extend(recipe.generate(recipe.accumulator(self._root, self._ctx), self._ctx))
-        return generated
-
-    def _edit_one(self, recipe: Recipe, source: SourceFile) -> Optional[SourceFile]:
-        # None deletes the file and, via _recurse's short-circuit, stops
-        # later recipes from visiting it
-        return recipe.editor().visit(source, self._ctx, self._root)
-
-    def _recurse(self, recipe: Recipe, t, fn):
-        """Apply fn to every recipe in the tree in pre-order, threading t through."""
-        t = fn(recipe, t)
-        for sub_recipe in self._sub_recipes(recipe):
-            if t is None:
-                return None
-            t = self._recurse(sub_recipe, t, fn)
-        return t
-
-    def _sub_recipes(self, recipe: Recipe) -> List[Recipe]:
-        resolved = self._recipe_lists.get(id(recipe))
-        if resolved is None:
-            resolved = recipe.recipe_list()
-            self._recipe_lists[id(recipe)] = resolved
-        return resolved
-
-    def _has_scanning_recipe(self, recipe: Recipe) -> bool:
-        if isinstance(recipe, ScanningRecipe):
-            return True
-        return any(self._has_scanning_recipe(r) for r in self._sub_recipes(recipe))
+    t = fn(recipe, initial)
+    for sub_recipe in _sub_recipes(recipe, recipe_lists):
+        if t is None:
+            return None
+        t = _recurse_recipe_list(sub_recipe, t, recipe_lists, fn)
+    return t

--- a/rewrite-python/rewrite/src/rewrite/recipe.py
+++ b/rewrite-python/rewrite/src/rewrite/recipe.py
@@ -286,14 +286,14 @@ class Recipe(ABC):
             # visit result is discarded and the original file is passed on to the
             # next recipe in the list. Returning None here would abort traversal
             # of the remainder of the recipe list, leaving nested scanners unrun.
-            def scan_one(recipe: Recipe, b: SourceFile) -> SourceFile:
+            def scan_one(recipe: Recipe, source: SourceFile) -> SourceFile:
                 if isinstance(recipe, ScanningRecipe):
-                    recipe.scanner(recipe.accumulator(cursor, ctx)).visit(b, ctx, cursor)
-                return b
+                    recipe.scanner(recipe.accumulator(cursor, ctx)).visit(source, ctx, cursor)
+                return source
 
             # edit() is used only to iterate the source files; scan_one returns
             # each file unchanged, so the returned source set is the same
-            after.edit(lambda b: _recurse_recipe_list(self, b, recipe_lists, scan_one))
+            after.edit(lambda source: _recurse_recipe_list(self, source, recipe_lists, scan_one))
 
             # Phase 2: collect generated files
             def generate_one(recipe: Recipe, generated: List[SourceFile]) -> List[SourceFile]:
@@ -305,10 +305,10 @@ class Recipe(ABC):
 
         # Phase 3: edit all files, including generated ones. An editor returning
         # None deletes the file and stops later recipes from visiting it.
-        def edit_one(recipe: Recipe, b: SourceFile) -> Optional[SourceFile]:
-            return recipe.editor().visit(b, ctx, cursor)
+        def edit_one(recipe: Recipe, source: SourceFile) -> Optional[SourceFile]:
+            return recipe.editor().visit(source, ctx, cursor)
 
-        after = after.edit(lambda b: _recurse_recipe_list(self, b, recipe_lists, edit_one))
+        after = after.edit(lambda source: _recurse_recipe_list(self, source, recipe_lists, edit_one))
         return after.get_changeset()
 
 
@@ -388,15 +388,13 @@ class ScanningRecipe(Recipe, Generic[T], ABC):
         per-instance key, so all phases of a run share it while separate runs
         (each with a fresh root cursor) start from initial_value().
         """
-        root = cursor
-        while root.parent is not None:
-            root = root.parent
+        root = cursor.root
         key = f"org.openrewrite.recipe.acc.{id(self)}"
-        if root.messages is None or key not in root.messages:
-            root.put_message(key, self.initial_value(ctx))
-        messages = root.messages
-        assert messages is not None
-        return cast(T, messages[key])
+        if root.messages is not None and key in root.messages:
+            return cast(T, root.messages[key])
+        acc = self.initial_value(ctx)
+        root.put_message(key, acc)
+        return acc
 
     def editor(self) -> TreeVisitor[Any, ExecutionContext]:
         """
@@ -429,7 +427,7 @@ class ScanningRecipe(Recipe, Generic[T], ABC):
 # rather than by recipe (dataclass-based recipes are unhashable); every keyed recipe stays
 # referenced through the cached lists (the root through the caller), so ids cannot be
 # recycled during the run.
-_RecipeLists = dict[int, List[Recipe]]
+_RecipeLists = dict[int, list[Recipe]]
 
 
 def _sub_recipes(recipe: Recipe, recipe_lists: _RecipeLists) -> List[Recipe]:

--- a/rewrite-python/rewrite/src/rewrite/recipe.py
+++ b/rewrite-python/rewrite/src/rewrite/recipe.py
@@ -25,6 +25,7 @@ from typing import (
     TYPE_CHECKING,
     TypeVar,
     Generic,
+    cast,
 )
 
 if TYPE_CHECKING:
@@ -271,22 +272,7 @@ class Recipe(ABC):
         """
         from rewrite.visitor import Cursor
 
-        lss = self._run_internal(before, ctx, Cursor(None, Cursor.ROOT_VALUE))
-        return lss.get_changeset()
-
-    def _run_internal(
-        self, before: LargeSourceSet, ctx: ExecutionContext, root: Cursor
-    ) -> LargeSourceSet:
-        """
-        Internal implementation of recipe execution.
-
-        Applies this recipe's editor to each source file, then recursively
-        applies any child recipes from recipe_list().
-        """
-        after = before.edit(lambda source: self.editor().visit(source, ctx, root))
-        for recipe in self.recipe_list():
-            after = recipe._run_internal(after, ctx, root)
-        return after
+        return _RecipeRun(ctx, Cursor(None, Cursor.ROOT_VALUE)).run(self, before).get_changeset()
 
 
 T = TypeVar("T")
@@ -357,14 +343,118 @@ class ScanningRecipe(Recipe, Generic[T], ABC):
         """
         return []
 
+    def accumulator(self, cursor: Cursor, ctx: ExecutionContext) -> T:
+        """
+        Get this recipe instance's accumulator, creating it on first access.
+
+        The accumulator is stored in the root cursor's messages under a
+        per-instance key, so all phases of a run share it while separate runs
+        (each with a fresh root cursor) start from initial_value().
+        """
+        root = cursor
+        while root.parent is not None:
+            root = root.parent
+        key = f"org.openrewrite.recipe.acc.{id(self)}"
+        if root.messages is None or key not in root.messages:
+            root.put_message(key, self.initial_value(ctx))
+        messages = root.messages
+        assert messages is not None
+        return cast(T, messages[key])
+
     def editor(self) -> TreeVisitor[Any, ExecutionContext]:
         """
-        Internal implementation - delegates to scanner and editor_with_data.
+        Internal implementation - delegates to editor_with_data() with the
+        current run's accumulator.
 
         Do not override this method. Override scanner() and editor_with_data()
         instead.
         """
-        # This will be set up by the recipe scheduler
         from rewrite.visitor import TreeVisitor
 
-        return TreeVisitor.noop()
+        recipe = self
+
+        class _AccumulatorEditor(TreeVisitor):
+            _delegate: Optional[TreeVisitor[Any, ExecutionContext]] = None
+
+            def visit(self, tree, p, parent=None):
+                if self._delegate is None:
+                    cursor = parent if parent is not None else self._cursor
+                    self._delegate = recipe.editor_with_data(recipe.accumulator(cursor, p))
+                return self._delegate.visit(tree, p, parent)
+
+        return _AccumulatorEditor()
+
+
+class _RecipeRun:
+    """
+    A single scheduled run of a recipe over a set of source files.
+
+    Mirrors the Java ``RecipeRunCycle`` lifecycle: every source file is
+    scanned by every ``ScanningRecipe`` in the recipe tree, then new files
+    are generated, then all files (including generated ones) are edited.
+    """
+
+    def __init__(self, ctx: ExecutionContext, root: Cursor):
+        self._ctx = ctx
+        self._root = root
+        # Recipes commonly instantiate their sub-recipes inline in recipe_list(),
+        # so each call yields new instances. Resolving each recipe's list once per
+        # run keeps sub-recipe identity — and therefore scanning-recipe accumulator
+        # identity — stable across the scan, generate, and edit phases. Keyed by
+        # id() because dataclass-based recipes are unhashable; every keyed recipe
+        # stays referenced through the cached lists (the root through the caller),
+        # so ids cannot be recycled during the run.
+        self._recipe_lists: dict[int, List[Recipe]] = {}
+
+    def run(self, recipe: Recipe, before: LargeSourceSet) -> LargeSourceSet:
+        after = before
+        if self._has_scanning_recipe(recipe):
+            # edit() is used only to iterate the source files; _scan returns
+            # each file unchanged, so the returned source set is the same
+            after.edit(lambda source: self._scan(recipe, source))
+            generated = self._recurse(recipe, [], self._generate_one)
+            after = after.generate(generated)
+        return after.edit(lambda source: self._recurse(recipe, source, self._edit_one))
+
+    def _scan(self, recipe: Recipe, source: SourceFile) -> SourceFile:
+        return self._recurse(recipe, source, self._scan_one)
+
+    def _scan_one(self, recipe: Recipe, source: SourceFile) -> SourceFile:
+        if isinstance(recipe, ScanningRecipe):
+            scanner = recipe.scanner(recipe.accumulator(self._root, self._ctx))
+            # Scanning must not modify the tree, so the visit result is discarded
+            # and the original file is passed on to the next recipe; in particular
+            # a scanner returning None must not halt the traversal.
+            scanner.visit(source, self._ctx, self._root)
+        return source
+
+    def _generate_one(self, recipe: Recipe, generated: List[SourceFile]) -> List[SourceFile]:
+        if isinstance(recipe, ScanningRecipe):
+            generated.extend(recipe.generate(recipe.accumulator(self._root, self._ctx), self._ctx))
+        return generated
+
+    def _edit_one(self, recipe: Recipe, source: SourceFile) -> Optional[SourceFile]:
+        # None deletes the file and, via _recurse's short-circuit, stops
+        # later recipes from visiting it
+        return recipe.editor().visit(source, self._ctx, self._root)
+
+    def _recurse(self, recipe: Recipe, t, fn):
+        """Apply fn to every recipe in the tree in pre-order, threading t through."""
+        t = fn(recipe, t)
+        for sub_recipe in self._sub_recipes(recipe):
+            if t is None:
+                return None
+            t = self._recurse(sub_recipe, t, fn)
+        return t
+
+    def _sub_recipes(self, recipe: Recipe) -> List[Recipe]:
+        resolved = self._recipe_lists.get(id(recipe))
+        if resolved is None:
+            resolved = recipe.recipe_list()
+            self._recipe_lists[id(recipe)] = resolved
+        return resolved
+
+    def _has_scanning_recipe(self, recipe: Recipe) -> bool:
+        if isinstance(recipe, ScanningRecipe):
+            return True
+        return any(self._has_scanning_recipe(r) for r in self._sub_recipes(recipe))

--- a/rewrite-python/rewrite/src/rewrite/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/visitor.py
@@ -34,6 +34,14 @@ class Cursor:
             object.__setattr__(self, 'messages', messages)
         messages[key] = value
 
+    @property
+    def root(self) -> Cursor:
+        """The top-most cursor in the parent chain."""
+        c = self
+        while c.parent is not None:
+            c = c.parent
+        return c
+
     def parent_tree_cursor(self) -> Cursor:
         c = self.parent
         while c is not None:

--- a/rewrite-python/rewrite/tests/test_recipe_run.py
+++ b/rewrite-python/rewrite/tests/test_recipe_run.py
@@ -1,0 +1,331 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the native recipe scheduler in ``Recipe.run``.
+
+Ports the scan/generate/edit lifecycle test suite from
+``rewrite-javascript/rewrite/test/run.test.ts``.
+"""
+
+import ast
+from pathlib import Path
+from typing import Any, Dict, List
+
+from rewrite import (
+    ExecutionContext,
+    InMemoryExecutionContext,
+    InMemoryLargeSourceSet,
+    Recipe,
+    ScanningRecipe,
+    TreeVisitor,
+)
+from rewrite.java import tree as j
+from rewrite.python._parser_visitor import ParserVisitor
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
+
+
+class Composite(Recipe):
+    """A plain composite recipe that only contributes a recipe list."""
+
+    def __init__(self, children: List[Recipe]):
+        self._children = children
+
+    @property
+    def name(self) -> str:
+        return "org.openrewrite.test.composite"
+
+    @property
+    def display_name(self) -> str:
+        return "Composite"
+
+    @property
+    def description(self) -> str:
+        return "A plain composite recipe that only contributes a recipe list."
+
+    def recipe_list(self) -> List[Recipe]:
+        return self._children
+
+
+class ScanningEditor(ScanningRecipe[Dict[str, int]]):
+    """Counts source files during scanning; appends the count to each string literal during editing."""
+
+    @property
+    def name(self) -> str:
+        return "org.openrewrite.test.scanning-editor"
+
+    @property
+    def display_name(self) -> str:
+        return "Scanning editor"
+
+    @property
+    def description(self) -> str:
+        return "Appends the count of source files to each string literal."
+
+    def initial_value(self, ctx: ExecutionContext) -> Dict[str, int]:
+        return {"count": 0}
+
+    def scanner(self, acc: Dict[str, int]) -> TreeVisitor[Any, ExecutionContext]:
+        class _Scanner(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu, p):
+                acc["count"] += 1
+                return cu
+
+        return _Scanner()
+
+    def editor_with_data(self, acc: Dict[str, int]) -> TreeVisitor[Any, ExecutionContext]:
+        return _AppendToLiteral(f" (count: {acc['count']})")
+
+
+class _AppendToLiteral(PythonVisitor[ExecutionContext]):
+    def __init__(self, suffix: str):
+        self._suffix = suffix
+
+    def visit_literal(self, literal: j.Literal, p: ExecutionContext) -> j.J:
+        if isinstance(literal.value, str) and literal.value_source:
+            new_value = literal.value + self._suffix
+            quote = literal.value_source[0]
+            return literal.replace(value=new_value, value_source=f"{quote}{new_value}{quote}")
+        return literal
+
+
+class InliningComposite(Recipe):
+    """A plain composite that instantiates its sub-recipes inside recipe_list()."""
+
+    @property
+    def name(self) -> str:
+        return "org.openrewrite.test.inlining-composite"
+
+    @property
+    def display_name(self) -> str:
+        return "Inlining composite"
+
+    @property
+    def description(self) -> str:
+        return "A plain composite that instantiates its sub-recipes inside recipe_list()."
+
+    def recipe_list(self) -> List[Recipe]:
+        return [ScanningEditor()]
+
+
+class Exclaim(Recipe):
+    """Appends an exclamation mark to each string literal."""
+
+    @property
+    def name(self) -> str:
+        return "org.openrewrite.test.exclaim"
+
+    @property
+    def display_name(self) -> str:
+        return "Exclaim"
+
+    @property
+    def description(self) -> str:
+        return "Appends an exclamation mark to each string literal."
+
+    def editor(self) -> TreeVisitor[Any, ExecutionContext]:
+        return _AppendToLiteral("!")
+
+
+class DeleteFile(Recipe):
+    """Deletes every source file it visits."""
+
+    @property
+    def name(self) -> str:
+        return "org.openrewrite.test.delete-file"
+
+    @property
+    def display_name(self) -> str:
+        return "Delete file"
+
+    @property
+    def description(self) -> str:
+        return "Deletes every source file it visits."
+
+    def editor(self) -> TreeVisitor[Any, ExecutionContext]:
+        class _Deleter(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu, p):
+                return None
+
+        return _Deleter()
+
+
+def _parse(*sources: str) -> List[CompilationUnit]:
+    parsed = []
+    for i, source in enumerate(sources):
+        cu = ParserVisitor(source, None, None).visit(ast.parse(source))
+        parsed.append(cu.replace(source_path=Path(f"file{i}.py")))
+    return parsed
+
+
+class TestScanningPhaseTraversal:
+    def test_scanning_recipe_one_level_under_a_plain_composite(self):
+        spec = RecipeSpec(recipe=Composite([ScanningEditor()]), type_attribution=False)
+        spec.rewrite_run(
+            python('s = "hello"', 's = "hello (count: 1)"')
+        )
+
+    def test_scanning_recipe_several_levels_deep(self):
+        spec = RecipeSpec(
+            recipe=Composite([Composite([Composite([ScanningEditor()])])]),
+            type_attribution=False,
+        )
+        spec.rewrite_run(
+            python('s = "hello"', 's = "hello (count: 1)"')
+        )
+
+    def test_scanning_recipe_positioned_after_a_plain_sibling(self):
+        # The root is itself a scanning recipe, so traversal starts out fine. The plain
+        # sibling in front of the scanning recipe must not abort the recipe list.
+        class ScanningRoot(ScanningRecipe[Dict[str, int]]):
+            @property
+            def name(self) -> str:
+                return "org.openrewrite.test.scanning-root"
+
+            @property
+            def display_name(self) -> str:
+                return "Scanning root"
+
+            @property
+            def description(self) -> str:
+                return "A scanning recipe that contributes a recipe list."
+
+            def initial_value(self, ctx: ExecutionContext) -> Dict[str, int]:
+                return {}
+
+            def recipe_list(self) -> List[Recipe]:
+                return [Composite([]), ScanningEditor()]
+
+        spec = RecipeSpec(recipe=ScanningRoot(), type_attribution=False)
+        spec.rewrite_run(
+            python('s = "hello"', 's = "hello (count: 1)"')
+        )
+
+    def test_scanning_recipe_instantiated_inside_recipe_list(self):
+        # The recipe list is resolved once per run, so the scan phase and the edit phase
+        # see the same sub-recipe instance and therefore the same accumulator.
+        spec = RecipeSpec(recipe=InliningComposite(), type_attribution=False)
+        spec.rewrite_run(
+            python('s = "alpha"', 's = "alpha (count: 2)"'),
+            python('s = "beta"', 's = "beta (count: 2)"'),
+        )
+
+    def test_accumulator_sees_every_file_before_any_file_is_edited(self):
+        spec = RecipeSpec(recipe=Composite([ScanningEditor()]), type_attribution=False)
+        spec.rewrite_run(
+            python('s = "alpha"', 's = "alpha (count: 3)"'),
+            python('s = "beta"', 's = "beta (count: 3)"'),
+            python('s = "gamma"', 's = "gamma (count: 3)"'),
+        )
+
+    def test_scanner_returning_none_does_not_halt_the_run(self):
+        # Scanning must not modify the tree, so the visit result is discarded entirely,
+        # matching the Java RecipeRunCycle, which keeps the original source file.
+        class DeletingScanner(ScanningRecipe[Dict[str, int]]):
+            @property
+            def name(self) -> str:
+                return "org.openrewrite.test.deleting-scanner"
+
+            @property
+            def display_name(self) -> str:
+                return "Deleting scanner"
+
+            @property
+            def description(self) -> str:
+                return "A scanner whose visitor returns None."
+
+            def initial_value(self, ctx: ExecutionContext) -> Dict[str, int]:
+                return {}
+
+            def scanner(self, acc: Dict[str, int]) -> TreeVisitor[Any, ExecutionContext]:
+                class _Deleter(PythonVisitor[ExecutionContext]):
+                    def visit_compilation_unit(self, cu, p):
+                        return None
+
+                return _Deleter()
+
+        spec = RecipeSpec(
+            recipe=Composite([DeletingScanner(), ScanningEditor()]),
+            type_attribution=False,
+        )
+        spec.rewrite_run(
+            python('s = "hello"', 's = "hello (count: 1)"')
+        )
+
+
+class TestGeneratePhase:
+    def test_generated_file_is_edited_by_later_recipes(self):
+        class Generating(ScanningRecipe[Dict[str, int]]):
+            @property
+            def name(self) -> str:
+                return "org.openrewrite.test.generating"
+
+            @property
+            def display_name(self) -> str:
+                return "Generating"
+
+            @property
+            def description(self) -> str:
+                return "Generates a new source file."
+
+            def initial_value(self, ctx: ExecutionContext) -> Dict[str, int]:
+                return {}
+
+            def generate(self, acc, ctx):
+                return _parse('s = "generated"')
+
+        before = _parse("x = 1")
+        results = Composite([Generating(), Exclaim()]).run(
+            InMemoryLargeSourceSet(before), InMemoryExecutionContext()
+        )
+
+        generated = [r for r in results if r._before is None]
+        assert len(generated) == 1
+        assert generated[0]._after.print_all() == 's = "generated!"'
+
+
+class TestEditPhaseShortCircuit:
+    def test_deleted_file_stops_being_visited(self):
+        before = _parse('s = "hello"')
+        results = Composite([DeleteFile(), Exclaim()]).run(
+            InMemoryLargeSourceSet(before), InMemoryExecutionContext()
+        )
+
+        assert len(results) == 1
+        assert results[0]._before is before[0]
+        assert results[0]._after is None
+
+    def test_deleted_file_stops_being_visited_when_the_run_also_scans(self):
+        before = _parse('s = "hello"')
+        results = Composite([ScanningEditor(), DeleteFile(), Exclaim()]).run(
+            InMemoryLargeSourceSet(before), InMemoryExecutionContext()
+        )
+
+        assert len(results) == 1
+        assert results[0]._before is before[0]
+        assert results[0]._after is None
+
+
+class TestMultiFileEdit:
+    def test_edit_of_earlier_file_survives_unchanged_later_file(self):
+        # The second file contains no string literal, so only the first is edited.
+        before = _parse('s = "hello"', "x = 1")
+        results = Exclaim().run(
+            InMemoryLargeSourceSet(before), InMemoryExecutionContext()
+        )
+
+        changed = [r for r in results if r._after is not None and r._after is not r._before]
+        assert len(changed) == 1
+        assert changed[0]._after.print_all() == 's = "hello!"'


### PR DESCRIPTION
- Related to #8385 — this is the Python analog of #8386, which fixed the same class of bug in the TypeScript scheduler.

## Motivation

A `ScanningRecipe` run through the Python-native scheduler (`Recipe.run`, as exercised by `RecipeSpec.rewrite_run`) silently no-oped: `Recipe.run` only invoked `editor()` for each recipe in the tree, there was no scan or generate phase at all, and `ScanningRecipe.editor()` returned a noop visitor with a comment deferring to a recipe scheduler that did not exist. The accumulator therefore stayed at `initial_value(...)` for the whole run and the edit phase produced no changes — with no error or warning, so a `RecipeSpec` test of such a recipe quietly read as "the recipe correctly made no change". This affected every `ScanningRecipe`, top-level or nested in a composite. The Java-orchestrated RPC path (`rewrite/rpc/server.py`) already implements the lifecycle correctly and is untouched.

## Summary

* `Recipe.run` now executes the scan/generate/edit lifecycle, mirroring the Java `RecipeRunCycle`: every source file is scanned by every `ScanningRecipe` in the recipe tree, then each scanning recipe's `generate(acc, ctx)` output is added to the source set, then all files (including generated ones) are edited. Every phase walks the entire recipe tree, so plain composites and plain siblings never stop traversal.
* The scan phase discards the scanner's visit result and always passes the original file on, matching `RecipeRunCycle.scanSources` — a scanner returning `None` must not halt the run. The edit phase keeps the short-circuit: an editor returning `None` deletes the file and stops later recipes from visiting it.
* Each recipe's `recipe_list()` is resolved once per run, and the accumulator is created once per run and stored in the root cursor's messages under a per-instance key (`ScanningRecipe.accumulator(cursor, ctx)`, mirroring the TypeScript implementation). Recipes commonly instantiate sub-recipes inline in `recipe_list()`, so without this the scan and edit phases would see different instances and different accumulators.
* `ScanningRecipe.editor()` now delegates to `editor_with_data(...)` with the current run's accumulator instead of returning a noop.
* `LargeSourceSet` gained a `generate(files)` method for adding generated source files; generated files appear in the changeset as `Result(None, file)`.
* Fixed a latent bug in `InMemoryLargeSourceSet.edit()`: the per-file `changed` flag was overwritten instead of accumulated, so an earlier file's edit (or deletion) was discarded whenever the last mapped file was unchanged.

## Test plan

- [x] New `tests/test_recipe_run.py` ports the #8386 suite (minus the `onComplete` test, which has no Python counterpart): scanning recipe one and three levels under plain composites, positioned after a plain sibling under a scanning root, instantiated inside `recipe_list()`, accumulator seeing every file before any edit, a scanner returning `None` not halting the run, and two edit-phase deletion short-circuit tests; plus a generated-file-is-edited test and a multi-file edit test covering the `changed`-flag fix
- [x] Confirmed the new tests fail against the previous scheduler first (8 of 10; the two that already passed are exactly the deletion short-circuit tests, matching the TypeScript result)
- [x] Full non-RPC suite: `pytest tests/ --ignore=tests/rpc` — 1836 passed, 7 skipped
- [x] RPC suite: `pytest tests/rpc/ --timeout=120` — 128 passed; the 4 failures in `test_java_recipes.py` are pre-existing Java-side request timeouts that fail identically on `main` without this change
