### PR TITLE
Gradle ChangeDependency: dedupe on GA identity and upgrade the survivor

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -40,6 +40,7 @@ import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.ResolvedDependency;
+import org.openrewrite.maven.tree.Version;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.DependencyMatcher;
@@ -220,6 +221,19 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                             }
                         });
 
+                // Also resolve for NEW-coord deps so survivor-upgrade can rewrite a variable that
+                // only the survivor references (the OLD dep might use a literal version).
+                new GradleDependency.Matcher()
+                        .groupId(newGroupId)
+                        .artifactId(newArtifactId)
+                        .get(getCursor())
+                        .ifPresent(dep -> {
+                            String varName = dep.getVersionVariable();
+                            if (varName != null && !StringUtils.isBlank(newVersion)) {
+                                resolveAndRecordVersion(varName, m, dep, ctx);
+                            }
+                        });
+
                 return m;
             }
 
@@ -250,10 +264,12 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
     public TreeVisitor<?, ExecutionContext> getVisitor(Accumulator acc) {
         TreeVisitor<?, ExecutionContext> gradleVisitor = Preconditions.check(new FindGradleProject(FindGradleProject.SearchCriteria.Marker).getVisitor(), new JavaIsoVisitor<ExecutionContext>() {
             final DependencyMatcher depMatcher = requireNonNull(DependencyMatcher.build(oldGroupId + ":" + oldArtifactId).getValue());
-            final DependencyMatcher existingMatcher = requireNonNull(DependencyMatcher.build(newGroupId + ":" + newArtifactId + (newVersion == null ? "" : ":" + newVersion)).getValue());
+            final DependencyMatcher existingMatcher = requireNonNull(DependencyMatcher.build(newGroupId + ":" + newArtifactId).getValue());
 
             @SuppressWarnings("NotNullFieldNotInitialized")
             GradleProject gradleProject;
+
+            final Set<String> configurationsWithSurvivorUpgrade = new HashSet<>();
 
             @Override
             public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
@@ -294,22 +310,14 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                     boolean oldFound = false;
                     boolean newFound = false;
                     for (Dependency d : c.getRequested()) {
-                        String version = d.getVersion();
-                        if (version == null) {
-                            ResolvedDependency rd = c.findResolvedDependency(d.getGroupId(), d.getArtifactId());
-                            if (rd == null) {
-                                continue;
-                            } else {
-                                version = rd.getVersion();
-                            }
-                        }
-                        oldFound |= depMatcher.matches(d.getGroupId(), d.getArtifactId(), version);
-                        newFound |= existingMatcher.matches(d.getGroupId(), d.getArtifactId(), version);
+                        oldFound |= depMatcher.matches(d.getGroupId(), d.getArtifactId());
+                        newFound |= existingMatcher.matches(d.getGroupId(), d.getArtifactId());
                     }
                     if (oldFound && newFound) {
                         sourceFile = (JavaSourceFile) new RemoveDependency(oldGroupId, oldArtifactId, c.getName())
                                 .getVisitor()
                                 .visitNonNull(sourceFile, ctx);
+                        configurationsWithSurvivorUpgrade.add(c.getName());
                     }
                 }
                 return sourceFile;
@@ -319,18 +327,85 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
 
-                GradleDependency.Matcher gradleDependencyMatcher = new GradleDependency.Matcher()
+                Optional<GradleDependency> maybeDep = new GradleDependency.Matcher()
                         .groupId(oldGroupId)
-                        .artifactId(oldArtifactId);
+                        .artifactId(oldArtifactId)
+                        .get(getCursor());
+                if (maybeDep.isPresent()) {
+                    return updateDependency(m, maybeDep.get(), ctx);
+                }
 
-                Optional<GradleDependency> maybeDep = gradleDependencyMatcher.get(getCursor());
-                return maybeDep.map(gradleDependency -> updateDependency(m, gradleDependency, ctx)).orElse(m);
+                // Survivor-upgrade: if this method invocation is the pre-existing NEW-coord dep in a
+                // configuration where dedupe removed the old coord, upgrade its version to newVersion.
+                if (!StringUtils.isBlank(newVersion) && !configurationsWithSurvivorUpgrade.isEmpty()) {
+                    Optional<GradleDependency> maybeSurvivor = new GradleDependency.Matcher()
+                            .groupId(newGroupId)
+                            .artifactId(newArtifactId)
+                            .get(getCursor());
+                    if (maybeSurvivor.isPresent() &&
+                            configurationsWithSurvivorUpgrade.contains(maybeSurvivor.get().getConfigurationName())) {
+                        return upgradeSurvivorVersion(m, maybeSurvivor.get(), ctx);
+                    }
+                }
+                return m;
+            }
+
+            private J.MethodInvocation upgradeSurvivorVersion(J.MethodInvocation m, GradleDependency dep, ExecutionContext ctx) {
+                String declaredVersion = dep.getDeclaredVersion();
+                String varName = dep.getVersionVariable();
+                if (varName != null) {
+                    // Variable-backed: if the variable is safe to update (used only by OLD or NEW/survivor coords),
+                    // let visitVariable rewrite the shared variable value. Otherwise write a literal override
+                    // to this method invocation so we don't drag unrelated deps along with the variable change.
+                    if (ChangeDependency.this.canSafelyUpdateVariable(varName, depMatcher, existingMatcher, acc)) {
+                        return m;
+                    }
+                    Object scanResult = acc.versionVariableUpdates.get(varName);
+                    if (scanResult instanceof MavenDownloadingException) {
+                        return ((MavenDownloadingException) scanResult).warn(m);
+                    }
+                    if (scanResult instanceof String) {
+                        return dep.withDeclaredVersion((String) scanResult).getTree();
+                    }
+                    return m;
+                }
+                if (StringUtils.isBlank(declaredVersion) && !Boolean.TRUE.equals(overrideManagedVersion)) {
+                    // BOM-managed: don't add a version tag unless the caller opted in via overrideManagedVersion
+                    return m;
+                }
+                try {
+                    String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
+                            .select(new GroupArtifact(dep.getGroupId(), dep.getArtifactId()),
+                                    dep.getConfigurationName(), newVersion, versionPattern, ctx);
+                    if (resolvedVersion != null && !resolvedVersion.equals(declaredVersion) &&
+                            !isDowngrade(declaredVersion, resolvedVersion)) {
+                        return dep.withDeclaredVersion(resolvedVersion).getTree();
+                    }
+                } catch (MavenDownloadingException e) {
+                    return e.warn(m);
+                }
+                return m;
+            }
+
+            private boolean isDowngrade(@Nullable String currentVersion, String candidateVersion) {
+                if (StringUtils.isBlank(currentVersion)) {
+                    return false;
+                }
+                try {
+                    return new Version(candidateVersion).compareTo(new Version(currentVersion)) < 0;
+                } catch (Exception e) {
+                    return false;
+                }
             }
 
             @Override
             public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext ctx) {
                 J.VariableDeclarations.NamedVariable v = super.visitVariable(variable, ctx);
-                if (!ChangeDependency.this.canSafelyUpdateVariable(v.getSimpleName(), depMatcher, acc)) {
+                // In survivor contexts, also treat NEW-coord usages of the variable as safe: renaming
+                // OLD→NEW makes both usages point at the same GA, so updating the shared variable is fine.
+                boolean allowSurvivorUsage = !configurationsWithSurvivorUpgrade.isEmpty();
+                if (!ChangeDependency.this.canSafelyUpdateVariable(v.getSimpleName(), depMatcher,
+                        allowSurvivorUsage ? existingMatcher : null, acc)) {
                     return v;
                 }
                 Object scanResult = acc.versionVariableUpdates.get(v.getSimpleName());
@@ -362,7 +437,9 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                 }
 
                 String varName = dep.getVersionVariable();
-                if (varName != null && !ChangeDependency.this.canSafelyUpdateVariable(varName, depMatcher, acc)) {
+                boolean allowSurvivorUsage = !configurationsWithSurvivorUpgrade.isEmpty();
+                if (varName != null && !ChangeDependency.this.canSafelyUpdateVariable(varName, depMatcher,
+                        allowSurvivorUsage ? existingMatcher : null, acc)) {
                     Object scanResult = acc.versionVariableUpdates.get(varName);
                     if (scanResult instanceof MavenDownloadingException) {
                         return ((MavenDownloadingException) scanResult).warn(m);
@@ -393,36 +470,49 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
             }
 
             private GradleProject updateGradleModel(GradleProject gp, ExecutionContext ctx) {
-                return gp.mapConfigurations(configuration ->
-                                configuration.mapDependencies(requested -> {
-                                    if (!depMatcher.matches(requested.getGroupId(), requested.getArtifactId())) {
-                                        return requested;
-                                    }
+                return gp.mapConfigurations(configuration -> {
+                    boolean isSurvivorConfig = configurationsWithSurvivorUpgrade.contains(configuration.getName());
+                    return configuration.mapDependencies(requested -> {
+                        boolean matchesOld = depMatcher.matches(requested.getGroupId(), requested.getArtifactId());
+                        boolean matchesNew = isSurvivorConfig && existingMatcher.matches(requested.getGroupId(), requested.getArtifactId());
 
-                                    GroupArtifactVersion gav = requested.getGav();
-                                    if (newGroupId != null) {
-                                        gav = gav.withGroupId(newGroupId);
-                                    }
-                                    if (newArtifactId != null) {
-                                        gav = gav.withArtifactId(newArtifactId);
-                                    }
-                                    if (!StringUtils.isBlank(newVersion) &&
-                                            (!StringUtils.isBlank(gav.getVersion()) || Boolean.TRUE.equals(overrideManagedVersion))) {
-                                        try {
-                                            String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
-                                                    .select(new GroupArtifact(gav.getGroupId(), gav.getArtifactId()), configuration.getName(),
-                                                            newVersion, versionPattern, ctx);
-                                            if (resolvedVersion != null && !resolvedVersion.equals(gav.getVersion())) {
-                                                gav = gav.withVersion(resolvedVersion);
-                                            }
-                                        } catch (MavenDownloadingException ignored) {
-                                            // Failure is already recorded in metadataFailures.
-                                        }
-                                    }
-                                    return gav == requested.getGav() ? requested : requested.withGav(gav);
-                                }, gp.getMavenRepositories(), ctx),
-                        ctx
-                );
+                        // In a survivor config, drop OLD-matched entries from the model — source-side
+                        // dedupe already removed them from the file. Renaming here would produce a
+                        // duplicate NEW-coord entry in the marker's requested list.
+                        if (matchesOld && isSurvivorConfig) {
+                            return null;
+                        }
+                        if (!matchesOld && !matchesNew) {
+                            return requested;
+                        }
+
+                        GroupArtifactVersion gav = requested.getGav();
+                        if (matchesOld) {
+                            if (newGroupId != null) {
+                                gav = gav.withGroupId(newGroupId);
+                            }
+                            if (newArtifactId != null) {
+                                gav = gav.withArtifactId(newArtifactId);
+                            }
+                        }
+                        if (!StringUtils.isBlank(newVersion) &&
+                                (!StringUtils.isBlank(gav.getVersion()) || Boolean.TRUE.equals(overrideManagedVersion))) {
+                            try {
+                                String resolvedVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
+                                        .select(new GroupArtifact(gav.getGroupId(), gav.getArtifactId()), configuration.getName(),
+                                                newVersion, versionPattern, ctx);
+                                // Survivor entries carry a pre-existing version the user chose — don't downgrade.
+                                if (resolvedVersion != null && !resolvedVersion.equals(gav.getVersion()) &&
+                                        !(matchesNew && !matchesOld && isDowngrade(gav.getVersion(), resolvedVersion))) {
+                                    gav = gav.withVersion(resolvedVersion);
+                                }
+                            } catch (MavenDownloadingException ignored) {
+                                // Failure is already recorded in metadataFailures.
+                            }
+                        }
+                        return gav == requested.getGav() ? requested : requested.withGav(gav);
+                    }, gp.getMavenRepositories(), ctx);
+                }, ctx);
             }
         });
 
@@ -470,12 +560,18 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
     }
 
     private boolean canSafelyUpdateVariable(String varName, DependencyMatcher depMatcher, Accumulator acc) {
+        return canSafelyUpdateVariable(varName, depMatcher, null, acc);
+    }
+
+    private boolean canSafelyUpdateVariable(String varName, DependencyMatcher depMatcher,
+                                            @Nullable DependencyMatcher alsoAllowed, Accumulator acc) {
         Set<GroupArtifact> usages = acc.versionVariableUsages.get(varName);
         if (usages == null) {
             return true;
         }
         for (GroupArtifact ga : usages) {
-            if (!depMatcher.matches(ga.getGroupId(), ga.getArtifactId())) {
+            if (!depMatcher.matches(ga.getGroupId(), ga.getArtifactId()) &&
+                    (alsoAllowed == null || !alsoAllowed.matches(ga.getGroupId(), ga.getArtifactId()))) {
                 return false;
             }
             if (acc.failedResolutions.contains(ga)) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/ChangeDependency.java
@@ -40,7 +40,6 @@ import org.openrewrite.maven.tree.Dependency;
 import org.openrewrite.maven.tree.GroupArtifact;
 import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.ResolvedDependency;
-import org.openrewrite.maven.tree.Version;
 import org.openrewrite.properties.PropertiesVisitor;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.DependencyMatcher;
@@ -357,7 +356,7 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                     // Variable-backed: if the variable is safe to update (used only by OLD or NEW/survivor coords),
                     // let visitVariable rewrite the shared variable value. Otherwise write a literal override
                     // to this method invocation so we don't drag unrelated deps along with the variable change.
-                    if (ChangeDependency.this.canSafelyUpdateVariable(varName, depMatcher, existingMatcher, acc)) {
+                    if (canSafelyUpdateVariable(varName, depMatcher, existingMatcher, acc)) {
                         return m;
                     }
                     Object scanResult = acc.versionVariableUpdates.get(varName);
@@ -388,24 +387,18 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
             }
 
             private boolean isDowngrade(@Nullable String currentVersion, String candidateVersion) {
-                if (StringUtils.isBlank(currentVersion)) {
-                    return false;
-                }
-                try {
-                    return new Version(candidateVersion).compareTo(new Version(currentVersion)) < 0;
-                } catch (Exception e) {
-                    return false;
-                }
+                return !StringUtils.isBlank(currentVersion) &&
+                        Semver.compare(candidateVersion, currentVersion, Semver.Ecosystem.MAVEN) < 0;
+            }
+
+            private @Nullable DependencyMatcher survivorAlsoAllowed() {
+                return configurationsWithSurvivorUpgrade.isEmpty() ? null : existingMatcher;
             }
 
             @Override
             public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext ctx) {
                 J.VariableDeclarations.NamedVariable v = super.visitVariable(variable, ctx);
-                // In survivor contexts, also treat NEW-coord usages of the variable as safe: renaming
-                // OLD→NEW makes both usages point at the same GA, so updating the shared variable is fine.
-                boolean allowSurvivorUsage = !configurationsWithSurvivorUpgrade.isEmpty();
-                if (!ChangeDependency.this.canSafelyUpdateVariable(v.getSimpleName(), depMatcher,
-                        allowSurvivorUsage ? existingMatcher : null, acc)) {
+                if (!canSafelyUpdateVariable(v.getSimpleName(), depMatcher, survivorAlsoAllowed(), acc)) {
                     return v;
                 }
                 Object scanResult = acc.versionVariableUpdates.get(v.getSimpleName());
@@ -437,9 +430,7 @@ public class ChangeDependency extends ScanningRecipe<ChangeDependency.Accumulato
                 }
 
                 String varName = dep.getVersionVariable();
-                boolean allowSurvivorUsage = !configurationsWithSurvivorUpgrade.isEmpty();
-                if (varName != null && !ChangeDependency.this.canSafelyUpdateVariable(varName, depMatcher,
-                        allowSurvivorUsage ? existingMatcher : null, acc)) {
+                if (varName != null && !canSafelyUpdateVariable(varName, depMatcher, survivorAlsoAllowed(), acc)) {
                     Object scanResult = acc.versionVariableUpdates.get(varName);
                     if (scanResult instanceof MavenDownloadingException) {
                         return ((MavenDownloadingException) scanResult).warn(m);

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/ChangeDependencyTest.java
@@ -903,10 +903,247 @@ class ChangeDependencyTest implements RewriteTest {
     }
 
     @Test
-    void noDuplicateJacksonDatabindDependenciesInGradle() {
+    void dedupeDoesNotDowngradeSurvivorAtHigherVersion() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new ChangeDependency(
+                "commons-lang",
+                "commons-lang",
+                "org.apache.commons",
+                "commons-lang3",
+                "3.11.x",
+                null,
+                null,
+                null
+            )),
+          buildGradle(
+            //language=gradle
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.14.0")
+                  implementation("commons-lang:commons-lang:2.6")
+              }
+              """,
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.14.0")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dedupeUpgradesSurvivorViaSharedVariable() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new ChangeDependency(
+                "commons-lang",
+                "commons-lang",
+                "org.apache.commons",
+                "commons-lang3",
+                "3.14.x",
+                null,
+                null,
+                null
+            )),
+          buildGradle(
+            //language=gradle
+            """
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              def commonsVersion = "3.11"
+              dependencies {
+                  implementation "org.apache.commons:commons-lang3:${commonsVersion}"
+                  implementation "commons-lang:commons-lang:2.6"
+              }
+              """,
+            """
+              plugins {
+                  id 'java-library'
+              }
+              repositories {
+                  mavenCentral()
+              }
+              def commonsVersion = "3.14.0"
+              dependencies {
+                  implementation "org.apache.commons:commons-lang3:${commonsVersion}"
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dedupesAndUpgradesSurvivorWhenExistingNewGAAtLowerVersion() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new ChangeDependency(
+                "commons-lang",
+                "commons-lang",
+                "org.apache.commons",
+                "commons-lang3",
+                "3.14.x",
+                null,
+                null,
+                null
+            )),
+          buildGradle(
+            //language=gradle
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.11")
+                  implementation("commons-lang:commons-lang:2.6")
+              }
+              """,
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.14.0")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void dedupesAndDoesNotAddVersionToBomManagedSurvivor() {
+        // Survivor is BOM-managed (no declared version); upgrade path should leave it alone.
         rewriteRun(
           spec -> spec.beforeRecipe(withToolingApi())
             .recipes(
+              new ChangeDependency(
+                "com.fasterxml.jackson",
+                "jackson-bom",
+                "tools.jackson",
+                "jackson-bom",
+                "3.0.x",
+                null,
+                null,
+                null
+              ),
+              new ChangeDependency(
+                "com.fasterxml.jackson.datatype",
+                "jackson-datatype-jsr310",
+                "tools.jackson.core",
+                "jackson-databind",
+                "3.0.x",
+                null,
+                null,
+                null
+              )
+            ),
+          buildGradle(
+            //language=gradle
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation platform("com.fasterxml.jackson:jackson-bom:2.19.0")
+                  implementation("tools.jackson.core:jackson-databind")
+                  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+              }
+              """,
+            spec -> spec.after(buildGradle ->
+              assertThat(buildGradle)
+                .containsOnlyOnce("tools.jackson.core:jackson-databind")
+                .doesNotContain(":jackson-databind:")  // no version was added to survivor
+                .doesNotContain("jackson-datatype-jsr310")
+                .actual())
+          )
+        );
+    }
+
+    @Test
+    void dedupeWithoutNewVersionDoesNotAlterSurvivor() {
+        // newVersion is null; dedupe should still fire but survivor's version stays untouched.
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipe(new ChangeDependency(
+                "commons-lang",
+                "commons-lang",
+                "org.apache.commons",
+                "commons-lang3",
+                null,
+                null,
+                null,
+                null
+            )),
+          buildGradle(
+            //language=gradle
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.11")
+                  implementation("commons-lang:commons-lang:2.6")
+              }
+              """,
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.11")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noDuplicateJacksonDatabindDependenciesInGradleWithBomManagedVersions() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipes(
+              new ChangeDependency(
+                "com.fasterxml.jackson",
+                "jackson-bom",
+                "tools.jackson",
+                "jackson-bom",
+                "3.0.4",
+                null,
+                null,
+                null
+              ),
               new ChangeDependency(
                 "com.fasterxml.jackson.core",
                 "jackson-databind",
@@ -938,15 +1175,78 @@ class ChangeDependencyTest implements RewriteTest {
                   mavenCentral()
               }
               dependencies {
+                  implementation platform("com.fasterxml.jackson:jackson-bom:2.19.0")
+                  implementation("com.fasterxml.jackson.core:jackson-databind")
+                  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
+              }
+              """,
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation platform("tools.jackson:jackson-bom:3.0.4")
+                  implementation("tools.jackson.core:jackson-databind")
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void noDuplicateJacksonDatabindDependenciesInGradle() {
+        rewriteRun(
+          spec -> spec.beforeRecipe(withToolingApi())
+            .recipes(
+              new ChangeDependency(
+                "com.fasterxml.jackson.core",
+                "jackson-databind",
+                "tools.jackson.core",
+                null,
+                "3.0.4",
+                null,
+                null,
+                null
+              ),
+              new ChangeDependency(
+                "com.fasterxml.jackson.datatype",
+                "jackson-datatype-jsr310",
+                "tools.jackson.core",
+                "jackson-databind",
+                "3.0.4",
+                null,
+                null,
+                null
+              )
+            ),
+          buildGradle(
+            //language=gradle
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
                   implementation("com.fasterxml.jackson.core:jackson-databind:2.19.0")
                   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.19.0")
               }
               """,
-            spec -> spec.after(buildGradle ->
-              assertThat(buildGradle)
-                .containsOnlyOnce("tools.jackson.core:jackson-databind:3")
-                .doesNotContain("datatype")
-                .actual())
+            """
+              plugins {
+                  id("java-library")
+              }
+              repositories {
+                  mavenCentral()
+              }
+              dependencies {
+                  implementation("tools.jackson.core:jackson-databind:3.0.4")
+              }
+              """
           )
         );
     }


### PR DESCRIPTION
## Summary

When `ChangeDependency` (Gradle) renames an OLD coord to a NEW coord that already exists in the same configuration, dedupe would silently skip the check whenever either dep's version was BOM-managed and could not currently be resolved (an earlier rename in the same recipe chain can orphan the OLD coord from the resolved graph). Even when dedupe did fire, the surviving NEW-coord entry stayed at its original version instead of being upgraded to `newVersion`, and cross-version GA collisions produced duplicate declarations at different versions in the same configuration.

The Maven counterpart, `ChangeDependencyGroupIdAndArtifactId`, already handles both dimensions:

- `renamedOldTagWouldDuplicate` matches on pure GA identity (+ classifier/type/scope), not version.
- `isSurvivorOfRemovedOldDependency` flags the retained entry so the version-update pass upgrades it to `newVersion`.

This PR brings the Gradle side in line.

## What changed

- **Dedupe uses pure GA identity.** `maybeRemoveDuplicateTargetDependency` no longer requires version resolution to fire, and `existingMatcher` no longer carries the `newVersion` constraint.
- **Survivor upgrade.** After dedupe removes the OLD tag from a configuration, any NEW-coord entry in that configuration is upgraded to `newVersion`. Handles literals, variable-backed versions (mirrors `updateDependency`'s safe / literal-override logic), and BOM-managed survivors (left alone unless `overrideManagedVersion == true`, matching Maven).
- **Downgrade guard.** A survivor whose declared version is already higher than the resolved `newVersion` is not touched. Compared via `org.openrewrite.maven.tree.Version`. Only applied to the survivor path, not the OLD rename (renaming's semantic still includes version upgrade there).
- **Variable safety widened for survivor contexts.** `canSafelyUpdateVariable` has a new overload accepting an `alsoAllowed` matcher. When dedupe has fired for at least one configuration, the survivor's NEW coord counts as a safe usage of a shared variable, so a variable serving both OLD and survivor can be updated in place instead of falling through to a literal override.
- **Scanner extended.** In addition to resolving `newVersion` for OLD-coord method invocations, the scanner now also resolves for NEW-coord invocations. Needed for the case where the OLD dep declares a literal version but the survivor uses a variable — without this the shared variable never gets a resolved value to write.
- **`updateGradleModel` keeps the marker consistent.** In survivor configurations, OLD-matched requested entries are dropped from the marker (source-side dedupe already removed them from the file), and NEW-matched entries are upgraded to `newVersion` with the same downgrade guard.

## Tests

Six new tests in `ChangeDependencyTest`:

- `noDuplicateJacksonDatabindDependenciesInGradleWithBomManagedVersions` — `platform(...)` BOM + Jackson deps without explicit versions.
- `dedupesAndUpgradesSurvivorWhenExistingNewGAAtLowerVersion` — pre-existing new GA at a lower version + OLD dep being renamed with a higher `newVersion` collapses to a single upgraded entry.
- `dedupesAndDoesNotAddVersionToBomManagedSurvivor` — BOM-managed survivor is left untouched.
- `dedupeWithoutNewVersionDoesNotAlterSurvivor` — `newVersion == null` dedupes but does not touch the survivor's version.
- `dedupeDoesNotDowngradeSurvivorAtHigherVersion` — survivor at `3.14.0` with rule targeting `3.11.x` stays at `3.14.0`.
- `dedupeUpgradesSurvivorViaSharedVariable` — `def commonsVersion = "3.11"` used by the survivor is rewritten to `3.14.0` when it's safe.

The existing `noDuplicateJacksonDatabindDependenciesInGradle` was tightened to use explicit before/after strings (was piecewise `containsOnlyOnce` / `doesNotContain` assertions), and its `newVersion` pinned to `3.0.4` for determinism.

## Test plan

- [x] `./gradlew :rewrite-gradle:test --tests 'org.openrewrite.gradle.ChangeDependencyTest'` — 34 tests pass
- [x] `./gradlew :rewrite-gradle:test` full suite — 1312 tests, 0 failures