### PR TITLE
Stop MergeYamlVisitor from grafting the document end comment onto inserted entries

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -144,38 +144,32 @@ public class MergeYaml extends Recipe {
 
             @Override
             public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
+                Yaml.Document d;
                 if ("$".equals(key) || "$.".equals(key)) {
-                    Yaml.Document d = document.withBlock((Yaml.Block)
+                    d = document.withBlock((Yaml.Block)
                             new MergeYamlVisitor<>(document.getBlock(), incoming, accptTheirs, objectIdentifyingProperty, insertMode, insertProperty)
                                     .visitNonNull(document.getBlock(), ctx, getCursor())
                     );
-                    if (getCursor().getMessage(REMOVE_DOCUMENT_PREFIX, false)) {
-                        d = d.withPrefix("");
+                } else {
+                    d = super.visitDocument(document, ctx);
+                    if ((createNewKeys == null || Boolean.TRUE.equals(createNewKeys)) && d == document && !getCursor().getMessage(FOUND_MATCHING_ELEMENT, false)) {
+                        // No matching element found, but check if the key maybe exists in the json path.
+                        String valueKey = maybeKeyFromJsonPath(key);
+                        if (valueKey != null) {
+                            // No matching element already exists, so it must be constructed.
+                            @Language("yml") String snippet;
+                            if (incoming instanceof Yaml.Mapping) {
+                                // Use two spaces as indent, the `MergeYamlVisitor` recipe will take care for proper indenting by calling `autoformat`,
+                                snippet = valueKey + ":\n  " + yaml.replaceAll("\n", "\n  ");
+                            } else {
+                                // If there is no space between the colon and the value it will not be interpreted as a mapping
+                                snippet = valueKey + ":" + (yaml.startsWith(" ") ? yaml : " " + yaml);
+                            }
+                            d = d.withBlock((Yaml.Block)
+                                    new MergeYamlVisitor<>(d.getBlock(), MergeYaml.parse(snippet), accptTheirs, objectIdentifyingProperty, insertMode, insertProperty)
+                                            .visitNonNull(d.getBlock(), ctx, getCursor()));
+                        }
                     }
-                    if (getCursor().getMessage(REMOVE_PREFIX, false)) {
-                        d = removeInlineCommentFromEnd(d);
-                    }
-                    return d;
-                }
-                Yaml.Document d = super.visitDocument(document, ctx);
-                if ((createNewKeys == null || Boolean.TRUE.equals(createNewKeys)) && d == document && !getCursor().getMessage(FOUND_MATCHING_ELEMENT, false)) {
-                    // No matching element found, but check if the key maybe exists in the json path.
-                    String valueKey = maybeKeyFromJsonPath(key);
-                    if (valueKey == null) {
-                        return d;
-                    }
-                    // No matching element already exists, so it must be constructed.
-                    @Language("yml") String snippet;
-                    if (incoming instanceof Yaml.Mapping) {
-                        // Use two spaces as indent, the `MergeYamlVisitor` recipe will take care for proper indenting by calling `autoformat`,
-                        snippet = valueKey + ":\n  " + yaml.replaceAll("\n", "\n  ");
-                    } else {
-                        // If there is no space between the colon and the value it will not be interpreted as a mapping
-                        snippet = valueKey + ":" + (yaml.startsWith(" ") ? yaml : " " + yaml);
-                    }
-                    return d.withBlock((Yaml.Block)
-                            new MergeYamlVisitor<>(d.getBlock(), MergeYaml.parse(snippet), accptTheirs, objectIdentifyingProperty, insertMode, insertProperty)
-                                    .visitNonNull(d.getBlock(), ctx, getCursor()));
                 }
                 if (getCursor().getMessage(REMOVE_DOCUMENT_PREFIX, false)) {
                     d = d.withPrefix("");

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYaml.java
@@ -130,6 +130,7 @@ public class MergeYaml extends Recipe {
 
     final static String FOUND_MATCHING_ELEMENT = "FOUND_MATCHING_ELEMENT";
     final static String REMOVE_PREFIX = "REMOVE_PREFIX";
+    final static String REMOVE_DOCUMENT_PREFIX = "REMOVE_DOCUMENT_PREFIX";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
@@ -148,13 +149,11 @@ public class MergeYaml extends Recipe {
                             new MergeYamlVisitor<>(document.getBlock(), incoming, accptTheirs, objectIdentifyingProperty, insertMode, insertProperty)
                                     .visitNonNull(document.getBlock(), ctx, getCursor())
                     );
+                    if (getCursor().getMessage(REMOVE_DOCUMENT_PREFIX, false)) {
+                        d = d.withPrefix("");
+                    }
                     if (getCursor().getMessage(REMOVE_PREFIX, false)) {
-                        if (insertMode == Before) {
-                            d = d.withPrefix("");
-                        } else {
-                            // Preserve newline before document separator in multi-document YAML
-                            d = d.withEnd(d.getEnd().withPrefix(preserveDocumentSeparator(d)));
-                        }
+                        d = removeInlineCommentFromEnd(d);
                     }
                     return d;
                 }
@@ -178,11 +177,19 @@ public class MergeYaml extends Recipe {
                             new MergeYamlVisitor<>(d.getBlock(), MergeYaml.parse(snippet), accptTheirs, objectIdentifyingProperty, insertMode, insertProperty)
                                     .visitNonNull(d.getBlock(), ctx, getCursor()));
                 }
+                if (getCursor().getMessage(REMOVE_DOCUMENT_PREFIX, false)) {
+                    d = d.withPrefix("");
+                }
                 if (getCursor().getMessage(REMOVE_PREFIX, false)) {
-                    // Preserve newline before document separator in multi-document YAML
-                    d = d.withEnd(d.getEnd().withPrefix(preserveDocumentSeparator(d)));
+                    d = removeInlineCommentFromEnd(d);
                 }
                 return d;
+            }
+
+            private Yaml.Document removeInlineCommentFromEnd(Yaml.Document document) {
+                Yaml.Document d = MergeYamlVisitor.removeInlineCommentFromEnd(document);
+                // Preserve newline before document separator in multi-document YAML
+                return d.getEnd().getPrefix().isEmpty() ? d.withEnd(d.getEnd().withPrefix(preserveDocumentSeparator(d))) : d;
             }
 
             private String preserveDocumentSeparator(Yaml.Document document) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -548,7 +548,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
      * Strips the inline comment that was copied onto a newly inserted entry from the prefix of the
      * last entry of the mapping it was copied from, so that it is not rendered twice.
      */
-    public static Yaml.Mapping removeInlineCommentFromLastEntry(Yaml.Mapping mapping) {
+    static Yaml.Mapping removeInlineCommentFromLastEntry(Yaml.Mapping mapping) {
         return mapping.withEntries(mapLast(mapping.getEntries(), entry ->
                 entry.withPrefix(removeInlineComment(entry.getPrefix()))));
     }
@@ -557,7 +557,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
      * Strips the inline comment from the prefix of the document end, which is where a comment on the
      * last line of a document is stored. Later lines are retained.
      */
-    public static Yaml.Document removeInlineCommentFromEnd(Yaml.Document document) {
+    static Yaml.Document removeInlineCommentFromEnd(Yaml.Document document) {
         String prefix = document.getEnd().getPrefix();
         String withoutComment = removeInlineComment(prefix);
         return prefix.equals(withoutComment) ? document : document.withEnd(document.getEnd().withPrefix(withoutComment));

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/MergeYamlVisitor.java
@@ -41,10 +41,15 @@ import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.internal.ListUtils.*;
 import static org.openrewrite.internal.StringUtils.*;
 import static org.openrewrite.yaml.MergeYaml.InsertMode.*;
+import static org.openrewrite.yaml.MergeYaml.REMOVE_DOCUMENT_PREFIX;
 import static org.openrewrite.yaml.MergeYaml.REMOVE_PREFIX;
 
 /**
  * Visitor class to merge two yaml files.
+ * <p>
+ * Apply this visitor to the enclosing {@link Yaml.Documents} or {@link Yaml.Document} rather than to just the block
+ * being merged into; an inline comment that has to move onto a newly inserted element is stored on an element that
+ * follows the merged block, which can be an element much higher in the tree, and is left behind otherwise.
  *
  * @param <P> An input object that is passed to every visit method.
  * @implNote Loops recursively through the documents, for every part a new MergeYamlVisitor instance will be created.
@@ -93,6 +98,25 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
     }
 
     @Override
+    public Yaml visitDocument(Yaml.Document document, P p) {
+        Yaml y = super.visitDocument(document, p);
+        if (!(y instanceof Yaml.Document)) {
+            return y;
+        }
+        Yaml.Document d = (Yaml.Document) y;
+        if (getCursor().getMessage(REMOVE_DOCUMENT_PREFIX, false)) {
+            d = d.withPrefix("");
+        }
+        if (getCursor().getMessage(REMOVE_PREFIX, false)) {
+            d = removeInlineCommentFromEnd(d);
+            if (d.getEnd().getPrefix().isEmpty() && preserveDocumentSeparator(document)) {
+                d = d.withEnd(d.getEnd().withPrefix(linebreak()));
+            }
+        }
+        return d;
+    }
+
+    @Override
     public Yaml visitScalar(Yaml.Scalar existingScalar, P p) {
         if (existing.isScope(existingScalar) && incoming instanceof Yaml.Scalar) {
             return mergeScalar(existingScalar, (Yaml.Scalar) incoming);
@@ -136,7 +160,11 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
 
             return mapping;
         }
-        return super.visitMapping(existingMapping, p);
+        Yaml y = super.visitMapping(existingMapping, p);
+        if (y instanceof Yaml.Mapping && getCursor().getMessage(REMOVE_PREFIX, false)) {
+            return removeInlineCommentFromLastEntry((Yaml.Mapping) y);
+        }
+        return y;
     }
 
     private Yaml.Mapping applySiblingBoundaryRepair(Yaml.Mapping mapping, Map<UUID, BoundaryRepair> repairs) {
@@ -224,7 +252,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                         ((Yaml.Mapping) ((Yaml.Document) getCursor().getParentOrThrow().getValue()).getBlock()).getEntries().equals(((Yaml.Mapping) existing).getEntries())) {
                     mutatedEntries.ls.set(mutatedEntries.firstNewlyAddedItemIndex, mutatedEntries.ls.get(0).withPrefix("")); // Remove linebreak from first entry
                     mutatedEntries.ls.set(mutatedEntries.lastNewlyAddedItemIndex + 1, afterInsertEntry.withPrefix(linebreak() + ((Yaml.Document) getCursor().getParentOrThrow().getValue()).getPrefix() + afterInsertEntry.getPrefix()));
-                    getCursor().getParentOrThrow().putMessage(REMOVE_PREFIX, true);
+                    getCursor().getParentOrThrow().putMessage(REMOVE_DOCUMENT_PREFIX, true);
                 } else {
                     Yaml.Mapping.Entry firstNewlyAddedEntry = mutatedEntries.ls.get(mutatedEntries.firstNewlyAddedItemIndex);
                     String partOne = substringOfBeforeFirstLineBreak(afterInsertEntry.getPrefix());
@@ -264,10 +292,7 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                     Yaml.Document doc = c.getValue();
                     // Don't treat document end prefix as comment if it contains a document separator
                     if (!preserveDocumentSeparator(doc)) {
-                        String endPrefix = doc.getEnd().getPrefix();
-                        if (endPrefix != null && endPrefix.contains("#")) {
-                            comment = endPrefix;
-                        }
+                        comment = inlineCommentOf(doc.getEnd().getPrefix());
                     }
                 } else if (c.getValue() instanceof Yaml.Mapping) {
                     List<Yaml.Mapping.Entry> entries = ((Yaml.Mapping) c.getValue()).getEntries();
@@ -295,11 +320,9 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
                         if (docCursor.getValue() instanceof Yaml.Document) {
                             Yaml.Document doc = docCursor.getValue();
                             if (!preserveDocumentSeparator(doc)) {
-                                String endPrefix = doc.getEnd().getPrefix();
-                                // Only use Document.End prefix if it contains a comment;
-                                // plain trailing whitespace should not be copied as a comment
-                                if (endPrefix != null && endPrefix.contains("#")) {
-                                    comment = endPrefix;
+                                String endComment = inlineCommentOf(doc.getEnd().getPrefix());
+                                if (isNotEmpty(endComment)) {
+                                    comment = endComment;
                                     c = docCursor;
                                 }
                             }
@@ -512,23 +535,41 @@ public class MergeYamlVisitor<P> extends YamlVisitor<P> {
         return lines.length > 1 ? String.join(linebreak(), Arrays.copyOfRange(lines, 1, lines.length)) : "";
     }
 
+    private static String inlineCommentOf(@Nullable String prefix) {
+        if (prefix == null) {
+            return "";
+        }
+        String[] lines = LINE_BREAK.split(prefix, -1);
+        String firstLine = lines.length > 0 ? lines[0] : "";
+        return firstLine.contains("#") ? firstLine : "";
+    }
+
     /**
-     * Strips an inline comment that is stored as the leading part (before the first line break) of
-     * the last entry's prefix. This is used to remove a trailing comment that was copied onto a
-     * newly-inserted entry, so that the comment is not rendered twice. When the mapping being merged
-     * is nested, the comment lives on a sibling entry of an ancestor mapping that is traversed by the
-     * outer visitor rather than the {@link MergeYamlVisitor}, hence this method is invoked from there.
+     * Strips the inline comment that was copied onto a newly inserted entry from the prefix of the
+     * last entry of the mapping it was copied from, so that it is not rendered twice.
      */
-    static Yaml.Mapping removeInlineCommentFromLastEntry(Yaml.Mapping mapping) {
-        return mapping.withEntries(mapLast(mapping.getEntries(), entry -> {
-            String prefix = entry.getPrefix();
-            String[] lines = LINE_BREAK.split(prefix, -1);
-            if (lines.length <= 1) {
-                return entry;
-            }
-            String linebreak = prefix.contains("\r\n") ? "\r\n" : "\n";
-            return entry.withPrefix(linebreak + String.join(linebreak, Arrays.copyOfRange(lines, 1, lines.length)));
-        }));
+    public static Yaml.Mapping removeInlineCommentFromLastEntry(Yaml.Mapping mapping) {
+        return mapping.withEntries(mapLast(mapping.getEntries(), entry ->
+                entry.withPrefix(removeInlineComment(entry.getPrefix()))));
+    }
+
+    /**
+     * Strips the inline comment from the prefix of the document end, which is where a comment on the
+     * last line of a document is stored. Later lines are retained.
+     */
+    public static Yaml.Document removeInlineCommentFromEnd(Yaml.Document document) {
+        String prefix = document.getEnd().getPrefix();
+        String withoutComment = removeInlineComment(prefix);
+        return prefix.equals(withoutComment) ? document : document.withEnd(document.getEnd().withPrefix(withoutComment));
+    }
+
+    private static String removeInlineComment(String prefix) {
+        String[] lines = LINE_BREAK.split(prefix, -1);
+        if (lines.length <= 1) {
+            return lines.length == 1 && lines[0].contains("#") ? "" : prefix;
+        }
+        String linebreak = prefix.contains("\r\n") ? "\r\n" : "\n";
+        return linebreak + String.join(linebreak, Arrays.copyOfRange(lines, 1, lines.length));
     }
 
     /**

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -21,16 +21,19 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.Validated;
 import org.openrewrite.config.CompositeRecipe;
 import org.openrewrite.test.RewriteTest;
+import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.yaml.Assertions.yaml;
 import static org.openrewrite.yaml.MergeYaml.InsertMode.After;
 import static org.openrewrite.yaml.MergeYaml.InsertMode.Before;
@@ -4268,6 +4271,117 @@ class MergeYamlTest implements RewriteTest {
               key: >-
                 replaced
               after: tail
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8416")
+    @Test
+    void doesNotCopyInlineCommentOfLastLineToInsertedEntry() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.config",
+            //language=yaml
+            """
+              newblock:
+                child:
+                  enabled: false
+              """,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null
+          )),
+          yaml(
+            """
+              config:
+                existing:
+                  nested:
+                    value: true # inline comment here
+              """,
+            """
+              config:
+                existing:
+                  nested:
+                    value: true # inline comment here
+                newblock:
+                  child:
+                    enabled: false
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8416")
+    @Test
+    void keepsCommentOnItsOwnLineAtTheEndOfTheDocument() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.config",
+            //language=yaml
+            """
+              newblock: value
+              """,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null
+          )),
+          yaml(
+            """
+              config:
+                existing: true # inline comment here
+              # standalone comment
+              """,
+            """
+              config:
+                existing: true # inline comment here
+                newblock: value
+              # standalone comment
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8416")
+    @Test
+    void mergeYamlVisitorAppliedToWholeDocument() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new YamlVisitor<>() {
+              @Override
+              public Yaml visitDocuments(Yaml.Documents documents, ExecutionContext ctx) {
+                  Yaml.Mapping root = (Yaml.Mapping) documents.getDocuments().get(0).getBlock();
+                  Yaml.Block config = root.getEntries().get(0).getValue();
+                  //language=yaml
+                  Yaml incoming = MergeYaml.parse("""
+                    newblock:
+                      child:
+                        enabled: false
+                    """);
+                  return new MergeYamlVisitor<ExecutionContext>(config, incoming, false, null, null, null)
+                    .visitNonNull(documents, ctx);
+              }
+          })),
+          yaml(
+            """
+              config:
+                existing:
+                  nested:
+                    value: true # inline comment here
+              """,
+            """
+              config:
+                existing:
+                  nested:
+                    value: true # inline comment here
+                newblock:
+                  child:
+                    enabled: false
               """
           )
         );

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/MergeYamlTest.java
@@ -4350,6 +4350,38 @@ class MergeYamlTest implements RewriteTest {
 
     @Issue("https://github.com/openrewrite/rewrite/issues/8416")
     @Test
+    void doesNotCopyInlineCommentOfLastLineWhenCreatingANewKey() {
+        rewriteRun(
+          spec -> spec.recipe(new MergeYaml(
+            "$.newkey",
+            //language=yaml
+            """
+              sub: value
+              """,
+            false,
+            null,
+            null,
+            null,
+            null,
+            null
+          )),
+          yaml(
+            """
+              config:
+                existing: true # inline comment here
+              """,
+            """
+              config:
+                existing: true # inline comment here
+              newkey:
+                sub: value
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8416")
+    @Test
     void mergeYamlVisitorAppliedToWholeDocument() {
         rewriteRun(
           spec -> spec.recipe(toRecipe(() -> new YamlVisitor<>() {


### PR DESCRIPTION
Fixes #8416

An inline comment on the last line of a document is stored on `Yaml.Document.End`. When `MergeYamlVisitor` appends entries to the block that comment trails, it has to copy the comment onto the first newly inserted entry, otherwise the comment slides down to the last line of the inserted block. Removing the copy it moved away from was left entirely to `MergeYaml`, through cursor messages on ancestors that `MergeYamlVisitor` does not traverse itself, so anyone using the visitor directly got the comment rendered twice.

`MergeYamlVisitor` now consumes those messages for the documents and mappings it does traverse, so applying it to the enclosing `Yaml.Documents`/`Yaml.Document` produces the same result as the `MergeYaml` recipe. That is now stated in the class javadoc. Merging into a block *without* passing the enclosing document remains unable to clean up `Yaml.Document.End` — the visitor returns only the block it was given — hence the javadoc note.

While confirming the recipe path, three related defects surfaced in how the document end prefix is treated. The first two only show up on documents ending in a line break, which `RewriteTest` strips from its text blocks, which is why no existing test caught them:

- The whole prefix was hoisted as the comment, so `value: true # inline\n` inserted a blank line before the new entry and dropped the file's trailing line break. Only the part before the first line break is taken now, and the rest is retained.
- A comment on a line of its own at the end of a document was hoisted too, moving it above the inserted block. It now stays put.
- The `createNewKeys` branch of `MergeYaml.visitDocument` returned before the cleanup ran, so the comment was duplicated onto the key created on the spot. Both branches now fall through to a single tail.