### PR TITLE
C#: type attribution for qualified names, arrays, members, and attribute values; marker and RPC fixes; MaybeAddUsing

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/AddUsingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/AddUsingTests.cs
@@ -1,0 +1,415 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+using OpenRewrite.Test;
+
+namespace OpenRewrite.Tests.CSharp;
+
+public class AddUsingTests : RewriteTest
+{
+    private static string ApplyAddUsing(string source, string type, bool onlyIfReferenced = true)
+    {
+        var cu = Parse(source);
+        var result = new AddUsing<int>(type, onlyIfReferenced).Visit(cu, 0);
+        return new CSharpPrinter<object>().Print(result!);
+    }
+
+    [Fact]
+    public void AddsToCompilationUnitUsings()
+    {
+        var after = ApplyAddUsing(
+            """
+            using System;
+
+            namespace N
+            {
+                public class C
+                {
+                    private Task field;
+                }
+            }
+            """,
+            "System.Threading.Tasks.Task");
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Threading.Tasks;
+
+            namespace N
+            {
+                public class C
+                {
+                    private Task field;
+                }
+            }
+            """, after);
+    }
+
+    [Fact]
+    public void SortedFileStaysSorted()
+    {
+        var after = ApplyAddUsing(
+            """
+            using System;
+            using System.Xml;
+
+            public class C
+            {
+                private Task field;
+            }
+            """,
+            "System.Threading.Tasks.Task");
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Threading.Tasks;
+            using System.Xml;
+
+            public class C
+            {
+                private Task field;
+            }
+            """, after);
+    }
+
+    [Fact]
+    public void UnsortedFileAppendsAfterTheLastUsing()
+    {
+        var after = ApplyAddUsing(
+            """
+            using System.Xml;
+            using System;
+
+            public class C
+            {
+                private Task field;
+            }
+            """,
+            "System.Threading.Tasks.Task");
+
+        Assert.Equal(
+            """
+            using System.Xml;
+            using System;
+            using System.Threading.Tasks;
+
+            public class C
+            {
+                private Task field;
+            }
+            """, after);
+    }
+
+    /// <summary>
+    /// Visual Studio's "System directives first" order is not ordinal-sorted; the insertion
+    /// point honors it when that is the order the file already satisfies.
+    /// </summary>
+    [Fact]
+    public void SystemFirstFileKeepsSystemFirst()
+    {
+        var after = ApplyAddUsing(
+            """
+            using System.Xml;
+            using Aaa;
+
+            public class C
+            {
+                private Task field;
+            }
+            """,
+            "System.Threading.Tasks.Task");
+
+        Assert.Equal(
+            """
+            using System.Threading.Tasks;
+            using System.Xml;
+            using Aaa;
+
+            public class C
+            {
+                private Task field;
+            }
+            """, after);
+    }
+
+    [Fact]
+    public void AddsIntoBlockScopedNamespaceWhenUsingsLiveThere()
+    {
+        var after = ApplyAddUsing(
+            """
+            namespace N
+            {
+                using System;
+
+                public class C
+                {
+                    private Task field;
+                }
+            }
+            """,
+            "System.Threading.Tasks.Task");
+
+        Assert.Equal(
+            """
+            namespace N
+            {
+                using System;
+                using System.Threading.Tasks;
+
+                public class C
+                {
+                    private Task field;
+                }
+            }
+            """, after);
+    }
+
+    [Fact]
+    public void FileScopedNamespaceKeepsUsingsAtCompilationUnitLevel()
+    {
+        var after = ApplyAddUsing(
+            """
+            namespace N;
+
+            public class C
+            {
+                private Task field;
+            }
+            """,
+            "System.Threading.Tasks.Task");
+
+        Assert.Equal(
+            """
+            using System.Threading.Tasks;
+
+            namespace N;
+
+            public class C
+            {
+                private Task field;
+            }
+            """, after);
+    }
+
+    [Fact]
+    public void FileWithoutUsingsGetsOneAfterTheLicenseHeader()
+    {
+        var after = ApplyAddUsing(
+            """
+            // Copyright example.
+
+            namespace N
+            {
+                public class C
+                {
+                    private Task field;
+                }
+            }
+            """,
+            "System.Threading.Tasks.Task");
+
+        Assert.Equal(
+            """
+            // Copyright example.
+
+            using System.Threading.Tasks;
+
+            namespace N
+            {
+                public class C
+                {
+                    private Task field;
+                }
+            }
+            """, after);
+    }
+
+    [Fact]
+    public void AlreadyPresentUsingIsReferenceEqualNoOp()
+    {
+        var cu = Parse(
+            """
+            using System.Threading.Tasks;
+
+            public class C
+            {
+                private Task field;
+            }
+            """);
+
+        var result = new AddUsing<int>("System.Threading.Tasks.Task").Visit(cu, 0);
+
+        Assert.Same(cu, result);
+    }
+
+    [Fact]
+    public void GlobalUsingInTheSameFileIsReferenceEqualNoOp()
+    {
+        var cu = Parse(
+            """
+            global using System.Threading.Tasks;
+
+            public class C
+            {
+                private Task field;
+            }
+            """);
+
+        var result = new AddUsing<int>("System.Threading.Tasks.Task").Visit(cu, 0);
+
+        Assert.Same(cu, result);
+    }
+
+    /// <summary>Adding the using would make the short name ambiguous (CS0104): the file already
+    /// binds it to its own type.</summary>
+    [Fact]
+    public void DeclinesWhenTheSimpleNameIsBoundToAnotherType()
+    {
+        var cu = Parse(
+            """
+            namespace N
+            {
+                public class Task
+                {
+                }
+
+                public class C
+                {
+                    private Task field;
+                }
+            }
+            """);
+
+        var result = new AddUsing<int>("System.Threading.Tasks.Task").Visit(cu, 0);
+
+        Assert.Same(cu, result);
+    }
+
+    [Fact]
+    public void DeclinesWhenTheTypeIsNotReferenced()
+    {
+        var cu = Parse(
+            """
+            using System;
+
+            public class C
+            {
+            }
+            """);
+
+        var result = new AddUsing<int>("System.Threading.Tasks.Task").Visit(cu, 0);
+
+        Assert.Same(cu, result);
+    }
+
+    [Fact]
+    public void FullyQualifiedReferenceAloneDoesNotCount()
+    {
+        var cu = Parse(
+            """
+            using System;
+
+            public class C
+            {
+                private System.Threading.Tasks.Task field;
+            }
+            """);
+
+        var result = new AddUsing<int>("System.Threading.Tasks.Task").Visit(cu, 0);
+
+        Assert.Same(cu, result);
+    }
+
+    [Fact]
+    public void AddsWithoutAReferenceWhenNotGatedOnOne()
+    {
+        var after = ApplyAddUsing(
+            """
+            using System;
+
+            public class C
+            {
+            }
+            """,
+            "System.Threading.Tasks.Task",
+            onlyIfReferenced: false);
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Threading.Tasks;
+
+            public class C
+            {
+            }
+            """, after);
+    }
+
+    [Fact]
+    public void TypeWithoutANamespaceIsANoOp()
+    {
+        var cu = Parse(
+            """
+            public class C
+            {
+            }
+            """);
+
+        var result = new AddUsing<int>("Task", onlyIfReferenced: false).Visit(cu, 0);
+
+        Assert.Same(cu, result);
+    }
+
+    /// <summary>The CSharpVisitor entry point registers the after-visitor once per type, so a
+    /// visitor asking repeatedly still yields a single using.</summary>
+    [Fact]
+    public void MaybeAddUsingOnCSharpVisitorAddsOnceAfterTheVisit()
+    {
+        var cu = Parse(
+            """
+            using System;
+
+            public class C
+            {
+            }
+            """);
+
+        var result = new UsingRequester("System.Threading.Tasks.Task").Visit(cu, 0);
+
+        Assert.Equal(
+            """
+            using System;
+            using System.Threading.Tasks;
+
+            public class C
+            {
+            }
+            """, new CSharpPrinter<object>().Print(result!));
+    }
+
+    private sealed class UsingRequester(string type) : CSharpVisitor<int>
+    {
+        public override J VisitClassDeclaration(ClassDeclaration cd, int p)
+        {
+            MaybeAddUsing(type, onlyIfReferenced: false);
+            MaybeAddUsing(type, onlyIfReferenced: false);
+            return base.VisitClassDeclaration(cd, p);
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/AssemblyTypeEnumeratorTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/AssemblyTypeEnumeratorTests.cs
@@ -104,9 +104,6 @@ public class AssemblyTypeEnumeratorTests
                 FullyQualifiedName: "System.AttributeUsageAttribute"
             });
 
-        // [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
-        // The positional argument resolves to the ValidOn property it feeds; the flags combination
-        // matches no single enum member, so the underlying value is kept rather than mis-named.
         var validOn = Assert.Single(usage.Values!.OfType<JavaType.Annotation.SingleElementValue>(),
             v => v.Element is JavaType.Variable { Name: "ValidOn" });
         Assert.NotNull(validOn.ConstantValue);

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/AssemblyTypeEnumeratorTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/AssemblyTypeEnumeratorTests.cs
@@ -81,4 +81,38 @@ public class AssemblyTypeEnumeratorTests
         Assert.Equal("System.Exception", supertype.FullyQualifiedName);
         Assert.Null(supertype.Methods);
     }
+
+    /// <summary>
+    /// The dependency type table is where a referenced type's attributes have to come from: an
+    /// LST resolves a dependency type through the table, not through the parse of the file that
+    /// mentions it. Newtonsoft's <c>JsonConvert</c> carries <c>[NullableContext]</c>/<c>[Nullable]</c>
+    /// compiler attributes; <c>JsonPropertyAttribute</c> carries an <c>[AttributeUsage]</c> with
+    /// both a positional and a named argument, which exercises both argument forms.
+    /// </summary>
+    [Fact]
+    public void OwnTypeAttributesAreEnumerated()
+    {
+        var types = AssemblyTypeEnumerator.Enumerate([NewtonsoftJsonDll()], RuntimeAssemblies());
+        var byFqn = types.OfType<JavaType.Class>().ToDictionary(c => c.FullyQualifiedName, c => c);
+
+        var jsonProperty = byFqn["Newtonsoft.Json.JsonPropertyAttribute"];
+        Assert.NotNull(jsonProperty.Annotations);
+
+        var usage = Assert.Single(jsonProperty.Annotations!.OfType<JavaType.Annotation>(),
+            a => a.AnnotationType is JavaType.Class
+            {
+                FullyQualifiedName: "System.AttributeUsageAttribute"
+            });
+
+        // [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
+        // The positional argument resolves to the ValidOn property it feeds; the flags combination
+        // matches no single enum member, so the underlying value is kept rather than mis-named.
+        var validOn = Assert.Single(usage.Values!.OfType<JavaType.Annotation.SingleElementValue>(),
+            v => v.Element is JavaType.Variable { Name: "ValidOn" });
+        Assert.NotNull(validOn.ConstantValue);
+
+        var allowMultiple = Assert.Single(usage.Values!.OfType<JavaType.Annotation.SingleElementValue>(),
+            v => v.Element is JavaType.Variable { Name: "AllowMultiple" });
+        Assert.Equal(false, allowMultiple.ConstantValue);
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
@@ -15,6 +15,7 @@
  */
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Testing;
 using OpenRewrite.CSharp;
 using OpenRewrite.Java;
 using OpenRewrite.Test;
@@ -41,9 +42,11 @@ public class CSharpTypeMappingTests : RewriteTest
         """,
         path: "__GlobalUsings__.g.cs");
 
-    private static CompilationUnit ParseWithSemanticModel(string code)
+    private static CompilationUnit ParseWithSemanticModel(string code,
+        ReferenceAssemblies? referenceAssemblies = null)
     {
-        var refs = Assemblies.Net90.ResolveAsync(LanguageNames.CSharp, CancellationToken.None)
+        var refs = (referenceAssemblies ?? Assemblies.Net90)
+            .ResolveAsync(LanguageNames.CSharp, CancellationToken.None)
             .GetAwaiter().GetResult();
         var syntaxTree = CSharpSyntaxTree.ParseText(code, path: "source.cs");
         var compilation = CSharpCompilation.Create("TestCompilation")
@@ -452,5 +455,115 @@ public class CSharpTypeMappingTests : RewriteTest
         Assert.NotNull(typeA);
         Assert.NotNull(typeB);
         Assert.Same(typeA, typeB);
+    }
+
+    [Fact]
+    public void SourceClass_DeclaredMembersAndMethodsArePopulated()
+    {
+        var cu = ParseWithSemanticModel("""
+            using System.Collections.Generic;
+            class Holder
+            {
+                private int _count;
+                public string Name { get; set; } = "";
+                public event System.EventHandler? Changed;
+                public List<string> Items() => new();
+                public void Reset(int to) { _count = to; }
+            }
+            class Test
+            {
+                void M() { Holder holder = new Holder(); }
+            }
+            """);
+
+        var holderType = Assert.IsType<JavaType.Class>(
+            FindVariableDeclaration(cu, "holder")!.TypeExpression?.Type);
+
+        Assert.NotNull(holderType.Members);
+        Assert.NotNull(holderType.Methods);
+
+        // Fields, properties and events are all reachable by name.
+        var count = Assert.Single(holderType.Members!, v => v.Name == "_count");
+        Assert.Equal(JavaType.Primitive.Of(JavaType.PrimitiveKind.Int), count.Type);
+        Assert.Same(holderType, count.Owner);
+
+        var name = Assert.Single(holderType.Members!, v => v.Name == "Name");
+        Assert.Equal("System.String", Assert.IsType<JavaType.Class>(name.Type).FullyQualifiedName);
+        Assert.Contains(holderType.Members!, v => v.Name == "Changed");
+
+        // The auto-property backing field and the get_/set_/add_/remove_ accessors are
+        // compiler-generated and must not leak into the model.
+        Assert.DoesNotContain(holderType.Members!, v => v.Name.StartsWith('<'));
+        Assert.DoesNotContain(holderType.Methods!, m => m.Name is "get_Name" or "set_Name"
+            or "add_Changed" or "remove_Changed");
+
+        var items = Assert.Single(holderType.Methods!, m => m.Name == "Items");
+        Assert.Equal("System.Collections.Generic.List",
+            Assert.IsType<JavaType.Class>(Assert.IsType<JavaType.Parameterized>(items.ReturnType).Type)
+                .FullyQualifiedName);
+
+        var reset = Assert.Single(holderType.Methods!, m => m.Name == "Reset");
+        Assert.Equal(["to"], reset.ParameterNames);
+        Assert.Same(holderType, reset.DeclaringType);
+
+        // The implicit parameterless constructor is a real member of the type.
+        Assert.Contains(holderType.Methods!, m => m.Name == ".ctor");
+
+        // Only declared members: `ToString` is inherited from System.Object and is reachable
+        // through the supertype chain, not through Holder's own member list.
+        Assert.DoesNotContain(holderType.Methods!, m => m.Name == "ToString");
+        var objectType = Assert.IsType<JavaType.Class>(holderType.Supertype);
+        Assert.Equal("System.Object", objectType.FullyQualifiedName);
+        Assert.Contains(objectType.Methods!, m => m.Name == "ToString");
+    }
+
+    [Fact]
+    public void MetadataClass_DeclaredMembersAndMethodsArePopulated()
+    {
+        // WPF types come from a reference assembly with no source, so they exercise the
+        // metadata path of the member mapping. Several WPF recipes need to answer
+        // "does ItemsControl declare a member named ItemsSource, and of what type?".
+        var cu = ParseWithSemanticModel("""
+            using System.Windows.Controls;
+            class Test
+            {
+                void M() { ItemsControl control = new ItemsControl(); }
+            }
+            """, Assemblies.Net90.AddPackage("Microsoft.WindowsDesktop.App.Ref", "9.0.16"));
+
+        var itemsControl = Assert.IsType<JavaType.Class>(
+            FindVariableDeclaration(cu, "control")!.TypeExpression?.Type);
+        Assert.Equal("System.Windows.Controls.ItemsControl", itemsControl.FullyQualifiedName);
+
+        Assert.NotNull(itemsControl.Members);
+        Assert.NotNull(itemsControl.Methods);
+
+        // Instance property declared on ItemsControl.
+        var itemsSource = Assert.Single(itemsControl.Members!, v => v.Name == "ItemsSource");
+        Assert.Equal("System.Collections.IEnumerable",
+            Assert.IsType<JavaType.Class>(itemsSource.Type).FullyQualifiedName);
+
+        // Static dependency-property field declared on ItemsControl.
+        var itemsSourceProperty = Assert.Single(itemsControl.Members!,
+            v => v.Name == "ItemsSourceProperty");
+        Assert.Equal("System.Windows.DependencyProperty",
+            Assert.IsType<JavaType.Class>(itemsSourceProperty.Type).FullyQualifiedName);
+
+        Assert.Contains(itemsControl.Methods!, m => m.Name == "GetItemsOwner");
+
+        // Members declared by a base class are found on that base class, not on ItemsControl.
+        Assert.DoesNotContain(itemsControl.Members!, v => v.Name == "Visibility");
+        var uiElement = Walk(itemsControl, "System.Windows.UIElement");
+        Assert.Contains(uiElement.Members!, v => v.Name == "Visibility");
+    }
+
+    private static JavaType.Class Walk(JavaType.Class from, string fullyQualifiedName)
+    {
+        for (JavaType.Class? c = from; c != null; c = c.Supertype as JavaType.Class)
+        {
+            if (c.FullyQualifiedName == fullyQualifiedName) return c;
+        }
+        throw new Xunit.Sdk.XunitException(
+            $"{fullyQualifiedName} not found in the supertype chain of {from.FullyQualifiedName}");
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
@@ -558,6 +558,223 @@ public class CSharpTypeMappingTests : RewriteTest
     }
 
     /// <summary>
+    /// Attributes written on a type in the analysed source are mapped onto
+    /// <see cref="JavaType.Class.Annotations"/>, with their named arguments resolved to the
+    /// attribute class' properties and their values carried as constants or type references.
+    /// </summary>
+    [Fact]
+    public void SourceClass_AnnotationsAreMapped()
+    {
+        var cu = ParseWithSemanticModel("""
+            using System;
+
+            [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+            sealed class MarkerAttribute : Attribute
+            {
+                public string? Name { get; set; }
+                public Type? Kind { get; set; }
+            }
+
+            [Marker(Name = "first", Kind = typeof(string))]
+            class Marked { }
+
+            class Test
+            {
+                void M() { Marked marked = new Marked(); }
+            }
+            """);
+
+        var marked = Assert.IsType<JavaType.Class>(
+            FindVariableDeclaration(cu, "marked")!.TypeExpression?.Type);
+
+        Assert.NotNull(marked.Annotations);
+        var marker = Assert.Single(marked.Annotations!.OfType<JavaType.Annotation>(),
+            a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "MarkerAttribute" });
+
+        Assert.NotNull(marker.Values);
+        Assert.Equal(2, marker.Values!.Count);
+
+        var name = Assert.Single(marker.Values!.OfType<JavaType.Annotation.SingleElementValue>(),
+            v => v.Element is JavaType.Variable { Name: "Name" });
+        Assert.Equal("first", name.ConstantValue);
+        Assert.Null(name.ReferenceValue);
+        // The element resolves to the property on the attribute class, typed as the property is.
+        Assert.Equal("MarkerAttribute",
+            Assert.IsType<JavaType.Class>(Assert.IsType<JavaType.Variable>(name.Element).Owner)
+                .FullyQualifiedName);
+
+        var kind = Assert.Single(marker.Values!.OfType<JavaType.Annotation.SingleElementValue>(),
+            v => v.Element is JavaType.Variable { Name: "Kind" });
+        Assert.Null(kind.ConstantValue);
+        Assert.Equal("System.String",
+            Assert.IsType<JavaType.Class>(kind.ReferenceValue).FullyQualifiedName);
+    }
+
+    /// <summary>
+    /// A positional (constructor) attribute argument has no element name of its own. It is
+    /// resolved to the property of the attribute class that the constructor parameter feeds,
+    /// matched case-insensitively on name — the universal C# convention.
+    /// </summary>
+    [Fact]
+    public void PositionalAttributeArguments_ResolveToTheMatchingProperty()
+    {
+        var cu = ParseWithSemanticModel("""
+            using System;
+
+            [Obsolete("use something else", true)]
+            class Old { }
+
+            class Test
+            {
+                void M() { Old old = new Old(); }
+            }
+            """);
+
+        var old = Assert.IsType<JavaType.Class>(
+            FindVariableDeclaration(cu, "old")!.TypeExpression?.Type);
+
+        var obsolete = Assert.Single(old.Annotations!.OfType<JavaType.Annotation>(),
+            a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "System.ObsoleteAttribute" });
+
+        // ObsoleteAttribute(string message, bool error). Positional arguments stay in declaration
+        // order.
+        var values = obsolete.Values!.Cast<JavaType.Annotation.SingleElementValue>().ToList();
+        Assert.Equal(2, values.Count);
+
+        // `message` names the Message property, so the value is attributed to it.
+        Assert.Equal("Message", Assert.IsType<JavaType.Variable>(values[0].Element).Name);
+        Assert.Equal("use something else", values[0].ConstantValue);
+
+        // `error` names no property — the property is called IsError — so rather than guessing a
+        // member it does not name, the value's element is the constructor that received it.
+        // Java's ElementValue.getElement() contract is non-null, so a null element would not
+        // survive the RPC round trip.
+        var ctor = Assert.IsType<JavaType.Method>(values[1].Element);
+        Assert.Equal(".ctor", ctor.Name);
+        Assert.Equal("System.ObsoleteAttribute",
+            Assert.IsAssignableFrom<JavaType.Class>(ctor.DeclaringType).FullyQualifiedName);
+        Assert.Equal(true, values[1].ConstantValue);
+    }
+
+    /// <summary>
+    /// Enum-valued arguments map to the enum member as a <see cref="JavaType.Variable"/>
+    /// reference (matching Java's <c>Attribute.Enum</c> -> <c>VarSymbol</c> mapping), and array
+    /// arguments map to an <see cref="JavaType.Annotation.ArrayElementValue"/>.
+    /// </summary>
+    [Fact]
+    public void EnumAndArrayAttributeArguments_AreMapped()
+    {
+        var cu = ParseWithSemanticModel("""
+            using System;
+
+            enum Level { Low, High }
+
+            sealed class ShapeAttribute : Attribute
+            {
+                public Level Level { get; set; }
+                public string[] Names { get; set; } = [];
+            }
+
+            [Shape(Level = Level.High, Names = new[] { "a", "b" })]
+            class Shaped { }
+
+            class Test
+            {
+                void M() { Shaped shaped = new Shaped(); }
+            }
+            """);
+
+        var shaped = Assert.IsType<JavaType.Class>(
+            FindVariableDeclaration(cu, "shaped")!.TypeExpression?.Type);
+        var shape = Assert.Single(shaped.Annotations!.OfType<JavaType.Annotation>(),
+            a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "ShapeAttribute" });
+
+        var level = Assert.Single(shape.Values!.OfType<JavaType.Annotation.SingleElementValue>(),
+            v => v.Element is JavaType.Variable { Name: "Level" });
+        var member = Assert.IsType<JavaType.Variable>(level.ReferenceValue);
+        Assert.Equal("High", member.Name);
+        Assert.Equal("Level", Assert.IsType<JavaType.Class>(member.Owner).FullyQualifiedName);
+
+        var names = Assert.Single(shape.Values!.OfType<JavaType.Annotation.ArrayElementValue>(),
+            v => v.Element is JavaType.Variable { Name: "Names" });
+        Assert.Equal(["a", "b"], names.ConstantValues);
+    }
+
+    /// <summary>
+    /// Attributes on methods and on fields/properties are mapped too.
+    /// </summary>
+    [Fact]
+    public void MethodAndVariableAnnotationsAreMapped()
+    {
+        var cu = ParseWithSemanticModel("""
+            using System;
+
+            class Holder
+            {
+                [Obsolete] public int Field;
+                [Obsolete] public void Method() { }
+            }
+
+            class Test
+            {
+                void M() { Holder holder = new Holder(); }
+            }
+            """);
+
+        var holder = Assert.IsType<JavaType.Class>(
+            FindVariableDeclaration(cu, "holder")!.TypeExpression?.Type);
+
+        var field = Assert.Single(holder.Members!, v => v.Name == "Field");
+        Assert.Contains(field.Annotations!.OfType<JavaType.Annotation>(),
+            a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "System.ObsoleteAttribute" });
+
+        var method = Assert.Single(holder.Methods!, m => m.Name == "Method");
+        Assert.Contains(method.Annotations!.OfType<JavaType.Annotation>(),
+            a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "System.ObsoleteAttribute" });
+    }
+
+    /// <summary>
+    /// The motivating case: <c>ComboBox</c> comes from a reference assembly and declares two
+    /// <c>[TemplatePart]</c> attributes. Both must survive, distinguished by their values — a
+    /// WPF recipe that only sees one of them silently loses <c>PART_Popup</c>.
+    /// </summary>
+    [Fact]
+    public void MetadataClass_RepeatedAnnotationsAreMappedWithTheirValues()
+    {
+        var cu = ParseWithSemanticModel("""
+            using System.Windows.Controls;
+            class Test
+            {
+                void M() { ComboBox box = new ComboBox(); }
+            }
+            """, Assemblies.Net90.AddPackage("Microsoft.WindowsDesktop.App.Ref", "9.0.16"));
+
+        var comboBox = Assert.IsType<JavaType.Class>(
+            FindVariableDeclaration(cu, "box")!.TypeExpression?.Type);
+        Assert.Equal("System.Windows.Controls.ComboBox", comboBox.FullyQualifiedName);
+
+        Assert.NotNull(comboBox.Annotations);
+        var templateParts = comboBox.Annotations!.OfType<JavaType.Annotation>()
+            .Where(a => a.AnnotationType is JavaType.Class
+            {
+                FullyQualifiedName: "System.Windows.TemplatePartAttribute"
+            })
+            .ToList();
+        Assert.Equal(2, templateParts.Count);
+
+        var byName = templateParts.ToDictionary(
+            a => (string)a.Values!.OfType<JavaType.Annotation.SingleElementValue>()
+                .Single(v => v.Element is JavaType.Variable { Name: "Name" }).ConstantValue!,
+            a => Assert.IsType<JavaType.Class>(
+                a.Values!.OfType<JavaType.Annotation.SingleElementValue>()
+                    .Single(v => v.Element is JavaType.Variable { Name: "Type" }).ReferenceValue)
+                .FullyQualifiedName);
+
+        Assert.Equal("System.Windows.Controls.TextBox", byName["PART_EditableTextBox"]);
+        Assert.Equal("System.Windows.Controls.Primitives.Popup", byName["PART_Popup"]);
+    }
+
+    /// <summary>
     /// An event reference carries <see cref="JavaType.Variable"/> attribution naming the type that
     /// declares it, exactly as a field or property reference does. Without it a recipe renaming an
     /// event has nothing to key an unqualified reference on — the enclosing type is the wrong

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
@@ -482,7 +482,6 @@ public class CSharpTypeMappingTests : RewriteTest
         Assert.NotNull(holderType.Members);
         Assert.NotNull(holderType.Methods);
 
-        // Fields, properties and events are all reachable by name.
         var count = Assert.Single(holderType.Members!, v => v.Name == "_count");
         Assert.Equal(JavaType.Primitive.Of(JavaType.PrimitiveKind.Int), count.Type);
         Assert.Same(holderType, count.Owner);
@@ -491,8 +490,6 @@ public class CSharpTypeMappingTests : RewriteTest
         Assert.Equal("System.String", Assert.IsType<JavaType.Class>(name.Type).FullyQualifiedName);
         Assert.Contains(holderType.Members!, v => v.Name == "Changed");
 
-        // The auto-property backing field and the get_/set_/add_/remove_ accessors are
-        // compiler-generated and must not leak into the model.
         Assert.DoesNotContain(holderType.Members!, v => v.Name.StartsWith('<'));
         Assert.DoesNotContain(holderType.Methods!, m => m.Name is "get_Name" or "set_Name"
             or "add_Changed" or "remove_Changed");
@@ -506,11 +503,8 @@ public class CSharpTypeMappingTests : RewriteTest
         Assert.Equal(["to"], reset.ParameterNames);
         Assert.Same(holderType, reset.DeclaringType);
 
-        // The implicit parameterless constructor is a real member of the type.
         Assert.Contains(holderType.Methods!, m => m.Name == ".ctor");
 
-        // Only declared members: `ToString` is inherited from System.Object and is reachable
-        // through the supertype chain, not through Holder's own member list.
         Assert.DoesNotContain(holderType.Methods!, m => m.Name == "ToString");
         var objectType = Assert.IsType<JavaType.Class>(holderType.Supertype);
         Assert.Equal("System.Object", objectType.FullyQualifiedName);
@@ -520,9 +514,6 @@ public class CSharpTypeMappingTests : RewriteTest
     [Fact]
     public void MetadataClass_DeclaredMembersAndMethodsArePopulated()
     {
-        // WPF types come from a reference assembly with no source, so they exercise the
-        // metadata path of the member mapping. Several WPF recipes need to answer
-        // "does ItemsControl declare a member named ItemsSource, and of what type?".
         var cu = ParseWithSemanticModel("""
             using System.Windows.Controls;
             class Test
@@ -538,12 +529,10 @@ public class CSharpTypeMappingTests : RewriteTest
         Assert.NotNull(itemsControl.Members);
         Assert.NotNull(itemsControl.Methods);
 
-        // Instance property declared on ItemsControl.
         var itemsSource = Assert.Single(itemsControl.Members!, v => v.Name == "ItemsSource");
         Assert.Equal("System.Collections.IEnumerable",
             Assert.IsType<JavaType.Class>(itemsSource.Type).FullyQualifiedName);
 
-        // Static dependency-property field declared on ItemsControl.
         var itemsSourceProperty = Assert.Single(itemsControl.Members!,
             v => v.Name == "ItemsSourceProperty");
         Assert.Equal("System.Windows.DependencyProperty",
@@ -551,7 +540,6 @@ public class CSharpTypeMappingTests : RewriteTest
 
         Assert.Contains(itemsControl.Methods!, m => m.Name == "GetItemsOwner");
 
-        // Members declared by a base class are found on that base class, not on ItemsControl.
         Assert.DoesNotContain(itemsControl.Members!, v => v.Name == "Visibility");
         var uiElement = Walk(itemsControl, "System.Windows.UIElement");
         Assert.Contains(uiElement.Members!, v => v.Name == "Visibility");
@@ -598,7 +586,6 @@ public class CSharpTypeMappingTests : RewriteTest
             v => v.Element is JavaType.Variable { Name: "Name" });
         Assert.Equal("first", name.ConstantValue);
         Assert.Null(name.ReferenceValue);
-        // The element resolves to the property on the attribute class, typed as the property is.
         Assert.Equal("MarkerAttribute",
             Assert.IsType<JavaType.Class>(Assert.IsType<JavaType.Variable>(name.Element).Owner)
                 .FullyQualifiedName);
@@ -636,19 +623,12 @@ public class CSharpTypeMappingTests : RewriteTest
         var obsolete = Assert.Single(old.Annotations!.OfType<JavaType.Annotation>(),
             a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "System.ObsoleteAttribute" });
 
-        // ObsoleteAttribute(string message, bool error). Positional arguments stay in declaration
-        // order.
         var values = obsolete.Values!.Cast<JavaType.Annotation.SingleElementValue>().ToList();
         Assert.Equal(2, values.Count);
 
-        // `message` names the Message property, so the value is attributed to it.
         Assert.Equal("Message", Assert.IsType<JavaType.Variable>(values[0].Element).Name);
         Assert.Equal("use something else", values[0].ConstantValue);
 
-        // `error` names no property — the property is called IsError — so rather than guessing a
-        // member it does not name, the value's element is the constructor that received it.
-        // Java's ElementValue.getElement() contract is non-null, so a null element would not
-        // survive the RPC round trip.
         var ctor = Assert.IsType<JavaType.Method>(values[1].Element);
         Assert.Equal(".ctor", ctor.Name);
         Assert.Equal("System.ObsoleteAttribute",
@@ -801,8 +781,6 @@ public class CSharpTypeMappingTests : RewriteTest
             }
             """);
 
-        // The declaration and both references — one unqualified from a derived type, one through
-        // `this` — all name the declaring type.
         var occurrences = new IdentifierFinder("Changed").Collect(cu);
         Assert.Equal(3, occurrences.Count);
 

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CSharpTypeMappingTests.cs
@@ -557,6 +557,70 @@ public class CSharpTypeMappingTests : RewriteTest
         Assert.Contains(uiElement.Members!, v => v.Name == "Visibility");
     }
 
+    /// <summary>
+    /// An event reference carries <see cref="JavaType.Variable"/> attribution naming the type that
+    /// declares it, exactly as a field or property reference does. Without it a recipe renaming an
+    /// event has nothing to key an unqualified reference on — the enclosing type is the wrong
+    /// answer as soon as the reference is made from a derived type.
+    /// </summary>
+    [Fact]
+    public void EventReferencesCarryVariableAttribution()
+    {
+        var cu = ParseWithSemanticModel("""
+            using System;
+            class Base
+            {
+                public event EventHandler? Changed;
+            }
+            class Derived : Base
+            {
+                void M()
+                {
+                    Changed += this.OnChanged;
+                    this.Changed += this.OnChanged;
+                }
+
+                void OnChanged(object? sender, EventArgs e) { }
+            }
+            """);
+
+        // The declaration and both references — one unqualified from a derived type, one through
+        // `this` — all name the declaring type.
+        var occurrences = new IdentifierFinder("Changed").Collect(cu);
+        Assert.Equal(3, occurrences.Count);
+
+        foreach (var occurrence in occurrences)
+        {
+            var attribution = Assert.IsType<JavaType.Variable>(occurrence.FieldType);
+            Assert.Equal("Changed", attribution.Name);
+            Assert.Equal("Base", Assert.IsType<JavaType.Class>(attribution.Owner).FullyQualifiedName);
+            Assert.Equal("System.EventHandler",
+                Assert.IsType<JavaType.Class>(attribution.Type).FullyQualifiedName);
+        }
+    }
+
+    private class IdentifierFinder(string name) : CSharpVisitor<int>
+    {
+        private readonly List<Identifier> _found = [];
+
+        public List<Identifier> Collect(CompilationUnit cu)
+        {
+            Cursor = new OpenRewrite.Core.Cursor(null, OpenRewrite.Core.Cursor.ROOT_VALUE);
+            Visit(cu, 0);
+            return _found;
+        }
+
+        public override J VisitIdentifier(Identifier identifier, int p)
+        {
+            if (identifier.SimpleName == name)
+            {
+                _found.Add(identifier);
+            }
+
+            return identifier;
+        }
+    }
+
     private static JavaType.Class Walk(JavaType.Class from, string fullyQualifiedName)
     {
         for (JavaType.Class? c = from; c != null; c = c.Supertype as JavaType.Class)

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/ClassDeclarationNameMarkerTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/ClassDeclarationNameMarkerTests.cs
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+using OpenRewrite.Test;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.CSharp;
+
+/// <summary>
+/// The printer used to write a class name with <c>p.Append(classDecl.Name.SimpleName)</c> after
+/// visiting only its prefix, which skipped the identifier's markers — so a search recipe that named
+/// the type it had found produced output identical to a clean run. Every other name in the file goes
+/// through <c>VisitIdentifier</c>; this one did not.
+/// </summary>
+public class ClassDeclarationNameMarkerTests : RewriteTest
+{
+    [Fact]
+    public void MarkerOnClassNameIsPrinted()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new MarkClassName()),
+            CSharp(
+                "class C { }",
+                "class /*~~(look here)~~>*/C { }"
+            )
+        );
+    }
+
+    [Fact]
+    public void MarkerOnGenericClassNameIsPrinted()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new MarkClassName()),
+            CSharp(
+                "class C<T> { }",
+                "class /*~~(look here)~~>*/C<T> { }"
+            )
+        );
+    }
+
+    private class MarkClassName : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Mark class names";
+        public override string Description => "Marks the identifier of every class declaration.";
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor() => new Visitor();
+
+        private class Visitor : CSharpVisitor<ExecutionContext>
+        {
+            public override J VisitClassDeclaration(ClassDeclaration cd, ExecutionContext ctx)
+            {
+                cd = (ClassDeclaration)base.VisitClassDeclaration(cd, ctx);
+                return cd.WithName(Markup.CreateWarn(cd.Name, "look here"));
+            }
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/JWitherContractTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/JWitherContractTests.cs
@@ -44,8 +44,26 @@ public class JWitherContractTests
         return data;
     }
 
+    /// <summary>
+    /// Every concrete <c>Tree</c> in the assembly — not just the J family — because
+    /// <c>SearchResult.Found</c> accepts any <c>Tree</c> (e.g. <c>ParseError</c> in parse-failure
+    /// flows, the Xml family) and throws where the wither is missing.
+    /// </summary>
+    public static TheoryData<Type> TreeNodeTypes()
+    {
+        var data = new TheoryData<Type>();
+        foreach (var type in typeof(global::OpenRewrite.Core.Tree).Assembly.GetTypes())
+        {
+            if (type is { IsClass: true, IsAbstract: false } && typeof(global::OpenRewrite.Core.Tree).IsAssignableFrom(type))
+            {
+                data.Add(type);
+            }
+        }
+        return data;
+    }
+
     [Theory]
-    [MemberData(nameof(NodeTypes))]
+    [MemberData(nameof(TreeNodeTypes))]
     public void ExposesWithMarkers(Type nodeType) =>
         Assert.True(nodeType.GetMethod("WithMarkers", [typeof(Markers)]) != null,
             $"{nodeType.FullName} has no WithMarkers(Markers); markers attached to it would be silently dropped.");

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/JWitherContractTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/JWitherContractTests.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Java;
+
+namespace OpenRewrite.Tests.Core;
+
+/// <summary>
+/// Every LST node has a prefix and markers, so every concrete node type must expose the withers for
+/// them. <c>Markup</c>, <c>SearchResult</c>, <c>J.SetPrefix</c> and <c>J.SetMarkers</c> all reach
+/// those withers reflectively and now throw when a type has none — this test is what keeps that
+/// throw unreachable for in-tree nodes.
+/// <para>
+/// The gap this guards against is invisible without it: <c>Cs.ExpressionStatement</c> delegated
+/// <c>Prefix</c>/<c>Markers</c> to the expression it wraps but declared neither wither, so every
+/// search recipe that marked a bare expression statement (<c>Foo();</c>) reported nothing at all.
+/// </para>
+/// </summary>
+public class JWitherContractTests
+{
+    public static TheoryData<Type> NodeTypes()
+    {
+        var data = new TheoryData<Type>();
+        foreach (var type in typeof(J).Assembly.GetTypes())
+        {
+            if (type is { IsClass: true, IsAbstract: false } && typeof(J).IsAssignableFrom(type))
+            {
+                data.Add(type);
+            }
+        }
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(NodeTypes))]
+    public void ExposesWithMarkers(Type nodeType) =>
+        Assert.True(nodeType.GetMethod("WithMarkers", [typeof(Markers)]) != null,
+            $"{nodeType.FullName} has no WithMarkers(Markers); markers attached to it would be silently dropped.");
+
+    [Theory]
+    [MemberData(nameof(NodeTypes))]
+    public void ExposesWithPrefix(Type nodeType) =>
+        Assert.True(nodeType.GetMethod("WithPrefix", [typeof(Space)]) != null,
+            $"{nodeType.FullName} has no WithPrefix(Space); whitespace assigned to it would be silently dropped.");
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/MarkupTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/MarkupTests.cs
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+using OpenRewrite.Test;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Core;
+
+/// <summary>
+/// <c>Markup</c> and <c>J.SetPrefix</c> resolve their withers reflectively. Both used to return the
+/// node unchanged when the type had none, which turned a modelling gap into a silent no-op:
+/// <c>Cs.ExpressionStatement</c> declares neither wither of its own, so every search recipe that
+/// marked a bare expression statement (<c>Foo();</c>) reported nothing and looked like a clean run.
+/// </summary>
+public class MarkupTests : RewriteTest
+{
+    [Fact]
+    public void WarnOnExpressionStatementIsPrinted()
+    {
+        RewriteRun(
+            spec => spec.SetRecipe(new MarkExpressionStatements()),
+            CSharp(
+                """
+                class C
+                {
+                    void M()
+                    {
+                        Foo();
+                    }
+
+                    void Foo() { }
+                }
+                """,
+                """
+                class C
+                {
+                    void M()
+                    {
+                        /*~~(side effect)~~>*/Foo();
+                    }
+
+                    void Foo() { }
+                }
+                """
+            )
+        );
+    }
+
+    /// <summary>
+    /// Marking the statement and marking the expression it wraps print identically — the wrapper has
+    /// no syntax of its own — which is exactly why the dropped marker went unnoticed. Recipes should
+    /// be free to mark whichever of the two they mean.
+    /// </summary>
+    [Fact]
+    public void MarkingStatementAndExpressionPrintTheSame()
+    {
+        var parser = new CSharpParser();
+        var source = parser.Parse("class C { void M() { Foo(); } void Foo() { } }", sourcePath: "c.cs");
+        var printer = new CSharpPrinter<object>();
+
+        var statementMarked = new MarkExpressionStatements().GetVisitor().Visit(source, new ExecutionContext());
+        var expressionMarked = new MarkWrappedExpressions().GetVisitor().Visit(source, new ExecutionContext());
+
+        Assert.Equal(printer.Print((SourceFile)expressionMarked!), printer.Print((SourceFile)statementMarked!));
+    }
+
+    [Fact]
+    public void SetPrefixOnExpressionStatementReachesTheExpression()
+    {
+        var statement = new ExpressionStatement(Guid.NewGuid(),
+            new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty));
+
+        var spaced = J.SetPrefix(statement, Space.SingleSpace);
+
+        Assert.Equal(" ", spaced.Prefix.Whitespace);
+        Assert.Equal(" ", spaced.Expression.Prefix.Whitespace);
+    }
+
+    [Fact]
+    public void MarkupThrowsWhenTheNodeHasNoWithMarkers()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => Markup.CreateWarn(new WitherlessNode(), "dropped"));
+        Assert.Contains("WithMarkers", ex.Message);
+    }
+
+    [Fact]
+    public void SetPrefixThrowsWhenTheNodeHasNoWithPrefix()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => J.SetPrefix(new WitherlessNode(), Space.SingleSpace));
+        Assert.Contains("WithPrefix", ex.Message);
+    }
+
+    private class MarkExpressionStatements : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Mark expression statements";
+        public override string Description => "Marks every expression statement.";
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor() => new Visitor();
+
+        private class Visitor : CSharpVisitor<ExecutionContext>
+        {
+            public override J VisitExpressionStatement(ExpressionStatement es, ExecutionContext ctx) =>
+                Markup.CreateWarn((ExpressionStatement)base.VisitExpressionStatement(es, ctx), "side effect");
+        }
+    }
+
+    private class MarkWrappedExpressions : global::OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Mark wrapped expressions";
+        public override string Description => "Marks the expression inside every expression statement.";
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor() => new Visitor();
+
+        private class Visitor : CSharpVisitor<ExecutionContext>
+        {
+            public override J VisitExpressionStatement(ExpressionStatement es, ExecutionContext ctx)
+            {
+                es = (ExpressionStatement)base.VisitExpressionStatement(es, ctx);
+                return es.WithExpression(Markup.CreateWarn(es.Expression, "side effect"));
+            }
+        }
+    }
+
+    /// <summary>A node that declares no withers, standing in for a future modelling gap.</summary>
+    private sealed class WitherlessNode : J
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+        public Space Prefix => Space.Empty;
+        public Markers Markers => Markers.Empty;
+        public global::OpenRewrite.Core.Tree WithId(Guid id) => this;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/SearchResultTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/SearchResultTests.cs
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Java;
+
+namespace OpenRewrite.Tests.Core;
+
+/// <summary>
+/// <c>SearchResult.Found</c> resolves <c>WithMarkers</c> reflectively and used to return the node
+/// unchanged when the type had none — the same silent no-op <c>Markup.AddMarker</c> and
+/// <c>J.SetPrefix</c> already throw for. <c>ParseError</c> was the one in-tree type without the
+/// wither, so marking a parse failure quietly reported nothing.
+/// </summary>
+public class SearchResultTests
+{
+    [Fact]
+    public void FoundOnParseErrorAttachesTheMarker()
+    {
+        var error = ParseError.Build("broken.cs", "class {", new Exception("boom"));
+
+        var found = SearchResult.Found(error, "failed to parse");
+
+        Assert.NotSame(error, found);
+        var marker = Assert.Single(found.Markers.MarkerList.OfType<SearchResult>());
+        Assert.Equal("failed to parse", marker.Description);
+        Assert.Equal(error.Id, found.Id);
+        Assert.Equal(error.SourcePath, found.SourcePath);
+        Assert.Equal(error.Text, found.Text);
+    }
+
+    [Fact]
+    public void FoundOnJNodeAttachesTheMarker()
+    {
+        var empty = new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty);
+
+        var found = SearchResult.Found(empty, "here");
+
+        var marker = Assert.Single(found.Markers.MarkerList.OfType<SearchResult>());
+        Assert.Equal("here", marker.Description);
+        Assert.Equal(empty.Id, found.Id);
+    }
+
+    [Fact]
+    public void FoundThrowsWhenTheNodeHasNoWithMarkers()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => SearchResult.Found(new WitherlessTree()));
+        Assert.Contains("WithMarkers", ex.Message);
+        Assert.Contains(nameof(WitherlessTree), ex.Message);
+    }
+
+    /// <summary>A non-J node that declares no withers, standing in for a future modelling gap.</summary>
+    private sealed class WitherlessTree : global::OpenRewrite.Core.Tree
+    {
+        public Guid Id { get; } = Guid.NewGuid();
+        public Markers Markers => Markers.Empty;
+        public global::OpenRewrite.Core.Tree WithId(Guid id) => this;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/JavaTypeAnnotationRpcTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/JavaTypeAnnotationRpcTest.cs
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Text.Json;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using OpenRewrite.Core;
+using OpenRewrite.Core.Rpc;
+using OpenRewrite.CSharp;
+using OpenRewrite.CSharp.Rpc;
+using OpenRewrite.Java;
+using OpenRewrite.Java.Rpc;
+using OpenRewrite.Test;
+using Rewrite.Core.Rpc;
+using ExecutionContext = OpenRewrite.Core.ExecutionContext;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// A type may carry several annotations of the <em>same</em> annotation type, told apart only by
+/// their element values — <c>System.Windows.Controls.ComboBox</c> declares two
+/// <c>[TemplatePart]</c>s. The identity function <see cref="JavaSender"/> hands to
+/// <c>GetAndSendListAsRef</c> must therefore fold the values in, as Java's
+/// <c>DefaultJavaTypeSignatureBuilder.annotationSignature</c> does; keying on the annotation type
+/// alone makes the two indistinguishable to the before/after diff.
+/// </summary>
+public class JavaTypeAnnotationRpcTest
+{
+    private static JavaType.Annotation TemplatePart(string partName, string partType)
+    {
+        var attributeType = JavaType.ShallowClass.Build("System.Windows.TemplatePartAttribute");
+        return new JavaType.Annotation(attributeType,
+        [
+            new JavaType.Annotation.SingleElementValue(
+                new JavaType.Variable("Name", attributeType,
+                    JavaType.ShallowClass.Build("System.String"), null),
+                partName, null),
+            new JavaType.Annotation.SingleElementValue(
+                new JavaType.Variable("Type", attributeType,
+                    JavaType.ShallowClass.Build("System.Type"), null),
+                null, JavaType.ShallowClass.Build(partType))
+        ]);
+    }
+
+    private static JavaType.Class ComboBox() =>
+        new JavaType.Class().UnsafeSet(1, JavaType.FullyQualified.FullyQualifiedKind.Class,
+            "System.Windows.Controls.ComboBox", null, null, null,
+            [
+                TemplatePart("PART_EditableTextBox", "System.Windows.Controls.TextBox"),
+                TemplatePart("PART_Popup", "System.Windows.Controls.Primitives.Popup")
+            ],
+            null, null, null);
+
+    /// <summary>
+    /// Both annotations must reach the other side, each with its own values.
+    /// </summary>
+    [Fact]
+    public void RepeatedAnnotationsOfTheSameTypeRoundTrip()
+    {
+        var received = RoundTrip(ComboBox());
+
+        Assert.NotNull(received.Annotations);
+        var parts = received.Annotations!.OfType<JavaType.Annotation>().ToList();
+        Assert.Equal(2, parts.Count);
+
+        var names = parts
+            .Select(a => a.Values!.OfType<JavaType.Annotation.SingleElementValue>()
+                .Single(v => v.Element is JavaType.Variable { Name: "Name" }).ConstantValue)
+            .ToList();
+        Assert.Equal(["PART_EditableTextBox", "PART_Popup"], names);
+
+        var types = parts
+            .Select(a => Assert.IsAssignableFrom<JavaType.Class>(
+                    a.Values!.OfType<JavaType.Annotation.SingleElementValue>()
+                        .Single(v => v.Element is JavaType.Variable { Name: "Type" }).ReferenceValue)
+                .FullyQualifiedName)
+            .ToList();
+        Assert.Equal(
+            ["System.Windows.Controls.TextBox", "System.Windows.Controls.Primitives.Popup"],
+            types);
+    }
+
+    /// <summary>
+    /// The identity function is what pairs an after-item with its before-item when the annotation
+    /// list is diffed. Two annotations that differ only in their element values must land on
+    /// distinct positions; keying on the annotation type alone folds them onto one another, so
+    /// the second one's position is reported as the first one's.
+    /// </summary>
+    [Fact]
+    public void SenderKeysRepeatedAnnotationsDistinctly()
+    {
+        var before = ComboBox();
+        var after = ComboBox();
+
+        var data = new List<RpcObjectData>();
+        var q = new RpcSendQueue(1024, batch => data.AddRange(batch),
+            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+
+        // Sent unwrapped, so the walk carries `before` down into the annotation list rather than
+        // re-adding the whole graph the way a Reference-wrapped slot does.
+        q.Send(after, before, () => new JavaSender().VisitType(after, q));
+        q.Flush();
+
+        // A two-element list whose items both match the before list must produce [0, 1];
+        // [1, 1] means both after-items resolved to the same before-item.
+        var positionLists = data
+            .Select(d => d.Value)
+            .OfType<List<int>>()
+            .Where(p => p.Count == 2)
+            .ToList();
+        Assert.NotEmpty(positionLists);
+        Assert.Contains(positionLists, p => p is [0, 1]);
+        Assert.DoesNotContain(positionLists, p => p is [1, 1] or [0, 0]);
+    }
+
+    private static List<RpcObjectData> Send(JavaType.Class after, JavaType.Class? before = null)
+    {
+        var data = new List<RpcObjectData>();
+        var q = new RpcSendQueue(1024, batch => data.AddRange(batch),
+            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+        q.Send(Reference.AsRef(after), before == null ? null : Reference.AsRef(before),
+            () => new JavaSender().VisitType(after, q));
+        q.Flush();
+        return data;
+    }
+
+    private static JavaType.Class RoundTrip(JavaType.Class after, JavaType.Class? before = null)
+    {
+        // Through the JSON wire format, so that enums, numbers and strings arrive the way the
+        // remote peer would actually see them rather than as live CLR objects.
+        var data = JsonSerializer.Deserialize<List<RpcObjectData>>(
+            JsonSerializer.Serialize(Send(after, before), RpcJson.Options), RpcJson.Options)!;
+        var receiveQueue = new RpcReceiveQueue(data, new Dictionary<int, object>(), null);
+        return Assert.IsAssignableFrom<JavaType.Class>(
+            receiveQueue.Receive<JavaType>(before, t => new JavaReceiver().VisitType(t, receiveQueue)!));
+    }
+}
+
+/// <summary>
+/// The full-fidelity proof, against the real Java peer: a type carrying two same-typed,
+/// value-bearing annotations goes C# &rarr; Java &rarr; C# through the production sender/receiver
+/// pairs on both sides. The Java-side <c>JavaTypeAnnotationProbe</c> (test scope in the
+/// rewrite-csharp Java module) renders the annotations it materialized into a SearchResult
+/// description — which only comes out right if the C# sender and Java receiver agreed on every
+/// element and value — and replaces the probed class' type with freshly built annotations whose
+/// string constants carry a <c>probed:</c> prefix, defeating the delta cache so the return leg
+/// exercises the real Java sender and real C# receiver rather than resolving to local instances.
+/// </summary>
+public class JavaTypeAnnotationRealRpcTest : RpcRewriteTest
+{
+    public JavaTypeAnnotationRealRpcTest(RpcFixture fixture) : base(fixture) { }
+
+    private const string CsCompilationUnitType = "org.openrewrite.csharp.tree.Cs$CompilationUnit";
+
+    [Fact]
+    public void RepeatedValueBearingAnnotationsRoundTripThroughJava()
+    {
+        var source = """
+            using System;
+
+            [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+            sealed class PartAttribute : Attribute
+            {
+                public string Name { get; set; } = "";
+                public Type Type { get; set; } = typeof(object);
+            }
+
+            [Part(Name = "PART_A", Type = typeof(string))]
+            [Part(Name = "PART_B", Type = typeof(Uri))]
+            public class Both { }
+            """;
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, path: "Both.cs");
+        var references = Assemblies.Net90
+            .ResolveAsync(Microsoft.CodeAnalysis.LanguageNames.CSharp, CancellationToken.None)
+            .GetAwaiter().GetResult();
+        var compilation = CSharpCompilation.Create("AnnotationRpcTest")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(references)
+            .AddSyntaxTrees(syntaxTree);
+        var cu = new CSharpParser().Parse(source, sourcePath: "Both.cs",
+            semanticModel: compilation.GetSemanticModel(syntaxTree));
+
+        var server = RewriteRpcServer.Current!;
+        var treeId = cu.Id.ToString();
+        server.StoreLocalObject(treeId, cu);
+        var ctxId = Guid.NewGuid().ToString();
+        server.StoreLocalObject(ctxId, new ExecutionContext());
+
+        var returned = server.VisitOnRemote(
+            "org.openrewrite.csharp.rpc.JavaTypeAnnotationProbe",
+            treeId, CsCompilationUnitType, ctxId,
+            new Dictionary<string, object?> { ["type"] = "Both" });
+
+        var both = FindClassDeclaration((J)returned, "Both");
+
+        // C# -> Java: the description was rendered on the Java side from the annotations Java
+        // received. Both [Part]s, their elements and their values must have arrived intact.
+        var marker = both.Markers.FindFirst<SearchResult>();
+        Assert.NotNull(marker);
+        Assert.Equal(
+            "@PartAttribute(Name=PART_A,Type=System.String);" +
+            "@PartAttribute(Name=PART_B,Type=System.Uri)",
+            marker!.Description);
+
+        // Java -> C#: the probe rebuilt the annotations as fresh instances with transformed
+        // string constants, so what this side reads now necessarily crossed the wire back.
+        var cls = Assert.IsAssignableFrom<JavaType.Class>(both.Type);
+        var parts = cls.Annotations!.OfType<JavaType.Annotation>()
+            .Where(a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "PartAttribute" })
+            .ToList();
+        Assert.Equal(2, parts.Count);
+
+        var names = parts.Select(a => a.Values!.OfType<JavaType.Annotation.SingleElementValue>()
+            .Single(v => v.Element is JavaType.Variable { Name: "Name" }).ConstantValue).ToList();
+        Assert.Equal(["probed:PART_A", "probed:PART_B"], names);
+
+        var types = parts.Select(a => Assert.IsAssignableFrom<JavaType.Class>(
+                a.Values!.OfType<JavaType.Annotation.SingleElementValue>()
+                    .Single(v => v.Element is JavaType.Variable { Name: "Type" }).ReferenceValue)
+            .FullyQualifiedName).ToList();
+        Assert.Equal(["System.String", "System.Uri"], types);
+    }
+
+    private static ClassDeclaration FindClassDeclaration(J tree, string simpleName)
+    {
+        var finder = new ClassFinder(simpleName)
+        {
+            Cursor = new Cursor(null, Cursor.ROOT_VALUE)
+        };
+        finder.Visit(tree, 0);
+        Assert.NotNull(finder.Found);
+        return finder.Found!;
+    }
+
+    private class ClassFinder(string name) : CSharpVisitor<int>
+    {
+        public ClassDeclaration? Found { get; private set; }
+
+        public override J VisitClassDeclaration(ClassDeclaration cd, int p)
+        {
+            if (cd.Name.SimpleName == name)
+            {
+                Found = cd;
+            }
+            return base.VisitClassDeclaration(cd, p);
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/JavaTypeAnnotationRpcTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/JavaTypeAnnotationRpcTest.cs
@@ -108,13 +108,9 @@ public class JavaTypeAnnotationRpcTest
         var q = new RpcSendQueue(1024, batch => data.AddRange(batch),
             new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
 
-        // Sent unwrapped, so the walk carries `before` down into the annotation list rather than
-        // re-adding the whole graph the way a Reference-wrapped slot does.
         q.Send(after, before, () => new JavaSender().VisitType(after, q));
         q.Flush();
 
-        // A two-element list whose items both match the before list must produce [0, 1];
-        // [1, 1] means both after-items resolved to the same before-item.
         var positionLists = data
             .Select(d => d.Value)
             .OfType<List<int>>()
@@ -138,8 +134,6 @@ public class JavaTypeAnnotationRpcTest
 
     private static JavaType.Class RoundTrip(JavaType.Class after, JavaType.Class? before = null)
     {
-        // Through the JSON wire format, so that enums, numbers and strings arrive the way the
-        // remote peer would actually see them rather than as live CLR objects.
         var data = JsonSerializer.Deserialize<List<RpcObjectData>>(
             JsonSerializer.Serialize(Send(after, before), RpcJson.Options), RpcJson.Options)!;
         var receiveQueue = new RpcReceiveQueue(data, new Dictionary<int, object>(), null);
@@ -206,8 +200,6 @@ public class JavaTypeAnnotationRealRpcTest : RpcRewriteTest
 
         var both = FindClassDeclaration((J)returned, "Both");
 
-        // C# -> Java: the description was rendered on the Java side from the annotations Java
-        // received. Both [Part]s, their elements and their values must have arrived intact.
         var marker = both.Markers.FindFirst<SearchResult>();
         Assert.NotNull(marker);
         Assert.Equal(
@@ -215,8 +207,6 @@ public class JavaTypeAnnotationRealRpcTest : RpcRewriteTest
             "@PartAttribute(Name=PART_B,Type=System.Uri)",
             marker!.Description);
 
-        // Java -> C#: the probe rebuilt the annotations as fresh instances with transformed
-        // string constants, so what this side reads now necessarily crossed the wire back.
         var cls = Assert.IsAssignableFrom<JavaType.Class>(both.Type);
         var parts = cls.Annotations!.OfType<JavaType.Annotation>()
             .Where(a => a.AnnotationType is JavaType.Class { FullyQualifiedName: "PartAttribute" })

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/LiteralValueReceiveTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/LiteralValueReceiveTest.cs
@@ -44,8 +44,6 @@ public class LiteralValueReceiveTest
         sendQueue.Send(after, before, () => new JavaSender().Visit(after, sendQueue));
         sendQueue.Flush();
 
-        // Through the JSON wire format, so the value arrives the way a remote peer's message
-        // actually deserializes — as a JsonElement, not a live CLR string.
         var wireData = JsonSerializer.Deserialize<List<RpcObjectData>>(
             JsonSerializer.Serialize(data, RpcJson.Options), RpcJson.Options)!;
         var receiveQueue = new RpcReceiveQueue(wireData, new Dictionary<int, object>(), null);

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/LiteralValueReceiveTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/LiteralValueReceiveTest.cs
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Text.Json;
+using OpenRewrite.Core;
+using OpenRewrite.Core.Rpc;
+using OpenRewrite.Java;
+using OpenRewrite.Java.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// Regression test: <see cref="Literal.Value"/> is declared <c>object</c>, so a received value
+/// arrives as a System.Text.Json <see cref="JsonElement"/> unless the receiver materializes the
+/// scalar. Before the fix, every recipe pattern of the form <c>Literal {{ Value: string s }}</c>
+/// silently stopped matching once the tree crossed the RPC boundary — unit tests (which parse
+/// locally) passed while `mod run` found nothing. Observed as WPF0130/0131 finding no
+/// <c>GetTemplateChild("PART_...")</c> lookups on a real repo.
+/// </summary>
+public class LiteralValueReceiveTest
+{
+    [Fact]
+    public void StringLiteralValueMaterializesThroughJsonWire()
+    {
+        var before = new Literal(Guid.NewGuid(), Space.Empty, Markers.Empty,
+            null, "\"before\"", null, JavaType.Primitive.Of(JavaType.PrimitiveKind.String));
+        var after = before.WithValue("PART_EditableTextBox").WithValueSource("\"PART_EditableTextBox\"");
+
+        var data = new List<RpcObjectData>();
+        var sendQueue = new RpcSendQueue(1024, batch => data.AddRange(batch),
+            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+        sendQueue.Send(after, before, () => new JavaSender().Visit(after, sendQueue));
+        sendQueue.Flush();
+
+        // Through the JSON wire format, so the value arrives the way a remote peer's message
+        // actually deserializes — as a JsonElement, not a live CLR string.
+        var wireData = JsonSerializer.Deserialize<List<RpcObjectData>>(
+            JsonSerializer.Serialize(data, RpcJson.Options), RpcJson.Options)!;
+        var receiveQueue = new RpcReceiveQueue(wireData, new Dictionary<int, object>(), null);
+        var received = (Literal)receiveQueue.Receive<J>(before,
+            t => new JavaReceiver().Visit(t, receiveQueue)!)!;
+
+        var s = Assert.IsType<string>(received.Value);
+        Assert.Equal("PART_EditableTextBox", s);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueJavaTypeNameConcurrencyTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueJavaTypeNameConcurrencyTest.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Concurrent;
+using System.Reflection;
+using OpenRewrite.Core.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+/// <summary>
+/// <c>RpcSendQueue</c>'s Java-type-name overrides are process-wide mutable state: bundles register
+/// into it on whichever thread loads them, while every send queue in the process reads it in
+/// parallel. Held in a plain <c>Dictionary</c>, a write that resizes the buckets while another
+/// thread is walking them corrupts the map — observed as a burst of <c>IndexOutOfRangeException</c>s
+/// thrown from lookups that have nothing to do with the type being registered.
+/// </summary>
+public class RpcSendQueueJavaTypeNameConcurrencyTest
+{
+    /// <summary>Nesting this gives an endless supply of distinct <see cref="Type"/> keys.</summary>
+    private sealed class Box<T>;
+
+    private static List<Type> DistinctTypes(int count)
+    {
+        var types = new List<Type>(count);
+        var t = typeof(RpcSendQueueJavaTypeNameConcurrencyTest);
+        for (var i = 0; i < count; i++)
+        {
+            t = typeof(Box<>).MakeGenericType(t);
+            types.Add(t);
+        }
+        return types;
+    }
+
+    [Fact]
+    public void OverrideMapIsConcurrent()
+    {
+        var field = typeof(RpcSendQueue).GetField("JavaTypeNameOverrides",
+            BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(field);
+        Assert.True(field!.FieldType.IsGenericType &&
+                    field.FieldType.GetGenericTypeDefinition() == typeof(ConcurrentDictionary<,>),
+            $"JavaTypeNameOverrides is a {field.FieldType.Name}. It is written from bundle-loading " +
+            "threads while send queues read it in parallel, so it has to be a concurrent map.");
+    }
+
+    [Fact]
+    public void RegistrationAndLookupRunInParallelWithoutCorruption()
+    {
+        var types = DistinctTypes(400);
+        var registered = new ConcurrentBag<Type>();
+
+        // The registrations resize the map repeatedly while the lookups walk it.
+        Parallel.For(0, types.Count, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i =>
+        {
+            RpcSendQueue.RegisterJavaTypeName(types[i], "org.openrewrite.test.Box" + i);
+            registered.Add(types[i]);
+
+            foreach (var seen in registered)
+            {
+                RpcSendQueue.ToJavaTypeName(seen);
+            }
+        });
+
+        for (var i = 0; i < types.Count; i++)
+        {
+            Assert.Equal("org.openrewrite.test.Box" + i, RpcSendQueue.ToJavaTypeName(types[i]));
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueJavaTypeNameConcurrencyTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueJavaTypeNameConcurrencyTest.cs
@@ -62,7 +62,6 @@ public class RpcSendQueueJavaTypeNameConcurrencyTest
         var types = DistinctTypes(400);
         var registered = new ConcurrentBag<Type>();
 
-        // The registrations resize the map repeatedly while the lookups walk it.
         Parallel.For(0, types.Count, new ParallelOptions { MaxDegreeOfParallelism = 8 }, i =>
         {
             RpcSendQueue.RegisterJavaTypeName(types[i], "org.openrewrite.test.Box" + i);

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/ArrayTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/ArrayTests.cs
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;
@@ -248,5 +252,71 @@ public class ArrayTests : RewriteTest
                 """
             )
         );
+    }
+
+    /// <summary>
+    /// An array type carries its resolved type like every other <c>TypeTree</c>, so a recipe can
+    /// reason about <c>typeof(int[])</c> or an array-typed declaration.
+    /// </summary>
+    [Fact]
+    public void ArrayTypeIsAttributed()
+    {
+        var arrayType = FirstArrayType(
+            """
+            class Foo {
+                int[] arr;
+            }
+            """);
+
+        var elementType = Assert.IsType<JavaType.Array>(arrayType.Type).ElemType;
+        Assert.Equal(JavaType.Primitive.PrimitiveKind.Int, Assert.IsType<JavaType.Primitive>(elementType).Kind);
+    }
+
+    /// <summary>
+    /// The outermost rank carries the whole type. The inner levels of a jagged type are left
+    /// unattributed: the syntax nests the ranks in the opposite order from the symbol, so there is
+    /// no per-level type to hand out.
+    /// </summary>
+    [Fact]
+    public void JaggedArrayTypeIsAttributedAtTheOutermostRank()
+    {
+        var arrayType = FirstArrayType(
+            """
+            class Foo {
+                int[][] arr;
+            }
+            """);
+
+        var elementType = Assert.IsType<JavaType.Array>(arrayType.Type).ElemType;
+        Assert.IsType<JavaType.Array>(elementType);
+    }
+
+    private static ArrayType FirstArrayType(string code)
+    {
+        var references = Assemblies.Net90
+            .ResolveAsync(LanguageNames.CSharp, CancellationToken.None)
+            .GetAwaiter().GetResult();
+        var syntaxTree = CSharpSyntaxTree.ParseText(code, path: "source.cs");
+        var compilation = CSharpCompilation.Create("TestCompilation")
+            .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+            .AddReferences(references)
+            .AddSyntaxTrees(syntaxTree);
+
+        var cu = new CSharpParser().Parse(code, semanticModel: compilation.GetSemanticModel(syntaxTree));
+
+        var collector = new ArrayTypeCollector();
+        collector.Visit(cu, 0);
+        return collector.Found[0];
+    }
+
+    private sealed class ArrayTypeCollector : CSharpVisitor<int>
+    {
+        internal List<ArrayType> Found { get; } = [];
+
+        public override J VisitArrayType(ArrayType arrayType, int ctx)
+        {
+            Found.Add(arrayType);
+            return base.VisitArrayType(arrayType, ctx);
+        }
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/AddUsing.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/AddUsing.cs
@@ -1,0 +1,471 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.Java;
+
+namespace OpenRewrite.CSharp;
+
+/// <summary>
+/// Adds a plain namespace <c>using</c> directive for the namespace of a type to a
+/// <see cref="CompilationUnit"/>, the C# counterpart of Java's <c>AddImport</c>. Designed to run
+/// as an after-visitor via <see cref="CSharpVisitor{P}.MaybeAddUsing"/>: the directive is only
+/// added when the type is referenced by its simple name (unless <c>onlyIfReferenced</c> is
+/// false), never duplicated — a textually matching plain or <c>global</c> using anywhere in the
+/// file is a no-op — and declined when the file already binds the simple name to a different
+/// type (the CS0104 risk). <c>using static</c> and alias directives are out of scope.
+/// <para>
+/// Placement follows the file: the compilation unit's using list when it has one, otherwise the
+/// first block-scoped namespace that keeps usings, otherwise the compilation unit (file-scoped
+/// namespaces keep usings at the compilation unit level). A sorted list stays sorted — plain
+/// ordinal or Visual Studio's System-first order, whichever the file already satisfies — and an
+/// unsorted list appends after its last using.
+/// </para>
+/// </summary>
+public class AddUsing<P> : CSharpVisitor<P>, IEquatable<AddUsing<P>>
+{
+    private readonly string _fullyQualifiedTypeName;
+    private readonly string? _namespace;
+    private readonly string _typeName;
+    private readonly bool _onlyIfReferenced;
+
+    /// <param name="fullyQualifiedTypeName">The type whose namespace should be imported, e.g.
+    /// <c>System.Windows.DependencyProperty</c>. A name without a namespace is a no-op.</param>
+    /// <param name="onlyIfReferenced">When true (the default), the using is only added when the
+    /// file references the type by its simple name.</param>
+    public AddUsing(string fullyQualifiedTypeName, bool onlyIfReferenced = true)
+    {
+        _fullyQualifiedTypeName = fullyQualifiedTypeName;
+        var lastDot = fullyQualifiedTypeName.LastIndexOf('.');
+        _namespace = lastDot > 0 ? fullyQualifiedTypeName[..lastDot] : null;
+        _typeName = lastDot > 0 ? fullyQualifiedTypeName[(lastDot + 1)..] : fullyQualifiedTypeName;
+        _onlyIfReferenced = onlyIfReferenced;
+    }
+
+    public override J? PreVisit(J tree, P p)
+    {
+        StopAfterPreVisit();
+        if (tree is not CompilationUnit cu || _namespace == null)
+        {
+            return tree;
+        }
+
+        if (AddUsing.HasNamespaceUsing(cu, _namespace)
+            || (_onlyIfReferenced && !IsReferenced(cu))
+            || AddUsing.IsShadowedInFile(cu, _typeName, _fullyQualifiedTypeName))
+        {
+            return cu;
+        }
+
+        return Insert(cu);
+    }
+
+    private bool IsReferenced(CompilationUnit cu)
+    {
+        var finder = new FindSimpleNameReference(_typeName, _fullyQualifiedTypeName);
+        finder.Visit(cu, 0);
+        return finder.Found;
+    }
+
+    private CompilationUnit Insert(CompilationUnit cu)
+    {
+        var newline = DetectNewline(cu);
+
+        if (cu.Usings.Any(u => u.Element is UsingDirective))
+        {
+            return cu.WithUsings(InsertInto(cu.Usings, newline));
+        }
+
+        foreach (var ns in AddUsing.Namespaces(cu.Members))
+        {
+            if (ns.Name.Markers.FindFirst<Semicolon>() == null &&
+                ns.Usings.Any(u => u.Element is UsingDirective))
+            {
+                return (CompilationUnit)new ReplaceNamespaceUsings(ns.Id, InsertInto(ns.Usings, newline))
+                    .Visit(cu, 0)!;
+            }
+        }
+
+        return InsertFirstUsing(cu, newline);
+    }
+
+    private List<JRightPadded<Statement>> InsertInto(IList<JRightPadded<Statement>> list, string newline)
+    {
+        var linePrefix = Space.Format(newline + IndentOf(list));
+        var index = InsertionIndex(list);
+
+        var result = new List<JRightPadded<Statement>>(list);
+        if (index == 0)
+        {
+            var displaced = result[0];
+            result[0] = displaced.WithElement(J.SetPrefix(displaced.Element, linePrefix));
+            result.Insert(0, JRightPadded<Statement>.Build(CreateUsing(displaced.Element.Prefix)));
+        }
+        else
+        {
+            result.Insert(index, JRightPadded<Statement>.Build(CreateUsing(linePrefix)));
+        }
+        return result;
+    }
+
+    private int InsertionIndex(IList<JRightPadded<Statement>> list)
+    {
+        var plain = new List<(int Index, string Name)>();
+        var lastUsing = -1;
+        for (var i = 0; i < list.Count; i++)
+        {
+            if (list[i].Element is UsingDirective directive)
+            {
+                lastUsing = i;
+                if (directive is { IsStatic: false, Alias: null }
+                    && AddUsing.QualifiedNameOf(directive.NamespaceOrType) is { } name)
+                {
+                    plain.Add((i, name));
+                }
+            }
+        }
+
+        if (plain.Count > 0)
+        {
+            foreach (var compare in (Comparison<string>[])[CompareOrdinal, CompareSystemFirst])
+            {
+                if (!IsSorted(plain, compare))
+                {
+                    continue;
+                }
+                foreach (var (index, name) in plain)
+                {
+                    if (compare(name, _namespace!) > 0)
+                    {
+                        return index;
+                    }
+                }
+                return plain[^1].Index + 1;
+            }
+        }
+
+        return lastUsing + 1;
+    }
+
+    private static bool IsSorted(List<(int Index, string Name)> plain, Comparison<string> compare)
+    {
+        for (var i = 1; i < plain.Count; i++)
+        {
+            if (compare(plain[i - 1].Name, plain[i].Name) > 0)
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int CompareOrdinal(string left, string right) => string.CompareOrdinal(left, right);
+
+    /// <summary>Visual Studio's "place System directives first" ordering.</summary>
+    private static int CompareSystemFirst(string left, string right)
+    {
+        var systemLeft = IsSystemNamespace(left);
+        var systemRight = IsSystemNamespace(right);
+        return systemLeft == systemRight ? string.CompareOrdinal(left, right) : systemLeft ? -1 : 1;
+    }
+
+    private static bool IsSystemNamespace(string ns) =>
+        ns == "System" || ns.StartsWith("System.", StringComparison.Ordinal);
+
+    private static string IndentOf(IList<JRightPadded<Statement>> list)
+    {
+        foreach (var padded in list)
+        {
+            var whitespace = padded.Element.Prefix.Whitespace;
+            var newlineIndex = whitespace.LastIndexOf('\n');
+            if (newlineIndex >= 0)
+            {
+                return whitespace[(newlineIndex + 1)..];
+            }
+        }
+        return "";
+    }
+
+    private static string DetectNewline(CompilationUnit cu)
+    {
+        foreach (var whitespace in CandidateWhitespace(cu))
+        {
+            if (whitespace.Contains("\r\n"))
+            {
+                return "\r\n";
+            }
+            if (whitespace.Contains('\n'))
+            {
+                return "\n";
+            }
+        }
+        return "\n";
+    }
+
+    private static IEnumerable<string> CandidateWhitespace(CompilationUnit cu)
+    {
+        yield return cu.Prefix.Whitespace;
+        foreach (var comment in cu.Prefix.Comments)
+        {
+            yield return comment.Suffix;
+        }
+        foreach (var list in AddUsing.UsingLists(cu))
+        {
+            foreach (var padded in list)
+            {
+                yield return padded.Element.Prefix.Whitespace;
+            }
+        }
+        foreach (var member in cu.Members)
+        {
+            yield return member.Element.Prefix.Whitespace;
+        }
+        yield return cu.Eof.Whitespace;
+    }
+
+    /// <summary>A file with no usings gets its first one at the compilation unit level: after
+    /// the file header (which lives in the compilation unit prefix), before the first
+    /// declaration, separated from it by a blank line.</summary>
+    private CompilationUnit InsertFirstUsing(CompilationUnit cu, string newline)
+    {
+        var usings = new List<JRightPadded<Statement>>(cu.Usings);
+        var ownLine = usings.Count > 0 || cu.Externs.Count > 0;
+        usings.Add(JRightPadded<Statement>.Build(CreateUsing(ownLine ? Space.Format(newline) : Space.Empty)));
+        cu = cu.WithUsings(usings);
+
+        IList<Comment> moved = [];
+        var headerComments = cu.Prefix.Comments;
+        var split = headerComments.Count;
+        while (split > 0 && headerComments[split - 1] is CsDocComment)
+        {
+            split--;
+        }
+        if (split < headerComments.Count && cu.AttributeLists.Count == 0 && cu.Members.Count > 0)
+        {
+            moved = headerComments.Skip(split).ToList();
+            cu = cu.WithPrefix(cu.Prefix.WithComments(headerComments.Take(split).ToList()));
+        }
+
+        var blank = newline + newline;
+        if (cu.AttributeLists.Count > 0)
+        {
+            if (!cu.AttributeLists[0].Prefix.Whitespace.Contains('\n'))
+            {
+                var lists = new List<AttributeList>(cu.AttributeLists);
+                lists[0] = lists[0].WithPrefix(lists[0].Prefix.WithWhitespace(blank));
+                cu = cu.WithAttributeLists(lists);
+            }
+        }
+        else if (cu.Members.Count > 0)
+        {
+            var first = cu.Members[0];
+            var prefix = first.Element.Prefix;
+            if (moved.Count > 0)
+            {
+                prefix = new Space(blank, moved.Concat(prefix.Comments).ToList());
+            }
+            else if (!prefix.Whitespace.Contains('\n'))
+            {
+                prefix = prefix.WithWhitespace(blank);
+            }
+            if (!ReferenceEquals(prefix, first.Element.Prefix))
+            {
+                var members = new List<JRightPadded<Statement>>(cu.Members)
+                {
+                    [0] = first.WithElement(J.SetPrefix(first.Element, prefix)),
+                };
+                cu = cu.WithMembers(members);
+            }
+        }
+        return cu;
+    }
+
+    private UsingDirective CreateUsing(Space prefix) =>
+        new(Guid.NewGuid(),
+            prefix,
+            Markers.Empty,
+            new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
+            new JLeftPadded<bool>(Space.Empty, false),
+            new JLeftPadded<bool>(Space.Empty, false),
+            null,
+            BuildNamespaceName(_namespace!));
+
+    /// <summary>Builds the name tree for a dotted namespace; the outermost node carries the
+    /// single space that separates it from the <c>using</c> keyword.</summary>
+    private static TypeTree BuildNamespaceName(string ns)
+    {
+        var parts = ns.Split('.');
+        Expression name = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], parts[0], null, null);
+        for (var i = 1; i < parts.Length; i++)
+        {
+            name = new FieldAccess(Guid.NewGuid(), Space.Empty, Markers.Empty, name,
+                new JLeftPadded<Identifier>(Space.Empty,
+                    new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], parts[i], null, null)),
+                null);
+        }
+        return (TypeTree)J.SetPrefix((J)name, Space.SingleSpace);
+    }
+
+    public bool Equals(AddUsing<P>? other) =>
+        other is not null
+        && string.Equals(_fullyQualifiedTypeName, other._fullyQualifiedTypeName, StringComparison.Ordinal)
+        && _onlyIfReferenced == other._onlyIfReferenced;
+
+    public override bool Equals(object? obj) => Equals(obj as AddUsing<P>);
+    public override int GetHashCode() => HashCode.Combine(_fullyQualifiedTypeName, _onlyIfReferenced);
+
+    private sealed class ReplaceNamespaceUsings(Guid namespaceId, IList<JRightPadded<Statement>> usings)
+        : CSharpVisitor<int>
+    {
+        public override J VisitNamespaceDeclaration(NamespaceDeclaration ns, int p) =>
+            ns.Id == namespaceId ? ns.WithUsings(usings) : base.VisitNamespaceDeclaration(ns, p);
+    }
+
+    /// <summary>
+    /// Looks for the type written by its simple name. An identifier counts when its attributed
+    /// type is the requested one, or when it carries no attribution at all — recipes synthesize
+    /// short-name identifiers whose types only materialize on the next parse. Qualified
+    /// spellings (the name side of a member access) do not count: they resolve without the
+    /// using.
+    /// </summary>
+    private sealed class FindSimpleNameReference(string simpleName, string fullyQualifiedName)
+        : CSharpVisitor<int>
+    {
+        internal bool Found { get; private set; }
+
+        public override J? Visit(Tree? tree, int p) => Found ? tree as J : base.Visit(tree, p);
+
+        public override J VisitUsingDirective(UsingDirective usingDirective, int p) => usingDirective;
+
+        public override J VisitIdentifier(Identifier identifier, int p)
+        {
+            if (string.Equals(identifier.SimpleName, simpleName, StringComparison.Ordinal)
+                && !(Cursor.ParentTree.Value is FieldAccess parent && ReferenceEquals(parent.Name.Element, identifier))
+                && (TypeUtils.GetFullyQualifiedName(identifier.Type) is not { Length: > 0 } resolved
+                    || string.Equals(resolved, fullyQualifiedName, StringComparison.Ordinal)))
+            {
+                Found = true;
+            }
+            return identifier;
+        }
+    }
+}
+
+/// <summary>
+/// Companion checks for <see cref="AddUsing{P}"/>, shared with recipes that need the same
+/// answers to decide whether a simple name can be written at all.
+/// </summary>
+public static class AddUsing
+{
+    /// <summary>
+    /// True when the file already writes <paramref name="simpleName"/> as a name that resolves
+    /// to something other than <paramref name="fullyQualifiedName"/>.
+    /// <para>
+    /// Roslyn's <c>ToMinimalDisplayString</c> falls back to the qualified name when the short
+    /// one would be ambiguous (CS0104); nothing in the LST answers "could this name be
+    /// ambiguous", but the case that actually bites — the file uses that short name for a
+    /// different type — is visible, and is checked here. A short name is only ever written when
+    /// this returns false, so the failure direction is a needlessly qualified name rather than
+    /// a compile error.
+    /// </para>
+    /// </summary>
+    public static bool IsShadowedInFile(CompilationUnit cu, string simpleName, string fullyQualifiedName)
+    {
+        var collector = new NameCollector(simpleName, fullyQualifiedName);
+        collector.Visit(cu, 0);
+        return collector.Shadowed;
+    }
+
+    /// <summary>Cursor form of <see cref="IsShadowedInFile(CompilationUnit,string,string)"/>;
+    /// false when no compilation unit encloses the cursor.</summary>
+    public static bool IsShadowedInFile(Cursor cursor, string simpleName, string fullyQualifiedName) =>
+        cursor.FirstEnclosing<CompilationUnit>() is { } cu
+        && IsShadowedInFile(cu, simpleName, fullyQualifiedName);
+
+    /// <summary>True when the file already has a plain (non-static, non-alias) using for
+    /// <paramref name="ns"/> — at the compilation unit level or on any namespace declaration,
+    /// including <c>global using</c> directives.</summary>
+    public static bool HasNamespaceUsing(CompilationUnit cu, string ns) =>
+        UsingLists(cu).SelectMany(list => list).Any(padded =>
+            padded.Element is UsingDirective { IsStatic: false, Alias: null } directive
+            && string.Equals(QualifiedNameOf(directive.NamespaceOrType), ns, StringComparison.Ordinal));
+
+    internal static IEnumerable<IList<JRightPadded<Statement>>> UsingLists(CompilationUnit cu)
+    {
+        yield return cu.Usings;
+        foreach (var ns in Namespaces(cu.Members))
+        {
+            yield return ns.Usings;
+        }
+    }
+
+    internal static IEnumerable<NamespaceDeclaration> Namespaces(IList<JRightPadded<Statement>> members)
+    {
+        foreach (var member in members)
+        {
+            if (member.Element is NamespaceDeclaration ns)
+            {
+                yield return ns;
+                foreach (var nested in Namespaces(ns.Members))
+                {
+                    yield return nested;
+                }
+            }
+        }
+    }
+
+    /// <summary>The dotted text of a possibly-qualified name, as written.</summary>
+    public static string? QualifiedNameOf(J? expression) => expression switch
+    {
+        Identifier id => id.SimpleName,
+        FieldAccess fa => QualifiedNameOf(fa.Target) is { } target
+            ? target + "." + fa.Name.Element.SimpleName
+            : null,
+        _ => null,
+    };
+
+    /// <summary>
+    /// Looks for a name written as <c>simpleName</c> that resolves to a type other than
+    /// <c>fullyQualifiedName</c> — the in-file evidence that the short name is taken.
+    /// </summary>
+    private sealed class NameCollector(string simpleName, string fullyQualifiedName)
+        : CSharpVisitor<int>
+    {
+        internal bool Shadowed { get; private set; }
+
+        public override J VisitClassDeclaration(ClassDeclaration cd, int p)
+        {
+            Check(cd.Name.SimpleName, cd.Type);
+            return base.VisitClassDeclaration(cd, p);
+        }
+
+        public override J VisitIdentifier(Identifier identifier, int p)
+        {
+            Check(identifier.SimpleName, identifier.Type);
+            return identifier;
+        }
+
+        private void Check(string name, JavaType? type)
+        {
+            if (!Shadowed
+                && string.Equals(name, simpleName, StringComparison.Ordinal)
+                && TypeUtils.GetFullyQualifiedName(type) is { Length: > 0 } resolved
+                && !string.Equals(resolved, fullyQualifiedName, StringComparison.Ordinal))
+            {
+                Shadowed = true;
+            }
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/AssemblyTypeEnumerator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/AssemblyTypeEnumerator.cs
@@ -210,9 +210,20 @@ internal sealed class AssemblyTypeMapping
             : null;
 
         cls.UnsafeSet(flags, kind, fqn, typeParameters, supertype, owningClass,
-            null, interfaces, MapMembers(symbol, cls), MapMethods(symbol, cls));
+            ListAnnotations(symbol), interfaces, MapMembers(symbol, cls), MapMethods(symbol, cls));
         return cls;
     }
+
+    /// <summary>
+    /// The attributes on a symbol. This is the only place a referenced control's
+    /// <c>[TemplatePart]</c>s can come from once the source set has been parsed: an LST resolves
+    /// dependency types through the type table this enumerator feeds, not through the per-file
+    /// parse, so an attribute mapped only by <see cref="CSharpTypeMapping"/> would not survive a
+    /// build.
+    /// </summary>
+    private IList<JavaType.FullyQualified>? ListAnnotations(ISymbol symbol) =>
+        AttributeMapping.ListAnnotations(symbol, Map, MapVariable,
+            m => Map(m.ContainingType) is JavaType.Class owner ? MapMethod(m, owner) : null);
 
     private List<JavaType.Variable>? MapMembers(INamedTypeSymbol symbol, JavaType.Class owner)
     {
@@ -247,7 +258,14 @@ internal sealed class AssemblyTypeMapping
 
     private JavaType.Method MapMethod(IMethodSymbol symbol, JavaType.Class owner)
     {
+        // Shell-cache before mapping annotations: an attribute applied to an attribute class'
+        // own constructor leads straight back here.
+        if (_cache.TryGetValue(symbol, out var cached) && cached is JavaType.Method cachedMethod)
+        {
+            return cachedMethod;
+        }
         var method = new JavaType.Method();
+        _cache[symbol] = method;
         // Constructors return void in Roslyn, but the Java model expects the declaring type.
         var returnType = symbol.MethodKind == MethodKind.Constructor
             ? owner
@@ -260,15 +278,16 @@ internal sealed class AssemblyTypeMapping
             symbol.Parameters.Length > 0 ? symbol.Parameters.Select(p => p.Name).ToList() : null,
             symbol.Parameters.Length > 0 ? symbol.Parameters.Select(p => Map(p.Type)).ToList()! : null,
             null,
-            null,
+            null, // annotations, set below once this method's shell is cached
             null,
             symbol.TypeParameters.Length > 0 ? symbol.TypeParameters.Select(tp => tp.Name).ToList() : null);
+        method.Annotations = ListAnnotations(symbol);
         return method;
     }
 
     private JavaType.Variable MapVariable(ISymbol symbol, string name, JavaType? owner, JavaType? type)
     {
-        return new JavaType.Variable(name, owner, type, null)
+        return new JavaType.Variable(name, owner, type, ListAnnotations(symbol))
         {
             FlagsBitMap = CSharpTypeMapping.MapFlags(symbol)
         };

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/AssemblyTypeEnumerator.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/AssemblyTypeEnumerator.cs
@@ -258,8 +258,6 @@ internal sealed class AssemblyTypeMapping
 
     private JavaType.Method MapMethod(IMethodSymbol symbol, JavaType.Class owner)
     {
-        // Shell-cache before mapping annotations: an attribute applied to an attribute class'
-        // own constructor leads straight back here.
         if (_cache.TryGetValue(symbol, out var cached) && cached is JavaType.Method cachedMethod)
         {
             return cachedMethod;
@@ -278,7 +276,7 @@ internal sealed class AssemblyTypeMapping
             symbol.Parameters.Length > 0 ? symbol.Parameters.Select(p => p.Name).ToList() : null,
             symbol.Parameters.Length > 0 ? symbol.Parameters.Select(p => Map(p.Type)).ToList()! : null,
             null,
-            null, // annotations, set below once this method's shell is cached
+            null,
             null,
             symbol.TypeParameters.Length > 0 ? symbol.TypeParameters.Select(tp => tp.Name).ToList() : null);
         method.Annotations = ListAnnotations(symbol);

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/AttributeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/AttributeMapping.cs
@@ -191,18 +191,11 @@ internal static class AttributeMapping
         switch (constant.Kind)
         {
             case TypedConstantKind.Type:
-                // typeof(X). A null argument (`typeof` cannot be null, but a `Type`-typed element
-                // left at its default can) carries no type to reference.
                 return constant.Value is ITypeSymbol typeValue
                     ? (null, mapType(typeValue))
                     : (null, null);
 
             case TypedConstantKind.Enum:
-                // Java maps an enum-valued element to the enum constant's VarSymbol, i.e. a
-                // JavaType.Variable. Roslyn only carries the underlying numeric value, so the
-                // member has to be recovered from it. A combination of [Flags] members matches no
-                // single member; rather than invent one, the underlying value is kept as the
-                // constant so nothing is silently mis-named.
                 return MapEnumConstant(constant, mapType, mapMember) is { } member
                     ? (null, member)
                     : (constant.Value, null);
@@ -211,11 +204,9 @@ internal static class AttributeMapping
                 return (constant.Value, null);
 
             case TypedConstantKind.Array:
-                // A nested array (jagged attribute arguments are not expressible in C#).
                 return (null, JavaType.Unknown.Instance);
 
             default:
-                // TypedConstantKind.Error - the argument did not compile.
                 return (null, JavaType.Unknown.Instance);
         }
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/AttributeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/AttributeMapping.cs
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using Microsoft.CodeAnalysis;
+using OpenRewrite.Java;
+
+namespace OpenRewrite.CSharp;
+
+/// <summary>
+/// Maps a Roslyn symbol's attributes onto <see cref="JavaType"/>'s <c>Annotations</c>, mirroring
+/// <c>ReloadableJava21TypeMapping</c>'s <c>listAnnotations</c>/<c>annotationType</c>/
+/// <c>annotationElementValue</c>.
+/// <para>
+/// Shared by the two mappers that build <see cref="JavaType"/> from Roslyn symbols —
+/// <see cref="CSharpTypeMapping"/> for the file being parsed and <c>AssemblyTypeMapping</c> for
+/// the dependency type table — so a control's <c>[TemplatePart]</c>s look the same whether the
+/// control is in the analysed source or in a referenced assembly. Each caller supplies its own
+/// type and member mappings, so an attribute's type resolves to the same instance every other
+/// reference to that type does, and so each mapper keeps its own cycle-breaking cache.
+/// </para>
+/// </summary>
+internal static class AttributeMapping
+{
+    /// <summary>
+    /// Maps a member (property, field or enum constant) of an attribute class.
+    /// </summary>
+    internal delegate JavaType.Variable MapMember(
+        ISymbol symbol, string name, JavaType? owner, JavaType? type);
+
+    /// <summary>
+    /// Maps a method (an attribute class' constructor, for positional arguments that name no
+    /// property).
+    /// </summary>
+    internal delegate JavaType.Method? MapMethodSymbol(IMethodSymbol symbol);
+
+    /// <summary>
+    /// The attributes applied to a symbol, or null when it carries none, matching
+    /// <c>ReloadableJava21TypeMapping.listAnnotations</c>' null-for-empty convention.
+    /// </summary>
+    internal static IList<JavaType.FullyQualified>? ListAnnotations(
+        ISymbol symbol, Func<ITypeSymbol?, JavaType?> mapType, MapMember mapMember,
+        MapMethodSymbol mapMethod)
+    {
+        var attributes = symbol.GetAttributes();
+        if (attributes.Length == 0) return null;
+
+        List<JavaType.FullyQualified>? annotations = null;
+        foreach (var attribute in attributes)
+        {
+            if (MapAnnotation(attribute, mapType, mapMember, mapMethod) is not { } mapped) continue;
+            (annotations ??= new List<JavaType.FullyQualified>(attributes.Length)).Add(mapped);
+        }
+        return annotations;
+    }
+
+    /// <summary>
+    /// Maps one attribute application, mirroring <c>ReloadableJava21TypeMapping.annotationType</c>.
+    /// </summary>
+    /// <remarks>
+    /// Java annotation elements are always named, because they are interface methods. C# splits
+    /// them into positional constructor arguments and named property/field initializers. Named
+    /// arguments resolve to the property or field they name. A positional argument has no name of
+    /// its own, so it is resolved to the property or field the constructor parameter feeds, matched
+    /// case-insensitively on the parameter name — the near-universal C# convention
+    /// (<c>ObsoleteAttribute(string message)</c> -> <c>Message</c>). When no such member exists
+    /// (<c>ObsoleteAttribute(..., bool error)</c> feeds <c>IsError</c>) the value's element is the
+    /// constructor itself: guessing a differently-named member would misattribute the value, and
+    /// Java's <c>ElementValue.getElement()</c> contract is non-null, so an element-less value
+    /// cannot cross the RPC boundary. A value whose element resolves to nothing at all (only
+    /// possible for code that does not compile) is omitted entirely.
+    /// </remarks>
+    private static JavaType.Annotation? MapAnnotation(
+        AttributeData attribute, Func<ITypeSymbol?, JavaType?> mapType, MapMember mapMember,
+        MapMethodSymbol mapMethod)
+    {
+        if (attribute.AttributeClass is not { } attributeClass ||
+            attributeClass is IErrorTypeSymbol ||
+            mapType(attributeClass) is not JavaType.FullyQualified annotationType)
+        {
+            return null;
+        }
+
+        List<JavaType.Annotation.ElementValue>? values = null;
+
+        if (attribute.AttributeConstructor is { } constructor)
+        {
+            for (int i = 0; i < attribute.ConstructorArguments.Length && i < constructor.Parameters.Length; i++)
+            {
+                JavaType? element =
+                    MapAnnotationElement(attributeClass, constructor.Parameters[i].Name, mapType, mapMember)
+                    ?? (JavaType?)mapMethod(constructor);
+                if (element == null) continue;
+                (values ??= []).Add(
+                    MapAnnotationElementValue(element, attribute.ConstructorArguments[i], mapType, mapMember));
+            }
+        }
+
+        foreach (var named in attribute.NamedArguments)
+        {
+            if (MapAnnotationElement(attributeClass, named.Key, mapType, mapMember) is not { } element) continue;
+            (values ??= []).Add(MapAnnotationElementValue(element, named.Value, mapType, mapMember));
+        }
+
+        return new JavaType.Annotation(annotationType, values);
+    }
+
+    /// <summary>
+    /// Resolves the annotation element a value belongs to: the property or field of the attribute
+    /// class with that name, matched case-insensitively so that a constructor parameter finds the
+    /// property it feeds. Base types are searched too, since an attribute may inherit its elements.
+    /// </summary>
+    private static JavaType.Variable? MapAnnotationElement(
+        INamedTypeSymbol attributeClass, string name,
+        Func<ITypeSymbol?, JavaType?> mapType, MapMember mapMember)
+    {
+        for (INamedTypeSymbol? type = attributeClass; type != null; type = type.BaseType)
+        {
+            foreach (var member in type.GetMembers())
+            {
+                var memberType = member switch
+                {
+                    IPropertySymbol p => p.Type,
+                    IFieldSymbol f => f.Type,
+                    _ => null
+                };
+
+                if (memberType == null ||
+                    !string.Equals(member.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                return mapMember(member, member.Name, mapType(type), mapType(memberType));
+            }
+        }
+        return null;
+    }
+
+    private static JavaType.Annotation.ElementValue MapAnnotationElementValue(
+        JavaType? element, TypedConstant constant,
+        Func<ITypeSymbol?, JavaType?> mapType, MapMember mapMember)
+    {
+        if (constant.Kind == TypedConstantKind.Array)
+        {
+            if (constant.IsNull)
+            {
+                return new JavaType.Annotation.ArrayElementValue(element, null, null);
+            }
+
+            List<object?>? constantValues = null;
+            List<JavaType>? referenceValues = null;
+            foreach (var item in constant.Values)
+            {
+                var (itemConstant, itemReference) = MapAnnotationConstant(item, mapType, mapMember);
+                if (itemReference != null)
+                {
+                    (referenceValues ??= []).Add(itemReference);
+                }
+                else
+                {
+                    (constantValues ??= []).Add(itemConstant);
+                }
+            }
+            return new JavaType.Annotation.ArrayElementValue(element, constantValues, referenceValues);
+        }
+
+        var (value, reference) = MapAnnotationConstant(constant, mapType, mapMember);
+        return new JavaType.Annotation.SingleElementValue(element, value, reference);
+    }
+
+    /// <summary>
+    /// Maps a single attribute argument, mirroring
+    /// <c>ReloadableJava21TypeMapping.annotationElementValue</c>: primitives and strings become
+    /// constants, <c>typeof(X)</c> and enum members become type references.
+    /// </summary>
+    private static (object? Constant, JavaType? Reference) MapAnnotationConstant(
+        TypedConstant constant, Func<ITypeSymbol?, JavaType?> mapType, MapMember mapMember)
+    {
+        switch (constant.Kind)
+        {
+            case TypedConstantKind.Type:
+                // typeof(X). A null argument (`typeof` cannot be null, but a `Type`-typed element
+                // left at its default can) carries no type to reference.
+                return constant.Value is ITypeSymbol typeValue
+                    ? (null, mapType(typeValue))
+                    : (null, null);
+
+            case TypedConstantKind.Enum:
+                // Java maps an enum-valued element to the enum constant's VarSymbol, i.e. a
+                // JavaType.Variable. Roslyn only carries the underlying numeric value, so the
+                // member has to be recovered from it. A combination of [Flags] members matches no
+                // single member; rather than invent one, the underlying value is kept as the
+                // constant so nothing is silently mis-named.
+                return MapEnumConstant(constant, mapType, mapMember) is { } member
+                    ? (null, member)
+                    : (constant.Value, null);
+
+            case TypedConstantKind.Primitive:
+                return (constant.Value, null);
+
+            case TypedConstantKind.Array:
+                // A nested array (jagged attribute arguments are not expressible in C#).
+                return (null, JavaType.Unknown.Instance);
+
+            default:
+                // TypedConstantKind.Error - the argument did not compile.
+                return (null, JavaType.Unknown.Instance);
+        }
+    }
+
+    private static JavaType.Variable? MapEnumConstant(
+        TypedConstant constant, Func<ITypeSymbol?, JavaType?> mapType, MapMember mapMember)
+    {
+        if (constant.Type is not INamedTypeSymbol { TypeKind: TypeKind.Enum } enumType) return null;
+
+        foreach (var member in enumType.GetMembers())
+        {
+            if (member is IFieldSymbol { IsConst: true, HasConstantValue: true } field &&
+                Equals(field.ConstantValue, constant.Value))
+            {
+                return mapMember(field, field.Name, mapType(enumType), mapType(enumType));
+            }
+        }
+        return null;
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -2155,6 +2155,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var prefix = ExtractPrefix(node);
 
+        // Parse attribute lists
+        var attributeLists = new List<AttributeList>();
+        foreach (var attrList in node.AttributeLists)
+        {
+            attributeLists.Add((AttributeList)Visit(attrList)!);
+        }
+
         // Parse modifiers
         var modifiers = new List<Modifier>();
         foreach (var mod in node.Modifiers)
@@ -2225,9 +2232,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.SemicolonToken.Span.End;
         }
 
-        return new PropertyDeclaration(
+        var propertyDecl = new PropertyDeclaration(
             Guid.NewGuid(),
-            prefix,
+            attributeLists.Count > 0 ? Space.Empty : prefix,
             Markers.Empty,
             [],
             modifiers,
@@ -2238,6 +2245,22 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             expressionBody,
             initializer
         );
+
+        // C# attributes are modelled as an AnnotatedStatement wrapper, matching fields, methods
+        // and type declarations. The wrapper owns the declaration's leading whitespace; the space
+        // between the attribute list and the declaration is already held by the first modifier.
+        if (attributeLists.Count > 0)
+        {
+            return new AnnotatedStatement(
+                Guid.NewGuid(),
+                prefix,
+                Markers.Empty,
+                attributeLists,
+                propertyDecl
+            );
+        }
+
+        return propertyDecl;
     }
 
     private new Block VisitAccessorList(AccessorListSyntax node)
@@ -8746,17 +8769,21 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             Markers.Empty,
             [],
             rightText,
-            null,
+            _typeMapping?.Type(qualified.Right),
             null
         );
 
+        // Attribute the qualified name itself, so a type written in fully qualified form
+        // (`System.Windows.DependencyProperty x = ...`) carries the same type as the simple
+        // form. Resolves to null for the namespace segments of a qualified name, which is
+        // correct — only the full name denotes a type.
         return new FieldAccess(
             Guid.NewGuid(),
             prefix,
             Markers.Empty,
             left,
             new JLeftPadded<Identifier>(dotSpace, right),
-            null
+            _typeMapping?.Type(qualified)
         );
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -2155,7 +2155,6 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var prefix = ExtractPrefix(node);
 
-        // Parse attribute lists
         var attributeLists = new List<AttributeList>();
         foreach (var attrList in node.AttributeLists)
         {
@@ -2246,9 +2245,6 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             initializer
         );
 
-        // C# attributes are modelled as an AnnotatedStatement wrapper, matching fields, methods
-        // and type declarations. The wrapper owns the declaration's leading whitespace; the space
-        // between the attribute list and the declaration is already held by the first modifier.
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
@@ -8554,10 +8550,6 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 );
             }
 
-            // Attribute the outermost ArrayType with the whole array type, so `typeof(int[])` and
-            // an array-typed declaration carry a resolvable type like every other TypeTree does.
-            // Inner levels of a jagged/multi-rank type stay unattributed: the syntax nests the
-            // ranks in the opposite order from the symbol, so there is no per-level type to hand out.
             if (result is ArrayType outermost)
             {
                 result = outermost.WithType(_typeMapping?.Type(arrayType));
@@ -8782,10 +8774,6 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             null
         );
 
-        // Attribute the qualified name itself, so a type written in fully qualified form
-        // (`System.Windows.DependencyProperty x = ...`) carries the same type as the simple
-        // form. Resolves to null for the namespace segments of a qualified name, which is
-        // correct — only the full name denotes a type.
         return new FieldAccess(
             Guid.NewGuid(),
             prefix,

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -8554,6 +8554,15 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 );
             }
 
+            // Attribute the outermost ArrayType with the whole array type, so `typeof(int[])` and
+            // an array-typed declaration carry a resolvable type like every other TypeTree does.
+            // Inner levels of a jagged/multi-rank type stay unattributed: the syntax nests the
+            // ranks in the opposite order from the symbol, so there is no per-level type to hand out.
+            if (result is ArrayType outermost)
+            {
+                result = outermost.WithType(_typeMapping?.Type(arrayType));
+            }
+
             return result;
         }
         else if (type is TupleTypeSyntax tupleType)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -1320,9 +1320,10 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
             p.Append(GetClassKindString(classDecl.ClassKind.Type));
         }
 
-        // Print name
-        VisitSpace(classDecl.Name.Prefix, p);
-        p.Append(classDecl.Name.SimpleName);
+        // Print name. Visit the Identifier rather than appending its SimpleName: VisitIdentifier
+        // emits the prefix and the node's markers, so hand-rolling the two would discard any marker
+        // a search recipe attached to the class name.
+        Visit(classDecl.Name, p);
 
         // Print type parameters (generics) — only print <attrs variance name, ...>
         if (classDecl.TypeParameters != null)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -1320,9 +1320,7 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
             p.Append(GetClassKindString(classDecl.ClassKind.Type));
         }
 
-        // Print name. Visit the Identifier rather than appending its SimpleName: VisitIdentifier
-        // emits the prefix and the node's markers, so hand-rolling the two would discard any marker
-        // a search recipe attached to the class name.
+        // Print name
         Visit(classDecl.Name, p);
 
         // Print type parameters (generics) — only print <attrs variance name, ...>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -238,12 +238,101 @@ internal class CSharpTypeMapping
             ? symbol.Interfaces.Select(i => (JavaType.FullyQualified)MapType(i)!).ToList()
             : null;
 
-        // For now, skip members and methods to avoid excessive traversal
-        // These can be populated lazily or in a future enhancement
         cls.UnsafeSet(flags, kind, fqn, typeParameters, supertype, owningClass,
             null, interfaces, null, null);
 
+        // Members/methods are populated only once the shell above is in the cache, so a member
+        // whose signature refers back to the declaring type resolves to that shell instead of
+        // recursing forever. Population itself is queued rather than nested (see DrainMemberQueue)
+        // so that the transitive member -> signature type -> its members walk stays iterative.
+        _memberQueue.Enqueue((symbol, cls));
+        DrainMemberQueue();
+
         return cls;
+    }
+
+    /// <summary>
+    /// Types whose <see cref="JavaType.Class.Members"/>/<see cref="JavaType.Class.Methods"/>
+    /// still need filling in. Populating a type's members maps the member signature types, which
+    /// in turn queues those types; draining iteratively keeps the recursion depth bounded by the
+    /// supertype/interface/type-argument graph rather than by the member graph.
+    /// </summary>
+    private readonly Queue<(INamedTypeSymbol Symbol, JavaType.Class Class)> _memberQueue = new();
+
+    private bool _draining;
+
+    private void DrainMemberQueue()
+    {
+        if (_draining) return;
+        _draining = true;
+        try
+        {
+            while (_memberQueue.Count > 0)
+            {
+                var (symbol, cls) = _memberQueue.Dequeue();
+                PopulateMembers(symbol, cls);
+            }
+        }
+        finally
+        {
+            _draining = false;
+        }
+    }
+
+    /// <summary>
+    /// Maps the members a type <em>declares</em> (inherited members stay reachable through
+    /// <see cref="JavaType.Class.Supertype"/>/<see cref="JavaType.Class.Interfaces"/>, matching
+    /// the Java type mapping). Compiler-generated members (auto-property backing fields, property
+    /// and event accessors, static initializers, and anything with a mangled name) are skipped.
+    /// </summary>
+    private void PopulateMembers(INamedTypeSymbol symbol, JavaType.Class cls)
+    {
+        List<JavaType.Variable>? members = null;
+        List<JavaType.Method>? methods = null;
+
+        foreach (var member in symbol.GetMembers())
+        {
+            if (IsCompilerGenerated(member)) continue;
+
+            switch (member)
+            {
+                case IFieldSymbol field:
+                    (members ??= []).Add(MapVariable(field, field.Name, cls, MapType(field.Type)));
+                    break;
+                case IPropertySymbol property:
+                    (members ??= []).Add(MapVariable(property, property.Name, cls, MapType(property.Type)));
+                    break;
+                case IEventSymbol evt:
+                    (members ??= []).Add(MapVariable(evt, evt.Name, cls, MapType(evt.Type)));
+                    break;
+                case IMethodSymbol method:
+                    (methods ??= []).Add(MapMethod(method));
+                    break;
+            }
+        }
+
+        cls.Members = members;
+        cls.Methods = methods;
+    }
+
+    private static bool IsCompilerGenerated(ISymbol member)
+    {
+        // Mangled names: auto-property backing fields (`<Prop>k__BackingField`), record `<Clone>$`,
+        // iterator/async state machines, etc.
+        if (member.Name.Length == 0 || member.Name[0] == '<') return true;
+
+        return member switch
+        {
+            // Backing field of an auto-property or field-like event.
+            IFieldSymbol field => field.AssociatedSymbol != null,
+            // get_/set_/init_/add_/remove_ accessors; the property/event itself is already listed.
+            // Static constructors mirror Java's skipping of static initializer blocks.
+            IMethodSymbol method => method.AssociatedSymbol != null ||
+                                    method.MethodKind == MethodKind.StaticConstructor,
+            // Nested types are reachable via their own mapping, not through Members/Methods.
+            INamedTypeSymbol => true,
+            _ => false
+        };
     }
 
     private JavaType MapArrayType(IArrayTypeSymbol symbol)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -160,10 +160,6 @@ internal class CSharpTypeMapping
             ILocalSymbol l => MapVariable(l, l.Name, null, MapType(l.Type)),
             IParameterSymbol p => MapVariable(p, p.Name, null, MapType(p.Type)),
             IPropertySymbol prop => MapVariable(prop, prop.Name, MapType(prop.ContainingType), MapType(prop.Type)),
-            // An event is a member reference like a field or property. Java has no IEventSymbol
-            // counterpart, but JavaType.Variable carries everything a reference to one needs —
-            // name, declaring type, delegate type — and PopulateMembers already lists events that
-            // way, so attributing references the same way keeps the two consistent.
             IEventSymbol evt => MapVariable(evt, evt.Name, MapType(evt.ContainingType), MapType(evt.Type)),
             _ => null
         };
@@ -246,10 +242,6 @@ internal class CSharpTypeMapping
         cls.UnsafeSet(flags, kind, fqn, typeParameters, supertype, owningClass,
             null, interfaces, null, null);
 
-        // Members/methods are populated only once the shell above is in the cache, so a member
-        // whose signature refers back to the declaring type resolves to that shell instead of
-        // recursing forever. Population itself is queued rather than nested (see DrainMemberQueue)
-        // so that the transitive member -> signature type -> its members walk stays iterative.
         _memberQueue.Enqueue((symbol, cls));
         DrainMemberQueue();
 
@@ -292,9 +284,6 @@ internal class CSharpTypeMapping
     /// </summary>
     private void PopulateMembers(INamedTypeSymbol symbol, JavaType.Class cls)
     {
-        // Attributes are mapped here rather than in MapNamedType for the same reason members are:
-        // an attribute class is itself a type, so mapping one re-enters the mapper. Doing it from
-        // inside the drain loop means that re-entry only enqueues, keeping the walk iterative.
         cls.Annotations = ListAnnotations(symbol);
 
         List<JavaType.Variable>? members = null;
@@ -327,19 +316,13 @@ internal class CSharpTypeMapping
 
     private static bool IsCompilerGenerated(ISymbol member)
     {
-        // Mangled names: auto-property backing fields (`<Prop>k__BackingField`), record `<Clone>$`,
-        // iterator/async state machines, etc.
         if (member.Name.Length == 0 || member.Name[0] == '<') return true;
 
         return member switch
         {
-            // Backing field of an auto-property or field-like event.
             IFieldSymbol field => field.AssociatedSymbol != null,
-            // get_/set_/init_/add_/remove_ accessors; the property/event itself is already listed.
-            // Static constructors mirror Java's skipping of static initializer blocks.
             IMethodSymbol method => method.AssociatedSymbol != null ||
                                     method.MethodKind == MethodKind.StaticConstructor,
-            // Nested types are reachable via their own mapping, not through Members/Methods.
             INamedTypeSymbol => true,
             _ => false
         };
@@ -404,15 +387,13 @@ internal class CSharpTypeMapping
             parameterNames,
             parameterTypes,
             null, // thrownExceptions (C# doesn't have checked exceptions)
-            null, // annotations, set below once this method is cached
+            null, // annotations
             null, // defaultValue
             symbol.TypeParameters.Length > 0
                 ? symbol.TypeParameters.Select(tp => tp.Name).ToList()
                 : null
         );
 
-        // Set after the shell is cached and populated: mapping an attribute maps its type, which
-        // can lead back here (an attribute class' own constructor, say).
         method.Annotations = ListAnnotations(symbol);
 
         return method;
@@ -428,8 +409,6 @@ internal class CSharpTypeMapping
             FlagsBitMap = MapFlags(symbol)
         };
         _typeCache[symbol] = variable;
-        // Set after caching, so that an attribute whose mapping leads back to this same symbol
-        // resolves to the shell rather than recursing.
         variable.Annotations = ListAnnotations(symbol);
         return variable;
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -160,6 +160,11 @@ internal class CSharpTypeMapping
             ILocalSymbol l => MapVariable(l, l.Name, null, MapType(l.Type)),
             IParameterSymbol p => MapVariable(p, p.Name, null, MapType(p.Type)),
             IPropertySymbol prop => MapVariable(prop, prop.Name, MapType(prop.ContainingType), MapType(prop.Type)),
+            // An event is a member reference like a field or property. Java has no IEventSymbol
+            // counterpart, but JavaType.Variable carries everything a reference to one needs —
+            // name, declaring type, delegate type — and PopulateMembers already lists events that
+            // way, so attributing references the same way keeps the two consistent.
+            IEventSymbol evt => MapVariable(evt, evt.Name, MapType(evt.ContainingType), MapType(evt.Type)),
             _ => null
         };
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpTypeMapping.cs
@@ -292,6 +292,11 @@ internal class CSharpTypeMapping
     /// </summary>
     private void PopulateMembers(INamedTypeSymbol symbol, JavaType.Class cls)
     {
+        // Attributes are mapped here rather than in MapNamedType for the same reason members are:
+        // an attribute class is itself a type, so mapping one re-enters the mapper. Doing it from
+        // inside the drain loop means that re-entry only enqueues, keeping the walk iterative.
+        cls.Annotations = ListAnnotations(symbol);
+
         List<JavaType.Variable>? members = null;
         List<JavaType.Method>? methods = null;
 
@@ -399,12 +404,16 @@ internal class CSharpTypeMapping
             parameterNames,
             parameterTypes,
             null, // thrownExceptions (C# doesn't have checked exceptions)
-            null, // annotations
+            null, // annotations, set below once this method is cached
             null, // defaultValue
             symbol.TypeParameters.Length > 0
                 ? symbol.TypeParameters.Select(tp => tp.Name).ToList()
                 : null
         );
+
+        // Set after the shell is cached and populated: mapping an attribute maps its type, which
+        // can lead back here (an attribute class' own constructor, say).
+        method.Annotations = ListAnnotations(symbol);
 
         return method;
     }
@@ -419,8 +428,19 @@ internal class CSharpTypeMapping
             FlagsBitMap = MapFlags(symbol)
         };
         _typeCache[symbol] = variable;
+        // Set after caching, so that an attribute whose mapping leads back to this same symbol
+        // resolves to the shell rather than recursing.
+        variable.Annotations = ListAnnotations(symbol);
         return variable;
     }
+
+    /// <summary>
+    /// Maps the attributes applied to a symbol onto <c>Annotations</c>. The type and member
+    /// mappings passed in are this mapper's, so an attribute's type resolves to the same instance
+    /// every other reference to it does.
+    /// </summary>
+    private IList<JavaType.FullyQualified>? ListAnnotations(ISymbol symbol) =>
+        AttributeMapping.ListAnnotations(symbol, MapType, MapVariable, MapMethod);
 
     internal static JavaType.Primitive? MapPrimitive(INamedTypeSymbol symbol)
     {

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
@@ -144,6 +144,20 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         };
     }
 
+    /// <summary>
+    /// Registers an <see cref="AddUsing{P}"/> after-visitor (once per type) that adds
+    /// <c>using &lt;namespace&gt;;</c> for the namespace of
+    /// <paramref name="fullyQualifiedTypeName"/> when the current source file has been fully
+    /// visited — the C# counterpart of Java's <c>maybeAddImport</c>. No-op when the using is
+    /// already present, when the type is not referenced by its simple name (unless
+    /// <paramref name="onlyIfReferenced"/> is false), or when the file already binds the simple
+    /// name to a different type.
+    /// </summary>
+    public void MaybeAddUsing(string fullyQualifiedTypeName, bool onlyIfReferenced = true)
+    {
+        MaybeDoAfterVisit(new AddUsing<P>(fullyQualifiedTypeName, onlyIfReferenced));
+    }
+
     public virtual J VisitCompilationUnit(CompilationUnit compilationUnit, P p)
     {
         return compilationUnit

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Cs.cs
@@ -52,6 +52,20 @@ public sealed class ExpressionStatement(
     public Space Prefix => Expression.Prefix;
     public Markers Markers => Expression.Markers;
 
+    /// <summary>
+    /// Delegates to the wrapped expression, mirroring <see cref="Markers"/>. Without it the
+    /// reflective wither lookup in <c>Markup</c>/<c>SearchResult</c> finds nothing on this type,
+    /// so marking a bare expression statement (<c>Foo();</c>) would silently drop the marker.
+    /// </summary>
+    public ExpressionStatement WithMarkers(Markers markers) =>
+        WithExpression(J.SetMarkers(Expression, markers));
+
+    /// <summary>
+    /// Delegates to the wrapped expression, mirroring <see cref="Prefix"/>.
+    /// </summary>
+    public ExpressionStatement WithPrefix(Space prefix) =>
+        WithExpression(J.SetPrefix(Expression, prefix));
+
     Tree Tree.WithId(Guid id) => WithId(id);
 
     public bool Equals(ExpressionStatement? other) => other is not null && Id == other.Id;

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/DirectiveBoundaryInjector.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/DirectiveBoundaryInjector.cs
@@ -84,7 +84,7 @@ public partial class DirectiveBoundaryInjector : CSharpVisitor<int>
 
         var marker = new DirectiveBoundaryMarker(Guid.NewGuid(), indices);
         var newMarkers = node.Markers.Add(marker);
-        return SetMarkers(node, newMarkers);
+        return J.SetMarkers(node, newMarkers);
     }
 
     private static List<int> FindDirectiveIndices(Space space)
@@ -102,15 +102,5 @@ public partial class DirectiveBoundaryInjector : CSharpVisitor<int>
             }
         }
         return indices;
-    }
-
-    /// <summary>
-    /// Uses reflection to call WithMarkers on any concrete J type,
-    /// following the pattern established by <see cref="SearchResult.Found{T}"/>.
-    /// </summary>
-    private static J SetMarkers(J node, Markers markers)
-    {
-        var withMarkers = node.GetType().GetMethod("WithMarkers", [typeof(Markers)]);
-        return withMarkers != null ? (J)withMarkers.Invoke(node, [markers])! : node;
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -1743,11 +1743,15 @@ public class RewriteRpcServer
     /// Returns the (possibly modified) tree.
     /// </summary>
     public Tree VisitOnRemote(string visitorName, string treeId, string? sourceFileType,
-        string? pId = null)
+        string? pId = null, Dictionary<string, object?>? visitorOptions = null)
     {
         var response = _jsonRpc!.InvokeWithParameterObjectAsync<VisitResponse>(
             "Visit",
-            new VisitRequest { VisitorName = visitorName, TreeId = treeId, SourceFileType = sourceFileType, PId = pId }
+            new VisitRequest
+            {
+                VisitorName = visitorName, TreeId = treeId, SourceFileType = sourceFileType,
+                PId = pId, VisitorOptions = visitorOptions
+            }
         ).GetAwaiter().GetResult();
 
         Log.Debug("RPC VisitOnRemote: {VisitorName} on {TreeId} => modified={Modified}",
@@ -2362,6 +2366,12 @@ public class VisitRequest
     public string? PId { get; set; }
     [JsonPropertyName("cursor")]
     public List<string>? CursorIds { get; set; }
+
+    /// <summary>
+    /// Constructor/property values for a visitor the peer instantiates by class name
+    /// (see Java's <c>PreparedRecipeCache.instantiateVisitor</c>).
+    /// </summary>
+    public Dictionary<string, object?>? VisitorOptions { get; set; }
 }
 
 public class VisitResponse

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Markup.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Markup.cs
@@ -31,12 +31,16 @@ public abstract class Markup(Guid id, string message, string? detail) : Marker, 
     public override bool Equals(object? obj) => Equals(obj as Markup);
     public override int GetHashCode() => Id.GetHashCode();
 
+    /// <summary>
+    /// Attaches <paramref name="marker"/> to <paramref name="tree"/>, resolving the wither on the
+    /// concrete type. Throws when the node exposes none: a search recipe's whole output is the marker
+    /// it attaches, so quietly returning the node unchanged reports "no findings" for code that does
+    /// have them — a failure mode with no symptom at all. Every J type in this assembly exposes
+    /// <c>WithMarkers(Markers)</c> (enforced by <c>JWitherContractTests</c>), so this cannot fire for
+    /// in-tree nodes.
+    /// </summary>
     private static T AddMarker<T>(T tree, Markup marker) where T : J
-    {
-        var newMarkers = tree.Markers.Add(marker);
-        var withMarkers = tree.GetType().GetMethod("WithMarkers", [typeof(Markers)]);
-        return withMarkers != null ? (T)withMarkers.Invoke(tree, [newMarkers])! : tree;
-    }
+        => J.SetMarkers(tree, tree.Markers.Add(marker));
 
     /// <summary>
     /// Adds an Error markup marker to the given tree node.

--- a/rewrite-csharp/csharp/OpenRewrite/Core/ParseError.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/ParseError.cs
@@ -44,6 +44,9 @@ public sealed class ParseError(
     public Tree WithId(Guid id) =>
         id == Id ? this : new ParseError(id, Markers, SourcePath, CharsetName, CharsetBomMarked, Checksum, FileAttributes, Text);
 
+    public ParseError WithMarkers(Markers markers) =>
+        ReferenceEquals(markers, Markers) ? this : new ParseError(Id, markers, SourcePath, CharsetName, CharsetBomMarked, Checksum, FileAttributes, Text);
+
     public SourceFile WithSourcePath(string sourcePath) =>
         sourcePath == SourcePath ? this : new ParseError(Id, Markers, sourcePath, CharsetName, CharsetBomMarked, Checksum, FileAttributes, Text);
 

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Collections.Concurrent;
 using Rewrite.Core.Rpc;
 using static OpenRewrite.Core.Rpc.RpcObjectData;
 using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;
@@ -24,8 +25,14 @@ public class RpcSendQueue
     /// <summary>
     /// Overrides for C# types whose Java names don't follow the convention.
     /// Key: C# type, Value: Java fully-qualified class name.
+    /// <para>
+    /// Concurrent because process-wide: registration happens on whichever thread first loads a
+    /// recipe bundle, while <see cref="ToJavaTypeName"/> reads it from every send queue in
+    /// parallel. A plain <c>Dictionary</c> here corrupts its internal buckets under a concurrent
+    /// write, which surfaces as spurious <c>IndexOutOfRangeException</c>s on unrelated reads.
+    /// </para>
     /// </summary>
-    private static readonly Dictionary<Type, string> JavaTypeNameOverrides = new();
+    private static readonly ConcurrentDictionary<Type, string> JavaTypeNameOverrides = new();
 
     public static void RegisterJavaTypeName(Type csharpType, string javaTypeName)
     {

--- a/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
@@ -27,14 +27,25 @@ public sealed class SearchResult(Guid id, string? description) : Marker, IRpcCod
     public string? Description { get; } = description;
 
     /// <summary>
-    /// Adds a SearchResult marker to the given tree node.
-    /// Uses reflection to call WithMarkers on the concrete type.
+    /// Adds a SearchResult marker to the given tree node, resolving <c>WithMarkers(Markers)</c> on the
+    /// concrete type. Throws when the node exposes none: a search recipe's whole output is the marker
+    /// it attaches, so quietly returning the node unchanged reports "no findings" for code that does
+    /// have them — a failure mode with no symptom at all. Every concrete <c>Tree</c> type in this
+    /// assembly exposes the wither (enforced by <c>JWitherContractTests</c>), so this cannot fire for
+    /// in-tree nodes.
     /// </summary>
     public static T Found<T>(T tree, string? description = null) where T : Tree
     {
         var newMarkers = tree.Markers.Add(new SearchResult(Guid.NewGuid(), description));
+        if (tree is J j)
+            return (T)J.SetMarkers(j, newMarkers);
+
         var withMarkers = tree.GetType().GetMethod("WithMarkers", [typeof(Markers)]);
-        return withMarkers != null ? (T)withMarkers.Invoke(tree, [newMarkers])! : tree;
+        if (withMarkers == null)
+            throw new InvalidOperationException(
+                $"{tree.GetType().FullName} does not expose WithMarkers(Markers), so markers cannot be attached to it.");
+
+        return (T)withMarkers.Invoke(tree, [newMarkers])!;
     }
 
     public void RpcSend(SearchResult after, RpcSendQueue q)

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.Helpers.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.Helpers.cs
@@ -23,20 +23,47 @@ public partial interface J
 {
     private static readonly ConcurrentDictionary<Type, MethodInfo?> WithPrefixCache = new();
     private static readonly ConcurrentDictionary<Type, MethodInfo?> WithIdCache = new();
+    private static readonly ConcurrentDictionary<Type, MethodInfo?> WithMarkersCache = new();
 
     /// <summary>
     /// Call WithPrefix on any J node via cached reflection, preserving the concrete type.
-    /// Returns the original node unchanged if the type doesn't have WithPrefix.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The concrete type exposes no <c>WithPrefix(Space)</c>. Every LST node carries a prefix, so a
+    /// missing wither is a modelling defect in that node, not a runtime condition to absorb: silently
+    /// returning the node unchanged turns a formatting bug into invisible whitespace loss much further
+    /// downstream. <c>EveryJTypeExposesWithers</c> in <c>JWitherContractTests</c> keeps every type in
+    /// this assembly out of this branch.
+    /// </exception>
     public static T SetPrefix<T>(T node, Space prefix) where T : J
     {
         var method = WithPrefixCache.GetOrAdd(node.GetType(), type =>
             type.GetMethod("WithPrefix", [typeof(Space)]));
 
-        if (method != null)
-            return (T)method.Invoke(node, [prefix])!;
+        if (method == null)
+            throw new InvalidOperationException(
+                $"{node.GetType().FullName} does not expose WithPrefix(Space), so its prefix cannot be set.");
 
-        return node;
+        return (T)method.Invoke(node, [prefix])!;
+    }
+
+    /// <summary>
+    /// Call WithMarkers on any J node via cached reflection, preserving the concrete type.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// The concrete type exposes no <c>WithMarkers(Markers)</c>. See <see cref="SetPrefix{T}"/> for why
+    /// this throws rather than returning the node unchanged.
+    /// </exception>
+    public static T SetMarkers<T>(T node, Markers markers) where T : J
+    {
+        var method = WithMarkersCache.GetOrAdd(node.GetType(), type =>
+            type.GetMethod("WithMarkers", [typeof(Markers)]));
+
+        if (method == null)
+            throw new InvalidOperationException(
+                $"{node.GetType().FullName} does not expose WithMarkers(Markers), so markers cannot be attached to it.");
+
+        return (T)method.Invoke(node, [markers])!;
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
@@ -422,10 +422,6 @@ public class JavaReceiver : JavaVisitor<RpcReceiveQueue>
 
     public override J VisitLiteral(Literal literal, RpcReceiveQueue q)
     {
-        // Literal.Value is declared object, so the receive queue has no target type and hands
-        // back the raw JsonElement the formatter produced — materialize the scalar (see
-        // MaterializeScalar) or every recipe pattern like `Literal { Value: string s }` silently
-        // stops matching once the tree has crossed the RPC boundary.
         var value = MaterializeScalar(q.Receive(literal.Value));
         var valueSource = q.Receive(literal.ValueSource);
         var unicodeEscapes = q.ReceiveList(literal.UnicodeEscapes, ue => new Literal.UnicodeEscape(

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Text.Json;
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.CSharp;
@@ -421,7 +422,11 @@ public class JavaReceiver : JavaVisitor<RpcReceiveQueue>
 
     public override J VisitLiteral(Literal literal, RpcReceiveQueue q)
     {
-        var value = q.Receive(literal.Value);
+        // Literal.Value is declared object, so the receive queue has no target type and hands
+        // back the raw JsonElement the formatter produced — materialize the scalar (see
+        // MaterializeScalar) or every recipe pattern like `Literal { Value: string s }` silently
+        // stops matching once the tree has crossed the RPC boundary.
+        var value = MaterializeScalar(q.Receive(literal.Value));
         var valueSource = q.Receive(literal.ValueSource);
         var unicodeEscapes = q.ReceiveList(literal.UnicodeEscapes, ue => new Literal.UnicodeEscape(
             q.Receive(ue?.ValueSourceIndex ?? 0),
@@ -831,17 +836,39 @@ public class JavaReceiver : JavaVisitor<RpcReceiveQueue>
             {
                 var constantValues = q.ReceiveList(array.ConstantValues, x => x);
                 var refValues = q.ReceiveList(array.ReferenceValues, t => VisitType(t, q)!);
-                return new JavaType.Annotation.ArrayElementValue(element, constantValues, refValues);
+                return new JavaType.Annotation.ArrayElementValue(element,
+                    constantValues?.Select(MaterializeScalar).ToList(), refValues);
             }
             default:
             {
                 var single = v as JavaType.Annotation.SingleElementValue;
                 var constantValue = q.Receive(single?.ConstantValue);
                 var refValue = q.Receive(single?.ReferenceValue, t => VisitType(t, q)!);
-                return new JavaType.Annotation.SingleElementValue(element, constantValue, refValue);
+                return new JavaType.Annotation.SingleElementValue(element,
+                    MaterializeScalar(constantValue), refValue);
             }
         }
     }
+
+    /// <summary>
+    /// A value declared as <c>object</c> (an annotation element's constant, a literal's value)
+    /// gives the receive queue no target type to convert to, so it hands back the raw
+    /// <see cref="JsonElement"/> the formatter produced. Recipes read these values — a
+    /// <c>[TemplatePart(Name = "...")]</c> part name, a <c>Literal</c>'s string — and match them
+    /// against CLR types, so the scalar has to be materialised here. The wire does not carry the
+    /// numeric subtype (see JavaSender), so integers arrive as <c>long</c> and reals as
+    /// <c>double</c>.
+    /// </summary>
+    internal static object? MaterializeScalar(object? value) => value switch
+    {
+        JsonElement { ValueKind: JsonValueKind.String } e => e.GetString(),
+        JsonElement { ValueKind: JsonValueKind.True } => true,
+        JsonElement { ValueKind: JsonValueKind.False } => false,
+        JsonElement { ValueKind: JsonValueKind.Null } => null,
+        JsonElement { ValueKind: JsonValueKind.Number } e =>
+            e.TryGetInt64(out var l) ? l : e.GetDouble(),
+        _ => value
+    };
 
     // Utility methods
 

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
@@ -695,12 +695,6 @@ public class JavaSender : JavaVisitor<RpcSendQueue>
             case JavaType.Annotation annotation:
                 q.GetAndSend(annotation, a => AsRef(a.AnnotationType),
                     t => VisitType(GetValueNonNull<JavaType>(t), q));
-                // The identity key folds the value in alongside the element: two values of the
-                // same annotation can share an element signature (e.g. two positional arguments
-                // that both fell back to the constructor as their element), and colliding keys
-                // would pair an after-value with the wrong before-value in the list diff. Keys
-                // are sender-local, so this needs no Java-side counterpart and does not change
-                // the wire format.
                 q.GetAndSendListAsRef(
                     annotation,
                     a => a.Values,

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaSender.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Text;
 using OpenRewrite.Core;
 using OpenRewrite.Core.Rpc;
 using OpenRewrite.CSharp;
@@ -694,10 +695,17 @@ public class JavaSender : JavaVisitor<RpcSendQueue>
             case JavaType.Annotation annotation:
                 q.GetAndSend(annotation, a => AsRef(a.AnnotationType),
                     t => VisitType(GetValueNonNull<JavaType>(t), q));
+                // The identity key folds the value in alongside the element: two values of the
+                // same annotation can share an element signature (e.g. two positional arguments
+                // that both fell back to the constructor as their element), and colliding keys
+                // would pair an after-value with the wrong before-value in the list diff. Keys
+                // are sender-local, so this needs no Java-side counterpart and does not change
+                // the wire format.
                 q.GetAndSendListAsRef(
                     annotation,
                     a => a.Values,
-                    v => v.Element != null ? TypeSignature(v.Element) : "null",
+                    v => (v.Element != null ? TypeSignature(v.Element).ToString() : "{undefined}") +
+                         "=" + ElementValueSignature(v),
                     v => VisitAnnotationElementValue(v, q));
                 break;
 
@@ -849,7 +857,7 @@ public class JavaSender : JavaVisitor<RpcSendQueue>
                     (mc.ThrowableTypes ?? []).Select(TypeSignature)),
                 JavaType.Intersection i => string.Join(" & ",
                     (i.Bounds ?? []).Select(TypeSignature)),
-                JavaType.Annotation a => "@" + (a.AnnotationType != null ? TypeSignature(a.AnnotationType) : "{undefined}"),
+                JavaType.Annotation a => AnnotationSignature(a),
                 JavaType.Unknown => "{undefined}",
                 _ => "{undefined}"
             };
@@ -859,6 +867,56 @@ public class JavaSender : JavaVisitor<RpcSendQueue>
             _typeSignatureStack.Remove(type);
         }
     }
+
+    /// <summary>
+    /// Mirrors DefaultJavaTypeSignatureBuilder.annotationSignature. The element values are part of
+    /// the signature because a type may carry several annotations of the same annotation type,
+    /// distinguished only by them — <c>System.Windows.Controls.ComboBox</c> declares two
+    /// <c>[TemplatePart]</c>s. Keying on the annotation type alone would make the two collide in
+    /// the before/after index that GetAndSendListAsRef builds.
+    /// </summary>
+    private static string AnnotationSignature(JavaType.Annotation annotation)
+    {
+        var s = new StringBuilder("@");
+        s.Append(annotation.AnnotationType != null
+            ? TypeSignature(annotation.AnnotationType)
+            : "{undefined}");
+
+        var values = annotation.Values;
+        if (values is { Count: > 0 })
+        {
+            s.Append('(');
+            for (int i = 0; i < values.Count; i++)
+            {
+                if (i > 0) s.Append(',');
+                var value = values[i];
+                s.Append(value.Element != null ? TypeSignature(value.Element) : "{undefined}")
+                    .Append('=')
+                    .Append(ElementValueSignature(value));
+            }
+            s.Append(')');
+        }
+        return s.ToString();
+    }
+
+    /// <summary>
+    /// The Java builder appends <c>ElementValue.getValue()</c>, whose JavaType members render as
+    /// their own signature (JavaType.toString delegates to the signature builder).
+    /// </summary>
+    private static string ElementValueSignature(JavaType.Annotation.ElementValue value) => value switch
+    {
+        JavaType.Annotation.SingleElementValue single =>
+            single.ConstantValue != null
+                ? single.ConstantValue.ToString() ?? "null"
+                : single.ReferenceValue != null
+                    ? TypeSignature(single.ReferenceValue).ToString()!
+                    : "null",
+        JavaType.Annotation.ArrayElementValue array =>
+            "[" + string.Join(", ", array.ReferenceValues != null
+                ? array.ReferenceValues.Select(t => TypeSignature(t).ToString()!)
+                : (array.ConstantValues ?? []).Select(c => c?.ToString() ?? "null")) + "]",
+        _ => "null"
+    };
 
     private static string GetPrimitiveKeyword(JavaType.PrimitiveKind kind) => kind switch
     {

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -83,6 +83,35 @@ public abstract class RewriteTest
             csprojParsed = ParseCsprojFilesTogether(csprojSpecs);
         }
 
+        // Compile every C# source into ONE compilation, so a type declared in one file is
+        // attributed in another. This mirrors how a real run parses a whole project, and is what
+        // makes multi-file ScanningRecipe tests meaningful — with one compilation per file a
+        // cross-file reference resolves to nothing and the recipe silently sees no type.
+        var sharedTrees = new Dictionary<SourceSpec, SyntaxTree>();
+        CSharpCompilation? sharedCompilation = null;
+        if (metadataReferences != null)
+        {
+            foreach (var spec in specs)
+            {
+                var isCsproj = spec.SourcePath != null && IsCsprojPath(spec.SourcePath);
+                var isCs = spec.SourcePath == null ||
+                           spec.SourcePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
+                if (isCs && !isCsproj)
+                {
+                    sharedTrees[spec] = CSharpSyntaxTree.ParseText(
+                        spec.Before, path: spec.SourcePath ?? "source.cs");
+                }
+            }
+
+            if (sharedTrees.Count > 0)
+            {
+                sharedCompilation = CSharpCompilation.Create("TestCompilation")
+                    .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
+                    .AddReferences(metadataReferences)
+                    .AddSyntaxTrees(sharedTrees.Values);
+            }
+        }
+
         foreach (var spec in specs)
         {
             SourceFile source;
@@ -109,14 +138,9 @@ public abstract class RewriteTest
                 // Local C# parsing
                 var localSourcePath = spec.SourcePath ?? "source.cs";
                 SemanticModel? semanticModel = null;
-                if (metadataReferences != null)
+                if (sharedCompilation != null && sharedTrees.TryGetValue(spec, out var syntaxTree))
                 {
-                    var syntaxTree = CSharpSyntaxTree.ParseText(spec.Before, path: localSourcePath);
-                    var compilation = CSharpCompilation.Create("TestCompilation")
-                        .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary))
-                        .AddReferences(metadataReferences)
-                        .AddSyntaxTrees(syntaxTree);
-                    semanticModel = compilation.GetSemanticModel(syntaxTree);
+                    semanticModel = sharedCompilation.GetSemanticModel(syntaxTree);
                 }
 
                 source = parser.Parse(spec.Before, sourcePath: localSourcePath, semanticModel: semanticModel);

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RewriteTest.cs
@@ -83,10 +83,6 @@ public abstract class RewriteTest
             csprojParsed = ParseCsprojFilesTogether(csprojSpecs);
         }
 
-        // Compile every C# source into ONE compilation, so a type declared in one file is
-        // attributed in another. This mirrors how a real run parses a whole project, and is what
-        // makes multi-file ScanningRecipe tests meaningful — with one compilation per file a
-        // cross-file reference resolves to nothing and the recipe silently sees no type.
         var sharedTrees = new Dictionary<SourceSpec, SyntaxTree>();
         CSharpCompilation? sharedCompilation = null;
         if (metadataReferences != null)

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/JavaTypeAnnotationProbe.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/rpc/JavaTypeAnnotationProbe.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import lombok.RequiredArgsConstructor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.csharp.CSharpIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test-only visitor the C# {@code JavaTypeAnnotationRpcTest} runs on this Java peer to prove type
+ * annotations survive the RPC boundary in both directions:
+ * <ul>
+ *   <li><b>C# &rarr; Java:</b> the {@link SearchResult} description this visitor attaches is
+ *   rendered from the annotations <em>as materialized on the Java side</em> — it can only come out
+ *   right if the C# sender and the Java receiver agreed on every element and value.</li>
+ *   <li><b>Java &rarr; C#:</b> the probed class' type is replaced with a freshly built
+ *   {@link JavaType.Class} whose annotation values are visibly transformed ({@code "probed:"}
+ *   prefix on string constants). Fresh instances defeat the delta cache, so the annotations travel
+ *   back through the real Java sender and real C# receiver rather than resolving to the C# side's
+ *   local copies.</li>
+ * </ul>
+ * Instantiated by name via {@code PreparedRecipeCache.instantiateVisitor}, with the fully
+ * qualified name of the class to probe as the {@code type} visitor option.
+ */
+@RequiredArgsConstructor
+public class JavaTypeAnnotationProbe extends CSharpIsoVisitor<ExecutionContext> {
+    private final String type;
+
+    @Override
+    public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext ctx) {
+        J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, ctx);
+        if (!(cd.getType() instanceof JavaType.Class)) {
+            return cd;
+        }
+        JavaType.Class cls = (JavaType.Class) cd.getType();
+        if (!type.equals(cls.getFullyQualifiedName()) || cls.getAnnotations().isEmpty()) {
+            return cd;
+        }
+
+        StringBuilder description = new StringBuilder();
+        List<JavaType.FullyQualified> transformed = new ArrayList<>(cls.getAnnotations().size());
+        for (JavaType.FullyQualified annotation : cls.getAnnotations()) {
+            if (description.length() > 0) {
+                description.append(';');
+            }
+            if (!(annotation instanceof JavaType.Annotation)) {
+                description.append(annotation.getFullyQualifiedName());
+                transformed.add(annotation);
+                continue;
+            }
+            JavaType.Annotation a = (JavaType.Annotation) annotation;
+            description.append(render(a));
+            transformed.add(transform(a));
+        }
+
+        return SearchResult.found(cd.withType(cls.withAnnotations(transformed)), description.toString());
+    }
+
+    private static String render(JavaType.Annotation annotation) {
+        StringBuilder s = new StringBuilder("@");
+        s.append(annotation.getType() == null ? "{undefined}" : annotation.getType().getFullyQualifiedName());
+        List<JavaType.Annotation.ElementValue> values = annotation.getValues();
+        if (!values.isEmpty()) {
+            s.append('(');
+            for (int i = 0; i < values.size(); i++) {
+                if (i > 0) {
+                    s.append(',');
+                }
+                JavaType.Annotation.ElementValue value = values.get(i);
+                s.append(renderElement(value.getElement())).append('=').append(renderValue(value));
+            }
+            s.append(')');
+        }
+        return s.toString();
+    }
+
+    private static String renderElement(JavaType element) {
+        if (element instanceof JavaType.Variable) {
+            return ((JavaType.Variable) element).getName();
+        }
+        if (element instanceof JavaType.Method) {
+            return ((JavaType.Method) element).getName() + "()";
+        }
+        return String.valueOf(element);
+    }
+
+    private static String renderValue(JavaType.Annotation.ElementValue value) {
+        if (value instanceof JavaType.Annotation.SingleElementValue) {
+            JavaType.Annotation.SingleElementValue single = (JavaType.Annotation.SingleElementValue) value;
+            if (single.getConstantValue() != null) {
+                return String.valueOf(single.getConstantValue());
+            }
+            return renderReference(single.getReferenceValue());
+        }
+        if (value instanceof JavaType.Annotation.ArrayElementValue) {
+            JavaType.Annotation.ArrayElementValue array = (JavaType.Annotation.ArrayElementValue) value;
+            StringBuilder s = new StringBuilder("[");
+            if (array.getConstantValues() != null) {
+                for (int i = 0; i < array.getConstantValues().length; i++) {
+                    if (i > 0) {
+                        s.append(',');
+                    }
+                    s.append(array.getConstantValues()[i]);
+                }
+            } else if (array.getReferenceValues() != null) {
+                for (int i = 0; i < array.getReferenceValues().length; i++) {
+                    if (i > 0) {
+                        s.append(',');
+                    }
+                    s.append(renderReference(array.getReferenceValues()[i]));
+                }
+            }
+            return s.append(']').toString();
+        }
+        return String.valueOf(value);
+    }
+
+    private static String renderReference(JavaType reference) {
+        if (reference instanceof JavaType.Variable) {
+            JavaType.Variable variable = (JavaType.Variable) reference;
+            String owner = variable.getOwner() instanceof JavaType.FullyQualified ?
+                    ((JavaType.FullyQualified) variable.getOwner()).getFullyQualifiedName() : "?";
+            return owner + "." + variable.getName();
+        }
+        if (reference instanceof JavaType.FullyQualified) {
+            return ((JavaType.FullyQualified) reference).getFullyQualifiedName();
+        }
+        return String.valueOf(reference);
+    }
+
+    private static JavaType.FullyQualified transform(JavaType.Annotation annotation) {
+        List<JavaType.Annotation.ElementValue> values = new ArrayList<>(annotation.getValues().size());
+        for (JavaType.Annotation.ElementValue value : annotation.getValues()) {
+            if (value instanceof JavaType.Annotation.SingleElementValue &&
+                ((JavaType.Annotation.SingleElementValue) value).getConstantValue() instanceof String) {
+                JavaType.Annotation.SingleElementValue single = (JavaType.Annotation.SingleElementValue) value;
+                values.add(new JavaType.Annotation.SingleElementValue(
+                        single.getElement(), "probed:" + single.getConstantValue(), null));
+            } else {
+                values.add(value);
+            }
+        }
+        return new JavaType.Annotation(annotation.getType(), values);
+    }
+}


### PR DESCRIPTION
Type attribution and marker fixes in the C# SDK, found while porting the ~80 [WpfAnalyzers](https://github.com/DotNetAnalyzers/WpfAnalyzers) diagnostics to OpenRewrite recipes. Each item is an independent fix; they are separate commits and can be reviewed in order.

### Type attribution

- **Qualified type names carried no type.** `VisitQualifiedName` built the `FieldAccess` and its terminal `Identifier` with `null`, so `System.Windows.DependencyProperty x = ...` was unattributed while the simple form was fine. Affects any recipe type-checking a qualified name.
- **Array types carried no type.** `J.ArrayType` was constructed with `type: null`, so `typeof(int[])` and every array-typed declaration were unattributed. Inner ranks of a jagged type stay null — the syntax nests ranks in the opposite order from the symbol.
- **Property attribute lists were dropped.** `VisitPropertyDeclaration` never read `node.AttributeLists`, so a property's attributes were absorbed into the following modifier's prefix whitespace: no `Annotation`, no `AnnotatedStatement`, invisible to recipes.
- **Declared members and methods are now populated** on mapped types (previously always `null`, so "does type T declare member X?" was unanswerable — including for types from referenced assemblies). Declared-only, matching Java; inherited members remain reachable via `Supertype`/`Interfaces`. Compiler-generated members (backing fields, accessors, static ctors) are filtered out. Population is queued and drained iteratively after the shell is cached, so the transitive walk cannot recurse unboundedly.
- **Event symbols are attributed** as `JavaType.Variable`, consistent with how `PopulateMembers` already listed them.
- **Attribute values are now in the type model.** `Annotations` is populated on `Class`, `Method` and `Variable` from `AttributeData`, building `JavaType.Annotation` with `ElementValue`s — porting Java's `listAnnotations`/`annotationType`/`annotationElementValue`. Named arguments resolve `Element` to the attribute's property; positional arguments resolve to the constructor parameter's matching property, falling back to the constructor (Java's `getElement()` contract is non-null). Mixed `object[]` and nested-array arguments are skipped rather than mapped wrongly.

### RPC

- **Annotation identity keys now match Java's signature.** The C# `TypeSignature` returned `@Type` while `DefaultJavaTypeSignatureBuilder.annotationSignature` produces `@Type(elem=value,...)`; repeated same-typed annotations (e.g. several `[TemplatePart]` on one control) collapsed in the sender's delta cache. The `Values` list key now includes the value for the same reason. Sender-local — no wire-format change.
- **`J.Literal.Value` arrived as a raw `JsonElement`**, so `Literal { Value: string }` patterns matched in-process but never over RPC. Now materialized to the scalar type.
- **`RpcSendQueue.RegisterJavaTypeName` was not thread-safe** — a `static readonly Dictionary` mutated from parallel threads, producing sporadic `IndexOutOfRangeException`. Now a `ConcurrentDictionary`.

### Markers

Three paths silently discarded markers, which is invisible for a search recipe because the marker *is* the output:

- **`Markup.AddMarker` no-opped on `Cs.ExpressionStatement`**, which delegates `Prefix`/`Markers` to its wrapped expression but defined neither wither. It now has both, and the reflection path throws rather than returning the tree unchanged. Safe: a contract test asserts every concrete type exposes the wither.
- **`SearchResult.Found` had the same fallback.** `ParseError` gained `WithMarkers` (the only `Tree` implementation missing it), the contract test was widened from `J` to all of `Tree`, and the fallback now throws.
- **`CSharpPrinter` dropped markers on a class name** by appending `SimpleName` instead of visiting the `Identifier`. Output is byte-identical for unmarked code.

`DirectiveBoundaryInjector` carried a private copy of the same silent-fallback helper; it now uses `J.SetMarkers`.

### New API

- **`CSharpVisitor.MaybeAddUsing`** and the `AddUsing` after-visitor — the C# counterpart of `maybeAddImport`/`AddImport`, which had no equivalent. Idempotent, adds only when the type is referenced by simple name, dedups against existing plain and `global` usings, declines when the simple name is already bound to a different type (CS0104), and matches the file's existing placement and sort convention (compilation-unit vs block-scoped namespace, `System`-first or ordinal, insertion after a file header).

### Testing

`RewriteTest` compiled each C# source into its own compilation, so a type declared in one file was unattributed in another and multi-file `ScanningRecipe` tests were silently meaningless. All C# sources in a run now share one compilation, matching how a project is really parsed.

Coverage added throughout, including an RPC round-trip test that sends a type carrying two same-typed value-bearing annotations through a live Java peer and asserts the values survive in both directions. Suite: 2362 passing.
