### PR TITLE
Relativize GoResolutionResult.Path in ParseProject

### DIFF
--- a/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
+++ b/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
 // TestParseProjectRelativizesGoModSourcePath pins down that a GoMod LST
@@ -73,5 +74,72 @@ func writeFile(t *testing.T, path, content string) {
 	}
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestParseProjectRelativizesGoResolutionResultPath pins down that the GoResolutionResult
+// marker riding on a GoMod carries a project-root-relative Path, like every other path on
+// the tree. It was built from the absolute path the directory walk produced while the
+// GoMod's own SourcePath was relativized just below, so a recipe correlating the two
+// silently matched nothing and fell back to unqualified results.
+func TestParseProjectRelativizesGoResolutionResultPath(t *testing.T) {
+	// given
+	s, _ := newTestServer(t)
+	projectDir := t.TempDir()
+	writeFile(t, filepath.Join(projectDir, "go.mod"), "module example.com/foo\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(projectDir, "main.go"), "package main\n\nfunc main() {}\n")
+	writeFile(t, filepath.Join(projectDir, "go.sum"), "")
+	writeFile(t, filepath.Join(projectDir, "examples", "go.mod"), "module example.com/foo/examples\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(projectDir, "examples", "demo.go"), "package examples\n")
+
+	relativeTo := projectDir
+	params, err := json.Marshal(parseProjectRequest{
+		ProjectPath: projectDir,
+		RelativeTo:  &relativeTo,
+	})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	// when
+	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
+		t.Fatalf("handleParseProject: %v", rpcErr.Message)
+	}
+
+	// then
+	onGoMod, onGoSum := 0, 0
+	for _, obj := range s.localObjects {
+		switch sf := obj.(type) {
+		case *golang.GoMod:
+			for _, mrr := range resolutionResults(sf.Markers.Entries) {
+				onGoMod++
+				assertMarkerPath(t, mrr.Path, sf.SourcePath, sf.SourcePath)
+			}
+		case *golang.GoSum:
+			for _, mrr := range resolutionResults(sf.Markers.Entries) {
+				onGoSum++
+				assertMarkerPath(t, mrr.Path, filepath.Join(filepath.Dir(sf.SourcePath), "go.mod"), sf.SourcePath)
+			}
+		}
+	}
+	if onGoMod != 2 || onGoSum != 1 {
+		t.Fatalf("expected markers on 2 go.mod and 1 go.sum, got %d and %d", onGoMod, onGoSum)
+	}
+}
+
+func resolutionResults(entries []java.Marker) []golang.GoResolutionResult {
+	var found []golang.GoResolutionResult
+	for _, entry := range entries {
+		if mrr, ok := entry.(golang.GoResolutionResult); ok {
+			found = append(found, mrr)
+		}
+	}
+	return found
+}
+
+func assertMarkerPath(t *testing.T, got, want, attachedTo string) {
+	t.Helper()
+	if got != want {
+		t.Errorf("marker on %q has Path %q, want %q", attachedTo, got, want)
 	}
 }

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2339,6 +2339,13 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 			s.logger.Printf("ParseProject: skip malformed go.mod %s: %v", modPath, err)
 			continue
 		}
+		// modPath is absolute (directory walk), but the marker rides on the LST where paths
+		// are project-root-relative — recipes correlating it with source paths match nothing.
+		if req.RelativeTo != nil && *req.RelativeTo != "" {
+			if rel, relErr := filepath.Rel(*req.RelativeTo, modPath); relErr == nil {
+				mrr.Path = rel
+			}
+		}
 		// If a sibling go.sum exists, populate ResolvedDependencies too.
 		sumPath := filepath.Join(filepath.Dir(modPath), "go.sum")
 		if sumData, err := os.ReadFile(sumPath); err == nil {

--- a/rewrite-go/pkg/tree/golang/go_resolution_result.go
+++ b/rewrite-go/pkg/tree/golang/go_resolution_result.go
@@ -28,7 +28,7 @@ type GoResolutionResult struct {
 	ModulePath           string
 	GoVersion            string // empty if no `go` directive
 	Toolchain            string // empty if no `toolchain` directive
-	Path                 string // path to the go.mod file
+	Path                 string // project-root-relative path to the go.mod file
 	Requires             []GoRequire
 	Replaces             []GoReplace
 	Excludes             []GoExclude

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/GoResolutionResult.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/GoResolutionResult.java
@@ -70,7 +70,7 @@ public class GoResolutionResult implements Marker, RpcCodec<GoResolutionResult> 
     @Nullable String toolchain;
 
     /**
-     * Absolute or repo-relative path to the go.mod file.
+     * Project-root-relative path to the go.mod file, matching the {@code GoMod}'s own source path.
      */
     @ToString.Include
     String path;


### PR DESCRIPTION
## The bug

`handleParseProject` builds the `GoResolutionResult` marker from the absolute path its directory walk produced:

```go
mrr, err := goparser.ParseGoMod(modPath, string(data))   // modPath is absolute
```

while the `GoMod`'s own `SourcePath` is relativized a few lines below, with a comment explaining exactly why that matters:

```go
// Relativize before building the LST so the GoMod's own SourcePath
// matches the response item ...
```

So the marker disagreed with every other path on the tree. Recipes that correlate it with source paths — to work out which module governs a package, for instance — matched nothing and degraded silently to unqualified results. Observed downstream as every Go package reporting as a bare directory (`pkg/term` rather than `github.com/cli/go-gh/v2/pkg/term`).

## The fix

Relativize at the point of construction, so both attachment sites — the `GoMod` and its sibling `GoSum` — get a correct marker, rather than patching each in turn. The `mods` map stays keyed on the absolute directory, which is what the `.go` file lookup at `filepath.Rel(m.dir, goFile)` needs; only the marker's `Path` field changes.

Only `parseProject` was affected. The single-file `Parse` path already passes `r.sourcePath`, which is relative.

## Why no test caught it

`pkg/test/spec.go:201` hardcodes `ParseGoMod("go.mod", ...)`, so in the shared harness the marker path and the source path always coincide and both spellings pass. The new test drives `handleParseProject` directly with `RelativeTo` set, covering:

- a root module
- a nested module
- the `GoSum` attachment, whose marker points at the *sibling go.mod* rather than its own source path — so a future refactor that "helpfully" sets it to `gs.SourcePath` fails rather than silently misleading recipes

## Docs

Both sides said "path to the go.mod file"; the Java javadoc added *"Absolute or repo-relative"*, which documented the defect as though it were a contract and is why this looked intentional. Both now state project-root-relative.

For reference, every sibling relativizes before a path reaches a marker — `MavenParser` via `source.getRelativePath(relativeTo)`, Python via `text.getSourcePath()`, JavaScript via `path.relative(...)`. `parseProject` was the only place that didn't.

## Verification

Baseline on unmodified `origin/main`: 29 failures in `./cmd/rpc` (Windows `TempDir` cleanup holding `server.log`). With this change: 30, the delta being the new test hitting that same pre-existing cleanup issue — its assertions pass.