### PR TITLE
Keep an aliased import's alias when `ChangeType` retargets it

### DIFF
--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/ChangeTypeAdaptabilityTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/ChangeTypeAdaptabilityTest.java
@@ -89,6 +89,29 @@ class ChangeTypeAdaptabilityTest implements RewriteTest {
         );
     }
 
+    @Test
+    void changeImportKeepsAlias() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeType("java.util.ArrayList", "java.util.LinkedList", true)),
+          groovy(
+            """
+              import java.util.ArrayList as MyList
+
+              class A {
+                  MyList type
+              }
+              """,
+            """
+              import java.util.LinkedList as MyList
+
+              class A {
+                  MyList type
+              }
+              """
+          )
+        );
+    }
+
     @SuppressWarnings("GrPackage")
     @Test
     void changeType() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/AddImport.java
@@ -157,7 +157,12 @@ public class AddImport<P> extends JavaIsoVisitor<P> {
                             member != null, Markers.EMPTY),
                     TypeTree.build(fullyQualifiedName +
                             (member == null ? "" : "." + member)).withPrefix(Space.SINGLE_SPACE),
-                    null);
+                    // Java has no import alias to print, so this stays null there; it carries the
+                    // alias for languages that share this visitor and do print one, such as Groovy.
+                    alias == null ? null : new JLeftPadded<>(Space.SINGLE_SPACE,
+                            new J.Identifier(randomId(), Space.SINGLE_SPACE, Markers.EMPTY,
+                                    emptyList(), alias, null, null),
+                            Markers.EMPTY));
 
             List<JRightPadded<J.Import>> imports = new ArrayList<>(cu.getPadding().getImports());
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeType.java
@@ -187,13 +187,13 @@ public class ChangeType extends Recipe {
 
         @Override
         public J visitImport(J.Import import_, ExecutionContext ctx) {
-            // Collect alias import information here
-            // If there is an existing import with an alias, we need to add a target import with an alias accordingly.
-            // If there is an existing import without an alias, we need to add a target import with an alias accordingly.
-            if (hasSameFQN(import_, originalType)) {
-                if (import_.getAlias() != null) {
-                    importAlias = import_.getAlias();
-                }
+            // An alias on the original type has to be reused for the target import, or references to
+            // it stop resolving. Imports nested in a block (a function body, an `if TYPE_CHECKING:`)
+            // bind a narrower scope than the file-level import that would be added in their place,
+            // so only file-level ones are considered.
+            if (import_.getAlias() != null && getCursor().firstEnclosing(J.Block.class) == null &&
+                    hasSameFQN(import_, originalType)) {
+                importAlias = import_.getAlias();
             }
 
             // visitCompilationUnit() handles changing the imports.

--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -206,9 +206,25 @@ class AddImport(PythonVisitor):
             def __init__(self):
                 super().__init__()
                 self.found = False
+                self.in_import = False
+
+            def visit_import(self, import_: Import, p) -> J:
+                # Identifiers in import statements are bindings, not references.
+                self.in_import = True
+                try:
+                    return super().visit_import(import_, p)
+                finally:
+                    self.in_import = False
+
+            def visit_multi_import(self, multi: MultiImport, p) -> J:
+                self.in_import = True
+                try:
+                    return super().visit_multi_import(multi, p)
+                finally:
+                    self.in_import = False
 
             def visit_identifier(self, ident: Identifier, p) -> J:
-                if ident.simple_name == target_name:
+                if not self.in_import and ident.simple_name == target_name:
                     self.found = True
                 return ident
 

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -149,6 +149,27 @@ class TestMaybeAddImport:
             )
         )
 
+    def test_only_if_referenced_ignores_identifiers_in_imports(self):
+        """``pathlib`` occurs only as the module of the existing aliased import."""
+        class AddPathlibVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_add_import(self, AddImportOptions(
+                    module='pathlib',
+                    only_if_referenced=True
+                ))
+                return super().visit_compilation_unit(cu, p)
+
+        spec = RecipeSpec(recipe=from_visitor(AddPathlibVisitor()))
+        spec.rewrite_run(
+            python(
+                """
+                import pathlib as o
+
+                x = o.sep
+                """,
+            )
+        )
+
     def test_merge_into_existing_from_import(self):
         """Merge a new name into an existing 'from X import ...' statement.
 

--- a/rewrite-python/rewrite/tests/rpc/test_java_recipes.py
+++ b/rewrite-python/rewrite/tests/rpc/test_java_recipes.py
@@ -66,6 +66,152 @@ class TestChangeType:
         )
 
 
+    def test_change_type_preserves_import_alias(self, java_rpc):
+        """The alias carries over to the new import, so usages of ``L`` need no
+        rewriting."""
+        from rewrite.python import ChangeType
+
+        spec = RecipeSpec(
+            recipe=ChangeType(
+                old_fully_qualified_type_name="typing.List",
+                new_fully_qualified_type_name="builtins.list"
+            )
+        )
+        spec.rewrite_run(
+            python(
+                """
+                from typing import List as L
+
+                def foo(items: L[str]) -> L[int]:
+                    pass
+                """,
+                """
+                from builtins import list as L
+
+                def foo(items: L[str]) -> L[int]:
+                    pass
+                """
+            )
+        )
+
+
+    def test_change_type_preserves_alias_of_reexported_import(self, java_rpc):
+        """``collections.abc.Iterable`` is attributed as ``typing.Iterable``, so the
+        recipe names a type this source never spells. Miss the alias here and the
+        old import is retired with nothing left to bind ``I``.
+        """
+        from rewrite.python import ChangeType
+
+        spec = RecipeSpec(
+            recipe=ChangeType(
+                old_fully_qualified_type_name="typing.Iterable",
+                new_fully_qualified_type_name="typing.Sequence"
+            )
+        )
+        spec.rewrite_run(
+            python(
+                """
+                from collections.abc import Iterable as I
+
+                def f(it: I) -> None:
+                    pass
+                """,
+                """
+                from typing import Sequence as I
+
+                def f(it: I) -> None:
+                    pass
+                """
+            )
+        )
+
+
+    def test_change_type_preserves_alias_of_plain_module_import(self, java_rpc):
+        """A standalone ``import <module> as <alias>`` parses as a plain
+        ``J.Import`` rather than a ``Py.MultiImport`` — a second shape the alias
+        lookup has to cover.
+        """
+        from rewrite.python import ChangeType
+
+        spec = RecipeSpec(
+            recipe=ChangeType(
+                old_fully_qualified_type_name="os",
+                new_fully_qualified_type_name="pathlib"
+            )
+        )
+        spec.rewrite_run(
+            python(
+                """
+                import os as o
+
+                x = o.sep
+                """,
+                """
+                import pathlib as o
+
+                x = o.sep
+                """
+            )
+        )
+
+
+    def test_change_type_ignores_function_local_aliased_import(self, java_rpc):
+        """A function-local import binds a name the top-level import machinery
+        does not manage, so the file's text stays unchanged.
+        """
+        from rewrite.python import ChangeType
+
+        spec = RecipeSpec(
+            recipe=ChangeType(
+                old_fully_qualified_type_name="typing.List",
+                new_fully_qualified_type_name="builtins.list"
+            ),
+            # ChangeType updates the type attribution of the local usages — an
+            # LST change with no printed-output change.
+            allow_empty_diff=True,
+        )
+        spec.rewrite_run(
+            python(
+                """
+                def foo():
+                    from typing import List as L
+                    items: L[int] = []
+                    return items
+                """
+            )
+        )
+
+
+    def test_change_type_ignores_type_checking_aliased_import(self, java_rpc):
+        """Same for an import under ``if TYPE_CHECKING:``, the common way to keep
+        typing-only imports out of the runtime path.
+        """
+        from rewrite.python import ChangeType
+
+        spec = RecipeSpec(
+            recipe=ChangeType(
+                old_fully_qualified_type_name="typing.List",
+                new_fully_qualified_type_name="builtins.list"
+            ),
+            allow_empty_diff=True,
+        )
+        spec.rewrite_run(
+            python(
+                """
+                from __future__ import annotations
+
+                from typing import TYPE_CHECKING
+
+                if TYPE_CHECKING:
+                    from typing import List as L
+
+                def foo(items: L[int]) -> None:
+                    pass
+                """
+            )
+        )
+
+
     def test_change_simple_type_updates_type_attribution(self, java_rpc):
         """The renamed identifiers must also carry the *new* JavaType, so that
         downstream type-driven logic (``uses_type``, MethodMatcher, a second


### PR DESCRIPTION
## Motivation

`ChangeType` reuses an aliased import's alias when it retargets a type, so that `import a.b.Original as MyAlias` becomes `import x.y.Target as MyAlias` and references to `MyAlias` keep resolving (#3558, #3560). Verifying that behaviour across languages turned up three ways it goes wrong outside Kotlin.

In Python, imports can appear inside a function body or under `if TYPE_CHECKING:`. The alias capture considered every `J.Import` it visited, so such an import produced a *file-level* aliased import while the nested one stayed put and went on shadowing it wherever it applied. The file gained a line that changed no behaviour.

In Groovy, the alias was found but silently discarded on the way out: `import java.util.ArrayList as MyList` became `import java.util.LinkedList`, leaving `MyList` unresolved and the file broken.

Python's `AddImport` also treated a name bound by an existing import as a reference to that name, so `only_if_referenced` was satisfied by the import itself and a redundant second import was added.

## Examples

Python keeps the alias, and usages need no rewriting:

```python
# ChangeType("typing.List", "builtins.list")
from typing import List as L

def foo(items: L[str]) -> L[int]:
    pass
```

```python
from builtins import list as L

def foo(items: L[str]) -> L[int]:
    pass
```

A function-local import is left alone. Previously the file gained a `from builtins import list as L` line above `def foo`, while the local import stayed and kept shadowing it inside the function:

```python
# ChangeType("typing.List", "builtins.list") — output identical to input
def foo():
    from typing import List as L
    items: L[int] = []
    return items
```

The same holds for `if TYPE_CHECKING:`, where the added line would sit outside the guard that exists to keep the import off the runtime path:

```python
# ChangeType("typing.List", "builtins.list") — output identical to input
from __future__ import annotations

from typing import TYPE_CHECKING

if TYPE_CHECKING:
    from typing import List as L

def foo(items: L[int]) -> None:
    pass
```

Groovy keeps the alias instead of dropping it:

```groovy
// ChangeType("java.util.ArrayList", "java.util.LinkedList")
import java.util.LinkedList as MyList

class A {
    MyList type
}
```

## Summary

- Restrict `ChangeType`'s alias capture to imports with no enclosing `J.Block`. Java, Kotlin, and Groovy have no nested imports and are unaffected; Python's function-local and `if TYPE_CHECKING:` imports are now skipped, since the file-level import that would replace them binds a wider scope than the original.
- Set the alias on the `J.Import` that Java's `AddImport` constructs. It has reached the visitor since #3560 — threaded through `maybeAddImport`/`addImportVisitor` so Kotlin's own `AddImport` could receive it — but was never applied to the import Java's implementation builds, so Groovy lost it. `JavaPrinter` emits no alias, so a Java file prints identically whatever the import holds. The non-aliased add that `ChangeType` also queues is skipped, because by then the type is explicitly imported.
- Ignore identifiers inside import statements in Python's `AddImport` reference check, matching `RemoveImport`'s collector and Java's `AddImport`.

## Test plan

- [x] New Python RPC tests in `tests/rpc/test_java_recipes.py` covering the aliased from-import, a re-exported import named by its canonical type (`collections.abc.Iterable` is attributed `typing.Iterable`), the standalone `import <module> as <alias>` statement, and the function-local and `if TYPE_CHECKING:` imports left unchanged. Both nested cases were confirmed to fail without the guard.
- [x] New Groovy `changeImportKeepsAlias` in `ChangeTypeAdaptabilityTest`, which fails on `main` and passes here.
- [x] New `test_add_import.py` case for a name occurring only inside an import statement.
- [x] Full module suites, all green: `rewrite-java-test` (2167 tests), `rewrite-kotlin` (1309, including `changeImportAlias`, `changeTypeWithGenericArgumentAlias`, `addImportAlias`, `updateImportAlias`), `rewrite-groovy` (678), and Python (1803 across `tests/python`, `tests/recipes`, `tests/rpc`).
- [x] `RequirementsTxtParserTest.markerContainsDependenciesFromFreeze` fails on this branch, but fails identically on a clean checkout of `main` — it resolves live packages from PyPI and is unrelated to these changes.
