### PR TITLE
Go: default case in switch parsed same as in Java

### DIFF
--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1416,8 +1416,15 @@ func (ctx *parseContext) mapCaseClause(clause *ast.CaseClause) *java.Case {
 		}
 		exprs = java.Container[java.Expression]{Elements: elements}
 	} else {
-		// default:
+		// default: mirror the shape every other parser produces — a single
+		// J.Identifier named "default" as the sole case label, so a visitor
+		// indexing J.Case.getCaseLabels().get(0) stays safe.
 		ctx.skip(len("default"))
+		exprs = java.Container[java.Expression]{
+			Elements: []java.RightPadded[java.Expression]{
+				{Element: &java.Identifier{ID: uuid.New(), Name: "default"}},
+			},
+		}
 	}
 
 	// Skip the colon
@@ -1428,13 +1435,8 @@ func (ctx *parseContext) mapCaseClause(clause *ast.CaseClause) *java.Case {
 		ctx.skip(1) // ":"
 	}
 
-	// For case: last expression's After gets the space before colon
-	// For default: exprs.Before gets the space before colon
-	if len(exprs.Elements) > 0 {
-		exprs.Elements[len(exprs.Elements)-1].After = colonPrefix
-	} else {
-		exprs.Before = colonPrefix
-	}
+	// The last label's After gets the space before the colon.
+	exprs.Elements[len(exprs.Elements)-1].After = colonPrefix
 
 	// Body statements
 	var body []java.RightPadded[java.Statement]

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -590,10 +590,27 @@ func (p *GoPrinter) VisitSwitch(sw *java.Switch, param any) java.J {
 	return sw
 }
 
+// isDefaultCase reports whether a J.Case is Go's `default:` clause, modeled as a
+// single J.Identifier label named "default" (matching every other parser). Since
+// `default` is a reserved keyword, no real case expression can be that identifier.
+func isDefaultCase(c *java.Case) bool {
+	if len(c.Expressions.Elements) != 1 {
+		return false
+	}
+	id, ok := c.Expressions.Elements[0].Element.(*java.Identifier)
+	return ok && id.Name == "default"
+}
+
 func (p *GoPrinter) VisitCase(c *java.Case, param any) java.J {
 	out := param.(*PrintOutputCapture)
 	p.beforeSyntax(c.Prefix, c.Markers, out)
-	if len(c.Expressions.Elements) > 0 {
+	if isDefaultCase(c) {
+		// `default:` — a single J.Identifier named "default" (mirroring Java);
+		// print the label itself, with no `case` keyword.
+		rp := c.Expressions.Elements[0]
+		p.Visit(rp.Element, out)
+		p.visitSpace(rp.After, out)
+	} else if len(c.Expressions.Elements) > 0 {
 		out.Append("case")
 		for i, rp := range c.Expressions.Elements {
 			p.Visit(rp.Element, out)
@@ -604,9 +621,6 @@ func (p *GoPrinter) VisitCase(c *java.Case, param any) java.J {
 				p.visitSpace(rp.After, out)
 			}
 		}
-	} else {
-		out.Append("default")
-		p.visitSpace(c.Expressions.Before, out)
 	}
 	out.Append(":")
 	for _, rp := range c.Body {


### PR DESCRIPTION
## What's changed?

Fixing how we parse Go `default` cases in switches.
Now parsing the same as in Java - i.e. a case with `default` as the (artificial) identifier.

## What's your motivation?

- solves the second part of #8461

To fix some of the Java recipes in rewrite-static-analysis (and probably others) crashing on Go code.