### PR TITLE
Pin ref-slot diff wire states and make Reference.value final

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/Reference.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/Reference.java
@@ -27,7 +27,15 @@ import static java.util.Objects.requireNonNull;
 @Getter
 public class Reference {
     @Nullable
-    private Object value;
+    private final Object value;
+
+    protected Reference() {
+        this.value = null;
+    }
+
+    private Reference(@Nullable Object value) {
+        this.value = value;
+    }
 
     /**
      * @param t Any instance.
@@ -36,9 +44,7 @@ public class Reference {
      * before and after references at the same time, so they must not share state.
      */
     public static Reference asRef(@Nullable Object t) {
-        Reference ref = new Reference();
-        ref.value = t;
-        return ref;
+        return new Reference(t);
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RpcSendQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RpcSendQueueTest.java
@@ -15,12 +15,14 @@
  */
 package org.openrewrite.rpc;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.AccessMode;
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,6 +95,56 @@ class RpcSendQueueTest {
           new RpcObjectData(ADD, null, "T2", 2, false),
           new RpcObjectData(ADD, null, null, 2, false)
         );
+    }
+
+    @Test
+    void deletedRefSlotIsSent() {
+        RefSlotDiff diff = diffRefSlot("java.util.List", null);
+        assertThat(diff.data())
+          .extracting(RpcObjectData::getState)
+          .containsExactly(RpcObjectData.State.CHANGE, RpcObjectData.State.DELETE);
+        assertThat(diff.consumed()).isNull();
+    }
+
+    @Test
+    void identicalRefSlotIsNoChange() {
+        Object type = new Object();
+        RefSlotDiff diff = diffRefSlot(type, type);
+        assertThat(diff.data())
+          .extracting(RpcObjectData::getState)
+          .containsExactly(RpcObjectData.State.CHANGE, RpcObjectData.State.NO_CHANGE);
+        assertThat(diff.consumed()).isNull();
+    }
+
+    @Test
+    void changedRefSlotOfDifferentClassIsAdded() {
+        RefSlotDiff diff = diffRefSlot(1, "java.util.ArrayList");
+        assertThat(diff.data())
+          .extracting(RpcObjectData::getState)
+          .containsExactly(RpcObjectData.State.CHANGE, RpcObjectData.State.ADD);
+        assertThat(diff.consumed()).isEqualTo("java.util.ArrayList");
+    }
+
+    /**
+     * Diffs one ref-wrapped slot between a before and an after holder. The slot is emitted
+     * from within the holders' own diff (send &rarr; onChange &rarr; getAndSend), which is what
+     * seeds the queue's before context; a bare getAndSend would diff against null and always ADD.
+     */
+    private RefSlotDiff diffRefSlot(@Nullable Object beforeValue, @Nullable Object afterValue) {
+        List<RpcObjectData> data = new ArrayList<>();
+        RpcSendQueue q = new RpcSendQueue(100, data::addAll, new IdentityHashMap<>(), null, false);
+        Holder after = new Holder(afterValue);
+        AtomicReference<Object> consumed = new AtomicReference<>();
+        q.send(after, new Holder(beforeValue), () ->
+          q.getAndSend(after, h -> Reference.asRef(h.value), v -> consumed.set(Reference.getValue(v))));
+        q.flush();
+        return new RefSlotDiff(data, consumed.get());
+    }
+
+    private record RefSlotDiff(List<RpcObjectData> data, @Nullable Object consumed) {
+    }
+
+    private record Holder(@Nullable Object value) {
     }
 
     @Test


### PR DESCRIPTION
## Motivation

- Follow-up to #8392, which fixed the `Reference.asRef` flyweight and settled the re-ADD semantics for changed ref-deduplicated slots. The DELETE, identical-value NO_CHANGE, and class-changed ADD paths of a ref-wrapped slot diff were equally corrupted by the old flyweight (both sides of the comparison collapsed onto one mutable wrapper) but have no wire-level regression coverage on main. This adds it, and hardens `Reference` so the per-call-instance guarantee that #8392's semantics rely on is structural rather than comment-enforced.

## Summary

- `RpcSendQueueTest`: three new tests pinning the wire states a diffed ref slot emits — `deletedRefSlotIsSent` (CHANGE, DELETE), `identicalRefSlotIsNoChange` (CHANGE, NO_CHANGE), `changedRefSlotOfDifferentClassIsAdded` (CHANGE, ADD) — including that the onChange consumer sees the after value (or is not invoked for DELETE/NO_CHANGE), via a small `diffRefSlot` helper that seeds the queue's before context the same way senders do
- `Reference.value` is now `final`, assigned through a private constructor; a protected no-arg constructor keeps the `GitProvenance` subclass compiling unchanged

## Test plan

- [x] `./gradlew :rewrite-core:test --tests "org.openrewrite.rpc.RpcSendQueueTest"`
- [x] Full `./gradlew :rewrite-core:test` (covers `GitProvenance` marker round trips against the constructor change)