### PR TITLE
Default relativeTo to the project path in the RPC clients

### DIFF
--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
@@ -253,6 +253,8 @@ public class GoRewriteRpc extends RewriteRpc {
      * @return Stream of parsed source files
      */
     public Stream<SourceFile> parseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo, ExecutionContext ctx) {
+        // The server relativizes only against this, so without it source paths land on the LST absolute.
+        Path base = relativeTo == null ? projectPath : relativeTo;
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
 
         return StreamSupport.stream(new Spliterator<SourceFile>() {
@@ -263,7 +265,7 @@ public class GoRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, base), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 
@@ -277,7 +279,6 @@ public class GoRewriteRpc extends RewriteRpc {
                 if (Quark.class.getName().equals(item.getSourceFileType())) {
                     // Oversize file the Go side declined to parse; build the Quark
                     // locally from its path (plus file attributes) — no content on the wire.
-                    Path base = relativeTo != null ? relativeTo : projectPath;
                     Path sourcePath = Paths.get(Objects.requireNonNull(item.getSourcePath()));
                     action.accept(new Quark(Tree.randomId(), sourcePath, Markers.EMPTY, null,
                             FileAttributes.fromPath(base.resolve(sourcePath))));

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -168,6 +168,8 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
      * @return Stream of parsed source files
      */
     public Stream<SourceFile> parseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo, ExecutionContext ctx) {
+        // The server relativizes only against this, so without it source paths land on the LST absolute.
+        Path base = relativeTo == null ? projectPath : relativeTo;
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
         JavaScriptValidator<Integer> validator = new JavaScriptValidator<>();
 
@@ -179,7 +181,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, base), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 
@@ -193,7 +195,6 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
                 if (Quark.class.getName().equals(item.getSourceFileType())) {
                     // Oversize file the TypeScript side declined to parse; build the Quark
                     // locally from its path (plus file attributes) — no content on the wire.
-                    Path base = relativeTo != null ? relativeTo : projectPath;
                     Path sourcePath = Paths.get(item.getSourcePath());
                     action.accept(new Quark(Tree.randomId(), sourcePath, Markers.EMPTY, null,
                             FileAttributes.fromPath(base.resolve(sourcePath))));

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -175,7 +175,8 @@ public class PythonRewriteRpc extends RewriteRpc {
      *
      * @param projectPath Path to the project directory to parse
      * @param exclusions  Optional glob patterns to exclude from parsing
-     * @param relativeTo  Optional path to make source file paths relative to
+     * @param relativeTo  Optional path to make source file paths relative to. If not specified,
+     *                    paths are relative to projectPath.
      * @param ctx         Execution context for parsing
      * @return Stream of parsed source files
      * @deprecated Use {@link #parseProject(Path, ParseProjectOptions, ExecutionContext)} instead.
@@ -201,7 +202,8 @@ public class PythonRewriteRpc extends RewriteRpc {
      */
     public Stream<SourceFile> parseProject(Path projectPath, ParseProjectOptions options, ExecutionContext ctx) {
         @Nullable List<String> exclusions = options.getExclusions();
-        @Nullable Path relativeTo = options.getRelativeTo();
+        // The server relativizes only against this, so without it source paths land on the LST absolute.
+        Path relativeTo = options.getRelativeTo() == null ? projectPath : options.getRelativeTo();
         @Nullable Path dependencyPath = options.getDependencyPath();
         ParsingEventListener parsingListener = ParsingExecutionContextView.view(ctx).getParsingListener();
 
@@ -227,10 +229,9 @@ public class PythonRewriteRpc extends RewriteRpc {
                 if (Quark.class.getName().equals(item.getSourceFileType())) {
                     // Oversize file the Python side declined to parse; build the Quark
                     // locally from its path (plus file attributes) — no content on the wire.
-                    Path base = relativeTo != null ? relativeTo : projectPath;
                     Path sourcePath = Paths.get(item.getSourcePath());
                     action.accept(new Quark(Tree.randomId(), sourcePath, Markers.EMPTY, null,
-                            FileAttributes.fromPath(base.resolve(sourcePath))));
+                            FileAttributes.fromPath(relativeTo.resolve(sourcePath))));
                     return true;
                 }
 


### PR DESCRIPTION
## The problem

`parseProject`'s convenience overloads pass a null `relativeTo`:

```java
public Stream<SourceFile> parseProject(Path projectPath, ExecutionContext ctx) {
    return parseProject(projectPath, null, null, ctx);
}
```

and the servers only relativize when given a base. So Go and Python emitted **absolute source paths onto the LST** whenever a caller used the short overload — which is every in-repo integration test.

Both already documented the opposite. `GoRewriteRpc`: *"If not specified, paths are relative to projectPath."* `ParseProjectOptions.relativeTo`: *"When `null`, paths are relative to the project path."* Neither implemented it.

## Why not fix the servers

JavaScript *did* implement it, but server-side — `parse-project.ts` substitutes `projectPath` when the request omits `relativeTo`. That put the default in the wrong layer: it gave one engine a semantic the other three lacked, and it quietly repaired callers that had simply forgotten to say what to relativize against.

`relativeTo` isn't meant to be null in the first place. The real caller always sets it; only the convenience overloads don't. So the default belongs at the client, where the caller's intent is known — after which every server sees a non-null value and none needs a special case.

## What changed

Each client defaults in its core `parseProject`:

```java
Path base = relativeTo == null ? projectPath : relativeTo;
```

Go and JavaScript reuse that for the Quark `FileAttributes` resolution, which previously duplicated the same ternary inside the anonymous `Spliterator`, so the two can no longer drift. Python centralises in its one options-consuming method, covering all its overloads; its copy of the ternary is now unreachable and removed.

Null remains legal on the full overload for a caller that deliberately wants no relativization — it just stops being the accidental default.

## Deliberately not done

JavaScript's server-side fallback stays. Removing it isn't a line deletion — `relativeTo` becomes possibly-undefined at three `path.relative(...)` call sites, so matching the others would mean emitting absolute paths in a branch no client can now reach. It's unreachable belt-and-braces.

## Behaviour change

Go and Python stop emitting absolute source paths for short-overload callers. Anyone depending on absolute paths there would be affected, though every javadoc already promised relative.

## Test coverage

No new test. `JavaScriptRewriteRpcTest` already asserts exact relative paths through the null-`relativeTo` overload, but it passed before via the server fallback and passes after via the client default, so it doesn't distinguish the two. Go's `ParseProjectModuleContextTest` uses `endsWith("go.mod")`, deliberately tolerant of either form.

Tightening that `endsWith` to an exact match is the assertion that would have failed before this change and passes after — happy to add it if reviewers want the guard.