### PR TITLE
Measure RPC request timeout by wall clock instead of counting sleep intervals

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -768,13 +769,14 @@ public class RewriteRpc {
 
             // future.get(timeout) from a FJP worker triggers ManagedBlocker compensation,
             // which spawns helper threads that can leak per-thread RewriteRpc state.
-            // Poll non-blockingly + Thread.sleep so FJP doesn't compensate.
-            long totalTimeoutMs = timeout.toMillis();
+            // Poll non-blockingly + Thread.sleep so FJP doesn't compensate. Use nanoTime 
+            // as Thread.sleep(1) is imprecise.
             long pollIntervalMs = 1;
-            long livenessIntervalMs = 500;
-            long elapsedMs = 0;
-            long lastLivenessMs = 0;
-            while (elapsedMs < totalTimeoutMs) {
+            long livenessIntervalNanos = TimeUnit.MILLISECONDS.toNanos(500);
+            long startNanos = System.nanoTime();
+            long deadlineNanos = startNanos + TimeUnit.MILLISECONDS.toNanos(timeout.toMillis());
+            long lastLivenessNanos = startNanos;
+            while (System.nanoTime() < deadlineNanos) {
                 JsonRpcSuccess result = future.getNow(null);
                 if (result != null) {
                     return result.getResult(responseType);
@@ -783,10 +785,10 @@ public class RewriteRpc {
                     return future.get().getResult(responseType);
                 }
                 Thread.sleep(pollIntervalMs);
-                elapsedMs += pollIntervalMs;
-                if (elapsedMs - lastLivenessMs >= livenessIntervalMs) {
+                long nowNanos = System.nanoTime();
+                if (nowNanos - lastLivenessNanos >= livenessIntervalNanos) {
                     checkLiveness();
-                    lastLivenessMs = elapsedMs;
+                    lastLivenessNanos = nowNanos;
                 }
             }
 

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -769,8 +769,6 @@ public class RewriteRpc {
 
             // future.get(timeout) from a FJP worker triggers ManagedBlocker compensation,
             // which spawns helper threads that can leak per-thread RewriteRpc state.
-            // Poll non-blockingly + Thread.sleep so FJP doesn't compensate. Use nanoTime 
-            // as Thread.sleep(1) is imprecise.
             long pollIntervalMs = 1;
             long livenessIntervalNanos = TimeUnit.MILLISECONDS.toNanos(500);
             long startNanos = System.nanoTime();


### PR DESCRIPTION
## Background / problem

`RewriteRpc#send` polls its response future in a loop that sleeps 1 ms per iteration and books exactly 1 ms of elapsed time for each pass, so the configured timeout is really an iteration count rather than a duration. `Thread.sleep(1)` routinely oversleeps: Windows timer resolution rounds waits up (15.6 ms per tick by default, and Windows 11 may refuse high-resolution timers for background processes), and any scheduler delay or liveness-check cost adds on top. Every oversleep silently stretches the effective timeout by the same factor, so a 1 hour request timeout can take several hours of wall time to fire. We saw this in the field as a language-server parse request on Windows that appeared to never time out.

## Solution

Compute a deadline from `System.nanoTime()` when the request is sent and compare against the monotonic clock on each pass, so the timeout fires at the configured wall-clock duration regardless of how long each sleep actually took. The liveness check cadence now also runs on wall time rather than iteration count. The non-blocking poll structure is unchanged, since blocking on `future.get(timeout)` from a ForkJoinPool worker would still trigger ManagedBlocker compensation.

## Test plan

- [x] `:rewrite-core:test --tests 'org.openrewrite.rpc.*'` (51 tests) passes
