### PR TITLE
Python: add space to negation unary operator

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/printer.py
+++ b/rewrite-python/rewrite/src/rewrite/python/printer.py
@@ -1849,6 +1849,8 @@ class PythonJavaPrinter:
 
         if unary.operator == Unary.Type.Not:
             p.append("not")
+            if not unary.expression.prefix.whitespace:
+                p.append(" ")
         elif unary.operator == Unary.Type.Positive:
             p.append("+")
         elif unary.operator == Unary.Type.Negative:

--- a/rewrite-python/rewrite/tests/python/all/tree/unary_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/unary_test.py
@@ -1,13 +1,27 @@
-from rewrite.java.support_types import JavaType
+from rewrite.java.support_types import JavaType, Space
 from rewrite.java.tree import Unary
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
-from rewrite.test import RecipeSpec, python
+from rewrite.test import RecipeSpec, from_visitor, python
 
 
 def test_bool_ops():
     # language=python
     RecipeSpec().rewrite_run(python("assert not True"))
+
+
+def test_not_keeps_separator_when_operand_prefix_collapses():
+    class RemoveWhitespace(PythonVisitor):
+        def visit_unary(self, unary, p):
+            u = super().visit_unary(unary, p)
+            if isinstance(u, Unary) and u.operator == Unary.Type.Not:
+                return u.replace(_expression=u.expression.replace(_prefix=Space.EMPTY))
+            return u
+
+    RecipeSpec(recipe=from_visitor(RemoveWhitespace())).rewrite_run(
+        # language=python
+        python("assert not  x", "assert not x")
+    )
 
 
 def test_arithmetic_ops():


### PR DESCRIPTION
## What's changed?

Adding a safety mechanism to Python printer to add an artificial (not stored in LST) whitespace after the negation operator.

## What's your motivation?

Without the fix, Java recipes when executed against Python code might produce invalid code, e.g.
```python
while notx:
  x = check()
```
instead of
```python
while not x:
  x = check()
```

- In Java, the negation operator (`!`) doesn't require a space after it, i.e. you can write `!x`. Therefore the recipes don't bother with adding any space.
- In Python, the operator is `not` and requires a space in practice, otherwise it becomes `notx`, should be `not x`.

I am not fully sure, but I figured a safety mechanism in the printer might actually be helpful. It violates the idempotency expectation.

Alternative would be to have special code in all recipes adding negation (typically in rewrite-static-analysis) to have special handling for Python and add space there.

