### PR TITLE
Python: fix ty-types client deadlock and restore type attribution on Windows

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/ty_client.py
+++ b/rewrite-python/rewrite/src/rewrite/python/ty_client.py
@@ -24,12 +24,17 @@ cross-file deduplication.
 from __future__ import annotations
 
 import json
+import logging
 import os
-import select
+import queue
 import subprocess
 import sys
+import threading
+import time
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class TyTypesClient:
@@ -66,6 +71,8 @@ class TyTypesClient:
         self._initialized = False
         self._project_root: Optional[str] = None
         self._virtual_env: Optional[str] = str(virtual_env) if virtual_env else None
+        self._responses: queue.Queue = queue.Queue()
+        self._consecutive_timeouts = 0
 
         # Cumulative type table for the lifetime of this ``--serve`` session.
         #
@@ -117,6 +124,37 @@ class TyTypesClient:
             raise RuntimeError(
                 "ty-types is not installed. Ensure the ty-types binary is on PATH."
             )
+
+        # Daemon threads drain both pipes: select() is sockets-only on Windows, and an undrained pipe deadlocks ty once its buffer fills.
+        self._responses = queue.Queue()
+        self._consecutive_timeouts = 0
+        threading.Thread(target=self._drain_stdout, args=(self._process,),
+                         name="ty-types-stdout", daemon=True).start()
+        threading.Thread(target=self._drain_stderr, args=(self._process,),
+                         name="ty-types-stderr", daemon=True).start()
+
+    def _drain_stdout(self, process: subprocess.Popen) -> None:
+        """Read response lines into the queue until EOF; EOF enqueues None."""
+        responses = self._responses
+        stdout = process.stdout
+        while True:
+            line = stdout.readline()
+            if not line:
+                responses.put(None)
+                return
+            try:
+                responses.put(json.loads(line.decode('utf-8')))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                logger.debug("ty-types emitted a non-JSON line on stdout")
+
+    @staticmethod
+    def _drain_stderr(process: subprocess.Popen) -> None:
+        stderr = process.stderr
+        while True:
+            line = stderr.readline()
+            if not line:
+                return
+            logger.debug("ty-types stderr: %s", line.decode('utf-8', 'replace').rstrip())
 
     @staticmethod
     def _subprocess_env(base_env: Optional[Dict[str, str]] = None,
@@ -183,9 +221,13 @@ class TyTypesClient:
             return Path(ty_types)
         return None
 
+    # Kill the process after this many consecutive timeouts; further requests degrade to None.
+    _MAX_CONSECUTIVE_TIMEOUTS = 3
+
     def _send_request(self, method: str, params: Optional[Dict[str, Any]] = None,
                       timeout: float = 0) -> Optional[Any]:
-        """Send a JSON-RPC request and read the response.
+        """Send a JSON-RPC request and wait for its response from the reader
+        thread's queue.
 
         Args:
             method: The JSON-RPC method name.
@@ -209,29 +251,35 @@ class TyTypesClient:
         try:
             self._process.stdin.write(line.encode('utf-8'))
             self._process.stdin.flush()
+        except (BrokenPipeError, OSError):
+            return None
 
-            if self._process.stdout is None:
+        end = None if timeout <= 0 else time.monotonic() + timeout
+        while True:
+            try:
+                remaining = None if end is None else end - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    raise queue.Empty
+                response = self._responses.get(timeout=remaining)
+            except queue.Empty:
+                self._consecutive_timeouts += 1
+                if self._consecutive_timeouts >= self._MAX_CONSECUTIVE_TIMEOUTS:
+                    logger.debug("ty-types unresponsive after %d timeouts; shutting it down",
+                                 self._consecutive_timeouts)
+                    self._kill()
                 return None
 
-            if timeout > 0:
-                ready, _, _ = select.select([self._process.stdout], [], [], timeout)
-                if not ready:
-                    return None
-
-            response_line = self._process.stdout.readline().decode('utf-8')
-            if not response_line:
+            if response is None:
+                # EOF sentinel: the process exited.
                 return None
-            response = json.loads(response_line)
-
+            # A response to an abandoned earlier request; drop it and keep waiting.
             if response.get('id') != self._request_id:
-                return None
+                continue
 
+            self._consecutive_timeouts = 0
             if response.get('error') is not None:
                 return None
-
             return response.get('result')
-        except (BrokenPipeError, OSError, json.JSONDecodeError):
-            return None
 
     def initialize(self, project_root: str) -> bool:
         """Initialize the ty-types session with a project root.
@@ -249,7 +297,9 @@ class TyTypesClient:
             self.session_types.clear()
             self._start_process()
 
-        result = self._send_request("initialize", {"projectRoot": project_root})
+        # Bounded so a wedged ty degrades to untyped instead of hanging; large because ty indexes the whole project up front.
+        result = self._send_request("initialize", {"projectRoot": project_root},
+                                    timeout=600)
         if result and result.get("ok"):
             self._initialized = True
             self._project_root = project_root
@@ -296,7 +346,7 @@ class TyTypesClient:
             return
 
         try:
-            self._send_request("shutdown")
+            self._send_request("shutdown", timeout=5)
             self._process.wait(timeout=5)
         except (subprocess.TimeoutExpired, OSError):
             if self._process is not None:
@@ -305,3 +355,15 @@ class TyTypesClient:
             self._process = None
             self._initialized = False
             self._project_root = None
+
+    def _kill(self) -> None:
+        """Forcibly terminate an unresponsive ty-types process."""
+        process = self._process
+        self._process = None
+        self._initialized = False
+        self._project_root = None
+        if process is not None:
+            try:
+                process.kill()
+            except OSError:
+                pass

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -560,12 +560,21 @@ def handle_parse(params: dict) -> List[str]:
     return results
 
 
+# Never-source dirs (caches, venvs, VCS, dependency trees, build output); caller exclusions extend, not replace.
+DEFAULT_PARSE_EXCLUSIONS = [
+    '__pycache__', '.venv', 'venv', '.git', '.tox', '*.egg-info', '.moderne',
+    'node_modules', '.pytest_cache', '.mypy_cache', 'build', 'dist', 'target',
+]
+
+
 def handle_parse_project(params: dict) -> List[dict]:
     """Handle a ParseProject RPC request."""
     import fnmatch
 
     project_path = params.get('projectPath', '.')
-    exclusions = params.get('exclusions', ['__pycache__', '.venv', 'venv', '.git', '.tox', '*.egg-info', '.moderne'])
+    exclusions = DEFAULT_PARSE_EXCLUSIONS + [
+        excl for excl in (params.get('exclusions') or []) if excl not in DEFAULT_PARSE_EXCLUSIONS
+    ]
     relative_to = params.get('relativeTo') or project_path
     # Per-request explicit override (mirror of the Parse RPC options carrier).
     options = params.get('options') or {}

--- a/rewrite-python/rewrite/tests/python/test_ty_client.py
+++ b/rewrite-python/rewrite/tests/python/test_ty_client.py
@@ -1,0 +1,100 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""TyTypesClient protocol tests against a fake `ty-types --serve`.
+
+The fake server answers per the requested file's name: "slow-<seconds>" delays
+the response and "big" pads it to ~64KB. Every request also writes to stderr,
+so an undrained stderr pipe would wedge it just like the real binary can.
+"""
+import os
+import stat
+import sys
+import textwrap
+
+import pytest
+
+from rewrite.python.ty_client import TyTypesClient
+
+FAKE_SERVER = textwrap.dedent('''\
+    #!/usr/bin/env python3
+    import json
+    import re
+    import sys
+    import time
+
+    for line in sys.stdin:
+        req = json.loads(line)
+        params = req.get("params") or {}
+        print("handled " + req["method"] + " " * 512, file=sys.stderr, flush=True)
+        if req["method"] == "shutdown":
+            break
+        if req["method"] == "initialize":
+            result = {"ok": True}
+        else:
+            name = params.get("file", "")
+            slow = re.search(r"slow-(\\d+(?:\\.\\d+)?)", name)
+            if slow:
+                time.sleep(float(slow.group(1)))
+            padding = "x" * 65536 if "big" in name else ""
+            result = {"types": {"1": {"kind": "class", "name": "str"}}, "pad": padding}
+        sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req["id"], "result": result}) + "\\n")
+        sys.stdout.flush()
+''')
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    server = tmp_path / "fake-ty-types"
+    server.write_text(FAKE_SERVER)
+    server.chmod(server.stat().st_mode | stat.S_IEXEC)
+    if os.name == 'nt':
+        pytest.skip("fake server uses a shebang launcher")
+    monkeypatch.setattr(TyTypesClient, '_find_binary', staticmethod(lambda: server))
+    c = TyTypesClient()
+    yield c
+    c.shutdown()
+
+
+def test_round_trip(client):
+    assert client.initialize("/some/project")
+    result = client.get_types("/some/project/app.py")
+    assert result is not None
+    assert result["types"]["1"]["name"] == "str"
+
+
+def test_timeout_returns_none_then_recovers(client):
+    assert client.initialize("/some/project")
+    assert client.get_types("/some/project/slow-1.py", timeout=0.05) is None
+    # The abandoned request's late response must be discarded, not returned here.
+    result = client.get_types("/some/project/ok.py", timeout=10)
+    assert result is not None
+    assert result["types"]["1"]["name"] == "str"
+
+
+def test_unread_big_responses_do_not_deadlock(client):
+    # Windows-hang regression: abandoned ~64KB responses must be absorbed; interleaved successes keep the breaker from tripping.
+    assert client.initialize("/some/project")
+    for i in range(20):
+        assert client.get_types(f"/some/project/big-slow-0.2-{i}.py", timeout=0.01) is None
+        result = client.get_types("/some/project/ok.py", timeout=30)
+        assert result is not None, f"client wedged after {i + 1} abandoned responses"
+
+
+def test_consecutive_timeouts_shut_the_process_down(client):
+    assert client.initialize("/some/project")
+    for i in range(3):
+        assert client.get_types(f"/some/project/slow-5-{i}.py", timeout=0.05) is None
+    assert not client.is_available
+    # Degrades fast instead of waiting on a dead process.
+    assert client.get_types("/some/project/ok.py", timeout=5) is None


### PR DESCRIPTION
## Background / problem

The ty-types client guards its response reads with `select.select()`, which only supports sockets on Windows. Every `getTypes` call there raised immediately inside the guard, was caught, and returned `None` — so Python LSTs built on Windows have had no ty type attribution since the client was introduced. Worse, each abandoned request left its response unread: ty kept writing responses into a stdout pipe nobody drained, blocked once the pipe filled (Windows pipes buffer only a few KB), stopped reading its stdin, and the engine then blocked forever in `stdin.flush()`. On a 4,600-file repository this reproduced as a parse that hangs indefinitely at zero CPU, confirmed by py-spy stacks on both sides of the wedge and by the build completing within minutes of killing the ty process.

## Solution

Responses are now drained by a daemon reader thread into a queue, and `_send_request` waits on that queue with a wall-clock deadline, discarding late responses for abandoned request ids. stderr is drained too. A consecutive-timeout breaker kills a genuinely hung ty process after three strikes so requests degrade to `None` fast instead of waiting forever, and `initialize` now has a generous bound instead of none. Separately, the ParseProject walk's default exclusions gain `node_modules`, cache, and build-output directories, and caller-supplied exclusions now extend the defaults rather than replace them.

With the fix, the previously-hanging 4,600-file Windows repro builds in 76 seconds and a cross-platform single-file check attributes identical types on Windows and macOS.

## Test plan

- [x] New `test_ty_client.py`: round trip, timeout-then-recover with stale-response discard, abandoned-big-response deadlock regression, and consecutive-timeout breaker (fake `ty-types --serve` subprocess)
- [x] Full engine suite: 2012 passed, 12 skipped (pre-existing)
- [x] Windows validation: hung repro now `MOD SUCCEEDED in 1m 16s`; single-file type attribution matches macOS
