### PR TITLE
Share service SPI packages across the recipe classloader

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -104,7 +104,6 @@ public class RecipeClassLoader extends URLClassLoader {
             "org.openrewrite.java.internal.TypesInUse",
             "org.openrewrite.java.TypeNameMatcher",
             "org.openrewrite.java.internal.JavaTypeFactory",
-            "org.openrewrite.java.service",
             "org.openrewrite.maven.MavenDownloadingException",
             "org.openrewrite.maven.MavenDownloadingExceptions",
             "org.openrewrite.maven.MavenExecutionContextView",
@@ -233,20 +232,22 @@ public class RecipeClassLoader extends URLClassLoader {
             }
         }
 
-        // Check for tree/marker/style types using package structure
-        return isTreeMarkerStyleType(className);
+        return isSharedApiType(className);
     }
 
-    private boolean isTreeMarkerStyleType(String className) {
+    private boolean isSharedApiType(String className) {
         String[] parts = className.split("\\.");
         if (parts.length < 4) {
             return false;
         }
 
-        // Check if any package part is tree, marker, or style
+        // `service` covers both halves of the service SPI: a language's `service()` override runs
+        // on the loader that defined its `tree` class and hands the implementation to a
+        // recipe-side caller holding the same interface, so both must resolve to one class.
         for (int i = 2; i < parts.length - 1; i++) {
             String part = parts[i];
-            if ("tree".equals(part) || "marker".equals(part) || "style".equals(part)) {
+            if ("tree".equals(part) || "marker".equals(part) || "style".equals(part) ||
+                "service".equals(part)) {
                 return true;
             }
         }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
@@ -263,25 +264,31 @@ class RecipeClassLoaderTest {
     }
 
     @Test
-    void serviceInterfacesShouldDelegateToParent(@TempDir Path tempDir) throws Exception {
+    void servicePackagesShouldDelegateToParent(@TempDir Path tempDir) throws Exception {
         // Reproduces the ClassCastException a child-loaded ChangeType hits when it casts
-        // Py.CompilationUnit's parent-loaded PythonImportService to its own ImportService;
-        // see PARENT_DELEGATED_PREFIXES in RecipeClassLoader.
-        Path parentLib = tempDir.resolve("parent");
-        Files.createDirectories(parentLib.resolve("org/openrewrite/java/service"));
-        Files.write(parentLib.resolve("org/openrewrite/java/service/ImportService.class"),
-          stubClass("org/openrewrite/java/service/ImportService"));
+        // Py.CompilationUnit's parent-loaded PythonImportService to its own ImportService.
+        String[] services = {
+          "org/openrewrite/java/service/ImportService",
+          "org/openrewrite/kotlin/service/KotlinImportService"
+        };
 
+        Path parentLib = tempDir.resolve("parent");
         Path childLib = tempDir.resolve("child");
-        Files.createDirectories(childLib.resolve("org/openrewrite/java/service"));
-        Files.write(childLib.resolve("org/openrewrite/java/service/ImportService.class"),
-          stubClass("org/openrewrite/java/service/ImportService"));
+        for (String service : services) {
+            for (Path lib : Arrays.asList(parentLib, childLib)) {
+                Path classFile = lib.resolve(service + ".class");
+                Files.createDirectories(classFile.getParent());
+                Files.write(classFile, stubClass(service));
+            }
+        }
 
         try (URLClassLoader parent = new URLClassLoader(new URL[]{parentLib.toUri().toURL()}, null);
              RecipeClassLoader classLoader = new RecipeClassLoader(new URL[]{childLib.toUri().toURL()}, parent)) {
-            assertThat(classLoader.loadClass("org.openrewrite.java.service.ImportService").getClassLoader())
-              .as("service interfaces cross the recipe/parent boundary and must be shared")
-              .isSameAs(parent);
+            for (String service : services) {
+                assertThat(classLoader.loadClass(service.replace('/', '.')).getClassLoader())
+                  .as("%s crosses the recipe/parent boundary and must be shared", service)
+                  .isSameAs(parent);
+            }
         }
     }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -148,21 +148,13 @@ public interface G extends J {
         @Override
         public <S, T extends S> T service(Class<S> service) {
             String serviceName = service.getName();
-            try {
-                Class<S> serviceClass;
-                if (GroovyAutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
-                } else if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyAutoFormatService.class.getName());
-                } else if (WhitespaceValidationService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyWhitespaceValidationService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
-                }
-                return (T) serviceClass.getConstructor().newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (AutoFormatService.class.getName().equals(serviceName) ||
+                GroovyAutoFormatService.class.getName().equals(serviceName)) {
+                return (T) new GroovyAutoFormatService();
+            } else if (WhitespaceValidationService.class.getName().equals(serviceName)) {
+                return (T) new GroovyWhitespaceValidationService();
             }
+            return JavaSourceFile.super.service(service);
         }
 
         List<JRightPadded<Statement>> statements;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -225,18 +225,10 @@ public interface JS extends J {
         @Override
         @SuppressWarnings("unchecked")
         public <S, T extends S> T service(Class<S> service) {
-            String serviceName = service.getName();
-            try {
-                Class<S> serviceClass;
-                if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(JavaScriptAutoFormatService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
-                }
-                return (T) serviceClass.getConstructor().newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (AutoFormatService.class.getName().equals(service.getName())) {
+                return (T) new JavaScriptAutoFormatService();
             }
+            return JavaSourceFile.super.service(service);
         }
 
         @Transient

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -345,23 +345,14 @@ public interface K extends J {
         @SuppressWarnings("unchecked")
         public <S, T extends S> T service(Class<S> service) {
             String serviceName = service.getName();
-            try {
-                Class<S> serviceClass;
-                if (KotlinImportService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
-                } else if (ImportService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(KotlinImportService.class.getName());
-                } else if (KotlinAutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
-                } else if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(KotlinAutoFormatService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
-                }
-                return (T) serviceClass.getConstructor().newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (ImportService.class.getName().equals(serviceName) ||
+                KotlinImportService.class.getName().equals(serviceName)) {
+                return (T) new KotlinImportService();
+            } else if (AutoFormatService.class.getName().equals(serviceName) ||
+                       KotlinAutoFormatService.class.getName().equals(serviceName)) {
+                return (T) new KotlinAutoFormatService();
             }
+            return JavaSourceFile.super.service(service);
         }
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinServiceLoaderTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinServiceLoaderTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.service.AutoFormatService;
+import org.openrewrite.java.service.ImportService;
+import org.openrewrite.kotlin.service.KotlinAutoFormatService;
+import org.openrewrite.kotlin.service.KotlinImportService;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KotlinServiceLoaderTest {
+
+    @Test
+    void servicesResolveWithoutTheRequestedInterfacesClassLoader() throws Exception {
+        SourceFile cu = KotlinParser.builder().build()
+          .parse("class A")
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("no source file parsed"));
+
+        URL rewriteJava = ImportService.class.getProtectionDomain().getCodeSource().getLocation();
+        // Stands in for a recipe classloader carrying rewrite-java but no Kotlin module, so the
+        // service has to resolve through this tree's own loader.
+        try (URLClassLoader isolated = new URLClassLoader(new URL[]{rewriteJava},
+          ClassLoader.getSystemClassLoader().getParent())) {
+            Class<?> importService = isolated.loadClass(ImportService.class.getName());
+            Class<?> autoFormatService = isolated.loadClass(AutoFormatService.class.getName());
+            assertThat(importService).isNotSameAs(ImportService.class);
+
+            assertThat((Object) cu.service(importService)).isInstanceOf(KotlinImportService.class);
+            assertThat((Object) cu.service(autoFormatService)).isInstanceOf(KotlinAutoFormatService.class);
+        }
+    }
+
+    @Test
+    void theKotlinTypeCanBeRequestedDirectly() {
+        SourceFile cu = KotlinParser.builder().build()
+          .parse("class A")
+          .findFirst()
+          .orElseThrow(() -> new AssertionError("no source file parsed"));
+
+        assertThat((Object) cu.service(KotlinImportService.class)).isInstanceOf(KotlinImportService.class);
+        assertThat((Object) cu.service(KotlinAutoFormatService.class)).isInstanceOf(KotlinAutoFormatService.class);
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/tree/S.java
@@ -254,19 +254,11 @@ public interface S extends J {
         @Override
         public <S, T extends S> T service(Class<S> service) {
             String serviceName = service.getName();
-            try {
-                Class<S> serviceClass;
-                if (ScalaAutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = service;
-                } else if (AutoFormatService.class.getName().equals(serviceName)) {
-                    serviceClass = (Class<S>) service.getClassLoader().loadClass(ScalaAutoFormatService.class.getName());
-                } else {
-                    return JavaSourceFile.super.service(service);
-                }
-                return (T) serviceClass.getConstructor().newInstance();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (AutoFormatService.class.getName().equals(serviceName) ||
+                ScalaAutoFormatService.class.getName().equals(serviceName)) {
+                return (T) new ScalaAutoFormatService();
             }
+            return JavaSourceFile.super.service(service);
         }
 
         @Override


### PR DESCRIPTION
## Motivation

Follow-up to #8427, which shared `org.openrewrite.java.service` so a recipe-side `ChangeType` and a host-loaded `Py.CompilationUnit` agree on `ImportService`. That fixed the interfaces but left the implementations split, and it made one existing mechanism depend on a deployment coincidence.

`org.openrewrite.<lang>.service` is loaded child-first, and a recipe bundle normally ships the language module as a dependency, so the bundle defines its own `KotlinImportService` while the host-defined `K.CompilationUnit` instantiates the host's. A single `service()` method could hand back either, depending on which overload you called:

```java
cu.service(ImportService.class)        // host's KotlinImportService
cu.service(KotlinImportService.class)  // the bundle's KotlinImportService
```

Separately, Kotlin, Groovy, JavaScript, and Scala resolved their implementation with `service.getClassLoader().loadClass("...KotlinImportService")`. Since #8427 that loader is the host's, so the lookup only succeeds because the host happens to carry every language module. It is correct today, but by deployment coincidence rather than by construction.

Recognizing `service` as a shared package alongside `tree`, `marker`, and `style` fixes both. There is then one implementation class in every configuration, so each language can instantiate it with plain `new`, which resolves through the loader that defined its own tree class — the same loader the tree class came from, whether that is the host or the bundle. Delegation stays parent-first with the existing child fallback, so a language module present only in a bundle still resolves.

## Summary

- `service` joins `tree`, `marker`, and `style` in the package convention that marks types as shared; `isTreeMarkerStyleType` is renamed `isSharedApiType` to match.
- The explicit `org.openrewrite.java.service` prefix added in #8427 is redundant under the convention and is removed.
- Kotlin, Groovy, JavaScript, and Scala instantiate their service implementations with `new`, dropping the classloader indirection and its reflection.
- Python, C#, and Go already instantiated directly and are unchanged.

## Test plan

- [x] `RecipeClassLoaderTest#servicePackagesShouldDelegateToParent` covers both an interface (`org.openrewrite.java.service.ImportService`) and a language implementation (`org.openrewrite.kotlin.service.KotlinImportService`) when parent and child can each define them.
- [x] New `KotlinServiceLoaderTest` asks for `ImportService` and `AutoFormatService` through a classloader carrying rewrite-java but no Kotlin module and asserts the Kotlin implementations come back; verified failing with a `ClassNotFoundException` against the previous indirection and passing now.
- [x] `./gradlew :rewrite-kotlin:test :rewrite-groovy:test :rewrite-scala:test :rewrite-javascript:test` passes (forced re-run, 90 tasks executed).
- [x] Verified against a Moderne CLI build resolving a local rewrite via `latest.integration`: a real `CliRecipeClassLoader` sweep over every language's service implementations passes for a bundle shipping the language module, a bundle shipping `rewrite-java` only, and a language present only in the bundle.
