### PR TITLE
Python: stop ParseProject pruning build/dist below the project root

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -36,7 +36,7 @@ import threading
 
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Callable, Set
+from typing import Dict, Any, Iterator, Optional, List, Callable, Set
 from uuid import uuid4
 
 try:
@@ -560,17 +560,36 @@ def handle_parse(params: dict) -> List[str]:
     return results
 
 
-# Never-source dirs (caches, venvs, VCS, dependency trees, build output); caller exclusions extend, not replace.
+# These nest anywhere in a project.
 DEFAULT_PARSE_EXCLUSIONS = [
     '__pycache__', '.venv', 'venv', '.git', '.tox', '*.egg-info', '.moderne',
-    'node_modules', '.pytest_cache', '.mypy_cache', 'build', 'dist', 'target',
+    'node_modules', '.pytest_cache', '.mypy_cache',
 ]
+
+# Build output, which only ever sits at the project root; deeper down these are
+# ordinary packages — ``src/build/`` is the PyPI ``build`` package's own layout.
+ROOT_PARSE_EXCLUSIONS = ['build', 'dist']
+
+
+def _walk_python_files(project_path: str, exclusions: List[str]) -> Iterator[str]:
+    """Yield every ``.py`` path under ``project_path`` outside an excluded directory."""
+    import fnmatch
+
+    def excluded(name: str, patterns: List[str]) -> bool:
+        return any(fnmatch.fnmatch(name, pattern) for pattern in patterns)
+
+    for root, dirs, files in os.walk(project_path):
+        at_root = root == project_path
+        patterns = exclusions + ROOT_PARSE_EXCLUSIONS if at_root else exclusions
+        dirs[:] = [d for d in dirs if not excluded(d, patterns)]
+
+        for file in files:
+            if file.endswith('.py'):
+                yield os.path.join(root, file)
 
 
 def handle_parse_project(params: dict) -> List[dict]:
     """Handle a ParseProject RPC request."""
-    import fnmatch
-
     project_path = params.get('projectPath', '.')
     exclusions = DEFAULT_PARSE_EXCLUSIONS + [
         excl for excl in (params.get('exclusions') or []) if excl not in DEFAULT_PARSE_EXCLUSIONS
@@ -603,26 +622,21 @@ def handle_parse_project(params: dict) -> List[dict]:
         pass
 
     try:
-        for root, dirs, files in os.walk(project_path):
-            dirs[:] = [d for d in dirs if not any(fnmatch.fnmatch(d, excl) for excl in exclusions)]
-
-            for file in files:
-                if file.endswith('.py'):
-                    path = os.path.join(root, file)
-                    try:
-                        oversize = os.path.getsize(path) > MAX_PARSEABLE_SIZE_BYTES
-                    except OSError:
-                        oversize = False  # let the normal path surface the read error
-                    if oversize:
-                        results.append(_create_quark(path, relative_to))
-                        continue
-                    try:
-                        result = parse_python_file(path, relative_to, ty_client,
-                                                   language_level=language_level,
-                                                   project_language_level=project_language_level)
-                        results.append(result)
-                    except Exception as e:
-                        logger.error(f"Error parsing {path}: {e}")
+        for path in _walk_python_files(project_path, exclusions):
+            try:
+                oversize = os.path.getsize(path) > MAX_PARSEABLE_SIZE_BYTES
+            except OSError:
+                oversize = False  # let the normal path surface the read error
+            if oversize:
+                results.append(_create_quark(path, relative_to))
+                continue
+            try:
+                result = parse_python_file(path, relative_to, ty_client,
+                                           language_level=language_level,
+                                           project_language_level=project_language_level)
+                results.append(result)
+            except Exception as e:
+                logger.error(f"Error parsing {path}: {e}")
     finally:
         if ty_client is not None:
             ty_client.shutdown()

--- a/rewrite-python/rewrite/tests/python/test_parse_project_exclusions.py
+++ b/rewrite-python/rewrite/tests/python/test_parse_project_exclusions.py
@@ -1,0 +1,64 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Which directories a ParseProject walk prunes."""
+from pathlib import Path
+
+from rewrite.rpc.server import DEFAULT_PARSE_EXCLUSIONS, _walk_python_files
+
+
+def _sources(tmp_path, *relative_paths, exclusions=None):
+    """Build a project from the given paths and return what the walk finds."""
+    for relative in relative_paths:
+        source = tmp_path / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text("x = 1\n")
+    found = _walk_python_files(
+        str(tmp_path), DEFAULT_PARSE_EXCLUSIONS if exclusions is None else exclusions
+    )
+    return sorted(Path(p).relative_to(tmp_path).as_posix() for p in found)
+
+
+def test_build_output_is_pruned_at_the_project_root(tmp_path):
+    assert _sources(tmp_path, 'build/out.py', 'dist/out.py', 'app.py') == ['app.py']
+
+
+def test_build_and_dist_below_the_root_are_ordinary_packages(tmp_path):
+    assert _sources(tmp_path, 'src/build/mod.py', 'src/dist/mod.py') == [
+        'src/build/mod.py',
+        'src/dist/mod.py',
+    ]
+
+
+def test_target_is_not_a_python_convention(tmp_path):
+    assert _sources(tmp_path, 'target/mod.py') == ['target/mod.py']
+
+
+def test_caches_and_dependency_trees_are_pruned_at_any_depth(tmp_path):
+    assert _sources(
+        tmp_path,
+        'src/pkg/__pycache__/mod.py',
+        'src/node_modules/dep/mod.py',
+        'src/pkg/.venv/lib/mod.py',
+        'src/pkg/mod.py',
+    ) == ['src/pkg/mod.py']
+
+
+def test_caller_exclusions_extend_the_defaults(tmp_path):
+    assert _sources(
+        tmp_path,
+        'vendor/mod.py',
+        'src/__pycache__/mod.py',
+        'src/app.py',
+        exclusions=DEFAULT_PARSE_EXCLUSIONS + ['vendor'],
+    ) == ['src/app.py']

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
@@ -34,8 +34,9 @@ class ParseProject implements RpcRequest {
     Path projectPath;
 
     /**
-     * Optional glob patterns to exclude from parsing.
-     * If not provided, default exclusions (__pycache__, .venv, etc.) will be used.
+     * Optional glob patterns matched against directory names, not paths.
+     * These extend the parser's built-in exclusions (__pycache__, .venv, etc.)
+     * rather than replacing them.
      */
     @Nullable
     List<String> exclusions;

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProjectOptions.java
@@ -34,8 +34,8 @@ import java.util.List;
 public class ParseProjectOptions {
 
     /**
-     * Glob patterns to exclude from parsing. When {@code null}, the parser's default exclusions
-     * ({@code __pycache__}, {@code .venv}, etc.) are used.
+     * Glob patterns matched against directory names, not paths. These extend the parser's built-in
+     * exclusions ({@code __pycache__}, {@code .venv}, etc.) rather than replacing them.
      */
     @Nullable
     List<String> exclusions;


### PR DESCRIPTION
## Motivation

`handle_parse_project` prunes directories by matching `fnmatch` against the bare directory name at every level of the walk. That is right for caches, venvs, VCS metadata, and dependency trees, which legitimately nest anywhere. It is wrong for build output: `build`, `dist`, and `target` were matched at any depth, so a package carrying one of those names was silently dropped from the results — `src/build/` is the layout the PyPI `build` package itself uses. Because caller exclusions extend the defaults rather than replacing them, a caller had no way to get those files back.

`target` is a Maven convention with no meaning in a Python project; neither the JavaScript nor the Go peer excludes it.

## Summary

- `build` and `dist` moved to a separate `ROOT_PARSE_EXCLUSIONS` list, applied only at the project root. Everything else in `DEFAULT_PARSE_EXCLUSIONS` still matches at any depth.
- `target` dropped.
- Directory pruning extracted into `_walk_python_files`, so the walk can be tested without standing up a parse and a ty-types session.
- The javadoc on `ParseProject.exclusions` and `ParseProjectOptions.exclusions` said "If not provided, default exclusions will be used", implying caller patterns replace the defaults. The server extends them. Both now say so, and both note that patterns match directory names rather than paths.

## Not in scope

Caller exclusions keep their extend semantics. The JavaScript peer replaces (`request.exclusions ?? DEFAULT_EXCLUSIONS`) while Go extends a hardcoded list, so there is no single convention to converge on, and no caller in this repo passes exclusions to the Python server today.

Relatedly, the one real caller-supplied pattern in the repo is `List.of("**/vendor/**")` in a JavaScript integration test. Path globs of that shape match nothing under the Python or Go servers, which both match a single directory name. That mismatch is worth fixing but is a separate change to the pattern grammar.

## Test plan

- [x] New `tests/python/test_parse_project_exclusions.py`, five cases, all failing before the change: root-level `build`/`dist` pruned, nested `src/build/` and `src/dist/` kept, `target/` kept, caches and dependency trees pruned at depth, and caller exclusions extending the defaults.
- [x] `pytest tests/python` — 1608 passed, 10 skipped.
- [x] `ruff check --select E501,F401` reports only the four violations that already existed in `server.py` (lines 39, 1878, 2078, 2111); none are in the changed region.
