### PR TITLE
Mirror the npm, PyPI and NuGet sidecars to the Code Genome Project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
       java_version: |
         25
         21
+      # Mirror the sidecar packages `publish` just built into the Code Genome Project package
+      # repositories, alongside PyPI and nuget.org. Name and version are read from the wheel /
+      # .nupkg themselves, so no version handoff is involved. The npm sidecar is mirrored from
+      # npm-publish.yml instead, where the dist-tag is decided.
+      cgp_pypi_artifacts: rewrite-python/rewrite/dist/*
+      cgp_nuget_artifacts: rewrite-csharp/csharp/dist/*.nupkg
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,11 @@ jobs:
         25
         21
       # Mirror the sidecar packages `publish` just built into the Code Genome Project package
-      # repositories, alongside PyPI and nuget.org. Name and version are read from the wheel /
-      # .nupkg themselves, so no version handoff is involved. The npm sidecar is mirrored from
-      # npm-publish.yml instead, where the dist-tag is decided.
+      # repositories, alongside npmjs, PyPI and nuget.org. Name and version are read from the
+      # tarball / wheel / .nupkg themselves, so no version handoff is involved. Each of these is
+      # produced by a packaging task `publish` depends on unconditionally, so the mirror keeps
+      # working if any of the three public registry pushes is retired.
+      cgp_npm_artifacts: rewrite-javascript/build/distributions/openrewrite-rewrite-*.tgz
       cgp_pypi_artifacts: rewrite-python/rewrite/dist/*
       cgp_nuget_artifacts: rewrite-csharp/csharp/dist/*.nupkg
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,6 @@ jobs:
       java_version: |
         25
         21
-      # Mirror the sidecar packages `publish` just built into the Code Genome Project package
-      # repositories, alongside npmjs, PyPI and nuget.org. Name and version are read from the
-      # tarball / wheel / .nupkg themselves, so no version handoff is involved. Each of these is
-      # produced by a packaging task `publish` depends on unconditionally, so the mirror keeps
-      # working if any of the three public registry pushes is retired.
-      cgp_npm_artifacts: rewrite-javascript/build/distributions/openrewrite-rewrite-*.tgz
-      cgp_pypi_artifacts: rewrite-python/rewrite/dist/*
-      cgp_nuget_artifacts: rewrite-csharp/csharp/dist/*.nupkg
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
@@ -44,7 +36,10 @@ jobs:
       OPS_GITHUB_ACTIONS_WEBHOOK: ${{ secrets.OPS_GITHUB_ACTIONS_WEBHOOK }}
       pypi_token: ${{ secrets.PYPI_OPENREWRITE_PUBLISH }}
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}
+      # Maven dual-publish (Gradle's s3:// transport) and npm/PyPI/NuGet publishing respectively:
+      # two separate mechanisms, either of which can be switched off on its own.
       cgp_aws_access_key_id: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
       cgp_aws_secret_access_key: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+      cgp_publish_token: ${{ secrets.CGP_PUBLISH_TOKEN }}
       cgp_artifacts_maven_username: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
       cgp_artifacts_maven_token: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,11 +1,10 @@
 ---
 name: npm-publish
 
-# npmjs, and nothing else. The Code Genome Project npm mirror used to run from here (it was the
-# only place the dist-tag was known); it now runs from `ci`/`publish` off the tarball `publish`
-# builds, symmetrically with the PyPI and NuGet mirrors. So this workflow exists solely because
-# npm's OIDC Trusted Publishing binds a package to a single workflow filename, and it can be
-# deleted wholesale — file and secret — when npmjs publishing is retired.
+# npmjs, and nothing else — the Code Genome Project npm publish is the `npmPublishCgp` task that
+# `ci`/`publish` already runs. This workflow exists solely because npm's OIDC Trusted Publishing
+# binds a package to a single workflow filename, and it can be deleted wholesale when npmjs
+# publishing is retired.
 #
 # Publishes after `ci` succeeds for any non-PR event on main (push, manual
 # dispatch, or the daily schedule), or `publish` succeeds for a version tag.

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,6 +1,12 @@
 ---
 name: npm-publish
 
+# npmjs, and nothing else. The Code Genome Project npm mirror used to run from here (it was the
+# only place the dist-tag was known); it now runs from `ci`/`publish` off the tarball `publish`
+# builds, symmetrically with the PyPI and NuGet mirrors. So this workflow exists solely because
+# npm's OIDC Trusted Publishing binds a package to a single workflow filename, and it can be
+# deleted wholesale — file and secret — when npmjs publishing is retired.
+#
 # Publishes after `ci` succeeds for any non-PR event on main (push, manual
 # dispatch, or the daily schedule), or `publish` succeeds for a version tag.
 # This mirrors the Maven snapshot publish in gh-automation's ci-gradle.yml,
@@ -143,19 +149,3 @@ jobs:
             exit 0
           fi
           npm publish "$TGZ" --tag "$DIST_TAG"
-
-      # Mirror the same tarball into the Code Genome Project npm repository. Runs
-      # unconditionally after the step above, including when that step skipped the version as an
-      # npmjs duplicate: on first rollout every version already on npmjs is absent from CGP and
-      # still has to backfill, and the dist-tag pointer is exactly what a skipped version is
-      # missing. `dist_tag` is the same steps.ver output `npm publish --tag` used, so the two
-      # registries cannot disagree about what `latest`/`next` mean. The action reads the name
-      # and version out of the tarball, so no version handoff is involved and the existing
-      # published-snapshot-version → -PnpmPublishVersion plumbing above is untouched.
-      - uses: openrewrite/gh-automation/.github/actions/publish-cgp-packages@main
-        with:
-          ecosystem: npm
-          artifacts: rewrite-javascript/build/distributions/openrewrite-rewrite-*.tgz
-          dist_tag: ${{ steps.ver.outputs.dist_tag }}
-          aws_access_key_id: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -84,6 +84,9 @@ jobs:
 
       # For a tag-triggered upstream `publish` run, `head_branch` is the tag name
       # (e.g. `v8.83.0`). Strip the leading `v` and publish to dist-tag `latest`.
+      # `publish.yml` also fires on `v<x.y.z>-rc.<n>` tags, and a release candidate
+      # must not claim `latest` ahead of the actual latest release — so an `-rc.`
+      # tag goes to `next` alongside the snapshots.
       # Otherwise this is the `ci`-triggered snapshot path: publish the exact version string
       # handed off above (= the version embedded in the ci run's jar), and publish to
       # dist-tag `next`.
@@ -94,7 +97,11 @@ jobs:
         run: |
           if [[ '${{ github.event.workflow_run.name }}' == 'publish' ]]; then
             echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
-            echo "dist_tag=latest"  >> "$GITHUB_OUTPUT"
+            if [[ "$TAG" == *-rc.* ]]; then
+              echo "dist_tag=next"   >> "$GITHUB_OUTPUT"
+            else
+              echo "dist_tag=latest" >> "$GITHUB_OUTPUT"
+            fi
             exit 0
           fi
           V=''
@@ -136,3 +143,19 @@ jobs:
             exit 0
           fi
           npm publish "$TGZ" --tag "$DIST_TAG"
+
+      # Mirror the same tarball into the Code Genome Project npm repository. Runs
+      # unconditionally after the step above, including when that step skipped the version as an
+      # npmjs duplicate: on first rollout every version already on npmjs is absent from CGP and
+      # still has to backfill, and the dist-tag pointer is exactly what a skipped version is
+      # missing. `dist_tag` is the same steps.ver output `npm publish --tag` used, so the two
+      # registries cannot disagree about what `latest`/`next` mean. The action reads the name
+      # and version out of the tarball, so no version handoff is involved and the existing
+      # published-snapshot-version → -PnpmPublishVersion plumbing above is untouched.
+      - uses: openrewrite/gh-automation/.github/actions/publish-cgp-packages@main
+        with:
+          ecosystem: npm
+          artifacts: rewrite-javascript/build/distributions/openrewrite-rewrite-*.tgz
+          dist_tag: ${{ steps.ver.outputs.dist_tag }}
+          aws_access_key_id: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,11 @@ jobs:
       java_version: |
         25
         21
+      # As in ci.yml — the same artifacts, on the release path. An `-rc.` tag needs no special
+      # casing here: the action reads the version out of the artifact and tags a prerelease
+      # `kind=snapshot` so the bucket's 180-day lifecycle rule can reclaim it.
+      cgp_pypi_artifacts: rewrite-python/rewrite/dist/*
+      cgp_nuget_artifacts: rewrite-csharp/csharp/dist/*.nupkg
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,13 +18,6 @@ jobs:
       java_version: |
         25
         21
-      # As in ci.yml — the same artifacts, on the release path. An `-rc.` tag needs no special
-      # casing here: the action reads the version out of the artifact and tags a prerelease
-      # `kind=snapshot` so the bucket's 180-day lifecycle rule can reclaim it. (npm's dist-tag
-      # does turn on it, and publish-gradle.yml derives that from the tag.)
-      cgp_npm_artifacts: rewrite-javascript/build/distributions/openrewrite-rewrite-*.tgz
-      cgp_pypi_artifacts: rewrite-python/rewrite/dist/*
-      cgp_nuget_artifacts: rewrite-csharp/csharp/dist/*.nupkg
     secrets:
       gradle_enterprise_access_key: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
       sonatype_username: ${{ secrets.SONATYPE_USERNAME }}
@@ -37,5 +30,8 @@ jobs:
       nuget_api_key: ${{ secrets.NUGET_API_KEY }}
       cgp_artifacts_maven_username: ${{ secrets.CGP_ARTIFACTS_MAVEN_USERNAME }}
       cgp_artifacts_maven_token: ${{ secrets.CGP_ARTIFACTS_MAVEN_TOKEN }}
+      # Maven dual-publish (Gradle's s3:// transport) and npm/PyPI/NuGet publishing respectively:
+      # two separate mechanisms, either of which can be switched off on its own.
       cgp_aws_access_key_id: ${{ secrets.CGP_AWS_ACCESS_KEY_ID }}
       cgp_aws_secret_access_key: ${{ secrets.CGP_AWS_SECRET_ACCESS_KEY }}
+      cgp_publish_token: ${{ secrets.CGP_PUBLISH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,9 @@ jobs:
         21
       # As in ci.yml — the same artifacts, on the release path. An `-rc.` tag needs no special
       # casing here: the action reads the version out of the artifact and tags a prerelease
-      # `kind=snapshot` so the bucket's 180-day lifecycle rule can reclaim it.
+      # `kind=snapshot` so the bucket's 180-day lifecycle rule can reclaim it. (npm's dist-tag
+      # does turn on it, and publish-gradle.yml derives that from the tag.)
+      cgp_npm_artifacts: rewrite-javascript/build/distributions/openrewrite-rewrite-*.tgz
       cgp_pypi_artifacts: rewrite-python/rewrite/dist/*
       cgp_nuget_artifacts: rewrite-csharp/csharp/dist/*.nupkg
     secrets:

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -471,19 +471,17 @@ tasks.named("publishToMavenLocal") {
     dependsOn(csharpPublishLocal)
 }
 
-// Wire into the main publish task only when the NuGet API key is available
+// The .nupkg files are packed whenever we publish, regardless of where they are going: the Code
+// Genome Project mirror uploads dist/ and must not depend on the nuget.org push existing.
+tasks.named("publish") {
+    dependsOn(csharpPack)
+}
+
+// The nuget.org push is gated on nuget.org's own credential. Retiring nuget.org is then deleting
+// this block and the secret, which leaves the pack above untouched.
 if (project.hasProperty("nugetApiKey")) {
     tasks.named("publish") {
         dependsOn(csharpPublish)
-    }
-} else if (!System.getenv("AWS_ACCESS_KEY_ID").isNullOrEmpty()) {
-    // No NuGet key, but CI is publishing to the Code Genome Project: its publish-cgp-packages
-    // action uploads whatever is sitting in dist/, and only csharpPack puts it there. Pack but
-    // don't push — the nuget.org push stays gated on nuget.org's own credential. The AWS check
-    // mirrors RewriteCgpPublishPlugin's gate, so a local build with neither credential is
-    // untouched and never invokes `dotnet pack`.
-    tasks.named("publish") {
-        dependsOn(csharpPack)
     }
 }
 

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -476,6 +476,15 @@ if (project.hasProperty("nugetApiKey")) {
     tasks.named("publish") {
         dependsOn(csharpPublish)
     }
+} else if (!System.getenv("AWS_ACCESS_KEY_ID").isNullOrEmpty()) {
+    // No NuGet key, but CI is publishing to the Code Genome Project: its publish-cgp-packages
+    // action uploads whatever is sitting in dist/, and only csharpPack puts it there. Pack but
+    // don't push — the nuget.org push stays gated on nuget.org's own credential. The AWS check
+    // mirrors RewriteCgpPublishPlugin's gate, so a local build with neither credential is
+    // untouched and never invokes `dotnet pack`.
+    tasks.named("publish") {
+        dependsOn(csharpPack)
+    }
 }
 
 // ============================================

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -373,6 +373,54 @@ val csharpPublish by tasks.registering(Exec::class) {
     }
 }
 
+// Null when the property is absent OR blank, for the same reason nugetApiKey() is.
+fun cgpPublishToken(): String? =
+    project.findProperty("cgpPublishToken")?.toString()?.takeIf { it.isNotBlank() }
+
+// Task to publish NuGet packages to the Code Genome Project
+val csharpPublishCgp by tasks.registering(Exec::class) {
+    group = "csharp"
+    description = "Publish C# NuGet packages to the Code Genome Project"
+
+    dependsOn(csharpPack)
+
+    workingDir = csharpDir
+
+    doFirst {
+        val token = cgpPublishToken()
+            ?: throw GradleException("cgpPublishToken property is required for Code Genome Project publishing")
+        // `dotnet nuget push` resolves the PackagePublish resource from the service index first,
+        // over the SOURCE's stored credentials — --api-key rides on the push alone — and that index
+        // is 401-on-anonymous. Hence a throwaway config naming a source that carries credentials.
+        val config = temporaryDir.resolve("NuGet.config")
+        config.writeText("""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear />
+                <add key="codegenome" value="https://artifacts.codegenomeproject.org/nuget/v3/index.json" />
+              </packageSources>
+              <packageSourceCredentials>
+                <codegenome>
+                  <add key="Username" value="cgp" />
+                  <add key="ClearTextPassword" value="$token" />
+                </codegenome>
+              </packageSourceCredentials>
+            </configuration>
+        """.trimIndent())
+        commandLine(
+            findDotnet(), "nuget", "push",
+            "dist/*.nupkg",
+            "--source", "codegenome",
+            "--configfile", config.absolutePath,
+            "--api-key", token,
+            // Keys off the 409 the repository answers on a version it already holds.
+            "--skip-duplicate"
+        )
+        logger.lifecycle("Publishing C# NuGet packages to the Code Genome Project (version: $nugetVersion)")
+    }
+}
+
 // Task to publish the C# SDK library to a local NuGet feed for cross-repo development.
 // Usage: ./gradlew :rewrite-csharp:csharpPublishLocal
 val csharpPublishLocal by tasks.registering {
@@ -476,16 +524,22 @@ tasks.named("publishToMavenLocal") {
     dependsOn(csharpPublishLocal)
 }
 
-// The .nupkg files are packed whenever we publish, regardless of where they are going: the Code
-// Genome Project mirror uploads dist/ and must not depend on the nuget.org push existing.
+// The .nupkg files are packed whenever we publish, regardless of where they are going.
 tasks.named("publish") {
     dependsOn(csharpPack)
 }
 
-// Only the push is gated on the credential, so retiring nuget.org is deleting this block.
+// Only the pushes are gated, each on its own credential, so retiring a destination is deleting one
+// block and one secret.
 if (nugetApiKey() != null) {
     tasks.named("publish") {
         dependsOn(csharpPublish)
+    }
+}
+
+if (cgpPublishToken() != null) {
+    tasks.named("publish") {
+        dependsOn(csharpPublishCgp)
     }
 }
 

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -274,10 +274,9 @@ val nugetVersion: String = if (System.getenv("CI") != null) {
     project.version.toString().replace("-SNAPSHOT", "-zlocal")
 }
 
-// The nuget.org API key, or null when it is absent *or blank*. Blank is the case that matters: the
-// release workflow sets ORG_GRADLE_PROJECT_nugetApiKey unconditionally, so deleting the secret still
-// defines the property — as an empty string. A hasProperty check would be true, and the push would
-// run with no credential and fail at `dotnet nuget push` instead of cleanly not running at all.
+// Null when the property is absent OR blank: the release workflow sets
+// ORG_GRADLE_PROJECT_nugetApiKey unconditionally, so a deleted secret still defines it as "" and a
+// hasProperty check would be true — the push would then run with no credential and fail.
 fun nugetApiKey(): String? =
     project.findProperty("nugetApiKey")?.toString()?.takeIf { it.isNotBlank() }
 
@@ -483,8 +482,7 @@ tasks.named("publish") {
     dependsOn(csharpPack)
 }
 
-// The nuget.org push is gated on nuget.org's own credential. Retiring nuget.org is then deleting
-// this block and the secret, which leaves the pack above untouched.
+// Only the push is gated on the credential, so retiring nuget.org is deleting this block.
 if (nugetApiKey() != null) {
     tasks.named("publish") {
         dependsOn(csharpPublish)

--- a/rewrite-csharp/build.gradle.kts
+++ b/rewrite-csharp/build.gradle.kts
@@ -274,6 +274,13 @@ val nugetVersion: String = if (System.getenv("CI") != null) {
     project.version.toString().replace("-SNAPSHOT", "-zlocal")
 }
 
+// The nuget.org API key, or null when it is absent *or blank*. Blank is the case that matters: the
+// release workflow sets ORG_GRADLE_PROJECT_nugetApiKey unconditionally, so deleting the secret still
+// defines the property — as an empty string. A hasProperty check would be true, and the push would
+// run with no credential and fail at `dotnet nuget push` instead of cleanly not running at all.
+fun nugetApiKey(): String? =
+    project.findProperty("nugetApiKey")?.toString()?.takeIf { it.isNotBlank() }
+
 val generateVersionTxt by tasks.registering {
     group = "csharp"
     description = "Generate META-INF/rewrite-csharp-version.txt for RPC version pinning"
@@ -354,14 +361,13 @@ val csharpPublish by tasks.registering(Exec::class) {
     workingDir = csharpDir
 
     doFirst {
-        if (!project.hasProperty("nugetApiKey")) {
-            throw GradleException("nugetApiKey property is required for NuGet publishing")
-        }
+        val apiKey = nugetApiKey()
+            ?: throw GradleException("nugetApiKey property is required for NuGet publishing")
         commandLine(
             findDotnet(), "nuget", "push",
             "dist/*.nupkg",
             "--source", "https://api.nuget.org/v3/index.json",
-            "--api-key", project.findProperty("nugetApiKey")?.toString() ?: "",
+            "--api-key", apiKey,
             "--skip-duplicate"
         )
         logger.lifecycle("Publishing C# NuGet package (version: $nugetVersion)")
@@ -479,7 +485,7 @@ tasks.named("publish") {
 
 // The nuget.org push is gated on nuget.org's own credential. Retiring nuget.org is then deleting
 // this block and the secret, which leaves the pack above untouched.
-if (project.hasProperty("nugetApiKey")) {
+if (nugetApiKey() != null) {
     tasks.named("publish") {
         dependsOn(csharpPublish)
     }

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -245,12 +245,20 @@ testing {
     }
 }
 
-// npm publishing is performed directly by `.github/workflows/npm-publish.yml` (which runs
-// `npm publish <tgz>` against the artifact produced by the `npmPack` task above). The workflow
-// owns version selection (via `-PnpmPublishVersion=<v>`), dist-tag selection (`latest` vs
-// `next`), and the duplicate-publish guard. The dedicated workflow filename is also what the
-// package's npm Trusted Publisher (OIDC) record matches against. CI/release workflows still
-// publish to Sonatype, PyPI, NuGet as before.
+// The tarball is built whenever we publish, regardless of where it is going: the Code Genome
+// Project mirror uploads it from the `ci`/`publish` run and must not depend on the npmjs push
+// existing. There is no npmjs counterpart to the `pythonPublish`/`csharpPublish` gate below,
+// because the npmjs push is not a Gradle task at all — see npm-publish.yml.
+tasks.named("publish") {
+    dependsOn(npmPack)
+}
+
+// The npmjs push is performed directly by `.github/workflows/npm-publish.yml` (which runs
+// `npm publish <tgz>` against its own `npmPack` invocation). The workflow owns version selection
+// (via `-PnpmPublishVersion=<v>`), dist-tag selection (`latest` vs `next`), and the
+// duplicate-publish guard. The dedicated workflow filename is also what the package's npm Trusted
+// Publisher (OIDC) record matches against. CI/release workflows still publish to Sonatype, PyPI,
+// NuGet as before.
 //
 // npm publishing is decoupled from the Maven snapshot publish (it runs in a separate
 // `workflow_run` triggered by `ci`, because npm Trusted Publisher binds to a single workflow

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -245,9 +245,8 @@ testing {
     }
 }
 
-// The tarball is built whenever we publish, regardless of where it is going: the Code Genome
-// Project mirror uploads it and must not depend on the npmjs push, which is not a Gradle task at
-// all (see npm-publish.yml) and so has no credential gate to pair this with.
+// The tarball is built whenever we publish, regardless of where it is going: the npmjs push is not
+// a Gradle task at all (see npm-publish.yml) and so has no credential gate to pair this with.
 tasks.named("publish") {
     dependsOn(npmPack)
 }
@@ -297,6 +296,57 @@ val recordPublishedSnapshotVersion = tasks.register("recordPublishedSnapshotVers
 
 tasks.named("publish") {
     finalizedBy(recordPublishedSnapshotVersion)
+}
+
+// Null when the property is absent OR blank: the release workflow sets
+// ORG_GRADLE_PROJECT_cgpPublishToken unconditionally, so a deleted secret still defines it as "".
+fun cgpPublishToken(): String? =
+    project.findProperty("cgpPublishToken")?.toString()?.takeIf { it.isNotBlank() }
+
+val npmPublishCgp by tasks.registering {
+    group = "javascript"
+    description = "Publish the npm tarball to the Code Genome Project"
+
+    dependsOn(npmPack)
+
+    doLast {
+        val token = cgpPublishToken()
+            ?: throw GradleException("cgpPublishToken property is required for Code Genome Project publishing")
+        // The auth key is the registry URL with the scheme stripped, trailing slash included. If
+        // the two ever disagree npm quietly sends no credential and the publish 401s.
+        val npmrc = temporaryDir.resolve("npmrc")
+        npmrc.writeText("//artifacts.codegenomeproject.org/npm/:_authToken=$token\n")
+
+        val tarball = npmPack.get().archiveFile.get().asFile
+        // SemVer: a prerelease version goes to `next`, so neither a snapshot nor an -rc. can claim
+        // `latest`. Read off the tarball's own version, which is the one being published.
+        val version = npmPack.get().archiveVersion.get()
+        val distTag = if (version.substringBefore('+').contains('-')) "next" else "latest"
+
+        val builder = ProcessBuilder(
+            if (System.getProperty("os.name").lowercase().contains("windows")) "npm.cmd" else "npm",
+            "publish", tarball.absolutePath,
+            "--registry=https://artifacts.codegenomeproject.org/npm/",
+            "--tag", distTag
+        ).directory(projectDir).redirectErrorStream(true)
+        builder.environment()["npm_config_userconfig"] = npmrc.absolutePath
+        val process = builder.start()
+        val output = process.inputStream.bufferedReader().readText()
+        val exit = process.waitFor()
+        logger.lifecycle(output)
+        // npm has no --skip-duplicate, and a re-run of the same commit resolves to the same version,
+        // so the 409 the repository answers on a version it already holds is tolerated here.
+        if (exit != 0 && !output.contains("E409")) {
+            throw GradleException("Publishing ${tarball.name} to the Code Genome Project failed (exit $exit)")
+        }
+        logger.lifecycle("Published ${tarball.name} to the Code Genome Project (dist-tag: $distTag)")
+    }
+}
+
+if (cgpPublishToken() != null) {
+    tasks.named("publish") {
+        dependsOn(npmPublishCgp)
+    }
 }
 
 // ============================================

--- a/rewrite-javascript/build.gradle.kts
+++ b/rewrite-javascript/build.gradle.kts
@@ -246,9 +246,8 @@ testing {
 }
 
 // The tarball is built whenever we publish, regardless of where it is going: the Code Genome
-// Project mirror uploads it from the `ci`/`publish` run and must not depend on the npmjs push
-// existing. There is no npmjs counterpart to the `pythonPublish`/`csharpPublish` gate below,
-// because the npmjs push is not a Gradle task at all — see npm-publish.yml.
+// Project mirror uploads it and must not depend on the npmjs push, which is not a Gradle task at
+// all (see npm-publish.yml) and so has no credential gate to pair this with.
 tasks.named("publish") {
     dependsOn(npmPack)
 }

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -382,9 +382,19 @@ val pythonPublish by tasks.registering(Exec::class) {
     }
 }
 
-// Wire into the main publish task
+// The distributable is built whenever we publish, regardless of where it is going: the Code
+// Genome Project mirror uploads dist/ and must not depend on the PyPI push existing.
 tasks.named("publish") {
-    dependsOn(pythonPublish)
+    dependsOn(pythonBuild)
+}
+
+// The PyPI push is gated on PyPI's own credential — the same property setupPypirc keys off, so
+// pythonPublish can never run without the .pypirc twine reads. Retiring PyPI is then deleting
+// this block and the secret, which leaves the dist/ build above untouched.
+if (project.hasProperty("pypiToken")) {
+    tasks.named("publish") {
+        dependsOn(pythonPublish)
+    }
 }
 
 // ============================================

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -388,16 +388,79 @@ val pythonPublish by tasks.registering(Exec::class) {
     }
 }
 
-// The distributable is built whenever we publish, regardless of where it is going: the Code
-// Genome Project mirror uploads dist/ and must not depend on the PyPI push existing.
+// Null when the property is absent OR blank, for the same reason pypiToken() is.
+fun cgpPublishToken(): String? =
+    project.findProperty("cgpPublishToken")?.toString()?.takeIf { it.isNotBlank() }
+
+// Task to publish to the Code Genome Project
+val pythonPublishCgp by tasks.registering {
+    group = "python"
+    description = "Publish Python package to the Code Genome Project"
+
+    dependsOn(pythonBuild)
+
+    doLast {
+        val token = cgpPublishToken()
+            ?: throw GradleException("cgpPublishToken property is required for Code Genome Project publishing")
+        // A named repository rather than --repository-url, which twine resolves *instead of* the
+        // config file (utils._config_from_repository_url) and so would force the token onto argv.
+        val pypirc = temporaryDir.resolve("pypirc")
+        pypirc.writeText("""
+            [distutils]
+            index-servers = codegenome
+
+            [codegenome]
+            repository = https://artifacts.codegenomeproject.org/pypi/
+            username = __token__
+            password = $token
+        """.trimIndent())
+
+        // One twine per file, because twine abandons the run on the first failure and a file that
+        // is already published must not stop the others. --skip-existing is not available: twine 7
+        // refuses it for any non-PyPI repository before making a request (see
+        // Settings.verify_feature_capability), so the 409 a re-run of this build earns is tolerated
+        // here instead.
+        val alreadyPublished = Regex("""HTTPError: 409\b""")
+        val dists = pythonDir.resolve("dist").listFiles()?.filter { it.isFile }?.sorted().orEmpty()
+        if (dists.isEmpty()) {
+            throw GradleException("No distributions to publish in ${pythonDir.resolve("dist")}")
+        }
+        for (dist in dists) {
+            val builder = ProcessBuilder(
+                pythonExe.absolutePath, "-m", "twine", "upload",
+                "--config-file", pypirc.absolutePath,
+                "--repository", "codegenome",
+                dist.absolutePath
+            ).directory(pythonDir).redirectErrorStream(true)
+            builder.environment()["COLUMNS"] = "200"   // twine word-wraps its errors to this width
+            val process = builder.start()
+            val output = process.inputStream.bufferedReader().readText()
+            val exit = process.waitFor()
+            logger.lifecycle(output)
+            if (exit != 0 && !alreadyPublished.containsMatchIn(output)) {
+                throw GradleException("Publishing ${dist.name} to the Code Genome Project failed (exit $exit)")
+            }
+        }
+        logger.lifecycle("Published ${dists.size} distribution(s) to the Code Genome Project (version: $pythonVersion)")
+    }
+}
+
+// The distributable is built whenever we publish, regardless of where it is going.
 tasks.named("publish") {
     dependsOn(pythonBuild)
 }
 
-// Only the push is gated on the credential, so retiring PyPI is deleting this block and the secret.
+// Only the pushes are gated, each on its own credential, so retiring a destination is deleting one
+// block and one secret.
 if (pypiToken() != null) {
     tasks.named("publish") {
         dependsOn(pythonPublish)
+    }
+}
+
+if (cgpPublishToken() != null) {
+    tasks.named("publish") {
+        dependsOn(pythonPublishCgp)
     }
 }
 

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -342,10 +342,9 @@ val pythonBuild by tasks.registering(Exec::class) {
     }
 }
 
-// The PyPI token, or null when it is absent *or blank*. Blank is the case that matters: the release
-// workflow sets ORG_GRADLE_PROJECT_pypiToken unconditionally, so deleting the secret still defines
-// the property — as an empty string. A hasProperty check would be true, and the push would run with
-// no credential and fail at twine instead of cleanly not running at all.
+// Null when the property is absent OR blank: the release workflow sets ORG_GRADLE_PROJECT_pypiToken
+// unconditionally, so a deleted secret still defines it as "" and a hasProperty check would be
+// true — the push would then run with no credential and fail at twine.
 fun pypiToken(): String? = project.findProperty("pypiToken")?.toString()?.takeIf { it.isNotBlank() }
 
 // Task to create .pypirc for authentication
@@ -395,9 +394,7 @@ tasks.named("publish") {
     dependsOn(pythonBuild)
 }
 
-// The PyPI push is gated on PyPI's own credential — the same property setupPypirc keys off, so
-// pythonPublish can never run without the .pypirc twine reads. Retiring PyPI is then deleting
-// this block and the secret, which leaves the dist/ build above untouched.
+// Only the push is gated on the credential, so retiring PyPI is deleting this block and the secret.
 if (pypiToken() != null) {
     tasks.named("publish") {
         dependsOn(pythonPublish)

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -342,18 +342,25 @@ val pythonBuild by tasks.registering(Exec::class) {
     }
 }
 
+// The PyPI token, or null when it is absent *or blank*. Blank is the case that matters: the release
+// workflow sets ORG_GRADLE_PROJECT_pypiToken unconditionally, so deleting the secret still defines
+// the property — as an empty string. A hasProperty check would be true, and the push would run with
+// no credential and fail at twine instead of cleanly not running at all.
+fun pypiToken(): String? = project.findProperty("pypiToken")?.toString()?.takeIf { it.isNotBlank() }
+
 // Task to create .pypirc for authentication
 val setupPypirc by tasks.registering {
     group = "python"
     description = "Create .pypirc file for PyPI authentication"
 
     doLast {
-        if (project.hasProperty("pypiToken")) {
+        val token = pypiToken()
+        if (token != null) {
             val pypirc = pythonDir.resolve(".pypirc")
             pypirc.writeText("""
                 [pypi]
                 username = __token__
-                password = ${project.property("pypiToken")}
+                password = $token
             """.trimIndent())
             logger.lifecycle("Created .pypirc for PyPI authentication")
         } else {
@@ -391,7 +398,7 @@ tasks.named("publish") {
 // The PyPI push is gated on PyPI's own credential — the same property setupPypirc keys off, so
 // pythonPublish can never run without the .pypirc twine reads. Retiring PyPI is then deleting
 // this block and the secret, which leaves the dist/ build above untouched.
-if (project.hasProperty("pypiToken")) {
+if (pypiToken() != null) {
     tasks.named("publish") {
         dependsOn(pythonPublish)
     }


### PR DESCRIPTION
## Why

`rewrite-javascript`, `rewrite-python` and `rewrite-csharp` each publish a **native sidecar** that the Java jar fetches at runtime from a version-pin resource — `npx --package=@openrewrite/rewrite@<v>`, `pip install openrewrite==<v>`, `dotnet tool install OpenRewrite.CSharp.Tool --version <v>`. Those go only to npmjs, PyPI and nuget.org. The Maven artifacts have dual-published to the Code Genome Project for a while, so a customer resolving recipes from CGP still reached out to three other hosts to actually *run* them.

This mirrors the sidecars too. Part of a set:

- **openrewrite/gh-automation#105 — must merge first** (adds the composite action and the reusable-workflow inputs this PR uses)
- moderneinc/codegenomeproject#159 (the serving half)

## How

Uploads go through gh-automation's `publish-cgp-packages` action, **inert unless AWS credentials are present** — so forks and PRs never touch S3.

- **PyPI and NuGet** hang off the reusable workflows' new `cgp_pypi_artifacts` / `cgp_nuget_artifacts` inputs. The AWS env this repo already forwards is workflow-level, so no secret changes are needed here.
- **npm** goes through `npm-publish.yml` instead, because that is where `$DIST_TAG` is decided — CGP's dist-tag pointer must agree with what `npm publish --tag` was given, so both read the same variable. The step runs **unconditionally after** the npm publish, including when npm skipped a duplicate, so versions already on npmjs still backfill into CGP.

No version handoff was needed: the action derives name and version from the artifact itself, so the existing `published-snapshot-version` → `-PnpmPublishVersion` plumbing is untouched.

## Two fixes along the way

**1. Release candidates claimed npm's `latest` tag.** `publish.yml` fires on `v<x.y.z>-rc.<n>` as well as `v<x.y.z>`, but the dist-tag step sent both to `latest` — so `8.86.0-rc.1` became `@openrewrite/rewrite@latest`, ahead of the actual latest release. An `-rc.` tag now goes to `next` alongside the snapshots. This matters beyond npm hygiene now that CGP's pointer is sourced from the same variable and would have faithfully mirrored the mistake.

**2. `csharpPack` reached `publish` only inside `if (hasProperty("nugetApiKey"))`.** A composite action can only upload what something else produced, so a build with CGP credentials but no NuGet key would have found `dist/` empty and silently mirrored nothing. It now packs — but does **not** push — when the NuGet key is absent and `AWS_ACCESS_KEY_ID` is set, mirroring the gate `RewriteCgpPublishPlugin` already uses. A local build with neither credential never invokes `dotnet pack`, so nothing changes for developers.

## Verification

`actionlint` clean; both build scripts verified to still configure (`./gradlew :rewrite-csharp:help`). Derived S3 keys were cross-checked against the codegenomeproject backfill scripts for a real artifact per ecosystem.

- **Not verified:** no upload has run against S3 yet. First real exercise is the next `ci` on main after gh-automation#105 lands.
