### PR TITLE
JS: let .gitignore decide which directories are output

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/project-parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/project-parser.ts
@@ -129,6 +129,17 @@ export const DEFAULT_EXCLUSIONS = [
 ];
 
 /**
+ * Exclusions that apply even to files git reports. Dependency trees and minified
+ * bundles are sometimes committed but are never a project's own source, whereas the
+ * remaining entries in {@link DEFAULT_EXCLUSIONS} are what a .gitignore already says.
+ */
+export const DEFAULT_TRACKED_EXCLUSIONS = [
+    "**/node_modules/**",
+    "**/*.min.js",
+    "**/*.bundle.js"
+];
+
+/**
  * Source file extensions for JavaScript/TypeScript.
  */
 const SOURCE_EXTENSIONS = new Set([
@@ -177,6 +188,7 @@ export class ProjectParser {
     private readonly projectPath: string;
     private readonly relativeTo: string;
     private readonly exclusions: string[];
+    private readonly gitExclusions: string[];
     private readonly ctx: ExecutionContext;
     private readonly useGit: boolean;
     private readonly onProgress?: ProjectParserOptions["onProgress"];
@@ -187,6 +199,7 @@ export class ProjectParser {
         this.projectPath = path.resolve(projectPath);
         this.relativeTo = options.relativeTo ? path.resolve(options.relativeTo) : this.projectPath;
         this.exclusions = options.exclusions ?? DEFAULT_EXCLUSIONS;
+        this.gitExclusions = options.exclusions ?? DEFAULT_TRACKED_EXCLUSIONS;
         this.ctx = options.ctx ?? new ExecutionContext();
         this.useGit = options.useGit ?? this.isGitRepository();
         this.onProgress = options.onProgress;
@@ -533,7 +546,7 @@ export class ProjectParser {
         }
 
         // Filter by our exclusion patterns and accepted file types
-        return files.filter(file => this.isAcceptedFile(file));
+        return files.filter(file => this.isAcceptedFile(file, this.gitExclusions));
     }
 
     /**
@@ -580,13 +593,13 @@ export class ProjectParser {
     /**
      * Checks if a file should be accepted for parsing.
      */
-    private isAcceptedFile(filePath: string): boolean {
+    private isAcceptedFile(filePath: string, exclusions: string[] = this.exclusions): boolean {
         const basename = path.basename(filePath);
         const ext = path.extname(filePath).toLowerCase();
 
         // Check exclusion patterns with relative path
         const relativePath = path.relative(this.projectPath, filePath);
-        const isExcluded = picomatch(this.exclusions);
+        const isExcluded = picomatch(exclusions);
         if (isExcluded(relativePath)) {
             return false;
         }

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -72,16 +72,15 @@ export class ParseProject {
                     context.target = request.projectPath;
 
                     // Dynamic import to break circular dependency
-                    const {DEFAULT_EXCLUSIONS, ProjectParser} = await import("../../javascript/index.js");
+                    const {ProjectParser} = await import("../../javascript/index.js");
 
                     const projectPath = path.resolve(request.projectPath);
                     setLastParsedProject(projectPath);
-                    const exclusions = request.exclusions ?? DEFAULT_EXCLUSIONS;
                     // Use relativeTo if specified, otherwise default to projectPath
                     const relativeTo = request.relativeTo ? path.resolve(request.relativeTo) : projectPath;
 
-                    // Use ProjectParser for file discovery and Prettier detection
-                    const projectParser = new ProjectParser(projectPath, {exclusions});
+                    // Undefined when unset, so the parser can match exclusions to its discovery mode.
+                    const projectParser = new ProjectParser(projectPath, {exclusions: request.exclusions});
                     const discovered = await projectParser.discoverFiles();
                     const prettierLoader = await projectParser.createPrettierLoader();
 

--- a/rewrite-javascript/rewrite/test/rpc/project-parser-exclusions.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/project-parser-exclusions.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {spawnSync} from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import {dir} from "tmp-promise";
+import {ProjectParser} from "../../src/javascript/project-parser";
+
+function write(root: string, relativePath: string, content = "export const x = 1;\n"): void {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), {recursive: true});
+    fs.writeFileSync(file, content);
+}
+
+/** A git repo whose `dist/` is committed source and whose `build/` is ignored output. */
+function project(root: string): void {
+    write(root, ".gitignore", "build/\n");
+    write(root, "dist/keep.ts");
+    write(root, "build/out.ts");
+    write(root, "src/app.ts");
+    write(root, "vendor.min.js");
+    write(root, "node_modules/left-pad/index.js");
+
+    spawnSync("git", ["init"], {cwd: root});
+    // Staging is enough for `git ls-files`; the tests never need a commit.
+    spawnSync("git", ["add", "dist/keep.ts", "vendor.min.js", "node_modules/left-pad/index.js"],
+        {cwd: root});
+}
+
+async function discovered(root: string, options = {}): Promise<string[]> {
+    const files = await new ProjectParser(root, options).discoverFiles();
+    return files.jsFiles.map(f => path.relative(root, f).split(path.sep).join("/")).sort();
+}
+
+describe("ProjectParser exclusions", () => {
+    it("lets .gitignore decide which directories are output when git discovery is used", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            project(tmpDir.path);
+            expect(await discovered(tmpDir.path)).toEqual(["dist/keep.ts", "src/app.ts"]);
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+
+    it("still excludes committed bundles and dependency trees, which are never project source", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            project(tmpDir.path);
+            const files = await discovered(tmpDir.path);
+            expect(files).not.toContain("vendor.min.js");
+            expect(files).not.toContain("node_modules/left-pad/index.js");
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+
+    it("honours caller exclusions over git tracking", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            project(tmpDir.path);
+            const files = await discovered(tmpDir.path, {exclusions: ["**/dist/**"]});
+            expect(files).not.toContain("dist/keep.ts");
+            expect(files).toContain("src/app.ts");
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+
+    it("falls back to the default directory exclusions when walking without git", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            project(tmpDir.path);
+            expect(await discovered(tmpDir.path, {useGit: false})).toEqual(["src/app.ts"]);
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+});


### PR DESCRIPTION
## Motivation

`ProjectParser` has two discovery paths, and both end by filtering through the same glob list. On the git path that list is nearly redundant: candidates come from `git ls-files` plus `git ls-files --others --exclude-standard`, so `.gitignore` has already removed `node_modules`, `dist`, `build`, and `coverage` in essentially every project before a single pattern is evaluated.

Which means the default *directory* globs change the outcome only when they disagree with `.gitignore` — that is, only when the directory is tracked. And a tracked `dist/` is a directory the project deliberately committed as source. So on the git path those patterns did nothing except in the one case where excluding was wrong. `**/dist/**` also matches at any depth, so `src/dist/` was dropped along with it.

The file patterns are different in kind and do real work: `*.min.js` and `*.bundle.js` are frequently committed, and `.gitignore` will not identify them.

## Summary

- On the git discovery path the defaults narrow to `DEFAULT_TRACKED_EXCLUSIONS` — dependency trees and minified bundles, the things that are sometimes committed but are never a project's own source. Everything else is left to `.gitignore`.
- `node_modules` stays excluded unconditionally even when committed, matching the existing hardcoded guard on the walk path.
- The walk path is unchanged and keeps the full `DEFAULT_EXCLUSIONS`, including when git discovery fails and falls back to it. Without git there is no `.gitignore` evaluation to lean on, so the globs remain the only defence.
- Caller-supplied exclusions keep replacing the defaults and keep applying on both paths — an explicit list still wins over git tracking.
- `handle_parse_project` forwarded `request.exclusions ?? DEFAULT_EXCLUSIONS` into the parser, so the parser could never tell "caller specified the defaults" from "caller specified nothing". It now forwards an absent value as absent.

## Test plan

- [x] New `test/rpc/project-parser-exclusions.test.ts` builds a real git repo whose `dist/` is staged source and whose `build/` is gitignored output. Four cases: `.gitignore` decides directories under git discovery; committed bundles and dependency trees stay excluded; caller exclusions override git tracking; the no-git walk still applies the full defaults.
- [x] Two of the four failed before the change, for the reasons they name.
- [x] `npm test` — 169 files passed, 1 skipped; 1931 tests passed, 24 skipped.
- [x] `npm run typecheck` clean.

## Note for reviewers

- This makes JavaScript and Python diverge slightly in mechanism, deliberately. Python's `handle_parse_project` has no git discovery — it is a raw `os.walk` — so #8436 anchors `build`/`dist` to the project root instead. Root anchoring fixes the common `src/build/` case without a git dependency; letting `.gitignore` decide is the better answer where the plumbing already exists, which on the Python side it does not.
