### PR TITLE
Do not fabricate an owning class for package-qualified lowercase FQNs in `ShallowClass.build()`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTypeTest.java
@@ -203,4 +203,24 @@ class JavaTypeTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void shallowClassOwningClassInference() {
+        JavaType.ShallowClass nested = JavaType.ShallowClass.build("java.util.Map.Entry");
+        assertThat(nested.getOwningClass()).isNotNull();
+        assertThat(nested.getOwningClass().getFullyQualifiedName()).isEqualTo("java.util.Map");
+
+        // Lowercase class names (e.g. Python's builtins.list) are package-qualified, not nested
+        JavaType.ShallowClass lowercase = JavaType.ShallowClass.build("builtins.list");
+        assertThat(lowercase.getOwningClass()).isNull();
+        assertThat(lowercase.getPackageName()).isEqualTo("builtins");
+        assertThat(lowercase.getClassName()).isEqualTo("list");
+
+        assertThat(JavaType.ShallowClass.build("Foo").getOwningClass()).isNull();
+        assertThat(JavaType.ShallowClass.build("list").getOwningClass()).isNull();
+
+        // Default-package nested names get no owning class: ChangeType's plain-rename
+        // path depends on this (see ChangeTypeTest.doesNotModifyInnerClassesIfIgnoreDefinitionTrue)
+        assertThat(JavaType.ShallowClass.build("Test.InnerB").getOwningClass()).isNull();
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -680,7 +680,9 @@ public interface JavaType {
                 prev = c;
             }
 
-            if (lastDelimiter > firstClassNameIndex) {
+            // The first uppercase-led segment marks where the class-name chain starts; a
+            // name without one (e.g. Python's `builtins.list`) is package-qualified, not nested.
+            if (firstClassNameIndex > 0 && lastDelimiter > firstClassNameIndex) {
                 owningClass = build(fullyQualifiedName.substring(0, lastDelimiter));
             }
 


### PR DESCRIPTION
## Motivation

`JavaType.ShallowClass.build(String)` infers an owning-class chain from capitalization: the first uppercase-led segment of the FQN is taken as the start of the class-name chain, and everything before the last delimiter beyond it becomes the owning class. The sentinel for "no uppercase-led segment found" is `0`, which is indistinguishable from "found at index 0", so an FQN with no uppercase-led segment at all — e.g. Python's `builtins.list` — gets a fabricated owning class `builtins`.

That fabricated owning class is not just cosmetically wrong: `org.openrewrite.java.ChangeType` uses `getOwningClass() != null` on the target type to decide whether to take its inner-class path, which rebuilds the replacement type tree with `withType(null)`. As a result, `ChangeType(typing.List -> builtins.list)` on Python trees nulls out type attribution on the replaced identifiers.

With this change, an FQN containing no uppercase-led segment after a delimiter is treated as package-qualified and gets no owning class. The behavior delta is confined to exactly those names; all other FQNs resolve identically to before.

Two known limitations, both deliberate:

- An all-lowercase Java nested class written in dot form is inherently indistinguishable from a package-qualified name and now reads as one. Using the `Outer$nested` binary form still yields the owning class.
- A default-package nested name such as `Test.InnerB` still gets no owning class, even though `Test` clearly is one: the uppercase scan does not recognize a class-name segment at index 0. This is left as is because `ChangeType`'s plain-rename path depends on it — recognizing the owning class would route default-package targets into the inner-class path, which rebuilds the identifier without type attribution (see `ChangeTypeTest.doesNotModifyInnerClassesIfIgnoreDefinitionTrue`).

## Summary

- `ShallowClass.build` only infers an owning class when an uppercase-led segment exists beyond index 0, so package-qualified lowercase FQNs like `builtins.list` get `owningClass = null` instead of a fabricated chain.
- Added `JavaTypeTest.shallowClassOwningClassInference` covering nested names (`java.util.Map.Entry`), lowercase package-qualified names (`builtins.list`), simple names, and the default-package limitation.

## Test plan

- [x] `./gradlew :rewrite-java-test:test --tests "org.openrewrite.java.JavaTypeTest" --tests "org.openrewrite.java.ChangeTypeTest"`
- [x] Full `./gradlew :rewrite-java-test:test`
- [x] Full `./gradlew :rewrite-java:test`
