### PR TITLE
Share Java service interfaces across the recipe classloader boundary

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -103,14 +103,7 @@ public class RecipeClassLoader extends URLClassLoader {
             "org.openrewrite.java.TypeNameMatcher",
             "org.openrewrite.java.internal.TypesInUse",
             "org.openrewrite.java.TypeNameMatcher",
-            // JavaSourceSet#getTypeFactory crosses the recipe/parent classloader
-            // boundary when JavaTemplate reads it from the enclosing source file's
-            // marker; the interface must be shared so the cast in JavaTemplateParser
-            // succeeds.
             "org.openrewrite.java.internal.JavaTypeFactory",
-            // A language's `service()` override lives in its parent-delegated `tree` package, so
-            // the impl it returns extends the parent's interface. Child-loaded callers such as
-            // ChangeType cast that instance to their own service interface, so it must be shared.
             "org.openrewrite.java.service",
             "org.openrewrite.maven.MavenDownloadingException",
             "org.openrewrite.maven.MavenDownloadingExceptions",

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -108,6 +108,10 @@ public class RecipeClassLoader extends URLClassLoader {
             // marker; the interface must be shared so the cast in JavaTemplateParser
             // succeeds.
             "org.openrewrite.java.internal.JavaTypeFactory",
+            // A language's `service()` override lives in its parent-delegated `tree` package, so
+            // the impl it returns extends the parent's interface. Child-loaded callers such as
+            // ChangeType cast that instance to their own service interface, so it must be shared.
+            "org.openrewrite.java.service",
             "org.openrewrite.maven.MavenDownloadingException",
             "org.openrewrite.maven.MavenDownloadingExceptions",
             "org.openrewrite.maven.MavenExecutionContextView",

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
@@ -263,6 +263,29 @@ class RecipeClassLoaderTest {
     }
 
     @Test
+    void serviceInterfacesShouldDelegateToParent(@TempDir Path tempDir) throws Exception {
+        // Reproduces the ClassCastException a child-loaded ChangeType hits when it casts
+        // Py.CompilationUnit's parent-loaded PythonImportService to its own ImportService;
+        // see PARENT_DELEGATED_PREFIXES in RecipeClassLoader.
+        Path parentLib = tempDir.resolve("parent");
+        Files.createDirectories(parentLib.resolve("org/openrewrite/java/service"));
+        Files.write(parentLib.resolve("org/openrewrite/java/service/ImportService.class"),
+          stubClass("org/openrewrite/java/service/ImportService"));
+
+        Path childLib = tempDir.resolve("child");
+        Files.createDirectories(childLib.resolve("org/openrewrite/java/service"));
+        Files.write(childLib.resolve("org/openrewrite/java/service/ImportService.class"),
+          stubClass("org/openrewrite/java/service/ImportService"));
+
+        try (URLClassLoader parent = new URLClassLoader(new URL[]{parentLib.toUri().toURL()}, null);
+             RecipeClassLoader classLoader = new RecipeClassLoader(new URL[]{childLib.toUri().toURL()}, parent)) {
+            assertThat(classLoader.loadClass("org.openrewrite.java.service.ImportService").getClassLoader())
+              .as("service interfaces cross the recipe/parent boundary and must be shared")
+              .isSameAs(parent);
+        }
+    }
+
+    @Test
     void allResourcesShouldFindFromParentLast(@TempDir Path tempDir) throws Exception {
         Path lib1 = tempDir.resolve("lib1");
         Files.createDirectories(lib1);


### PR DESCRIPTION
## Motivation

Running a Python recipe that includes `ChangeType` fails on every Python source file with `java.lang.ClassCastException: class org.openrewrite.python.service.PythonImportService cannot be cast to class org.openrewrite.java.service.ImportService`. The two classes share a name but come from different classloaders. `ChangeType` comes from the recipe bundle and is defined by `RecipeClassLoader`, so its `service(ImportService.class)` call resolves `ImportService` child-first — `org.openrewrite.java.service` matched no entry in `PARENT_DELEGATED_PREFIXES`, and `isTreeMarkerStyleType` does not catch it either. Meanwhile `org.openrewrite.python.tree.Py` *is* parent-delegated under the `tree` package rule, so `Py.CompilationUnit.service()` runs in the parent and hands back a `PythonImportService` extending the parent's `ImportService`. The cast then fails.

Java sources never hit this because `JavaSourceFile.service()` instantiates the caller's own class reflectively — a trick that only works when the requested type *is* the implementation, which is never true for a language-specific subclass.

Service interfaces are shared API that crosses the recipe/parent boundary, exactly like the `org.openrewrite.java.internal.JavaTypeFactory` entry already in the list, so they belong on the parent.

## Summary

- Add `org.openrewrite.java.service` to `RecipeClassLoader.PARENT_DELEGATED_PREFIXES`, covering `ImportService`, `AutoFormatService`, `AnnotationService`, and `SourcePositionService`.
- The other service interfaces (`CommentService`, `NamingService`, `WhitespaceValidationService`) live in `org.openrewrite.internal` and were already parent-delegated, which is why Json/Xml/Yaml/Properties — and C#'s naming and whitespace services — were unaffected.
- No entry is needed for the `org.openrewrite.<lang>.service` packages: they hold only implementations. Python, C#, and Go instantiate theirs directly, so it resolves through the loader of the parent-delegated `tree` class; Kotlin, Groovy, JavaScript, and Scala go through `service.getClassLoader().loadClass(...)`, which now points at the parent.
- Keeping the implementation parent-loaded also matters for Python specifically: `PythonImportService` reaches the RPC connection through the statics in `PythonRewriteRpc` and `RewriteRpc`, which the host process owns.
- The same split broke Kotlin, Groovy, JavaScript, and Scala whenever a recipe bundle ships `rewrite-java` without the language module: `service.getClassLoader()` was then the recipe loader, which missed the implementation and fell back to the parent's. Those are fixed as well.

## Test plan

- [x] New `RecipeClassLoaderTest#serviceInterfacesShouldDelegateToParent` asserts `ImportService` resolves to the parent when both parent and child can define it; verified failing before the fix and passing after.
- [x] `./gradlew :rewrite-core:test` passes.
- [x] Reproduced against a Moderne CLI build, publishing rewrite locally and resolving it via `latest.integration`. Driving a real `CliRecipeClassLoader` over the rewrite jars, `Py.CompilationUnit.service(...)` returns an implementation the recipe-side caller cannot cast. Swept every language's service implementations against both a bundle that ships the language module and one that ships `rewrite-java` only: without the change, Python, C#, Go, Kotlin, Groovy, JavaScript, and Scala all report unassignable implementations; with it, every case passes and `:core:recipes:test` stays green.
