### PR TITLE
RemoveUnusedImports: keep a single-type import shadowed by a type in the compilation unit's own package

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/RemoveUnusedImportsTest.java
@@ -28,6 +28,7 @@ import org.openrewrite.test.TypeValidation;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
 import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.java.Assertions.withSourceTypesOnClasspath;
 
 class RemoveUnusedImportsTest implements RewriteTest {
 
@@ -2473,6 +2474,95 @@ class RemoveUnusedImportsTest implements RewriteTest {
                 }
             }
             """
+          )
+        );
+    }
+
+    @Test
+    void keepExplicitImportShadowedByTypeInOwnPackage() {
+        rewriteRun(
+          spec -> spec.parser(foldingComExampleTypes()).beforeRecipe(withSourceTypesOnClasspath()),
+          //language=java
+          java(
+            """
+              package com.example.types;
+
+              public class Organization {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              public class Organization {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              import com.example.types.Organization;
+              import com.example.types.*;
+
+              class Fetcher {
+                  Organization organization;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void removeExplicitImportCoveredByStarImportWhenOwnPackageHasNoConflict() {
+        rewriteRun(
+          spec -> spec.parser(foldingComExampleTypes()).beforeRecipe(withSourceTypesOnClasspath()),
+          //language=java
+          java(
+            """
+              package com.example.types;
+
+              public class Organization {}
+              """
+          ),
+          //language=java
+          java(
+            """
+              package com.example;
+
+              import com.example.types.Organization;
+              import com.example.types.*;
+
+              class Fetcher {
+                  Organization organization;
+              }
+              """,
+            """
+              package com.example;
+
+              import com.example.types.*;
+
+              class Fetcher {
+                  Organization organization;
+              }
+              """
+          )
+        );
+    }
+
+    private static JavaParser.Builder<?, ?> foldingComExampleTypes() {
+        return JavaParser.fromJavaVersion().styles(
+          singletonList(
+            new NamedStyles(
+              Tree.randomId(), "test", "test", "test", emptySet(), singletonList(
+              ImportLayoutStyle.builder()
+                .packageToFold("com.example.types.*")
+                .importAllOthers()
+                .importStaticAllOthers()
+                .build()
+            )
+            )
           )
         );
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveUnusedImports.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
 import org.openrewrite.java.internal.PackageNameUtils;
+import org.openrewrite.java.marker.JavaSourceSet;
 import org.openrewrite.java.style.ImportLayoutStyle;
 import org.openrewrite.java.style.IntelliJ;
 import org.openrewrite.java.tree.*;
@@ -286,6 +287,7 @@ public class RemoveUnusedImports extends Recipe {
 
             // Do not use direct imports that are imported by a wildcard import
             Set<String> ambiguousStaticImportNames = getAmbiguousStaticImportNames(cu);
+            Set<String> sourcePackageTypeNames = null;
             for (ImportUsage anImport : importUsage) {
                 if (anImport.imports.isEmpty()) {
                     continue; // Skip import usages that have been completely removed
@@ -300,8 +302,15 @@ public class RemoveUnusedImports extends Recipe {
                         }
                     } else {
                         if (usedWildcardImports.size() == 1 && usedWildcardImports.contains(elem.getPackageName()) && !elem.getTypeName().contains("$") && !conflictsWithJavaLang(elem)) {
-                            anImport.used = false;
-                            changed = true;
+                            if (sourcePackageTypeNames == null) {
+                                sourcePackageTypeNames = typeNamesInPackage(cu, sourcePackage, ctx);
+                            }
+                            // A type in the compilation unit's own package takes precedence over an
+                            // import on demand, so the single-type import is not redundant.
+                            if (!sourcePackageTypeNames.contains(elem.getClassName())) {
+                                anImport.used = false;
+                                changed = true;
+                            }
                         }
                     }
                 }
@@ -474,6 +483,24 @@ public class RemoveUnusedImports extends Recipe {
 
         private static boolean conflictsWithJavaLang(J.Import elem) {
             return JAVA_LANG_CLASS_NAMES.contains(elem.getClassName());
+        }
+
+        /**
+         * @return the simple names of every classpath type declared in {@code packageName}, or an empty set when the
+         * classpath is unavailable or cannot be trusted.
+         */
+        private static Set<String> typeNamesInPackage(J.CompilationUnit cu, String packageName, ExecutionContext ctx) {
+            Optional<JavaSourceSet> sourceSet = cu.getMarkers().findFirst(JavaSourceSet.class);
+            if (packageName.isEmpty() || !sourceSet.isPresent() || JavaSourceSet.isDirty(ctx, cu)) {
+                return emptySet();
+            }
+            Set<String> typeNames = new HashSet<>();
+            for (JavaType.FullyQualified fq : sourceSet.get().getClasspath()) {
+                if (packageName.equals(fq.getPackageName())) {
+                    typeNames.add(fq.getClassName());
+                }
+            }
+            return typeNames;
         }
 
         /**


### PR DESCRIPTION
## What's changed?

`RemoveUnusedImports` strips a single-type import when the same package is already covered by an import on demand. That fold already guards against `java.lang` conflicts, but not against a type of the same simple name declared in the compilation unit's **own package**.

Per [JLS 6.4.1](https://docs.oracle.com/javase/specs/jls/se17/html/jls-6.html#jls-6.4.1), a type in the compilation unit's package outranks anything from an import on demand, while a single-type import outranks both. So in a file like:

```java
package com.example;

import com.example.types.Organization;  // <- not redundant
import com.example.types.*;
```

the explicit import is load-bearing whenever `com.example.Organization` also exists. Removing it silently re-resolves every `Organization` in the file to the same-package type, which breaks the build.

`typeNamesInPackage` reads `JavaSourceSet.getClasspath()` — lazily, only once a removal is actually about to happen — and takes the safe path (keep the import) when the marker is absent or `JavaSourceSet.isDirty`. This mirrors the classpath-ambiguity handling already in `ChangeType` and `ChangePackage`.

Known limitation: the shadowing type has to be on the classpath. A shadowing type in a sibling *source file* of the same project isn't in `JavaSourceSet.classpath` and is still missed; covering that would mean making this a scanning recipe.

## Anything in particular you'd like reviewers to focus on?

Whether the `isDirty` bail-out is worth carrying here, or whether the plain "no marker, no opinion" fallback is enough.

## Have you considered any alternatives or workarounds?

Simply not folding away single-type imports covered by a star import — too blunt, that fold is wanted and covered by existing tests.

## How was it found in the wild?

`OrganizationDataFetcher.java` in an internal service sits in `io.moderne.organizations` and imports `io.moderne.organizations.types.Organization` alongside `io.moderne.organizations.types.*`. A dependency ships `io.moderne.organizations.Organization` in that same package, so dropping the explicit import breaks compilation. An `OrderImports` run made exactly this change once before and it had to be reverted by hand; a later `CommonStaticAnalysis` run reproduced it.

Verified with a throwaway test parsing against the real jar: reproduces on `main`, clean with the fix. Two permanent tests added to `RemoveUnusedImportsTest` (shadowed -> keep, not shadowed -> still remove). `:rewrite-java:test` and `:rewrite-java-test:test` are green.