### PR TITLE
Report types referenced only as a static member access qualifier

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
@@ -42,7 +42,11 @@ class FindTypesTest implements RewriteTest {
     String a1 = """
       package a;
       public class A1 extends Exception {
+          public static final String CONST = "const";
           public static void stat() {}
+          public static class Inner {
+              public static final String INNER_CONST = "innerConst";
+          }
       }
       """;
 
@@ -427,6 +431,183 @@ class FindTypesTest implements RewriteTest {
               import a.A1;
               class B {
                   Class<?> clazz = /*~~>*/A1.class;
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void staticFieldAccess() {
+        rewriteRun(
+          spec -> spec.dataTable(TypeUses.Row.class, rows -> assertThat(rows)
+            .containsExactly(
+              new TypeUses.Row("B.java", "A1", "a.A1")
+            )),
+          java(
+            """
+              import a.A1;
+              class B {
+                  String s = A1.CONST;
+              }
+              """,
+            """
+              import a.A1;
+              class B {
+                  String s = /*~~>*/A1.CONST;
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void staticFieldAccessOnNestedType() {
+        rewriteRun(
+          java(
+            """
+              import a.A1;
+              class B {
+                  String s = A1.Inner.INNER_CONST;
+              }
+              """,
+            """
+              import a.A1;
+              class B {
+                  String s = /*~~>*/A1.Inner.INNER_CONST;
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void enclosingTypeOfNestedTypeReference() {
+        rewriteRun(
+          java(
+            """
+              import a.A1;
+              class B {
+                  A1.Inner i;
+              }
+              """,
+            """
+              import a.A1;
+              class B {
+                  /*~~>*/A1.Inner i;
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void staticImportIsNotAReference() {
+        rewriteRun(
+          java(
+            """
+              import static a.A1.CONST;
+              class B {
+                  String s = CONST;
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void fullyQualifiedStaticFieldAccess() {
+        rewriteRun(
+          java(
+            """
+              class B {
+                  String s = a.A1.CONST;
+              }
+              """,
+            """
+              class B {
+                  String s = /*~~>*/a.A1.CONST;
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void staticFieldAccessOnDirectlyImportedNestedType() {
+        rewriteRun(
+          spec -> spec.recipe(new FindTypes("a.A1.Inner", false)),
+          java(
+            """
+              import a.A1.Inner;
+              class B {
+                  String s = Inner.INNER_CONST;
+              }
+              """,
+            """
+              import a.A1.Inner;
+              class B {
+                  String s = /*~~>*/Inner.INNER_CONST;
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void variableNamedLikeItsType() {
+        // `A1.CONST` resolves to the obscuring variable, not the type; the declarator name is matched by the
+        // separate `visitIdentifier` path
+        rewriteRun(
+          java(
+            """
+              import a.A1;
+              class B {
+                  void test() {
+                      A1 A1 = null;
+                      String s = A1.CONST;
+                  }
+              }
+              """,
+            """
+              import a.A1;
+              class B {
+                  void test() {
+                      /*~~>*/A1 /*~~>*/A1 = null;
+                      String s = A1.CONST;
+                  }
+              }
+              """
+          ),
+          java(a1)
+        );
+    }
+
+    @Test
+    void fieldAccessOnVariableOfMatchingType() {
+        rewriteRun(
+          java(
+            """
+              import a.A1;
+              class B {
+                  void test(A1 a1) {
+                      String s = a1.CONST;
+                  }
+              }
+              """,
+            """
+              import a.A1;
+              class B {
+                  void test(/*~~>*/A1 a1) {
+                      String s = a1.CONST;
+                  }
               }
               """
           ),

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -222,20 +222,33 @@ public class FindTypes extends Recipe {
         public J visitFieldAccess(J.FieldAccess fieldAccess, ExecutionContext ctx) {
             J.FieldAccess fa = (J.FieldAccess) super.visitFieldAccess(fieldAccess, ctx);
             JavaType.FullyQualified type = TypeUtils.asFullyQualified(fa.getTarget().getType());
-            if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type) &&
-                    "class".equals(fa.getName().getSimpleName())) {
-                return found(fa, ctx);
+            if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type)) {
+                if ("class".equals(fa.getName().getSimpleName())) {
+                    return found(fa, ctx);
+                }
+                // Identifiers under a field access are left to the enclosing name's `visitTypeName`, which covers
+                // qualified type names (`a.A1`) but not the type qualifying a static member access (`A1.CONST`).
+                // A null field type distinguishes an identifier naming the type from one that is a value of it.
+                if (fa.getTarget() instanceof J.Identifier &&
+                        ((J.Identifier) fa.getTarget()).getFieldType() == null &&
+                        getCursor().firstEnclosing(J.Import.class) == null) {
+                    return fa.withTarget(found((J.Identifier) fa.getTarget(), getCursor(), ctx));
+                }
             }
             return fa;
         }
 
         private <J2 extends TypedTree> J2 found(J2 j, ExecutionContext ctx) {
+            return found(j, getCursor().getParentTreeCursor(), ctx);
+        }
+
+        private <J2 extends TypedTree> J2 found(J2 j, Cursor parent, ExecutionContext ctx) {
             JavaType.FullyQualified fqn = TypeUtils.asFullyQualified(j.getType());
             if (!j.getMarkers().findFirst(SearchResult.class).isPresent()) {
                 // Avoid double-counting results in the data table
                 typeUses.insertRow(ctx, new TypeUses.Row(
                         getCursor().firstEnclosingOrThrow(SourceFile.class).getSourcePath().toString(),
-                        j.printTrimmed(getCursor().getParentTreeCursor()),
+                        j.printTrimmed(parent),
                         fqn == null ? j.getType().toString() : fqn.getFullyQualifiedName()
                 ));
             }


### PR DESCRIPTION
## Motivation

`FindTypes` did not report a type that is referenced only as the qualifier of a static member access. Given `import a.A1;` and `A1.CONST`, the type `A1` went unreported, even though a rename or migration of `A1` must change that site. This showed up when comparing `FindTypes` against a trigram-index reference search over javaparser: for `com.github.javaparser.ast.Node`, four files that reference `Node` only through an import plus a qualified static member access (`Node.LINE_SEPARATOR_KEY`, `Node.Parsedness.PARSED`) were found by the index and missed by `FindTypes`.

The cause is an asymmetry in `JavaVisitor`. A static `J.MethodInvocation`'s select is explicitly routed through `visitTypeName`, which is why `A1.stat()` was already reported. `visitFieldAccess` routes only the field access itself, never its target, so a qualifier that is a bare `J.Identifier` reached only `FindTypes.visitIdentifier` — which skips any identifier under a `J.FieldAccess`. That skip was introduced in a6b1ca0d95 as a blanket guard to stop the trailing `A1` of the qualified name `a.A1` being marked on top of the enclosing match; it was never a decision about static access. A qualifier that is itself a field access (`a.A1.CONST`) was unaffected, since the inner `a.A1` is a type name in its own right.

## Examples

```java
import a.A1;

class B {
    String s = A1.CONST;              // now reported; previously missed
    String t = A1.Inner.INNER_CONST;  // now reported; previously missed
    void m() { A1.stat(); }           // reported before and after
    String u = a.A1.CONST;            // reported before and after
}
```

Two cases deliberately remain unreported. Imports are excluded throughout `FindTypes`, so a static import (`import static a.A1.CONST;` and a bare `CONST`) is not a reference — consistent with plain imports, which are excluded for the same reason. A receiver that merely has the type is not a reference either, so `a1.CONST` on a variable `a1` is not reported.

## Summary

- `FindTypes.JavaSourceFileVisitor.visitFieldAccess` now marks the field access target when it is a `J.Identifier` naming the searched type.
- The target is recognised as naming a type via `J.Identifier#getFieldType() == null`, the same test `J.FieldAccess#isFullyQualifiedClassReference` uses. This distinguishes a type qualifier from a receiver that has the type, and works for a directly imported nested type (`import a.A1.Inner;` then `Inner.INNER_CONST`), whose `getClassName()` is `A1.Inner` and so does not equal the identifier text.
- Handling this in `visitFieldAccess` rather than relaxing the `visitIdentifier` skip keeps `a.A1` and `A1.class` single-marked, because a target that is itself a field access stays with the existing `visitTypeName` match.
- `found` gained a cursor overload so the `TypeUses` data table prints the marked identifier against its real parent. Data table rows continue to track the markers exactly.
- The static `FindTypes.find(...)` API is untouched, so `AddImport` and `J#findType` are unaffected.

One behaviour change is worth calling out: the enclosing type of a nested type reference in a type position is now reported too, so searching for `a.A1` marks `A1.Inner i;`. This is the same AST shape as `Node.Parsedness.PARSED`, so the two cannot be separated coherently — both are references to `A1` that a rename must touch. Covered by `enclosingTypeOfNestedTypeReference`.

## Test plan

- [x] New tests in `FindTypesTest`: `staticFieldAccess` (including a `TypeUses` data table assertion), `staticFieldAccessOnNestedType`, `staticFieldAccessOnDirectlyImportedNestedType`, `enclosingTypeOfNestedTypeReference`
- [x] New characterization tests locking in unchanged behaviour: `fullyQualifiedStaticFieldAccess`, `fieldAccessOnVariableOfMatchingType`, `variableNamedLikeItsType`, `staticImportIsNotAReference`
- [x] Existing `classReference` and `fullyQualifiedName` confirm no double-marking of `A1.class` or `a.A1`
- [x] `./gradlew :rewrite-java-test:test :rewrite-groovy:test :rewrite-kotlin:test`
