### PR TITLE
Move the builtins skip into the `AddImport` visitor so the RPC path honors it

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -91,10 +91,6 @@ def maybe_add_import(visitor: PythonVisitor, options: AddImportOptions) -> None:
         # Add: from typing import *
         maybe_add_import(visitor, AddImportOptions(module='typing', name='*'))
     """
-    # builtins are always available; only import them under an explicit alias
-    if options.module == 'builtins' and options.alias is None:
-        return
-
     # Check for duplicate registrations
     if visitor._after_visit is None:
         visitor._after_visit = []
@@ -127,6 +123,10 @@ class AddImport(PythonVisitor):
         self.only_if_referenced = options.only_if_referenced
 
     def visit_compilation_unit(self, cu: CompilationUnit, p) -> J:
+        # builtins are always available; only import them under an explicit alias
+        if self.module == 'builtins' and self.alias is None:
+            return cu
+
         # A bare builtin name (e.g. `list` when ChangeType retargets a type to a builtin) is
         # not a module, so there is no import that could bind it.
         if self.name is None and '.' not in self.module and hasattr(builtins, self.module):

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -16,7 +16,7 @@
 
 from rewrite import ExecutionContext, InMemoryExecutionContext
 from rewrite.java import J
-from rewrite.python.add_import import AddImportOptions, maybe_add_import
+from rewrite.python.add_import import AddImport, AddImportOptions, maybe_add_import
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python, from_visitor
@@ -339,6 +339,24 @@ class TestMaybeAddImport:
                 """
                 from builtins import list as _list
                 x = 1
+                """,
+            )
+        )
+
+
+class TestAddImportVisitor:
+    """Tests for AddImport constructed directly (bypassing maybe_add_import),
+    as the RPC server does for Java-initiated ``maybeAddImport`` calls."""
+
+    def test_skips_builtins_import(self):
+        """e.g. Java's ChangeType retargeting a type to ``builtins.list`` must
+        not add ``from builtins import list``."""
+        spec = RecipeSpec(recipe=from_visitor(AddImport(AddImportOptions(
+            module='builtins', name='list', only_if_referenced=False))))
+        spec.rewrite_run(
+            python(
+                """
+                x: list = []
                 """,
             )
         )

--- a/rewrite-python/rewrite/tests/rpc/test_java_recipes.py
+++ b/rewrite-python/rewrite/tests/rpc/test_java_recipes.py
@@ -33,10 +33,6 @@ from rewrite.test import RecipeSpec, python
 class TestChangeType:
     """Tests for the ChangeType Java recipe wrapper."""
 
-    @pytest.mark.xfail(strict=False, reason=(
-        "import removal requires the PythonImportService fallback to the "
-        "serving RPC connection (PythonRewriteRpc.get() is null when Python "
-        "spawned the JVM); remove this marker when that fix lands"))
     def test_change_type_with_unqualified_target(self, java_rpc):
         """Test changing a type reference to an unqualified target name
         (contrast ``builtins.list`` in the type-attribution test below).
@@ -70,10 +66,6 @@ class TestChangeType:
         )
 
 
-    @pytest.mark.xfail(strict=False, reason=(
-        "requires the PythonImportService fallback plus the ref-slot re-ADD "
-        "diff semantics (#8392) and the ShallowClass.build owning-class fix "
-        "(#8391); remove this marker when all three land"))
     def test_change_simple_type_updates_type_attribution(self, java_rpc):
         """The renamed identifiers must also carry the *new* JavaType, so that
         downstream type-driven logic (``uses_type``, MethodMatcher, a second


### PR DESCRIPTION
## Motivation

- The two ChangeType tests added as `xfail(strict=False)` in #8390 never got their markers removed after the prerequisite fixes (#8391, #8392, #8394) merged. Re-running them on current `main` showed one silently XPASSing and the other failing for a new, previously masked reason: `ChangeType(typing.List -> builtins.list)` produced a spurious `from builtins import list`. The builtins guard ("builtins are always available, don't import them without an alias") lived only in the `maybe_add_import()` helper, but Java-initiated `maybeAddImport` calls arrive via `PythonImportService` and the RPC server, which constructs the `AddImport` visitor directly from wire options — bypassing the guard. The visitor's own guard only covered the bare-module form (`import list`), not `from builtins import X`.

## Summary

- Move the builtins guard from `maybe_add_import()` into `AddImport.visit_compilation_unit`, the single spot both entry paths (Python-side registration and RPC dispatch) go through. Aliased builtins imports (`from builtins import list as _list`) are still added.
- Add `TestAddImportVisitor.test_skips_builtins_import` exercising the direct-construction path the RPC server uses.
- Remove the two stale `xfail` markers from `tests/rpc/test_java_recipes.py`; both tests now pass outright.

## Test plan

- [x] `pytest tests/python/test_add_import.py` (18 passed, including the new direct-visitor test and the pre-existing aliased-builtins test)
- [x] `pytest tests/rpc/test_java_recipes.py` (6 passed, both formerly-xfailed ChangeType tests now plain passes)
- [x] `pytest tests/python tests/recipes` (1624 passed, 10 skipped)
- [x] `pytest tests/rpc` (139 passed)