### PR TITLE
Go: add cursor helpers for function-body and init-wrapped-if checks

### DIFF
--- a/rewrite-go/pkg/visitor/cursor_helpers.go
+++ b/rewrite-go/pkg/visitor/cursor_helpers.go
@@ -28,11 +28,8 @@ func IsFunctionBodyBlock(c *Cursor) bool {
 	if parent == nil {
 		return false
 	}
-	switch parent.Value().(type) {
-	case *java.MethodDeclaration, *golang.MethodDeclaration:
-		return true
-	}
-	return false
+	_, ok := parent.Value().(*java.MethodDeclaration)
+	return ok
 }
 
 // Reports whether the If at the cursor is the inner statement of a

--- a/rewrite-go/pkg/visitor/cursor_helpers.go
+++ b/rewrite-go/pkg/visitor/cursor_helpers.go
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package visitor
+
+import (
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// Reports whether the block at the cursor is a function's body (its parent is a
+// function declaration) rather than a nested block such as a loop or if body.
+func IsFunctionBodyBlock(c *Cursor) bool {
+	parent := c.Parent()
+	if parent == nil {
+		return false
+	}
+	switch parent.Value().(type) {
+	case *java.MethodDeclaration, *golang.MethodDeclaration:
+		return true
+	}
+	return false
+}
+
+// Reports whether the If at the cursor is the inner statement of a
+// golang.StatementWithInit, i.e. it carried an `if init; cond` init clause.
+func IsInitWrappedIf(c *Cursor) bool {
+	parent := c.Parent()
+	if parent == nil {
+		return false
+	}
+	_, ok := parent.Value().(*golang.StatementWithInit)
+	return ok
+}

--- a/rewrite-go/pkg/visitor/cursor_helpers_test.go
+++ b/rewrite-go/pkg/visitor/cursor_helpers_test.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package visitor
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+func TestIsFunctionBodyBlock(t *testing.T) {
+	block := &java.Block{}
+	tests := []struct {
+		name   string
+		parent java.Tree
+		want   bool
+	}{
+		{"java method declaration parent", &java.MethodDeclaration{}, true},
+		{"golang method declaration parent", &golang.MethodDeclaration{}, true},
+		{"nested block parent", &java.Block{}, false},
+		{"no parent", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c *Cursor
+			if tt.parent == nil {
+				c = NewCursor(nil, block)
+			} else {
+				c = NewCursor(NewCursor(nil, tt.parent), block)
+			}
+			if got := IsFunctionBodyBlock(c); got != tt.want {
+				t.Errorf("IsFunctionBodyBlock() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsInitWrappedIf(t *testing.T) {
+	ifStmt := &java.If{}
+	tests := []struct {
+		name   string
+		parent java.Tree
+		want   bool
+	}{
+		{"statement with init parent", &golang.StatementWithInit{}, true},
+		{"plain block parent", &java.Block{}, false},
+		{"no parent", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var c *Cursor
+			if tt.parent == nil {
+				c = NewCursor(nil, ifStmt)
+			} else {
+				c = NewCursor(NewCursor(nil, tt.parent), ifStmt)
+			}
+			if got := IsInitWrappedIf(c); got != tt.want {
+				t.Errorf("IsInitWrappedIf() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/rewrite-go/pkg/visitor/cursor_helpers_test.go
+++ b/rewrite-go/pkg/visitor/cursor_helpers_test.go
@@ -14,63 +14,119 @@
  * limitations under the License.
  */
 
-package visitor
+package visitor_test
 
 import (
 	"testing"
 
-	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
+func cursorDepth(c *visitor.Cursor) int {
+	d := 0
+	for p := c.Parent(); p != nil; p = p.Parent() {
+		d++
+	}
+	return d
+}
+
+type innermostBlockFinder struct {
+	visitor.GoVisitor
+	depth  int
+	found  bool
+	result bool
+}
+
+func (v *innermostBlockFinder) VisitBlock(block *java.Block, p any) java.J {
+	if d := cursorDepth(v.Cursor()); !v.found || d > v.depth {
+		v.depth = d
+		v.result = visitor.IsFunctionBodyBlock(v.Cursor())
+		v.found = true
+	}
+	return v.GoVisitor.VisitBlock(block, p)
+}
+
+type firstIfFinder struct {
+	visitor.GoVisitor
+	found  bool
+	result bool
+}
+
+func (v *firstIfFinder) VisitIf(ifStmt *java.If, p any) java.J {
+	if !v.found {
+		v.found = true
+		v.result = visitor.IsInitWrappedIf(v.Cursor())
+	}
+	return v.GoVisitor.VisitIf(ifStmt, p)
+}
+
 func TestIsFunctionBodyBlock(t *testing.T) {
-	block := &java.Block{}
 	tests := []struct {
-		name   string
-		parent java.Tree
-		want   bool
+		name string
+		src  string
+		want bool
 	}{
-		{"java method declaration parent", &java.MethodDeclaration{}, true},
-		{"golang method declaration parent", &golang.MethodDeclaration{}, true},
-		{"nested block parent", &java.Block{}, false},
-		{"no parent", nil, false},
+		{
+			name: "method body is a function body block",
+			src:  "package main\n\ntype T int\n\nfunc (r T) m() {\n}\n",
+			want: true,
+		},
+		{
+			name: "if body is not a function body block",
+			src:  "package main\n\nfunc f(b bool) {\n\tif b {\n\t}\n}\n",
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var c *Cursor
-			if tt.parent == nil {
-				c = NewCursor(nil, block)
-			} else {
-				c = NewCursor(NewCursor(nil, tt.parent), block)
+			cu, err := parser.NewGoParser().Parse("fb.go", tt.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
 			}
-			if got := IsFunctionBodyBlock(c); got != tt.want {
-				t.Errorf("IsFunctionBodyBlock() = %v, want %v", got, tt.want)
+			v := visitor.Init(&innermostBlockFinder{})
+			v.Visit(cu, nil)
+			if !v.found {
+				t.Fatal("no block visited")
+			}
+			if v.result != tt.want {
+				t.Errorf("IsFunctionBodyBlock = %v, want %v", v.result, tt.want)
 			}
 		})
 	}
 }
 
 func TestIsInitWrappedIf(t *testing.T) {
-	ifStmt := &java.If{}
 	tests := []struct {
-		name   string
-		parent java.Tree
-		want   bool
+		name string
+		src  string
+		want bool
 	}{
-		{"statement with init parent", &golang.StatementWithInit{}, true},
-		{"plain block parent", &java.Block{}, false},
-		{"no parent", nil, false},
+		{
+			name: "if with init clause is init-wrapped",
+			src:  "package main\n\nfunc f() {\n\tif x := 1; x > 0 {\n\t}\n}\n",
+			want: true,
+		},
+		{
+			name: "plain if is not init-wrapped",
+			src:  "package main\n\nfunc f(b bool) {\n\tif b {\n\t}\n}\n",
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var c *Cursor
-			if tt.parent == nil {
-				c = NewCursor(nil, ifStmt)
-			} else {
-				c = NewCursor(NewCursor(nil, tt.parent), ifStmt)
+			cu, err := parser.NewGoParser().Parse("iw.go", tt.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
 			}
-			if got := IsInitWrappedIf(c); got != tt.want {
-				t.Errorf("IsInitWrappedIf() = %v, want %v", got, tt.want)
+			v := visitor.Init(&firstIfFinder{})
+			v.Visit(cu, nil)
+			if !v.found {
+				t.Fatal("no if visited")
+			}
+			if v.result != tt.want {
+				t.Errorf("IsInitWrappedIf = %v, want %v", v.result, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
## What

Adds two reusable cursor predicates to `rewrite-go` `pkg/visitor`:

- `IsFunctionBodyBlock(c *Cursor) bool` — reports whether the block at the cursor is a function's body rather than a nested block such as a loop or `if` body.
- `IsInitWrappedIf(c *Cursor) bool` — reports whether the `If` at the cursor is the inner statement of a `golang.StatementWithInit` (an `if init; cond` form).

## Why

This is the follow-up from https://github.com/moderneinc/recipes-go/pull/53#discussion_r3759564329, where these helpers were flagged as generic enough to belong upstream rather than duplicated in a downstream recipe repo. Hosting them in the `visitor` package lets recipes across languages share them. The package already imports both `java` and `golang`, so no new import cycle is introduced.

## Not upstreamed

- **`BaseIndent`** — not needed. `rewrite-go` already exposes the identical logic as `Space.Indent()` in `pkg/tree/java/space.go`, so callers should use that instead of a duplicate.
- **`IsErrNotNil`** — stays local to the recipe repo, as it is recipe-specific rather than generic LST navigation.