### PR TITLE
Parent-delegate `AnnotationMatcher` in `RecipeClassLoader`

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -99,13 +99,10 @@ public class RecipeClassLoader extends URLClassLoader {
             "org.openrewrite.java.JavadocVisitor",
             "org.openrewrite.java.JavaParser",
             "org.openrewrite.java.Java17Parser",
-            "org.openrewrite.java.MethodMatcher",
-            // Named in the shared AnnotationService#matches descriptor, so both loaders must
-            // resolve it to one class.
             "org.openrewrite.java.AnnotationMatcher",
+            "org.openrewrite.java.MethodMatcher",
             "org.openrewrite.java.TypeNameMatcher",
             "org.openrewrite.java.internal.TypesInUse",
-            "org.openrewrite.java.TypeNameMatcher",
             "org.openrewrite.java.internal.JavaTypeFactory",
             "org.openrewrite.java.service",
             "org.openrewrite.maven.MavenDownloadingException",

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeClassLoader.java
@@ -100,6 +100,9 @@ public class RecipeClassLoader extends URLClassLoader {
             "org.openrewrite.java.JavaParser",
             "org.openrewrite.java.Java17Parser",
             "org.openrewrite.java.MethodMatcher",
+            // Named in the shared AnnotationService#matches descriptor, so both loaders must
+            // resolve it to one class.
+            "org.openrewrite.java.AnnotationMatcher",
             "org.openrewrite.java.TypeNameMatcher",
             "org.openrewrite.java.internal.TypesInUse",
             "org.openrewrite.java.TypeNameMatcher",

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeClassLoaderTest.java
@@ -31,6 +31,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Properties;
@@ -282,6 +283,33 @@ class RecipeClassLoaderTest {
             assertThat(classLoader.loadClass("org.openrewrite.java.service.ImportService").getClassLoader())
               .as("service interfaces cross the recipe/parent boundary and must be shared")
               .isSameAs(parent);
+        }
+    }
+
+    @Test
+    void matcherTypesInSharedSignaturesShouldDelegateToParent(@TempDir Path tempDir) throws Exception {
+        String[] matchers = {
+          "org/openrewrite/java/AnnotationMatcher",
+          "org/openrewrite/java/MethodMatcher"
+        };
+
+        Path parentLib = tempDir.resolve("parent");
+        Path childLib = tempDir.resolve("child");
+        for (String matcher : matchers) {
+            for (Path lib : Arrays.asList(parentLib, childLib)) {
+                Path classFile = lib.resolve(matcher + ".class");
+                Files.createDirectories(classFile.getParent());
+                Files.write(classFile, stubClass(matcher));
+            }
+        }
+
+        try (URLClassLoader parent = new URLClassLoader(new URL[]{parentLib.toUri().toURL()}, null);
+             RecipeClassLoader classLoader = new RecipeClassLoader(new URL[]{childLib.toUri().toURL()}, parent)) {
+            for (String matcher : matchers) {
+                assertThat(classLoader.loadClass(matcher.replace('/', '.')).getClassLoader())
+                  .as("%s is named in shared API descriptors; split loaders raise a LinkageError on the call", matcher)
+                  .isSameAs(parent);
+            }
         }
     }
 


### PR DESCRIPTION
## Motivation

A recipe run on 8.88.3 fails with a `LinkageError` the first time `MissingOverrideAnnotation` reaches `AnnotationService#matches`:

```
java.lang.LinkageError: loader constraint violation: loader 'app' wants to load class
org.openrewrite.java.AnnotationMatcher. A different class with the same name was previously
loaded by io.moderne.cli.recipe.CliRecipeClassLoader.
  org.openrewrite.java.service.AnnotationService.matches(AnnotationService.java:38)
  org.openrewrite.staticanalysis.MissingOverrideAnnotation$MissingOverrideAnnotationVisitor.visitMethodDeclaration
```

- `AnnotationService#matches` names `AnnotationMatcher` in its descriptor. #8427 added `org.openrewrite.java.service` to `PARENT_DELEGATED_PREFIXES`, which moved the service to the host loader while `AnnotationMatcher` stayed child-loadable — and a recipe bundle shipping `rewrite-java` defines its own copy as soon as the recipe constructs a matcher. The JVM checks that both loaders agree on every type in a method's descriptor at resolution time, finds two `AnnotationMatcher` classes, and refuses the call. Before #8427 the service was child-first, so caller and callee shared one copy and nothing broke.

`MethodMatcher` is already in the list for the same reason; `AnnotationMatcher` is the same shape and was simply missed. It is the only such gap: every other type in a `org.openrewrite.java.service` public signature (`JavaVisitor`, `Tree`, `SourceFile`, `Cursor`, `ExecutionContext`, `J`, `JContainer`, `JRightPadded`, `Span`, `trait.Comments.Placement`, `internal.CommentService`/`NamingService`) is already delegated, and no language module subclasses `AnnotationService`.

## Summary

- `org.openrewrite.java.AnnotationMatcher` joins `MethodMatcher` and `TypeNameMatcher` in `PARENT_DELEGATED_PREFIXES`.

## Test plan

- [x] New `RecipeClassLoaderTest#matcherTypesInSharedSignaturesShouldDelegateToParent` gives both loaders a copy of `AnnotationMatcher` and `MethodMatcher` and asserts each resolves to the parent; verified failing on `AnnotationMatcher` before the fix (`MethodMatcher` already passed) and passing after.
- [x] `./gradlew :rewrite-core:test --tests "org.openrewrite.marketplace.RecipeClassLoaderTest"` passes, 11 tests.

## Release note

This is a regression introduced in 8.88.3 and affects any recipe reaching `AnnotationService#matches` from a recipe bundle, which includes `MissingOverrideAnnotation`. The Moderne CLI resolves rewrite as `latest.release`, so it needs a rebuild once this ships.
