### PR TITLE
Depend on released `io.moderne:jsonrpc` in published configurations

### DIFF
--- a/rewrite-core/build.gradle.kts
+++ b/rewrite-core/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("io.micrometer:micrometer-core:1.9.+")
     implementation("org.yaml:snakeyaml:latest.release")
 
-    implementation("io.moderne:jsonrpc:latest.integration")
+    implementation("io.moderne:jsonrpc:latest.release")
     implementation("org.objenesis:objenesis:latest.release")
 
     testImplementation("org.assertj:assertj-core:latest.release")

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
     api("com.fasterxml.jackson.core:jackson-annotations")
 
-    implementation("io.moderne:jsonrpc:latest.integration")
+    implementation("io.moderne:jsonrpc:latest.release")
 
     compileOnly(project(":rewrite-test"))
     compileOnly(project(":rewrite-xml"))

--- a/rewrite-go/build.gradle.kts
+++ b/rewrite-go/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
     api("com.fasterxml.jackson.core:jackson-annotations")
 
-    implementation("io.moderne:jsonrpc:latest.integration")
+    implementation("io.moderne:jsonrpc:latest.release")
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
     api("com.fasterxml.jackson.core:jackson-annotations")
 
-    implementation("io.moderne:jsonrpc:latest.integration")
+    implementation("io.moderne:jsonrpc:latest.release")
 
     compileOnly(project(":rewrite-test"))
 

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -29,7 +29,7 @@ dependencies {
     api("org.jetbrains:annotations:latest.release")
     api("com.fasterxml.jackson.core:jackson-annotations")
 
-    implementation("io.moderne:jsonrpc:latest.integration")
+    implementation("io.moderne:jsonrpc:latest.release")
     implementation(project(":rewrite-maven"))
 
     compileOnly(project(":rewrite-test"))


### PR DESCRIPTION
The v8.88.1 release failed at `:closeSonatypeStagingRepository`:

```
Failed to process request: Deployment reached an unexpected status: Failed
  pkg:maven/org.openrewrite/rewrite-csharp@8.88.1
  - Dependencies to SNAPSHOT versions not allowed for dependency: io.moderne:jsonrpc
  pkg:maven/org.openrewrite/rewrite-python@8.88.1
  pkg:maven/org.openrewrite/rewrite-javascript@8.88.1
  pkg:maven/org.openrewrite/rewrite-core@8.88.1
  pkg:maven/org.openrewrite/rewrite-go@8.88.1
  pkg:maven/org.openrewrite/rewrite-maven@8.88.1
```

Nothing changed in these modules. They have long declared
`implementation("io.moderne:jsonrpc:latest.integration")`, which *includes*
SNAPSHOTs. `io.moderne:jsonrpc:1.1.0-SNAPSHOT` first appeared upstream at
17:35 UTC — 74 minutes before the release ran — so the dependency silently
moved off the `1.0.10` release onto `1.1.0-20260805.173506-8`.

Two things made this hard to see:

1. **Nebula writes the resolved version into the POM**, not the declared
   string, so a dynamic version landing on a snapshot is invisible in the
   build files.
2. **The snapshot contaminated a sibling POM.** `rewrite-maven` already
   declared `latest.release`, yet was still rejected: it has
   `implementation(project(":rewrite-core"))`, and Gradle conflict-resolves
   `jsonrpc` to the highest version on the combined classpath, so
   `rewrite-core`'s `latest.integration` won. Fixing only the module named
   first in the error would not have been enough.

This switches the five **published** (`implementation`) declarations to
`latest.release`, matching what `rewrite-maven` already did.
`rewrite-python`'s `py2CompatibilityTest` JvmTestSuite and the various
`testImplementation` declarations are left alone — they never reach a POM.

## Verification

- `dependencyInsight` → `io.moderne:jsonrpc:latest.release -> 1.0.10`
- Generated POMs for `rewrite-csharp`, `rewrite-core` and `rewrite-maven` all
  carry `<version>1.0.10</version>`
- All five modules compile against `1.0.10`

Note that CI has been building against `1.1.0-SNAPSHOT` and will now use
`1.0.10`. Nothing on `main` uses 1.1.0-only APIs (it compiles clean), but if
that changes, the unblock is releasing jsonrpc 1.1.0 rather than this pin.

https://claude.ai/code/session_014tUremKxU4FWH2bD2aFGXF