### PR TITLE
FindTypes: mark parameterized type usages in non-Java trees

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -172,11 +172,18 @@ public class FindTypes extends Recipe {
 
         @Override
         public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
+            Object parent = getCursor().getParentOrThrow().getValue();
+            // An identifier is only subsumed by an enclosing parameterized type when that type is itself the
+            // match (see `visitParameterizedType`). The identifier can be the sole matching node, e.g. in
+            // Python `items: List[str]` the parameterized type is attributed as builtin `list` while the
+            // `List` identifier is attributed as `typing.List`.
+            boolean matchingParameterizedTypeParent = parent instanceof J.ParameterizedType &&
+                    parameterizedTypeMatches((J.ParameterizedType) parent);
             if (ident.getType() != null &&
                     getCursor().firstEnclosing(J.Import.class) == null &&
                     getCursor().firstEnclosing(J.FieldAccess.class) == null &&
-                    !(getCursor().getParentOrThrow().getValue() instanceof J.ParameterizedType) &&
-                    !(getCursor().getParentOrThrow().getValue() instanceof J.ArrayType)) {
+                    !matchingParameterizedTypeParent &&
+                    !(parent instanceof J.ArrayType)) {
                 JavaType.FullyQualified type = TypeUtils.asFullyQualified(ident.getType());
                 if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type) &&
                         ident.getSimpleName().equals(type.getClassName())) {
@@ -184,6 +191,24 @@ public class FindTypes extends Recipe {
                 }
             }
             return super.visitIdentifier(ident, ctx);
+        }
+
+        @Override
+        public J visitParameterizedType(J.ParameterizedType type, ExecutionContext ctx) {
+            // In Java trees a matching parameterized type is also marked via `visitTypeName`, invoked by the
+            // JavaVisitor parent (idempotently with this). Parents in other languages may visit it as a plain
+            // expression (e.g. Python's `Py.TypeHint`), so mark it here to uphold the invariant that
+            // `visitIdentifier` relies on: a matching parameterized type is always marked as a whole.
+            J.ParameterizedType pt = (J.ParameterizedType) super.visitParameterizedType(type, ctx);
+            if (parameterizedTypeMatches(pt) && getCursor().firstEnclosing(J.Import.class) == null) {
+                return found(pt, ctx);
+            }
+            return pt;
+        }
+
+        private boolean parameterizedTypeMatches(J.ParameterizedType type) {
+            return typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType,
+                    TypeUtils.asFullyQualified(type.getType()));
         }
 
         @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -173,10 +173,8 @@ public class FindTypes extends Recipe {
         @Override
         public J visitIdentifier(J.Identifier ident, ExecutionContext ctx) {
             Object parent = getCursor().getParentOrThrow().getValue();
-            // An identifier is only subsumed by an enclosing parameterized type when that type is itself the
-            // match (see `visitParameterizedType`). The identifier can be the sole matching node, e.g. in
-            // Python `items: List[str]` the parameterized type is attributed as builtin `list` while the
-            // `List` identifier is attributed as `typing.List`.
+            // The identifier can be the sole matching node, e.g. in Python `items: List[str]` only the
+            // `List` identifier is attributed `typing.List`; the parameterized type is builtin `list`
             boolean matchingParameterizedTypeParent = parent instanceof J.ParameterizedType &&
                     parameterizedTypeMatches((J.ParameterizedType) parent);
             if (ident.getType() != null &&
@@ -195,10 +193,8 @@ public class FindTypes extends Recipe {
 
         @Override
         public J visitParameterizedType(J.ParameterizedType type, ExecutionContext ctx) {
-            // In Java trees a matching parameterized type is also marked via `visitTypeName`, invoked by the
-            // JavaVisitor parent (idempotently with this). Parents in other languages may visit it as a plain
-            // expression (e.g. Python's `Py.TypeHint`), so mark it here to uphold the invariant that
-            // `visitIdentifier` relies on: a matching parameterized type is always marked as a whole.
+            // Non-Java parents (e.g. Python's `Py.TypeHint`) may not route the type through `visitTypeName`;
+            // in Java trees this is idempotent with the parent's `visitTypeName` call
             J.ParameterizedType pt = (J.ParameterizedType) super.visitParameterizedType(type, ctx);
             if (parameterizedTypeMatches(pt) && getCursor().firstEnclosing(J.Import.class) == null) {
                 return found(pt, ctx);

--- a/rewrite-python/src/test/java/org/openrewrite/python/search/FindTypesTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/search/FindTypesTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.search;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.openrewrite.java.search.FindTypes;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.python.Assertions.python;
+
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "No remote client/server available")
+class FindTypesTest implements RewriteTest {
+
+    @Test
+    void findsParameterizedTypeUsages() {
+        rewriteRun(
+          spec -> spec.recipe(new FindTypes("typing.List", false)),
+          python(
+            """
+              from typing import List
+
+              def foo(items: List[str]) -> List[int]:
+                  pass
+              """,
+            """
+              from typing import List
+
+              def foo(items: /*~~>*/List[str]) -> /*~~>*/List[int]:
+                  pass
+              """
+          )
+        );
+    }
+
+    @Test
+    void findsUserDefinedGenericUsages() {
+        // Unlike the aliased `typing` generics, a user-defined generic's parameterized type carries the
+        // searched type itself and is marked as a whole, matching the Java rendering.
+        rewriteRun(
+          spec -> spec.recipe(new FindTypes("file.Box", false)),
+          python(
+            """
+              from typing import Generic, TypeVar
+
+              T = TypeVar("T")
+
+              class Box(Generic[T]):
+                  pass
+
+              def foo(b: Box[str]) -> None:
+                  pass
+              """,
+            """
+              from typing import Generic, TypeVar
+
+              T = TypeVar("T")
+
+              class Box(Generic[T]):
+                  pass
+
+              def foo(b: /*~~>*/Box[str]) -> None:
+                  pass
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

`FindTypes` missed some type usages in Python LSTs. For `def foo(items: List[str]) -> List[int]` (with `from typing import List`), `FindTypes("typing.List")` marked the return hint but not the parameter annotation. `visitIdentifier` skipped any identifier whose parent is a `J.ParameterizedType`, expecting `visitTypeName` to mark the enclosing node instead — but `visitTypeName` only sees a parameterized type when a `JavaVisitor` parent routes it there. In Python the parent is `Py.TypeHint`, which visits it as a plain expression, so the usage was never marked. (`J.ArrayType` does not have this gap: `JavaVisitor.visitArrayType` routes its element type through `visitTypeName` itself.)

An extra twist: ty resolves the aliased `typing` generics per PEP 585, so the parameterized type `List[str]` is attributed as builtin `list<String>` while the `List` identifier inside carries `typing.List` — the identifier is the only node attributed with the searched type, so marking the parameterized node alone cannot fix this case.

## Summary

- `visitIdentifier` now skips an identifier inside a parameterized type only when the enclosing parameterized type is itself the match (and is therefore marked as a whole); otherwise the identifier is marked, which covers the aliased-generic case in Python.
- New `visitParameterizedType` override marks a matching parameterized type in every language, upholding the invariant the skip relies on. In Java trees this is idempotent with the existing `visitTypeName` marking (`SearchResult.found` dedups the marker and `found()` guards the data table row). In Python it covers non-aliased generics, e.g. a user-defined `Box[str]`.

## Test plan

- New `FindTypesTest` in `rewrite-python` (RPC-based, disabled in CI like the existing `ChangeTypeTest`): `findsParameterizedTypeUsages` asserts both `List` usages are marked; `findsUserDefinedGenericUsages` asserts a user-defined generic's parameterized type is marked as a whole.
- `./gradlew :rewrite-java-test:test --tests "org.openrewrite.java.search.*"` — all existing search tests (including `FindTypesTest`) pass unchanged.