### PR TITLE
Fix cyclic resolved-dependency graphs in serialization and RPC

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
+++ b/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
@@ -897,17 +897,19 @@ RpcCodecs.registerCodec(NpmrcKind, {
  */
 RpcCodecs.registerCodec(DependencyKind, {
     async rpcReceive(before: Dependency, q: RpcReceiveQueue): Promise<Dependency> {
-        return updateIfChanged(before, {
-            name: await q.receive(before.name),
-            versionConstraint: await q.receive(before.versionConstraint),
-            resolved: await q.receive(before.resolved),
-        });
+        // Populated in place: the receive queue registered this instance for the ref before calling
+        // the codec, so a back-reference closing a cycle resolves to the finished object.
+        const dep = castDraft(before);
+        dep.name = await q.receive(before.name);
+        dep.versionConstraint = await q.receive(before.versionConstraint);
+        dep.resolved = await q.receive(before.resolved);
+        return before;
     },
 
     async rpcSend(after: Dependency, q: RpcSendQueue): Promise<void> {
         await q.getAndSend(after, a => a.name);
         await q.getAndSend(after, a => a.versionConstraint);
-        await q.getAndSend(after, a => a.resolved);
+        await q.getAndSend(after, a => asRef(a.resolved));
     }
 });
 
@@ -916,16 +918,16 @@ RpcCodecs.registerCodec(DependencyKind, {
  */
 RpcCodecs.registerCodec(ResolvedDependencyKind, {
     async rpcReceive(before: ResolvedDependency, q: RpcReceiveQueue): Promise<ResolvedDependency> {
-        return updateIfChanged(before, {
-            name: await q.receive(before.name),
-            version: await q.receive(before.version),
-            dependencies: (await q.receiveList(before.dependencies)) || undefined,
-            devDependencies: (await q.receiveList(before.devDependencies)) || undefined,
-            peerDependencies: (await q.receiveList(before.peerDependencies)) || undefined,
-            optionalDependencies: (await q.receiveList(before.optionalDependencies)) || undefined,
-            engines: await q.receive(before.engines),
-            license: await q.receive(before.license),
-        });
+        const resolved = castDraft(before);
+        resolved.name = await q.receive(before.name);
+        resolved.version = await q.receive(before.version);
+        resolved.dependencies = (await q.receiveList(before.dependencies)) || undefined;
+        resolved.devDependencies = (await q.receiveList(before.devDependencies)) || undefined;
+        resolved.peerDependencies = (await q.receiveList(before.peerDependencies)) || undefined;
+        resolved.optionalDependencies = (await q.receiveList(before.optionalDependencies)) || undefined;
+        resolved.engines = await q.receive(before.engines);
+        resolved.license = await q.receive(before.license);
+        return before;
     },
 
     async rpcSend(after: ResolvedDependency, q: RpcSendQueue): Promise<void> {

--- a/rewrite-javascript/rewrite/test/javascript/node-resolution-cycle.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/node-resolution-cycle.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {createNodeResolutionResultMarker} from "../../src/javascript";
+
+describe("cyclic resolved-dependency graph", () => {
+
+    const marker = createNodeResolutionResultMarker(
+        "package.json",
+        {name: "my-app", version: "1.0.0", dependencies: {a: "^1.0.0"}},
+        {
+            packages: {
+                "": {},
+                "node_modules/a": {version: "1.0.0", dependencies: {b: "^1.0.0"}},
+                "node_modules/b": {version: "1.0.0", peerDependencies: {a: "^1.0.0"}}
+            }
+        });
+
+    test("a peer dependency links back to its dependent", () => {
+        const a = marker.resolvedDependencies.find(r => r.name === "a")!;
+        const b = a.dependencies![0].resolved!;
+
+        expect(b.name).toBe("b");
+        expect(b.peerDependencies![0].resolved).toBe(a);
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/node-resolution-cycle.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/node-resolution-cycle.test.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {createNodeResolutionResultMarker} from "../../src/javascript";
+import {createNodeResolutionResultMarker, NodeResolutionResult} from "../../src/javascript";
+import {ReferenceMap, RpcReceiveQueue, RpcSendQueue} from "../../src/rpc";
 
 describe("cyclic resolved-dependency graph", () => {
 
@@ -33,6 +34,24 @@ describe("cyclic resolved-dependency graph", () => {
         const b = a.dependencies![0].resolved!;
 
         expect(b.name).toBe("b");
+        expect(b.peerDependencies![0].resolved).toBe(a);
+    });
+
+    test("the cycle survives an RPC round trip", async () => {
+        const sq = new RpcSendQueue(new ReferenceMap(), undefined, false);
+        await sq.send(marker, undefined);
+        const batch = sq.finish();
+
+        const rq = new RpcReceiveQueue(new Map(), undefined, async () => batch, undefined, false);
+        const received = await rq.receive<NodeResolutionResult>(undefined);
+
+        const a = received.dependencies[0].resolved!;
+        expect(a.name).toBe("a");
+        const b = a.dependencies![0].resolved!;
+
+        // The dependency closing the cycle must carry its own state, not a blank placeholder
+        expect(b.peerDependencies![0].name).toBe("a");
+        // ...and resolve to the same instance the graph is navigated from
         expect(b.peerDependencies![0].resolved).toBe(a);
     });
 });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static java.util.Collections.emptyList;
+import static org.openrewrite.rpc.Reference.asRef;
 import static org.openrewrite.rpc.RpcReceiveQueue.toEnum;
 
 /**
@@ -175,8 +176,7 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
      * <p>
      * When the same name+versionConstraint appears multiple times, the same
      * Dependency instance is reused. This enables reference deduplication
-     * during RPC serialization. See {@link ResolvedDependency} for why both types are built
-     * through a no-arg creator.
+     * during RPC serialization. See {@link ResolvedDependency} for why both types are mutable.
      */
     @Getter
     @EqualsAndHashCode
@@ -198,15 +198,15 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
         public void rpcSend(Dependency after, RpcSendQueue q) {
             q.getAndSend(after, Dependency::getName);
             q.getAndSend(after, Dependency::getVersionConstraint);
-            q.getAndSend(after, Dependency::getResolved);
+            q.getAndSend(after, d -> asRef(d.getResolved()));
         }
 
         @Override
         public Dependency rpcReceive(Dependency before, RpcReceiveQueue q) {
-            return before
-                    .withName(q.receive(before.name))
-                    .withVersionConstraint(q.receive(before.versionConstraint))
-                    .withResolved(q.receive(before.resolved));
+            before.name = q.receive(before.name);
+            before.versionConstraint = q.receive(before.versionConstraint);
+            before.resolved = q.receive(before.resolved);
+            return before;
         }
     }
 
@@ -218,10 +218,11 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
      * whose {@code resolved} pointers reference other ResolvedDependency instances of the
      * same graph, so the graph is navigable to arbitrary depth and may contain cycles.
      * Producers uphold this by filling each instance's lists in place after construction
-     * rather than replacing instances with copies. Both this type and {@link Dependency} are built
-     * through a no-arg creator so Jackson binds the {@code @ref} id before reading nested values;
-     * a property-based creator cannot resolve a back-reference into an instance still being built.
+     * rather than replacing instances with copies.
      */
+    // Mutable behind a no-arg creator so a cycle can close while an instance is still being
+    // populated: Jackson binds the @ref id, and rpcReceive fills the instance the receive
+    // queue registered for that ref, before either reads nested values.
     @Getter
     @EqualsAndHashCode
     @ToString
@@ -279,26 +280,14 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
 
         @Override
         public ResolvedDependency rpcReceive(ResolvedDependency before, RpcReceiveQueue q) {
-            before = before
-                    .withName(q.receive(before.name));
-            before = before
-                    .withVersion(q.receive(before.version));
-            before = before
-                    .withDependencies(q.receiveList(before.dependencies,
-                            dep -> dep.rpcReceive(dep, q)));
-            before = before
-                    .withDevDependencies(q.receiveList(before.devDependencies,
-                            dep -> dep.rpcReceive(dep, q)));
-            before = before
-                    .withPeerDependencies(q.receiveList(before.peerDependencies,
-                            dep -> dep.rpcReceive(dep, q)));
-            before = before
-                    .withOptionalDependencies(q.receiveList(before.optionalDependencies,
-                            dep -> dep.rpcReceive(dep, q)));
-            before = before
-                    .withEngines(q.receive(before.engines));
-            before = before
-                    .withLicense(q.receive(before.license));
+            before.name = q.receive(before.name);
+            before.version = q.receive(before.version);
+            before.dependencies = q.receiveList(before.dependencies, dep -> dep.rpcReceive(dep, q));
+            before.devDependencies = q.receiveList(before.devDependencies, dep -> dep.rpcReceive(dep, q));
+            before.peerDependencies = q.receiveList(before.peerDependencies, dep -> dep.rpcReceive(dep, q));
+            before.optionalDependencies = q.receiveList(before.optionalDependencies, dep -> dep.rpcReceive(dep, q));
+            before.engines = q.receive(before.engines);
+            before.license = q.receive(before.license);
             return before;
         }
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
@@ -238,8 +238,8 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
         @ToString.Include
         String version; // Actual resolved version (e.g., "18.3.1")
 
-        // This package's own dependency requests. Excluded from equality, which recurses around a
-        // cycle; name and version already identify a resolution uniquely.
+        // This package's own dependency requests. Excluded from equality so it terminates on a
+        // cyclic graph; name and version already identify a resolution uniquely.
         @EqualsAndHashCode.Exclude
         @Nullable List<Dependency> dependencies;
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
@@ -15,11 +15,18 @@
  */
 package org.openrewrite.javascript.marker;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.Value;
 import lombok.With;
+import lombok.experimental.FieldDefaults;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -168,12 +175,18 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
      * <p>
      * When the same name+versionConstraint appears multiple times, the same
      * Dependency instance is reused. This enables reference deduplication
-     * during RPC serialization.
+     * during RPC serialization. See {@link ResolvedDependency} for why both types are built
+     * through a no-arg creator.
      */
-    @Value
+    @Getter
+    @EqualsAndHashCode
+    @ToString
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
-    public static class Dependency implements RpcCodec<Dependency> {
+    public static final class Dependency implements RpcCodec<Dependency> {
         String name;              // Package name (e.g., "react")
         String versionConstraint; // Version constraint (e.g., "^18.2.0")
 
@@ -205,22 +218,37 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
      * whose {@code resolved} pointers reference other ResolvedDependency instances of the
      * same graph, so the graph is navigable to arbitrary depth and may contain cycles.
      * Producers uphold this by filling each instance's lists in place after construction
-     * rather than replacing instances with copies.
+     * rather than replacing instances with copies. Both this type and {@link Dependency} are built
+     * through a no-arg creator so Jackson binds the {@code @ref} id before reading nested values;
+     * a property-based creator cannot resolve a back-reference into an instance still being built.
      */
-    @Value
+    @Getter
+    @EqualsAndHashCode
+    @ToString
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
-    public static class ResolvedDependency implements RpcCodec<ResolvedDependency> {
+    public static final class ResolvedDependency implements RpcCodec<ResolvedDependency> {
         @ToString.Include
         String name;    // Package name (e.g., "react")
 
         @ToString.Include
         String version; // Actual resolved version (e.g., "18.3.1")
 
-        // This package's own dependency requests
+        // This package's own dependency requests. Excluded from equality, which recurses around a
+        // cycle; name and version already identify a resolution uniquely.
+        @EqualsAndHashCode.Exclude
         @Nullable List<Dependency> dependencies;
+
+        @EqualsAndHashCode.Exclude
         @Nullable List<Dependency> devDependencies;
+
+        @EqualsAndHashCode.Exclude
         @Nullable List<Dependency> peerDependencies;
+
+        @EqualsAndHashCode.Exclude
         @Nullable List<Dependency> optionalDependencies;
 
         // Node/npm version requirements for this package

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NodeResolutionResult.java
@@ -22,7 +22,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.Value;
 import lombok.With;
@@ -183,7 +182,6 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
     @ToString
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @AllArgsConstructor
-    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
     public static final class Dependency implements RpcCodec<Dependency> {
@@ -193,6 +191,10 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
         // The resolved version of this dependency (from package-lock.json)
         @ToString.Exclude
         @Nullable ResolvedDependency resolved;
+
+        @JsonCreator
+        private Dependency() {
+        }
 
         @Override
         public void rpcSend(Dependency after, RpcSendQueue q) {
@@ -228,7 +230,6 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
     @ToString
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @AllArgsConstructor
-    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
     public static final class ResolvedDependency implements RpcCodec<ResolvedDependency> {
@@ -257,6 +258,10 @@ public class NodeResolutionResult implements Marker, RpcCodec<NodeResolutionResu
 
         // SPDX license identifier (e.g., "MIT", "Apache-2.0")
         @Nullable String license;
+
+        @JsonCreator
+        private ResolvedDependency() {
+        }
 
         @Override
         public void rpcSend(ResolvedDependency after, RpcSendQueue q) {

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/marker/NodeResolutionResultSerializationTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/marker/NodeResolutionResultSerializationTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.marker;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.javascript.internal.LockFileParser;
+import org.openrewrite.javascript.marker.NodeResolutionResult.Dependency;
+import org.openrewrite.javascript.marker.NodeResolutionResult.ResolvedDependency;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A resolved npm graph is cyclic (peer dependencies point back at their dependents), so the marker has to survive
+ * both a Jackson round trip and the {@code equals}/{@code hashCode} of any collection that holds it.
+ */
+class NodeResolutionResultSerializationTest {
+
+    private static final String CYCLIC_LOCK = "{\n" +
+                                              "  \"packages\": {\n" +
+                                              "    \"\": { },\n" +
+                                              "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                                              "    \"node_modules/b\": { \"version\": \"1.0.0\", \"peerDependencies\": { \"a\": \"^1.0.0\" } }\n" +
+                                              "  }\n" +
+                                              "}";
+
+    /**
+     * Mirrors the mapper configuration that serializes LSTs and recipe edits.
+     */
+    private static ObjectMapper mapper() {
+        ObjectMapper m = JsonMapper.builder()
+                .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
+                .configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER, true)
+                .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+                .build();
+        m.registerModule(new ParameterNamesModule());
+        m.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        m.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        m.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        m.setVisibility(m.getSerializationConfig().getDefaultVisibilityChecker()
+                .withCreatorVisibility(JsonAutoDetect.Visibility.PUBLIC_ONLY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY));
+        return m;
+    }
+
+    private static NodeResolutionResult cyclicMarker() {
+        LockFileParser.ParseResult result = LockFileParser.parse(CYCLIC_LOCK);
+        return new NodeResolutionResult(UUID.randomUUID(), "my-app", "1.0.0", null, "package.json", null,
+                singletonList(new Dependency("a", "^1.0.0", result.getTopLevel().get("a"))),
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                new ArrayList<>(result.getAll()),
+                null, null, null);
+    }
+
+    @Test
+    void roundTripCyclicGraph() throws Exception {
+        ObjectMapper mapper = mapper();
+        NodeResolutionResult read = mapper.readValue(mapper.writeValueAsString(cyclicMarker()), NodeResolutionResult.class);
+
+        ResolvedDependency a = read.getDependencies().get(0).getResolved();
+        assertThat(a).isNotNull();
+        ResolvedDependency b = a.getDependencies().get(0).getResolved();
+        assertThat(b).isNotNull();
+        assertThat(b.getPeerDependencies().get(0).getResolved())
+                .as("the back-reference closing the cycle must resolve to the same instance")
+                .isSameAs(a);
+    }
+
+    @Test
+    void equalsAndHashCodeTerminateOnCyclicGraph() {
+        ResolvedDependency a = LockFileParser.parse(CYCLIC_LOCK).getTopLevel().get("a");
+
+        assertThat(a.hashCode()).isEqualTo(a.hashCode());
+        assertThat(a).isEqualTo(LockFileParser.parse(CYCLIC_LOCK).getTopLevel().get("a"));
+    }
+}

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/rpc/NodeResolutionResultRpcTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/rpc/NodeResolutionResultRpcTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.javascript.internal.LockFileParser;
+import org.openrewrite.javascript.marker.NodeResolutionResult;
+import org.openrewrite.javascript.marker.NodeResolutionResult.Dependency;
+import org.openrewrite.javascript.marker.NodeResolutionResult.ResolvedDependency;
+import org.openrewrite.rpc.RpcObjectData;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NodeResolutionResultRpcTest {
+
+    private static final String CYCLIC_LOCK = "{\n" +
+                                              "  \"packages\": {\n" +
+                                              "    \"\": { },\n" +
+                                              "    \"node_modules/a\": { \"version\": \"1.0.0\", \"dependencies\": { \"b\": \"^1.0.0\" } },\n" +
+                                              "    \"node_modules/b\": { \"version\": \"1.0.0\", \"peerDependencies\": { \"a\": \"^1.0.0\" } }\n" +
+                                              "  }\n" +
+                                              "}";
+
+    @Test
+    void roundTripCyclicGraph() {
+        LockFileParser.ParseResult parsed = LockFileParser.parse(CYCLIC_LOCK);
+        NodeResolutionResult marker = new NodeResolutionResult(UUID.randomUUID(), "my-app", "1.0.0", null,
+                "package.json", null,
+                singletonList(new Dependency("a", "^1.0.0", parsed.getTopLevel().get("a"))),
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(),
+                new ArrayList<>(parsed.getAll()),
+                null, null, null);
+
+        NodeResolutionResult received = sendAndReceive(marker);
+
+        ResolvedDependency a = received.getDependencies().get(0).getResolved();
+        assertThat(a).isNotNull();
+        assertThat(a.getName()).isEqualTo("a");
+        ResolvedDependency b = a.getDependencies().get(0).getResolved();
+        assertThat(b).isNotNull();
+
+        Dependency backEdge = b.getPeerDependencies().get(0);
+        assertThat(backEdge.getName())
+                .as("the dependency closing the cycle must carry its own state, not a blank placeholder")
+                .isEqualTo("a");
+        assertThat(backEdge.getResolved())
+                .as("the back-reference closing the cycle must resolve to the same instance")
+                .isSameAs(a);
+    }
+
+    private static NodeResolutionResult sendAndReceive(NodeResolutionResult marker) {
+        Deque<List<RpcObjectData>> batches = new ArrayDeque<>();
+        RpcSendQueue sq = new RpcSendQueue(1_000_000, batches::addLast, new IdentityHashMap<>(), null, false);
+        sq.send(marker, null, null);
+        sq.flush();
+
+        // The wire carries a UUID as a string, as the transport's JSON encoding would.
+        List<RpcObjectData> all = new ArrayList<>();
+        while (!batches.isEmpty()) {
+            for (RpcObjectData data : batches.removeFirst()) {
+                all.add(data.getValue() instanceof UUID ?
+                        new RpcObjectData(data.getState(), data.getValueType(), data.getValue().toString(), data.getRef(), false) :
+                        data);
+            }
+        }
+        Deque<List<RpcObjectData>> drain = new ArrayDeque<>();
+        drain.add(all);
+
+        return new RpcReceiveQueue(new HashMap<>(), drain::removeFirst, null, null).receive(null);
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/marker/PythonResolutionResult.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marker/PythonResolutionResult.java
@@ -22,7 +22,6 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.Value;
 import lombok.With;
@@ -288,7 +287,6 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
     @ToString
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @AllArgsConstructor
-    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
     public static final class Dependency implements RpcCodec<Dependency> {
         String name;
@@ -298,6 +296,10 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
 
         @ToString.Exclude
         @Nullable ResolvedDependency resolved;
+
+        @JsonCreator
+        private Dependency() {
+        }
 
         @Override
         public void rpcSend(Dependency after, RpcSendQueue q) {
@@ -336,7 +338,6 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
     @ToString
     @FieldDefaults(level = AccessLevel.PRIVATE)
     @AllArgsConstructor
-    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
     public static final class ResolvedDependency implements RpcCodec<ResolvedDependency> {
@@ -356,6 +357,10 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
         @EqualsAndHashCode.Exclude
         @ToString.Exclude
         @Nullable List<ResolvedDependency> dependencies;
+
+        @JsonCreator
+        private ResolvedDependency() {
+        }
 
         @Override
         public void rpcSend(ResolvedDependency after, RpcSendQueue q) {

--- a/rewrite-python/src/main/java/org/openrewrite/python/marker/PythonResolutionResult.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marker/PythonResolutionResult.java
@@ -350,8 +350,8 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
 
         /**
          * Direct dependencies of this resolved package. Null when the package has no
-         * dependencies in the lock file. Excluded from equality and toString, which recurse
-         * around a cycle; name and version already identify a resolution uniquely.
+         * dependencies in the lock file. Excluded from equality and toString so they terminate on
+         * a cyclic graph; name and version already identify a resolution uniquely.
          */
         @EqualsAndHashCode.Exclude
         @ToString.Exclude

--- a/rewrite-python/src/main/java/org/openrewrite/python/marker/PythonResolutionResult.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/marker/PythonResolutionResult.java
@@ -15,11 +15,18 @@
  */
 package org.openrewrite.python.marker;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.Value;
 import lombok.With;
+import lombok.experimental.FieldDefaults;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -32,6 +39,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static java.util.Collections.emptyList;
+import static org.openrewrite.rpc.Reference.asRef;
 import static org.openrewrite.rpc.RpcReceiveQueue.toEnum;
 
 /**
@@ -272,11 +280,17 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
      * {@code optionalDependencies}, {@code dependencyGroups}).
      * <p>
      * When a lock file is available, the {@code resolved} field links to the
-     * corresponding {@link ResolvedDependency} entry.
+     * corresponding {@link ResolvedDependency} entry. See {@link ResolvedDependency} for why both
+     * types are mutable.
      */
-    @Value
+    @Getter
+    @EqualsAndHashCode
+    @ToString
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
-    public static class Dependency implements RpcCodec<Dependency> {
+    public static final class Dependency implements RpcCodec<Dependency> {
         String name;
         @Nullable String versionConstraint;
         @Nullable List<String> extras;
@@ -291,17 +305,17 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
             q.getAndSend(after, Dependency::getVersionConstraint);
             q.getAndSend(after, Dependency::getExtras);
             q.getAndSend(after, Dependency::getMarker);
-            q.getAndSend(after, Dependency::getResolved);
+            q.getAndSend(after, d -> asRef(d.getResolved()));
         }
 
         @Override
         public Dependency rpcReceive(Dependency before, RpcReceiveQueue q) {
-            return before
-                    .withName(q.receive(before.name))
-                    .withVersionConstraint(q.receive(before.versionConstraint))
-                    .withExtras(q.receive(before.extras))
-                    .withMarker(q.receive(before.marker))
-                    .withResolved(q.receive(before.resolved));
+            before.name = q.receive(before.name);
+            before.versionConstraint = q.receive(before.versionConstraint);
+            before.extras = q.receive(before.extras);
+            before.marker = q.receive(before.marker);
+            before.resolved = q.receive(before.resolved);
+            return before;
         }
     }
 
@@ -314,10 +328,18 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
      * Producers uphold this by filling each instance's list in place after construction
      * rather than replacing instances with copies.
      */
-    @Value
+    // Mutable behind a no-arg creator so a cycle can close while an instance is still being
+    // populated: Jackson binds the @ref id, and rpcReceive fills the instance the receive
+    // queue registered for that ref, before either reads nested values.
+    @Getter
+    @EqualsAndHashCode
+    @ToString
+    @FieldDefaults(level = AccessLevel.PRIVATE)
+    @AllArgsConstructor
+    @NoArgsConstructor(access = AccessLevel.PRIVATE, onConstructor_ = @JsonCreator)
     @With
     @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "@ref")
-    public static class ResolvedDependency implements RpcCodec<ResolvedDependency> {
+    public static final class ResolvedDependency implements RpcCodec<ResolvedDependency> {
         @ToString.Include
         String name;
 
@@ -328,8 +350,11 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
 
         /**
          * Direct dependencies of this resolved package. Null when the package has no
-         * dependencies in the lock file.
+         * dependencies in the lock file. Excluded from equality and toString, which recurse
+         * around a cycle; name and version already identify a resolution uniquely.
          */
+        @EqualsAndHashCode.Exclude
+        @ToString.Exclude
         @Nullable List<ResolvedDependency> dependencies;
 
         @Override
@@ -344,12 +369,11 @@ public class PythonResolutionResult implements Marker, RpcCodec<PythonResolution
 
         @Override
         public ResolvedDependency rpcReceive(ResolvedDependency before, RpcReceiveQueue q) {
-            return before
-                    .withName(q.receive(before.name))
-                    .withVersion(q.receive(before.version))
-                    .withSource(q.receive(before.source))
-                    .withDependencies(q.receiveList(before.dependencies,
-                            dep -> dep.rpcReceive(dep, q)));
+            before.name = q.receive(before.name);
+            before.version = q.receive(before.version);
+            before.source = q.receive(before.source);
+            before.dependencies = q.receiveList(before.dependencies, dep -> dep.rpcReceive(dep, q));
+            return before;
         }
     }
 

--- a/rewrite-python/src/test/java/org/openrewrite/python/marker/PythonResolutionResultRpcTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/marker/PythonResolutionResultRpcTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.python.marker.PythonResolutionResult.ResolvedDependency;
+import org.openrewrite.rpc.RpcObjectData;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PythonResolutionResultRpcTest {
+
+    @Test
+    void roundTripCyclicGraph() {
+        ResolvedDependency a = new ResolvedDependency("a", "1.0.0", null, new ArrayList<>());
+        ResolvedDependency b = new ResolvedDependency("b", "1.0.0", null, new ArrayList<>());
+        a.getDependencies().add(b);
+        b.getDependencies().add(a);
+
+        PythonResolutionResult marker = new PythonResolutionResult(UUID.randomUUID(), "my-app", "1.0.0",
+                null, null, "pyproject.toml", null, null,
+                emptyList(),
+                singletonList(new PythonResolutionResult.Dependency("a", "==1.0.0", null, null, a)),
+                emptyMap(), emptyMap(), emptyList(), emptyList(),
+                asList(a, b),
+                null, null);
+
+        ResolvedDependency received = sendAndReceive(marker).getDependencies().get(0).getResolved();
+        assertThat(received).isNotNull();
+
+        ResolvedDependency receivedB = received.getDependencies().get(0);
+        assertThat(receivedB.getName()).isEqualTo("b");
+
+        ResolvedDependency backEdge = receivedB.getDependencies().get(0);
+        assertThat(backEdge.getName())
+                .as("the dependency closing the cycle must carry its own state, not a blank placeholder")
+                .isEqualTo("a");
+        assertThat(backEdge)
+                .as("the back-reference closing the cycle must resolve to the same instance")
+                .isSameAs(received);
+    }
+
+    private static PythonResolutionResult sendAndReceive(PythonResolutionResult marker) {
+        Deque<List<RpcObjectData>> batches = new ArrayDeque<>();
+        RpcSendQueue sq = new RpcSendQueue(1_000_000, batches::addLast, new IdentityHashMap<>(), null, false);
+        sq.send(marker, null, null);
+        sq.flush();
+
+        // The wire carries a UUID as a string, as the transport's JSON encoding would.
+        List<RpcObjectData> all = new ArrayList<>();
+        while (!batches.isEmpty()) {
+            for (RpcObjectData data : batches.removeFirst()) {
+                all.add(data.getValue() instanceof UUID ?
+                        new RpcObjectData(data.getState(), data.getValueType(), data.getValue().toString(), data.getRef(), false) :
+                        data);
+            }
+        }
+        Deque<List<RpcObjectData>> drain = new ArrayDeque<>();
+        drain.add(all);
+
+        return new RpcReceiveQueue(new HashMap<>(), drain::removeFirst, null, null).receive(null);
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/marker/PythonResolutionResultSerializationTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/marker/PythonResolutionResultSerializationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.marker;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.python.marker.PythonResolutionResult.ResolvedDependency;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A resolved Python graph is cyclic — packages depend on each other through extras — so it has to survive both a
+ * Jackson round trip and the {@code equals}/{@code hashCode} of any collection that holds it.
+ */
+class PythonResolutionResultSerializationTest {
+
+    /**
+     * Mirrors the mapper configuration that serializes LSTs and recipe edits.
+     */
+    private static ObjectMapper mapper() {
+        ObjectMapper m = JsonMapper.builder()
+                .constructorDetector(ConstructorDetector.USE_PROPERTIES_BASED)
+                .configure(MapperFeature.PROPAGATE_TRANSIENT_MARKER, true)
+                .disable(MapperFeature.REQUIRE_TYPE_ID_FOR_SUBTYPES)
+                .build();
+        m.registerModule(new ParameterNamesModule());
+        m.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        m.disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        m.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        m.setVisibility(m.getSerializationConfig().getDefaultVisibilityChecker()
+                .withCreatorVisibility(JsonAutoDetect.Visibility.PUBLIC_ONLY)
+                .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withIsGetterVisibility(JsonAutoDetect.Visibility.NONE)
+                .withFieldVisibility(JsonAutoDetect.Visibility.ANY));
+        return m;
+    }
+
+    /**
+     * Linked the way {@code PythonResolutionLinker} does it: instances shared, lists filled in place.
+     */
+    private static ResolvedDependency cyclicGraph() {
+        ResolvedDependency a = new ResolvedDependency("a", "1.0.0", null, new ArrayList<>());
+        ResolvedDependency b = new ResolvedDependency("b", "1.0.0", null, new ArrayList<>());
+        a.getDependencies().add(b);
+        b.getDependencies().add(a);
+        return a;
+    }
+
+    @Test
+    void roundTripCyclicGraph() throws Exception {
+        ObjectMapper mapper = mapper();
+        ResolvedDependency read = mapper.readValue(mapper.writeValueAsString(cyclicGraph()), ResolvedDependency.class);
+
+        assertThat(read.getDependencies().get(0).getDependencies().get(0))
+                .as("the back-reference closing the cycle must resolve to the same instance")
+                .isSameAs(read);
+    }
+
+    @Test
+    void equalsAndHashCodeTerminateOnCyclicGraph() {
+        ResolvedDependency a = cyclicGraph();
+
+        assertThat(a.hashCode()).isEqualTo(a.hashCode());
+        assertThat(a).isEqualTo(cyclicGraph());
+    }
+}


### PR DESCRIPTION
## Motivation

After openrewrite/rewrite#8372 the resolved-dependency graph is fully linked, which makes it genuinely cyclic — npm peer dependencies routinely point back at their dependents. That shape cannot be deserialized: reading a `NodeResolutionResult` back off disk fails with

```
com.fasterxml.jackson.databind.exc.MismatchedInputException: No Object Id found for an instance of
  org.openrewrite.javascript.marker.NodeResolutionResult$Dependency, to assign to property '@ref'
  at com.fasterxml.jackson.databind.deser.impl.PropertyValueBuffer.handleIdValue(PropertyValueBuffer.java:398)
```

The message points at the writer, but the written stream is valid — every `@ref` back-reference has a defining `@id` earlier in the document:

```json
"peerDependencies":[{"@ref":6,"name":"a","versionConstraint":"^1.0.0","resolved":3}]
```

The constraint is on the read side. Both types were `@Value`, so Jackson deserializes them through a property-based creator, and a creator-built instance is registered with the object-id resolver only *after* its constructor runs — after every nested value has been read. A cycle contains a back-reference into an instance that is still being built, so it can never resolve. `@JsonIdentityInfo` has always required this; #8372 is simply what made the graph reach it.

Reported downstream as a recipe run failing while reading back the edit page holding `package.json`, which left a partial patch on disk.

Chasing that turned up two more defects of the same origin, both of which predate #8372:

**The RPC receive queue hands back a blank placeholder.** `RpcReceiveQueue` registers the instance it created for a ref *before* running the codec and replaces it once the codec returns, so that a codec which populates that instance in place can close a cycle. `Dependency.rpcReceive` rebuilt immutably with `with*` instead, so every back-reference resolved to the blank Objenesis instance: a cycle closed onto a `Dependency(name=null, versionConstraint=null)`, and instances shared on the sending side arrived duplicated. Silent — no exception, just a corrupt marker. The TypeScript queue works the same way and its codecs rebuilt with `updateIfChanged`, so both directions were affected. The TypeScript parser has produced cyclic graphs since #6308, so this has been reachable from a plain parse for months.

**`equals`/`hashCode` recursed forever.** Once a graph is genuinely cyclic, hashing a `ResolvedDependency` is a `StackOverflowError`.

`PythonResolutionResult` carries the same model and the same `PythonResolutionLinker` two-pass linking, so it has both of those (its Jackson round trip survives, because its cycle closes through a collection element, which Jackson can defer, rather than through a creator argument). `GoResolutionResult` is unaffected — `ModuleRef` holds only a module path and version, so its graph has no back-edges.

## Summary

- `Dependency` and `ResolvedDependency` (Node and Python) are mutable behind a private no-arg `@JsonCreator`, the pattern `MavenResolutionResult` uses for its cyclic parent/module graph. Jackson binds the `@ref` id right after instantiating the bean and before reading children, so back-references into a partially built instance resolve. The wire format is unchanged, and payloads written with or without `@ref` still read.
- `rpcReceive` populates the instance the receive queue registered for the ref, as the `JavaType` codecs do, on both the Java and TypeScript sides, and a dependency's `resolved` pointer travels as a ref (`asRef`) so it resolves to the same instance the resolution list holds instead of being re-sent whole per referrer.
- Cycle-forming fields are excluded from `equals`/`hashCode`, mirroring `org.openrewrite.maven.tree.ResolvedDependency`; `name` and `version` already identify a resolution uniquely. Python's `dependencies` is excluded from `toString` for the same reason (Node's cycle is already broken there by `Dependency.resolved`).

## Test plan

- [x] `NodeResolutionResultSerializationTest` / `PythonResolutionResultSerializationTest`: cyclic round trip asserting the back-edge resolves to the same instance, and `equals`/`hashCode` termination — written first and observed failing (`MismatchedInputException` and `StackOverflowError`) against the previous model
- [x] The round trips use the same Jackson configuration that serializes LSTs and recipe edits (properties-based constructor detection, parameter names, field visibility, non-null inclusion)
- [x] `NodeResolutionResultRpcTest` / `PythonResolutionResultRpcTest`: send/receive queue pair over a cyclic marker, asserting the closing dependency carries its own state and is the same instance — observed failing with the blank placeholder (`Dependency(name=null, versionConstraint=null)`) beforehand
- [x] `node-resolution-cycle.test.ts`: the TypeScript parser links a peer dependency back to its dependent, and that cycle survives a send/receive round trip — observed failing with the blank placeholder beforehand
- [x] `npm run typecheck && npx vitest run` — 1927 tests, 0 failures
- [x] `./gradlew :rewrite-javascript:test` — 451 tests, 0 failures
- [x] `./gradlew :rewrite-python:test` — 1927 tests; the one failure (`RequirementsTxtParserTest.declaredPackagesAreDirectAndUndeclaredTransitivesAreExcluded`) is pre-existing, confirmed by re-running with these changes stashed
