### PR TITLE
Scala: leading annotations no longer steal a declaration's prefix

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -759,14 +759,6 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
 
         if (scu.getPackageDeclaration() != null) {
             visit(scu.getPackageDeclaration(), p);
-            boolean packageEndsWithSemicolon = scu.getPackageDeclaration().getMarkers().findFirst(PackageSemicolon.class).isPresent();
-            if (!packageEndsWithSemicolon && !scu.getStatements().isEmpty()) {
-                Statement firstStatement = scu.getStatements().get(0);
-                String firstStatementPrefix = firstStatement.getPrefix().getWhitespace();
-                if (!firstStatementPrefix.startsWith("\n") && !firstStatementPrefix.startsWith(";")) {
-                    p.append("\n");
-                }
-            }
         }
 
         for (int i = 0; i < scu.getStatements().size(); i++) {

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -3051,15 +3051,8 @@ class ScalaTreeVisitor(
       return visitLambdaParameter(vd)
     }
     
-    // Special handling for variables with annotations
     val hasAnnotations = vd.mods != null && vd.mods.annotations.nonEmpty
-    val prefix = if (hasAnnotations) {
-      // Don't extract prefix yet - annotations will consume their own prefix
-      Space.EMPTY
-    } else {
-      extractPrefix(vd.span)
-    }
-    
+
     // Handle annotations first
     val leadingAnnotations = new util.ArrayList[J.Annotation]()
     if (hasAnnotations) {
@@ -3070,7 +3063,9 @@ class ScalaTreeVisitor(
         }
       }
     }
-    
+
+    val prefix = if (hasAnnotations) hoistAnnotationPrefix(leadingAnnotations) else extractPrefix(vd.span)
+
     // Extract modifiers and keywords from source
     // When we have annotations, cursor is positioned after them
     val adjustedStart = if (hasAnnotations) cursor else Math.max(0, vd.span.start - offsetAdjustment)
@@ -3584,9 +3579,6 @@ class ScalaTreeVisitor(
 
   private def visitModuleDef(md: untpd.ModuleDef): J.ClassDeclaration = {
     val hasAnnotations = md.mods != null && md.mods.annotations.nonEmpty
-    // When annotations are present they own the leading whitespace; otherwise
-    // the prefix lives on the ModuleDef itself.
-    val prefix = if (hasAnnotations) Space.EMPTY else extractPrefix(md.span)
 
     val leadingAnnotations = new util.ArrayList[J.Annotation]()
     if (hasAnnotations) {
@@ -3597,6 +3589,8 @@ class ScalaTreeVisitor(
         }
       }
     }
+
+    val prefix = if (hasAnnotations) hoistAnnotationPrefix(leadingAnnotations) else extractPrefix(md.span)
 
     // Extract the source text to find modifiers
     val adjustedStart = Math.max(0, md.span.start - offsetAdjustment)
@@ -4856,15 +4850,8 @@ class ScalaTreeVisitor(
   }
   
   private def visitClassDef(td: Trees.TypeDef[?]): J.ClassDeclaration = {
-    // Special handling for classes with annotations
     val hasAnnotations = td.mods.annotations.nonEmpty
-    val prefix = if (hasAnnotations) {
-      // Don't extract prefix yet - annotations will consume their own prefix
-      Space.EMPTY
-    } else {
-      extractPrefix(td.span)
-    }
-    
+
     // Handle annotations first
     val leadingAnnotations = new util.ArrayList[J.Annotation]()
     for (annot <- td.mods.annotations) {
@@ -4873,7 +4860,9 @@ class ScalaTreeVisitor(
         case _ => // Skip if not mapped to annotation
       }
     }
-    
+
+    val prefix = if (hasAnnotations) hoistAnnotationPrefix(leadingAnnotations) else extractPrefix(td.span)
+
     // After processing annotations, we need to find where modifiers/class keyword start
     // The cursor should now be positioned after the last annotation
     
@@ -8751,6 +8740,21 @@ class ScalaTreeVisitor(
     )
   }
   
+  /**
+   * Takes the whitespace and comments preceding the first annotation as the declaration's
+   * own prefix, leaving that annotation's prefix empty: as in the Java LST, a declaration
+   * owns the space ahead of it even when an annotation comes first in source.
+   */
+  private def hoistAnnotationPrefix(annotations: util.List[J.Annotation]): Space = {
+    if (annotations.isEmpty) {
+      Space.EMPTY
+    } else {
+      val first = annotations.get(0)
+      annotations.set(0, first.withPrefix(Space.EMPTY))
+      first.getPrefix
+    }
+  }
+
   def extractPrefix(span: Spans.Span): Space = {
     if (!span.exists) {
       return Space.EMPTY

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/tree/CompilationUnitTest.java
@@ -520,4 +520,77 @@ class CompilationUnitTest implements RewriteTest {
         );
     }
 
+    @Test
+    void packageThenAnnotatedClass() {
+        rewriteRun(
+          scala(
+            """
+            package foo.bar
+            @scala.annotation.meta.field
+            case class ConfigProperty(key: String, defaultValue: Object = null) extends scala.annotation.Annotation
+            """
+          )
+        );
+    }
+
+    @Test
+    void packageThenAnnotatedObject() {
+        rewriteRun(
+          scala(
+            """
+            package foo.bar
+            @deprecated
+            object Logging
+            """
+          )
+        );
+    }
+
+    @Test
+    void packageThenAnnotatedVal() {
+        rewriteRun(
+          scala(
+            """
+            package foo.bar
+            @deprecated
+            val x = 1
+            """
+          )
+        );
+    }
+
+    @Test
+    void packageThenBlankLineThenAnnotatedClass() {
+        rewriteRun(
+          scala(
+            """
+            package foo.bar
+
+            @deprecated
+            class Logging
+            """
+          )
+        );
+    }
+
+    @Test
+    void docCommentOnAnnotatedClassBelongsToTheClass() {
+        rewriteRun(
+          scala(
+            """
+            package foo.bar
+            /** A trait. */
+            @deprecated
+            trait Logging
+            """,
+            spec -> spec.afterRecipe(cu -> {
+                J.ClassDeclaration logging = (J.ClassDeclaration) cu.getStatements().get(0);
+                assertThat(logging.getComments()).hasSize(1);
+                assertThat(logging.getPrefix().getWhitespace()).isEqualTo("\n");
+                assertThat(logging.getLeadingAnnotations().get(0).getPrefix().getWhitespace()).isEmpty();
+            })
+          )
+        );
+    }
+
 }


### PR DESCRIPTION
## Motivation

- Two Scala files in a customer repo fail the parser's print idempotency check, blocking ingestion of the whole repository. Both are a package clause followed by a declaration that carries a leading annotation, and both come back with one extra blank line after the package clause.

The cause is where the parser puts the space ahead of an annotated declaration. `visitClassDef`, `visitModuleDef` and `visitValDef` gave such a declaration an empty prefix and let the first annotation consume the preceding whitespace and comments. `ScalaPrinter.visitScalaCompilationUnit` then compensated: after a package clause it appended a newline whenever the first statement's prefix did not already start with one. For an annotated first declaration that prefix is empty, so the printer emitted a newline and the annotation printed the source's own newline after it.

Beyond printing, this also cost recipes the ability to find a declaration's doc comment, which ended up on the annotation rather than on `J.ClassDeclaration`. `visitDefDefImpl` already followed the Java LST convention, which is why methods round-tripped.

## Summary

- `ScalaTreeVisitor.hoistAnnotationPrefix` takes the whitespace and comments preceding the first annotation as the declaration's own prefix, leaving that annotation's prefix empty; applied in `visitClassDef`, `visitModuleDef` and `visitValDef`.
- `ScalaPrinter` no longer injects a newline after a package clause. With the prefix on the declaration there is nothing to compensate for, and the printer emits only what the LST holds.
- Regression tests in `CompilationUnitTest` for a package clause followed by an annotated class, object and val, for a blank line between the two, and one asserting that a doc comment on an annotated trait belongs to the trait.

## Test plan

- [x] `./gradlew :rewrite-scala:test` — 932 tests, all green
- [x] The five new tests in `CompilationUnitTest` fail on `main` (all but the doc-comment one with the reported extra blank line) and pass here
- [x] Verified the printer's newline injection is needed by nothing else: the suite is green with it removed even without the parser change