### PR TITLE
Python: fix AttributeError in TyTypesClient.shutdown

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/ty_client.py
+++ b/rewrite-python/rewrite/src/rewrite/python/ty_client.py
@@ -71,8 +71,6 @@ class TyTypesClient:
         self._initialized = False
         self._project_root: Optional[str] = None
         self._virtual_env: Optional[str] = str(virtual_env) if virtual_env else None
-        self._responses: queue.Queue = queue.Queue()
-        self._consecutive_timeouts = 0
 
         # Cumulative type table for the lifetime of this ``--serve`` session.
         #
@@ -125,8 +123,9 @@ class TyTypesClient:
                 "ty-types is not installed. Ensure the ty-types binary is on PATH."
             )
 
-        # Daemon threads drain both pipes: select() is sockets-only on Windows, and an undrained pipe deadlocks ty once its buffer fills.
-        self._responses = queue.Queue()
+        # Draining both pipes keeps ty from deadlocking on a full buffer; threads
+        # because a pipe read cannot be bounded on Windows.
+        self._responses: queue.Queue = queue.Queue()
         self._consecutive_timeouts = 0
         threading.Thread(target=self._drain_stdout, args=(self._process,),
                          name="ty-types-stdout", daemon=True).start()
@@ -297,7 +296,8 @@ class TyTypesClient:
             self.session_types.clear()
             self._start_process()
 
-        # Bounded so a wedged ty degrades to untyped instead of hanging; large because ty indexes the whole project up front.
+        # Bounded so a wedged ty degrades to untyped instead of hanging; large
+        # because ty indexes the whole project up front.
         result = self._send_request("initialize", {"projectRoot": project_root},
                                     timeout=600)
         if result and result.get("ok"):
@@ -342,15 +342,16 @@ class TyTypesClient:
 
     def shutdown(self) -> None:
         """Gracefully shut down the ty-types process."""
-        if self._process is None:
+        # Local: the "shutdown" request can trip the breaker, whose ``_kill`` detaches ``self._process``.
+        process = self._process
+        if process is None:
             return
 
         try:
             self._send_request("shutdown", timeout=5)
-            self._process.wait(timeout=5)
+            process.wait(timeout=5)
         except (subprocess.TimeoutExpired, OSError):
-            if self._process is not None:
-                self._process.kill()
+            process.kill()
         finally:
             self._process = None
             self._initialized = False

--- a/rewrite-python/rewrite/tests/python/test_ty_client.py
+++ b/rewrite-python/rewrite/tests/python/test_ty_client.py
@@ -19,7 +19,6 @@ so an undrained stderr pipe would wedge it just like the real binary can.
 """
 import os
 import stat
-import sys
 import textwrap
 
 import pytest
@@ -53,17 +52,42 @@ FAKE_SERVER = textwrap.dedent('''\
 ''')
 
 
-@pytest.fixture
-def client(tmp_path, monkeypatch):
+WEDGED_SERVER = textwrap.dedent('''\
+    #!/usr/bin/env python3
+    import json
+    import sys
+
+    for line in sys.stdin:
+        req = json.loads(line)
+        if req["method"] == "initialize":
+            sys.stdout.write(json.dumps({"jsonrpc": "2.0", "id": req["id"], "result": {"ok": True}}) + "\\n")
+            sys.stdout.flush()
+''')
+
+
+def _install_server(tmp_path, monkeypatch, source):
     server = tmp_path / "fake-ty-types"
-    server.write_text(FAKE_SERVER)
+    server.write_text(source)
     server.chmod(server.stat().st_mode | stat.S_IEXEC)
     if os.name == 'nt':
         pytest.skip("fake server uses a shebang launcher")
     monkeypatch.setattr(TyTypesClient, '_find_binary', staticmethod(lambda: server))
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    _install_server(tmp_path, monkeypatch, FAKE_SERVER)
     c = TyTypesClient()
     yield c
     c.shutdown()
+
+
+@pytest.fixture
+def wedged_client(tmp_path, monkeypatch):
+    _install_server(tmp_path, monkeypatch, WEDGED_SERVER)
+    c = TyTypesClient()
+    yield c
+    c._kill()
 
 
 def test_round_trip(client):
@@ -83,7 +107,7 @@ def test_timeout_returns_none_then_recovers(client):
 
 
 def test_unread_big_responses_do_not_deadlock(client):
-    # Windows-hang regression: abandoned ~64KB responses must be absorbed; interleaved successes keep the breaker from tripping.
+    # Interleaved successes reset the breaker, so a failure here means the undrained pipe.
     assert client.initialize("/some/project")
     for i in range(20):
         assert client.get_types(f"/some/project/big-slow-0.2-{i}.py", timeout=0.01) is None
@@ -96,5 +120,14 @@ def test_consecutive_timeouts_shut_the_process_down(client):
     for i in range(3):
         assert client.get_types(f"/some/project/slow-5-{i}.py", timeout=0.05) is None
     assert not client.is_available
-    # Degrades fast instead of waiting on a dead process.
     assert client.get_types("/some/project/ok.py", timeout=5) is None
+
+
+def test_shutdown_when_its_own_request_trips_the_breaker(wedged_client):
+    assert wedged_client.initialize("/some/project")
+    # One short of the breaker, so the "shutdown" request supplies the last strike.
+    for i in range(TyTypesClient._MAX_CONSECUTIVE_TIMEOUTS - 1):
+        assert wedged_client.get_types(f"/some/project/f{i}.py", timeout=0.05) is None
+
+    wedged_client.shutdown()
+    assert not wedged_client.is_available


### PR DESCRIPTION
## Motivation

`TyTypesClient.shutdown` sends a bounded `"shutdown"` request and then reaps the process. That request counts toward the consecutive-timeout circuit breaker introduced in #8423, so when it happens to be the third consecutive timeout — the realistic case being a ty process that has already wedged at the end of a parse — `_kill` sets `self._process` to `None` before `shutdown` reaches `self._process.wait(timeout=5)`. The resulting `AttributeError: 'NoneType' object has no attribute 'wait'` is not covered by the surrounding `except (subprocess.TimeoutExpired, OSError)`, so it propagates out of the `finally` block in `handle_parse_project` and fails the entire ParseProject RPC — discarding every source file that had already been parsed successfully, instead of degrading gracefully to untyped LSTs.

Two smaller items from the same change ride along: `__init__` initialized `_responses` and `_consecutive_timeouts` only for `_start_process` to overwrite both before any reader thread exists, and several comments needed a discipline pass.

## Summary

- `shutdown` holds the process in a local before sending the request, so reaping is unaffected by the breaker detaching `self._process`. This also removes the now-redundant `is not None` guard in the `except` branch.
- Dropped the dead `_responses` / `_consecutive_timeouts` assignments from `__init__`. `_start_process` is the load-bearing one: it must reset both on a restart so a stale queue or timeout count cannot leak across ty sessions.
- Comment pass over the lines #8423 touched: two comments in `ty_client.py` and one in the test module were over the configured 120-column `line-length`, and the `_start_process` comment referred to `select()`, which the file no longer uses. Two comments that restated adjacent code were dropped, and an unused `sys` import removed from the test module.

## Test plan

- [x] New `test_shutdown_when_its_own_request_trips_the_breaker` fails on `main` with the exact `AttributeError` at `ty_client.py:350` and passes here. It drives a new `WEDGED_SERVER` fake that answers `initialize` and then goes silent, leaving `_consecutive_timeouts` at 2 so that the `shutdown` request itself trips the breaker.
- [x] `pytest tests/python/test_ty_client.py` — 5 passed.
- [x] `pytest tests/python` — 1603 passed, 10 skipped.
- [x] `ruff check --select E501,F401` clean on both changed files.
