### PR TITLE
Scala: drop the synthetic unit literal that closes a constructor body

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaPrinter.java
@@ -602,6 +602,7 @@ public class ScalaPrinter<P> extends JavaPrinter<P> {
                 p.append("=");
             }
             if (omitBodyBraces && body.getStatements().size() == 1) {
+                visitSpace(body.getPrefix(), Space.Location.BLOCK_PREFIX, p);
                 visit(body.getStatements().get(0), p);
             } else {
                 visit(body, p);

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaTreeVisitor.scala
@@ -276,6 +276,11 @@ class ScalaTreeVisitor(
   }
   
   private def visitLiteral(lit: Trees.Literal[?]): J.Literal = {
+    // An `()` the author wrote parses as an empty `Tuple`, so a unit literal is always the
+    // compiler's: no source text to print, and a `BoxedUnit` value no LST consumer accepts.
+    if (lit.const.tag == UnitTag) {
+      throw unmappedException(lit)
+    }
     val prefix = extractPrefix(lit.span)
     val value = lit.const.value
     val valueSource = extractSource(lit.span)
@@ -4750,9 +4755,16 @@ class ScalaTreeVisitor(
       }
     }
     
+    // Dotty closes an auxiliary constructor's body with a unit literal that spans no source,
+    // so dropping it leaves the cursor where the last statement ended.
+    val isSyntheticUnit = block.expr match {
+      case lit: Trees.Literal[?] => lit.const.tag == UnitTag
+      case _ => false
+    }
+
     // Handle the expression part of the block (if any)
     // Skip synthetic ??? added by compiler for procedure syntax
-    val isSyntheticExpr = if (!block.expr.isEmpty) {
+    val isSyntheticExpr = if (!block.expr.isEmpty && !isSyntheticUnit) {
       def hasTripleQ(t: Trees.Tree[?]): Boolean = t match {
         case sel: Trees.Select[?] => sel.name.toString == "???" || sel.name.toString == "$qmark$qmark$qmark" || hasTripleQ(sel.qualifier)
         case id: Trees.Ident[?] => id.name.toString == "???" || id.name.toString == "$qmark$qmark$qmark"
@@ -4776,7 +4788,7 @@ class ScalaTreeVisitor(
         else cursor = blockEnd2
       }
     }
-    if (!block.expr.isEmpty && !isSyntheticExpr) {
+    if (!block.expr.isEmpty && !isSyntheticExpr && !isSyntheticUnit) {
       // Visit the expression and check if it's a synthetic ??? that slipped through.
       // Detect structurally (a `Predef.???`-style field access), never by string-matching
       // the printed output — user code such as the string literal `"???"` is not synthetic.
@@ -6590,13 +6602,15 @@ class ScalaTreeVisitor(
               }
               val statements = new util.ArrayList[JRightPadded[Statement]]()
               statements.add(JRightPadded.build(stmtExpr))
-              new J.Block(Tree.randomId(), beforeEquals,
+              // A braceless body's block covers only what follows `=`, so the space after the
+              // `=` belongs to its statement.
+              new J.Block(Tree.randomId(), Space.EMPTY,
                 Markers.build(Collections.singletonList(new org.openrewrite.scala.marker.OmitBraces(Tree.randomId()))),
                 JRightPadded.build(false), statements, Space.EMPTY)
             case stmt: Statement =>
               val statements = new util.ArrayList[JRightPadded[Statement]]()
               statements.add(JRightPadded.build(stmt))
-              new J.Block(Tree.randomId(), beforeEquals,
+              new J.Block(Tree.randomId(), Space.EMPTY,
                 Markers.build(Collections.singletonList(new org.openrewrite.scala.marker.OmitBraces(Tree.randomId()))),
                 JRightPadded.build(false), statements, Space.EMPTY)
             case _ => null

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/MethodDeclarationTest.java
@@ -17,8 +17,12 @@ package org.openrewrite.scala.tree;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.marker.MethodBodyEqualsPrefix;
+import org.openrewrite.scala.marker.OmitBraces;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.scala.Assertions.scala;
 
 class MethodDeclarationTest implements RewriteTest {
@@ -770,6 +774,66 @@ class MethodDeclarationTest implements RewriteTest {
                 }
                 """
             )
+        );
+    }
+
+    @Test
+    void auxiliaryConstructorWithExpressionBody() {
+        rewriteRun(
+          scala(
+            """
+              class A(a: Int) {
+                def this() = this(0)
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.ClassDeclaration a = (J.ClassDeclaration) cu.getStatements().get(0);
+                J.MethodDeclaration constructor = (J.MethodDeclaration) a.getBody().getStatements().get(0);
+                assertThat(constructor.getSimpleName()).isEqualTo("this");
+                assertThat(constructor.getMarkers().findFirst(MethodBodyEqualsPrefix.class))
+                  .get().extracting(m -> m.getPrefix().getWhitespace()).isEqualTo(" ");
+
+                J.Block body = constructor.getBody();
+                assertThat(body).isNotNull();
+                assertThat(body.getMarkers().findFirst(OmitBraces.class)).isPresent();
+                assertThat(body.getPrefix().getWhitespace()).isEqualTo(" ");
+                // Dotty closes the body with a `()` literal the source does not contain
+                assertThat(body.getStatements()).singleElement()
+                  .isInstanceOfSatisfying(J.MethodInvocation.class, selfInvocation -> {
+                      assertThat(selfInvocation.getSimpleName()).isEqualTo("this");
+                      assertThat(selfInvocation.getArguments()).singleElement()
+                        .isInstanceOfSatisfying(J.Literal.class, arg -> assertThat(arg.getValue()).isEqualTo(0));
+                  });
+            })
+          )
+        );
+    }
+
+    @Test
+    void auxiliaryConstructorWithBlockBody() {
+        rewriteRun(
+          scala(
+            """
+              class A(a: Int) {
+                def this() = {
+                  this(0)
+                  println("init")
+                }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.ClassDeclaration a = (J.ClassDeclaration) cu.getStatements().get(0);
+                J.MethodDeclaration constructor = (J.MethodDeclaration) a.getBody().getStatements().get(0);
+
+                J.Block body = constructor.getBody();
+                assertThat(body).isNotNull();
+                assertThat(body.getMarkers().findFirst(OmitBraces.class)).isEmpty();
+                assertThat(body.getEnd().getWhitespace()).isEqualTo("\n  ");
+                assertThat(body.getStatements()).hasSize(2);
+                assertThat(((J.MethodInvocation) body.getStatements().get(0)).getSimpleName()).isEqualTo("this");
+                assertThat(body.getStatements().get(1)).isInstanceOf(J.MethodInvocation.class);
+            })
+          )
         );
     }
 


### PR DESCRIPTION
## Motivation

- Ingestion of a customer repository fails at LST write time with `No serializer found for class scala.runtime.BoxedUnit`, through this chain:

```
S$CompilationUnit["statements"] -> J$ClassDeclaration["body"] -> J$Block["statements"]
  -> J$MethodDeclaration["body"] -> J$Block["statements"][1]
  -> J$Return["expression"] -> J$Literal["value"]
```

The source is auxiliary constructors. Dotty closes a secondary constructor's body with a zero-width `()` literal:

```scala
class A(a: Int) {
  def this() = this(0)   // untyped tree: Block([this(0)], Literal(Constant(())))
}
```

`visitLiteral` passed that constant straight into `J.Literal.value`, where it lands as `scala.runtime.BoxedUnit`, and the block conversion wrapped it in an implicit-return `J.Return`. Because the span is zero-width the literal printed as the empty string, so print idempotency stayed green and the tree only failed when serialized.

```
Before                                          After
J.MethodDeclaration name=this                   J.MethodDeclaration name=this
└── J.Block markers=[OmitBraces]                └── J.Block markers=[OmitBraces]
    ├── J.MethodInvocation "this(0)"                └── J.MethodInvocation "this(0)"
    └── J.Return markers=[ImplicitReturn]
        └── J.Literal value=BoxedUnit valueSource=""
```

Dropping the node rather than repairing its value follows Groovy, which wraps a trailing expression in `J.Return` + `ImplicitReturn` only when the method's return type is not `void`, and Kotlin, which wraps only an expression that exists in the source. A trailing expression the author did write still gets the implicit return here: `def g(): Unit = { println("a"); println("b") }` ends in `Return[ImplicitReturn]` as before.

## Summary

- `visitBlock` drops a block result that is a unit literal. It spans no source, so the cursor stays where the last statement ended and the whitespace before the closing brace is still collected as the block's end padding.
- `visitLiteral` throws for a unit constant. An `()` the author wrote parses as an empty `Tuple`, so a unit literal is always the compiler's; any remaining path is a modeling gap, and one file failing to parse beats poisoning a batch's serialization.
- A braceless body's block prefix is empty for both Dotty's blocks and the parser's own expression-body wrappers, so the space after `=` consistently belongs to the statement. The printer emits that prefix in the single-statement branch, which previously dropped it.
- Structural regression tests for both constructor forms, asserting the body holds only its source statements, plus the markers and prefixes that carry the `=` spacing.

## Test plan

- [x] `./gradlew :rewrite-scala:test` — 934 tests, all green
- [x] Both new tests fail without the fix, with `[this(0), return]` and `[this(0), println.apply("init"), return]`
- [x] Located the shape by making `visitLiteral` throw on any non-serializable constant and running the full suite: only the two auxiliary-constructor tests hit it
- [x] Swept 14 other Unit-valued shapes (`if` without `else`, `while`, bare `return`, `match` with an empty case, explicit `()`, `classOf`) — none produce a unit literal