### PR TITLE
Drop receivers only when they have no observable effect

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
@@ -418,6 +418,116 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     }
 
     @Test
+    void qualifiedFieldReceiversAreDropped() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 static A shared = new A();
+                 A field = new A();
+
+                 class Inner {
+                     public void test() {
+                         C.shared.nonStatic();
+                         C.this.field.nonStatic();
+                     }
+                 }
+
+                 public void test() {
+                     this.field.nonStatic();
+                 }
+              }
+              """,
+            """
+              import a.A;
+              import b.B;
+
+              class C {
+                 static A shared = new A();
+                 A field = new A();
+
+                 class Inner {
+                     public void test() {
+                         B.nonStatic();
+                         B.nonStatic();
+                     }
+                 }
+
+                 public void test() {
+                     B.nonStatic();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void nestedMatchesInArgumentsAreRewritten() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value(..)", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public String value() { return "a"; }
+                 public String value(String s) { return s; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static String value() { return "b"; }
+                 public static String value(String s) { return s; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 public void test(A x, A y) {
+                     x.value(y.value());
+                 }
+              }
+              """,
+            """
+              import a.A;
+              import b.B;
+
+              class C {
+                 public void test(A x, A y) {
+                     B.value(B.value());
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void chainedSelfCallsCollapseOntoTargetType() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
@@ -503,6 +613,51 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               class C {
                  public void test() {
                      B.reverse();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void chainedCallOnCollapsingReceiverWithSideEffectingArgumentsIsNotChanged() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A *(..)", "b.B", "java.util.List", null, false)),
+          java(
+            """
+              package a;
+              import java.util.List;
+              public class A {
+                 public static A of(String s) { return new A(); }
+                 public List<String> reverse() { return null; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              import java.util.List;
+              public class B {
+                 public static List<String> of(String s) { return null; }
+                 public static List<String> reverse() { return null; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 int calls;
+
+                 String argument() {
+                     calls++;
+                     return "x";
+                 }
+
+                 public void test() {
+                     A.of(argument()).reverse();
                  }
               }
               """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
@@ -186,6 +186,566 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     }
 
     @Test
+    void receiverMethodCallIsNotDropped() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 int calls;
+
+                 A receiver() {
+                     calls++;
+                     return new A();
+                 }
+
+                 public void test() {
+                     receiver().nonStatic();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void receiverExpressionsThatCanThrowAreNotDropped() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 A field = new A();
+                 A[] array = new A[1];
+
+                 public void test(C other, Object o) {
+                     other.field.nonStatic();
+                     array[0].nonStatic();
+                     ((A) o).nonStatic();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void volatileFieldReceiverIsNotDropped() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 volatile A shared = new A();
+
+                 public void test() {
+                     shared.nonStatic();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void instantiationArgumentsAreNotDropped() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public A() {}
+                 public A(String s) {}
+                 public void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 int calls;
+
+                 String argument() {
+                     calls++;
+                     return "a";
+                 }
+
+                 public void test() {
+                     new A("a").nonStatic();
+                     new A(argument()).nonStatic();
+                 }
+              }
+              """,
+            """
+              import a.A;
+              import b.B;
+
+              class C {
+                 int calls;
+
+                 String argument() {
+                     calls++;
+                     return "a";
+                 }
+
+                 public void test() {
+                     B.nonStatic();
+                     new A(argument()).nonStatic();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableReceiversAreDropped() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static void nonStatic() {}
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 A field = new A();
+
+                 public void test(A parameter) {
+                     A local = new A();
+                     local.nonStatic();
+                     parameter.nonStatic();
+                     field.nonStatic();
+                 }
+              }
+              """,
+            """
+              import a.A;
+              import b.B;
+
+              class C {
+                 A field = new A();
+
+                 public void test(A parameter) {
+                     A local = new A();
+                     B.nonStatic();
+                     B.nonStatic();
+                     B.nonStatic();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void chainedSelfCallsCollapseOntoTargetType() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public A value() { return this; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static String value() { return "b"; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 public void test(A legacy) {
+                     legacy.value().value();
+                     legacy.value().value().value();
+                 }
+              }
+              """,
+            """
+              import a.A;
+              import b.B;
+
+              class C {
+                 public void test(A legacy) {
+                     B.value();
+                     B.value();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void chainedCallOnRewrittenStaticFactoryCollapses() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A *(..)", "b.B", "java.util.List", null, false)),
+          java(
+            """
+              package a;
+              import java.util.List;
+              public class A {
+                 public static A of(String s) { return new A(); }
+                 public List<String> reverse() { return null; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              import java.util.List;
+              public class B {
+                 public static List<String> of(String s) { return null; }
+                 public static List<String> reverse() { return null; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 public void test() {
+                     A.of("x").reverse();
+                 }
+              }
+              """,
+            """
+              import b.B;
+
+              class C {
+                 public void test() {
+                     B.reverse();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void chainedCallOnUndiscardableReceiverIsNotChanged() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public A value() { return this; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static String value() { return "b"; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              class C {
+                 int calls;
+
+                 A receiver() {
+                     calls++;
+                     return new A();
+                 }
+
+                 public void test() {
+                     receiver().value().value();
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void thisReceiversAreReplaced() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
+          java(
+            """
+              package b;
+              public class B {
+                 public static String value() { return "b"; }
+              }
+              """
+          ),
+          java(
+            """
+              package a;
+
+              import java.util.function.Supplier;
+
+              public class A {
+                 public String value() { return "a"; }
+
+                 public Supplier<String> direct() {
+                     return this::value;
+                 }
+
+                 class Inner {
+                     public Supplier<String> qualified() {
+                         return A.this::value;
+                     }
+
+                     public String call() {
+                         return A.this.value();
+                     }
+                 }
+              }
+              """,
+            """
+              package a;
+
+              import b.B;
+
+              import java.util.function.Supplier;
+
+              public class A {
+                 public String value() { return "a"; }
+
+                 public Supplier<String> direct() {
+                     return B::value;
+                 }
+
+                 class Inner {
+                     public Supplier<String> qualified() {
+                         return B::value;
+                     }
+
+                     public String call() {
+                         return B.value();
+                     }
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void memberReferenceOnMethodCallIsNotChanged() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public String value() { return "a"; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static String value() { return "b"; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              import java.util.function.Supplier;
+
+              class C {
+                 int calls;
+
+                 A receiver() {
+                     calls++;
+                     return new A();
+                 }
+
+                 public Supplier<String> test() {
+                     return receiver()::value;
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void memberReferenceOnVariableIsNotChanged() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public String value() { return "a"; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static String value() { return "b"; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              import java.util.function.Supplier;
+
+              class C {
+                 public Supplier<String> test(A a) {
+                     return a::value;
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void memberReferenceOnRewrittenCallCollapses() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A *(..)", "b.B", null, null, false)),
+          java(
+            """
+              package a;
+              public class A {
+                 public A self() { return this; }
+                 public String value() { return "a"; }
+              }
+              """
+          ),
+          java(
+            """
+              package b;
+              public class B {
+                 public static B self() { return new B(); }
+                 public static String value() { return "b"; }
+              }
+              """
+          ),
+          java(
+            """
+              import a.A;
+
+              import java.util.function.Supplier;
+
+              class C {
+                 public Supplier<String> test(A legacy) {
+                     return legacy.self()::value;
+                 }
+              }
+              """,
+            """
+              import a.A;
+              import b.B;
+
+              import java.util.function.Supplier;
+
+              class C {
+                 public Supplier<String> test(A legacy) {
+                     return B::value;
+                 }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void memberReferenceTargetToStatic() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A of(..)", "b.B", null, null, false)),

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/ChangeMethodTargetToStaticTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
@@ -24,6 +25,38 @@ import static org.openrewrite.java.Assertions.java;
 
 class ChangeMethodTargetToStaticTest implements RewriteTest {
 
+    @Language("java")
+    private static final String A_NON_STATIC = """
+      package a;
+      public class A {
+         public void nonStatic() {}
+      }
+      """;
+
+    @Language("java")
+    private static final String B_STATIC = """
+      package b;
+      public class B {
+         public static void nonStatic() {}
+      }
+      """;
+
+    @Language("java")
+    private static final String A_VALUE = """
+      package a;
+      public class A {
+         public String value() { return "a"; }
+      }
+      """;
+
+    @Language("java")
+    private static final String B_VALUE = """
+      package b;
+      public class B {
+         public static String value() { return "b"; }
+      }
+      """;
+
     @Test
     void targetToStatic() {
         rewriteRun(
@@ -31,14 +64,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false),
             new ChangeMethodName("b.B nonStatic()", "foo", null, null)
           ),
-          java(
-            """
-              package a;
-              public class A {
-                 public void nonStatic() {}
-              }
-              """
-          ),
+          java(A_NON_STATIC),
           java(
             """
               package b;
@@ -189,22 +215,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void receiverMethodCallIsNotDropped() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
-          java(
-            """
-              package a;
-              public class A {
-                 public void nonStatic() {}
-              }
-              """
-          ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static void nonStatic() {}
-              }
-              """
-          ),
+          java(A_NON_STATIC),
+          java(B_STATIC),
           java(
             """
               import a.A;
@@ -230,22 +242,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void receiverExpressionsThatCanThrowAreNotDropped() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
-          java(
-            """
-              package a;
-              public class A {
-                 public void nonStatic() {}
-              }
-              """
-          ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static void nonStatic() {}
-              }
-              """
-          ),
+          java(A_NON_STATIC),
+          java(B_STATIC),
           java(
             """
               import a.A;
@@ -254,10 +252,10 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
                  A field = new A();
                  A[] array = new A[1];
 
-                 public void test(C other, Object o) {
+                 public void test(C other, Object value) {
                      other.field.nonStatic();
                      array[0].nonStatic();
-                     ((A) o).nonStatic();
+                     ((A) value).nonStatic();
                  }
               }
               """
@@ -269,22 +267,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void volatileFieldReceiverIsNotDropped() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
-          java(
-            """
-              package a;
-              public class A {
-                 public void nonStatic() {}
-              }
-              """
-          ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static void nonStatic() {}
-              }
-              """
-          ),
+          java(A_NON_STATIC),
+          java(B_STATIC),
           java(
             """
               import a.A;
@@ -315,14 +299,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               }
               """
           ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static void nonStatic() {}
-              }
-              """
-          ),
+          java(B_STATIC),
           java(
             """
               import a.A;
@@ -367,22 +344,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void variableReceiversAreDropped() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
-          java(
-            """
-              package a;
-              public class A {
-                 public void nonStatic() {}
-              }
-              """
-          ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static void nonStatic() {}
-              }
-              """
-          ),
+          java(A_NON_STATIC),
+          java(B_STATIC),
           java(
             """
               import a.A;
@@ -421,22 +384,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void qualifiedFieldReceiversAreDropped() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A nonStatic()", "b.B", null, null, false)),
-          java(
-            """
-              package a;
-              public class A {
-                 public void nonStatic() {}
-              }
-              """
-          ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static void nonStatic() {}
-              }
-              """
-          ),
+          java(A_NON_STATIC),
+          java(B_STATIC),
           java(
             """
               import a.A;
@@ -490,7 +439,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               package a;
               public class A {
                  public String value() { return "a"; }
-                 public String value(String s) { return s; }
+                 public String value(String input) { return input; }
               }
               """
           ),
@@ -499,7 +448,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               package b;
               public class B {
                  public static String value() { return "b"; }
-                 public static String value(String s) { return s; }
+                 public static String value(String input) { return input; }
               }
               """
           ),
@@ -508,8 +457,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               import a.A;
 
               class C {
-                 public void test(A x, A y) {
-                     x.value(y.value());
+                 public void test(A receiver, A argument) {
+                     receiver.value(argument.value());
                  }
               }
               """,
@@ -518,7 +467,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               import b.B;
 
               class C {
-                 public void test(A x, A y) {
+                 public void test(A receiver, A argument) {
                      B.value(B.value());
                  }
               }
@@ -539,14 +488,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               }
               """
           ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static String value() { return "b"; }
-              }
-              """
-          ),
+          java(B_VALUE),
           java(
             """
               import a.A;
@@ -677,14 +619,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               }
               """
           ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static String value() { return "b"; }
-              }
-              """
-          ),
+          java(B_VALUE),
           java(
             """
               import a.A;
@@ -710,14 +645,7 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void thisReceiversAreReplaced() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
-          java(
-            """
-              package b;
-              public class B {
-                 public static String value() { return "b"; }
-              }
-              """
-          ),
+          java(B_VALUE),
           java(
             """
               package a;
@@ -775,22 +703,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void memberReferenceOnMethodCallIsNotChanged() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
-          java(
-            """
-              package a;
-              public class A {
-                 public String value() { return "a"; }
-              }
-              """
-          ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static String value() { return "b"; }
-              }
-              """
-          ),
+          java(A_VALUE),
+          java(B_VALUE),
           java(
             """
               import a.A;
@@ -818,22 +732,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
     void memberReferenceOnVariableIsNotChanged() {
         rewriteRun(
           spec -> spec.recipe(new ChangeMethodTargetToStatic("a.A value()", "b.B", null, null, false)),
-          java(
-            """
-              package a;
-              public class A {
-                 public String value() { return "a"; }
-              }
-              """
-          ),
-          java(
-            """
-              package b;
-              public class B {
-                 public static String value() { return "b"; }
-              }
-              """
-          ),
+          java(A_VALUE),
+          java(B_VALUE),
           java(
             """
               import a.A;
@@ -841,8 +741,8 @@ class ChangeMethodTargetToStaticTest implements RewriteTest {
               import java.util.function.Supplier;
 
               class C {
-                 public Supplier<String> test(A a) {
-                     return a::value;
+                 public Supplier<String> test(A receiver) {
+                     return receiver::value;
                  }
               }
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -119,6 +119,85 @@ public class ChangeMethodTargetToStatic extends Recipe {
         }
 
         /**
+         * Java evaluates the expression qualifying a static method invocation and then discards its value,
+         * without a null check. This only drops an expression whose evaluation cannot be observed: a type name,
+         * {@code this} (possibly qualified), or a simple non-volatile variable read (class initialization
+         * aside). As a deliberate exception that preserves the {@code new A().staticMethod()} shape this recipe
+         * exists to rewrite, an instantiation whose arguments are themselves discardable is also dropped, even
+         * though a constructor can run arbitrary code and throw. A method invocation, a dereference, an array
+         * access, a cast or any other expression may mutate state or throw, so the invocation is left alone
+         * instead.
+         */
+        private boolean isSafeToDiscard(@Nullable Expression expression) {
+            Expression expr = Expression.unwrap(expression);
+            if (expr == null || expr instanceof J.Empty || expr instanceof J.Literal) {
+                return true;
+            }
+            if (expr instanceof J.Identifier) {
+                JavaType.Variable fieldType = ((J.Identifier) expr).getFieldType();
+                return fieldType == null || !fieldType.hasFlags(Flag.Volatile);
+            }
+            if (expr instanceof J.FieldAccess) {
+                return isTypeReference(expr);
+            }
+            if (expr instanceof J.NewClass) {
+                // Instantiating a type only to call a static method on it is the case this recipe was written
+                // for, so the instantiation itself is still discarded even though a constructor can throw.
+                // Its arguments are not covered by that, so they have to be discardable in their own right.
+                J.NewClass newClass = (J.NewClass) expr;
+                if (newClass.getBody() != null || newClass.getEnclosing() != null) {
+                    return false;
+                }
+                for (Expression argument : newClass.getArguments()) {
+                    if (!isSafeToDiscard(argument)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
+        }
+
+        /**
+         * A qualifier that is itself an invocation this recipe rewrites needs no preservation: the recipe's
+         * long-standing treatment of such chains is to collapse them, so that with a fluent
+         * {@code a.Legacy value()} pattern {@code legacy.value().value()} becomes {@code Modern.value()}.
+         * Blocking that collapse would leave the rewritten qualifier behind as the receiver of the outer
+         * call, producing {@code Modern.value().value()}, which no longer resolves once the migrated method
+         * is static on the target type. The qualifier's own receiver is checked recursively, so a chain
+         * rooted in an expression that cannot be discarded is left entirely unchanged instead.
+         */
+        private boolean collapsesOntoTargetType(@Nullable Expression expression) {
+            Expression expr = Expression.unwrap(expression);
+            if (!(expr instanceof J.MethodInvocation)) {
+                return false;
+            }
+            J.MethodInvocation qualifier = (J.MethodInvocation) expr;
+            return !isAlreadyStaticCallOnTargetType(qualifier.getSelect(), qualifier) &&
+                   methodMatcher.matches(qualifier, matchUnknownTypes) &&
+                   (isSafeToDiscard(qualifier.getSelect()) || collapsesOntoTargetType(qualifier.getSelect()));
+        }
+
+        /**
+         * Check if the expression only names a type or is {@code this} (possibly qualified, as in
+         * {@code Outer.this}), so that evaluating it always succeeds without any observable effect. Unlike an
+         * invocation, a member reference evaluates and null checks its qualifier when the reference is created,
+         * so it only replaces a qualifier of that shape with the target type.
+         */
+        private boolean isTypeReference(@Nullable Expression expression) {
+            if (expression instanceof J.Identifier) {
+                J.Identifier identifier = (J.Identifier) expression;
+                return identifier.getFieldType() == null || "this".equals(identifier.getSimpleName());
+            }
+            if (expression instanceof J.FieldAccess) {
+                J.Identifier name = ((J.FieldAccess) expression).getName();
+                return (name.getFieldType() == null || "this".equals(name.getSimpleName())) &&
+                       name.getType() instanceof JavaType.FullyQualified;
+            }
+            return false;
+        }
+
+        /**
          * Transform the method type to reflect the new declaring type and static flag.
          */
         private JavaType.Method transformMethodType(JavaType.Method methodType) {
@@ -140,7 +219,8 @@ public class ChangeMethodTargetToStatic extends Recipe {
             J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
             Expression select = method.getSelect();
             if (!isAlreadyStaticCallOnTargetType(select, method) &&
-                methodMatcher.matches(method, matchUnknownTypes)) {
+                methodMatcher.matches(method, matchUnknownTypes) &&
+                (isSafeToDiscard(select) || collapsesOntoTargetType(select))) {
                 JavaType.Method transformedType = null;
                 if (method.getMethodType() != null) {
                     maybeRemoveImport(method.getMethodType().getDeclaringType());
@@ -174,7 +254,8 @@ public class ChangeMethodTargetToStatic extends Recipe {
             J.MemberReference m = (J.MemberReference) super.visitMemberReference(memberRef, ctx);
             Expression containing = memberRef.getContaining();
             if (!isAlreadyStaticCallOnTargetType(containing, memberRef) &&
-                methodMatcher.matches(memberRef)) {
+                methodMatcher.matches(memberRef) &&
+                (isTypeReference(containing) || collapsesOntoTargetType(containing))) {
                 JavaType.Method transformedType = null;
                 if (memberRef.getMethodType() != null) {
                     maybeRemoveImport(memberRef.getMethodType().getDeclaringType());

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -119,14 +119,10 @@ public class ChangeMethodTargetToStatic extends Recipe {
         }
 
         /**
-         * Java evaluates the expression qualifying a static method invocation and then discards its value,
-         * without a null check. This only drops an expression whose evaluation cannot be observed: a type name,
-         * {@code this} (possibly qualified), or a simple non-volatile variable read (class initialization
-         * aside). As a deliberate exception that preserves the {@code new A().staticMethod()} shape this recipe
-         * exists to rewrite, an instantiation whose arguments are themselves discardable is also dropped, even
-         * though a constructor can run arbitrary code and throw. A method invocation, a dereference, an array
-         * access, a cast or any other expression may mutate state or throw, so the invocation is left alone
-         * instead.
+         * Whether the receiver can be replaced by the target type name without the running program noticing:
+         * a type name, {@code this}, a literal, or a non-volatile field read qualified by neither. An
+         * invocation, a dereference, an array access or a cast may mutate state or throw, so those leave the
+         * call alone instead.
          */
         private boolean isSafeToDiscard(@Nullable Expression expression) {
             Expression expr = Expression.unwrap(expression);
@@ -138,12 +134,17 @@ public class ChangeMethodTargetToStatic extends Recipe {
                 return fieldType == null || !fieldType.hasFlags(Flag.Volatile);
             }
             if (expr instanceof J.FieldAccess) {
-                return isTypeReference(expr);
+                J.FieldAccess fieldAccess = (J.FieldAccess) expr;
+                if (isTypeReference(fieldAccess)) {
+                    return true;
+                }
+                JavaType.Variable fieldType = fieldAccess.getName().getFieldType();
+                return isTypeReference(fieldAccess.getTarget()) &&
+                       (fieldType == null || !fieldType.hasFlags(Flag.Volatile));
             }
             if (expr instanceof J.NewClass) {
-                // Instantiating a type only to call a static method on it is the case this recipe was written
-                // for, so the instantiation itself is still discarded even though a constructor can throw.
-                // Its arguments are not covered by that, so they have to be discardable in their own right.
+                // `new A().staticMethod()` is the shape this recipe exists to rewrite, so the instantiation is
+                // dropped even though a constructor can throw. Its arguments still have to stand on their own.
                 J.NewClass newClass = (J.NewClass) expr;
                 if (newClass.getBody() != null || newClass.getEnclosing() != null) {
                     return false;
@@ -159,13 +160,10 @@ public class ChangeMethodTargetToStatic extends Recipe {
         }
 
         /**
-         * A qualifier that is itself an invocation this recipe rewrites needs no preservation: the recipe's
-         * long-standing treatment of such chains is to collapse them, so that with a fluent
-         * {@code a.Legacy value()} pattern {@code legacy.value().value()} becomes {@code Modern.value()}.
-         * Blocking that collapse would leave the rewritten qualifier behind as the receiver of the outer
-         * call, producing {@code Modern.value().value()}, which no longer resolves once the migrated method
-         * is static on the target type. The qualifier's own receiver is checked recursively, so a chain
-         * rooted in an expression that cannot be discarded is left entirely unchanged instead.
+         * A qualifier that is itself an invocation this recipe rewrites needs no preservation, so that
+         * {@code legacy.value().value()} collapses to {@code Modern.value()} rather than to the
+         * {@code Modern.value().value()} that no longer resolves. Its own receiver and arguments are checked
+         * recursively, leaving a chain rooted in something undiscardable entirely unchanged.
          */
         private boolean collapsesOntoTargetType(@Nullable Expression expression) {
             Expression expr = Expression.unwrap(expression);
@@ -173,16 +171,49 @@ public class ChangeMethodTargetToStatic extends Recipe {
                 return false;
             }
             J.MethodInvocation qualifier = (J.MethodInvocation) expr;
-            return !isAlreadyStaticCallOnTargetType(qualifier.getSelect(), qualifier) &&
-                   methodMatcher.matches(qualifier, matchUnknownTypes) &&
-                   (isSafeToDiscard(qualifier.getSelect()) || collapsesOntoTargetType(qualifier.getSelect()));
+            if (isAlreadyStaticCallOnTargetType(qualifier.getSelect(), qualifier) ||
+                !methodMatcher.matches(qualifier, matchUnknownTypes) ||
+                !(isSafeToDiscard(qualifier.getSelect()) || collapsesOntoTargetType(qualifier.getSelect()))) {
+                return false;
+            }
+            for (Expression argument : qualifier.getArguments()) {
+                if (!isSafeToDiscard(argument)) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         /**
-         * Check if the expression only names a type or is {@code this} (possibly qualified, as in
-         * {@code Outer.this}), so that evaluating it always succeeds without any observable effect. Unlike an
-         * invocation, a member reference evaluates and null checks its qualifier when the reference is created,
-         * so it only replaces a qualifier of that shape with the target type.
+         * An invocation qualifying another matched invocation defers to that outer one, which either collapses
+         * it away or is itself left alone. Rewriting it here instead would strand a call to the migrated
+         * static method on a receiver that no longer declares it.
+         */
+        private boolean isQualifierOfMatchedCall(Expression expression) {
+            Cursor parent = getCursor().getParentTreeCursor();
+            while (parent.getValue() instanceof J.Parentheses) {
+                parent = parent.getParentTreeCursor();
+            }
+            Object value = parent.getValue();
+            if (value instanceof J.MethodInvocation) {
+                J.MethodInvocation outer = (J.MethodInvocation) value;
+                return Expression.unwrap(outer.getSelect()) == expression &&
+                       !isAlreadyStaticCallOnTargetType(outer.getSelect(), outer) &&
+                       methodMatcher.matches(outer, matchUnknownTypes);
+            }
+            if (value instanceof J.MemberReference) {
+                J.MemberReference outer = (J.MemberReference) value;
+                return Expression.unwrap(outer.getContaining()) == expression &&
+                       !isAlreadyStaticCallOnTargetType(outer.getContaining(), outer) &&
+                       methodMatcher.matches(outer);
+            }
+            return false;
+        }
+
+        /**
+         * Whether the expression only names a type or is {@code this}, possibly qualified as {@code Outer.this}.
+         * A member reference evaluates and null checks its qualifier when the reference is created, so unlike an
+         * invocation it accepts only a qualifier of that shape.
          */
         private boolean isTypeReference(@Nullable Expression expression) {
             if (expression instanceof J.Identifier) {
@@ -220,6 +251,7 @@ public class ChangeMethodTargetToStatic extends Recipe {
             Expression select = method.getSelect();
             if (!isAlreadyStaticCallOnTargetType(select, method) &&
                 methodMatcher.matches(method, matchUnknownTypes) &&
+                !isQualifierOfMatchedCall(method) &&
                 (isSafeToDiscard(select) || collapsesOntoTargetType(select))) {
                 JavaType.Method transformedType = null;
                 if (method.getMethodType() != null) {
@@ -230,7 +262,7 @@ public class ChangeMethodTargetToStatic extends Recipe {
                     maybeAddImport(fullyQualifiedTargetTypeName, m.getSimpleName(), !matchUnknownTypes);
                 } else {
                     maybeAddImport(fullyQualifiedTargetTypeName, !matchUnknownTypes);
-                    m = method.withSelect(
+                    m = m.withSelect(
                             new J.Identifier(randomId(),
                                     select == null ?
                                             Space.EMPTY :
@@ -262,7 +294,7 @@ public class ChangeMethodTargetToStatic extends Recipe {
                     transformedType = transformMethodType(memberRef.getMethodType());
                 }
                 maybeAddImport(fullyQualifiedTargetTypeName, !matchUnknownTypes);
-                m = memberRef.withContaining(
+                m = m.withContaining(
                         new J.Identifier(randomId(),
                                 containing.getPrefix(),
                                 Markers.EMPTY,

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodTargetToStatic.java
@@ -119,22 +119,20 @@ public class ChangeMethodTargetToStatic extends Recipe {
         }
 
         /**
-         * Whether the receiver can be replaced by the target type name without the running program noticing:
-         * a type name, {@code this}, a literal, or a non-volatile field read qualified by neither. An
-         * invocation, a dereference, an array access or a cast may mutate state or throw, so those leave the
-         * call alone instead.
+         * Returns true when dropping the receiver cannot change program behavior. Expressions that can have side
+         * effects or throw return false.
          */
         private boolean isSafeToDiscard(@Nullable Expression expression) {
-            Expression expr = Expression.unwrap(expression);
-            if (expr == null || expr instanceof J.Empty || expr instanceof J.Literal) {
+            Expression unwrapped = Expression.unwrap(expression);
+            if (unwrapped == null || unwrapped instanceof J.Empty || unwrapped instanceof J.Literal) {
                 return true;
             }
-            if (expr instanceof J.Identifier) {
-                JavaType.Variable fieldType = ((J.Identifier) expr).getFieldType();
+            if (unwrapped instanceof J.Identifier) {
+                JavaType.Variable fieldType = ((J.Identifier) unwrapped).getFieldType();
                 return fieldType == null || !fieldType.hasFlags(Flag.Volatile);
             }
-            if (expr instanceof J.FieldAccess) {
-                J.FieldAccess fieldAccess = (J.FieldAccess) expr;
+            if (unwrapped instanceof J.FieldAccess) {
+                J.FieldAccess fieldAccess = (J.FieldAccess) unwrapped;
                 if (isTypeReference(fieldAccess)) {
                     return true;
                 }
@@ -142,10 +140,10 @@ public class ChangeMethodTargetToStatic extends Recipe {
                 return isTypeReference(fieldAccess.getTarget()) &&
                        (fieldType == null || !fieldType.hasFlags(Flag.Volatile));
             }
-            if (expr instanceof J.NewClass) {
+            if (unwrapped instanceof J.NewClass) {
                 // `new A().staticMethod()` is the shape this recipe exists to rewrite, so the instantiation is
                 // dropped even though a constructor can throw. Its arguments still have to stand on their own.
-                J.NewClass newClass = (J.NewClass) expr;
+                J.NewClass newClass = (J.NewClass) unwrapped;
                 if (newClass.getBody() != null || newClass.getEnclosing() != null) {
                     return false;
                 }
@@ -160,17 +158,14 @@ public class ChangeMethodTargetToStatic extends Recipe {
         }
 
         /**
-         * A qualifier that is itself an invocation this recipe rewrites needs no preservation, so that
-         * {@code legacy.value().value()} collapses to {@code Modern.value()} rather than to the
-         * {@code Modern.value().value()} that no longer resolves. Its own receiver and arguments are checked
-         * recursively, leaving a chain rooted in something undiscardable entirely unchanged.
+         * Returns true when every receiver and argument in a matched call chain is safe to drop.
          */
         private boolean collapsesOntoTargetType(@Nullable Expression expression) {
-            Expression expr = Expression.unwrap(expression);
-            if (!(expr instanceof J.MethodInvocation)) {
+            Expression unwrapped = Expression.unwrap(expression);
+            if (!(unwrapped instanceof J.MethodInvocation)) {
                 return false;
             }
-            J.MethodInvocation qualifier = (J.MethodInvocation) expr;
+            J.MethodInvocation qualifier = (J.MethodInvocation) unwrapped;
             if (isAlreadyStaticCallOnTargetType(qualifier.getSelect(), qualifier) ||
                 !methodMatcher.matches(qualifier, matchUnknownTypes) ||
                 !(isSafeToDiscard(qualifier.getSelect()) || collapsesOntoTargetType(qualifier.getSelect()))) {
@@ -185,9 +180,8 @@ public class ChangeMethodTargetToStatic extends Recipe {
         }
 
         /**
-         * An invocation qualifying another matched invocation defers to that outer one, which either collapses
-         * it away or is itself left alone. Rewriting it here instead would strand a call to the migrated
-         * static method on a receiver that no longer declares it.
+         * Returns true when this expression is the receiver of another matched call. The outer call then decides
+         * whether the whole chain is safe to rewrite.
          */
         private boolean isQualifierOfMatchedCall(Expression expression) {
             Cursor parent = getCursor().getParentTreeCursor();
@@ -211,9 +205,7 @@ public class ChangeMethodTargetToStatic extends Recipe {
         }
 
         /**
-         * Whether the expression only names a type or is {@code this}, possibly qualified as {@code Outer.this}.
-         * A member reference evaluates and null checks its qualifier when the reference is created, so unlike an
-         * invocation it accepts only a qualifier of that shape.
+         * Returns true for a type name, {@code this}, or {@code Outer.this}.
          */
         private boolean isTypeReference(@Nullable Expression expression) {
             if (expression instanceof J.Identifier) {


### PR DESCRIPTION
**Suggested review order:** 28 of 52 (Score: 3.5)
**Review first:** https://github.com/openrewrite/rewrite-static-analysis/pull/975

## What's changed?

[`ChangeMethodTargetToStatic`](https://docs.openrewrite.org/recipes/java/changemethodtargettostatic) now rewrites a call only when the receiver can be deleted without the running program noticing. On main every matched receiver is replaced by the target type name, whatever it does.

Java requires the receiver to be evaluated: per [JLS 15.12.4.1](https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.12.4.1) the qualifier of `Primary.method(...)` is evaluated and its value discarded even when the invoked method is static, and per [JLS 15.13.3](https://docs.oracle.com/javase/specs/jls/se21/html/jls-15.html#jls-15.13.3) the qualifier of a bound method reference is evaluated and null checked when the reference is created. Main's output still compiles and still returns the same value, so only what the program does while it runs changes.

A receiver is still deleted when it is a type name, `this` (including `Outer.this`), a literal, a non-volatile variable read, a non-volatile field read qualified by a type name or `this`, or a `new A(...)` with no anonymous body, no enclosing instance and arguments that are themselves droppable. Every other form now stops the rewrite: an unmatched invocation, a field access on another expression such as `other.field`, an array access, a cast.

For a member reference the rule is stricter: the qualifier is replaced only when it is a type name, `this`, or a call this recipe rewrites away itself, since creating the reference already evaluates and null checks it.

Chains still collapse - with `a.A value()` retargeted to `b.B`, `legacy.value().value()` becomes `B.value()` - but only when the collapsed qualifier's own receiver *and* arguments are droppable. `legacy.combine(argument()).value()` is now left alone rather than losing `argument()`.

## What's your motivation?

**Recipe:** `org.openrewrite.java.ChangeMethodTargetToStatic`.

### Before

```java
return modifier().isPublic(1);
```

### Actual after the recipe

```java
return Modifier.isPublic(1);
```

### Expected after the recipe

(unchanged)

## Anything in particular you'd like reviewers to focus on?

No existing test expectation changed, so the existing tests show nothing of the rewrites the recipe no longer performs. Those are a real loss of coverage: a bound method reference on a variable, `a::value`, is no longer retargeted to `B::value`, because creating `a::value` null checks `a` while `B::value` does not.

Three recipes call this one, and all three keep working. `MockUtilsToStatic` in rewrite-testing-frameworks rewrites `new MockUtil().isMock(x)` and a `MockUtil` held in a local or a field - an instantiation and a variable read, both still droppable. `RemovedToolProviderConstructor` and `RemovedModifierAndConstantBootstrapsConstructors`, inside `UpgradeToJava17` in rewrite-migrate-java, target `javax.tools.ToolProvider`, `java.lang.reflect.Modifier` and `java.lang.invoke.ConstantBootstraps`, whose usages take the same two shapes. The one shape they lose is the receiver that is itself a call, `modifier().isPublic(1)`, which is the defect above.

Two receivers are still deleted although deleting them can be observed. Main deletes them too, so neither is a regression:

- `new A().staticMethod()` still loses the instantiation, though a constructor can run arbitrary code and throw. This is deliberate: it is the shape the recipe exists to rewrite, so treating an instantiation as undeletable would switch the recipe off for its main use.
- A bare static field name, `INSTANCE.stat()`, is a variable read and is still deleted, losing the class initialization [JLS 12.4.1](https://docs.oracle.com/javase/specs/jls/se21/html/jls-12.html#jls-12.4.1) requires on first use of a non-constant static field.

## Have you considered any alternatives or workarounds?

One alternative is to keep the receiver and emit it as a separate `receiver();` statement before the rewritten call. That is a much larger change: it has to decide whether the call sits somewhere a statement can be inserted at all - a field initializer or a ternary branch offers nowhere to put one - and for a member reference it has to generate an explicit null check, because the implicit one is lost once the qualifier becomes a type name. That work can follow this change; say so if you prefer it.

## Any additional context

Adds 15 tests to `ChangeMethodTargetToStaticTest`, taking it from 12 to 27. Nine fail without the code change; the rest cover rewrites the recipe must still perform, showing the change does not narrow it too far.

This change was prepared with AI assistance (Claude Code). I reviewed the code, the tests and this description.

### Checklist

- [x] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [ ] I've run `./gradlew build` locally, and committed any resulting changes to `recipes.csv`
- [x] I've [formatted the lines I changed](https://github.com/openrewrite/.github/blob/main/CONTRIBUTING.md#code-style-and-formatting), without reformatting code I didn't touch
