### PR TITLE
Go: distinguish integer widths instead of collapsing all to int

### DIFF
--- a/rewrite-go/pkg/matcher/matcher_test.go
+++ b/rewrite-go/pkg/matcher/matcher_test.go
@@ -92,6 +92,85 @@ func TestIsString(t *testing.T) {
 	}
 }
 
+func TestIsInt(t *testing.T) {
+	// Signed widths map to primitive keywords; unsigned widths to named types.
+	intLike := []java.JavaType{
+		&java.JavaTypePrimitive{Keyword: "int"},   // int, int32
+		&java.JavaTypePrimitive{Keyword: "long"},  // int64
+		&java.JavaTypePrimitive{Keyword: "short"}, // int16
+		&java.JavaTypePrimitive{Keyword: "byte"},  // int8, byte
+		&java.JavaTypeClass{FullyQualifiedName: "uint"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint8"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint16"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint32"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint64"},
+		&java.JavaTypeClass{FullyQualifiedName: "uintptr"},
+	}
+	for _, typ := range intLike {
+		if !IsInt(typ) {
+			t.Errorf("IsInt(%q) = false, want true", GetFullyQualifiedName(typ))
+		}
+	}
+	notInt := []java.JavaType{
+		&java.JavaTypePrimitive{Keyword: "double"},
+		&java.JavaTypePrimitive{Keyword: "String"},
+		&java.JavaTypePrimitive{Keyword: "boolean"},
+		nil,
+	}
+	for _, typ := range notInt {
+		if IsInt(typ) {
+			t.Errorf("IsInt(%q) = true, want false", GetFullyQualifiedName(typ))
+		}
+	}
+}
+
+func TestIsNumeric(t *testing.T) {
+	numeric := []java.JavaType{
+		// Signed widths, floats, and rune map to primitive keywords.
+		&java.JavaTypePrimitive{Keyword: "int"},    // int, int32
+		&java.JavaTypePrimitive{Keyword: "long"},   // int64
+		&java.JavaTypePrimitive{Keyword: "short"},  // int16
+		&java.JavaTypePrimitive{Keyword: "byte"},   // int8, byte
+		&java.JavaTypePrimitive{Keyword: "float"},  // float32
+		&java.JavaTypePrimitive{Keyword: "double"}, // float64
+		&java.JavaTypePrimitive{Keyword: "char"},   // rune
+		// Unsigned widths have no Java primitive, so they are named types.
+		&java.JavaTypeClass{FullyQualifiedName: "uint"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint8"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint16"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint32"},
+		&java.JavaTypeClass{FullyQualifiedName: "uint64"},
+		&java.JavaTypeClass{FullyQualifiedName: "uintptr"},
+	}
+	for _, typ := range numeric {
+		if !IsNumeric(typ) {
+			t.Errorf("IsNumeric(%q) = false, want true", GetFullyQualifiedName(typ))
+		}
+	}
+	if IsNumeric(&java.JavaTypePrimitive{Keyword: "String"}) {
+		t.Error("IsNumeric(String) = true, want false")
+	}
+	if IsNumeric(nil) {
+		t.Error("IsNumeric(nil) = true, want false")
+	}
+}
+
+// Pattern type names must resolve to the same signature the type mapper
+// produces, so int64 patterns match "long" and uint stays "uint".
+func TestResolveGoType(t *testing.T) {
+	tests := map[string]string{
+		"int": "int", "int32": "int", "int16": "short", "int8": "byte", "int64": "long",
+		"uint": "uint", "uint64": "uint64", "uintptr": "uintptr",
+		"float32": "float", "float64": "double",
+		"string": "String", "bool": "boolean", "byte": "byte", "rune": "char", "error": "error",
+	}
+	for in, want := range tests {
+		if got := resolveGoType(in); got != want {
+			t.Errorf("resolveGoType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
 func TestAsClass(t *testing.T) {
 	cls := &java.JavaTypeClass{FullyQualifiedName: "foo.Bar"}
 	if AsClass(cls) != cls {

--- a/rewrite-go/pkg/matcher/method_matcher.go
+++ b/rewrite-go/pkg/matcher/method_matcher.go
@@ -266,23 +266,31 @@ func isRegexpMeta(ch byte) bool {
 	return strings.ContainsRune(`\.+?{}[]()^$|`, rune(ch))
 }
 
-// resolveGoType maps common Go type names to their FQN equivalents
-// used by the type mapper. This allows patterns like "string" to match
-// both the primitive keyword and the FQN.
+// Maps a Go type name from a matcher pattern to the type signature the type
+// mapper produces, so patterns like "int64" match the mapped primitive keyword
+// ("long") and "uint" matches the synthetic FQN.
 func resolveGoType(name string) string {
-	// The type mapper maps Go primitives to JavaTypePrimitive keywords.
-	// Most Go types are already their own FQN.
+	// The type mapper maps Go integer widths that Java can express to their
+	// primitive keyword and unsigned widths to a synthetic class FQN.
 	switch name {
 	case "string":
 		return "String" // JavaTypePrimitive keyword for Go strings
 	case "bool":
 		return "boolean"
-	case "int", "int8", "int16", "int32", "int64":
-		return name
+	case "int", "int32":
+		return "int"
+	case "int16":
+		return "short"
+	case "int8":
+		return "byte"
+	case "int64":
+		return "long"
 	case "uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
-		return name
-	case "float32", "float64":
-		return name
+		return name // unsigned widths have no Java primitive; keep the Go FQN
+	case "float32":
+		return "float"
+	case "float64":
+		return "double"
 	case "byte":
 		return "byte"
 	case "rune":

--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -124,11 +124,9 @@ func IsNumeric(t java.JavaType) bool {
 			return true
 		}
 	}
-	fqn := GetFullyQualifiedName(t)
-	switch fqn {
-	case "int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
-		"float32", "float64", "byte", "rune":
+	// Go's unsigned integers have no Java primitive; they map to named types.
+	switch GetFullyQualifiedName(t) {
+	case "uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
 		return true
 	}
 	return false
@@ -137,16 +135,13 @@ func IsNumeric(t java.JavaType) bool {
 func IsInt(t java.JavaType) bool {
 	if p, ok := t.(*java.JavaTypePrimitive); ok {
 		switch p.Keyword {
-		case "int", "int8", "int16", "int32", "int64",
-			"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
-			"byte", "rune":
+		case "int", "long", "short", "byte":
 			return true
 		}
 	}
+	// Go's unsigned integers have no Java primitive; they map to named types.
 	switch GetFullyQualifiedName(t) {
-	case "int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
-		"byte", "rune":
+	case "uint", "uint8", "uint16", "uint32", "uint64", "uintptr":
 		return true
 	}
 	return false

--- a/rewrite-go/pkg/parser/type_mapper.go
+++ b/rewrite-go/pkg/parser/type_mapper.go
@@ -62,6 +62,9 @@ func (m *typeMapper) doMapType(t types.Type) java.JavaType {
 	switch v := t.(type) {
 	case *types.Basic:
 		return m.mapBasic(v)
+	case *types.Alias:
+		// Go 1.22+ materializes transparent aliases (including the predeclared `any`); map the target.
+		return m.mapType(types.Unalias(v))
 	case *types.Named:
 		if m.ownPkg != nil {
 			if pkg := v.Obj().Pkg(); pkg != nil && !m.ownPkg(pkg.Path()) {
@@ -119,11 +122,21 @@ func (m *typeMapper) mapBasic(b *types.Basic) java.JavaType {
 	switch b.Kind() {
 	case types.Bool, types.UntypedBool:
 		return &java.JavaTypePrimitive{Keyword: "boolean"}
-	case types.Int, types.Int8, types.Int16, types.Int32, types.Int64,
-		types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64,
-		types.Uintptr, types.UntypedInt:
+	case types.Int8:
+		return &java.JavaTypePrimitive{Keyword: "byte"}
+	case types.Int16:
+		return &java.JavaTypePrimitive{Keyword: "short"}
+	case types.Int64:
+		return &java.JavaTypePrimitive{Keyword: "long"}
+	case types.Int, types.Int32, types.UntypedInt:
 		return &java.JavaTypePrimitive{Keyword: "int"}
-	case types.Float32, types.Float64, types.UntypedFloat:
+	case types.Uint, types.Uint8, types.Uint16, types.Uint32, types.Uint64, types.Uintptr:
+		// Go's unsigned integer widths have no Java primitive equivalent, so they map to
+		// synthetic named types keyed by their Go type name (as with map/chan).
+		return &java.JavaTypeClass{FullyQualifiedName: b.Name(), Kind: "Class"}
+	case types.Float32:
+		return &java.JavaTypePrimitive{Keyword: "float"}
+	case types.Float64, types.UntypedFloat:
 		return &java.JavaTypePrimitive{Keyword: "double"}
 	case types.Complex64, types.Complex128, types.UntypedComplex:
 		return &java.JavaTypePrimitive{Keyword: "double"}
@@ -133,6 +146,9 @@ func (m *typeMapper) mapBasic(b *types.Basic) java.JavaType {
 		return &java.JavaTypePrimitive{Keyword: "char"}
 	case types.UntypedNil:
 		return &java.JavaTypePrimitive{Keyword: "void"}
+	case types.UnsafePointer:
+		// No Java primitive exists for it, so map it to a synthetic named type.
+		return &java.JavaTypeClass{FullyQualifiedName: "unsafe.Pointer", Kind: "Class"}
 	default:
 		return java.UnknownType
 	}

--- a/rewrite-go/test/method_matcher_width_test.go
+++ b/rewrite-go/test/method_matcher_width_test.go
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/matcher"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// Narrowing by integer width must work end to end: a pattern naming int64 matches
+// an int64 argument but rejects an int one, and vice versa.
+func TestMethodMatcherDistinguishesIntWidths(t *testing.T) {
+	cu, err := parser.NewGoParser().Parse("test.go", `package main
+
+import "strconv"
+
+func main() {
+	var i64 int64
+	var u64 uint64
+	var i int
+	_ = strconv.FormatInt(i64, 10)
+	_ = strconv.FormatUint(u64, 10)
+	_ = strconv.Itoa(i)
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	calls := map[string]*java.MethodInvocation{}
+	visitor.Walk(cu, func(n java.Tree) bool {
+		if mi, ok := n.(*java.MethodInvocation); ok {
+			calls[mi.Name.Name] = mi
+		}
+		return true
+	})
+
+	cases := []struct {
+		pattern string
+		call    string
+		want    bool
+	}{
+		// int64 argument: matches an int64 pattern, not an int pattern.
+		{"strconv FormatInt(int64, int)", "FormatInt", true},
+		{"strconv FormatInt(int, int)", "FormatInt", false},
+		// uint64 argument: matches a uint64 pattern, and is not confused with int64.
+		{"strconv FormatUint(uint64, int)", "FormatUint", true},
+		{"strconv FormatUint(int64, int)", "FormatUint", false},
+		// int argument: matches an int pattern, not an int64 pattern.
+		{"strconv Itoa(int)", "Itoa", true},
+		{"strconv Itoa(int64)", "Itoa", false},
+	}
+
+	for _, tc := range cases {
+		mi, ok := calls[tc.call]
+		if !ok {
+			t.Fatalf("no invocation of %q found in parsed tree", tc.call)
+		}
+		if got := matcher.NewMethodMatcher(tc.pattern).Matches(mi); got != tc.want {
+			t.Errorf("NewMethodMatcher(%q).Matches(%s call) = %v, want %v", tc.pattern, tc.call, got, tc.want)
+		}
+	}
+}

--- a/rewrite-go/test/type_width_attribution_test.go
+++ b/rewrite-go/test/type_width_attribution_test.go
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// Each Go integer width must be attributed distinctly: widths Java can express
+// map to the matching primitive keyword, and unsigned widths (which have no Java
+// primitive) map to a synthetic named type keyed by their Go name.
+func TestIntegerWidthAttribution(t *testing.T) {
+	cu, err := parser.NewGoParser().Parse("test.go", `package main
+
+func main() {
+	i := 1
+	i8 := int8(1)
+	i16 := int16(1)
+	i32 := int32(1)
+	i64 := int64(1)
+	u := uint(1)
+	u8 := uint8(1)
+	u16 := uint16(1)
+	u32 := uint32(1)
+	u64 := uint64(1)
+	up := uintptr(1)
+	f32 := float32(1)
+	f64 := float64(1)
+	_ = i
+	_ = i8
+	_ = i16
+	_ = i32
+	_ = i64
+	_ = u
+	_ = u8
+	_ = u16
+	_ = u32
+	_ = u64
+	_ = up
+	_ = f32
+	_ = f64
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Signed widths and floats map to distinct primitive keywords.
+	ExpectPrimitiveType(t, cu, "i", "int")
+	ExpectPrimitiveType(t, cu, "i8", "byte")
+	ExpectPrimitiveType(t, cu, "i16", "short")
+	ExpectPrimitiveType(t, cu, "i32", "int")
+	ExpectPrimitiveType(t, cu, "i64", "long")
+	ExpectPrimitiveType(t, cu, "f32", "float")
+	ExpectPrimitiveType(t, cu, "f64", "double")
+
+	// Unsigned widths have no Java primitive, so they become named types.
+	ExpectType(t, cu, "u", "uint")
+	ExpectType(t, cu, "u8", "uint8")
+	ExpectType(t, cu, "u16", "uint16")
+	ExpectType(t, cu, "u32", "uint32")
+	ExpectType(t, cu, "u64", "uint64")
+	ExpectType(t, cu, "up", "uintptr")
+}
+
+// A type alias is transparent, so it resolves to its target type rather than
+// regressing to JavaTypeUnknown.
+func TestTypeAliasAttribution(t *testing.T) {
+	cu, err := parser.NewGoParser().Parse("test.go", `package main
+
+type MyInt = int
+
+func main() {
+	b := MyInt(1)
+	_ = b
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ExpectPrimitiveType(t, cu, "b", "int")
+}
+
+// A value of type unsafe.Pointer has no Java primitive, so it maps to a named
+// type rather than JavaTypeUnknown.
+func TestUnsafePointerAttribution(t *testing.T) {
+	cu, err := parser.NewGoParser().Parse("test.go", `package main
+
+import "unsafe"
+
+func main() {
+	var c unsafe.Pointer
+	_ = c
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ExpectType(t, cu, "c", "unsafe.Pointer")
+}
+
+// The predeclared `any` alias resolves to the empty interface type rather than
+// JavaTypeUnknown.
+func TestAnyAttribution(t *testing.T) {
+	cu, err := parser.NewGoParser().Parse("test.go", `package main
+
+func main() {
+	var a any = 1
+	_ = a
+}
+`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	v := visitor.Init(&typeCollector{identTypes: make(map[string]java.JavaType)})
+	v.Visit(cu, nil)
+
+	typ, ok := v.identTypes["a"]
+	if !ok {
+		t.Fatal("no type attribution for a")
+	}
+	cls, ok := typ.(*java.JavaTypeClass)
+	if !ok {
+		t.Fatalf("any: type is %T, want *JavaTypeClass (empty interface)", typ)
+	}
+	if cls.Kind != "Interface" {
+		t.Errorf("any: Kind = %q, want %q", cls.Kind, "Interface")
+	}
+}


### PR DESCRIPTION
## Problem

Every Go integer type (`int`, `int8` through `int64`, `uint` through `uint64`, `uintptr`) was attributed as the same LST type, a `JavaType.Primitive` with keyword `int`, so recipe authors could not distinguish an `int` from an `int64` through the type system, which makes type-narrowing recipes unsafe. For example, a recipe rewriting `fmt.Sprintf("%d", n)` to `strconv.Itoa(n)` cannot be written correctly, because `Itoa` requires an `int` and the recipe has no way to know whether `n` is an `int` or an `int64`, so it produces non-compiling output when `n` is an `int64`. The same limitation blocked rewriting `strconv.ParseInt(s, 10, 0)`, which returns `int64`, to `strconv.Atoi(s)`, which returns `int`.

## Fix

Each Go integer width now maps to a distinct LST type, following the approach the C# and Kotlin ports already use. Widths that Java's primitive set can express map to the matching primitive keyword (`int64` to `long`, `int16` to `short`, `int8` to `byte`, `int` and `int32` to `int`), and the unsigned widths, which have no Java primitive, map to a synthetic named type keyed by their Go name (`uint`, `uint64`, `uintptr`, and so on), the same modeling that Go `map` and `chan` already use. This keeps the attribution safe to serialize to the Java side, since every primitive keyword is one that Java understands and the unsigned types travel as ordinary named types. `float32` now maps to `float` rather than `double` for the same reason. While auditing the mapper for types that fell through to `J.Unknown`, two related gaps were closed as well: Go 1.22+ type aliases, including the predeclared `any`, are now unwrapped to their target type, and `unsafe.Pointer` maps to a named type. The matcher helpers `IsInt`, `IsNumeric`, and the method-pattern type resolver were updated to match.
