### PR TITLE
Keep comments with the dependency they precede when adding a Gradle dependency

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/AddDependencyVisitor.java
@@ -167,18 +167,18 @@ public class AddDependencyVisitor extends JavaIsoVisitor<ExecutionContext> {
                                 J.MethodInvocation beforeDependency = (J.MethodInvocation) (dependencyComparator.getBeforeDependency() instanceof J.Return ?
                                         requireNonNull(((J.Return) dependencyComparator.getBeforeDependency()).getExpression()) :
                                         dependencyComparator.getBeforeDependency());
+                                Space currentPrefix = currentStatement.getPrefix();
                                 if (i == 0) {
                                     if (!addDependencyInvocation.getSimpleName().equals(beforeDependency.getSimpleName())) {
-                                        statements.set(i, currentStatement.withPrefix(Space.format("\n\n" + currentStatement.getPrefix().getIndent())));
+                                        statements.set(i, currentStatement.withPrefix(currentPrefix.withWhitespace("\n\n" + currentPrefix.getIndent())));
                                     }
                                 } else {
                                     Space originalPrefix = addDependencyInvocation.getPrefix();
-                                    addDependencyInvocation = addDependencyInvocation.withPrefix(currentStatement.getPrefix());
+                                    addDependencyInvocation = addDependencyInvocation.withPrefix(Space.format(currentPrefix.getWhitespace()));
 
-                                    if (addDependencyInvocation.getSimpleName().equals(beforeDependency.getSimpleName())) {
-                                        if (!currentStatement.getPrefix().equals(originalPrefix)) {
-                                            statements.set(i, currentStatement.withPrefix(originalPrefix));
-                                        }
+                                    if (addDependencyInvocation.getSimpleName().equals(beforeDependency.getSimpleName()) &&
+                                            !currentPrefix.getWhitespace().equals(originalPrefix.getWhitespace())) {
+                                        statements.set(i, currentStatement.withPrefix(currentPrefix.withWhitespace(originalPrefix.getWhitespace())));
                                     }
                                 }
                             }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/AddDependencyTest.java
@@ -2118,6 +2118,110 @@ class AddDependencyTest implements RewriteTest {
         );
     }
 
+    @Test
+    void doesNotDuplicateCommentsPrecedingTheFollowingDependency() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath", "implementation")),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    /*******************************
+                     * Test Dependencies
+                     *******************************/
+
+                    testImplementation "junit:junit:4.13.2"
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    implementation "com.google.guava:guava:29.0-jre"
+
+                    /*******************************
+                     * Test Dependencies
+                     *******************************/
+
+                    testImplementation "junit:junit:4.13.2"
+                }
+                """
+            )
+          )
+        );
+    }
+
+    @Test
+    void doesNotDuplicateCommentsWhenInsertingBetweenDependencies() {
+        rewriteRun(
+          spec -> spec.recipe(addDependency("com.google.guava:guava:29.0-jre", "com.google.common.math.IntMath", "implementation")),
+          mavenProject("project",
+            srcMainJava(
+              java(usingGuavaIntMath)
+            ),
+            buildGradle(
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    api "commons-lang:commons-lang:2.6"
+
+                    /*******************************
+                     * Test Dependencies
+                     *******************************/
+
+                    testImplementation "junit:junit:4.13.2"
+                }
+                """,
+              """
+                plugins {
+                    id "java-library"
+                }
+
+                repositories {
+                    mavenCentral()
+                }
+
+                dependencies {
+                    api "commons-lang:commons-lang:2.6"
+
+                    implementation "com.google.guava:guava:29.0-jre"
+
+                    /*******************************
+                     * Test Dependencies
+                     *******************************/
+
+                    testImplementation "junit:junit:4.13.2"
+                }
+                """
+            )
+          )
+        );
+    }
+
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {
         return addDependency(gav, null, null);
     }


### PR DESCRIPTION
When `AddDependencyVisitor` inserted a dependency ahead of an existing one, it copied the whole prefix `Space` — comments included — onto the new declaration while the existing statement kept its own, so a banner like `/*** Test Dependencies ***/` was reprinted once per added dependency; inserting at the top of the block deleted such comments outright instead.

Now only the whitespace portion of the prefix is moved, so comments stay attached to the statement they precede. Two tests cover inserting before the first dependency and between two dependencies.

Reported against `org.openrewrite.java.testing.junit5.GradleUseJunitJupiter` on `Netflix/metacat`, where three added dependencies each duplicated the Provided/Runtime/Test dependency comment banners.