### PR TITLE
Map a bodyless Groovy loop to a `J.Empty` body

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -2397,7 +2397,7 @@ public class GroovyParserVisitor {
                     return new J.ForLoop(randomId(), prefix, Markers.EMPTY,
                             new J.ForLoop.Control(randomId(), controlFmt,
                                     Markers.EMPTY, init, condition, update),
-                            JRightPadded.build(doVisit(forLoop.getLoopBlock())));
+                            JRightPadded.build(visitLoopBody(forLoop.getLoopBlock())));
                 } else {
                     Parameter param = forLoop.getVariable();
                     Space paramFmt = whitespace();
@@ -2427,7 +2427,7 @@ public class GroovyParserVisitor {
 
                     return new J.ForEachLoop(randomId(), prefix, forEachMarkers,
                             new J.ForEachLoop.Control(randomId(), controlFmt, Markers.EMPTY, variable, iterable),
-                            JRightPadded.build(doVisit(forLoop.getLoopBlock())));
+                            JRightPadded.build(visitLoopBody(forLoop.getLoopBlock())));
                 }
             }));
         }
@@ -3374,7 +3374,7 @@ public class GroovyParserVisitor {
         @Override
         public void visitDoWhileLoop(DoWhileStatement loop) {
             Space fmt = sourceBefore("do");
-            Statement body = doVisit(loop.getLoopBlock());
+            Statement body = visitLoopBody(loop.getLoopBlock());
             Space beforeWhile = sourceBefore("while");
             J.ControlParentheses<Expression> condition = new J.ControlParentheses<>(randomId(), sourceBefore("("), Markers.EMPTY,
                     JRightPadded.build((Expression) doVisit(loop.getBooleanExpression().getExpression()))
@@ -3391,8 +3391,27 @@ public class GroovyParserVisitor {
                     new J.ControlParentheses<>(randomId(), sourceBefore("("), Markers.EMPTY,
                             JRightPadded.build((Expression) doVisit(loop.getBooleanExpression().getExpression()))
                                     .withAfter(sourceBefore(")"))),
-                    JRightPadded.build(doVisit(loop.getLoopBlock()))
+                    JRightPadded.build(visitLoopBody(loop.getLoopBlock()))
             ));
+        }
+
+        /**
+         * An {@link EmptyStatement} loop body, as in {@code for (...);}, contributes nothing to the queue. The
+         * terminating {@code ;} is carried on the {@link J.Empty} as a marker, since the Groovy printer emits
+         * statement terminators only where the source has one.
+         */
+        private Statement visitLoopBody(org.codehaus.groovy.ast.stmt.Statement loopBlock) {
+            Statement body = doVisit(loopBlock);
+            if (body != null) {
+                return body;
+            }
+            Space prefix = whitespace();
+            Markers markers = Markers.EMPTY;
+            if (cursor < source.length() && source.charAt(cursor) == ';') {
+                skip(";");
+                markers = markers.add(new Semicolon(randomId()));
+            }
+            return new J.Empty(randomId(), prefix, markers);
         }
 
         private <J2 extends J> List<JRightPadded<J2>> convertAll(List<? extends ASTNode> nodes,

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ForLoopTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/ForLoopTest.java
@@ -16,8 +16,11 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 @SuppressWarnings({"GroovyEmptyStatementBody", "GroovyUnusedAssignment", "GrUnnecessarySemicolon", "GroovyUnnecessaryContinue"})
@@ -219,6 +222,81 @@ class ForLoopTest implements RewriteTest {
           groovy(
             """
               f: for(int i in [1, 2, 3]) { continue f }
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyClassicForLoop() {
+        rewriteRun(
+          groovy(
+            """
+              class A {
+                  void test() {
+                      int port = 0
+                      for (; port < 1024; port = port + 1);
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new GroovyIsoVisitor<Integer>() {
+                @Override
+                public J.ForLoop visitForLoop(J.ForLoop forLoop, Integer p) {
+                    assertThat(forLoop.getBody()).isInstanceOf(J.Empty.class);
+                    return super.visitForLoop(forLoop, p);
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyForLoopWithInit() {
+        rewriteRun(
+          groovy(
+            """
+              for (int i = 0; i < 10; i++);
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyInfiniteForLoop() {
+        rewriteRun(
+          groovy(
+            """
+              for (;;) ;
+              """
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyForEachLoop() {
+        rewriteRun(
+          groovy(
+            """
+              def list = [1, 2, 3]
+              for (x in list);
+              """,
+            spec -> spec.afterRecipe(cu -> new GroovyIsoVisitor<Integer>() {
+                @Override
+                public J.ForEachLoop visitForEachLoop(J.ForEachLoop forLoop, Integer p) {
+                    assertThat(forLoop.getBody()).isInstanceOf(J.Empty.class);
+                    return super.visitForEachLoop(forLoop, p);
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyForEachLoopWithColon() {
+        rewriteRun(
+          groovy(
+            """
+              for (def x : [1, 2, 3]);
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/WhileLoopTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/tree/WhileLoopTest.java
@@ -16,8 +16,11 @@
 package org.openrewrite.groovy.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.groovy.Assertions.groovy;
 
 @SuppressWarnings({"GroovyEmptyStatementBody", "GroovyInfiniteLoopStatement"})
@@ -41,6 +44,44 @@ class WhileLoopTest implements RewriteTest {
             """
               while(true) test()
               """
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyWhileLoop() {
+        rewriteRun(
+          groovy(
+            """
+              int i = 0
+              while (i++ < 10);
+              """,
+            spec -> spec.afterRecipe(cu -> new GroovyIsoVisitor<Integer>() {
+                @Override
+                public J.WhileLoop visitWhileLoop(J.WhileLoop whileLoop, Integer p) {
+                    assertThat(whileLoop.getBody()).isInstanceOf(J.Empty.class);
+                    return super.visitWhileLoop(whileLoop, p);
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void emptyBodyDoWhileLoop() {
+        rewriteRun(
+          groovy(
+            """
+              int i = 0
+              do; while (i++ < 10)
+              """,
+            spec -> spec.afterRecipe(cu -> new GroovyIsoVisitor<Integer>() {
+                @Override
+                public J.DoWhileLoop visitDoWhileLoop(J.DoWhileLoop doWhileLoop, Integer p) {
+                    assertThat(doWhileLoop.getBody()).isInstanceOf(J.Empty.class);
+                    return super.visitDoWhileLoop(doWhileLoop, p);
+                }
+            }.visit(cu, 0))
           )
         );
     }


### PR DESCRIPTION
## Motivation

A Groovy loop with an empty statement body parses into an invalid LST. Groovy models the missing body as an `EmptyStatement`, whose `visit()` is a no-op, so `doVisit(forLoop.getLoopBlock())` returns `null` and the resulting `J.ForLoop` holds a body `JRightPadded` whose element is `null`. `J.ForLoop.getBody()` is non-null by contract — the Java parser emits a `J.Empty` placeholder for `for (...);` — so any recipe that touches the body throws. `RewriteTest` also flagged these sources with "Source file was parsed into an LST that contains non-whitespace characters in its whitespace", because the trailing `;` was left stranded in a neighbouring `Space`.

This was seen in production running `org.openrewrite.staticanalysis.NeedBraces` over Netflix/metacat's `AbstractThriftServerTest.groovy`, which contains `for (; port < 1024; port = port + 1);`:

```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.JRightPadded.getElement()" because "this.body" is null
  at org.openrewrite.java.tree.J$ForLoop.getBody(J.java:2431)
  at org.openrewrite.staticanalysis.NeedBraces$NeedBracesVisitor.visitForLoop(NeedBraces.java:256)
```

All four loop forms were affected — the classic `for`, the for-each `for`, `while`, and `do`/`while` (`do; while (cond)` is valid Groovy).

## Summary

- Added `GroovyParserVisitor.visitLoopBody`, which substitutes a `J.Empty` when a loop's body contributes nothing to the queue, and consumes the terminating `;` onto it as a `Semicolon` marker. The marker is required because `GroovyPrinter` suppresses `printStatementTerminator` and emits `;` only where the source had one.
- Wired it into `visitForLoop` (both the classic and for-each branches), `visitWhileLoop`, and `visitDoWhileLoop`.

## Test plan

- [x] New `ForLoopTest` cases: the reported metacat construct, `for (int i = 0; i < 10; i++);`, `for (;;) ;`, `for (x in list);`, and `for (def x : [1, 2, 3]);` — each failed before the fix with the whitespace assertion.
- [x] New `WhileLoopTest` cases: `while (i++ < 10);` and `do; while (i++ < 10)`.
- [x] Three of the new tests assert via a `GroovyIsoVisitor` that the body is a `J.Empty`; calling `getBody()` is itself the reported NPE, and round-tripping alone would not catch a null body.
- [x] `./gradlew :rewrite-groovy:test :rewrite-gradle:test` passes.
