### PR TITLE
Go: parse `for (cond)` as Java `for` loop with J.Empty init/upgrade

### DIFF
--- a/rewrite-go/pkg/parser/for_control_test.go
+++ b/rewrite-go/pkg/parser/for_control_test.go
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// forControl parses src and returns the ForControl of the first for-loop in the
+// first top-level function's body.
+func forControl(t *testing.T, src string) *java.ForControl {
+	t.Helper()
+	loop, ok := firstStatementInBody(t, src).(*java.ForLoop)
+	if !ok {
+		t.Fatalf("expected first statement to be *java.ForLoop, got %T", firstStatementInBody(t, src))
+	}
+	return &loop.Control
+}
+
+// The J.ForLoop.Control contract every other parser upholds is that init and
+// update are single-element lists a visitor can index at 0. Go's condition-only
+// `for cond {}` must therefore carry a J.Empty in both slots, marked implicit.
+func TestConditionOnlyForHasEmptyInitAndUpdate(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f(data []byte) {\n\tfor len(data) > 0 {\n\t}\n}\n"
+
+	// when
+	control := forControl(t, src)
+
+	// then
+	if control.Init == nil {
+		t.Fatalf("Init must not be nil for a condition-only for")
+	}
+	if _, ok := control.Init.Element.(*java.Empty); !ok {
+		t.Fatalf("Init element must be *java.Empty, got %T", control.Init.Element)
+	}
+	if control.Update == nil {
+		t.Fatalf("Update must not be nil for a condition-only for")
+	}
+	if _, ok := control.Update.Element.(*java.Empty); !ok {
+		t.Fatalf("Update element must be *java.Empty, got %T", control.Update.Element)
+	}
+	if control.Condition == nil {
+		t.Fatalf("Condition must be the real condition, got nil")
+	}
+	if java.FindMarker[golang.ImplicitForClauses](control.Markers) == nil {
+		t.Fatalf("expected golang.ImplicitForClauses marker on the control")
+	}
+}
+
+// An infinite `for {}` has no condition, but its init/update placeholders must
+// still be present and marked implicit.
+func TestInfiniteForHasEmptyInitAndUpdate(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f() {\n\tfor {\n\t}\n}\n"
+
+	// when
+	control := forControl(t, src)
+
+	// then
+	if control.Init == nil {
+		t.Fatalf("Init must not be nil for an infinite for")
+	}
+	if _, ok := control.Init.Element.(*java.Empty); !ok {
+		t.Fatalf("Init element must be *java.Empty, got %T", control.Init.Element)
+	}
+	if control.Update == nil {
+		t.Fatalf("Update must not be nil for an infinite for")
+	}
+	if control.Condition != nil {
+		t.Fatalf("infinite for must have no condition, got %+v", control.Condition)
+	}
+	if java.FindMarker[golang.ImplicitForClauses](control.Markers) == nil {
+		t.Fatalf("expected golang.ImplicitForClauses marker on the control")
+	}
+}
+
+// A genuine 3-clause for keeps its real init and is NOT marked implicit; an
+// omitted update clause still gets a J.Empty placeholder so the list contract
+// holds, without acquiring the marker.
+func TestThreeClauseForIsNotMarkedImplicit(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f() {\n\tfor i := 0; i < 10; {\n\t}\n}\n"
+
+	// when
+	control := forControl(t, src)
+
+	// then
+	if java.FindMarker[golang.ImplicitForClauses](control.Markers) != nil {
+		t.Fatalf("a 3-clause for must not carry the ImplicitForClauses marker")
+	}
+	if control.Init == nil {
+		t.Fatalf("Init must not be nil")
+	}
+	if _, ok := control.Init.Element.(*java.Empty); ok {
+		t.Fatalf("Init element must be the real init statement, not J.Empty")
+	}
+	if control.Update == nil {
+		t.Fatalf("Update must not be nil for a 3-clause for without an update clause")
+	}
+	if _, ok := control.Update.Element.(*java.Empty); !ok {
+		t.Fatalf("omitted update must be a *java.Empty placeholder, got %T", control.Update.Element)
+	}
+}
+
+// Every for-loop form must round-trip parse → print byte-for-byte, proving the
+// synthetic placeholders and the marker do not corrupt printing.
+func TestForLoopFormsRoundTrip(t *testing.T) {
+	cases := []string{
+		"package main\n\nfunc f() {\n\tfor {\n\t}\n}\n",
+		"package main\n\nfunc f(data []byte) {\n\tfor len(data) > 0 {\n\t}\n}\n",
+		"package main\n\nfunc f() {\n\tfor i := 0; i < 10; i++ {\n\t}\n}\n",
+		"package main\n\nfunc f() {\n\tfor i := 0; i < 10; {\n\t\ti++\n\t}\n}\n",
+		"package main\n\nfunc f(cond bool) {\n\tfor ; cond; {\n\t}\n}\n",
+		"package main\n\nfunc f() {\n\tfor ; ; {\n\t}\n}\n",
+	}
+	for _, src := range cases {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			assertRoundTrip(t, src)
+		})
+	}
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1646,15 +1646,33 @@ func (ctx *parseContext) mapForStmt(stmt *ast.ForStmt) *java.ForLoop {
 			post := ctx.mapStmt(stmt.Post)
 			postRP := java.RightPadded[java.Statement]{Element: post}
 			control.Update = &postRP
+		} else {
+			// `for init; cond; {}` — no update clause. J.ForLoop.Control keeps
+			// update as a single-element list across every other parser, so a
+			// visitor can index it at 0; fill the slot with a J.Empty rather
+			// than leaving it null.
+			control.Update = &java.RightPadded[java.Statement]{Element: &java.Empty{ID: uuid.New()}}
 		}
-	} else if stmt.Cond != nil {
-		// Condition-only: for cond {}
-		cond := ctx.mapExpr(stmt.Cond)
-		control.Prefix, cond = hoistLeftPrefix(cond)
-		condRP := java.RightPadded[java.Expression]{Element: cond}
-		control.Condition = &condRP
+	} else {
+		// Condition-only `for cond {}` or infinite `for {}`: Go writes no `;`
+		// clause separators. Fill init and update with J.Empty placeholders so
+		// J.ForLoop.Control keeps the single-element-list shape every other
+		// parser produces — indexing getInit()/getUpdate() at 0 stays safe —
+		// and mark them synthetic so GoPrinter omits the placeholders and their
+		// separators.
+		if stmt.Cond != nil {
+			cond := ctx.mapExpr(stmt.Cond)
+			control.Prefix, cond = hoistLeftPrefix(cond)
+			condRP := java.RightPadded[java.Expression]{Element: cond}
+			control.Condition = &condRP
+		}
+		control.Init = &java.RightPadded[java.Statement]{Element: &java.Empty{ID: uuid.New()}}
+		control.Update = &java.RightPadded[java.Statement]{Element: &java.Empty{ID: uuid.New()}}
+		control.Markers = java.Markers{
+			ID:      uuid.New(),
+			Entries: []java.Marker{golang.NewImplicitForClauses()},
+		}
 	}
-	// else: infinite loop, all nil
 
 	body := ctx.mapBlockStmt(stmt.Body)
 

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -641,7 +641,16 @@ func (p *GoPrinter) VisitForLoop(forLoop *java.ForLoop, param any) java.J {
 func (p *GoPrinter) VisitForControl(control *java.ForControl, param any) java.J {
 	out := param.(*PrintOutputCapture)
 	p.beforeSyntax(control.Prefix, control.Markers, out)
-	if control.Init != nil {
+	if java.FindMarker[golang.ImplicitForClauses](control.Markers) != nil {
+		// Go's condition-only `for cond {}` or infinite `for {}`. Init and
+		// update hold synthetic J.Empty placeholders (kept only so the Java
+		// J.ForLoop.Control list contract holds); print just the condition,
+		// with no `;` separators.
+		if control.Condition != nil {
+			p.Visit(control.Condition.Element, out)
+			p.visitSpace(control.Condition.After, out)
+		}
+	} else if control.Init != nil {
 		// 3-clause form: init; cond; update
 		p.Visit(control.Init.Element, out)
 		p.visitSpace(control.Init.After, out)

--- a/rewrite-go/pkg/rpc/for_control_rpc_test.go
+++ b/rewrite-go/pkg/rpc/for_control_rpc_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// Go's condition-only `for cond {}` and infinite `for {}` fill their init/update
+// slots with synthetic J.Empty placeholders so J.ForLoop.Control keeps the
+// single-element-list shape a JavaVisitor may index at 0. The golang.
+// ImplicitForClauses marker records that they are synthetic. Both the
+// placeholders and the marker must survive the RPC wire, or the loop would
+// re-print as a 3-clause `for ; cond ; {}`.
+func TestImplicitForClausesSurvivesRpcRoundTrip(t *testing.T) {
+	cases := []string{
+		"package main\n\nfunc f(data []byte) {\n\tfor len(data) > 0 {\n\t}\n}\n",
+		"package main\n\nfunc f() {\n\tfor {\n\t}\n}\n",
+	}
+	for _, src := range cases {
+		src := src
+		t.Run(src, func(t *testing.T) {
+			// given: a parsed for-loop that already prints back to its source
+			cu, err := parser.NewGoParser().Parse("f.go", src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := printer.Print(cu); got != src {
+				t.Fatalf("parse-print idempotence failed:\n got=%q\nwant=%q", got, src)
+			}
+
+			// when: the whole compilation unit round-trips through the Go
+			// sender/receiver (the path a recipe edit forces)
+			seed := &golang.CompilationUnit{ID: cu.ID}
+			rt := roundTripNode(t, cu, seed).(java.Tree)
+
+			// then: it still prints identically...
+			if got := printer.Print(rt); got != src {
+				t.Errorf("for-loop shape corrupted on round-trip:\n got=%q\nwant=%q", got, src)
+			}
+			// ...and the control still carries the placeholders and the marker
+			control := firstForControl(t, rt)
+			if control.Init == nil {
+				t.Errorf("Init placeholder lost on round-trip")
+			}
+			if control.Update == nil {
+				t.Errorf("Update placeholder lost on round-trip")
+			}
+			if java.FindMarker[golang.ImplicitForClauses](control.Markers) == nil {
+				t.Errorf("ImplicitForClauses marker lost on round-trip")
+			}
+		})
+	}
+}
+
+// firstForControl returns the ForControl of the first for-loop found under t.
+func firstForControl(t *testing.T, tree java.Tree) *java.ForControl {
+	t.Helper()
+	cu, ok := tree.(*golang.CompilationUnit)
+	if !ok {
+		t.Fatalf("expected *golang.CompilationUnit, got %T", tree)
+	}
+	for _, st := range cu.Statements {
+		fn, ok := st.Element.(*java.MethodDeclaration)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		for _, bs := range fn.Body.Statements {
+			if loop, ok := bs.Element.(*java.ForLoop); ok {
+				return &loop.Control
+			}
+		}
+	}
+	t.Fatalf("no *java.ForLoop found")
+	return nil
+}

--- a/rewrite-go/pkg/rpc/space_rpc.go
+++ b/rewrite-go/pkg/rpc/space_rpc.go
@@ -190,6 +190,8 @@ func sendMarkerCodecFields(v any, q *SendQueue) {
 		q.GetAndSend(m, func(x any) any { return x.(golang.SelectStmt).Ident.String() }, nil)
 	case golang.TypeSwitchGuard:
 		q.GetAndSend(m, func(x any) any { return x.(golang.TypeSwitchGuard).Ident.String() }, nil)
+	case golang.ImplicitForClauses:
+		q.GetAndSend(m, func(x any) any { return x.(golang.ImplicitForClauses).Ident.String() }, nil)
 	case golang.StructTag:
 		// StructTag.rpcSend sends: id (UUID string), tag valueSource (string)
 		q.GetAndSend(m, func(x any) any { return x.(golang.StructTag).Ident.String() }, nil)
@@ -414,6 +416,14 @@ func receiveMarkersCodec(q *ReceiveQueue, before java.Markers) java.Markers {
 			}
 			return m
 		case golang.TypeSwitchGuard:
+			idStr := receiveScalar[string](q, m.Ident.String())
+			if idStr != "" {
+				if parsed, err := uuid.Parse(idStr); err == nil {
+					m.Ident = parsed
+				}
+			}
+			return m
+		case golang.ImplicitForClauses:
 			idStr := receiveScalar[string](q, m.Ident.String())
 			if idStr != "" {
 				if parsed, err := uuid.Parse(idStr); err == nil {

--- a/rewrite-go/pkg/rpc/value_types.go
+++ b/rewrite-go/pkg/rpc/value_types.go
@@ -114,6 +114,7 @@ func init() {
 	RegisterValueType(reflect.TypeOf(golang.InterfaceMethod{}), "org.openrewrite.golang.marker.InterfaceMethod")
 	RegisterValueType(reflect.TypeOf(golang.SelectStmt{}), "org.openrewrite.golang.marker.SelectStmt")
 	RegisterValueType(reflect.TypeOf(golang.TypeSwitchGuard{}), "org.openrewrite.golang.marker.TypeSwitchGuard")
+	RegisterValueType(reflect.TypeOf(golang.ImplicitForClauses{}), "org.openrewrite.golang.marker.ImplicitForClauses")
 	RegisterValueType(reflect.TypeOf(golang.StructTag{}), "org.openrewrite.golang.marker.StructTag")
 	RegisterValueType(reflect.TypeOf(golang.TrailingComma{}), "org.openrewrite.golang.marker.TrailingComma")
 	RegisterValueType(reflect.TypeOf(java.SearchResult{}), "org.openrewrite.marker.SearchResult")
@@ -251,6 +252,7 @@ func init() {
 	RegisterFactory("org.openrewrite.golang.marker.InterfaceMethod", func() any { return golang.InterfaceMethod{} })
 	RegisterFactory("org.openrewrite.golang.marker.SelectStmt", func() any { return golang.SelectStmt{} })
 	RegisterFactory("org.openrewrite.golang.marker.TypeSwitchGuard", func() any { return golang.TypeSwitchGuard{} })
+	RegisterFactory("org.openrewrite.golang.marker.ImplicitForClauses", func() any { return golang.ImplicitForClauses{} })
 	RegisterFactory("org.openrewrite.golang.marker.StructTag", func() any { return golang.StructTag{} })
 	RegisterFactory("org.openrewrite.golang.marker.TrailingComma", func() any { return golang.TrailingComma{} })
 	// Semicolon: RpcCodec on the Java side; sends only `id`. Replaces the

--- a/rewrite-go/pkg/tree/golang/markers.go
+++ b/rewrite-go/pkg/tree/golang/markers.go
@@ -50,3 +50,16 @@ func NewSemicolon() Semicolon {
 func NewGoProject(projectName, modulePath string) GoProject {
 	return GoProject{Ident: uuid.New(), ProjectName: projectName, ModulePath: modulePath}
 }
+
+// ImplicitForClauses marks a J.ForLoop.Control whose init/update are synthetic
+// J.Empty placeholders (Go's `for cond {}` / `for {}`), so the printer omits
+// them and their `;`. Mirrors org.openrewrite.golang.marker.ImplicitForClauses.
+type ImplicitForClauses struct {
+	Ident uuid.UUID
+}
+
+func (m ImplicitForClauses) ID() uuid.UUID { return m.Ident }
+
+func NewImplicitForClauses() ImplicitForClauses {
+	return ImplicitForClauses{Ident: uuid.New()}
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/ImplicitForClauses.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/ImplicitForClauses.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+import org.openrewrite.rpc.RpcCodec;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.UUID;
+
+/**
+ * Marks a {@link org.openrewrite.java.tree.J.ForLoop.Control} whose init and update clauses are absent in the
+ * source — Go's condition-only {@code for cond {}} and infinite {@code for {}} loops. The parser fills the init
+ * and update slots with {@link org.openrewrite.java.tree.J.Empty} placeholders so the control honours the same
+ * contract every other parser produces (init and update are single-element lists safe to index at 0); this marker
+ * records that those placeholders are synthetic so the Go printer omits them and their {@code ;} separators.
+ */
+@Value
+@With
+public class ImplicitForClauses implements Marker, RpcCodec<ImplicitForClauses> {
+    UUID id;
+
+    @Override
+    public void rpcSend(ImplicitForClauses after, RpcSendQueue q) {
+        q.getAndSend(after, Marker::getId);
+    }
+
+    @Override
+    public ImplicitForClauses rpcReceive(ImplicitForClauses before, RpcReceiveQueue q) {
+        return before.withId(q.receiveAndGet(before.getId(), UUID::fromString));
+    }
+}


### PR DESCRIPTION
## What's changed?

Fixing how we parse Go `for cond {}` loops.
The implicit clauses now land as `J.Empty` wrapped with the the typical `RightPadded`.
Instead of being `nil`.

## What's your motivation?

- solves the first part of #8461

To fix some of the Java recipes in rewrite-static-analysis (and probably others) crashing on Go code with errors like:
```
Recipe execution error
Index 0 out of bounds for length 0
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length
java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
java.base/java.util.Objects.checkIndex(Objects.java:365)
java.base/java.util.ArrayList.get(ArrayList.java:428) org.openrewrite.staticanalysis.DefaultComesLastVisitor.isDefaultCase(DefaultComesLastVisitor.java:237)
```