### PR TITLE
Never infer a negative tab size when autodetecting Java style

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/TabsAndIndentsTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.java.format;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.junitpioneer.jupiter.ExpectedToFail;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Issue;
@@ -2793,6 +2795,35 @@ class TabsAndIndentsTest implements RewriteTest {
                               : in
                       ).orElse(in);
                   }
+              }
+              """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, -1})
+    void nonPositiveTabSize(int tabSize) {
+        rewriteRun(
+          // Autodetect derives the indent size from the tab size, so both are non-positive together, leaving no width to indent by
+          autoFormat(style -> style.withUseTabCharacter(true).withTabSize(tabSize).withIndentSize(tabSize)),
+          java(
+            """
+              class Test {
+              \tvoid m() {
+              \t\tif (true) {
+              int n = 0;
+              \t\t}
+              \t}
+              }
+              """,
+            """
+              class Test {
+              void m() {
+              if (true) {
+              int n = 0;
+              }
+              }
               }
               """
           )

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
@@ -333,6 +333,28 @@ class AutodetectTest implements RewriteTest {
     }
 
     @Test
+    void tabsDeeperThanBlockDepth() {
+        var cus = jp().parse(
+          """
+            public class Test {
+            \tpublic int method(boolean b) {
+            \t\tif (b)
+            \t\t\t    return 1;
+            \t\treturn 0;
+            \t}
+            }
+            """
+        );
+
+        var detector = Autodetect.detector();
+        cus.forEach(detector::sample);
+        var tabsAndIndents = detector.build().getStyle(TabsAndIndentsStyle.class);
+        assertThat(tabsAndIndents.getUseTabCharacter()).isTrue();
+        assertThat(tabsAndIndents.getTabSize()).isEqualTo(4);
+        assertThat(tabsAndIndents.getIndentSize()).isEqualTo(4);
+    }
+
+    @Test
     void mixedTabAndWhiteSpacesIndentsWithTabSize4() {
         var cus = jp().parse(
           """

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/TabsAndIndentsVisitor.java
@@ -61,7 +61,8 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
     }
 
     public TabsAndIndentsVisitor(TabsAndIndentsStyle style, SpacesStyle spacesStyle, WrappingAndBracesStyle wrappingStyle, @Nullable Tree stopAfter) {
-        this.style = style;
+        // Indent math measures a tab as `tabSize` columns and divides by it, so only a positive width has meaning
+        this.style = style.getTabSize() > 0 ? style : style.withTabSize(IntelliJ.tabsAndIndents().getTabSize());
         this.wrappingStyle = wrappingStyle;
         this.stopAfter = stopAfter;
     }
@@ -731,7 +732,7 @@ public class TabsAndIndentsVisitor<P> extends JavaIsoVisitor<P> {
             } else {
                 len = text.length() + shift;
             }
-            if (len >= 0) {
+            if (len >= 0 && len < text.length()) {
                 text.delete(len, text.length());
             }
         }

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -288,7 +288,8 @@ public class Autodetect extends NamedStyles {
 
     private static int getBiggestGroupOfTabSize(IndentStatistic deltaSpaces) {
         Map<Integer, Integer> tabSizeToFrequencyMap = deltaSpaces.depthToSpaceIndentFrequencies.entrySet().stream()
-                .filter(entry -> entry.getKey().indentDepth != 0)
+                // A prefix with more tabs than its block depth has a negative delta, from which no tab size can be inferred
+                .filter(entry -> entry.getKey().indentDepth > 0)
                 .flatMap(entry -> entry.getValue().entrySet().stream()
                         .map(spaceCountToFrequency -> new AbstractMap.SimpleEntry<>(
                                 (int) Math.round(spaceCountToFrequency.getKey() / (double) entry.getKey().indentDepth),


### PR DESCRIPTION
## Motivation

`TabsAndIndentsVisitor.shift` can compute a delete range whose start is past the end of the whitespace buffer, which fails any recipe that auto-formats. On `spring-projects/spring-ai` this took down `MultipleVariableDeclarations` (`StringIndexOutOfBoundsException: Range [2, 1) out of bounds for length 1`) and `NeedBraces` (`Range [4, 1) out of bounds for length 1`) on the ANTLR-generated `FiltersLexer` / `FiltersParser` sources.

The offending branch is the outdent path of `shift`, where `len >= 0` guards only the lower bound:

```java
len = text.length() + (shift / tabIndent);
if (len >= 0) {
    text.delete(len, text.length());
}
```

For `shift <= 0` and a sane tab size that range is always within bounds, so `len > text.length()` means `tabIndent` — the style's tab size — is negative. It gets there like this:

1. `Autodetect` records, per statement prefix, the block depth less the tab count (`depth - tabIndent`) against the number of space characters, then divides the two to infer how many spaces a tab is worth. A prefix holding **more tabs than its block depth** makes that delta negative.
2. `getBiggestGroupOfTabSize` excluded only a delta of exactly `0`, so a negative delta divided into a positive space count produced a negative tab size.
3. In spring-ai, exactly one line does this — [`DeepSeekChatModel.java:247`](https://github.com/spring-projects/spring-ai/blob/main/models/spring-ai-deepseek/src/main/java/org/springframework/ai/deepseek/DeepSeekChatModel.java#L247), where a `// @formatter:on` inside a `@formatter:off` region is indented with 2 spaces followed by 8 tabs at block depth 6. Sampling every Java source in the repository leaves the delta statistics with a single usable entry, `depth=-2 {spaceCount 2}`, giving `Math.round(2 / -2.0)` = **-1**. Since `Autodetect` derives the indent size from the tab size, the detected style for the whole repository becomes `tabSize = indentSize = -1`.
4. `TabsAndIndentsVisitor` then measures every tab as -1 columns, so the target column of a nested statement goes negative and `shift` receives a negative shift. `shift / tabIndent` is then negative divided by negative, `len` lands past the end of the buffer, and `StringBuilder.delete` throws. A shift of -1 gives `Range [2, 1)` and -3 gives `Range [4, 1)`, matching both reported traces.

## Summary

- `Autodetect` only infers a tab size from prefixes whose block depth exceeds their tab count (`indentDepth > 0`), so a negative delta can no longer produce a negative tab size.
- `TabsAndIndentsVisitor` falls back to the IntelliJ default tab size when the style's is not positive. This also covers a hand-written or Checkstyle-derived style with a tab size of `0`, which previously divided by zero.
- The bounds check in `shift` now covers both ends of the delete range.

## Test plan

- [x] `AutodetectTest#tabsDeeperThanBlockDepth` — a statement indented deeper than its block depth with a mix of tabs and spaces detected `tabSize` -4 before the fix, 4 after.
- [x] `TabsAndIndentsTest#nonPositiveTabSize` — a style with `tabSize`/`indentSize` of -1 threw `StringIndexOutOfBoundsException: Range [4, 1) out of bounds for length 1` before the fix, byte-identical to the reported `NeedBraces` failure; a size of 0 silently left the source untouched.
- [x] `./gradlew :rewrite-java:test :rewrite-java-test:test :rewrite-groovy:test :rewrite-gradle:test` (the modules that consume `java.style.Autodetect` / `java.format.TabsAndIndentsVisitor`).
- [x] Sampled spring-ai's Java sources with `Autodetect` and dumped the raw delta statistics to confirm the single `depth=-2` entry described above; with the fix the repository detects `tabSize` 4.
