### PR TITLE
Return the listings an uninstall removed

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -122,10 +122,9 @@ public class RecipeMarketplace {
     }
 
     /**
-     * @return The listings actually removed, so callers report what went rather than diffing
-     * {@link #getAllRecipes()} across the call. That projection is keyed by recipe name, so a
-     * removal is invisible to a diff whenever another bundle declares the same name. Keyed by
-     * recipe name in the same way {@link #merge} reports what it added.
+     * @return The listings removed, keyed by recipe name as {@link #merge} keys what it added.
+     * Not recoverable by diffing {@link #getAllRecipes()}: that projection is keyed by name, so a
+     * removal another bundle's same-named listing was shadowing leaves its size unchanged.
      */
     public Set<RecipeListing> uninstall(String packageEcosystem, String packageName) {
         Set<RecipeListing> removed = new LinkedHashSet<>();

--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -121,9 +121,17 @@ public class RecipeMarketplace {
         }
     }
 
-    public void uninstall(String packageEcosystem, String packageName) {
-        root.uninstall(packageEcosystem, packageName);
+    /**
+     * @return The listings actually removed, so callers report what went rather than diffing
+     * {@link #getAllRecipes()} across the call. That projection is keyed by recipe name, so a
+     * removal is invisible to a diff whenever another bundle declares the same name. Keyed by
+     * recipe name in the same way {@link #merge} reports what it added.
+     */
+    public Set<RecipeListing> uninstall(String packageEcosystem, String packageName) {
+        Set<RecipeListing> removed = new LinkedHashSet<>();
+        root.uninstall(packageEcosystem, packageName, removed);
         bundles.remove(new BundleKey(packageEcosystem, packageName));
+        return removed;
     }
 
     @Getter
@@ -191,11 +199,17 @@ public class RecipeMarketplace {
             }
         }
 
-        private void uninstall(String packageEcosystem, String packageName) {
-            recipes.removeIf(r -> Objects.equals(r.getBundle().getPackageName(), packageName) &&
-                                  Objects.equals(r.getBundle().getPackageEcosystem(), packageEcosystem));
+        private void uninstall(String packageEcosystem, String packageName, Set<RecipeListing> removed) {
+            recipes.removeIf(r -> {
+                if (Objects.equals(r.getBundle().getPackageName(), packageName) &&
+                    Objects.equals(r.getBundle().getPackageEcosystem(), packageEcosystem)) {
+                    removed.add(r);
+                    return true;
+                }
+                return false;
+            });
             for (Category category : categories) {
-                category.uninstall(packageEcosystem, packageName);
+                category.uninstall(packageEcosystem, packageName, removed);
             }
         }
 

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -129,12 +129,11 @@ class RecipeMarketplaceInstallTest {
         marketplace.install(singleRecipeReader(a, "com.foo.Bar"));
         marketplace.install(singleRecipeReader(b, "com.foo.Bar"));
 
-        // getAllRecipes() is keyed by recipe name, so its size does not move here -- b's listing
-        // simply stops being shadowed. Anything diffing that projection concludes nothing went.
-        int before = marketplace.getAllRecipes().size();
         Set<RecipeListing> removed = marketplace.uninstall("maven", "org.example:a");
 
-        assertThat(marketplace.getAllRecipes()).hasSize(before);
+        assertThat(marketplace.getAllRecipes())
+                .as("b's listing merely stops being shadowed, so a diff of this cannot see the removal")
+                .hasSize(1);
         assertThat(removed).extracting(RecipeListing::getName).containsExactly("com.foo.Bar");
         assertThat(marketplace.bundleFor("maven", "org.example:a")).isNull();
     }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -121,6 +121,24 @@ class RecipeMarketplaceInstallTest {
                 .isInstanceOf(UnsupportedOperationException.class);
     }
 
+    @Test
+    void uninstallReportsWhatItRemovedEvenWhenAnotherBundleSharesTheName() {
+        RecipeBundle a = new RecipeBundle("maven", "org.example:a", "LATEST", "1.0.0", null);
+        RecipeBundle b = new RecipeBundle("maven", "org.example:b", "LATEST", "1.0.0", null);
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+        marketplace.install(singleRecipeReader(a, "com.foo.Bar"));
+        marketplace.install(singleRecipeReader(b, "com.foo.Bar"));
+
+        // getAllRecipes() is keyed by recipe name, so its size does not move here -- b's listing
+        // simply stops being shadowed. Anything diffing that projection concludes nothing went.
+        int before = marketplace.getAllRecipes().size();
+        Set<RecipeListing> removed = marketplace.uninstall("maven", "org.example:a");
+
+        assertThat(marketplace.getAllRecipes()).hasSize(before);
+        assertThat(removed).extracting(RecipeListing::getName).containsExactly("com.foo.Bar");
+        assertThat(marketplace.bundleFor("maven", "org.example:a")).isNull();
+    }
+
     private static List<RecipeListing> allListings(RecipeMarketplace.Category category) {
         List<RecipeListing> out = new java.util.ArrayList<>(category.getRecipes());
         for (RecipeMarketplace.Category child : category.getCategories()) {


### PR DESCRIPTION
`install(RecipeBundleReader)` and `merge(RecipeMarketplace)` both return the listings they
contributed. `uninstall` returned `void`, so a caller needing a count had to diff
`getAllRecipes()` across the call:

```java
int before = marketplace.getAllRecipes().size();
marketplace.uninstall(ecosystem, packageName);
return before - marketplace.getAllRecipes().size();
```

That projection is keyed by recipe name. When another bundle declares the same name the diff
reads **zero** even though listings were removed — the removal just stops shadowing the other
bundle, so the size does not move.

moderne-saas hit exactly this: `RecipeUninstallService` reported nothing removed and then skipped
writing the CSV on `removed > 0`, leaving the rows on disk with only a `debug` line.

## Scope

Source-compatible — existing statement calls still compile — but **binary**-incompatible, since the
return type is part of the method descriptor. Consumers must be recompiled, not just re-resolved.

Callers on `main`: none in rewrite outside `RecipeMarketplace` itself, none in moderne-cli, two in
moderne-saas (`UserRecipeMarketplaceStore`, `RecipeInstallProcessor`), both of which ignore the
return and are unaffected at source level.

## Testing

`rewrite-core` is 1251 tests, no failures. The new
`uninstallReportsWhatItRemovedEvenWhenAnotherBundleSharesTheName` pins the case the diff cannot
see: two bundles declaring `com.foo.Bar`, uninstall one, and `getAllRecipes()` stays the same size
while the returned set names the listing that went.