### PR TITLE
Assert the internal placeholder form in t-string template tests

### DIFF
--- a/rewrite-python/rewrite/tests/python/py314/test_tstring_template.py
+++ b/rewrite-python/rewrite/tests/python/py314/test_tstring_template.py
@@ -3,6 +3,7 @@
 import pytest
 
 from rewrite.python.template import template, pattern, capture, raw
+from rewrite.python.template.placeholder import substitute_placeholders
 
 
 # -- template() with t-strings --
@@ -17,14 +18,14 @@ class TestTemplateTstring:
     def test_single_capture(self):
         expr = capture('expr')
         tmpl = template(t"print({expr})")
-        assert tmpl.code == "print({expr})"
+        assert tmpl.code == "print(__plh_expr__)"
         assert tmpl.captures == {'expr': expr}
 
     def test_multiple_captures(self):
         a = capture('a')
         b = capture('b')
         tmpl = template(t"{a} + {b}")
-        assert tmpl.code == "{a} + {b}"
+        assert tmpl.code == "__plh_a__ + __plh_b__"
         assert tmpl.captures == {'a': a, 'b': b}
 
     def test_raw_code_spliced(self):
@@ -37,7 +38,7 @@ class TestTemplateTstring:
         method = raw("info")
         expr = capture('expr')
         tmpl = template(t"logger.{method}({expr})")
-        assert tmpl.code == "logger.info({expr})"
+        assert tmpl.code == "logger.info(__plh_expr__)"
         assert tmpl.captures == {'expr': expr}
 
     def test_non_capture_interpolation_raises(self):
@@ -53,13 +54,14 @@ class TestTemplateTstring:
         expr = capture('expr')
         t1 = template(t"print({expr})")
         t2 = template("print({expr})", expr=expr)
-        assert t1.code == t2.code
+        # t-strings pre-normalize captures to placeholders; the string form defers to the engine
+        assert t1.code == substitute_placeholders(t2.code, t2.captures)[0]
         assert t1.captures == t2.captures
 
     def test_with_imports(self):
         expr = capture('expr')
         tmpl = template(t"datetime.now() + {expr}", imports=["from datetime import datetime"])
-        assert tmpl.code == "datetime.now() + {expr}"
+        assert tmpl.code == "datetime.now() + __plh_expr__"
         assert tmpl.captures == {'expr': expr}
 
 
@@ -75,14 +77,14 @@ class TestPatternTstring:
     def test_single_capture(self):
         expr = capture('expr')
         pat = pattern(t"print({expr})")
-        assert pat.code == "print({expr})"
+        assert pat.code == "print(__plh_expr__)"
         assert pat.captures == {'expr': expr}
 
     def test_multiple_captures(self):
         a = capture('a')
         b = capture('b')
         pat = pattern(t"{a} + {b}")
-        assert pat.code == "{a} + {b}"
+        assert pat.code == "__plh_a__ + __plh_b__"
         assert pat.captures == {'a': a, 'b': b}
 
     def test_raw_code_spliced(self):
@@ -95,7 +97,7 @@ class TestPatternTstring:
         method = raw("info")
         expr = capture('expr')
         pat = pattern(t"logger.{method}({expr})")
-        assert pat.code == "logger.info({expr})"
+        assert pat.code == "logger.info(__plh_expr__)"
         assert pat.captures == {'expr': expr}
 
     def test_non_capture_interpolation_raises(self):
@@ -111,5 +113,6 @@ class TestPatternTstring:
         expr = capture('expr')
         p1 = pattern(t"print({expr})")
         p2 = pattern("print({expr})", expr=expr)
-        assert p1.code == p2.code
+        # t-strings pre-normalize captures to placeholders; the string form defers to the engine
+        assert p1.code == substitute_placeholders(p2.code, p2.captures)[0]
         assert p1.captures == p2.captures


### PR DESCRIPTION
`tests/python/py314/test_tstring_template.py` has 9 failing tests on `main`.
They don't fail CI because the file is collection-gated to Python 3.14+ by its
`conftest.py` (t-string syntax is a `SyntaxError` on older interpreters), and
CI runs an older Python. They show up as soon as you run pytest on a 3.14 venv:

```
9 failed, 1926 passed, 85 skipped
E  AssertionError: assert 'print(__plh_expr__)' == 'print({expr})'
```

The tests are wrong, not the implementation. `convert_tstring` emits
`__plh_name__` for `Capture` interpolations, which matches the pre-existing
f-string path — `Capture.__format__` returns the same thing, and
`test_capture.py` already pins it:

```python
assert template(f"print({expr})").code == "print(__plh_expr__)"
assert template(f"logger.{method}({expr})").code == "logger.warn(__plh_expr__)"
```

That normalization is deliberate: the docstring on `Capture.__format__` notes
the result is "already in the engine's internal format (a valid Python
identifier)". `{name}` is *not* a valid identifier, so pre-normalizing avoids
re-parsing ambiguity against literal braces in dict and set literals. Only the
`template("...", name=cap)` spelling keeps `{name}`, deferring substitution to
`substitute_placeholders` in the engine.

So these assertions are updated to the placeholder form. The two
`test_equivalent_to_string_form` cases asserted raw `.code` equality between
the t-string and string spellings, which is false by design; they now compare
after `substitute_placeholders`, which is where the two forms genuinely
converge — a stronger check than simply relaxing them.

## Verification

`1935 passed, 85 skipped` on Python 3.14.6, up from `1926 passed, 9 failed`,
with no other test disturbed.

Worth noting separately: CI cannot catch regressions in this file at all while
its interpreter predates 3.14.

https://claude.ai/code/session_014tUremKxU4FWH2bD2aFGXF