### PR TITLE
Go: do not parse .gitignored files

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -28,6 +28,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -2266,6 +2267,72 @@ type parseProjectResponseItem struct {
 // Matches the 1 MB cap in the JVM JavaScriptParser and the other RPC engines.
 const maxParseableSizeBytes = 1 << 20
 
+// filterGitIgnored removes paths that git would ignore under projectPath, so
+// build output and other gitignored sources are not parsed into the LST. Paths
+// are evaluated relative to projectPath via a single `git check-ignore --stdin`
+// call, which is index-aware: a tracked (e.g. force-added) file under an ignored
+// directory is never reported ignored and is kept. Fails open — if git is
+// unavailable, projectPath is not a work tree, or the invocation errors, every
+// path is returned unchanged.
+func filterGitIgnored(projectPath string, paths []string) []string {
+	if len(paths) == 0 {
+		return paths
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		return paths
+	}
+
+	// NUL-delimited I/O (-z) so paths containing a newline can't corrupt the
+	// protocol, matching the C# peer (GitCli.CheckIgnored).
+	var in bytes.Buffer
+	rels := make([]string, len(paths))
+	for i, p := range paths {
+		rel, err := filepath.Rel(projectPath, p)
+		if err != nil || strings.HasPrefix(rel, "..") {
+			continue // outside the work tree: not subject to its ignore rules
+		}
+		rel = filepath.ToSlash(rel)
+		rels[i] = rel
+		in.WriteString(rel)
+		in.WriteByte(0)
+	}
+	if in.Len() == 0 {
+		return paths
+	}
+
+	cmd := exec.Command("git", "check-ignore", "--stdin", "-z")
+	cmd.Dir = projectPath
+	cmd.Stdin = &in
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	if err := cmd.Run(); err != nil {
+		// Exit code 1 means "nothing ignored" (empty output), which is not an
+		// error for us. Anything else (128 = not a repo, git missing, ...) fails open.
+		if ee, ok := err.(*exec.ExitError); !ok || ee.ExitCode() != 1 {
+			return paths
+		}
+	}
+
+	ignored := make(map[string]struct{})
+	for _, line := range strings.Split(out.String(), "\x00") {
+		if line != "" {
+			ignored[line] = struct{}{}
+		}
+	}
+	if len(ignored) == 0 {
+		return paths
+	}
+
+	kept := make([]string, 0, len(paths))
+	for i, p := range paths {
+		if _, skip := ignored[rels[i]]; skip {
+			continue
+		}
+		kept = append(kept, p)
+	}
+	return kept
+}
+
 func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 	var req parseProjectRequest
 	if err := json.Unmarshal(params, &req); err != nil {
@@ -2317,6 +2384,14 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 	if err != nil {
 		return nil, &rpcError{Code: -32603, Message: fmt.Sprintf("Walk error: %v", err)}
 	}
+
+	// Go has no build-output directory convention, so name-based pruning can't
+	// find generated sources (they land wherever the build tooling chose). Let
+	// .gitignore decide instead: drop anything git would ignore. Index-aware, so
+	// a force-added file under an ignored directory survives.
+	disc.goFiles = filterGitIgnored(req.ProjectPath, disc.goFiles)
+	disc.oversizeFiles = filterGitIgnored(req.ProjectPath, disc.oversizeFiles)
+	disc.goMods = filterGitIgnored(req.ProjectPath, disc.goMods)
 
 	// Parse every go.mod once; index by directory so we can find the
 	// closest ancestor for each .go file. Failing to parse a go.mod is

--- a/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+)
+
+// Reproduces https://github.com/openrewrite/rewrite/issues/8475
+func TestParseProjectExcludesGitIgnored(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+
+	// given: a git repo that ignores build/, with generated Go files at the root
+	// and nested, a force-added source under an ignored path, and a plain source
+	s, _ := newTestServer(t)
+	projectDir := t.TempDir()
+	writeFile(t, filepath.Join(projectDir, ".gitignore"), "build/\n")
+	writeFile(t, filepath.Join(projectDir, "go.mod"), "module example.com/m\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(projectDir, "probe.go"), "package m\n")
+	writeFile(t, filepath.Join(projectDir, "build", "generated", "rootbuild.go"), "package generated\n")
+	writeFile(t, filepath.Join(projectDir, "sub", "build", "generated", "subbuild.go"), "package generated\n")
+	writeFile(t, filepath.Join(projectDir, "pkg", "build", "legit.go"), "package build\n")
+
+	gitInit(t, projectDir)
+	git(t, projectDir, "add", ".gitignore", "go.mod", "probe.go")
+	git(t, projectDir, "add", "-f", filepath.Join("pkg", "build", "legit.go"))
+	git(t, projectDir, "commit", "-qm", "init")
+
+	relativeTo := projectDir
+	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+
+	// when
+	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
+		t.Fatalf("handleParseProject: %v", rpcErr.Message)
+	}
+
+	// then
+	parsed := map[string]bool{}
+	for _, obj := range s.localObjects {
+		if cu, ok := obj.(*golang.CompilationUnit); ok {
+			parsed[filepath.ToSlash(cu.SourcePath)] = true
+		}
+	}
+	for _, want := range []string{"probe.go", "pkg/build/legit.go"} {
+		if !parsed[want] {
+			t.Errorf("expected %q to be parsed, but it was not", want)
+		}
+	}
+	for _, unwanted := range []string{"build/generated/rootbuild.go", "sub/build/generated/subbuild.go"} {
+		if parsed[unwanted] {
+			t.Errorf("expected gitignored %q to be excluded, but it was parsed", unwanted)
+		}
+	}
+}
+
+// TestFilterGitIgnoredFailsOpen pins the defensive behavior: with no git binary
+// on PATH, and outside a git work tree, every candidate path is returned
+// unchanged rather than dropped.
+func TestFilterGitIgnoredFailsOpen(t *testing.T) {
+	dir := t.TempDir()
+	paths := []string{
+		filepath.Join(dir, "a.go"),
+		filepath.Join(dir, "build", "gen.go"),
+	}
+
+	// given: a real git binary but projectPath is not a work tree
+	if _, err := exec.LookPath("git"); err == nil {
+		if got := filterGitIgnored(dir, paths); len(got) != len(paths) {
+			t.Errorf("not a git repo: expected all %d paths kept, got %d: %v", len(paths), len(got), got)
+		}
+	}
+
+	// given: git is not resolvable on PATH at all
+	t.Setenv("PATH", "")
+	if got := filterGitIgnored(dir, paths); len(got) != len(paths) {
+		t.Errorf("no git binary: expected all %d paths kept, got %d: %v", len(paths), len(got), got)
+	}
+}
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	git(t, dir, "init", "-q")
+	git(t, dir, "config", "user.email", "test@example.com")
+	git(t, dir, "config", "user.name", "test")
+}
+
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}


### PR DESCRIPTION
## What's changed?

Changing the Go parser logic to filter out `.gitignore`d files. Similar to what we do for other languages.

## What's your motivation?

- fixes #8475 
