### PR TITLE
Match nested type references by either `.` or `$` in `UsesType`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
@@ -17,11 +17,14 @@ package org.openrewrite.java.search;
 
 import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.java.table.TypeUses;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
@@ -468,6 +471,57 @@ class FindTypesTest implements RewriteTest {
                       </bean>
                   </property>
                 </bean>
+              </beans>
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a.b.Outer.Inner", "a.b.Outer$Inner"})
+    void nestedType(String type) {
+        rewriteRun(
+          spec -> spec.recipe(new FindTypes(type, false)),
+          java(
+            """
+              package a.b;
+              public class Outer {
+                  public static class Inner {}
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.b.Outer;
+              class Test {
+                  Outer.Inner i;
+              }
+              """,
+            """
+              import a.b.Outer;
+              class Test {
+                  /*~~>*/Outer.Inner i;
+              }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a.b.Outer.Inner", "a.b.Outer$Inner"})
+    void nestedTypeInSpringXml(String type) {
+        rewriteRun(
+          spec -> spec.recipe(new FindTypes(type, false)),
+          xml(
+            """
+              <beans xsi:schemaLocation="www.springframework.org/schema/beans">
+                <bean id="testBean" class="a.b.Outer$Inner"/>
+              </beans>
+              """,
+            """
+              <beans xsi:schemaLocation="www.springframework.org/schema/beans">
+                <bean id="testBean" <!--~~>-->class="a.b.Outer$Inner"/>
               </beans>
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/UsesTypeTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/UsesTypeTest.java
@@ -16,12 +16,16 @@
 package org.openrewrite.java.search;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
+import static org.openrewrite.xml.Assertions.xml;
 
 class UsesTypeTest implements RewriteTest {
 
@@ -448,6 +452,169 @@ class UsesTypeTest implements RewriteTest {
               class Test {
                   ArrayList<String> list = new ArrayList<>();
               }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedTypeInDottedForm() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new UsesType<>("a.b.Outer.Inner", false))),
+          java(
+            """
+              package a.b;
+              public class Outer {
+                  public static class Inner {}
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.b.Outer;
+              class Test {
+                  Outer.Inner i;
+              }
+              """,
+            """
+              /*~~>*/import a.b.Outer;
+              class Test {
+                  Outer.Inner i;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedTypeInBinaryForm() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new UsesType<>("a.b.Outer$Inner", false))),
+          java(
+            """
+              package a.b;
+              public class Outer {
+                  public static class Inner {}
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.b.Outer;
+              class Test {
+                  Outer.Inner i;
+              }
+              """,
+            """
+              /*~~>*/import a.b.Outer;
+              class Test {
+                  Outer.Inner i;
+              }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a.b.Outer.Mid.Inner", "a.b.Outer$Mid$Inner", "a.b.Outer.Mid$Inner"})
+    void doublyNestedType(String type) {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new UsesType<>(type, false))),
+          java(
+            """
+              package a.b;
+              public class Outer {
+                  public static class Mid {
+                      public static class Inner {}
+                  }
+              }
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.b.Outer;
+              class Test {
+                  Outer.Mid.Inner i;
+              }
+              """,
+            """
+              /*~~>*/import a.b.Outer;
+              class Test {
+                  Outer.Mid.Inner i;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void topLevelTypeMiss() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new UsesType<>("a.b.Other", false))),
+          java(
+            """
+              package a.b;
+              public class Thing {}
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.b.Thing;
+              class Test {
+                  Thing t;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void packageSegmentStartingUppercase() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new UsesType<>("a.B.Thing", false))),
+          java(
+            """
+              package a.B;
+              public class Thing {}
+              """,
+            SourceSpec::skip
+          ),
+          java(
+            """
+              import a.B.Thing;
+              class Test {
+                  Thing t;
+              }
+              """,
+            """
+              /*~~>*/import a.B.Thing;
+              class Test {
+                  Thing t;
+              }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"a.b.Outer.Inner", "a.b.Outer$Inner"})
+    void nestedTypeReference(String type) {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new UsesType<>(type, false))),
+          xml(
+            """
+              <beans xsi:schemaLocation="www.springframework.org/schema/beans">
+                  <bean id="abc" class="a.b.Outer$Inner"/>
+              </beans>
+              """,
+            """
+              <!--~~>--><beans xsi:schemaLocation="www.springframework.org/schema/beans">
+                  <bean id="abc" class="a.b.Outer$Inner"/>
+              </beans>
               """
           )
         );

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/UsesType.java
@@ -286,7 +286,8 @@ public class UsesType<P> extends TreeVisitor<Tree, P> {
 
         @Override
         public boolean matchesReference(Reference reference) {
-            return reference.getKind() == Reference.Kind.TYPE && qualifiedName.equals(reference.getValue());
+            return reference.getKind() == Reference.Kind.TYPE &&
+                   TypeUtils.fullyQualifiedNamesAreEqual(qualifiedName, reference.getValue());
         }
 
         @Override


### PR DESCRIPTION
## Motivation

`UsesType` is used as a precondition by a large fraction of search and migration recipes, so anything it rejects is invisible to the recipe behind it — the caller gets zero results rather than an error, and cannot tell "no usages" from "your type name was rejected". Its `Reference.Matcher` for `SourceFileWithReferences` (Spring XML, properties, YAML) compared the requested type name to the reference value with `String.equals`, while every other matching path in the same recipes goes through `TypeNameMatcher`, which treats `.` and `$` as equivalent at a nested-type boundary. A nested type written the way a developer writes it — `a.b.Outer.Inner` — therefore never matched a reference stored in binary form, and `FindTypes` was gated to zero by its own precondition even though its `TypeMatcher` would have matched.

Note that the Java source path was already correct: `TypesInUse.hasType` canonicalizes the query and the trie carries a canonical alias for every `$`-containing FQN, and the legacy fallback compares via `TypeUtils.isAssignableTo(String, JavaType)`. This PR closes the one remaining path where the comparison was literal.

## Summary

- `UsesType.ExactMatch.matchesReference` compares with `TypeUtils.fullyQualifiedNamesAreEqual` instead of `String.equals`, so a nested type matches a reference written in either form.
- Added `UsesTypeTest` coverage for nested types in dotted and binary form (single and double nesting, including the mixed `a.b.Outer.Mid$Inner`), a top-level miss, an uppercase package segment that must not be treated as a nesting boundary, and the XML reference case.
- Added `FindTypesTest` coverage asserting both forms produce the same result, on Java sources and on a Spring XML bean class.

The trie lookup is untouched, so the `O(1)` fast path for exact fully qualified names is unchanged.

## Test plan

- [x] `./gradlew :rewrite-java-test:test --tests "org.openrewrite.java.search.UsesTypeTest" --tests "org.openrewrite.java.search.FindTypesTest"` passes.
- [x] With the `UsesType` change reverted, `FindTypesTest > nestedTypeInSpringXml [1] type = "a.b.Outer.Inner"` is the single failure — the new tests fail for the intended reason.
- [x] `./gradlew :rewrite-java-test:test :rewrite-java:test` passes in full.
