### PR TITLE
Consolidate .editorconfig files into one at the repository root

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**/src/{test,integTest}/**.java]
+indent_size = 4
+ij_continuation_indent_size = 2
+trim_trailing_whitespace = false
+
+[*/rewrite/{test,tests,fixtures}/**]
+trim_trailing_whitespace = false
+
+# Golden files are compared byte for byte.
+[**/resources/**]
+insert_final_newline = false
+trim_trailing_whitespace = false

--- a/rewrite-core/src/test/java/org/openrewrite/.editorconfig
+++ b/rewrite-core/src/test/java/org/openrewrite/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-csharp/src/test/java/.editorconfig
+++ b/rewrite-csharp/src/test/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-docker/src/test/java/.editorconfig
+++ b/rewrite-docker/src/test/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-go/src/integTest/java/.editorconfig
+++ b/rewrite-go/src/integTest/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/.editorconfig
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-groovy/src/test/java/.editorconfig
+++ b/rewrite-groovy/src/test/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-hcl/src/test/java/org/openrewrite/hcl/.editorconfig
+++ b/rewrite-hcl/src/test/java/org/openrewrite/hcl/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-java-21/src/test/java/org/openrewrite/java/.editorconfig
+++ b/rewrite-java-21/src/test/java/org/openrewrite/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-java-tck/src/main/java/.editorconfig
+++ b/rewrite-java-tck/src/main/java/.editorconfig
@@ -1,5 +1,5 @@
-root = true
-
+# The tck ships its tests from src/main so every Java parser module can run them.
 [*.java]
 indent_size = 4
 ij_continuation_indent_size = 2
+trim_trailing_whitespace = false

--- a/rewrite-java-test/src/test/java/org/openrewrite/.editorconfig
+++ b/rewrite-java-test/src/test/java/org/openrewrite/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-java/src/test/java/org/openrewrite/java/.editorconfig
+++ b/rewrite-java/src/test/java/org/openrewrite/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-javascript/src/integTest/.editorconfig
+++ b/rewrite-javascript/src/integTest/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/.editorconfig
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-json/src/test/java/org/openrewrite/json/.editorconfig
+++ b/rewrite-json/src/test/java/org/openrewrite/json/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-kotlin/src/test/.editorconfig
+++ b/rewrite-kotlin/src/test/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/.editorconfig
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-properties/src/test/java/org/openrewrite/properties/.editorconfig
+++ b/rewrite-properties/src/test/java/org/openrewrite/properties/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/.editorconfig
+++ b/rewrite-protobuf/src/test/java/org/openrewrite/protobuf/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-python/src/test/java/.editorconfig
+++ b/rewrite-python/src/test/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-test/src/test/java/org/openrewrite/.editorconfig
+++ b/rewrite-test/src/test/java/org/openrewrite/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-toml/src/test/java/.editorconfig
+++ b/rewrite-toml/src/test/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/.editorconfig
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2

--- a/rewrite-yaml/src/test/java/.editorconfig
+++ b/rewrite-yaml/src/test/java/.editorconfig
@@ -1,5 +1,0 @@
-root = true
-
-[*.java]
-indent_size = 4
-ij_continuation_indent_size = 2


### PR DESCRIPTION
Replaces 22 identical per-directory `.editorconfig` files with a single one at the repository root, matching what `rewrite-static-analysis` does. Every one of those files declared `root = true`, so nothing above them could ever apply, and modules such as `rewrite-scala` had no coverage at all; the root file now covers all `src/test` and `src/integTest` Java sources uniformly.

Unlike `rewrite-static-analysis`, trailing whitespace is *not* trimmed under test sources, resources and the JS/Python fixture trees — this repository is the parser and formatter, so trailing whitespace is often the thing under test (`AutoFormatTest.java` alone has 257 lines ending in whitespace, and goldens such as `META-INF/rewrite/recipes.csv` and the gradle-wrapper checksums carry it deliberately). `rewrite-java-tck` keeps its existing file in place, since it ships its tests from `src/main`; it only drops `root = true` so the root settings reach it.

Every rule was verified with the `editorconfig` core CLI against representative files in each category.