### PR TITLE
MavenPomDownloader authentication fixes

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -1049,19 +1049,17 @@ public class MavenPomDownloader {
     /**
      * Probes {@code url} to establish whether the repository host answers at all. Anonymous first, as every
      * other request is, but a host that refuses unauthenticated requests without answering them — a connection
-     * reset or a dropped TLS handshake rather than a 401 — must not be written off as unreachable until tried with credentials. A repository declared to be behind authentication is often exactly the
+     * reset or a dropped TLS handshake rather than a 401 — must not be written off as unreachable until tried
+     * with credentials. A repository declared to be behind authentication is often exactly such a host, so when
+     * credentials are configured the probe is retried with them before concluding the repository is unreachable.
      */
     private ReachabilityResult reachable(MavenRepository repository, HttpSender.Method method, String url) {
-        ReachabilityResult anonymous = reachable(applyTimeoutToRequest(repository, newRequest(method, url)));
+        ReachabilityResult anonymous = reachable(applyTimeoutToRequest(repository, httpSender.newRequest(url).withMethod(method)));
         if (anonymous.isReachable() || !hasAuthentication(repository)) {
             return anonymous;
         }
-        ReachabilityResult authenticated = reachable(applyAuthenticationAndTimeoutToRequest(repository, newRequest(method, url)));
+        ReachabilityResult authenticated = reachable(applyAuthenticationAndTimeoutToRequest(repository, httpSender.newRequest(url).withMethod(method)));
         return authenticated.isReachable() ? authenticated : anonymous;
-    }
-
-    private HttpSender.Request.Builder newRequest(HttpSender.Method method, String url) {
-        return httpSender.newRequest(url).withMethod(method);
     }
 
     @Value

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -1008,12 +1008,7 @@ public class MavenPomDownloader {
         // URLs are case-sensitive after the domain name, so it can be incorrect to lowerCase() a whole URL
         // This regex accepts any capitalization of the letters in "http"
         String originalUrl = repository.getUri();
-        String httpsUri = originalUrl.toLowerCase().startsWith("http:") ?
-                repository.getUri().replaceFirst("[hH][tT][tT][pP]://", "https://") :
-                repository.getUri();
-        if (!httpsUri.endsWith("/")) {
-            httpsUri += "/";
-        }
+        String httpsUri = normalizedRepositoryUri(originalUrl);
 
         ReachabilityResult reachability = reachable(repository, HttpSender.Method.OPTIONS, httpsUri);
         if (reachability.isSuccess()) {
@@ -1035,6 +1030,20 @@ public class MavenPomDownloader {
         }
         // Won't be null if server is unreachable
         throw Objects.requireNonNull(reachability.throwable);
+    }
+
+    /**
+     * The URI form {@link #normalizeRepository(MavenRepository)} prefers: https over http, with a trailing
+     * slash so artifact paths can be appended directly. Since that is the form a reachable repository is
+     * normalized to, it is also the URI recorded on the POMs it serves. Exposed so callers keyed on that URI
+     * — a {@link org.openrewrite.maven.cache.MavenPomCache} matching a downloaded POM back to the repository
+     * declaration it came from, for one — can derive it without reimplementing the rule and drifting from it.
+     */
+    public static String normalizedRepositoryUri(String uri) {
+        String httpsUri = uri.toLowerCase().startsWith("http:") ?
+                uri.replaceFirst("[hH][tT][tT][pP]://", "https://") :
+                uri;
+        return httpsUri.endsWith("/") ? httpsUri : httpsUri + "/";
     }
 
     /**

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -1015,28 +1015,44 @@ public class MavenPomDownloader {
             httpsUri += "/";
         }
 
-        HttpSender.Request.Builder request = httpSender.options(httpsUri);
-
-        ReachabilityResult reachability = reachable(applyTimeoutToRequest(repository, request));
+        ReachabilityResult reachability = reachable(repository, HttpSender.Method.OPTIONS, httpsUri);
         if (reachability.isSuccess()) {
             return repository.withUri(httpsUri);
         }
-        reachability = reachable(applyTimeoutToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(httpsUri)));
+        reachability = reachable(repository, HttpSender.Method.HEAD, httpsUri);
         if (reachability.isReachable()) {
             return repository.withUri(httpsUri);
         }
         if (!originalUrl.equals(httpsUri)) {
-            reachability = reachable(applyTimeoutToRequest(repository, request.withMethod(HttpSender.Method.OPTIONS).url(originalUrl)));
+            reachability = reachable(repository, HttpSender.Method.OPTIONS, originalUrl);
             if (reachability.isSuccess()) {
                 return repository.withUri(originalUrl);
             }
-            reachability = reachable(applyTimeoutToRequest(repository, request.withMethod(HttpSender.Method.HEAD).url(originalUrl)));
+            reachability = reachable(repository, HttpSender.Method.HEAD, originalUrl);
             if (reachability.isReachable()) {
                 return repository.withUri(originalUrl);
             }
         }
         // Won't be null if server is unreachable
         throw Objects.requireNonNull(reachability.throwable);
+    }
+
+    /**
+     * Probes {@code url} to establish whether the repository host answers at all. Anonymous first, as every
+     * other request is, but a host that refuses unauthenticated requests without answering them — a connection
+     * reset or a dropped TLS handshake rather than a 401 — must not be written off as unreachable until tried with credentials. A repository declared to be behind authentication is often exactly the
+     */
+    private ReachabilityResult reachable(MavenRepository repository, HttpSender.Method method, String url) {
+        ReachabilityResult anonymous = reachable(applyTimeoutToRequest(repository, newRequest(method, url)));
+        if (anonymous.isReachable() || !hasAuthentication(repository)) {
+            return anonymous;
+        }
+        ReachabilityResult authenticated = reachable(applyAuthenticationAndTimeoutToRequest(repository, newRequest(method, url)));
+        return authenticated.isReachable() ? authenticated : anonymous;
+    }
+
+    private HttpSender.Request.Builder newRequest(HttpSender.Method method, String url) {
+        return httpSender.newRequest(url).withMethod(method);
     }
 
     @Value

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenPomDownloader.java
@@ -1082,10 +1082,10 @@ public class MavenPomDownloader {
 
     private boolean jarExistsForPomUri(MavenRepository repo, String pomUrl) {
         String jarUrl = pomUrl.replaceAll("\\.pom$", ".jar");
-        // If this host has already required credentials in this session, authenticate preemptively rather than
-        // paying another anonymous round-trip. Otherwise probe anonymously first.
+        // If this host has already required authentication in this session, authenticate preemptively rather
+        // than paying another anonymous round-trip. Otherwise probe anonymously first.
         String endpoint = endpointOrNull(URI.create(jarUrl));
-        boolean preemptive = hasCredentials(repo) && endpoint != null &&
+        boolean preemptive = hasAuthentication(repo) && endpoint != null &&
                              ctx.getAuthenticationRequiredEndpoints().contains(endpoint);
         try {
             try {
@@ -1099,7 +1099,7 @@ public class MavenPomDownloader {
                 });
             } catch (FailsafeException failsafeException) {
                 Throwable cause = failsafeException.getCause();
-                if (cause instanceof HttpSenderResponseException && !preemptive && hasCredentials(repo) &&
+                if (cause instanceof HttpSenderResponseException && !preemptive && hasAuthentication(repo) &&
                     ((HttpSenderResponseException) cause).isClientSideException()) {
                     return Failsafe.with(retryPolicy).get(() -> {
                         HttpSender.Request authenticated = applyAuthenticationAndTimeoutToRequest(repo, httpSender.head(jarUrl)).build();
@@ -1126,16 +1126,16 @@ public class MavenPomDownloader {
      * credentials once the server challenges the anonymous request with a 4xx.
      */
     private byte[] requestAsAuthenticatedOrAnonymous(MavenRepository repo, String uriString) throws HttpSenderResponseException, IOException {
-        // If this host has already required credentials in this session, authenticate preemptively rather than
-        // paying another anonymous round-trip. Otherwise request anonymously first.
+        // If this host has already required authentication in this session, authenticate preemptively rather
+        // than paying another anonymous round-trip. Otherwise request anonymously first.
         String endpoint = endpointOrNull(URI.create(uriString));
-        if (hasCredentials(repo) && endpoint != null && ctx.getAuthenticationRequiredEndpoints().contains(endpoint)) {
+        if (hasAuthentication(repo) && endpoint != null && ctx.getAuthenticationRequiredEndpoints().contains(endpoint)) {
             return sendRequest(applyAuthenticationAndTimeoutToRequest(repo, httpSender.get(uriString)).build());
         }
         try {
             return sendRequest(applyTimeoutToRequest(repo, httpSender.get(uriString)).build());
         } catch (HttpSenderResponseException e) {
-            if (hasCredentials(repo) && e.isClientSideException()) {
+            if (hasAuthentication(repo) && e.isClientSideException()) {
                 return retryRequestWithCredentials(repo, uriString, e);
             } else {
                 throw e;
@@ -1195,21 +1195,36 @@ public class MavenPomDownloader {
      */
     private HttpSender.Request.Builder applyAuthenticationAndTimeoutToRequest(MavenRepository repository, HttpSender.Request.Builder request) {
         applyTimeoutToRequest(repository, request);
-        if (mavenSettings != null && mavenSettings.getServers() != null) {
-            for (MavenSettings.Server server : mavenSettings.getServers().getServers()) {
-                MavenSettings.ServerConfiguration configuration = server.getConfiguration();
-                if (server.getId().equals(repository.getId()) && configuration != null &&
-                    configuration.getHttpHeaders() != null) {
-                    for (MavenSettings.HttpHeader header : configuration.getHttpHeaders()) {
-                        request.withHeader(header.getName(), header.getValue());
-                    }
-                }
-            }
+        for (MavenSettings.HttpHeader header : resolveHttpHeaders(repository)) {
+            request.withHeader(header.getName(), header.getValue());
         }
         if (hasCredentials(repository)) {
             return request.withBasicAuthentication(repository.getUsername(), repository.getPassword());
         }
         return request;
+    }
+
+    /**
+     * Whether an authenticated request to this repository would differ from an anonymous one at all, and so
+     * whether retrying with authentication after a 4xx is worth a round-trip. A {@code <server>} may carry
+     * only {@code <httpHeaders>} (a bearer token or PAT) with no username or password, which authenticates
+     * just as much as basic credentials do. Mirrors {@code MavenArtifactDownloader#hasAuthentication}.
+     */
+    private boolean hasAuthentication(MavenRepository repository) {
+        return hasCredentials(repository) || !resolveHttpHeaders(repository).isEmpty();
+    }
+
+    private List<MavenSettings.HttpHeader> resolveHttpHeaders(MavenRepository repository) {
+        if (mavenSettings != null && mavenSettings.getServers() != null) {
+            for (MavenSettings.Server server : mavenSettings.getServers().getServers()) {
+                MavenSettings.ServerConfiguration configuration = server.getConfiguration();
+                if (server.getId().equals(repository.getId()) && configuration != null &&
+                    configuration.getHttpHeaders() != null) {
+                    return configuration.getHttpHeaders();
+                }
+            }
+        }
+        return emptyList();
     }
 
     private static boolean hasCredentials(MavenRepository repository) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddRepositoryTest.java
@@ -15,10 +15,25 @@
  */
 package org.openrewrite.maven;
 
+import okhttp3.OkHttpClient;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.HttpSenderExecutionContextView;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
+import org.openrewrite.maven.http.OkHttpSender;
 import org.openrewrite.test.RewriteTest;
+
+import java.net.InetAddress;
+import java.nio.file.Path;
+import java.time.Duration;
 
 import static org.openrewrite.maven.Assertions.pomXml;
 
@@ -306,56 +321,146 @@ class AddRepositoryTest implements RewriteTest {
     }
 
     @Test
-    @DisabledIfEnvironmentVariable(named = "CI", matches = "true",
-      disabledReason = "Artifactory mirror does not proxy https://repo.spring.io/snapshot")
-    void updateToSpringBoot30Snapshot() {
-        rewriteRun(
-          spec -> spec.recipes(
-            new AddRepository("boot-snapshots", "https://repo.spring.io/snapshot", null, null,
-              true, null, null,
-              null, null, null, null),
-            new UpgradeParentVersion(
-              "org.springframework.boot",
-              "spring-boot-starter-parent",
-              "3.0.0-SNAPSHOT",
-              null,
-              null)
-          ),
-          pomXml(
-            """
-              <project>
-                <parent>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>2.7.3</version>
-                </parent>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-              </project>
-              """,
-            """
-              <project>
-                <parent>
-                  <groupId>org.springframework.boot</groupId>
-                  <artifactId>spring-boot-starter-parent</artifactId>
-                  <version>3.0.0-SNAPSHOT</version>
-                </parent>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <repositories>
-                  <repository>
-                    <id>boot-snapshots</id>
-                    <url>https://repo.spring.io/snapshot</url>
-                    <snapshots>
-                      <enabled>true</enabled>
-                    </snapshots>
-                  </repository>
-                </repositories>
-              </project>
+    void updateToSpringBoot30Snapshot() throws Exception {
+        // Serve over TLS: MavenPomDownloader#normalizeRepository probes https first and only falls back to
+        // http once that fails, so a plaintext mock costs two doomed handshakes per repository before anything
+        // resolves.
+        HeldCertificate certificate = new HeldCertificate.Builder()
+          .addSubjectAlternativeName(InetAddress.getByName("localhost").getCanonicalHostName())
+          .build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+          .heldCertificate(certificate)
+          .build();
+        HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+          .addTrustedCertificate(certificate.certificate())
+          .build();
+
+        try (MockWebServer mockRepo = new MockWebServer()) {
+            mockRepo.useHttps(serverCertificates.sslSocketFactory(), false);
+            mockRepo.setDispatcher(new Dispatcher() {
+                @Override
+                public MockResponse dispatch(RecordedRequest request) {
+                    String path = request.getPath();
+                    if (path == null) {
+                        return new MockResponse().setResponseCode(404);
+                    }
+                    if (path.endsWith("/spring-boot-starter-parent/maven-metadata.xml")) {
+                        return new MockResponse().setResponseCode(200).setBody(
+                          //language=xml
+                          """
+                            <metadata>
+                              <groupId>org.springframework.boot</groupId>
+                              <artifactId>spring-boot-starter-parent</artifactId>
+                              <versioning>
+                                <versions>
+                                  <version>2.7.3</version>
+                                  <version>3.0.0-SNAPSHOT</version>
+                                </versions>
+                              </versioning>
+                            </metadata>
+                            """);
+                    }
+                    if (path.endsWith("/spring-boot-starter-parent-2.7.3.pom")) {
+                        return new MockResponse().setResponseCode(200).setBody(parentPom("2.7.3"));
+                    }
+                    if (path.endsWith("/spring-boot-starter-parent-3.0.0-SNAPSHOT.pom")) {
+                        return new MockResponse().setResponseCode(200).setBody(parentPom("3.0.0-SNAPSHOT"));
+                    }
+                    // No dated-snapshot metadata, so the plain -SNAPSHOT file name is requested
+                    return new MockResponse().setResponseCode(404);
+                }
+            });
+            mockRepo.start();
+
+            // Mirroring everything means the repository the recipe adds is served by the mock too, so the
+            // test asserts on the URL the recipe writes without depending on that host being reachable.
+            MavenSettings settings = MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+              //language=xml
               """
-          )
-        );
+                <settings>
+                    <mirrors>
+                        <mirror>
+                            <id>mock</id>
+                            <mirrorOf>*</mirrorOf>
+                            <url>https://%s:%d</url>
+                        </mirror>
+                    </mirrors>
+                </settings>
+                """.formatted(mockRepo.getHostName(), mockRepo.getPort())
+            ), new InMemoryExecutionContext());
+
+            OkHttpClient client = new OkHttpClient.Builder()
+              .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager())
+              .connectTimeout(Duration.ofSeconds(1))
+              .readTimeout(Duration.ofSeconds(1))
+              .build();
+
+            rewriteRun(
+              spec -> spec
+                .recipes(
+                  new AddRepository("boot-snapshots", "https://repo.spring.io/snapshot", null, null,
+                    true, null, null,
+                    null, null, null, null),
+                  new UpgradeParentVersion(
+                    "org.springframework.boot",
+                    "spring-boot-starter-parent",
+                    "3.0.0-SNAPSHOT",
+                    null,
+                    null)
+                )
+                .executionContext(MavenExecutionContextView.view(
+                    HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+                      .setHttpSender(new OkHttpSender(client)))
+                  .setMavenSettings(settings)),
+              pomXml(
+                """
+                  <project>
+                    <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>2.7.3</version>
+                    </parent>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                  </project>
+                  """,
+                """
+                  <project>
+                    <parent>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-starter-parent</artifactId>
+                      <version>3.0.0-SNAPSHOT</version>
+                    </parent>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <repositories>
+                      <repository>
+                        <id>boot-snapshots</id>
+                        <url>https://repo.spring.io/snapshot</url>
+                        <snapshots>
+                          <enabled>true</enabled>
+                        </snapshots>
+                      </repository>
+                    </repositories>
+                  </project>
+                  """
+              )
+            );
+        }
+    }
+
+    @Language("xml")
+    private static String parentPom(String version) {
+        return """
+          <project>
+            <modelVersion>4.0.0</modelVersion>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-parent</artifactId>
+            <version>%s</version>
+            <packaging>pom</packaging>
+          </project>
+          """.formatted(version);
     }
 }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -16,10 +16,13 @@
 package org.openrewrite.maven;
 
 import com.google.common.collect.Lists;
+import okhttp3.OkHttpClient;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
+import okhttp3.tls.HandshakeCertificates;
+import okhttp3.tls.HeldCertificate;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,14 +30,18 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.HttpSenderExecutionContextView;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.Parser;
+import org.openrewrite.maven.http.OkHttpSender;
 import org.openrewrite.maven.tree.MavenResolutionResult;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
+import java.net.InetAddress;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -3048,7 +3055,21 @@ class UpgradeDependencyVersionTest implements RewriteTest {
 
     @Test
     void bomUpgradeSkipsSnapshotVersions() throws Exception {
+        // Serve over TLS: MavenPomDownloader#normalizeRepository probes https first and only falls back to
+        // http once that fails, so a plaintext mock costs two doomed handshakes per repository before anything
+        // resolves.
+        HeldCertificate certificate = new HeldCertificate.Builder()
+          .addSubjectAlternativeName(InetAddress.getByName("localhost").getCanonicalHostName())
+          .build();
+        HandshakeCertificates serverCertificates = new HandshakeCertificates.Builder()
+          .heldCertificate(certificate)
+          .build();
+        HandshakeCertificates clientCertificates = new HandshakeCertificates.Builder()
+          .addTrustedCertificate(certificate.certificate())
+          .build();
+
         try (var mockRepo = new MockWebServer()) {
+            mockRepo.useHttps(serverCertificates.sslSocketFactory(), false);
             mockRepo.setDispatcher(new Dispatcher() {
                 @Override
                 public MockResponse dispatch(RecordedRequest request) {
@@ -3168,7 +3189,7 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                         <mirror>
                             <mirrorOf>*</mirrorOf>
                             <name>mock</name>
-                            <url>http://%s:%d</url>
+                            <url>https://%s:%d</url>
                             <id>mock</id>
                         </mirror>
                     </mirrors>
@@ -3176,10 +3197,18 @@ class UpgradeDependencyVersionTest implements RewriteTest {
                 """.formatted(mockRepo.getHostName(), mockRepo.getPort())
             ), new InMemoryExecutionContext());
 
+            OkHttpClient client = new OkHttpClient.Builder()
+              .sslSocketFactory(clientCertificates.sslSocketFactory(), clientCertificates.trustManager())
+              .connectTimeout(Duration.ofSeconds(1))
+              .readTimeout(Duration.ofSeconds(1))
+              .build();
+
             rewriteRun(
               spec -> spec
                 .recipe(new UpgradeDependencyVersion("com.example", "my-lib", "2.x", null, true, null))
-                .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
+                .executionContext(MavenExecutionContextView.view(
+                    HttpSenderExecutionContextView.view(new InMemoryExecutionContext())
+                      .setHttpSender(new OkHttpSender(client)))
                   .setMavenSettings(settings, "mock")),
               pomXml(
                 """

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -42,6 +42,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.xml.tree.Xml;
 
 import javax.net.ssl.SSLSocketFactory;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
@@ -1551,6 +1552,70 @@ class MavenPomDownloaderTest implements RewriteTest {
                   .build());
 
                 assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
+        void usesHttpHeaderAuthenticationWhenServerHasNoUsernameOrPassword() {
+            MavenSettings settings = MavenSettings.parse(new Parser.Input(
+              Paths.get("settings.xml"), () -> new ByteArrayInputStream(
+              //language=xml
+              """
+                <settings>
+                    <servers>
+                        <server>
+                            <id>id</id>
+                            <configuration>
+                                <httpHeaders>
+                                    <property>
+                                        <name>X-Auth-Token</name>
+                                        <value>token</value>
+                                    </property>
+                                </httpHeaders>
+                            </configuration>
+                        </server>
+                    </servers>
+                </settings>
+                """.getBytes())), ctx);
+            MavenExecutionContextView.view(ctx).setMavenSettings(settings);
+
+            var downloader = new MavenPomDownloader(emptyMap(), ctx);
+            var gav = new GroupArtifactVersion("fred", "fred", "1.0.0");
+            try (MockWebServer mockRepo = getMockServer()) {
+                List<@Nullable String> getRequestTokens = synchronizedList(new ArrayList<>());
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        if ("GET".equalsIgnoreCase(recordedRequest.getMethod())) {
+                            getRequestTokens.add(recordedRequest.getHeaders().get("X-Auth-Token"));
+                        }
+                        if (recordedRequest.getHeaders().get("X-Auth-Token") == null) {
+                            return new MockResponse().setResponseCode(401).setBody("");
+                        }
+                        return new MockResponse().setResponseCode(200).setBody(
+                          //language=xml
+                          """
+                            <project>
+                                <groupId>fred</groupId>
+                                <artifactId>fred</artifactId>
+                                <version>1.0.0</version>
+                            </project>
+                            """);
+                    }
+                });
+                mockRepo.start();
+                // No <username>/<password>: the token header is the only credential this server has.
+                var repositories = List.of(MavenRepository.builder()
+                  .id("id")
+                  .uri("http://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .build());
+
+                assertDoesNotThrow(() -> downloader.download(gav, null, null, repositories));
+
+                // Anonymous first, then a retry carrying the header — as with username/password credentials.
+                assertThat(getRequestTokens).containsExactly(null, "token");
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/internal/MavenPomDownloaderTest.java
@@ -1472,6 +1472,38 @@ class MavenPomDownloaderTest implements RewriteTest {
         }
 
         @Test
+        void normalizesRepositoryThatDropsAnonymousRequests() {
+            try (MockWebServer mockRepo = getMockServer()) {
+                mockRepo.setDispatcher(new Dispatcher() {
+                    @Override
+                    public MockResponse dispatch(RecordedRequest recordedRequest) {
+                        if (recordedRequest.getHeaders().get("Authorization") == null) {
+                            // Close without a status line, as an authenticating gateway may do, so the probe
+                            // sees a connection failure rather than a 401 it could recognize as "server exists"
+                            return new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AFTER_REQUEST);
+                        }
+                        return new MockResponse().setResponseCode(200).setBody("");
+                    }
+                });
+                mockRepo.start();
+                MavenRepository repository = MavenRepository.builder()
+                  .id("id")
+                  .uri("https://%s:%d/maven".formatted(mockRepo.getHostName(), mockRepo.getPort()))
+                  .username("user")
+                  .password("pass")
+                  .build();
+
+                MavenRepository normalized = new MavenPomDownloader(emptyMap(), ctx)
+                  .normalizeRepository(repository, MavenExecutionContextView.view(ctx), null);
+
+                assertThat(normalized).isNotNull();
+                assertThat(MavenExecutionContextView.view(ctx).getUnreachableEndpoints()).isEmpty();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Test
         void authenticatesPreemptivelyAfterCredentialsRequired() {
             var downloader = new MavenPomDownloader(emptyMap(), ctx);
             try (MockWebServer mockRepo = getMockServer()) {


### PR DESCRIPTION
`MavenPomDownloader` now treats a <server> with only <httpHeaders> (bearer token/PAT, no username+password) as authenticated, so those headers are actually sent on the retry after a 4xx.
`normalizeRepository` now retries its reachability probe with authentication before writing a host off as unreachable, instead of giving up on the anonymous failure. 

Incidentally fixed up a couple tests that were slow/disabled