### PR TITLE
Fix properties line continuation handling

### DIFF
--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -64,7 +64,7 @@ public class PropertiesParser implements Parser {
         StringBuilder buff = new StringBuilder();
         String s = source.readFully();
 
-        char prev = '$';
+        int trailingBackslashes = 0;
         boolean isEscapedNewLine = false;
         for (char c : s.toCharArray()) {
             if (isEscapedNewLine) {
@@ -77,7 +77,7 @@ public class PropertiesParser implements Parser {
             }
 
             if (c == '\n') {
-                if (prev == '\\') {
+                if (trailingBackslashes % 2 == 1) {
                     isEscapedNewLine = true;
                     buff.append(c);
                 } else {
@@ -91,7 +91,12 @@ public class PropertiesParser implements Parser {
             } else {
                 buff.append(c);
             }
-            prev = c;
+
+            if (c == '\\') {
+                trailingBackslashes++;
+            } else if (c != '\r') {
+                trailingBackslashes = 0;
+            }
         }
 
         Properties.Content content = extractContent(buff.toString(), prefix);

--- a/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
+++ b/rewrite-properties/src/main/java/org/openrewrite/properties/PropertiesParser.java
@@ -64,11 +64,10 @@ public class PropertiesParser implements Parser {
         StringBuilder buff = new StringBuilder();
         String s = source.readFully();
 
-        int trailingBackslashes = 0;
         boolean isEscapedNewLine = false;
         for (char c : s.toCharArray()) {
             if (isEscapedNewLine) {
-                if (Character.isWhitespace(c)) {
+                if (c != '\n' && c != '\r' && Character.isWhitespace(c)) {
                     buff.append(c);
                     continue;
                 } else {
@@ -77,7 +76,7 @@ public class PropertiesParser implements Parser {
             }
 
             if (c == '\n') {
-                if (trailingBackslashes % 2 == 1) {
+                if (continuesOnNextLine(buff)) {
                     isEscapedNewLine = true;
                     buff.append(c);
                 } else {
@@ -90,12 +89,6 @@ public class PropertiesParser implements Parser {
                 }
             } else {
                 buff.append(c);
-            }
-
-            if (c == '\\') {
-                trailingBackslashes++;
-            } else if (c != '\r') {
-                trailingBackslashes = 0;
             }
         }
 
@@ -118,6 +111,36 @@ public class PropertiesParser implements Parser {
         );
     }
 
+    private static boolean continuesOnNextLine(StringBuilder line) {
+        int end = line.length();
+        if (end > 0 && line.charAt(end - 1) == '\r') {
+            end--;
+        }
+        int backslashes = 0;
+        while (backslashes < end && line.charAt(end - 1 - backslashes) == '\\') {
+            backslashes++;
+        }
+        return backslashes % 2 == 1 && !isComment(line);
+    }
+
+    private static boolean isComment(CharSequence line) {
+        for (int i = 0; i < line.length(); i++) {
+            char c = line.charAt(i);
+            if (!Character.isWhitespace(c)) {
+                return c == '#' || c == '!';
+            }
+        }
+        return false;
+    }
+
+    private static boolean endsWithEscape(CharSequence text) {
+        int backslashes = 0;
+        while (backslashes < text.length() && text.charAt(text.length() - 1 - backslashes) == '\\') {
+            backslashes++;
+        }
+        return backslashes % 2 == 1;
+    }
+
     private Properties.@Nullable Content extractContent(String line, StringBuilder prefix) {
         Properties.Content content = null;
         if (line.trim().startsWith("#") || line.trim().startsWith("!")) {
@@ -137,7 +160,7 @@ public class PropertiesParser implements Parser {
     }
 
     private boolean isDelimitedByWhitespace(String line) {
-        return line.length() >= 3 && !Character.isWhitespace(line.charAt(0)) && !Character.isWhitespace(line.length() - 1) && line.contains(" ");
+        return line.length() >= 3 && !Character.isWhitespace(line.charAt(0)) && !Character.isWhitespace(line.charAt(line.length() - 1)) && line.contains(" ");
     }
 
     private Properties.Comment commentFromLine(String line, String prefix, Properties.Comment.Delimiter delimiter) {
@@ -202,7 +225,6 @@ public class PropertiesParser implements Parser {
                 value = new StringBuilder();
 
         Properties.Entry.Delimiter delimiter = Properties.Entry.Delimiter.NONE;
-        char prev = '$';
         State state = State.WHITESPACE_BEFORE_KEY;
         for (int i = 0; i < line.length(); i++) {
             char c = line.charAt(i);
@@ -215,7 +237,7 @@ public class PropertiesParser implements Parser {
                     state = State.KEY;
                 case KEY:
                     if (c == '=' || c == ':') {
-                        if (prev == '\\') {
+                        if (endsWithEscape(key)) {
                             key.append(c);
                             break;
                         } else {
@@ -284,7 +306,6 @@ public class PropertiesParser implements Parser {
                         break;
                     }
             }
-            prev = c;
         }
 
         return new Properties.Entry(

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
@@ -273,6 +273,65 @@ class PropertiesParserTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @Test
+    void lineContinuationWithWhitespaceBeforeBackslash() {
+        rewriteRun(
+          properties(
+            """
+              # Gradle JVM args with backslash continuations
+              org.gradle.jvmargs=-Xms1g -Xmx4g \\
+                --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \\
+                --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+              """,
+            spec -> spec.beforeRecipe(p -> {
+                var entry = (Properties.Entry) p.getContent().get(1);
+                assertThat(entry.getValue().getSource()).isEqualTo(
+                  "-Xms1g -Xmx4g \\\n  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \\\n  --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED");
+                assertThat(entry.getValue().getText()).isEqualTo(
+                  "-Xms1g -Xmx4g --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED");
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @Test
+    void lineContinuationWithCarriageReturn() {
+        rewriteRun(
+          properties(
+            "org.gradle.jvmargs=-Xms1g \\\r\n  -Xmx4g\r\nother=value\r\n",
+            spec -> spec
+              .noTrim()
+              .beforeRecipe(p -> {
+                  assertThat(p.getContent()).hasSize(2);
+                  var entry = (Properties.Entry) p.getContent().getFirst();
+                  assertThat(entry.getValue().getSource()).isEqualTo("-Xms1g \\\r\n  -Xmx4g");
+                  assertThat(entry.getValue().getText()).isEqualTo("-Xms1g -Xmx4g");
+                  assertThat(((Properties.Entry) p.getContent().get(1)).getKey()).isEqualTo("other");
+              })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @Test
+    void escapedBackslashAtEndOfLineDoesNotContinue() {
+        rewriteRun(
+          properties(
+            """
+              path=C:\\\\dir\\\\
+              other=value
+              """,
+            spec -> spec.beforeRecipe(p -> {
+                assertThat(p.getContent()).hasSize(2);
+                assertThat(((Properties.Entry) p.getContent().getFirst()).getValue().getSource()).isEqualTo("C:\\\\dir\\\\");
+                assertThat(((Properties.Entry) p.getContent().get(1)).getKey()).isEqualTo("other");
+            })
+          )
+        );
+    }
+
     private static Consumer<SourceSpec<Properties.File>> containsValues(String... valueAssertions) {
         return spec -> spec.beforeRecipe(props -> {
             List<String> values = TreeVisitor.collect(new PropertiesVisitor<>() {

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/PropertiesParserTest.java
@@ -332,6 +332,88 @@ class PropertiesParserTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @ParameterizedTest
+    @ValueSource(strings = {"\n", "\r\n"})
+    void commentEndingInBackslashDoesNotContinue(String lineSeparator) {
+        rewriteRun(
+          properties(
+            "# default install dir: C:\\Program Files\\App\\" + lineSeparator + "key=value" + lineSeparator,
+            spec -> spec
+              .noTrim()
+              .beforeRecipe(p -> {
+                  assertThat(p.getContent()).hasSize(2);
+                  assertThat(p.getContent().getFirst()).isInstanceOf(Properties.Comment.class);
+                  assertThat(((Properties.Entry) p.getContent().get(1)).getKey()).isEqualTo("key");
+              })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @ParameterizedTest
+    @ValueSource(strings = {"\n", "\r\n"})
+    void blankLineTerminatesContinuedLine(String lineSeparator) {
+        rewriteRun(
+          properties(
+            "key=a \\" + lineSeparator + lineSeparator + "next=value" + lineSeparator,
+            spec -> spec
+              .noTrim()
+              .beforeRecipe(p -> {
+                  assertThat(p.getContent()).hasSize(2);
+                  assertThat(((Properties.Entry) p.getContent().get(1)).getKey()).isEqualTo("next");
+              })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @Test
+    void strayCarriageReturnIsNotPartOfContinuation() {
+        rewriteRun(
+          properties(
+            "key=a\\\r\r\nnext=value\r\n",
+            spec -> spec
+              .noTrim()
+              .beforeRecipe(p -> {
+                  assertThat(p.getContent()).hasSize(2);
+                  assertThat(((Properties.Entry) p.getContent().get(1)).getKey()).isEqualTo("next");
+              })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @Test
+    void escapedBackslashBeforeDelimiterIsNotAnEscapedDelimiter() {
+        rewriteRun(
+          properties(
+            """
+              a\\\\=b
+              """,
+            spec -> spec.beforeRecipe(p -> {
+                var entry = (Properties.Entry) p.getContent().getFirst();
+                assertThat(entry.getKeySource()).isEqualTo("a\\\\");
+                assertThat(entry.getDelimiter()).isEqualTo(Properties.Entry.Delimiter.EQUALS);
+                assertThat(entry.getValue().getText()).isEqualTo("b");
+            })
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8417")
+    @Test
+    void whitespaceDelimitedEntryIsParsedRegardlessOfLineLength() {
+        rewriteRun(
+          properties(
+            """
+              key vvvvvvvv
+              """,
+            containsValues("vvvvvvvv")
+          )
+        );
+    }
+
     private static Consumer<SourceSpec<Properties.File>> containsValues(String... valueAssertions) {
         return spec -> spec.beforeRecipe(props -> {
             List<String> values = TreeVisitor.collect(new PropertiesVisitor<>() {


### PR DESCRIPTION
## What's changed?

`PropertiesParser` decided whether a line continued from a single character of lookbehind (`prev == '\\'`). This replaces that with a check of the buffered line itself — an odd number of trailing backslashes, ignoring the CR of a CRLF pair, and never on a comment line — and fixes the neighbouring defects of the same kind that surfaced while testing it.

## Note on the reported symptom

The round-trip in the issue's repro **does not reproduce on `main`** — the LST already keeps the raw, continued text in `Properties.Value.text` (`getSource()` returns it with continuations, `getText()` returns it flattened), and `PropertiesPrinter` prints `getSource()`. I verified this end-to-end:

```properties
# Gradle JVM args with backslash continuations
org.gradle.jvmargs=-Xms1g -Xmx4g \
  --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
  --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
```

parses and prints back byte-for-byte, and `ChangePropertyValue`/`ChangePropertyKey`/`AddProperty`/`DeleteProperty` all leave the continued entry's formatting intact when they touch a *different* property. (Changing the continued value itself does replace the whole value, which is expected — the new value has no continuation layout to keep.) That case is now covered by `lineContinuationWithWhitespaceBeforeBackslash` as a characterization test.

What digging around it did turn up is a cluster of continuation bugs that are invisible to a round-trip — the raw text is always printed back verbatim — but corrupt the LST, so recipes either silently skip a property or delete it. All of these drop an `Entry` from `Properties.File.getContent()`:

**1. CRLF line endings broke continuation detection.** With `\r\n` the character before the newline is `\r`, not `\\`, so `org.gradle.jvmargs=-Xms1g \<CRLF>  -Xmx4g<CRLF>` parsed the value as the truncated `-Xms1g \` and absorbed the continuation line as whitespace prefix. `getText()` returned `-Xms1g \` instead of `-Xms1g -Xmx4g`, so any recipe reading or rewriting that value operated on a wrong value — the kind of thing that forces the text-splicing workaround described in the issue.

**2. An escaped backslash at end of line was treated as a continuation.** `\\` is a literal backslash, so `path=C:\\dir\\` followed by `other=value` is two entries; the parser merged `other=value` into `path`'s value and dropped the `other` entry.

**3. Comments were continued.** `java.util.Properties` never continues a comment, so `# install dir: C:\App\` followed by `key=value` swallowed the entry into the comment message. Worse than a missed match: a recipe that edits that comment deletes the real property.

**4. A blank line after a continuation did not terminate the logical line.** `key=a \` / blank / `next=value` absorbed `next=value` into `key`'s value. Since `ChangePropertyValue` does `value.withText(newValue)` over that whole multi-line text, running it on `key` emits `key=b` and **silently deletes the `next=value` line** from the user's file.

**5. `entryFromLine` had the same single-character escape lookback for `=`/`:` in keys.** `a\\=b` parsed as one escaped key with `Delimiter.NONE` and an empty value, instead of key `a\` and value `b`.

**6. `isDelimitedByWhitespace` passed an index where a char was wanted** — `Character.isWhitespace(line.length() - 1)` instead of `charAt(...)`. A whitespace-delimited line whose length happened to land in 10-14 or 29-33 (those minus one being the whitespace code points) was dropped from the LST entirely.

3-6 are pre-existing rather than new, but they're all the same defect — deciding a lexical property of a line from one character — and 3 and 4 become much easier to hit once CRLF files reach the continuation path, so fixing them together seemed better than leaving landmines behind the fix.

## Anything in particular you'd like reviewers to focus on?

- Whether `Relates to` vs `Fixes` is right for #8417: I couldn't reproduce the exact reported flattening on `main`, so I'd rather leave the issue open for the reporter to confirm against a real file (CRLF endings would be my first guess at the difference) than auto-close it.
- One confirmed defect deliberately **not** fixed here: a file ending in a dangling `a=b\` leaves `getText()` as `b\` where `java.util.Properties` reports `b`. Fixing it properly means teaching `Properties.Continuation` to do real escape processing (`getText()` today doesn't unescape `\n`, `\t` or `\:` either), which changes the semantics of a public API for every recipe that matches on values — too big to smuggle into this PR.

## Checklist

- [x] Unit tests for the reported case and for each of the six fixed cases
- [x] `./gradlew :rewrite-properties:test` — 135 tests, 0 failures; every new test verified to fail without its fix
- [x] Downstream consumers exercised: `:rewrite-gradle:test --tests "*Propert*" --tests "*Wrapper*"`, `:rewrite-maven:test --tests "*Propert*"`, `:rewrite-android:test` — all green
