### PR TITLE
Make the import ChangeType adds agree with how a nested reference is written

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeTypeTest.java
@@ -66,6 +66,38 @@ class ChangeTypeTest implements RewriteTest {
       }
       """;
 
+    @Language("java")
+    String flatOld = """
+      package a;
+      public enum Old { A }
+      """;
+
+    @Language("java")
+    String nestedTargetOuter = """
+      package b;
+      public class Outer {
+          public enum Nested { A }
+      }
+      """;
+
+    @Language("java")
+    String nestedOriginalOuter = """
+      package a;
+      public class Outer {
+          public enum Nested { A }
+      }
+      """;
+
+    @Language("java")
+    String deeplyNestedTarget = """
+      package b;
+      public class A {
+          public static class B {
+              public enum C { A }
+          }
+      }
+      """;
+
     @DocumentExample
     @Test
     void doNotAddJavaLangWrapperImports() {
@@ -332,6 +364,235 @@ class ChangeTypeTest implements RewriteTest {
 
               class Test {
                   Map.Entry p;
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    void replaceFullyQualifiedReferenceWithNestedType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("java.io.File", "java.util.Map$Entry", true)),
+          java(
+            """
+              class Test {
+                  java.io.File p;
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class Test {
+                  Map.Entry p;
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite-cucumber-jvm/issues/47")
+    @Test
+    void changeToNestedType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("a.Old", "b.Outer$Nested", null)),
+          java(nestedTargetOuter, SourceSpec::skip),
+          java(flatOld, SourceSpec::skip),
+          java(
+            """
+              package c;
+              public class Nested {}
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.Old;
+
+              class Test {
+                  Old value = Old.A;
+              }
+              """,
+            """
+              import b.Outer;
+
+              class Test {
+                  Outer.Nested value = Outer.Nested.A;
+              }
+              """
+          ),
+          java(
+            """
+              import a.Old;
+              import c.Nested;
+
+              class UnrelatedSameSimpleName {
+                  Nested other;
+                  Old value = Old.A;
+              }
+              """,
+            """
+              import b.Outer;
+              import c.Nested;
+
+              class UnrelatedSameSimpleName {
+                  Nested other;
+                  Outer.Nested value = Outer.Nested.A;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToNestedTypeWhenOuterClassNameIsTaken() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("a.Old", "b.Outer$Nested", null)),
+          java(nestedTargetOuter, SourceSpec::skip),
+          java(flatOld, SourceSpec::skip),
+          java(
+            """
+              package c;
+              public class Outer {}
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.Old;
+              import c.Outer;
+
+              class Test {
+                  Outer other;
+                  Old value = Old.A;
+              }
+              """,
+            """
+              import c.Outer;
+
+              class Test {
+                  Outer other;
+                  b.Outer.Nested value = b.Outer.Nested.A;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeFromNestedTypeToFlatType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("a.Outer$Nested", "b.New", null)),
+          java(nestedOriginalOuter, SourceSpec::skip),
+          java(
+            """
+              package b;
+              public enum New { A }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.Outer.Nested;
+
+              class Test {
+                  Nested value = Nested.A;
+              }
+              """,
+            """
+              import b.New;
+
+              class Test {
+                  New value = New.A;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeFromNestedTypeToNestedType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("a.Outer$Nested", "b.Other$Inner", null)),
+          java(nestedOriginalOuter, SourceSpec::skip),
+          java(
+            """
+              package b;
+              public class Other {
+                  public enum Inner { A }
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.Outer.Nested;
+
+              class ViaImport {
+                  Nested value = Nested.A;
+              }
+              """,
+            """
+              import b.Other;
+
+              class ViaImport {
+                  Other.Inner value = Other.Inner.A;
+              }
+              """
+          ),
+          java(
+            """
+              import a.Outer;
+
+              class ViaOuterClass {
+                  Outer.Nested value = Outer.Nested.A;
+              }
+              """,
+            """
+              import b.Other;
+
+              class ViaOuterClass {
+                  Other.Inner value = Other.Inner.A;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void changeToDeeplyNestedType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("a.Old", "b.A$B$C", null)),
+          java(deeplyNestedTarget, SourceSpec::skip),
+          java(flatOld, SourceSpec::skip),
+          java(
+            """
+              import a.Old;
+
+              class ViaImport {
+                  Old value = Old.A;
+              }
+              """,
+            """
+              import b.A;
+
+              class ViaImport {
+                  A.B.C value = A.B.C.A;
+              }
+              """
+          ),
+          java(
+            """
+              class ViaPackageQualifiedName {
+                  a.Old value = a.Old.A;
+              }
+              """,
+            """
+              import b.A;
+
+              class ViaPackageQualifiedName {
+                  A.B.C value = A.B.C.A;
               }
               """
           )

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -267,17 +267,11 @@ public class ChangeType extends Recipe {
                 }
 
                 JavaType.FullyQualified fullyQualifiedTarget = TypeUtils.asFullyQualified(targetType);
-                if (fullyQualifiedTarget != null) {
-                    JavaType.FullyQualified owningClass = fullyQualifiedTarget.getOwningClass();
-                    if (!topLevelClassnames.contains(getTopLevelClassName(fullyQualifiedTarget).getFullyQualifiedName())) {
-                        if (hasNoConflictingImport(sf)) {
-                            if (owningClass != null && !"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
-                                addImport(owningClass);
-                            }
-                            if (!"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
-                                addImport(fullyQualifiedTarget);
-                            }
-                        }
+                if (fullyQualifiedTarget != null && !"java.lang".equals(fullyQualifiedTarget.getPackageName())) {
+                    if (!topLevelClassnames.contains(getTopLevelClassName(fullyQualifiedTarget).getFullyQualifiedName()) &&
+                            hasNoConflictingImport(sf)) {
+                        // An alias binds the nested type; otherwise the outermost class binds the reference.
+                        addImport(importAlias == null ? getTopLevelClassName(fullyQualifiedTarget) : fullyQualifiedTarget);
                     }
                 }
 
@@ -448,6 +442,8 @@ public class ChangeType extends Recipe {
                     return typeTree.withType(updateType(targetType));
                 }
 
+                boolean inImport = getCursor().firstEnclosing(J.Import.class) != null;
+
                 Stack<Expression> typeStack = new Stack<>();
                 typeStack.push(typeTree);
 
@@ -483,8 +479,11 @@ public class ChangeType extends Recipe {
                         }
                     } else if (e instanceof J.FieldAccess) {
                         if (attrStack.size() == typeStack.size() + 1) {
-                            attributed = ((J.FieldAccess) e).withTarget(attributed)
-                                    .withType(attrStack.pop());
+                            JavaType.FullyQualified segmentType = attrStack.pop();
+                            J.FieldAccess fa = ((J.FieldAccess) e).withTarget(attributed)
+                                    .withType(segmentType);
+                            // Attributing the name makes the outer classes visible as referenced; an import is not a usage.
+                            attributed = inImport ? fa : fa.withName(fa.getName().withType(segmentType));
                         } else {
                             attributed = ((J.FieldAccess) e).withTarget(attributed);
                         }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/ChangeTypeTest.java
@@ -166,6 +166,43 @@ class ChangeTypeTest implements RewriteTest {
         );
     }
 
+    @Test
+    void changeImportAliasToNestedType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("a.b.Original", "x.y.Outer$Nested", true)),
+          kotlin(
+            """
+              package a.b
+              class Original
+              """
+          ),
+          kotlin(
+            """
+              package x.y
+              class Outer {
+                  class Nested
+              }
+              """
+          ),
+          kotlin(
+            """
+              import a.b.Original as MyAlias
+
+              class A {
+                  val type : MyAlias = MyAlias()
+              }
+              """,
+            """
+              import x.y.Outer.Nested as MyAlias
+
+              class A {
+                  val type : MyAlias = MyAlias()
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite-kotlin/issues/42")
     @Test
     void changeTypeWithGenericArgument() {


### PR DESCRIPTION
- Fixes #8398

## What's changed

`ChangeType` decided the *reference* form for a nested target type in `visitIdentifier` /
`visitFieldAccess`, and decided *which import to add* independently in `postVisit`. The two did not
have to agree, and whether they did depended on whether `AddImport.findTypeReference` happened to
spot a reference — so the same logical change produced four different outputs (see the issue).

This makes the import follow the reference: a nested target is written through its outer class
chain, so the import added is the **outermost** class and never the nested type itself.

```diff
  new ChangeType("a.Old", "b.Outer$Nested", null)

  import b.Outer;
- import b.Outer.Nested;      // nothing resolves through this

  class Test {
      Outer.Nested value = Outer.Nested.A;
  }
```

Three related defects live in the same code and are fixed here as well:

- **Missing import on package-qualified references.** `updateOuterClassTypes` rebuilt the type tree
  without attributing the intermediate `name` identifiers, so neither `AddImport`'s reference check
  nor `ShortenFullyQualifiedTypeReferences` could see the outer class was referenced, and *no*
  import was added — `Map.Entry p;` on its own does not compile. Names inside an import statement
  are deliberately left unattributed: an import is not a usage, and treating it as one makes the
  outer class look referenced when it isn't (this is what keeps `ChangePackageTest.innerType`
  passing).
- **Wrong import for deeper nesting.** A `b.A$B$C` target is written `A.B.C` but imported the
  owning class `b.A.B` instead of the outermost `b.A`.
- **Aliased imports of a nested target.** An alias binds the nested type directly, so importing
  only the outermost class leaves nothing referencing it and `AddImport`'s `onlyIfReferenced` check
  emits nothing at all. Kotlin's `import a.b.Original as MyAlias` migrated to *no import*, which
  does not compile. The import target now follows how the reference is actually bound.

Two live downstream recipes hit the missing-import variant today: rewrite-apache's
`IOReactorConfig.Builder` migration and rewrite-spring-v1's `ResponseEntity.BodyBuilder` migration.

## Scope of the guarantee

Narrower than "always emits `Outer.Nested`": when a file already has a single-type import of the
nested type, that import is rewritten in place rather than removed and re-added, and the bare
reference survives. The guarantee is that the import which gets *added* always matches the
reference form that gets *written*, which is what closes the issue. `ChangePackageTest.innerType`
covers that case and is unchanged.

## Behaviour change: output is more verbose when the outer class name is taken

Raised by @knutwannheden. If the target's **outermost** class name collides with an existing
import, the reference falls back to fully qualified rather than being written through the outer
class:

```java
import c.Outer;                          import c.Outer;
import a.Old;

class Test {                     →       class Test {
    Outer other;                             Outer other;
    Old value = Old.A;                       b.Outer.Nested value = b.Outer.Nested.A;
}                                        }
```

`main` produces `import b.Outer.Nested;` + `Nested value = Nested.A;` here — shorter, but by
importing the nested type, which is the shape this change moves away from. Both compile, so this is
readability rather than correctness, and it follows from the direction rather than from a bug: if
the outer name cannot be bound, `Outer.Nested` is not available. Covered by
`changeToNestedTypeWhenOuterClassNameIsTaken`.

Worth noting for review: `hasNoConflictingImport` compares `newType.getClassName()`, the dotted
`"Outer.Nested"`, so it never fires for a nested target — the collision is caught one layer down by
`AddImport.checkImportsForType` returning `IMPORT_AMBIGUITY`, which then triggers
`FullyQualifyTypeReference`. The outcome is right, but reached by a different route than the code
reads. Aligning that check is deliberately left out of this PR; see
https://github.com/openrewrite/rewrite/pull/8399#issuecomment-5203527343.

## Tests

All additions — no existing expectation in `ChangeTypeTest` is modified.

`ChangeTypeTest` gains coverage asserting the import and the reference form **together**, which no
existing test did. Cases that differ only in how the input reference is written are grouped into a
single run with one source file per form:

- `changeToNestedType` — the reported repro (flat → nested), plus a file where an unrelated import
  shares the nested type's simple name
- `changeToNestedTypeWhenOuterClassNameIsTaken` — the collision case above
- `changeFromNestedTypeToFlatType`
- `changeFromNestedTypeToNestedType` — `ViaImport` and `ViaOuterClass` source files
- `changeToDeeplyNestedType` — `ViaImport` and `ViaPackageQualifiedName` source files
- `replaceFullyQualifiedReferenceWithNestedType` — pins the previously missing import

`changeImportAliasToNestedType` is added to `rewrite-kotlin`'s `ChangeTypeTest`, since Java has no
import aliases. It fails without the alias fix above.

Four of these fail against `origin/main`, which is what pins the defects:
`changeToNestedType`, `changeFromNestedTypeToNestedType`, `changeToDeeplyNestedType`,
`replaceFullyQualifiedReferenceWithNestedType`.

## Downstream impact

Measured by publishing this branch to the local Maven repository and diffing full downstream test
suites against a baseline run of the same suite — many downstream failures are offline
dependency-resolution noise, so only a diff is meaningful.

| repository | new failures |
|---|---|
| rewrite-apache | 0 |
| rewrite-migrate-java | 0 |
| rewrite-testing-frameworks | 0 |
| rewrite-jackson | 3 |
| rewrite-spring-v1 | 3 |

The six are all goldens that currently assert the bare nested name and would move to the
outer-qualified one:

- rewrite-jackson — `ReplacePropertyNamingStrategyConstantsTest` x2,
  `CodehausToFasterXMLTest.onlyJsonSerializeInclusion`
- rewrite-spring-v1 — `JaxrsToSpringMvcResponseEntityTest` x2,
  `AuthorizeHttpRequestsTest.noArgAuthorizeRequestsWithVars`

rewrite-spring-v2 could not be measured; it does not compile against any core version right now
(`MigrateListenableFuture.java:42`, `Preconditions.check(UsesType, ListenableToCompletableFuture)`),
pre-existing and unrelated to this change.

These measurements predate the alias fix and the collision test. The alias fix only changes
behaviour when an import alias is present, and no scanned downstream repository combines an aliased
import with a nested-type `ChangeType` target, so the numbers should still hold — but they were not
re-measured against the final commit.

The trade-off against the alternative direction (preferring the bare nested name, which is what a
hand migration usually writes) is laid out in
https://github.com/openrewrite/rewrite/issues/8398#issuecomment-5192256690 — it costs more
downstream churn and needs a same-file consistency problem solved first. **Draft** pending a call
on which shape we want as the default.

## Verification

`rewrite-java-test`, `rewrite-java`, `rewrite-kotlin` and `rewrite-groovy` green locally; CI green
on the pre-condensing commit (https://github.com/openrewrite/rewrite/actions/runs/31035918079) and
re-running for the current one.
