### PR TITLE
Emit J.Empty for a Groovy loop body that is an empty statement

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2374,9 +2374,13 @@ public class GroovyParserVisitor {
             return labels.get(0).withStatement(condenseLabels(labels.subList(1, labels.size()), s));
         }
 
-        private Statement visitLoopBody(org.codehaus.groovy.ast.stmt.Statement loopBlock) {
-            if (!(loopBlock instanceof EmptyStatement)) {
-                return doVisit(loopBlock);
+        /**
+         * Visits the body of a loop or {@code if}, mapping a body that is just {@code ;} to a {@link J.Empty} rather
+         * than the {@code null} that visiting an {@link EmptyStatement} would otherwise produce.
+         */
+        private Statement visitBody(org.codehaus.groovy.ast.stmt.Statement body) {
+            if (!(body instanceof EmptyStatement)) {
+                return doVisit(body);
             }
             Space prefix = whitespace();
             Markers markers = Markers.EMPTY;
@@ -2410,7 +2414,7 @@ public class GroovyParserVisitor {
                     return new J.ForLoop(randomId(), prefix, Markers.EMPTY,
                             new J.ForLoop.Control(randomId(), controlFmt,
                                     Markers.EMPTY, init, condition, update),
-                            JRightPadded.build(visitLoopBody(forLoop.getLoopBlock())));
+                            JRightPadded.build(visitBody(forLoop.getLoopBlock())));
                 } else {
                     Parameter param = forLoop.getVariable();
                     Space paramFmt = whitespace();
@@ -2440,7 +2444,7 @@ public class GroovyParserVisitor {
 
                     return new J.ForEachLoop(randomId(), prefix, forEachMarkers,
                             new J.ForEachLoop.Control(randomId(), controlFmt, Markers.EMPTY, variable, iterable),
-                            JRightPadded.build(visitLoopBody(forLoop.getLoopBlock())));
+                            JRightPadded.build(visitBody(forLoop.getLoopBlock())));
                 }
             }));
         }
@@ -2450,7 +2454,7 @@ public class GroovyParserVisitor {
             Space fmt = sourceBefore("if");
             J.ControlParentheses<Expression> ifCondition = new J.ControlParentheses<>(randomId(), sourceBefore("("), Markers.EMPTY,
                     JRightPadded.build((Expression) doVisit(ifElse.getBooleanExpression().getExpression())).withAfter(sourceBefore(")")));
-            JRightPadded<Statement> then = maybeSemicolon(doVisit(ifElse.getIfBlock()));
+            JRightPadded<Statement> then = maybeSemicolon(visitBody(ifElse.getIfBlock()));
             J.If.Else else_ = ifElse.getElseBlock() instanceof EmptyStatement ? null :
                     new J.If.Else(randomId(), sourceBefore("else"), Markers.EMPTY,
                             maybeSemicolon(doVisit(ifElse.getElseBlock())));
@@ -3387,7 +3391,7 @@ public class GroovyParserVisitor {
         @Override
         public void visitDoWhileLoop(DoWhileStatement loop) {
             Space fmt = sourceBefore("do");
-            Statement body = visitLoopBody(loop.getLoopBlock());
+            Statement body = visitBody(loop.getLoopBlock());
             Space beforeWhile = sourceBefore("while");
             J.ControlParentheses<Expression> condition = new J.ControlParentheses<>(randomId(), sourceBefore("("), Markers.EMPTY,
                     JRightPadded.build((Expression) doVisit(loop.getBooleanExpression().getExpression()))
@@ -3404,7 +3408,7 @@ public class GroovyParserVisitor {
                     new J.ControlParentheses<>(randomId(), sourceBefore("("), Markers.EMPTY,
                             JRightPadded.build((Expression) doVisit(loop.getBooleanExpression().getExpression()))
                                     .withAfter(sourceBefore(")"))),
-                    JRightPadded.build(visitLoopBody(loop.getLoopBlock()))
+                    JRightPadded.build(visitBody(loop.getLoopBlock()))
             ));
         }
 

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2374,6 +2374,19 @@ public class GroovyParserVisitor {
             return labels.get(0).withStatement(condenseLabels(labels.subList(1, labels.size()), s));
         }
 
+        private Statement visitLoopBody(org.codehaus.groovy.ast.stmt.Statement loopBlock) {
+            if (!(loopBlock instanceof EmptyStatement)) {
+                return doVisit(loopBlock);
+            }
+            Space prefix = whitespace();
+            Markers markers = Markers.EMPTY;
+            if (cursor < source.length() && source.charAt(cursor) == ';') {
+                skip(";");
+                markers = markers.add(new Semicolon(randomId()));
+            }
+            return new J.Empty(randomId(), prefix, markers);
+        }
+
         @SuppressWarnings("unchecked")
         @Override
         public void visitForLoop(ForStatement forLoop) {
@@ -2397,7 +2410,7 @@ public class GroovyParserVisitor {
                     return new J.ForLoop(randomId(), prefix, Markers.EMPTY,
                             new J.ForLoop.Control(randomId(), controlFmt,
                                     Markers.EMPTY, init, condition, update),
-                            JRightPadded.build(doVisit(forLoop.getLoopBlock())));
+                            JRightPadded.build(visitLoopBody(forLoop.getLoopBlock())));
                 } else {
                     Parameter param = forLoop.getVariable();
                     Space paramFmt = whitespace();
@@ -2427,7 +2440,7 @@ public class GroovyParserVisitor {
 
                     return new J.ForEachLoop(randomId(), prefix, forEachMarkers,
                             new J.ForEachLoop.Control(randomId(), controlFmt, Markers.EMPTY, variable, iterable),
-                            JRightPadded.build(doVisit(forLoop.getLoopBlock())));
+                            JRightPadded.build(visitLoopBody(forLoop.getLoopBlock())));
                 }
             }));
         }
@@ -3374,7 +3387,7 @@ public class GroovyParserVisitor {
         @Override
         public void visitDoWhileLoop(DoWhileStatement loop) {
             Space fmt = sourceBefore("do");
-            Statement body = doVisit(loop.getLoopBlock());
+            Statement body = visitLoopBody(loop.getLoopBlock());
             Space beforeWhile = sourceBefore("while");
             J.ControlParentheses<Expression> condition = new J.ControlParentheses<>(randomId(), sourceBefore("("), Markers.EMPTY,
                     JRightPadded.build((Expression) doVisit(loop.getBooleanExpression().getExpression()))
@@ -3391,7 +3404,7 @@ public class GroovyParserVisitor {
                     new J.ControlParentheses<>(randomId(), sourceBefore("("), Markers.EMPTY,
                             JRightPadded.build((Expression) doVisit(loop.getBooleanExpression().getExpression()))
                                     .withAfter(sourceBefore(")"))),
-                    JRightPadded.build(doVisit(loop.getLoopBlock()))
+                    JRightPadded.build(visitLoopBody(loop.getLoopBlock()))
             ));
         }
 

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ForLoopTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ForLoopTest.java
@@ -16,8 +16,11 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 @SuppressWarnings({"GroovyEmptyStatementBody", "GroovyUnusedAssignment", "GrUnnecessarySemicolon", "GroovyUnnecessaryContinue"})
@@ -129,6 +132,48 @@ class ForLoopTest implements RewriteTest {
           groovy(
             """
               for(;;) test()
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyBody() {
+        rewriteRun(
+          groovy(
+            """
+              int port = 0
+              Random rand = new Random()
+              for (; port < 1024; port = rand.nextInt(65536));
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.ForLoop visitForLoop(J.ForLoop forLoop, Object o) {
+                    assertThat(forLoop.getBody()).isInstanceOf(J.Empty.class);
+                    return super.visitForLoop(forLoop, o);
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyWithSpaceBeforeSemicolon() {
+        rewriteRun(
+          groovy(
+            """
+              for (int i = 0; i < 10; i++)  ;
+              """
+          )
+        );
+    }
+
+    @Test
+    void forEachWithEmptyBody() {
+        rewriteRun(
+          groovy(
+            """
+              for (def i : [1, 2, 3]);
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/IfTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/IfTest.java
@@ -16,8 +16,11 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 @SuppressWarnings({"GroovyIfStatementWithIdenticalBranches", "GroovyConstantIfStatement", "GrUnnecessarySemicolon", "GroovyUnusedIncOrDec", "GroovyEmptyStatementBody"})
@@ -62,6 +65,35 @@ class IfTest implements RewriteTest {
               if (n == 0) n++;
               else if (n == 1) n++;
               else n++;
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyBody() {
+        rewriteRun(
+          groovy(
+            """
+              if (true);
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<>() {
+                @Override
+                public J.If visitIf(J.If iff, Object o) {
+                    assertThat(iff.getThenPart()).isInstanceOf(J.Empty.class);
+                    return super.visitIf(iff, o);
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyWithElse() {
+        rewriteRun(
+          groovy(
+            """
+              if (true); else println 'a'
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/WhileLoopTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/WhileLoopTest.java
@@ -44,4 +44,28 @@ class WhileLoopTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void emptyBody() {
+        rewriteRun(
+          groovy(
+            """
+              int i = 0
+              while (i++ < 10);
+              """
+          )
+        );
+    }
+
+    @Test
+    void doWhileWithEmptyBody() {
+        rewriteRun(
+          groovy(
+            """
+              int i = 0
+              do; while (i++ < 10)
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
- Fixes #8459

`GroovyParserVisitor` built loop bodies as `JRightPadded.build(doVisit(forLoop.getLoopBlock()))`. When the body is an empty statement (`for (...);`), `doVisit` returns `null`, so the padding held a `null` element and `J.ForLoop#getBody()` threw a `NullPointerException` for any visitor that touched it:

```
NullPointerException: Cannot invoke "org.openrewrite.java.tree.JRightPadded.getElement()" because "this.body" is null
  org.openrewrite.java.tree.J$ForLoop.getBody(J.java:2431)
  org.openrewrite.staticanalysis.NeedBraces$NeedBracesVisitor.visitForLoop(NeedBraces.java:256)
```

The trailing `;` was also never consumed, so the parse failed `rewrite-test`'s "non-whitespace characters in its whitespace" check.

Loop bodies now go through a `visitLoopBody` helper that emits a `J.Empty` for an `EmptyStatement` — matching what the Java parser produces — carrying a `Semicolon` marker so the `;` round-trips. Since Groovy prints the semicolon from that marker rather than from `printStatementTerminator`, putting it on the `J.Empty` itself (not on the padding) also means a recipe that replaces the body with a block doesn't leave a stray `;` behind.

Applied to all four loop forms, all of which had the same shape: classic `for`, `for`-each, `while` and `do`/`while`.