### PR TITLE
Attribute Python import names with ty's canonical types

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -832,14 +832,15 @@ class ParserVisitor(ast.NodeVisitor):
         return multi_import
 
     def visit_alias(self, node):
+        alias_type = self._type_mapping.import_alias_type(node)
         return j.Import(
             random_id(),
             self.__whitespace(),
             Markers.EMPTY,
             self.__pad_left(Space.EMPTY, False),
-            self.__convert_qualified_name(node.name),
+            self.__convert_qualified_name(node.name, alias_type),
             None if not node.asname else
-            self.__pad_left(self.__source_before('as'), self.__convert_name(node.asname))
+            self.__pad_left(self.__source_before('as'), self.__convert_name(node.asname, alias_type))
         )
 
     def visit_keyword(self, node):
@@ -863,7 +864,7 @@ class ParserVisitor(ast.NodeVisitor):
                 self._type_mapping.type(node.value),
             )
 
-    def __convert_qualified_name(self, name: str) -> j.FieldAccess:
+    def __convert_qualified_name(self, name: str, name_type: Optional[JavaType] = None) -> j.FieldAccess:
         if '.' not in name:
             return j.FieldAccess(
                 random_id(),
@@ -872,11 +873,14 @@ class ParserVisitor(ast.NodeVisitor):
                 j.Empty(random_id(), Space.EMPTY, Markers.EMPTY),
                 self.__pad_left(
                     Space.EMPTY,
-                    self.__convert_name(name)
+                    self.__convert_name(name, name_type)
                 ),
-                None
+                name_type
             )
-        return cast(j.FieldAccess, self.__convert_name(name))
+        # For dotted names only the outermost FieldAccess names the full path,
+        # so only it carries the type.
+        qualid = cast(j.FieldAccess, self.__convert_name(name))
+        return qualid.replace(type=name_type) if name_type is not None else qualid
 
     def visit_Global(self, node):
         return self.__visit_variable_scope(node, 'global', py.VariableScope.Kind.GLOBAL)

--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -24,7 +24,7 @@ from rewrite.java import J
 from rewrite.java.support_types import JContainer, JLeftPadded, JRightPadded
 from rewrite.java.tree import Empty, FieldAccess, Identifier, Import, Literal, Space
 from rewrite.markers import Markers
-from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name, pad_right
+from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name, get_canonical_fqn, pad_right
 from rewrite.python.tree import CompilationUnit, ExpressionStatement, MultiImport
 from rewrite.python.visitor import PythonVisitor
 
@@ -174,10 +174,14 @@ class AddImport(PythonVisitor):
             if multi.from_ is None:
                 return False  # This is not a "from" import
             from_name = get_name_string(multi.from_)
-            if from_name != self.module:
-                return False
             for imp in multi.names:
-                if self._import_name_matches(imp, self.name, self.alias):
+                if from_name == self.module and self._import_name_matches(imp, self.name, self.alias):
+                    return True
+                # A member canonically matching the requested module.name
+                # satisfies the request too — provided it binds the same name,
+                # so references to the requested name resolve through it.
+                if get_canonical_fqn(imp) == f"{self.module}.{self.name}" and \
+                        (get_alias_name(imp) or get_qualid_name(imp.qualid)) == (self.alias or self.name):
                     return True
         return False
 

--- a/rewrite-python/rewrite/src/rewrite/python/import_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/import_utils.py
@@ -16,7 +16,7 @@
 
 from typing import Optional
 
-from rewrite.java.support_types import JRightPadded, Space
+from rewrite.java.support_types import JavaType, JRightPadded, Space
 from rewrite.java.tree import Empty, FieldAccess, Identifier, Import
 from rewrite.markers import Markers
 
@@ -55,6 +55,28 @@ def get_alias_name(imp: Import) -> Optional[str]:
     alias = imp.alias
     if isinstance(alias, Identifier):
         return alias.simple_name
+    return None
+
+
+def get_canonical_fqn(imp: Import) -> Optional[str]:
+    """The canonical fully qualified name of the symbol ``imp`` binds, read off
+    the type attributed to its qualid (see
+    ``PythonTypeMapping.import_alias_type``), or None when unattributed. Differs
+    from the written path for re-exports: ``from os.path import join`` yields
+    ``posixpath.join``."""
+    t = getattr(imp.qualid, 'type', None)
+    if isinstance(t, JavaType.Method):
+        declaring = t.declaring_type
+        if isinstance(declaring, JavaType.FullyQualified) and \
+                not isinstance(declaring, JavaType.Unknown) and t.name:
+            declaring_fqn = getattr(declaring, 'fully_qualified_name', None)
+            if declaring_fqn:
+                return f"{declaring_fqn}.{t.name}"
+        return None
+    if isinstance(t, JavaType.Parameterized):
+        t = t.type
+    if isinstance(t, JavaType.FullyQualified) and not isinstance(t, JavaType.Unknown):
+        return getattr(t, 'fully_qualified_name', None) or None
     return None
 
 

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -275,14 +275,12 @@ class RemoveImport(PythonVisitor):
         return self._prune_names(multi, new_padded)
 
     def _canonical_module_matches(self, imp: Import) -> bool:
-        """True when ``imp`` canonically is the requested module (``from os
-        import path`` for ``os.path``) or a symbol canonically declared in it
-        (``from os.path import join`` for ``posixpath``)."""
-        fqn = get_canonical_fqn(imp)
-        if fqn is None:
-            return False
-        return fqn == self.module or \
-            ('.' in fqn and fqn.rsplit('.', 1)[0] == self.module)
+        """True when ``imp`` binds the requested module itself (``from os import
+        path`` for ``os.path``). Membership is deliberately not enough: a module
+        is the canonical home of every symbol re-exported through it, so
+        matching members would sweep up imports written against other modules.
+        """
+        return get_canonical_fqn(imp) == self.module
 
     def _remove_name_from_import(self, multi: MultiImport) -> Optional[MultiImport]:
         """Remove a specific name from a 'from X import a, b, c' statement.

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -20,7 +20,7 @@ from typing import Optional, Set
 from rewrite.java import J
 from rewrite.java.support_types import JContainer, JRightPadded
 from rewrite.java.tree import Identifier, Import, MethodDeclaration, Space
-from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name
+from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name, get_canonical_fqn
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
 
@@ -256,12 +256,11 @@ class RemoveImport(PythonVisitor):
         """Remove an entire module import (import X or from X import ...)."""
         if multi.from_ is not None:
             # This is a "from X import Y" statement
-            from_name = get_name_string(multi.from_)
-            if from_name != self.module:
-                return multi
+            syntactic = get_name_string(multi.from_) == self.module
             new_padded = [
                 padded_imp for padded_imp in multi.padding.names.padding.elements
-                if not self._is_removable(padded_imp.element,
+                if not (syntactic or self._canonical_module_matches(padded_imp.element))
+                or not self._is_removable(padded_imp.element,
                                           get_qualid_name(padded_imp.element.qualid))
             ]
         else:
@@ -275,19 +274,34 @@ class RemoveImport(PythonVisitor):
 
         return self._prune_names(multi, new_padded)
 
+    def _canonical_module_matches(self, imp: Import) -> bool:
+        """True when ``imp`` canonically is the requested module (``from os
+        import path`` for ``os.path``) or a symbol canonically declared in it
+        (``from os.path import join`` for ``posixpath``)."""
+        fqn = get_canonical_fqn(imp)
+        if fqn is None:
+            return False
+        return fqn == self.module or \
+            ('.' in fqn and fqn.rsplit('.', 1)[0] == self.module)
+
     def _remove_name_from_import(self, multi: MultiImport) -> Optional[MultiImport]:
-        """Remove a specific name from a 'from X import a, b, c' statement."""
+        """Remove a specific name from a 'from X import a, b, c' statement.
+
+        A member matches when written module and name match, or when its
+        canonical FQN equals the requested ``module.name``.
+        """
         if multi.from_ is None:
             return multi  # Not a "from" import
 
-        from_name = get_name_string(multi.from_)
-        if from_name != self.module:
-            return multi  # Different module
+        syntactic = get_name_string(multi.from_) == self.module
+        target_fqn = f"{self.module}.{self.name}"
 
         new_padded = []
         for padded_imp in multi.padding.names.padding.elements:
             name = get_qualid_name(padded_imp.element.qualid)
-            if name != self.name or not self._is_removable(padded_imp.element, name):
+            matches = (syntactic and name == self.name) or \
+                get_canonical_fqn(padded_imp.element) == target_fqn
+            if not matches or not self._is_removable(padded_imp.element, name):
                 new_padded.append(padded_imp)
 
         return self._prune_names(multi, new_padded)

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -855,6 +855,32 @@ class PythonTypeMapping:
             return expr_type, JavaType.Variable(_name=node.attr, _type=expr_type, _owner=receiver_type)
         return expr_type, None
 
+    def import_alias_type(self, node: ast.alias) -> Optional[JavaType]:
+        """The canonical type of the symbol an import name binds, named at its
+        definition site (``from os.path import join`` yields a Method declared
+        in ``posixpath``). Functions become a whole :class:`JavaType.Method`,
+        not the return type expression positions use, so that callers can
+        derive an FQN from declaring type plus name.
+        """
+        type_id = self._lookup_type_id(node)
+        if type_id is None:
+            return None
+        descriptor = self._type_registry.get(type_id)
+        if descriptor is None:
+            return None
+        kind = descriptor.get('kind')
+        if kind == 'module':
+            module_name = descriptor.get('moduleName', '')
+            # ty types a non-aliased dotted `import a.b.c` as the bound root
+            # package `a`, while the qualid names the full dotted path.
+            if not node.asname and '.' in node.name and node.name != module_name:
+                module_name = node.name
+            return self._create_class_type(module_name) if module_name else None
+        if kind in _FUNCTION_KINDS:
+            return self._create_method_from_descriptor(
+                descriptor, self._get_declaration_declaring_type(descriptor))
+        return self._resolve_type(type_id)
+
     def method_declaration_type(self, node: ast.FunctionDef) -> Optional[JavaType.Method]:
         """Get the method type for a function/method declaration.
 

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -360,3 +360,62 @@ class TestAddImportVisitor:
                 """,
             )
         )
+
+
+class TestCanonicalAddImportDedup:
+    """An existing import already satisfies a requested (module, name) when
+    its canonical FQN matches (``os.path.join`` is canonically
+    ``posixpath.join``), not just when its written path does."""
+
+    def test_canonical_request_matches_written_from_import(self):
+        RecipeSpec(recipe=from_visitor(_add_import_visitor('posixpath', 'join'))).rewrite_run(
+            python(
+                """
+                from os.path import join
+                x = join('a', 'b')
+                """,
+            )
+        )
+
+    def test_canonical_request_matches_written_class_import(self):
+        RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'Iterable'))).rewrite_run(
+            python(
+                """
+                from collections.abc import Iterable
+                def f(x: Iterable): ...
+                """,
+            )
+        )
+
+    def test_canonical_match_requires_same_bound_name(self):
+        """An aliased binding does not satisfy a request for the plain name."""
+        RecipeSpec(recipe=from_visitor(_add_import_visitor('posixpath', 'join'))).rewrite_run(
+            python(
+                """
+                from os.path import join as j
+                x = 1
+                """,
+                """
+                from os.path import join as j
+                from posixpath import join
+                x = 1
+                """,
+            )
+        )
+
+    def test_canonical_mismatch_still_adds(self):
+        """os.path.exists is canonically genericpath.exists, so a posixpath
+        request is a different symbol and gets its own import."""
+        RecipeSpec(recipe=from_visitor(_add_import_visitor('posixpath', 'exists'))).rewrite_run(
+            python(
+                """
+                from os.path import exists
+                x = 1
+                """,
+                """
+                from os.path import exists
+                from posixpath import exists
+                x = 1
+                """,
+            )
+        )

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -424,3 +424,99 @@ class TestMaybeRemoveImport:
                 after_recipe=_assert_ids_accessible,
             )
         )
+
+
+class TestCanonicalRemoveImport:
+    """A requested (module, name) also matches an import by its canonical FQN
+    (``os.path.join`` is canonically ``posixpath.join``), not just by its
+    written path."""
+
+    @staticmethod
+    def _remover(module, name=None):
+        class RemoveVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module=module, name=name, only_if_unused=False))
+                return super().visit_compilation_unit(cu, p)
+
+        return RecipeSpec(recipe=from_visitor(RemoveVisitor()))
+
+    def test_remove_reexported_function_by_canonical_fqn(self):
+        self._remover('posixpath', 'join').rewrite_run(
+            python(
+                """
+                from os.path import join
+                x = 1
+                """,
+                """
+                x = 1
+                """,
+            )
+        )
+
+    def test_remove_reexported_class_by_canonical_fqn(self):
+        self._remover('typing', 'Iterable').rewrite_run(
+            python(
+                """
+                from collections.abc import Iterable
+                x = 1
+                """,
+                """
+                x = 1
+                """,
+            )
+        )
+
+    def test_canonical_removal_keeps_other_names(self):
+        self._remover('posixpath', 'join').rewrite_run(
+            python(
+                """
+                from os.path import exists, join
+                x = 1
+                """,
+                """
+                from os.path import exists
+                x = 1
+                """,
+            )
+        )
+
+    def test_remove_module_by_canonical_membership(self):
+        """Removing all imports of a module also matches members whose
+        canonical declaring module is the requested one."""
+        self._remover('posixpath').rewrite_run(
+            python(
+                """
+                from os.path import join
+                x = 1
+                """,
+                """
+                x = 1
+                """,
+            )
+        )
+
+    def test_remove_module_binding_by_canonical_fqn(self):
+        """`from os import path` binds the module canonically named os.path."""
+        self._remover('os.path').rewrite_run(
+            python(
+                """
+                from os import path
+                x = 1
+                """,
+                """
+                x = 1
+                """,
+            )
+        )
+
+    def test_canonical_mismatch_is_not_removed(self):
+        """os.path.exists is canonically genericpath.exists, not posixpath.exists."""
+        self._remover('posixpath', 'exists').rewrite_run(
+            python(
+                """
+                from os.path import exists
+                x = 1
+                """,
+            )
+        )

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -481,21 +481,6 @@ class TestCanonicalRemoveImport:
             )
         )
 
-    def test_remove_module_by_canonical_membership(self):
-        """Removing all imports of a module also matches members whose
-        canonical declaring module is the requested one."""
-        self._remover('posixpath').rewrite_run(
-            python(
-                """
-                from os.path import join
-                x = 1
-                """,
-                """
-                x = 1
-                """,
-            )
-        )
-
     def test_remove_module_binding_by_canonical_fqn(self):
         """`from os import path` binds the module canonically named os.path."""
         self._remover('os.path').rewrite_run(
@@ -516,6 +501,19 @@ class TestCanonicalRemoveImport:
             python(
                 """
                 from os.path import exists
+                x = 1
+                """,
+            )
+        )
+
+    def test_whole_module_removal_spares_canonically_related_members(self):
+        """`typing` is the canonical home of many re-exports, so a whole-module
+        request must match only bindings of the module itself — not every member
+        that happens to be declared there."""
+        self._remover('typing').rewrite_run(
+            python(
+                """
+                from collections.abc import Iterable
                 x = 1
                 """,
             )

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3459,3 +3459,68 @@ class TestPydanticModelMembers:
         # Methods still populate.
         assert cls._methods is not None
         assert 'greeting' in [m._name for m in cls._methods]
+
+
+@requires_ty_types_cli
+class TestImportNameAttribution:
+    """Each import name's qualid carries the canonical type of the symbol it
+    binds (``from os.path import join`` binds ``posixpath.join``), which is
+    what lets the import machinery match imports by canonical FQN in addition
+    to the written path."""
+
+    @staticmethod
+    def _first_import(cu):
+        from rewrite.python.tree import MultiImport
+        stmt = cu.statements[0]
+        if isinstance(stmt, MultiImport):
+            return stmt.names[0]
+        return stmt
+
+    def _qualid_type(self, src):
+        cu, tmpdir, client = _parse_with_types({'m.py': src})
+        try:
+            return self._first_import(cu).qualid.type
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+    def test_reexported_function(self):
+        t = self._qualid_type('from os.path import join\n')
+        assert isinstance(t, JavaType.Method), f"expected Method, got {t!r}"
+        assert t.name == 'join'
+        assert t.declaring_type.fully_qualified_name == 'posixpath'
+
+    def test_reexported_function_with_alias(self):
+        t = self._qualid_type('from os.path import join as j\n')
+        assert isinstance(t, JavaType.Method), f"expected Method, got {t!r}"
+        assert t.name == 'join'
+        assert t.declaring_type.fully_qualified_name == 'posixpath'
+
+    def test_reexported_class(self):
+        t = self._qualid_type('from collections.abc import Iterable\n')
+        assert isinstance(t, JavaType.Class), f"expected Class, got {t!r}"
+        assert t.fully_qualified_name == 'typing.Iterable'
+
+    def test_plain_module_import(self):
+        t = self._qualid_type('import os\n')
+        assert isinstance(t, JavaType.Class), f"expected Class, got {t!r}"
+        assert t.fully_qualified_name == 'os'
+
+    def test_plain_dotted_module_import(self):
+        # ty types the Alias binding as just the root package `os`
+        t = self._qualid_type('import os.path\n')
+        assert isinstance(t, JavaType.Class), f"expected Class, got {t!r}"
+        assert t.fully_qualified_name == 'os.path'
+
+    def test_plain_dotted_module_import_with_alias(self):
+        t = self._qualid_type('import os.path as osp\n')
+        assert isinstance(t, JavaType.Class), f"expected Class, got {t!r}"
+        assert t.fully_qualified_name == 'os.path'
+
+    def test_from_import_of_module(self):
+        t = self._qualid_type('from os import path\n')
+        assert isinstance(t, JavaType.Class), f"expected Class, got {t!r}"
+        assert t.fully_qualified_name == 'os.path'
+
+    def test_unresolvable_import_stays_untyped(self):
+        t = self._qualid_type('from nonexistent_module_xyz import something\n')
+        assert t is None or isinstance(t, JavaType.Unknown)

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -595,3 +595,36 @@ class TestChangeImport:
                 """,
             )
         )
+
+
+class TestChangeImportLeavesUnrelatedImports:
+    """ChangeImport schedules a whole-module RemoveImport for the old module,
+    which must not reach imports the recipe was never asked about."""
+
+    def test_unrelated_canonically_related_import_survives(self):
+        """`Iterable` is canonically typing.Iterable, but the file imports it
+        from collections.abc and the recipe only concerns typing.List."""
+        spec = RecipeSpec(recipe=ChangeImport(
+            old_module='typing',
+            old_name='List',
+            new_module='mytypes',
+            new_name='List',
+        ))
+        spec.rewrite_run(
+            python(
+                """
+                from collections.abc import Iterable
+                import typing
+
+                def f(x: Iterable) -> typing.List:
+                    return []
+                """,
+                """
+                from collections.abc import Iterable
+                import mytypes
+
+                def f(x: Iterable) -> mytypes.List:
+                    return []
+                """,
+            )
+        )


### PR DESCRIPTION
## Motivation

ty attributes a re-exported symbol at its *definition* site, not at the path a file imports it through. Usages of `from os.path import join` are attributed as `posixpath.join`, and `from collections.abc import Iterable` as `typing.Iterable`. Import qualids, meanwhile, carried no type at all, so nothing connected the two spellings: an FQN derived from type attribution never matched the import statement's written path, and a recipe asking `RemoveImport` to drop `posixpath.join` left the `os.path` import sitting there unused. The same gap runs the other way — a recipe pattern written against the public path could not be compared to what attribution reports.

The fix is entirely parser-side. ty's `getTypes` response already carries what is needed: for each import name it emits an `Alias` node at that name's byte range whose descriptor names the canonical location, e.g. `{"nodeKind": "Alias", "start": 20, "end": 24, "typeId": 1}` resolving to `{"kind": "function", "moduleName": "posixpath", "name": "join"}`. The parser now consumes those nodes, and the Python import machinery matches a requested `(module, name)` against both the written path and the canonical FQN.

## Examples

Import names carry the canonical type of the symbol they bind:

```python
cu = ParserVisitor(src, path, ty_client).visit_Module(ast.parse("from os.path import join\n"))
t = cu.statements[0].names[0].qualid.type
# JavaType.Method: name 'join', declaring type 'posixpath'
```

`RemoveImport` accepts either spelling, so a Java-side recipe that only knows the canonical FQN can clean up after itself:

```python
# both of these remove `from os.path import join`
maybe_remove_import(self, RemoveImportOptions(module='os.path', name='join'))
maybe_remove_import(self, RemoveImportOptions(module='posixpath', name='join'))
```

`AddImport` treats an existing public-path import as already satisfying a canonical request, rather than adding a redundant second import:

```python
# no-op when the file already has `from os.path import join`
maybe_add_import(self, AddImportOptions(module='posixpath', name='join'))
```

## Summary

- `PythonTypeMapping.import_alias_type(ast.alias)` maps ty's `Alias` descriptor to a `JavaType`: module kinds become the module's class, function kinds a whole `JavaType.Method` (not the return type that expression positions use, so callers can derive an FQN from declaring type plus name), and everything else resolves normally.
- `ParserVisitor.visit_alias` attaches that type to the import's qualid and to any `as` alias identifier. For dotted names only the outermost `FieldAccess` — the one naming the full path — carries it.
- A non-aliased dotted `import os.path` is typed by ty as the bound root package `os`; the qualid keeps the full dotted path, since that is what the name denotes.
- New `import_utils.get_canonical_fqn(imp)` reads the canonical FQN back off an attributed import, joining declaring type and name for methods.
- `RemoveImport` matches a member when the written module and name match **or** its canonical FQN equals the requested `module.name`. Whole-module removal additionally matches an import that *binds* the module itself (`from os import path` for `os.path`). Membership deliberately does not count: a module is the canonical home of every symbol re-exported through it, so matching members would sweep up imports written against other modules — `RemoveImport(module='typing')` would reach `from collections.abc import Iterable`.
- `AddImport`'s duplicate check accepts a canonically matching member, guarded on it binding the same name so references to the requested name still resolve. Merging a new name into an existing `from` statement stays purely syntactic — merging a canonical request into a differently-written statement would need a canonical-to-public reverse mapping, which is unbounded.

## Test plan

- [x] `tests/python/test_type_attribution.py::TestImportNameAttribution` — 8 new cases covering re-exported functions (with and without an alias), re-exported classes, plain and dotted module imports, `from X import <module>`, and an unresolvable module staying untyped.
- [x] `tests/python/test_remove_import.py::TestCanonicalRemoveImport` — 6 new cases: removal by canonical FQN for functions and classes, canonical removal leaving sibling names intact, whole-module removal by module binding, a negative case (`os.path.exists` is canonically `genericpath.exists`, so a `posixpath.exists` request must not match), and a whole-module request sparing canonically-related members of another module.
- [x] `tests/recipes/test_change_import.py::TestChangeImportLeavesUnrelatedImports` — ChangeImport's whole-module removal of the old module leaves an unrelated, canonically-related import in place.
- [x] `tests/python/test_add_import.py::TestCanonicalAddImportDedup` — 4 new cases: canonical requests deduplicating against written from-imports for functions and classes, an aliased binding *not* satisfying a plain-name request, and a canonical mismatch still adding its own import.
- [x] Full non-RPC `rewrite-python` suite green: 1863 passed, 7 skipped.
