### PR TITLE
Route Python type positions through visitTypeName

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
@@ -98,7 +98,13 @@ public class PythonVisitor<P> extends JavaVisitor<P>
     public J visitExceptionType(Py.ExceptionType exceptionType, P p) {
         exceptionType = exceptionType.withPrefix(visitSpace(exceptionType.getPrefix(), PySpace.Location.EXCEPTION_TYPE_PREFIX, p));
         exceptionType = exceptionType.withMarkers(visitMarkers(exceptionType.getMarkers(), p));
-        return exceptionType.withExpression(visitAndCast(exceptionType.getExpression(), p));
+        return exceptionType.withExpression((Expression) visitTypeNameIfNameTree(visitAndCast(exceptionType.getExpression(), p), p));
+    }
+
+    // Python type positions hold `Expression`/`J` children (to allow e.g. `None`, subscripts, or forward-reference
+    // strings), so only route the ones that are actually name trees through `visitTypeName`
+    private @Nullable J visitTypeNameIfNameTree(@Nullable J j, P p) {
+        return j instanceof NameTree ? visitTypeName((NameTree) j, p) : j;
     }
 
     public J visitLiteralType(Py.LiteralType literalType, P p) {
@@ -116,7 +122,7 @@ public class PythonVisitor<P> extends JavaVisitor<P>
     public J visitTypeHint(Py.TypeHint typeHint, P p) {
         typeHint = typeHint.withPrefix(visitSpace(typeHint.getPrefix(), PySpace.Location.TYPE_HINT_PREFIX, p));
         typeHint = typeHint.withMarkers(visitMarkers(typeHint.getMarkers(), p));
-        return typeHint.withTypeTree(visitAndCast(typeHint.getTypeTree(), p));
+        return typeHint.withTypeTree((Expression) visitTypeNameIfNameTree(visitAndCast(typeHint.getTypeTree(), p), p));
     }
 
     public J visitCompilationUnit(Py.CompilationUnit compilationUnit, P p) {
@@ -140,7 +146,7 @@ public class PythonVisitor<P> extends JavaVisitor<P>
         }
         expressionTypeTree = (Py.ExpressionTypeTree) tempExpression;
         expressionTypeTree = expressionTypeTree.withMarkers(visitMarkers(expressionTypeTree.getMarkers(), p));
-        return expressionTypeTree.withReference(visitAndCast(expressionTypeTree.getReference(), p));
+        return expressionTypeTree.withReference(visitTypeNameIfNameTree(visitAndCast(expressionTypeTree.getReference(), p), p));
     }
 
     public J visitStatementExpression(Py.StatementExpression statementExpression, P p) {
@@ -286,7 +292,8 @@ public class PythonVisitor<P> extends JavaVisitor<P>
         typeAlias = (Py.TypeAlias) tempStatement;
         typeAlias = typeAlias.withMarkers(visitMarkers(typeAlias.getMarkers(), p));
         typeAlias = typeAlias.withName(visitAndCast(typeAlias.getName(), p));
-        return typeAlias.getPadding().withValue(visitLeftPadded(typeAlias.getPadding().getValue(), PyLeftPadded.Location.TYPE_ALIAS_VALUE, p));
+        typeAlias = typeAlias.getPadding().withValue(visitLeftPadded(typeAlias.getPadding().getValue(), PyLeftPadded.Location.TYPE_ALIAS_VALUE, p));
+        return typeAlias.getPadding().withValue(typeAlias.getPadding().getValue().withElement(visitTypeNameIfNameTree(typeAlias.getPadding().getValue().getElement(), p)));
     }
 
     public J visitYieldFrom(Py.YieldFrom yieldFrom, P p) {
@@ -310,7 +317,8 @@ public class PythonVisitor<P> extends JavaVisitor<P>
         }
         unionType = (Py.UnionType) tempExpression;
         unionType = unionType.withMarkers(visitMarkers(unionType.getMarkers(), p));
-        return unionType.getPadding().withTypes(ListUtils.map(unionType.getPadding().getTypes(), el -> visitRightPadded(el, PyRightPadded.Location.UNION_TYPE_TYPES, p)));
+        unionType = unionType.getPadding().withTypes(ListUtils.map(unionType.getPadding().getTypes(), el -> visitRightPadded(el, PyRightPadded.Location.UNION_TYPE_TYPES, p)));
+        return unionType.getPadding().withTypes(ListUtils.map(unionType.getPadding().getTypes(), el -> el.withElement((Expression) visitTypeNameIfNameTree(el.getElement(), p))));
     }
 
     public J visitVariableScope(Py.VariableScope variableScope, P p) {

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonVisitorTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonVisitorTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.openrewrite.java.tree.NameTree;
+import org.openrewrite.python.tree.Py;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.python.Assertions.python;
+
+/**
+ * Verifies that Python type positions are routed through {@link PythonVisitor#visitTypeName}, so
+ * recipes hooking type names (e.g. {@code ChangeType}, {@code FindTypes}) see them on Python trees
+ * just as they do on Java trees.
+ */
+@DisabledIfEnvironmentVariable(named = "CI", matches = "true", disabledReason = "No remote client/server available")
+class PythonVisitorTest implements RewriteTest {
+
+    private static List<String> collectTypeNames(Py.CompilationUnit cu) {
+        List<String> names = new ArrayList<>();
+        new PythonVisitor<List<String>>() {
+            @Override
+            public <N extends NameTree> N visitTypeName(N nameTree, List<String> ns) {
+                ns.add(nameTree.getClass().getSimpleName() + ":" + nameTree.printTrimmed(getCursor()));
+                return nameTree;
+            }
+        }.visit(cu, names);
+        return names;
+    }
+
+    @Test
+    void parameterAnnotationIsVisitedAsTypeName() {
+        rewriteRun(
+          python(
+            """
+              from typing import List
+
+              def foo(items: List[str]) -> List[int]:
+                  pass
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(collectTypeNames(cu))
+              .contains("ParameterizedType:List[str]"))
+          )
+        );
+    }
+
+    @Test
+    void returnTypeHintTreeIsVisitedAsTypeName() {
+        rewriteRun(
+          python(
+            """
+              class Box:
+                  pass
+
+              def g() -> Box:
+                  pass
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(collectTypeNames(cu))
+              .contains("Identifier:Box"))
+          )
+        );
+    }
+
+    @Test
+    void exceptionTypeExpressionIsVisitedAsTypeName() {
+        rewriteRun(
+          python(
+            """
+              try:
+                  pass
+              except ValueError:
+                  pass
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(collectTypeNames(cu))
+              .contains("Identifier:ValueError"))
+          )
+        );
+    }
+
+    @Test
+    void unionTypeMembersAreVisitedAsTypeNames() {
+        rewriteRun(
+          python(
+            """
+              def f(x: int | str) -> None:
+                  pass
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(collectTypeNames(cu))
+              .contains("Identifier:int", "Identifier:str"))
+          )
+        );
+    }
+
+    @Test
+    void typeAliasValueIsVisitedAsTypeName() {
+        rewriteRun(
+          python(
+            """
+              from typing import List
+
+              type Aliased = List
+              """,
+            spec -> spec.afterRecipe(cu -> assertThat(collectTypeNames(cu))
+              .contains("Identifier:List"))
+          )
+        );
+    }
+}


### PR DESCRIPTION
## Motivation

- `JavaVisitor` parents route type expressions through `visitTypeName`, which is how recipes that hook type names (`ChangeType`, `FindTypes`, ...) find type usages. Python's parameter annotations already benefit, because the annotation tree sits directly in `J.VariableDeclarations#typeExpression`. But the `Py`-specific nodes visited their type children as plain expressions, so type names in return hints (`Py.TypeHint`), `except` clauses (`Py.ExceptionType`, whose own type attribution is null — the inner name carries the type), PEP 604 unions (`Py.UnionType`), type aliases (`Py.TypeAlias`), and `Py.ExpressionTypeTree` references never reached `visitTypeName` on Python trees. This is a follow-up to #8397, which worked around one instance of this gap inside `FindTypes` (that guard stays, as other languages may have the same traversal shape).

## Summary

- `PythonVisitor` routes the type-name children of `Py.TypeHint`, `Py.ExceptionType`, `Py.UnionType` (each member), `Py.TypeAlias` (the value), and `Py.ExpressionTypeTree` through `visitTypeName`, guarded on `NameTree` since these fields are typed `Expression`/`J` to allow `None`, subscripts, and forward-reference strings.
- New `PythonVisitorTest` pins the routing per position, plus a characterization test for the already-working parameter-annotation path.

## Test plan

- `./gradlew :rewrite-python:test --tests "org.openrewrite.python.PythonVisitorTest"` — four new position tests failed before the change and pass after; the parameter characterization test passes throughout.
- `./gradlew :rewrite-python:test` for `org.openrewrite.python.search.*`, `ChangeTypeTest`, and `AddDependencyTest` — recipes overriding `visitTypeName` on Python trees stay green.