### PR TITLE
Fix nil pointer panic when printing Go type switches

### DIFF
--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -529,8 +529,19 @@ func (r *JavaReceiver) VisitSwitch(sw *java.Switch, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *sw // shallow copy to avoid mutating remoteObjects baseline
 	sw = &c
-	// selector - Java sends ControlParentheses, extract inner Expression for Tag
-	if cpResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
+	// Java ships the selector as a ControlParentheses; reconstruct its baseline from the
+	// existing Tag so a changed selector's unchanged children keep their values,
+	// mirroring receiveBlockBody.
+	var selectorBaseline any
+	if sw.Tag != nil {
+		selectorBaseline = &java.ControlParentheses{
+			Tree: java.RightPadded[java.Expression]{
+				Element: sw.Tag.Element,
+				After:   sw.Tag.After,
+			},
+		}
+	}
+	if cpResult := q.Receive(selectorBaseline, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
 		if cp, ok := cpResult.(*java.ControlParentheses); ok {
 			if _, isEmpty := cp.Tree.Element.(*java.Empty); !isEmpty {
 				sw.Tag = &java.RightPadded[java.Expression]{

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -395,22 +395,30 @@ func (s *JavaSender) VisitForEachControl(fc *java.ForEachControl, p any) java.J 
 	return fc
 }
 
+// Derives a stable UUID for a synthetic switch-selector node from the owning
+// switch's ID so repeated sends stay byte-identical. The salt keeps the wrapper,
+// its markers, and the tagless Empty distinct.
+func switchSelectorID(switchID uuid.UUID, salt string) uuid.UUID {
+	return uuid.NewSHA1(uuid.Nil, append([]byte(salt), switchID[:]...))
+}
+
 func (s *JavaSender) VisitSwitch(sw *java.Switch, p any) java.J {
 	q := p.(*SendQueue)
-	// selector - wrap tag in ControlParentheses for Java's J.Switch model
+	// Java models the selector as a ControlParentheses, so synthesize one with IDs
+	// derived from the switch and carry the tag's trailing space (before `{`).
 	q.GetAndSend(sw, func(v any) any {
-		tag := v.(*java.Switch).Tag
-		var inner java.Expression
+		swNode := v.(*java.Switch)
+		tag := swNode.Tag
+		inner := java.Expression(&java.Empty{ID: switchSelectorID(swNode.ID, "empty")})
+		after := java.EmptySpace
 		if tag != nil {
 			inner = tag.Element
-		} else {
-			// Tagless switch: use Empty as the expression
-			inner = &java.Empty{ID: uuid.New()}
+			after = tag.After
 		}
 		return &java.ControlParentheses{
-			ID:      uuid.New(),
-			Markers: java.Markers{ID: uuid.New()},
-			Tree:    java.RightPadded[java.Expression]{Element: inner, After: java.EmptySpace},
+			ID:      switchSelectorID(swNode.ID, "cp"),
+			Markers: java.Markers{ID: switchSelectorID(swNode.ID, "markers")},
+			Tree:    java.RightPadded[java.Expression]{Element: inner, After: after},
 		}
 	}, func(v any) { s.Visit(v.(java.Tree), q) })
 	// cases (Block)

--- a/rewrite-go/pkg/rpc/switch_selector_sender_rpc_test.go
+++ b/rewrite-go/pkg/rpc/switch_selector_sender_rpc_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// Drives the GoSender over `before` and returns the emitted wire messages,
+// without a receive step.
+func serializeNode(t *testing.T, before java.Tree) []RpcObjectData {
+	t.Helper()
+	var messages []RpcObjectData
+	sendQ := NewSendQueue(1000, func(batch []RpcObjectData) {
+		messages = append(messages, batch...)
+	}, NewReferenceMap())
+	NewGoSender().Visit(before, sendQ)
+	sendQ.Flush()
+	return messages
+}
+
+// Verifies that serializing the same switch twice produces identical wire messages,
+// covering the deterministic IDs synthesized for the tagless `select {}` / `switch {}`
+// path (the ControlParentheses wrapper and its synthetic Empty selector).
+func TestSwitchSelectorSend_TaglessDeterministic(t *testing.T) {
+	sw := &java.Switch{
+		ID:   uuid.New(),
+		Body: &java.Block{ID: uuid.New(), End: java.Space{Whitespace: "\n"}},
+	}
+
+	first := serializeNode(t, sw)
+	second := serializeNode(t, sw)
+
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("tagless switch serialization is non-deterministic across sends:\nfirst:  %+v\nsecond: %+v", first, second)
+	}
+}
+
+// Verifies that the space between the selector and the opening `{` survives the
+// round trip.
+func TestSwitchSelectorRoundTrip_PreservesTagAfterSpace(t *testing.T) {
+	swID := uuid.New()
+	before := &java.Switch{
+		ID:   swID,
+		Tag:  &java.RightPadded[java.Expression]{Element: makeIdent("x"), After: java.Space{Whitespace: " "}},
+		Body: &java.Block{ID: uuid.New(), End: java.Space{Whitespace: "\n"}},
+	}
+	seed := &java.Switch{ID: swID}
+
+	got := roundTripNode(t, before, seed).(*java.Switch)
+
+	if got.Tag == nil {
+		t.Fatal("Tag: got nil, want the selector")
+	}
+	if got.Tag.After.Whitespace != " " {
+		t.Errorf("Tag.After.Whitespace: got %q, want %q (the space before `{`)", got.Tag.After.Whitespace, " ")
+	}
+}

--- a/rewrite-go/pkg/rpc/switch_type_guard_rpc_test.go
+++ b/rewrite-go/pkg/rpc/switch_type_guard_rpc_test.go
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// Covers the `switch v := x.(type)` shape, where the selector is an Assignment
+// whose value is the TypeCast.
+func TestSwitchTypeGuardRoundTrip_AssignmentSelector(t *testing.T) {
+	swID := uuid.New()
+	asgID := uuid.New()
+	tcID := uuid.New()
+
+	// The `(type)` wrapper (TypeCast.Clazz) ships as NO_CHANGE because the recipe never touches it.
+	clazz := &java.ControlParentheses{
+		ID:   uuid.New(),
+		Tree: java.RightPadded[java.Expression]{Element: makeIdent("type")},
+	}
+	variable := makeIdent("v")
+
+	// before: `switch v := x.(type) { }`.
+	beforeTag := &java.RightPadded[java.Expression]{
+		Element: &java.Assignment{
+			ID:       asgID,
+			Variable: variable,
+			Value: java.LeftPadded[java.Expression]{
+				Before:  java.Space{Whitespace: " "},
+				Element: &java.TypeCast{ID: tcID, Expr: makeIdent("x"), Clazz: clazz},
+			},
+		},
+		After: java.Space{Whitespace: " "},
+	}
+	body := &java.Block{ID: uuid.New(), End: java.Space{Whitespace: "\n"}}
+	before := &java.Switch{ID: swID, Tag: beforeTag, Body: body}
+
+	// after: the recipe edited the cast operand (x -> y), so the selector is a CHANGE
+	// while the `(type)` wrapper (Clazz, same pointer) stays NO_CHANGE.
+	after := &java.Switch{
+		ID: swID,
+		Tag: &java.RightPadded[java.Expression]{
+			Element: &java.Assignment{
+				ID:       asgID,
+				Variable: variable, // same pointer -> NO_CHANGE
+				Value: java.LeftPadded[java.Expression]{
+					Before:  java.Space{Whitespace: " "},
+					Element: &java.TypeCast{ID: tcID, Expr: makeIdent("y"), Clazz: clazz},
+				},
+			},
+			After: java.Space{Whitespace: " "},
+		},
+		Body: body, // same pointer -> NO_CHANGE
+	}
+
+	// seed mirrors the baseline a real session holds from a prior GET_OBJECT.
+	seed := &java.Switch{ID: swID, Tag: beforeTag, Body: body}
+
+	got := roundTripNodeWithBefore(t, after, before, seed).(*java.Switch)
+
+	if got.Tag == nil {
+		t.Fatal("Tag: got nil, want the type-switch selector")
+	}
+	assign, ok := got.Tag.Element.(*java.Assignment)
+	if !ok {
+		t.Fatalf("Tag.Element: got %T, want *Assignment", got.Tag.Element)
+	}
+	tc, ok := assign.Value.Element.(*java.TypeCast)
+	if !ok {
+		t.Fatalf("Assignment.Value.Element: got %T, want *TypeCast", assign.Value.Element)
+	}
+	if tc.Clazz == nil {
+		t.Fatal("TypeCast.Clazz: got nil, want the `(type)` ControlParentheses")
+	}
+	if id, ok := tc.Clazz.Tree.Element.(*java.Identifier); !ok || id.Name != "type" {
+		t.Errorf("TypeCast.Clazz.Tree.Element: got %+v, want Identifier{type}", tc.Clazz.Tree.Element)
+	}
+
+	// Printing exercises the VisitSwitch -> VisitAssignment -> VisitTypeCast ->
+	// VisitControlParentheses path from the reported panic.
+	if out := printer.Print(got); out == "" {
+		t.Error("printed output: got empty string, want rendered switch")
+	}
+}
+
+// Covers `switch f(); v := x.(type)`, where the type switch is wrapped in a
+// golang.StatementWithInit and the init clause is unchanged.
+func TestSwitchTypeGuardRoundTrip_WithInitClause(t *testing.T) {
+	swiID, swID, asgID, tcID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	clazz := &java.ControlParentheses{
+		ID:   uuid.New(),
+		Tree: java.RightPadded[java.Expression]{Element: makeIdent("type")},
+	}
+	variable := makeIdent("v")
+	body := &java.Block{ID: uuid.New(), End: java.Space{Whitespace: "\n"}}
+	// The init clause `f()` stays unchanged across the diff.
+	init := java.RightPadded[java.Statement]{Element: makeMethodInvocation(), After: java.Space{Whitespace: " "}}
+
+	mkSwitch := func(cast java.Expression) *java.Switch {
+		return &java.Switch{
+			ID: swID,
+			Tag: &java.RightPadded[java.Expression]{
+				Element: &java.Assignment{
+					ID:       asgID,
+					Variable: variable,
+					Value: java.LeftPadded[java.Expression]{
+						Before:  java.Space{Whitespace: " "},
+						Element: &java.TypeCast{ID: tcID, Expr: cast, Clazz: clazz},
+					},
+				},
+				After: java.Space{Whitespace: " "},
+			},
+			Body: body,
+		}
+	}
+
+	// The recipe edited the cast operand (x -> y), so the inner selector is a CHANGE
+	// while the init clause and the `(type)` wrapper stay NO_CHANGE.
+	before := &golang.StatementWithInit{ID: swiID, Init: init, Statement: mkSwitch(makeIdent("x"))}
+	after := &golang.StatementWithInit{ID: swiID, Init: init, Statement: mkSwitch(makeIdent("y"))}
+	seed := &golang.StatementWithInit{ID: swiID, Init: init, Statement: mkSwitch(makeIdent("x"))}
+
+	got := roundTripNodeWithBefore(t, after, before, seed).(*golang.StatementWithInit)
+
+	sw, ok := got.Statement.(*java.Switch)
+	if !ok {
+		t.Fatalf("Statement: got %T, want *Switch", got.Statement)
+	}
+	asg, ok := sw.Tag.Element.(*java.Assignment)
+	if !ok {
+		t.Fatalf("Tag.Element: got %T, want *Assignment", sw.Tag.Element)
+	}
+	tc, ok := asg.Value.Element.(*java.TypeCast)
+	if !ok {
+		t.Fatalf("Assignment.Value.Element: got %T, want *TypeCast", asg.Value.Element)
+	}
+	if tc.Clazz == nil {
+		t.Fatal("TypeCast.Clazz: got nil, want the `(type)` ControlParentheses")
+	}
+	if id, ok := tc.Clazz.Tree.Element.(*java.Identifier); !ok || id.Name != "type" {
+		t.Errorf("TypeCast.Clazz.Tree.Element: got %+v, want Identifier{type}", tc.Clazz.Tree.Element)
+	}
+
+	// Printing exercises the StatementWithInit -> Switch -> Assignment -> TypeCast ->
+	// ControlParentheses path.
+	if out := printer.Print(got); out == "" {
+		t.Error("printed output: got empty string, want rendered switch")
+	}
+}


### PR DESCRIPTION
## Problem

Running a recipe on Go code that contains a type switch can crash the run instead of producing the refactored source. When a recipe edits inside a type-switch guard, the Go printer panics:

```go
switch v := x.(type) {
case int:
    return v
}
```

```
PANIC in Print: runtime error: invalid memory address or nil pointer dereference
  printer.(*GoPrinter).VisitControlParentheses  go_printer.go:974
  printer.(*GoPrinter).VisitTypeCast            go_printer.go:967
  printer.(*GoPrinter).VisitAssignment          go_printer.go:234
  printer.(*GoPrinter).VisitSwitch              go_printer.go:585
```

## Fix

Java models a switch selector as a `ControlParentheses`, but Go's `java.Switch` stores the tag directly, so `JavaReceiver.VisitSwitch` passed a `nil` baseline. On the diff path the JVM sends the changed selector as `CHANGE` and the untouched `(type)` wrapper (`TypeCast.Clazz`) as `NO_CHANGE`. Against a `nil` baseline that child collapses to `nil`, and the printer dereferences it.

- `JavaReceiver.VisitSwitch` reconstructs the `ControlParentheses` baseline from the existing `Tag`, so a changed selector's unchanged children keep their values. This mirrors `receiveBlockBody` for `if`/`for` bodies.
- `JavaSender.VisitSwitch` derives the synthetic wrapper's IDs from the switch instead of minting a fresh UUID per send, and carries the space before `{`.

- Part of #8424. The `END_OF_OBJECT` and `coerceToStatementRP` errors reported there are a separate baseline slot and remain open.
