### PR TITLE
Ignore blank GAVs in `retainVersions` and `except`

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -24,6 +24,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.tree.*;
+import org.openrewrite.maven.utilities.RetainVersions;
 import org.openrewrite.semver.ExactVersion;
 import org.openrewrite.semver.LatestIntegration;
 import org.openrewrite.semver.Semver;
@@ -115,20 +116,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
 
     @Override
     public Validated<Object> validate() {
-        Validated<Object> validated = Validated.none();
-        if (except != null) {
-            for (int i = 0; i < except.size(); i++) {
-                final String retainVersion = except.get(i);
-                validated = validated.and(Validated.test(
-                        String.format("except[%d]", i),
-                        "did not look like a two-or-three-part GAV",
-                        retainVersion,
-                        maybeGav -> {
-                            final int gavParts = maybeGav.split(":").length;
-                            return gavParts == 2 || gavParts == 3;
-                        }));
-            }
-        }
+        Validated<Object> validated = RetainVersions.validate("except", except);
         if (onlyIfVersionsMatch != null && onlyIfManagedVersionIs != null) {
             validated = validated.and(Validated.invalid("onlyIfVersionsMatch", onlyIfVersionsMatch, "is deprecated in favor of onlyIfManagedVersionIs, and they cannot be used together"));
         }
@@ -366,6 +354,9 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                     return true;
                 }
                 for (final String gav : except) {
+                    if (StringUtils.isBlank(gav)) {
+                        continue;
+                    }
                     String[] split = gav.split(":");
                     String exceptedGroupId = split[0];
                     String exceptedArtifactId = split[1];

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -107,7 +107,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         if (newVersion != null) {
             validated = validated.and(Semver.validate(newVersion, versionPattern));
         }
-        return validated;
+        return validated.and(RetainVersions.validate("retainVersions", retainVersions));
     }
 
     String displayName = "Upgrade Maven dependency version";

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/RetainVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/utilities/RetainVersions.java
@@ -15,7 +15,10 @@
  */
 package org.openrewrite.maven.utilities;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.Recipe;
+import org.openrewrite.Validated;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId;
 import org.openrewrite.maven.MavenVisitor;
 import org.openrewrite.maven.search.FindDependency;
@@ -31,12 +34,40 @@ import java.util.function.Predicate;
 public class RetainVersions {
 
     /**
+     * Validates that every non-blank entry of a GAV list option consists of a group ID, an artifact ID,
+     * and optionally a version. Blank entries are tolerated, as they are ignored when the recipe runs.
+     */
+    public static Validated<Object> validate(String optionName, @Nullable List<String> gavs) {
+        Validated<Object> validated = Validated.none();
+        if (gavs != null) {
+            for (int i = 0; i < gavs.size(); i++) {
+                String gav = gavs.get(i);
+                if (StringUtils.isBlank(gav)) {
+                    continue;
+                }
+                validated = validated.and(Validated.test(
+                        String.format("%s[%d]", optionName, i),
+                        "did not look like a two-or-three-part GAV",
+                        gav,
+                        maybeGav -> {
+                            int gavParts = maybeGav.split(":").length;
+                            return gavParts == 2 || gavParts == 3;
+                        }));
+            }
+        }
+        return validated;
+    }
+
+    /**
      * Returns a list of recipes which can be applied to add explicit versions
      * for dependencies matching the GAVs in param `retainVersions`
      */
     public static List<Recipe> plan(MavenVisitor<?> visitor, List<String> retainVersions) {
         List<Recipe> recipes = new ArrayList<>();
         for (String gav : retainVersions) {
+            if (StringUtils.isBlank(gav)) {
+                continue;
+            }
             String[] split = gav.split(":");
             String requestedRetainedGroupId = split[0];
             String requestedRetainedArtifactId = split[1];

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -2443,6 +2443,58 @@ class UpgradeDependencyVersionTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        void retainVersionWithoutArtifactIdFailsValidation() {
+            assertThat(new UpgradeDependencyVersion("*", "jackson*", "latest.patch", null, null,
+              singletonList("com.jcraft")).validate().isValid()).isFalse();
+        }
+
+        @Test
+        void blankRetainVersionIsIgnored() {
+            rewriteRun(spec -> spec.recipe(new UpgradeDependencyVersion("*", "spring-cloud-config*", "3.1.4", null, true, singletonList(""))),
+              pomXml(
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencyManagement>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.springframework.cloud</groupId>
+                          <artifactId>spring-cloud-config-dependencies</artifactId>
+                          <version>3.1.2</version>
+                          <type>pom</type>
+                          <scope>import</scope>
+                        </dependency>
+                      </dependencies>
+                    </dependencyManagement>
+                  </project>
+                  """,
+                """
+                  <project>
+                    <modelVersion>4.0.0</modelVersion>
+                    <groupId>org.sample</groupId>
+                    <artifactId>sample</artifactId>
+                    <version>1.0.0</version>
+                    <dependencyManagement>
+                      <dependencies>
+                        <dependency>
+                          <groupId>org.springframework.cloud</groupId>
+                          <artifactId>spring-cloud-config-dependencies</artifactId>
+                          <version>3.1.4</version>
+                          <type>pom</type>
+                          <scope>import</scope>
+                        </dependency>
+                      </dependencies>
+                    </dependencyManagement>
+                  </project>
+                  """
+              )
+            );
+        }
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/4333")


### PR DESCRIPTION
Running `UpgradeDependencyVersion` with `Group=*`, `Artifact=jackson*`, `New version=latest.patch` and an untouched *Retain versions* field crashed with `ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 1` at `RetainVersions.plan`: the glob matches the `tools.jackson:jackson-bom` import tag, which is the only path that expands `retainVersions`, and a blank list entry (what a UI sends for an untouched list option) splits into a single element. Blank entries are now skipped both there and in `RemoveRedundantDependencyVersions`, which `UpgradeDependencyVersion` hands the same list to as `except`.

The GAV-list validation moves from `RemoveRedundantDependencyVersions` into `RetainVersions.validate` and is now applied to `retainVersions` too, so an entry missing its artifact ID fails up front with "did not look like a two-or-three-part GAV" instead of throwing the same exception mid-run; blank entries are tolerated so an untouched field does not fail validation either.

Verified against `spring-projects/spring-hateoas@main`'s `pom.xml`: those exact options reproduce the reported stack before the fix and upgrade `<jackson-bom.version>` cleanly after it.