### PR TITLE
Diff lists as `CHANGE` regardless of concrete implementation class

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -114,20 +114,25 @@ public class RpcSendQueue {
 
         if (beforeVal == afterVal) {
             put(new RpcObjectData(NO_CHANGE, null, null, null, trace));
-        } else if (beforeVal == null || (afterVal != null && afterVal.getClass() != beforeVal.getClass() &&
-                                         !(afterVal instanceof List && beforeVal instanceof List))) {
-            // Treat as ADD when before is null OR types differ (it's a new object, not a change).
-            // The concrete List implementation class (e.g. List.of vs ArrayList) is exempt from
-            // the type comparison: two non-null lists must diff as CHANGE, because sendList emits
+        } else if (afterVal instanceof List && beforeVal instanceof List) {
+            // The concrete List implementation class (e.g. List.of vs ArrayList) is irrelevant
+            // to the diff: two non-null lists always diff as CHANGE, because sendList emits
             // positions into the before list while the receiver's ADD path starts from an empty one.
+            sendChange(afterVal, beforeVal, onChange);
+        } else if (beforeVal == null || (afterVal != null && afterVal.getClass() != beforeVal.getClass())) {
+            // Treat as ADD when before is null OR types differ (it's a new object, not a change)
             add(after, onChange);
         } else if (afterVal == null) {
             put(new RpcObjectData(DELETE, null, null, null, trace));
         } else {
-            RpcCodec<Object> afterCodec = RpcCodec.forInstance(afterVal, sourceFileType);
-            put(new RpcObjectData(CHANGE, getValueType(afterVal), onChange == null && afterCodec == null ? afterVal : null, null, trace));
-            doChange(afterVal, beforeVal, onChange, afterCodec);
+            sendChange(afterVal, beforeVal, onChange);
         }
+    }
+
+    private void sendChange(Object afterVal, Object beforeVal, @Nullable Runnable onChange) {
+        RpcCodec<Object> afterCodec = RpcCodec.forInstance(afterVal, sourceFileType);
+        put(new RpcObjectData(CHANGE, getValueType(afterVal), onChange == null && afterCodec == null ? afterVal : null, null, trace));
+        doChange(afterVal, beforeVal, onChange, afterCodec);
     }
 
     <T> void sendList(@Nullable List<T> after,

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -114,8 +114,12 @@ public class RpcSendQueue {
 
         if (beforeVal == afterVal) {
             put(new RpcObjectData(NO_CHANGE, null, null, null, trace));
-        } else if (beforeVal == null || (afterVal != null && afterVal.getClass() != beforeVal.getClass())) {
-            // Treat as ADD when before is null OR types differ (it's a new object, not a change)
+        } else if (beforeVal == null || (afterVal != null && afterVal.getClass() != beforeVal.getClass() &&
+                                         !(afterVal instanceof List && beforeVal instanceof List))) {
+            // Treat as ADD when before is null OR types differ (it's a new object, not a change).
+            // The concrete List implementation class (e.g. List.of vs ArrayList) is exempt from
+            // the type comparison: two non-null lists must diff as CHANGE, because sendList emits
+            // positions into the before list while the receiver's ADD path starts from an empty one.
             add(after, onChange);
         } else if (afterVal == null) {
             put(new RpcObjectData(DELETE, null, null, null, trace));

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RpcSendQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RpcSendQueueTest.java
@@ -18,8 +18,7 @@ package org.openrewrite.rpc;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.AccessMode;
-import java.util.IdentityHashMap;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -72,6 +71,32 @@ class RpcSendQueueTest {
         q.flush();
 
         assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+    }
+
+    @Test
+    void listImplementationClassMayDiffer() {
+        List<String> before = new ArrayList<>(List.of("A", "B"));
+        List<String> after = List.of("A");
+
+        assertThat(roundTripList(after, before)).isEqualTo(after);
+    }
+
+    @Test
+    void listImplementationClassMayDifferReverse() {
+        List<String> before = List.of("A");
+        List<String> after = new ArrayList<>(List.of("A", "B"));
+
+        assertThat(roundTripList(after, before)).isEqualTo(after);
+    }
+
+    private List<String> roundTripList(List<String> after, List<String> before) {
+        Deque<List<RpcObjectData>> batches = new ArrayDeque<>();
+        RpcSendQueue sq = new RpcSendQueue(1, batches::addLast, new IdentityHashMap<>(), null, false);
+        RpcReceiveQueue rq = new RpcReceiveQueue(new HashMap<>(), batches::removeFirst, null, null);
+
+        sq.sendList(after, before, Function.identity(), null, false);
+        sq.flush();
+        return rq.receiveList(before, null);
     }
 
     @Test

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueListTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueListTest.cs
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+public class RpcSendQueueListTest
+{
+    [Fact]
+    public void ListImplementationClassMayDiffer()
+    {
+        var before = new List<string> { "A", "B" };
+        string[] after = ["A"];
+
+        Assert.Equal(after, RoundTripList(after, before));
+    }
+
+    [Fact]
+    public void ListImplementationClassMayDifferReverse()
+    {
+        string[] before = ["A"];
+        var after = new List<string> { "A", "B" };
+
+        Assert.Equal(after, RoundTripList(after, before));
+    }
+
+    private static IList<string>? RoundTripList(IList<string> after, IList<string> before)
+    {
+        var batches = new Queue<List<RpcObjectData>>();
+        var sq = new RpcSendQueue(1, batches.Enqueue,
+            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+        var rq = new RpcReceiveQueue(new Dictionary<int, object>(), batches.Dequeue, null);
+
+        sq.SendList(after, before, x => x, null, false);
+        sq.Flush();
+        return rq.ReceiveList(before, (Func<string, string>?)null);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -143,8 +143,13 @@ public class RpcSendQueue
         {
             Put(new RpcObjectData { State = NO_CHANGE });
         }
-        else if (beforeVal == null || (afterVal != null && afterVal.GetType() != beforeVal.GetType()))
+        else if (beforeVal == null || (afterVal != null && afterVal.GetType() != beforeVal.GetType() &&
+                                       !(afterVal is System.Collections.IList && beforeVal is System.Collections.IList)))
         {
+            // The concrete list implementation class (e.g. List<T> vs T[]) is exempt from
+            // the type comparison: two non-null lists must diff as CHANGE, because SendList
+            // emits positions into the before list while the receiver's ADD path starts
+            // from an empty one.
             Add(after!, onChange);
         }
         else if (afterVal == null)
@@ -164,7 +169,7 @@ public class RpcSendQueue
         }
     }
 
-    private void SendList<T>(IList<T>? after, IList<T>? before,
+    internal void SendList<T>(IList<T>? after, IList<T>? before,
                               Func<T, object> id, Action<T>? onChange, bool asRef)
     {
         Send(after, before, () =>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -143,13 +143,16 @@ public class RpcSendQueue
         {
             Put(new RpcObjectData { State = NO_CHANGE });
         }
-        else if (beforeVal == null || (afterVal != null && afterVal.GetType() != beforeVal.GetType() &&
-                                       !(afterVal is System.Collections.IList && beforeVal is System.Collections.IList)))
+        else if (afterVal is System.Collections.IList && beforeVal is System.Collections.IList)
         {
-            // The concrete list implementation class (e.g. List<T> vs T[]) is exempt from
-            // the type comparison: two non-null lists must diff as CHANGE, because SendList
+            // The concrete list implementation class (e.g. List<T> vs T[]) is irrelevant
+            // to the diff: two non-null lists always diff as CHANGE, because SendList
             // emits positions into the before list while the receiver's ADD path starts
             // from an empty one.
+            SendChange(afterVal, beforeVal, onChange);
+        }
+        else if (beforeVal == null || (afterVal != null && afterVal.GetType() != beforeVal.GetType()))
+        {
             Add(after!, onChange);
         }
         else if (afterVal == null)
@@ -158,15 +161,20 @@ public class RpcSendQueue
         }
         else
         {
-            var afterCodec = GetCodecFor(afterVal);
-            Put(new RpcObjectData
-            {
-                State = CHANGE,
-                ValueType = GetValueType(afterVal),
-                Value = onChange == null && afterCodec == null ? afterVal : null
-            });
-            DoChange(afterVal, beforeVal, onChange, afterCodec);
+            SendChange(afterVal, beforeVal, onChange);
         }
+    }
+
+    private void SendChange(object afterVal, object beforeVal, Action? onChange)
+    {
+        var afterCodec = GetCodecFor(afterVal);
+        Put(new RpcObjectData
+        {
+            State = CHANGE,
+            ValueType = GetValueType(afterVal),
+            Value = onChange == null && afterCodec == null ? afterVal : null
+        });
+        DoChange(afterVal, beforeVal, onChange, afterCodec);
     }
 
     internal void SendList<T>(IList<T>? after, IList<T>? before,

--- a/rewrite-python/rewrite/tests/rpc/test_list_type_roundtrip.py
+++ b/rewrite-python/rewrite/tests/rpc/test_list_type_roundtrip.py
@@ -1,0 +1,45 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The concrete sequence type (list vs tuple) must not affect the list diff protocol.
+
+``send_list`` resolves the list-level state from nullability alone, never from
+``type(after) != type(before)``: two non-null sequences always diff as CHANGE with
+positions into the before sequence. A type comparison there would emit ADD, which the
+receiver answers by resetting its before to an empty list — desyncing every position.
+"""
+from rewrite.rpc.receive_queue import RpcReceiveQueue
+from rewrite.rpc.send_queue import RpcSendQueue
+
+
+def _round_trip_list(after, before):
+    sq = RpcSendQueue()
+    sq.send_list(after, before, lambda x: x)
+    batch = list(sq.q)
+
+    def pull():
+        out = batch[:]
+        batch.clear()
+        return out
+
+    rq = RpcReceiveQueue({}, None, pull)
+    return rq.receive_list(before)
+
+
+def test_tuple_before_list_after():
+    assert _round_trip_list(["A"], ("A", "B")) == ["A"]
+
+
+def test_list_before_tuple_after():
+    assert _round_trip_list(("A", "B"), ["A"]) == ["A", "B"]


### PR DESCRIPTION
## Motivation

The RPC send queues decide whether a value is a CHANGE or an ADD partly by comparing concrete classes. For lists this is wrong: `sendList` delegates the list-level state decision to `send`, so a `List.of(...)` diffed against an `ArrayList` (e.g. produced by `ListUtils.map`) resolves to ADD — but the onChange closure still emits positions computed against the non-null before list. The receiver's ADD path resets its before to a new empty list and then dereferences `before.get(position)`, throwing `IndexOutOfBoundsException` (or silently corrupting the tree if all positions happen to be -1). Production mostly avoids this because parsers and `ListUtils` consistently produce `ArrayList`s, but any recipe or mapper returning `List.of`/`singletonList`/`Arrays.asList` for a slot that was an `ArrayList` (or vice versa) triggers it.

## Summary

- `rewrite-core`: `RpcSendQueue.send` resolves two non-null `List`s to CHANGE in a dedicated branch ahead of the class comparison, so lists always diff by positions regardless of implementation class; regression tests round-trip `List.of("A")` against `new ArrayList<>(List.of("A", "B"))` (and the reverse) through a real `RpcReceiveQueue`
- `rewrite-csharp`: same fix in `RpcSendQueue.Send` (the C# port has the identical delegation and `GetType()` comparison), with a `List<string>` vs `string[]` round-trip test; `SendList` is now `internal` for test access via the existing `InternalsVisibleTo`
- `rewrite-python`: already safe — `send_list` resolves list-level state from nullability alone and never type-compares at the list level; added a list-vs-tuple round-trip test pinning that behavior
- `rewrite-javascript` and `rewrite-go`: verified safe by construction — JS's `typesAreDifferent` compares `kind` properties, which plain arrays never have, and Go's `sendList` normalizes both sides to `[]any` before the type comparison; no changes

## Test plan

- [x] New Java regression tests fail with `IndexOutOfBoundsException: Index 0 out of bounds for length 0` before the fix, pass after
- [x] New C# regression tests fail with `ArgumentOutOfRangeException` before the fix, pass after
- [x] Full `:rewrite-core:test` suite passes
- [x] Full C# suite passes (1964 tests), including the `RpcFixture` cross-process tests running against a Java RPC server built from this branch — exercising the Java and C# fixes together
- [x] New Python round-trip tests pass alongside the existing RPC queue tests