### PR TITLE
Remove dead native-image visitor guard from `Py.accept`

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
@@ -46,11 +46,6 @@ public interface Py extends J {
     @SuppressWarnings("unchecked")
     @Override
     default <R extends Tree, P> R accept(TreeVisitor<R, P> v, P p) {
-        final String visitorName = v.getClass().getCanonicalName();
-        // FIXME HACK TO AVOID RUNTIME VISITOR-ADAPTING IN NATIVE IMAGE
-        if (visitorName != null && visitorName.startsWith("io.moderne.serialization.")) {
-            return (R) this;
-        }
         return (R) acceptPython(v.adapt(PythonVisitor.class), p);
     }
 


### PR DESCRIPTION
`Py.accept` short-circuits any visitor whose class name starts with `io.moderne.serialization.` — returning the node unvisited — to avoid runtime visitor adaptation under a GraalVM native image. There is no native-image build anymore, so the guard is dead code.

It is not harmless dead code, though. It silently stops `JavaVisitor`-based tooling (search recipes, symbol indexing) from traversing a Python LST for those visitors, so they see nothing at all. `JS.accept` and `Cs.accept` carry no such guard, which is why the same tooling traverses JavaScript and C# but not Python. The check also hard-codes a downstream package name into the public tree.

This removes the guard so Python adapts to `PythonVisitor` unconditionally, exactly as JS and C# already do.
