### PR TITLE
Report why a recipe class could not be loaded, not just that it wasn't

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/YamlResourceLoader.java
@@ -375,12 +375,13 @@ public class YamlResourceLoader implements ResourceLoader {
                         recipeName,
                         null,
                         e.getMessage());
-            } catch (NoClassDefFoundError e) {
+            } catch (LinkageError e) {
                 addInvalidRecipeValidation(
                         addValidation,
                         recipeName,
                         null,
-                        "Recipe class " + recipeName + " cannot be found");
+                        "Recipe class " + recipeName + " could not be loaded: " + e,
+                        e);
             }
         } else if (recipeData instanceof Map) {
             Map.Entry<String, Object> nameAndConfig = ((Map<String, Object>) recipeData).entrySet().iterator().next();
@@ -396,7 +397,8 @@ public class YamlResourceLoader implements ResourceLoader {
                                     addValidation,
                                     recipeName,
                                     recipeArgs,
-                                    "Recipe class " + recipeName + " cannot be found");
+                                    "Recipe class " + recipeName + " cannot be found",
+                                    e);
                         } else {
                             addInvalidRecipeValidation(
                                     addValidation,
@@ -410,12 +412,13 @@ public class YamlResourceLoader implements ResourceLoader {
                                 recipeName,
                                 recipeArgs,
                                 e.getMessage());
-                    } catch (NoClassDefFoundError e) {
+                    } catch (LinkageError e) {
                         addInvalidRecipeValidation(
                                 addValidation,
                                 recipeName,
                                 recipeArgs,
-                                "Recipe class " + nameAndConfig.getKey() + " cannot be found");
+                                "Recipe class " + nameAndConfig.getKey() + " could not be loaded: " + e,
+                                e);
                     }
                 } else {
                     addInvalidRecipeValidation(
@@ -442,7 +445,13 @@ public class YamlResourceLoader implements ResourceLoader {
 
     private void addInvalidRecipeValidation(Consumer<Validated<Object>> addValidation, String recipeName,
                                             @Nullable Object recipeArgs, String message) {
-        addValidation.accept(Validated.invalid(recipeName, recipeArgs, message));
+        addInvalidRecipeValidation(addValidation, recipeName, recipeArgs, message, null);
+    }
+
+    private void addInvalidRecipeValidation(Consumer<Validated<Object>> addValidation, String recipeName,
+                                            @Nullable Object recipeArgs, String message,
+                                            @Nullable Throwable exception) {
+        addValidation.accept(Validated.invalid(recipeName, recipeArgs, message, exception));
     }
 
     public Collection<RecipeListing> listRecipeListings(RecipeBundle bundle) {

--- a/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/config/YamlResourceLoaderTest.java
@@ -279,6 +279,28 @@ class YamlResourceLoaderTest implements RewriteTest {
           Map.of(RecipeWithBadStaticInitializer.class.getName(), Map.of()));
     }
 
+    @Test
+    void loadRecipeWhoseStaticInitializerHasNotYetFailed() {
+        // Unlike RecipeWithBadStaticInitializer, this class is never pre-loaded, so the first
+        // load throws ExceptionInInitializerError rather than NoClassDefFoundError.
+        final List<Validated<Object>> invalidRecipes = new ArrayList<>();
+
+        createYamlResourceLoader().loadRecipe(
+          "org.company.CustomRecipe",
+          0,
+          RecipeFailingOnFirstLoad.class.getName(),
+          recipe -> {
+          },
+          recipe -> {
+          },
+          invalidRecipes::add);
+
+        assertEquals(1, invalidRecipes.size());
+        Validated.Invalid<Object> invalid = (Validated.Invalid<Object>) invalidRecipes.get(0);
+        assertThat(invalid.getException()).isInstanceOf(ExceptionInInitializerError.class);
+        assertThat(invalid.getMessage()).contains("ExceptionInInitializerError");
+    }
+
     private void assertRecipeWithRecipeDataThatThrowsNoClassDefFoundError(Object recipeData) {
         final List<Validated<Object>> invalidRecipes = new ArrayList<>();
         YamlResourceLoader resourceLoader = createYamlResourceLoader();
@@ -294,6 +316,13 @@ class YamlResourceLoaderTest implements RewriteTest {
           invalidRecipes::add);
 
         assertEquals(1, invalidRecipes.size());
+        Validated.Invalid<Object> invalid = (Validated.Invalid<Object>) invalidRecipes.get(0);
+        assertThat(invalid.getMessage())
+          .as("must report why the class could not be loaded, not merely that it could not be")
+          .contains("Could not initialize class");
+        assertThat(invalid.getException())
+          .as("the originating error must be retained for callers that can surface it")
+          .isInstanceOf(NoClassDefFoundError.class);
     }
 
     private YamlResourceLoader createYamlResourceLoader() {
@@ -333,6 +362,20 @@ class YamlResourceLoaderTest implements RewriteTest {
             .build().listRecipes().iterator().next()),
           text("hello", "/bin/java")
         );
+    }
+
+    private static class RecipeFailingOnFirstLoad extends Recipe {
+        static final int val = 1 / 0;
+
+        @Override
+        public String getDisplayName() {
+            return "";
+        }
+
+        @Override
+        public String getDescription() {
+            return "";
+        }
     }
 
     private static class RecipeWithBadStaticInitializer extends Recipe {


### PR DESCRIPTION
## What

When a declarative recipe's `recipeList` names an imperative recipe that fails to load, `YamlResourceLoader` reported:

```
Recipe class io.example.SomeRecipe cannot be found
```

That message is misleading. `NoClassDefFoundError` is raised *after* the class has been located — either linking hit a missing referenced type, or initialization already failed. The class is found; it can't be used. Meanwhile the one piece of information identifying the actual problem, the throwable's message naming the missing class, was discarded.

This changes the message to include the cause and attaches the throwable to the resulting `Validated.Invalid`, which has accepted an optional `Throwable` all along:

```
Recipe class io.example.SomeRecipe could not be loaded:
java.lang.NoClassDefFoundError: org/example/MissingType
```

## Why it matters

Tracking down a recipe that disappeared this way took hours of elimination against a real recipe bundle — ruling out classloader wiring, stale artifacts, missing POM entries and version skew one at a time. With the cause included it took a single run and named a dependency that was missing from the recipe's runtime classpath.

## Widening to `LinkageError`

`ExceptionInInitializerError` is not a `NoClassDefFoundError`, so it wasn't caught at all. The **first** recipe to trigger a failing static initializer propagated out of `loadRecipe` and aborted the entire YAML load, while every subsequent attempt degraded to an ordinary validation error. The existing tests had to pre-poison the class in `@BeforeAll` to work around exactly this.

`LinkageError` covers both, plus `UnsupportedClassVersionError` — so a recipe jar built for a newer JDK now says so instead of aborting the load or claiming the class is absent.

`VirtualMachineError` is a **sibling** of `LinkageError`, not a subtype, so `OutOfMemoryError` and `StackOverflowError` are still not caught here. `ClasspathScanningLoader` already catches `ClassNotFoundException | LinkageError` around its own class load, so this is consistent with the sibling loader — and narrower, since it reports rather than ignores.

`ClassNotFoundException` is deliberately not handled: `RecipeLoader.load` absorbs it into the Jackson fallback, and a name that isn't a Java class needs to reach the `IllegalArgumentException` → `addLazyLoadRecipe` branch. That's how a YAML recipe referencing another YAML recipe resolves.

## Tests

The two existing tests asserted only `assertEquals(1, invalidRecipes.size())` — that an error occurred, never what it said. That is how the misleading message survived. They now assert the cause reaches the message and that the throwable is retained.

Added a test for the first-load case the `@BeforeAll` was papering over, using a fixture that is never pre-loaded so it raises `ExceptionInInitializerError`. Verified it fails without the widening, where the error propagates straight out of `loadRecipe`.