### PR TITLE
Go: fix RPC receives for Switches

### DIFF
--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -530,7 +530,13 @@ func (r *JavaReceiver) VisitSwitch(sw *java.Switch, p any) java.J {
 	c := *sw // shallow copy to avoid mutating remoteObjects baseline
 	sw = &c
 	// selector - Java sends ControlParentheses, extract inner Expression for Tag
-	if cpResult := q.Receive(nil, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
+	var selBefore any
+	if sw.Tag != nil {
+		selBefore = &java.ControlParentheses{
+			Tree: java.RightPadded[java.Expression]{Element: sw.Tag.Element, After: sw.Tag.After, Markers: sw.Tag.Markers},
+		}
+	}
+	if cpResult := q.Receive(selBefore, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
 		if cp, ok := cpResult.(*java.ControlParentheses); ok {
 			if _, isEmpty := cp.Tree.Element.(*java.Empty); !isEmpty {
 				sw.Tag = &java.RightPadded[java.Expression]{

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcPrintRoundTripIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcPrintRoundTripIntegTest.java
@@ -22,11 +22,15 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.SourceFile;
 import org.openrewrite.golang.GolangParser;
+import org.openrewrite.golang.GolangVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -269,6 +273,35 @@ class GoRpcPrintRoundTripIntegTest {
                 \t}
                 }
                 """);
+    }
+
+    @Test
+    void switchSelectorReSendKeepsTagPrefix() {
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        String source =
+                """
+                package main
+
+                func f(x int) {
+                \tswitch v := x; v {
+                \tcase 1:
+                \t}
+                }
+                """;
+        SourceFile cu = GolangParser.builder().build()
+                .parse(source).findFirst().orElseThrow();
+        assertThat(cu).as("parse must yield a Go.CompilationUnit, not a ParseError: %s", cu)
+                .isInstanceOf(org.openrewrite.golang.tree.Go.CompilationUnit.class);
+
+        SourceFile mutated = (SourceFile) new GolangVisitor<Integer>() {
+            @Override
+            public J visitSwitch(J.Switch aSwitch, Integer p) {
+                J.Switch s = (J.Switch) super.visitSwitch(aSwitch, p);
+                return s.withSelector(s.getSelector().withPrefix(Space.build(" ", emptyList())));
+            }
+        }.visitNonNull(cu, 0);
+
+        assertThat(rpc.print(mutated)).isEqualTo(source);
     }
 
     @Test


### PR DESCRIPTION
## What's changed?

Fix the Go RPC logic for receiving Switch statements.

## What's your motivation?

Without it, it might collapse whitespace around `switch` e.g.
```diff
- switch choice {
+ switchchoice {
```
in https://github.com/zyedidia/knit/blob/f7d4e39a0e24b9b6a7d33d085a684aea2c06c3a6/rules/tool.go#L99