### PR TITLE
Report the line number of each search result in `TypeUses` and `MethodCalls`

### DIFF
--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/java/DenseJavaFileState.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/java/DenseJavaFileState.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.benchmarks.java;
+
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.LargeSourceSet;
+import org.openrewrite.SourceFile;
+import org.openrewrite.internal.InMemoryLargeSourceSet;
+import org.openrewrite.java.JavaParser;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+
+/**
+ * A large source file with hundreds of {@code java.util.List} references, so that a search's
+ * per-file work is measured where matches are dense.
+ */
+@SuppressWarnings("NotNullFieldNotInitialized")
+@State(Scope.Benchmark)
+public class DenseJavaFileState {
+    List<SourceFile> sourceFiles;
+
+    private static final String DENSE_FILE = "rewrite-java/src/main/java/org/openrewrite/java/tree/J.java";
+
+    @Setup
+    public void setup() {
+        sourceFiles = JavaParser.fromJavaVersion()
+                .classpath("jsr305", "jackson-annotations", "jspecify", "lombok", "annotations")
+                .build()
+                .parse(singletonList(denseFile()), null, new InMemoryExecutionContext())
+                .collect(toList());
+    }
+
+    /**
+     * Located by walking up from the working directory, which holds whichever module Gradle
+     * launched the benchmark from.
+     */
+    private static Path denseFile() {
+        for (Path dir = Paths.get(System.getProperty("user.dir")); dir != null; dir = dir.getParent()) {
+            Path candidate = dir.resolve(DENSE_FILE);
+            if (Files.exists(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("Cannot find " + DENSE_FILE + " above " + System.getProperty("user.dir"));
+    }
+
+    @TearDown
+    public void tearDown(Blackhole hole) {
+        hole.consume(sourceFiles.size());
+    }
+
+    public LargeSourceSet getSourceSet() {
+        return new InMemoryLargeSourceSet(sourceFiles);
+    }
+
+    public SourceFile getDenseFile() {
+        return sourceFiles.get(0);
+    }
+}

--- a/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/java/FindTypesBenchmark.java
+++ b/rewrite-benchmarks/src/jmh/java/org/openrewrite/benchmarks/java/FindTypesBenchmark.java
@@ -22,6 +22,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.java.search.FindTypes;
 
 import java.util.concurrent.TimeUnit;
@@ -46,5 +47,20 @@ public class FindTypesBenchmark {
     public void findTypes(JavaCompilationUnitState state) {
         new FindTypes("java.util.List", false)
                 .run(state.getSourceSet(), new InMemoryExecutionContext());
+    }
+
+    @Benchmark
+    public void findTypesInDenseFile(DenseJavaFileState state) {
+        new FindTypes("java.util.List", false)
+                .run(state.getSourceSet(), new InMemoryExecutionContext());
+    }
+
+    /**
+     * One whole-file print, for scale against {@link #findTypesInDenseFile}.
+     */
+    @Benchmark
+    public String printDenseFile(DenseJavaFileState state) {
+        return state.getDenseFile().printAll(
+                new PrintOutputCapture<>(0, PrintOutputCapture.MarkerPrinter.FENCED));
     }
 }

--- a/rewrite-core/src/main/java/org/openrewrite/table/SearchResultRows.java
+++ b/rewrite-core/src/main/java/org/openrewrite/table/SearchResultRows.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.table;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.*;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.SearchResult;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+
+import static java.util.Collections.emptyMap;
+
+/**
+ * Buffers the rows a search produces for one source file so each row can carry the line number
+ * of its own match, which is known only once the file is printed. Call {@link #found} in place of
+ * {@link SearchResult#found(Tree)} at each match, and {@link #insertRows} when the file has been
+ * visited.
+ */
+public class SearchResultRows<R> {
+    private final DataTable<R> table;
+
+    /**
+     * Keyed by the fence {@link PrintOutputCapture.MarkerPrinter#FENCED} prints for the marker that
+     * locates the match, so that locating one is a lookup of a string this registered.
+     */
+    private final Map<String, Function<@Nullable Integer, R>> rows = new LinkedHashMap<>();
+
+    private final Set<UUID> matched = new HashSet<>();
+
+    public SearchResultRows(DataTable<R> table) {
+        this.table = table;
+    }
+
+    /**
+     * Marks {@code t} as a search result and buffers the row describing it, to be built once the
+     * match's line number is known. Buffers nothing when this search already matched {@code t},
+     * so that an element reached by two visit methods is reported once.
+     */
+    public <T extends Tree> T found(T t, Function<@Nullable Integer, R> row) {
+        if (!matched.add(t.getId())) {
+            return t;
+        }
+        Markers markers = t.getMarkers().add(new SearchResult(Tree.randomId(), null));
+        // `Markers.add` keeps out a search result equal to one an earlier search left, and every
+        // search result on an element fences in the same place, so any of them locates the match
+        markers.findFirst(SearchResult.class)
+                .ifPresent(located -> rows.put("{{" + located.getId() + "}}", row));
+        return t.withMarkers(markers);
+    }
+
+    /**
+     * Inserts every buffered row with the line its match starts on in {@code searched} as printed,
+     * or with no line when the printer locates no marker for it, and empties the buffer.
+     */
+    public void insertRows(@Nullable Tree searched, ExecutionContext ctx) {
+        if (rows.isEmpty()) {
+            return;
+        }
+        Map<String, Integer> lines = searched instanceof SourceFile ?
+                lineNumbers((SourceFile) searched, rows.keySet()) : emptyMap();
+        for (Map.Entry<String, Function<@Nullable Integer, R>> row : rows.entrySet()) {
+            table.insertRow(ctx, row.getValue().apply(lines.get(row.getKey())));
+        }
+        rows.clear();
+        matched.clear();
+    }
+
+    /**
+     * The 1-based line each of {@code fences} begins on, keyed by fence.
+     */
+    private static Map<String, Integer> lineNumbers(SourceFile searched, Set<String> fences) {
+        LineCounter counter = new LineCounter(fences);
+        try {
+            searched.printAll(counter);
+        } catch (RuntimeException ignored) {
+            return emptyMap();
+        }
+        return counter.lines;
+    }
+
+    /**
+     * Counts lines as a file prints, noting the line each of the fences it is looking for opens on.
+     * {@link PrintOutputCapture.MarkerPrinter#FENCED} appends each fence on its own after the
+     * marked syntax's prefix, and printers only ever append to a capture, so a fence can be placed
+     * as it arrives and the printed text stays unbuilt.
+     */
+    private static class LineCounter extends PrintOutputCapture<Integer> {
+        private static final int FENCE_LENGTH = "{{".length() + 36 + "}}".length();
+
+        private final Set<String> fences;
+        final Map<String, Integer> lines = new HashMap<>();
+        private int line = 1;
+
+        LineCounter(Set<String> fences) {
+            super(0, MarkerPrinter.FENCED);
+            this.fences = fences;
+        }
+
+        @Override
+        public PrintOutputCapture<Integer> append(@Nullable String text) {
+            if (text == null || text.isEmpty()) {
+                return this;
+            }
+            // Length and brace rule out all but a fence before hashing the string
+            if (text.length() == FENCE_LENGTH && text.charAt(0) == '{' && fences.contains(text)) {
+                // Syntax is fenced on both sides; the opening fence is the one that locates it.
+                lines.putIfAbsent(text, line);
+                return this;
+            }
+            for (int i = text.indexOf('\n'); i >= 0; i = text.indexOf('\n', i + 1)) {
+                line++;
+            }
+            return this;
+        }
+
+        @Override
+        public PrintOutputCapture<Integer> append(char c) {
+            if (c == '\n') {
+                line++;
+            }
+            return this;
+        }
+    }
+}

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindDistinctMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindDistinctMethodsTest.java
@@ -29,8 +29,8 @@ class FindDistinctMethodsTest implements RewriteTest {
           spec -> spec.dataTableAsCsv(MethodCalls.class.getName(),
             //language=csv
             """
-              sourceFile,method,className,methodName,argumentTypes
-              Test.java,"System.out.print(""hello"")",java.io.PrintStream,print,java.lang.String
+              sourceFile,method,className,methodName,argumentTypes,line
+              Test.java,"System.out.print(""hello"")",java.io.PrintStream,print,java.lang.String,3
               """
           ).recipe(new FindDistinctMethods("java.io.PrintStream print(..)", false)),
           java(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindMethodsTest.java
@@ -266,12 +266,84 @@ class FindMethodsTest implements RewriteTest {
     }
 
     @Test
+    void lineNumberOfEachMatch() {
+        rewriteRun(
+          spec -> spec.recipe(new FindMethods("java.util.List add(..)", false))
+            .dataTable(MethodCalls.Row.class, rows -> assertThat(rows)
+              .extracting(MethodCalls.Row::getLine)
+              .containsExactly(4, 8, 10)),
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  void test(List<String> l) {
+                      l.add("a");
+                      /*
+                       * A comment spanning lines, mentioning add.
+                       */
+                      l.add(
+                              "b");
+                      Runnable r = () -> l.add("c");
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              class Test {
+                  void test(List<String> l) {
+                      /*~~>*/l.add("a");
+                      /*
+                       * A comment spanning lines, mentioning add.
+                       */
+                      /*~~>*/l.add(
+                              "b");
+                      Runnable r = () -> /*~~>*/l.add("c");
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void reportsAMatchAlreadyMarkedByAnotherSearch() {
+        rewriteRun(
+          spec -> spec.recipes(
+              new FindMethods("java.util.Collection isEmpty()", true),
+              new FindMethods("java.util.List isEmpty()", false))
+            // One marker covers both searches, and each still reports its call at the right line
+            .dataTable(MethodCalls.Row.class, rows -> assertThat(rows)
+              .extracting(MethodCalls.Row::getLine)
+              .containsExactly(4, 4)),
+          java(
+            """
+              import java.util.List;
+              class Test {
+                  void test(List<String> l) {
+                      l.isEmpty();
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+              class Test {
+                  void test(List<String> l) {
+                      /*~~>*/l.isEmpty();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void datatableFormat() {
         rewriteRun(
           spec -> spec.dataTableAsCsv(MethodCalls.class.getName(),
             """
-              sourceFile,method,className,methodName,argumentTypes
-              A.java,"new B.C().foo(bar, 123)","B$C",foo,"java.lang.String, int"
+              sourceFile,method,className,methodName,argumentTypes,line
+              A.java,"new B.C().foo(bar, 123)","B$C",foo,"java.lang.String, int",3
               """
           ).recipe(new FindMethods("B.C foo(..)", false)),
           java(

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/search/FindTypesTest.java
@@ -27,6 +27,7 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.xml.Assertions.xml;
 
@@ -52,7 +53,7 @@ class FindTypesTest implements RewriteTest {
         rewriteRun(
           spec -> spec.dataTable(TypeUses.Row.class, rows -> assertThat(rows)
             .containsExactly(
-              new TypeUses.Row("B.java", "A1", "a.A1")
+              new TypeUses.Row("B.java", "A1", "a.A1", 2)
             )),
           java(
             """
@@ -163,6 +164,7 @@ class FindTypesTest implements RewriteTest {
                 assertThat(rows).hasSize(1);
                 assertThat(rows.getFirst().getConcreteType()).isEqualTo("java.util.List");
                 assertThat(rows.getFirst().getCode()).isEqualTo("List<String>");
+                assertThat(rows.getFirst().getLine()).isEqualTo(3);
             }),
           java(
             """
@@ -178,6 +180,41 @@ class FindTypesTest implements RewriteTest {
               }
               """
           )
+        );
+    }
+
+    @Test
+    void lineNumberOfEachMatch() {
+        rewriteRun(
+          spec -> spec.dataTable(TypeUses.Row.class, rows -> assertThat(rows)
+            .extracting(TypeUses.Row::getCode, TypeUses.Row::getLine)
+            .containsExactly(
+              tuple("A1", 6),
+              tuple("A1", 7)
+            )),
+          java(
+            """
+              import a.A1;
+
+              /**
+               * Prose mentioning A1 on a line that holds no reference to it.
+               */
+              public class B extends A1 {
+                  A1 field;
+              }
+              """,
+            """
+              import a.A1;
+
+              /**
+               * Prose mentioning A1 on a line that holds no reference to it.
+               */
+              public class B extends /*~~>*/A1 {
+                  /*~~>*/A1 field;
+              }
+              """
+          ),
+          java(a1)
         );
     }
 

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDeprecatedMethods.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.service.AnnotationService;
 import org.openrewrite.java.table.MethodCalls;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.table.SearchResultRows;
 
 import java.util.Iterator;
 
@@ -108,6 +109,16 @@ public class FindDeprecatedMethods extends Recipe {
         }
 
         return Preconditions.check(precondition, new JavaIsoVisitor<ExecutionContext>() {
+            final SearchResultRows<MethodCalls.Row> rows = new SearchResultRows<>(deprecatedMethodCalls);
+
+            @Override
+            public @Nullable J postVisit(J tree, ExecutionContext ctx) {
+                if (tree instanceof SourceFile) {
+                    rows.insertRows(tree, ctx);
+                }
+                return super.postVisit(tree, ctx);
+            }
+
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
@@ -128,19 +139,19 @@ public class FindDeprecatedMethods extends Recipe {
                             }
 
                             JavaSourceFile javaSourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                            if (javaSourceFile != null) {
-                                deprecatedMethodCalls.insertRow(ctx, new MethodCalls.Row(
-                                        javaSourceFile.getSourcePath().toString(),
-                                        method.printTrimmed(getCursor().getParentTreeCursor()),
-                                        method.getMethodType().getDeclaringType().getFullyQualifiedName(),
-                                        method.getSimpleName(),
-                                        method.getArguments().stream()
-                                                .map(Expression::getType)
-                                                .map(String::valueOf)
-                                                .collect(joining(", "))
-                                ));
+                            if (javaSourceFile == null) {
+                                m = SearchResult.found(m);
+                            } else {
+                                String sourceFile = javaSourceFile.getSourcePath().toString();
+                                String code = method.printTrimmed(getCursor().getParentTreeCursor());
+                                String declaringType = method.getMethodType().getDeclaringType().getFullyQualifiedName();
+                                String argumentTypes = method.getArguments().stream()
+                                        .map(Expression::getType)
+                                        .map(String::valueOf)
+                                        .collect(joining(", "));
+                                m = rows.found(m, line -> new MethodCalls.Row(sourceFile, code, declaringType,
+                                        method.getSimpleName(), argumentTypes, line));
                             }
-                            m = SearchResult.found(m);
                         }
                     }
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindDistinctMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindDistinctMethods.java
@@ -25,7 +25,7 @@ import org.openrewrite.java.table.MethodCalls;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.MethodCall;
-import org.openrewrite.marker.SearchResult;
+import org.openrewrite.table.SearchResultRows;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -99,6 +99,15 @@ public class FindDistinctMethods extends ScanningRecipe<Map<String, UUID>> {
     public TreeVisitor<?, ExecutionContext> getVisitor(Map<String, UUID> acc) {
         return Preconditions.check(new UsesMethod<>(getMethodPattern(), matchOverrides), new JavaVisitor<ExecutionContext>() {
             final MethodMatcher methodMatcher = new MethodMatcher(getMethodPattern(), matchOverrides);
+            final SearchResultRows<MethodCalls.Row> rows = new SearchResultRows<>(methodCalls);
+
+            @Override
+            public @Nullable J postVisit(J tree, ExecutionContext ctx) {
+                if (tree instanceof SourceFile) {
+                    rows.insertRows(tree, ctx);
+                }
+                return super.postVisit(tree, ctx);
+            }
 
             @Override
             public J visitExpression(Expression expression, ExecutionContext ctx) {
@@ -109,16 +118,16 @@ public class FindDistinctMethods extends ScanningRecipe<Map<String, UUID>> {
                         String key = methodCall.getMethodType().toString();
                         if (methodCall.getId().equals(acc.get(key))) {
                             Cursor methodCursor = getCursor();
-                            methodCalls.insertRow(ctx, new MethodCalls.Row(
-                                    methodCursor.firstEnclosingOrThrow(SourceFile.class).getSourcePath().toString(),
-                                    methodCall.printTrimmed(methodCursor),
-                                    requireNonNull(methodCall.getMethodType()).getDeclaringType().getFullyQualifiedName(),
-                                    methodCall.getMethodType().getName(),
-                                    methodCall.getMethodType().getParameterTypes().stream().map(Object::toString)
-                                            .collect(joining(","))
-                            ));
+                            String sourceFile = methodCursor.firstEnclosingOrThrow(SourceFile.class).getSourcePath().toString();
+                            String code = methodCall.printTrimmed(methodCursor);
+                            String declaringType = requireNonNull(methodCall.getMethodType()).getDeclaringType().getFullyQualifiedName();
+                            String methodName = methodCall.getMethodType().getName();
+                            String parameterTypes = methodCall.getMethodType().getParameterTypes().stream()
+                                    .map(Object::toString)
+                                    .collect(joining(","));
                             acc.remove(key);
-                            e = SearchResult.found(e);
+                            e = rows.found(e, line -> new MethodCalls.Row(sourceFile, code, declaringType,
+                                    methodName, parameterTypes, line));
                         }
                     }
                 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindMethods.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.table.SearchResultRows;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -87,6 +88,15 @@ public class FindMethods extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return Preconditions.check(new UsesMethod<>(methodPattern, matchOverrides), new JavaIsoVisitor<ExecutionContext>() {
             final MethodMatcher methodMatcher = new MethodMatcher(methodPattern, matchOverrides);
+            final SearchResultRows<MethodCalls.Row> rows = new SearchResultRows<>(methodCalls);
+
+            @Override
+            public @Nullable J postVisit(J tree, ExecutionContext ctx) {
+                if (tree instanceof SourceFile) {
+                    rows.insertRows(tree, ctx);
+                }
+                return super.postVisit(tree, ctx);
+            }
 
             @Override
             public J.Identifier visitIdentifier(J.Identifier identifier, ExecutionContext ctx) {
@@ -96,19 +106,16 @@ public class FindMethods extends Recipe {
                     !(getCursor().getParentTreeCursor().getValue() instanceof J.MethodInvocation)) {
                     JavaType.Method m = (JavaType.Method) i.getType();
                     JavaSourceFile javaSourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                    if (javaSourceFile != null) {
-                        methodCalls.insertRow(ctx, new MethodCalls.Row(
-                                javaSourceFile.getSourcePath().toString(),
-                                m.getName(),
-                                m.getDeclaringType().getFullyQualifiedName(),
-                                m.getName(),
-                                m.getParameterTypes().stream()
-                                        .map(String::valueOf)
-                                        .collect(joining(", "))
-
-                        ));
+                    if (javaSourceFile == null) {
+                        return SearchResult.found(i);
                     }
-                    i = SearchResult.found(i);
+                    String sourceFile = javaSourceFile.getSourcePath().toString();
+                    String declaringType = m.getDeclaringType().getFullyQualifiedName();
+                    String parameterTypes = m.getParameterTypes().stream()
+                            .map(String::valueOf)
+                            .collect(joining(", "));
+                    i = rows.found(i, line -> new MethodCalls.Row(sourceFile, m.getName(), declaringType,
+                            m.getName(), parameterTypes, line));
                 }
                 return i;
             }
@@ -118,19 +125,18 @@ public class FindMethods extends Recipe {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
                 if (methodMatcher.matches(method)) {
                     JavaSourceFile javaSourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                    if (javaSourceFile != null) {
-                        methodCalls.insertRow(ctx, new MethodCalls.Row(
-                                javaSourceFile.getSourcePath().toString(),
-                                method.printTrimmed(getCursor().getParentTreeCursor()),
-                                method.getMethodType().getDeclaringType().getFullyQualifiedName(),
-                                method.getSimpleName(),
-                                method.getArguments().stream()
-                                        .map(Expression::getType)
-                                        .map(String::valueOf)
-                                        .collect(joining(", "))
-                        ));
+                    if (javaSourceFile == null) {
+                        return SearchResult.found(m);
                     }
-                    m = SearchResult.found(m);
+                    String sourceFile = javaSourceFile.getSourcePath().toString();
+                    String code = method.printTrimmed(getCursor().getParentTreeCursor());
+                    String declaringType = method.getMethodType().getDeclaringType().getFullyQualifiedName();
+                    String argumentTypes = method.getArguments().stream()
+                            .map(Expression::getType)
+                            .map(String::valueOf)
+                            .collect(joining(", "));
+                    m = rows.found(m, line -> new MethodCalls.Row(sourceFile, code, declaringType,
+                            method.getSimpleName(), argumentTypes, line));
                 }
                 return m;
             }
@@ -140,19 +146,19 @@ public class FindMethods extends Recipe {
                 J.MemberReference m = super.visitMemberReference(memberRef, ctx);
                 if (methodMatcher.matches(m.getMethodType())) {
                     JavaSourceFile javaSourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                    if (javaSourceFile != null) {
-                        methodCalls.insertRow(ctx, new MethodCalls.Row(
-                                javaSourceFile.getSourcePath().toString(),
-                                memberRef.printTrimmed(getCursor().getParentTreeCursor()),
-                                memberRef.getMethodType().getDeclaringType().getFullyQualifiedName(),
-                                memberRef.getMethodType().getName(),
-                                memberRef.getArguments().stream()
-                                        .map(Expression::getType)
-                                        .map(String::valueOf)
-                                        .collect(joining(", "))
-                        ));
+                    if (javaSourceFile == null) {
+                        return m.withReference(SearchResult.found(m.getReference()));
                     }
-                    m = m.withReference(SearchResult.found(m.getReference()));
+                    String sourceFile = javaSourceFile.getSourcePath().toString();
+                    String code = memberRef.printTrimmed(getCursor().getParentTreeCursor());
+                    String declaringType = memberRef.getMethodType().getDeclaringType().getFullyQualifiedName();
+                    String methodName = memberRef.getMethodType().getName();
+                    String argumentTypes = memberRef.getArguments().stream()
+                            .map(Expression::getType)
+                            .map(String::valueOf)
+                            .collect(joining(", "));
+                    m = m.withReference(rows.found(m.getReference(), line -> new MethodCalls.Row(sourceFile, code,
+                            declaringType, methodName, argumentTypes, line)));
                 }
                 return m;
             }
@@ -162,19 +168,18 @@ public class FindMethods extends Recipe {
                 J.NewClass n = super.visitNewClass(newClass, ctx);
                 if (methodMatcher.matches(newClass)) {
                     JavaSourceFile javaSourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                    if (javaSourceFile != null) {
-                        methodCalls.insertRow(ctx, new MethodCalls.Row(
-                                javaSourceFile.getSourcePath().toString(),
-                                newClass.printTrimmed(getCursor().getParentTreeCursor()),
-                                newClass.getType().toString(),
-                                "<constructor>",
-                                newClass.getArguments().stream()
-                                        .map(Expression::getType)
-                                        .map(String::valueOf)
-                                        .collect(joining(", "))
-                        ));
+                    if (javaSourceFile == null) {
+                        return SearchResult.found(n);
                     }
-                    n = SearchResult.found(n);
+                    String sourceFile = javaSourceFile.getSourcePath().toString();
+                    String code = newClass.printTrimmed(getCursor().getParentTreeCursor());
+                    String declaringType = newClass.getType().toString();
+                    String argumentTypes = newClass.getArguments().stream()
+                            .map(Expression::getType)
+                            .map(String::valueOf)
+                            .collect(joining(", "));
+                    n = rows.found(n, line -> new MethodCalls.Row(sourceFile, code, declaringType,
+                            "<constructor>", argumentTypes, line));
                 }
                 return n;
             }

--- a/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/search/FindTypes.java
@@ -26,6 +26,7 @@ import org.openrewrite.java.TypeNameMatcher;
 import org.openrewrite.java.table.TypeUses;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.SearchResult;
+import org.openrewrite.table.SearchResultRows;
 import org.openrewrite.trait.Trait;
 
 import java.util.HashSet;
@@ -165,9 +166,18 @@ public class FindTypes extends Recipe {
 
     private class JavaSourceFileVisitor extends JavaVisitor<ExecutionContext> {
         private final TypeNameMatcher fullyQualifiedType;
+        private final SearchResultRows<TypeUses.Row> rows = new SearchResultRows<>(typeUses);
 
         public JavaSourceFileVisitor(TypeNameMatcher fullyQualifiedType) {
             this.fullyQualifiedType = fullyQualifiedType;
+        }
+
+        @Override
+        public @Nullable J postVisit(J tree, ExecutionContext ctx) {
+            if (tree instanceof SourceFile) {
+                rows.insertRows(tree, ctx);
+            }
+            return super.postVisit(tree, ctx);
         }
 
         @Override
@@ -185,7 +195,7 @@ public class FindTypes extends Recipe {
                 JavaType.FullyQualified type = TypeUtils.asFullyQualified(ident.getType());
                 if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type) &&
                         ident.getSimpleName().equals(type.getClassName())) {
-                    return found(ident, ctx);
+                    return found(ident);
                 }
             }
             return super.visitIdentifier(ident, ctx);
@@ -197,7 +207,7 @@ public class FindTypes extends Recipe {
             // in Java trees this is idempotent with the parent's `visitTypeName` call
             J.ParameterizedType pt = (J.ParameterizedType) super.visitParameterizedType(type, ctx);
             if (parameterizedTypeMatches(pt) && getCursor().firstEnclosing(J.Import.class) == null) {
-                return found(pt, ctx);
+                return found(pt);
             }
             return pt;
         }
@@ -213,7 +223,7 @@ public class FindTypes extends Recipe {
             JavaType.FullyQualified type = TypeUtils.asFullyQualified(n.getType());
             if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type) &&
                     getCursor().firstEnclosing(J.Import.class) == null) {
-                return found(n, ctx);
+                return found(n);
             }
             return n;
         }
@@ -224,22 +234,21 @@ public class FindTypes extends Recipe {
             JavaType.FullyQualified type = TypeUtils.asFullyQualified(fa.getTarget().getType());
             if (typeMatches(Boolean.TRUE.equals(checkAssignability), fullyQualifiedType, type) &&
                     "class".equals(fa.getName().getSimpleName())) {
-                return found(fa, ctx);
+                return found(fa);
             }
             return fa;
         }
 
-        private <J2 extends TypedTree> J2 found(J2 j, ExecutionContext ctx) {
-            JavaType.FullyQualified fqn = TypeUtils.asFullyQualified(j.getType());
-            if (!j.getMarkers().findFirst(SearchResult.class).isPresent()) {
-                // Avoid double-counting results in the data table
-                typeUses.insertRow(ctx, new TypeUses.Row(
-                        getCursor().firstEnclosingOrThrow(SourceFile.class).getSourcePath().toString(),
-                        j.printTrimmed(getCursor().getParentTreeCursor()),
-                        fqn == null ? j.getType().toString() : fqn.getFullyQualifiedName()
-                ));
+        private <J2 extends TypedTree> J2 found(J2 j) {
+            if (j.getMarkers().findFirst(SearchResult.class).isPresent()) {
+                // Already matched by another visit method
+                return j;
             }
-            return SearchResult.found(j);
+            JavaType.FullyQualified fqn = TypeUtils.asFullyQualified(j.getType());
+            String sourceFile = getCursor().firstEnclosingOrThrow(SourceFile.class).getSourcePath().toString();
+            String code = j.printTrimmed(getCursor().getParentTreeCursor());
+            String concreteType = fqn == null ? j.getType().toString() : fqn.getFullyQualifiedName();
+            return rows.found(j, line -> new TypeUses.Row(sourceFile, code, concreteType, line));
         }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/MethodCalls.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/MethodCalls.java
@@ -18,6 +18,7 @@ package org.openrewrite.java.table;
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import lombok.Setter;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Column;
 import org.openrewrite.DataTable;
 import org.openrewrite.ExecutionContext;
@@ -53,6 +54,12 @@ public class MethodCalls extends DataTable<MethodCalls.Row> {
         @Column(displayName = "Argument types",
                 description = "The argument types of the method call.")
         String argumentTypes;
+
+        @Column(displayName = "Line number",
+                description = "The 1-based line that the method call starts on, in the source as printed when the " +
+                        "search ran. Empty when no position could be established for it.")
+        @Nullable
+        Integer line;
     }
 
     @Override

--- a/rewrite-java/src/main/java/org/openrewrite/java/table/TypeUses.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/table/TypeUses.java
@@ -17,6 +17,7 @@ package org.openrewrite.java.table;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import lombok.Value;
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Column;
 import org.openrewrite.DataTable;
 import org.openrewrite.Recipe;
@@ -42,5 +43,11 @@ public class TypeUses extends DataTable<TypeUses.Row> {
         @Column(displayName = "Concrete type",
                 description = "The concrete type in use, which may be a subtype of a searched type.")
         String concreteType;
+
+        @Column(displayName = "Line number",
+                description = "The 1-based line that the type use starts on, in the source as printed when the " +
+                        "search ran. Empty when no position could be established for it.")
+        @Nullable
+        Integer line;
     }
 }


### PR DESCRIPTION
## Motivation

A caller who runs `FindTypes` or `FindMethods` learns which files matched and what the matched code was, but not where it was. `TypeUses.Row` records *what* matched, not *where*, so acting on a row means going back and grepping for a position the search had already computed and thrown away. In measured agent runs, 45 of 48 file reads were preceded by a grep whose only purpose was recovering that line number.

`SourcePositionService.positionOf` already returns absolute line numbers, but it prints from the compilation unit per element, so using it per match would be O(matches × file). This takes the approach used by moderne-cli's `SearchIndexing` instead: tag the matches, print the file once, recover every position from that one pass.

## Examples

`TypeUses` and `MethodCalls` each gain a `Line number` column, appended last so positional consumers of the CSV keep working:

```
sourceFile,method,className,methodName,argumentTypes,line
A.java,"new B.C().foo(bar, 123)","B$C",foo,"java.lang.String, int",3
```

A search populates it by handing `SearchResultRows` the row it wants, in place of calling `SearchResult.found`:

```java
private <J2 extends TypedTree> J2 found(J2 j) {
    String code = j.printTrimmed(getCursor().getParentTreeCursor());
    return rows.found(j, line -> new TypeUses.Row(sourceFile, code, concreteType, line));
}

@Override
public @Nullable J postVisit(J tree, ExecutionContext ctx) {
    if (tree instanceof SourceFile) {
        rows.insertRows(tree, ctx);
    }
    return super.postVisit(tree, ctx);
}
```

## Summary

- `SearchResultRows` (new, `rewrite-core`) buffers the rows a search produces for one source file, then prints that file once with `PrintOutputCapture.MarkerPrinter.FENCED`, which wraps each marked element in `{{markerId}}` after its prefix. A `PrintOutputCapture` counts newlines as the file prints and places each fence as it arrives, so one print positions every match and no printed text is retained. Files with no matches never print.
- `TypeUses.Row` and `MethodCalls.Row` gain a nullable `line` column.
- `FindTypes`, `FindMethods`, `FindDeprecatedMethods`, and `FindDistinctMethods` populate it — all four recipes that write these two tables.
- A search reports each element it matches once, tracked by element id, so two visit methods reaching the same element yield one row while a search running after another that marked the same element still reports its own match. Since `Markers.add` keeps out a `SearchResult` equal to one already present, and every search result on an element fences in the same place, a row is positioned by whichever marker the element carries.
- Positions describe the source as printed when the search ran. When no position can be established the column is left empty rather than guessed from the first textual occurrence of the name, which would report matches on unrelated lines that merely share a word.
- `FindTypesBenchmark` gains a dense-file scenario, which locates its input by walking up from the working directory. `JavaCompilationUnitState` resolves the repository root through `Class.getResource`, which is null once the JMH plugin runs from its shaded jar, so the benchmarks using that state currently fail in warmup on `main`.

### Cost

Measured on `J.java` (6799 lines, ~190 `java.util.List` matches) with 3 forks × 10 iterations, the added cost against a search-only recipe run is **+2.03ms (+19.8%)** and **+1.06MB (+13.2%)**. That is the worst case: one print per *matched* file, nothing for unmatched files, and `UsesType` already skips most files.

Removing all ~190 per-match `printTrimmed` calls was measured to save only 95KB and ≤0.4ms, so the whole-file print is additive here rather than a replacement — `TypeUses` matches are type names of a few nodes each, unlike the declarations moderne-cli anchors on. The remaining cost is the print traversal itself, where the per-node `Cursor` allocation in `TreeVisitor.visit` is the lever; that would speed up all printing and belongs in its own change.

## Test plan

- [x] `FindTypesTest.lineNumberOfEachMatch` — each match gets its own line, and a javadoc mentioning the type name in prose does not attract a position, so newlines inside comments are counted
- [x] `FindMethodsTest.lineNumberOfEachMatch` — invocation, a call split across lines following a three-line comment, and a call inside a lambda
- [x] `FindMethodsTest.reportsAMatchAlreadyMarkedByAnotherSearch` — two overlapping searches over one call each report their own row, at the right line; verified failing before the fix
- [x] `FindTypesTest.simpleName`, `FindTypesTest.dataTable`, `FindMethodsTest.datatableFormat`, `FindDistinctMethodsTest.markFirstOccurrenceOfMethod` — existing row and CSV assertions updated with expected lines
- [x] `./gradlew :rewrite-core:test :rewrite-java:test :rewrite-java-test:test`
- [x] `./gradlew licenseFormat` (no changes) and `:rewrite-benchmarks:jmhClasses`
