### PR TITLE
`PythonImportService`: fall back to the serving RPC connection when the JVM is the spawned server

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -268,20 +268,17 @@ public class RewriteRpc {
     }
 
     /**
-     * The {@link RewriteRpc} over which the request currently being handled on this thread
-     * arrived, or {@code null} when the thread is not handling an RPC request. Visitors
-     * instantiated on behalf of a remote peer use this to dispatch follow-up visits back to
-     * that peer — the owner of the tree being visited — when this process is the spawned
-     * server and so holds no process-manager handle to the peer (e.g. Python- or JS-hosted
-     * recipe runs delegating to Java recipes).
+     * The instance the request currently being handled on this thread arrived on, or
+     * {@code null} outside request handling. Lets a visitor dispatch follow-up visits back
+     * to the requesting peer when this process is the spawned server and has no other
+     * handle to it.
      */
     public static @Nullable RewriteRpc current() {
         return CURRENT.get();
     }
 
     /**
-     * Runs {@code work} with this instance discoverable via {@link #current()}. Request
-     * handlers wrap the execution of remotely requested work in this.
+     * Runs {@code work} with this instance discoverable via {@link #current()}.
      */
     public <T> T withCurrent(Callable<T> work) throws Exception {
         RewriteRpc previous = CURRENT.get();

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -41,6 +41,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.*;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -63,6 +64,8 @@ import static org.openrewrite.rpc.RpcObjectData.State.END_OF_OBJECT;
  */
 @SuppressWarnings("UnusedReturnValue")
 public class RewriteRpc {
+    private static final ThreadLocal<@Nullable RewriteRpc> CURRENT = new ThreadLocal<>();
+
     private final JsonRpc jsonRpc;
     private final AtomicInteger batchSize = new AtomicInteger(1000);
     private Duration timeout = Duration.ofSeconds(30);
@@ -167,9 +170,9 @@ public class RewriteRpc {
             }
             return o;
         };
-        jsonRpc.rpc("Visit", new Visit.Handler(localObjects, preparedRecipes,
+        jsonRpc.rpc("Visit", new Visit.Handler(this, localObjects, preparedRecipes,
                 getRecipeObject, this::getCursor));
-        jsonRpc.rpc("BatchVisit", new BatchVisit.Handler(localObjects, preparedRecipes,
+        jsonRpc.rpc("BatchVisit", new BatchVisit.Handler(this, localObjects, preparedRecipes,
                 getRecipeObject, this::getCursor));
         jsonRpc.rpc("Generate", new Generate.Handler(localObjects, preparedRecipes,
                 getRecipeObject));
@@ -262,6 +265,36 @@ public class RewriteRpc {
         });
 
         jsonRpc.bind();
+    }
+
+    /**
+     * The {@link RewriteRpc} over which the request currently being handled on this thread
+     * arrived, or {@code null} when the thread is not handling an RPC request. Visitors
+     * instantiated on behalf of a remote peer use this to dispatch follow-up visits back to
+     * that peer — the owner of the tree being visited — when this process is the spawned
+     * server and so holds no process-manager handle to the peer (e.g. Python- or JS-hosted
+     * recipe runs delegating to Java recipes).
+     */
+    public static @Nullable RewriteRpc current() {
+        return CURRENT.get();
+    }
+
+    /**
+     * Runs {@code work} with this instance discoverable via {@link #current()}. Request
+     * handlers wrap the execution of remotely requested work in this.
+     */
+    public <T> T withCurrent(Callable<T> work) throws Exception {
+        RewriteRpc previous = CURRENT.get();
+        CURRENT.set(this);
+        try {
+            return work.call();
+        } finally {
+            if (previous == null) {
+                CURRENT.remove();
+            } else {
+                CURRENT.set(previous);
+            }
+        }
     }
 
     public RewriteRpc livenessCheck(Supplier<? extends @Nullable RuntimeException> livenessCheck) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/BatchVisit.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/BatchVisit.java
@@ -22,6 +22,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.internal.PreparedRecipeCache;
 import org.openrewrite.scheduling.RecipeRunCycle;
 import org.openrewrite.scheduling.WatchableExecutionContext;
@@ -49,6 +50,7 @@ public class BatchVisit implements RpcRequest {
 
     @RequiredArgsConstructor
     public static class Handler extends JsonRpcMethod<BatchVisit> {
+        private final RewriteRpc rpc;
         private final Map<String, Object> localObjects;
         private final PreparedRecipeCache preparedRecipes;
         private final BiFunction<String, @Nullable String, ?> getObject;
@@ -56,6 +58,11 @@ public class BatchVisit implements RpcRequest {
 
         @Override
         protected Object handle(BatchVisit request) throws Exception {
+            // Make this connection discoverable via RewriteRpc.current() while the visitors run.
+            return rpc.withCurrent(() -> doHandle(request));
+        }
+
+        private Object doHandle(BatchVisit request) {
             Tree tree = (Tree) getObject.apply(request.getTreeId(), request.getSourceFileType());
             Object p = getVisitorP(request);
             Cursor cursor = getCursor.apply(request.getCursor(), request.getSourceFileType());

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/Visit.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/Visit.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.rpc.RewriteRpc;
 import org.openrewrite.rpc.internal.PreparedRecipeCache;
 import org.openrewrite.scheduling.RecipeRunCycle;
 import org.openrewrite.scheduling.WatchableExecutionContext;
@@ -57,6 +58,7 @@ public class Visit implements RpcRequest {
 
     @RequiredArgsConstructor
     public static class Handler extends JsonRpcMethod<Visit> {
+        private final RewriteRpc rpc;
         private final Map<String, Object> localObjects;
         private final PreparedRecipeCache preparedRecipes;
         private final BiFunction<String, @Nullable String, ?> getObject;
@@ -64,19 +66,22 @@ public class Visit implements RpcRequest {
 
         @Override
         protected Object handle(Visit request) throws Exception {
-            Tree before = (Tree) getObject.apply(request.getTreeId(), request.getSourceFileType());
-            Object p = getVisitorP(request);
-            TreeVisitor<?, Object> visitor = preparedRecipes.instantiateVisitor(request.getVisitor(),
-                    request.getVisitorOptions());
-            Tree after = visitor.visit(before, p, getCursor.apply(request.getCursor(),
-                    request.getSourceFileType()));
-            if (after == null) {
-                localObjects.remove(before.getId().toString());
-            } else {
-                localObjects.put(after.getId().toString(), after);
-            }
+            // Make this connection discoverable via RewriteRpc.current() while the visitor runs.
+            return rpc.withCurrent(() -> {
+                Tree before = (Tree) getObject.apply(request.getTreeId(), request.getSourceFileType());
+                Object p = getVisitorP(request);
+                TreeVisitor<?, Object> visitor = preparedRecipes.instantiateVisitor(request.getVisitor(),
+                        request.getVisitorOptions());
+                Tree after = visitor.visit(before, p, getCursor.apply(request.getCursor(),
+                        request.getSourceFileType()));
+                if (after == null) {
+                    localObjects.remove(before.getId().toString());
+                } else {
+                    localObjects.put(after.getId().toString(), after);
+                }
 
-            return new VisitResponse(before != after);
+                return new VisitResponse(before != after);
+            });
         }
 
         private Object getVisitorP(Visit request) {

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -259,6 +259,32 @@ class RewriteRpcTest implements RewriteTest {
         );
     }
 
+    /**
+     * A visitor running inside a Visit request handler can discover the {@link RewriteRpc} the
+     * request arrived on via {@link RewriteRpc#current()} and dispatch a follow-up visit back to
+     * the requesting peer, which owns the tree. This is how Java-side visitors reach the host's
+     * own visitors when the JVM is the spawned server (e.g. Python-hosted recipe runs dispatching
+     * {@code org.openrewrite.python.AddImport} back to Python).
+     */
+    @Test
+    void nestedVisitBackToRequestOriginator() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new TreeVisitor<>() {
+              @Override
+              @SneakyThrows
+              public Tree preVisit(Tree tree, ExecutionContext ctx) {
+                  Tree t = client.visit((SourceFile) tree, DispatchBackToOriginator.class.getName(), 0);
+                  stopAfterPreVisit();
+                  return requireNonNull(t);
+              }
+          })),
+          text(
+            "Hello Jon!",
+            "Hello World!"
+          )
+        );
+    }
+
     @Disabled("Print requires bidirectional RPC (GetObject callback) which deadlocks in the in-process test setup. " +
               "Works correctly when calling to a real subprocess (e.g., Java to Python/JS).")
     @Test
@@ -565,6 +591,18 @@ class RewriteRpcTest implements RewriteTest {
         @Override
         public PlainText visitText(PlainText text, Integer p) {
             return text.withText("Hello World!");
+        }
+    }
+
+    /**
+     * Runs on the peer handling a Visit request and delegates the actual change to a visitor on
+     * the requesting peer via {@link RewriteRpc#current()}.
+     */
+    static class DispatchBackToOriginator extends PlainTextVisitor<Integer> {
+        @Override
+        public PlainText visitText(PlainText text, Integer p) {
+            RewriteRpc serving = requireNonNull(RewriteRpc.current(), "expected the serving RewriteRpc to be discoverable");
+            return (PlainText) requireNonNull(serving.visit(text, ChangeText.class.getName(), p));
         }
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -259,13 +259,6 @@ class RewriteRpcTest implements RewriteTest {
         );
     }
 
-    /**
-     * A visitor running inside a Visit request handler can discover the {@link RewriteRpc} the
-     * request arrived on via {@link RewriteRpc#current()} and dispatch a follow-up visit back to
-     * the requesting peer, which owns the tree. This is how Java-side visitors reach the host's
-     * own visitors when the JVM is the spawned server (e.g. Python-hosted recipe runs dispatching
-     * {@code org.openrewrite.python.AddImport} back to Python).
-     */
     @Test
     void nestedVisitBackToRequestOriginator() {
         rewriteRun(
@@ -594,10 +587,6 @@ class RewriteRpcTest implements RewriteTest {
         }
     }
 
-    /**
-     * Runs on the peer handling a Visit request and delegates the actual change to a visitor on
-     * the requesting peer via {@link RewriteRpc#current()}.
-     */
     static class DispatchBackToOriginator extends PlainTextVisitor<Integer> {
         @Override
         public PlainText visitText(PlainText text, Integer p) {

--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -14,6 +14,7 @@
 
 """AddImport visitor for Python import handling."""
 
+import builtins
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
@@ -126,6 +127,11 @@ class AddImport(PythonVisitor):
         self.only_if_referenced = options.only_if_referenced
 
     def visit_compilation_unit(self, cu: CompilationUnit, p) -> J:
+        # A bare builtin name (e.g. `list` when ChangeType retargets a type to a builtin) is
+        # not a module, so there is no import that could bind it.
+        if self.name is None and '.' not in self.module and hasattr(builtins, self.module):
+            return cu
+
         # Check if import already exists
         if self._import_exists(cu):
             return cu

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -117,6 +117,18 @@ class TestMaybeAddImport:
             )
         )
 
+    def test_builtin_name_is_not_imported(self):
+        """A bare builtin name (e.g. from ChangeType retargeting to `list`) is not a module;
+        adding an import for it is a no-op."""
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('list')))
+        spec.rewrite_run(
+            python(
+                """
+                x: list[int] = []
+                """,
+            )
+        )
+
     def test_only_if_referenced(self):
         """Don't add import when the name is not referenced and only_if_referenced=True."""
         class AddJoinVisitor(PythonVisitor[ExecutionContext]):

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonImportService.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonImportService.java
@@ -25,6 +25,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.service.ImportService;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.rpc.RewriteRpc;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -102,7 +103,12 @@ public class PythonImportService extends ImportService {
             if (!(tree instanceof SourceFile)) {
                 return (J) tree;
             }
-            PythonRewriteRpc rpc = PythonRewriteRpc.get();
+            RewriteRpc rpc = PythonRewriteRpc.get();
+            if (rpc == null) {
+                // Without a process-manager handle, the peer whose request is being handled is
+                // the one that implements the import visitors; see RewriteRpc.current().
+                rpc = RewriteRpc.current();
+            }
             if (rpc == null) {
                 return (J) tree;
             }

--- a/rewrite-python/src/test/java/org/openrewrite/python/RemoveImport.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/RemoveImport.java
@@ -22,9 +22,8 @@ import org.openrewrite.marker.SearchResult;
 
 /**
  * Test stand-in for the Python-side {@code rewrite.python.remove_import.RemoveImport} visitor,
- * which registers under this fully-qualified name. Lets a JVM peer play the Python host in RPC
- * tests: instead of editing imports it marks the tree with the (module, name) pair it was asked
- * to remove, so tests can assert the dispatch arrived with the right options.
+ * which registers under this fully-qualified name. Marks the tree with the (module, name) pair
+ * it was asked to remove, so tests can assert the dispatch arrived with the right options.
  */
 public class RemoveImport extends JavaVisitor<Object> {
     public String module;

--- a/rewrite-python/src/test/java/org/openrewrite/python/RemoveImport.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/RemoveImport.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.marker.SearchResult;
+
+/**
+ * Test stand-in for the Python-side {@code rewrite.python.remove_import.RemoveImport} visitor,
+ * which registers under this fully-qualified name. Lets a JVM peer play the Python host in RPC
+ * tests: instead of editing imports it marks the tree with the (module, name) pair it was asked
+ * to remove, so tests can assert the dispatch arrived with the right options.
+ */
+public class RemoveImport extends JavaVisitor<Object> {
+    public String module;
+
+    public @Nullable String name;
+
+    @Override
+    public @Nullable J preVisit(J tree, Object o) {
+        stopAfterPreVisit();
+        return SearchResult.found(tree, name == null ? module : module + "." + name);
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import io.moderne.jsonrpc.JsonRpc;
+import io.moderne.jsonrpc.formatter.JsonMessageFormatter;
+import io.moderne.jsonrpc.handler.HeaderDelimitedMessageHandler;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.marketplace.RecipeMarketplace;
+import org.openrewrite.python.tree.Py;
+import org.openrewrite.rpc.RewriteRpc;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.file.Paths;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises the Python-hosted topology in-process: the "host" peer plays the Python process that
+ * owns the {@link Py.CompilationUnit} and requests a visit; the "server" peer plays the JVM it
+ * spawned. The JVM then holds no {@link org.openrewrite.python.rpc.PythonRewriteRpc} handle, so
+ * {@link PythonImportService} must dispatch import edits back over the serving connection.
+ */
+class PythonImportServiceRpcTest {
+    RewriteRpc host;
+    RewriteRpc server;
+
+    @BeforeEach
+    void before() throws IOException {
+        var serverOut = new PipedOutputStream();
+        var hostOut = new PipedOutputStream();
+        var serverIn = new PipedInputStream(hostOut);
+        var hostIn = new PipedInputStream(serverOut);
+
+        host = new RewriteRpc(new JsonRpc(new HeaderDelimitedMessageHandler(
+          new JsonMessageFormatter(new ParameterNamesModule()), hostIn, hostOut)), new RecipeMarketplace())
+          .batchSize(1);
+        server = new RewriteRpc(new JsonRpc(new HeaderDelimitedMessageHandler(
+          new JsonMessageFormatter(new ParameterNamesModule()), serverIn, serverOut)), new RecipeMarketplace())
+          .batchSize(1);
+    }
+
+    @AfterEach
+    void after() {
+        host.shutdown();
+        server.shutdown();
+    }
+
+    @Test
+    void dispatchesImportEditBackToRequestingPeer() {
+        Py.CompilationUnit cu = new Py.CompilationUnit(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
+          Paths.get("test.py"), null, null, false, null, emptyList(), emptyList(), Space.EMPTY);
+
+        // The host asks the server to run a visitor that queues a maybeRemoveImport; the
+        // resulting org.openrewrite.python.RemoveImport dispatch lands back on the host, whose
+        // test stand-in marks the tree with the (module, name) pair it received.
+        Tree after = host.visit(cu, RemovesTypingList.class.getName(), 0);
+
+        assertThat(after).isInstanceOf(Py.CompilationUnit.class);
+        assertThat(((SourceFile) after).getMarkers().findFirst(SearchResult.class))
+          .hasValueSatisfying(found -> assertThat(found.getDescription()).isEqualTo("typing.List"));
+    }
+
+    public static class RemovesTypingList extends JavaVisitor<Object> {
+        @Override
+        public @Nullable J preVisit(J tree, Object o) {
+            stopAfterPreVisit();
+            maybeRemoveImport("typing.List");
+            return tree;
+        }
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
@@ -44,9 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Exercises the Python-hosted topology in-process: the "host" peer plays the Python process that
- * owns the {@link Py.CompilationUnit} and requests a visit; the "server" peer plays the JVM it
- * spawned. The JVM then holds no {@link org.openrewrite.python.rpc.PythonRewriteRpc} handle, so
- * {@link PythonImportService} must dispatch import edits back over the serving connection.
+ * owns the tree, the "server" peer the spawned JVM, which has no
+ * {@link org.openrewrite.python.rpc.PythonRewriteRpc} handle.
  */
 class PythonImportServiceRpcTest {
     RewriteRpc host;
@@ -78,9 +77,8 @@ class PythonImportServiceRpcTest {
         Py.CompilationUnit cu = new Py.CompilationUnit(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
           Paths.get("test.py"), null, null, false, null, emptyList(), emptyList(), Space.EMPTY);
 
-        // The host asks the server to run a visitor that queues a maybeRemoveImport; the
-        // resulting org.openrewrite.python.RemoveImport dispatch lands back on the host, whose
-        // test stand-in marks the tree with the (module, name) pair it received.
+        // The maybeRemoveImport queued on the server dispatches org.openrewrite.python.RemoveImport
+        // back to the host, where the test stand-in receives it.
         Tree after = host.visit(cu, RemovesTypingList.class.getName(), 0);
 
         assertThat(after).isInstanceOf(Py.CompilationUnit.class);


### PR DESCRIPTION
## Motivation

- PR #8323 added `PythonImportService`, which lets `org.openrewrite.java.ChangeType` (and any `maybeAddImport`/`maybeRemoveImport` caller) retire and add Python imports by dispatching the Python side's own `AddImport`/`RemoveImport` visitors over RPC. Its dispatch obtained the connection via `PythonRewriteRpc.get()`, which is only non-null when the JVM spawned the Python peer (JVM-as-host, e.g. Moderne CLI). In the inverted topology — Python (or JavaScript) spawning `org.openrewrite.maven.rpc.JavaRewriteRpc` as a subprocess, as the pytest harness in #8390 does — the handle is always null and the import edit silently no-oped: `ChangeType(typing.List -> list)` rewrote the annotations but left the now-unused `from typing import List` behind.

The peer that sent the in-flight `Visit` request both owns the tree being visited and implements the import visitors, so the serving connection is exactly the right place to dispatch to. This PR makes that connection discoverable from visitor code.

## Examples

A visitor executing on behalf of a remote peer can reach that peer's own visitors:

```java
// Inside code running under a Visit/BatchVisit request handler:
RewriteRpc rpc = RewriteRpc.current(); // the connection the in-flight request arrived on
rpc.visit(tree, "org.openrewrite.python.RemoveImport", options, p, cursor);
```

`PythonImportService` uses it as a fallback:

```java
RewriteRpc rpc = PythonRewriteRpc.get();
if (rpc == null) {
    rpc = RewriteRpc.current();
}
```

## Summary

- `RewriteRpc.current()`: a request-scoped thread-local holding the `RewriteRpc` instance the currently handled request arrived on, or null outside request handling. `Visit.Handler` and `BatchVisit.Handler` scope it around visitor execution via `withCurrent(...)`, which saves and restores the previous value in a finally block.
- `PythonImportService.RpcImportVisitor.dispatch` falls back to `RewriteRpc.current()` when `PythonRewriteRpc.get()` is null, making Java-side Python import edits work in the Python- and JS-hosted topologies.
- Python's `AddImport` visitor no-ops for a bare builtin name (`hasattr(builtins, module)`): with the add path actually running, `ChangeType` retargeting a type to a builtin such as `list` would otherwise emit a nonsensical `import list`. The guard lives in the visitor rather than `maybe_add_import` because the RPC visitor registry constructs `AddImport` directly.

## Test plan

- [x] `RewriteRpcTest.nestedVisitBackToRequestOriginator`: a visitor served on one peer discovers the connection via `RewriteRpc.current()` and dispatches a follow-up visit back to the requesting peer, which modifies the tree — also proving the nested bidirectional exchange works in the in-process piped setup.
- [x] `PythonImportServiceRpcTest`: two in-process `RewriteRpc` peers where the host plays the Python process; a served visitor's `maybeRemoveImport("typing.List")` dispatches back to the host with options `{module: typing, name: List}`, received by a test stand-in registered under `org.openrewrite.python.RemoveImport`.
- [x] `test_add_import.py::test_builtin_name_is_not_imported` for the builtin guard.
- [x] Full `:rewrite-core:test` and `:rewrite-python:test` suites, plus the pure-Python suites (1627 passed).
- [x] End-to-end with the #8390 harness: `pytest tests/rpc/test_java_recipes.py::TestChangeType` passes — annotations rewritten, `from typing import List` removed, no spurious import. The corresponding xfail in #8390 can be dropped once both are merged.