### PR TITLE
Check the bound name (alias) per import in Python `RemoveImport`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -89,44 +89,46 @@ class RemoveImport(PythonVisitor):
         self.module = options.module
         self.name = options.name
         self.only_if_unused = options.only_if_unused
+        self._used: Optional[Set[str]] = None
+        self._cu: Optional[CompilationUnit] = None
 
     def visit_compilation_unit(self, cu: CompilationUnit, p) -> J:
-        # If only_if_unused is True, check if the identifier is used
-        if self.only_if_unused:
-            if self._is_referenced(cu):
-                return cu
-
-        # Remove the import
+        self._used = self._collect_used_identifiers(cu) if self.only_if_unused else None
+        self._cu = cu
         return self._remove_import(cu)
 
-    def _is_referenced(self, cu: CompilationUnit) -> bool:
-        """Check if the identifier we're removing is still used elsewhere."""
-        target_name = self.name or self.module.split('.')[-1]
-
-        # Collect all used identifiers (excluding import statements)
-        used = self._collect_used_identifiers(cu)
-        if target_name not in used:
-            return False
-
+    def _is_removable(self, imp: Import, fallback_bound: str) -> bool:
+        """True when ``only_if_unused`` permits removing ``imp``, judged by the
+        name the import binds: ``from typing import List as L`` binds ``L``,
+        not ``List``."""
+        if self._used is None:
+            return True
+        bound = get_alias_name(imp) or fallback_bound
+        if bound not in self._used:
+            return True
         # Removable anyway if another import already binds the name (what ChangeType leaves behind),
         # since that binding shadows this one and the references keep resolving through it.
-        return not self._bound_by_another_import(cu, target_name)
+        return self._bound_by_another_import(self._cu, bound, imp)
 
-    def _bound_by_another_import(self, cu: CompilationUnit, target_name: str) -> bool:
-        """True when some import other than the one being removed binds ``target_name``."""
+    def _bound_by_another_import(self, cu: CompilationUnit, target_name: str,
+                                 removing: Import) -> bool:
+        """True when some import other than ``removing`` binds ``target_name``."""
         for stmt in cu.statements:
             if isinstance(stmt, MultiImport):
                 from_name = get_name_string(stmt.from_) if stmt.from_ is not None else None
                 for imp in stmt.names:
-                    if self._binds_other(imp, from_name, target_name):
+                    if self._binds_other(imp, from_name, target_name, removing):
                         return True
             elif isinstance(stmt, Import):
-                if self._binds_other(stmt, None, target_name):
+                if self._binds_other(stmt, None, target_name, removing):
                     return True
         return False
 
-    def _binds_other(self, imp: Import, from_name: Optional[str], target_name: str) -> bool:
+    def _binds_other(self, imp: Import, from_name: Optional[str], target_name: str,
+                     removing: Import) -> bool:
         """True when ``imp`` binds ``target_name`` and is not the import being removed."""
+        if imp is removing:
+            return False
         alias = get_alias_name(imp)
         qualid = get_qualid_name(imp.qualid)
         bound = alias or (qualid if from_name is not None else qualid.split('.')[0])
@@ -237,7 +239,7 @@ class RemoveImport(PythonVisitor):
         if self.name is not None:
             return imp
         name = get_qualid_name(imp.qualid)
-        if name == self.module:
+        if name == self.module and self._is_removable(imp, self.module.split('.')[-1]):
             return None
         return imp
 
@@ -251,49 +253,27 @@ class RemoveImport(PythonVisitor):
             return self._remove_name_from_import(multi)
 
     def _remove_module_import(self, multi: MultiImport) -> Optional[MultiImport]:
-        """Remove an entire module import (import X or from X import *)."""
+        """Remove an entire module import (import X or from X import ...)."""
         if multi.from_ is not None:
             # This is a "from X import Y" statement
             from_name = get_name_string(multi.from_)
-            if from_name == self.module:
-                # Check if removing all names or just star import
-                if len(multi.names) == 1:
-                    name = get_qualid_name(multi.names[0].qualid)
-                    if name == '*':
-                        return None  # Remove "from X import *"
-                # For "from X import a, b, c", only remove if we want to remove all
-                return None
+            if from_name != self.module:
+                return multi
+            new_padded = [
+                padded_imp for padded_imp in multi.padding.names.padding.elements
+                if not self._is_removable(padded_imp.element,
+                                          get_qualid_name(padded_imp.element.qualid))
+            ]
         else:
             # This is a "import X" statement
-            existing_padded = multi.padding.names.padding.elements
             new_padded = []
-            for padded_imp in existing_padded:
+            for padded_imp in multi.padding.names.padding.elements:
                 name = get_qualid_name(padded_imp.element.qualid)
-                if name != self.module:
+                if name != self.module or not self._is_removable(
+                        padded_imp.element, name.split('.')[-1]):
                     new_padded.append(padded_imp)
 
-            if len(new_padded) == 0:
-                return None  # Remove entire statement
-            if len(new_padded) < len(existing_padded):
-                # Fix up first element prefix
-                first = new_padded[0]
-                if first.element.prefix != Space.EMPTY:
-                    new_padded[0] = first.replace(_element=first.element.replace(prefix=Space.EMPTY))
-
-                return MultiImport(
-                    multi.id,
-                    multi.prefix,
-                    multi.markers,
-                    multi.padding.from_,
-                    multi.parenthesized,
-                    JContainer(
-                        multi.padding.names.before,
-                        new_padded,
-                        multi.padding.names.markers
-                    )
-                )
-
-        return multi
+        return self._prune_names(multi, new_padded)
 
     def _remove_name_from_import(self, multi: MultiImport) -> Optional[MultiImport]:
         """Remove a specific name from a 'from X import a, b, c' statement."""
@@ -304,35 +284,41 @@ class RemoveImport(PythonVisitor):
         if from_name != self.module:
             return multi  # Different module
 
-        # Filter padded elements, preserving their padding
-        existing_padded = multi.padding.names.padding.elements
         new_padded = []
-        for padded_imp in existing_padded:
+        for padded_imp in multi.padding.names.padding.elements:
             name = get_qualid_name(padded_imp.element.qualid)
-            if name != self.name:
+            if name != self.name or not self._is_removable(padded_imp.element, name):
                 new_padded.append(padded_imp)
 
+        return self._prune_names(multi, new_padded)
+
+    def _prune_names(self, multi: MultiImport, new_padded: list) -> Optional[MultiImport]:
+        """Rebuild ``multi`` with only ``new_padded`` names, preserving padding.
+
+        Returns None when nothing is left, or the original when nothing was removed.
+        """
+        existing_padded = multi.padding.names.padding.elements
         if len(new_padded) == 0:
             return None  # Remove entire statement
-        if len(new_padded) < len(existing_padded):
-            # Fix up the first element's prefix to not have a leading space
-            # (only relevant if the removed element was the first one)
-            first = new_padded[0]
-            if first.element.prefix != Space.EMPTY:
-                new_padded[0] = first.replace(_element=first.element.replace(prefix=Space.EMPTY))
+        if len(new_padded) == len(existing_padded):
+            return multi
 
-            return MultiImport(
-                multi.id,
-                multi.prefix,
-                multi.markers,
-                multi.padding.from_,
-                multi.parenthesized,
-                JContainer(
-                    multi.padding.names.before,
-                    new_padded,
-                    multi.padding.names.markers
-                )
+        # Fix up the first element's prefix to not have a leading space
+        # (only relevant if the removed element was the first one)
+        first = new_padded[0]
+        if first.element.prefix != Space.EMPTY:
+            new_padded[0] = first.replace(_element=first.element.replace(prefix=Space.EMPTY))
+
+        return MultiImport(
+            multi.id,
+            multi.prefix,
+            multi.markers,
+            multi.padding.from_,
+            multi.parenthesized,
+            JContainer(
+                multi.padding.names.before,
+                new_padded,
+                multi.padding.names.markers
             )
-
-        return multi
+        )
 

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -232,6 +232,144 @@ class TestMaybeRemoveImport:
             )
         )
 
+    def test_keep_aliased_from_import_when_alias_used(self):
+        """Keep 'from typing import List as L' while L is used."""
+        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module='typing',
+                    name='List',
+                    only_if_unused=True
+                ))
+                return super().visit_compilation_unit(cu, p)
+
+        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import List as L
+                x = L
+                """,
+            )
+        )
+
+    def test_remove_aliased_from_import_when_alias_unused(self):
+        """Remove 'from typing import List as L' when L is not used."""
+        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module='typing',
+                    name='List',
+                    only_if_unused=True
+                ))
+                return super().visit_compilation_unit(cu, p)
+
+        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import List as L
+                x = 1
+                """,
+                """
+                x = 1
+                """,
+            )
+        )
+
+    def test_remove_aliased_from_import_even_when_imported_name_used(self):
+        """A use of the bare imported name is some other binding and must not
+        keep the aliased import alive."""
+        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module='typing',
+                    name='List',
+                    only_if_unused=True
+                ))
+                return super().visit_compilation_unit(cu, p)
+
+        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import List as L
+                List = [1]
+                """,
+                """
+                List = [1]
+                """,
+            )
+        )
+
+    def test_mixed_multi_import_removes_only_unreferenced_bindings(self):
+        """Only the entry whose bound name is unreferenced is removed."""
+        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module='typing',
+                    name='List',
+                    only_if_unused=True
+                ))
+                return super().visit_compilation_unit(cu, p)
+
+        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec.rewrite_run(
+            python(
+                """
+                from typing import List, List as L
+                x = L
+                """,
+                """
+                from typing import List as L
+                x = L
+                """,
+            )
+        )
+
+    def test_keep_aliased_direct_import_when_alias_used(self):
+        """Keep 'import numpy as np' while np is used."""
+        class RemoveNumpyVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module='numpy',
+                    only_if_unused=True
+                ))
+                return super().visit_compilation_unit(cu, p)
+
+        spec = RecipeSpec(recipe=from_visitor(RemoveNumpyVisitor()))
+        spec.rewrite_run(
+            python(
+                """
+                import numpy as np
+                x = np
+                """,
+            )
+        )
+
+    def test_remove_aliased_direct_import_when_alias_unused(self):
+        """Remove 'import numpy as np' when np is not used."""
+        class RemoveNumpyVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module='numpy',
+                    only_if_unused=True
+                ))
+                return super().visit_compilation_unit(cu, p)
+
+        spec = RecipeSpec(recipe=from_visitor(RemoveNumpyVisitor()))
+        spec.rewrite_run(
+            python(
+                """
+                import numpy as np
+                x = 1
+                """,
+                """
+                x = 1
+                """,
+            )
+        )
+
     def test_partial_from_import_removal_keeps_ids_accessible(self):
         """Removing one name from a from-import rebuilds the MultiImport from the
         public `.id` property; the rebuilt node's id must remain accessible


### PR DESCRIPTION
## Motivation

The Python `RemoveImport` visitor decided whether an import was still referenced using the *imported* name, but an aliased import such as `from typing import List as L` binds `L`, not `List`. Removing `typing.List` from a file whose code references `L` therefore found no references to `List`, deemed the import unused, and removed it — leaving the `L` usages dangling. This was reproducible end-to-end: running Java's `ChangeType(typing.List -> list)` over RPC on a file using the alias deleted the import and left broken code behind. With this fix, that flow becomes a conservative no-op until alias-aware re-adding lands on the Java `ChangeType`/`ImportService` side.

## Summary

- The single statement-level `_is_referenced` pre-check is replaced by a per-import-entry `_is_removable` check that judges removability by the name the entry actually binds: its alias if present, else the imported name.
- `MultiImport` name lists are filtered entry by entry, so a statement mixing aliased and unaliased names (e.g. `from typing import List, List as L`) only drops the bindings that are unreferenced.
- The converse also holds: an aliased import is removable when its alias is unused, even if the bare imported name appears in the code — that name is a different binding.
- Module-only removal of a `from X import a, b` statement now also checks each entry's bound name instead of the module's last segment, so entries that are still in use are kept rather than deleted with the statement.
- `_binds_other` additionally excludes the entry under evaluation by identity, so the "another import already binds this name" escape hatch (kept for what `ChangeType` leaves behind) cannot count an import against itself; the existing module/name comparison still covers duplicate statements.
- The three near-identical `MultiImport` rebuild blocks are consolidated into a `_prune_names` helper.

## Test plan

- [x] Six new unit tests in `tests/python/test_remove_import.py`: aliased from-import kept while its alias is used and removed when unused, removal proceeding when only the bare imported name appears, per-entry pruning of a mixed `List, List as L` statement, and the aliased plain-import (`import numpy as np`) equivalents. Four failed before the fix; two guard the removal direction.
- [x] `python -m pytest tests/python/test_remove_import.py --timeout=60` — 16 passed.
- [x] Full non-RPC suite `python -m pytest tests/python tests/recipes --timeout=60` — 1634 passed, 6 skipped.
