### PR TITLE
Preserve comments on composite literals with a trailing comma

### DIFF
--- a/rewrite-go/pkg/rpc/space_rpc.go
+++ b/rewrite-go/pkg/rpc/space_rpc.go
@@ -195,10 +195,10 @@ func sendMarkerCodecFields(v any, q *SendQueue) {
 		q.GetAndSend(m, func(x any) any { return x.(golang.StructTag).Ident.String() }, nil)
 		q.GetAndSend(m, func(x any) any { return x.(golang.StructTag).Tag.Source }, nil)
 	case golang.TrailingComma:
-		// TrailingComma.rpcSend sends: id (UUID string), before whitespace, after whitespace
+		// TrailingComma.rpcSend sends: id (UUID string), before space, after space
 		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).Ident.String() }, nil)
-		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).Before.Whitespace }, nil)
-		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).After.Whitespace }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).Before }, func(x any) { sendSpace(x.(java.Space), q) })
+		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).After }, func(x any) { sendSpace(x.(java.Space), q) })
 	case golang.Semicolon:
 		// Semicolon.rpcSend sends: id (UUID string)
 		q.GetAndSend(m, func(x any) any { return x.(golang.Semicolon).Ident.String() }, nil)
@@ -453,10 +453,8 @@ func receiveMarkersCodec(q *ReceiveQueue, before java.Markers) java.Markers {
 					m.Ident = parsed
 				}
 			}
-			beforeWs := receiveScalar[string](q, m.Before.Whitespace)
-			m.Before = java.Space{Whitespace: beforeWs}
-			afterWs := receiveScalar[string](q, m.After.Whitespace)
-			m.After = java.Space{Whitespace: afterWs}
+			m.Before = receiveValue(q, m.Before, func(e java.Space) any { return receiveSpace(e, q) })
+			m.After = receiveValue(q, m.After, func(e java.Space) any { return receiveSpace(e, q) })
 			return m
 		case golang.Semicolon:
 			idStr := receiveScalar[string](q, m.Ident.String())

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/CompositeTrailingCommentRpcIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/CompositeTrailingCommentRpcIntegTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.SourceFile;
+import org.openrewrite.golang.GolangParser;
+import org.openrewrite.golang.marker.TrailingComma;
+import org.openrewrite.golang.tree.Go;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A composite literal that ends with a trailing comma carries a {@link TrailingComma} marker whose
+ * {@code after} space is the gap between that comma and the closing brace, holding any trailing line
+ * comment. The marker's RPC codec carries both its {@code before} and {@code after} spaces with their
+ * comments. {@code reset()} clears both caches so {@code Print} deserializes the whole tree from the
+ * wire rather than reusing cached nodes.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class CompositeTrailingCommentRpcIntegTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(binaryPath)
+                .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    private void roundTrip(String source) {
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        SourceFile cu = GolangParser.builder().build()
+                .parse(source).findFirst().orElseThrow();
+        assertThat(cu).isInstanceOf(Go.CompilationUnit.class);
+        rpc.reset();
+        assertThat(rpc.print(cu)).isEqualTo(source);
+    }
+
+    @Test
+    void newlineBeforeClosingBraceNoComment() {
+        roundTrip("""
+                package main
+
+                var x = &T{
+                \tA: 1,
+                }
+                """);
+    }
+
+    @Test
+    void commentAfterTrailingComma() {
+        roundTrip("""
+                package main
+
+                var x = &T{
+                \tA: 1, // trailing comment
+                }
+                """);
+    }
+
+    @Test
+    void commentBeforeTrailingComma() {
+        roundTrip("""
+                package main
+
+                var x = []int{
+                \t1 /* before comma */,
+                }
+                """);
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/TrailingComma.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/TrailingComma.java
@@ -17,8 +17,7 @@ package org.openrewrite.golang.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -37,15 +36,15 @@ public class TrailingComma implements Marker, RpcCodec<TrailingComma> {
     @Override
     public void rpcSend(TrailingComma after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, TrailingComma::getBefore, space -> new JavaSender().visitSpace(space, q));
-        q.getAndSend(after, TrailingComma::getAfter, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, TrailingComma::getBefore, space -> JavaSpaceRpcCodec.sendSpace(space, q));
+        q.getAndSend(after, TrailingComma::getAfter, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public TrailingComma rpcReceive(TrailingComma before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withBefore(q.receive(before.getBefore(), space -> new JavaReceiver().visitSpace(space, q)))
-                .withAfter(q.receive(before.getAfter(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withBefore(q.receive(before.getBefore(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)))
+                .withAfter(q.receive(before.getAfter(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/TrailingComma.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/TrailingComma.java
@@ -17,6 +17,8 @@ package org.openrewrite.golang.marker;
 
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.java.internal.rpc.JavaReceiver;
+import org.openrewrite.java.internal.rpc.JavaSender;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -35,15 +37,15 @@ public class TrailingComma implements Marker, RpcCodec<TrailingComma> {
     @Override
     public void rpcSend(TrailingComma after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, t -> t.getBefore().getWhitespace());
-        q.getAndSend(after, t -> t.getAfter().getWhitespace());
+        q.getAndSend(after, TrailingComma::getBefore, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, TrailingComma::getAfter, space -> new JavaSender().visitSpace(space, q));
     }
 
     @Override
     public TrailingComma rpcReceive(TrailingComma before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withBefore(Space.format(q.receive(before.getBefore() == null ? "" : before.getBefore().getWhitespace())))
-                .withAfter(Space.format(q.receive(before.getAfter() == null ? "" : before.getAfter().getWhitespace())));
+                .withBefore(q.receive(before.getBefore(), space -> new JavaReceiver().visitSpace(space, q)))
+                .withAfter(q.receive(before.getAfter(), space -> new JavaReceiver().visitSpace(space, q)));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
@@ -610,17 +610,7 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
     }
 
     public Space visitSpace(Space space, RpcReceiveQueue q) {
-        return space
-                .withComments(q.receiveList(space.getComments(), c -> {
-                    if (c instanceof TextComment) {
-                        return ((TextComment) c).withMultiline(q.receive(c.isMultiline()))
-                                .withText(q.receive(((TextComment) c).getText()))
-                                .withSuffix(q.receive(c.getSuffix()))
-                                .withMarkers(q.receive(c.getMarkers()));
-                    }
-                    return c;
-                }))
-                .withWhitespace(q.receive(space.getWhitespace()));
+        return JavaSpaceRpcCodec.receiveSpace(space, q);
     }
 
     public <J2 extends J> JContainer<J2> visitContainer(JContainer<J2> container, RpcReceiveQueue q) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
@@ -621,27 +621,7 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
     }
 
     public void visitSpace(Space space, RpcSendQueue q) {
-        q.getAndSendList(space, Space::getComments,
-                c -> {
-                    if (c instanceof TextComment) {
-                        return ((TextComment) c).getText() + c.getSuffix();
-                    } else if (c instanceof Javadoc.DocComment) {
-                        return ((Javadoc.DocComment) c).getId();
-                    }
-                    throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
-                },
-                c -> {
-                    if (c instanceof TextComment) {
-                        TextComment tc = (TextComment) c;
-                        q.getAndSend(tc, TextComment::isMultiline);
-                        q.getAndSend(tc, TextComment::getText);
-                    } else {
-                        throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
-                    }
-                    q.getAndSend(c, Comment::getSuffix);
-                    q.getAndSend(c, Comment::getMarkers);
-                });
-        q.getAndSend(space, Space::getWhitespace);
+        JavaSpaceRpcCodec.sendSpace(space, q);
     }
 
     private final JavaTypeSender javaTypeSender = new JavaTypeSender();

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSpaceRpcCodec.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSpaceRpcCodec.java
@@ -15,8 +15,11 @@
  */
 package org.openrewrite.java.internal.rpc;
 
+import org.openrewrite.java.tree.Comment;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Javadoc;
 import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TextComment;
 import org.openrewrite.rpc.DynamicDispatchRpcCodec;
 import org.openrewrite.rpc.RpcReceiveQueue;
 import org.openrewrite.rpc.RpcSendQueue;
@@ -35,11 +38,57 @@ public class JavaSpaceRpcCodec extends DynamicDispatchRpcCodec<Space> {
 
     @Override
     public void rpcSend(Space after, RpcSendQueue q) {
-        new JavaSender().visitSpace(after, q);
+        sendSpace(after, q);
     }
 
     @Override
     public Space rpcReceive(Space before, RpcReceiveQueue q) {
-        return new JavaReceiver().visitSpace(before, q);
+        return receiveSpace(before, q);
+    }
+
+    /**
+     * Serializes a {@link Space} (its comments and whitespace) onto the send queue. Shared by the Java
+     * visitor and by markers that carry a {@code Space}, so none of them need to allocate a {@code JavaSender}
+     * just to reach the queue.
+     */
+    public static void sendSpace(Space space, RpcSendQueue q) {
+        q.getAndSendList(space, Space::getComments,
+                c -> {
+                    if (c instanceof TextComment) {
+                        return ((TextComment) c).getText() + c.getSuffix();
+                    } else if (c instanceof Javadoc.DocComment) {
+                        return ((Javadoc.DocComment) c).getId();
+                    }
+                    throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
+                },
+                c -> {
+                    if (c instanceof TextComment) {
+                        TextComment tc = (TextComment) c;
+                        q.getAndSend(tc, TextComment::isMultiline);
+                        q.getAndSend(tc, TextComment::getText);
+                    } else {
+                        throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
+                    }
+                    q.getAndSend(c, Comment::getSuffix);
+                    q.getAndSend(c, Comment::getMarkers);
+                });
+        q.getAndSend(space, Space::getWhitespace);
+    }
+
+    /**
+     * Reconstructs a {@link Space} from the receive queue, the inverse of {@link #sendSpace}.
+     */
+    public static Space receiveSpace(Space before, RpcReceiveQueue q) {
+        return before
+                .withComments(q.receiveList(before.getComments(), c -> {
+                    if (c instanceof TextComment) {
+                        return ((TextComment) c).withMultiline(q.receive(c.isMultiline()))
+                                .withText(q.receive(((TextComment) c).getText()))
+                                .withSuffix(q.receive(c.getSuffix()))
+                                .withMarkers(q.receive(c.getMarkers()));
+                    }
+                    return c;
+                }))
+                .withWhitespace(q.receive(before.getWhitespace()));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/NullSafe.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/NullSafe.java
@@ -18,8 +18,7 @@ package org.openrewrite.java.marker;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -58,13 +57,13 @@ public class NullSafe implements Marker, RpcCodec<NullSafe> {
     @Override
     public void rpcSend(NullSafe after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, NullSafe::getDotPrefix, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, NullSafe::getDotPrefix, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public NullSafe rpcReceive(NullSafe before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withDotPrefix(q.receive(before.getDotPrefix(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withDotPrefix(q.receive(before.getDotPrefix(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/marker/TrailingComma.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/marker/TrailingComma.java
@@ -17,8 +17,7 @@ package org.openrewrite.java.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -36,13 +35,13 @@ public class TrailingComma implements Marker, RpcCodec<TrailingComma> {
     @Override
     public void rpcSend(TrailingComma after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, TrailingComma::getSuffix, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, TrailingComma::getSuffix, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public TrailingComma rpcReceive(TrailingComma before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withSuffix(q.receive(before.getSuffix(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withSuffix(q.receive(before.getSuffix(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/DelegatedYield.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/DelegatedYield.java
@@ -17,8 +17,7 @@ package org.openrewrite.javascript.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -36,13 +35,13 @@ public class DelegatedYield implements Marker, RpcCodec<DelegatedYield> {
     @Override
     public void rpcSend(DelegatedYield after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, DelegatedYield::getPrefix, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, DelegatedYield::getPrefix, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public DelegatedYield rpcReceive(DelegatedYield before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withPrefix(q.receive(before.getPrefix(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withPrefix(q.receive(before.getPrefix(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/FunctionDeclaration.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/FunctionDeclaration.java
@@ -17,8 +17,7 @@ package org.openrewrite.javascript.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -36,13 +35,13 @@ public class FunctionDeclaration implements Marker, RpcCodec<FunctionDeclaration
     @Override
     public void rpcSend(FunctionDeclaration after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, FunctionDeclaration::getPrefix, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, FunctionDeclaration::getPrefix, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public FunctionDeclaration rpcReceive(FunctionDeclaration before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withPrefix(q.receive(before.getPrefix(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withPrefix(q.receive(before.getPrefix(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/Generator.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/Generator.java
@@ -17,8 +17,7 @@ package org.openrewrite.javascript.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -36,13 +35,13 @@ public class Generator implements Marker, RpcCodec<Generator> {
     @Override
     public void rpcSend(Generator after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, Generator::getPrefix, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, Generator::getPrefix, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public Generator rpcReceive(Generator before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withPrefix(q.receive(before.getPrefix(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withPrefix(q.receive(before.getPrefix(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NonNullAssertion.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/NonNullAssertion.java
@@ -17,8 +17,7 @@ package org.openrewrite.javascript.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -36,13 +35,13 @@ public class NonNullAssertion implements Marker, RpcCodec<NonNullAssertion> {
     @Override
     public void rpcSend(NonNullAssertion after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, NonNullAssertion::getPrefix, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, NonNullAssertion::getPrefix, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public NonNullAssertion rpcReceive(NonNullAssertion before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withPrefix(q.receive(before.getPrefix(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withPrefix(q.receive(before.getPrefix(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/Optional.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/marker/Optional.java
@@ -17,8 +17,7 @@ package org.openrewrite.javascript.marker;
 
 import lombok.Value;
 import lombok.With;
-import org.openrewrite.java.internal.rpc.JavaReceiver;
-import org.openrewrite.java.internal.rpc.JavaSender;
+import org.openrewrite.java.internal.rpc.JavaSpaceRpcCodec;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -36,13 +35,13 @@ public class Optional implements Marker, RpcCodec<Optional> {
     @Override
     public void rpcSend(Optional after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, Optional::getPrefix, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, Optional::getPrefix, space -> JavaSpaceRpcCodec.sendSpace(space, q));
     }
 
     @Override
     public Optional rpcReceive(Optional before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withPrefix(q.receive(before.getPrefix(), space -> new JavaReceiver().visitSpace(space, q)));
+                .withPrefix(q.receive(before.getPrefix(), space -> JavaSpaceRpcCodec.receiveSpace(space, q)));
     }
 }


### PR DESCRIPTION
## Problem

When a recipe runs against Go source, a composite literal whose last element is followed by a trailing comma and a comment loses that comment, and the closing brace collapses onto the previous line.

Given this input:

```go
var x = &Context{
	queryCache: url.Values{"a": []string{"b"}},
	Request:    &http.Request{URL: validURL}, // valid request
}
```

the recipe writes back:

```go
var x = &Context{
	queryCache: url.Values{"a": []string{"b"}},
	Request:    &http.Request{URL: validURL}, }
```

The comment is gone and the `}` no longer sits on its own line. This is silent: the run reports success, so users cannot tell the change was corrupted. On real repositories (for example `gin-gonic/gin`'s `context_test.go`) it surfaces as unexpected diffs, and in related forms as internal errors while writing the patch:

```
expected CHANGE with positions, got END_OF_OBJECT (value=<nil>, valueType=<nil>)
coerceToStatementRP: element does not implement java.Statement (rp=<nil> elem=<nil> nil=true)
```

## Cause

A trailing comma is recorded with a `TrailingComma` marker whose `before` and `after` spaces hold the surrounding whitespace and any comment. Its RPC codec carried only each space's whitespace string, so comments were not sent across the wire.

## Fix

The `TrailingComma` codec now sends and receives the full `before` and `after` spaces, comments included, on both the Java and Go sides.
