### PR TITLE
Align the Python RPC server's framing and exit codes with the JS peer

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -80,9 +80,10 @@ _metrics_lock = threading.Lock()
 _request_id_counter = 0
 _request_id_lock = threading.Lock()
 
-# Pending requests waiting for responses
-_pending_requests: Dict[int, Any] = {}
-_pending_lock = threading.Lock()
+# Ids of the calls currently on the stack, and responses that arrived for one of them
+# while another was waiting; anything no listed call claims is dropped rather than kept.
+_awaiting_ids: Set[Any] = set()
+_pending_responses: Dict[Any, dict] = {}
 
 # Flag for trace mode
 _trace_rpc = False
@@ -144,21 +145,44 @@ def send_request(method: str, params: dict, timeout_seconds: float = 30.0) -> An
     # Send the request to Java via stdout
     write_message(request)
 
-    # Read the response from Java with timeout
-    response = read_message_with_timeout(timeout_seconds)
+    _awaiting_ids.add(request_id)
+    try:
+        while True:
+            response = _pending_responses.pop(request_id, None)
+            if response is None:
+                try:
+                    response = read_message_with_timeout(timeout_seconds)
+                except TimeoutError as e:
+                    raise RuntimeError(f"No response received for {method} request ({e})")
+                if response is None:
+                    raise RuntimeError(f"Host closed the stream while awaiting a response to {method}")
 
-    if response is None:
-        raise RuntimeError(f"No response received for {method} request (timeout after {timeout_seconds}s)")
+            # Java can call us while we are calling Java; serve it and keep waiting, as
+            # the JS peer's connection does for a request arriving mid-call.
+            if response.get('method') is not None:
+                _serve(response)
+                continue
 
-    if _trace_rpc:
-        logger.debug(f"Received response from Java: {json.dumps(response)}")
+            response_id = response.get('id')
+            if response_id != request_id:
+                if response_id in _awaiting_ids:
+                    _pending_responses[response_id] = response
+                else:
+                    logger.warning(f"Discarding response for request {response_id}; "
+                                   f"no call is awaiting it")
+                continue
 
-    # Check for errors
-    if 'error' in response:
-        error = response['error']
-        raise RuntimeError(f"RPC error from Java: {error.get('message', 'Unknown error')}")
+            if _trace_rpc:
+                logger.debug(f"Received response from Java: {json.dumps(response)}")
 
-    return response.get('result')
+            if 'error' in response:
+                error = response['error']
+                raise RuntimeError(f"RPC error from Java: {error.get('message', 'Unknown error')}")
+
+            return response.get('result')
+    finally:
+        _awaiting_ids.discard(request_id)
+        _pending_responses.pop(request_id, None)
 
 
 def _require_tree(tree: Any, source_file_type: Optional[str]) -> Any:
@@ -2544,6 +2568,10 @@ def handle_request(method: str, params: dict) -> Any:
         raise ValueError(f"Unknown method: {method}")
 
 
+class _ProtocolError(Exception):
+    """The stream can no longer be framed, so no later message can be trusted."""
+
+
 class _StdinBuffer:
     """Buffered reader for raw stdin file descriptor.
 
@@ -2556,6 +2584,7 @@ class _StdinBuffer:
     def __init__(self):
         self._fd: Optional[int] = None
         self._buf = bytearray()
+        self.at_eof = False
 
     def _get_fd(self) -> int:
         fd = self._fd
@@ -2621,6 +2650,7 @@ class _StdinBuffer:
         else:
             chunk = os.read(self._get_fd(), self._CHUNK_SIZE)
         if not chunk:
+            self.at_eof = True
             return False
         self._buf += chunk
         return True
@@ -2629,75 +2659,70 @@ class _StdinBuffer:
 _stdin_buffer = _StdinBuffer()
 
 
-def read_message_with_timeout(timeout_seconds: float) -> Optional[dict]:
-    """Read a JSON-RPC message from stdin with timeout.
+def _read_body(header_line: bytes) -> Optional[dict]:
+    """Read the remainder of a message whose header line has been consumed.
 
-    Args:
-        timeout_seconds: Maximum time to wait for complete message
+    No deadline applies past the header. A message the reader walks away from
+    half-read leaves its body to be parsed as the next message's header, which
+    desynchronizes every read that follows.
 
     Returns:
-        Parsed JSON message, or None on timeout/error
+        Parsed JSON message
+
+    Raises:
+        _ProtocolError: If the frame cannot be parsed or ends early
     """
-    deadline = time.time() + timeout_seconds
+    header_str = header_line.decode('utf-8', 'replace').strip()
+    if not header_str.startswith('Content-Length:'):
+        raise _ProtocolError(f"invalid header: {header_str}")
 
     try:
-        # Read Content-Length header
-        header_line = _stdin_buffer.read_line(deadline)
-        if not header_line:
-            logger.warning(f"Timeout waiting for RPC response header after {timeout_seconds}s")
-            return None
-
-        header_str = header_line.decode('utf-8').strip()
-        if not header_str.startswith('Content-Length:'):
-            logger.error(f"Invalid header: {header_str}")
-            return None
-
         content_length = int(header_str.split(':')[1].strip())
+    except ValueError:
+        raise _ProtocolError(f"invalid content length: {header_str}")
 
-        # Read empty line (separator)
-        separator = _stdin_buffer.read_line(deadline)
-        if separator is None:
-            logger.warning(f"Timeout waiting for header separator")
-            return None
+    # The separator line. A stream ending mid-frame has truncated a message rather
+    # than closed between two, so it is a fault and not the host hanging up.
+    if _stdin_buffer.read_line() is None:
+        raise _ProtocolError("stream ended before the message body")
 
-        # Read content
-        content_bytes = _stdin_buffer.read_bytes(content_length, deadline)
-        if content_bytes is None:
-            logger.warning(f"Timeout waiting for message content")
-            return None
+    content_bytes = _stdin_buffer.read_bytes(content_length)
+    if content_bytes is None:
+        raise _ProtocolError(f"stream ended inside a {content_length} byte message body")
 
+    try:
         return json.loads(content_bytes.decode('utf-8'))
-    except Exception as e:
-        logger.error(f"Error reading message with timeout: {e}")
-        return None
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        raise _ProtocolError(f"invalid message body: {e}")
+
+
+def read_message_with_timeout(timeout_seconds: float) -> Optional[dict]:
+    """Read a JSON-RPC message from stdin, bounding the wait for it to *start*.
+
+    Args:
+        timeout_seconds: Maximum time to wait for a message to begin arriving
+
+    Returns:
+        Parsed JSON message, or None if the host closed the stream
+
+    Raises:
+        TimeoutError: If no message begins arriving within the deadline
+        _ProtocolError: If the frame cannot be parsed or ends early
+    """
+    header_line = _stdin_buffer.read_line(time.time() + timeout_seconds)
+    if header_line is None:
+        if _stdin_buffer.at_eof:
+            return None
+        raise TimeoutError(f"no RPC message arrived within {timeout_seconds}s")
+    return _read_body(header_line)
 
 
 def read_message() -> Optional[dict]:
-    """Read a JSON-RPC message from stdin (blocking, no timeout)."""
-    try:
-        # Read Content-Length header
-        header_line = _stdin_buffer.read_line()
-        if not header_line:
-            return None
-
-        header_str = header_line.decode('utf-8').strip()
-        if not header_str.startswith('Content-Length:'):
-            logger.error(f"Invalid header: {header_str}")
-            return None
-
-        content_length = int(header_str.split(':')[1].strip())
-
-        # Read empty line (separator)
-        _stdin_buffer.read_line()
-
-        # Read content
-        content_bytes = _stdin_buffer.read_bytes(content_length)
-        if not content_bytes:
-            return None
-        return json.loads(content_bytes.decode('utf-8'))
-    except Exception as e:
-        logger.error(f"Error reading message: {e}")
+    """Read a JSON-RPC message from stdin (blocking, no timeout). None on EOF."""
+    header_line = _stdin_buffer.read_line()
+    if not header_line:
         return None
+    return _read_body(header_line)
 
 
 def write_message(response: dict):
@@ -2710,6 +2735,72 @@ def write_message(response: dict):
     content_bytes = json.dumps(response).encode('utf-8')
     header = f"Content-Length: {len(content_bytes)}\r\n\r\n".encode('utf-8')
     os.write(sys.stdout.fileno(), header + content_bytes)
+
+
+def _error_response(request_id: Any, e: Exception) -> dict:
+    """Must be called while handling ``e``, so the traceback reaches the host."""
+    return {
+        'jsonrpc': '2.0',
+        'id': request_id,
+        'error': {
+            'code': -32603,
+            'message': str(e),
+            'data': traceback.format_exc()
+        }
+    }
+
+
+def _write_response(response: dict) -> None:
+    """Send a response, substituting an error when the result cannot be encoded.
+
+    Encoding sits outside the guard around the handler, and a value JSON cannot
+    represent is that one request's failure rather than the server's.
+    """
+    try:
+        if _trace_rpc:
+            logger.debug(f"Sending: {json.dumps(response)}")
+        write_message(response)
+    except (TypeError, ValueError) as e:
+        request_id = response.get('id')
+        logger.exception(f"Error encoding response for request {request_id}: {e}")
+        write_message(_error_response(request_id, e))
+
+
+def _serve(message: dict) -> None:
+    """Handle one inbound request and reply to it."""
+    request_id = message.get('id')
+    method = message.get('method')
+    params = message.get('params', {})
+
+    if method is None:
+        logger.error("Missing 'method' in request")
+        return
+
+    if _trace_rpc:
+        logger.debug(f"Received: {json.dumps(message)}")
+
+    metric_start = time.monotonic()
+    metric_error = ''
+    try:
+        response = {
+            'jsonrpc': '2.0',
+            'id': request_id,
+            'result': handle_request(method, params)
+        }
+    except _ProtocolError:
+        # A nested call can raise this. Answering it as a request-level error would
+        # leave main() reading on, so let it through and end the process.
+        raise
+    except Exception as e:
+        logger.exception(f"Error handling request: {e}")
+        metric_error = str(e)
+        response = _error_response(request_id, e)
+    _record_metric(method, (time.monotonic() - metric_start) * 1000.0, metric_error)
+
+    # Notifications (no id, e.g. Evict) get no reply — a null-id response would
+    # fail every in-flight request on the Java reader.
+    if request_id is not None:
+        _write_response(response)
 
 
 def _init_pyroscope() -> None:
@@ -2806,6 +2897,11 @@ def _close_metrics() -> None:
         _metrics_file = _metrics_writer = None
 
 
+# Exit status for a fault, distinguishing it from the 0 of a host-closed stream.
+# Matches the JS server's `process.on('uncaughtException') -> process.exit(8)`.
+FATAL_EXIT_CODE = 8
+
+
 def main():
     """Main entry point for the RPC server."""
     global _trace_rpc
@@ -2850,64 +2946,27 @@ def main():
 
     logger.info("Python RPC server starting...")
 
-    while True:
-        try:
+    exit_code = 0
+    try:
+        while True:
             message = read_message()
             if message is None:
                 break
-
-            if args.trace_rpc_messages:
-                logger.debug(f"Received: {json.dumps(message)}")
-
-            request_id = message.get('id')
-            method = message.get('method')
-            params = message.get('params', {})
-
-            if method is None:
-                logger.error("Missing 'method' in request")
-                continue
-
-            metric_start = time.monotonic()
-            metric_error = ''
-            try:
-                result = handle_request(method, params)
-                response = {
-                    'jsonrpc': '2.0',
-                    'id': request_id,
-                    'result': result
-                }
-            except Exception as e:
-                logger.exception(f"Error handling request: {e}")
-                # Include full stack trace in error response for debugging
-                tb_str = traceback.format_exc()
-                metric_error = str(e)
-                response = {
-                    'jsonrpc': '2.0',
-                    'id': request_id,
-                    'error': {
-                        'code': -32603,
-                        'message': str(e),
-                        'data': tb_str
-                    }
-                }
-            _record_metric(method, (time.monotonic() - metric_start) * 1000.0, metric_error)
-
-            if args.trace_rpc_messages:
-                logger.debug(f"Sending: {json.dumps(response)}")
-
-            # Notifications (no id, e.g. Evict) get no reply — a null-id response would
-            # fail every in-flight request on the Java reader.
-            if request_id is not None:
-                write_message(response)
-
-        except Exception as e:
-            logger.exception(f"Fatal error: {e}")
-            break
+            _serve(message)
+    except _ProtocolError as e:
+        logger.error(f"Protocol error, cannot continue: {e}")
+        exit_code = FATAL_EXIT_CODE
+    except Exception as e:
+        logger.exception(f"Fatal error: {e}")
+        exit_code = FATAL_EXIT_CODE
 
     # No ty-types cleanup needed here — clients are scoped per parse batch
 
     _close_metrics()
     logger.info("Python RPC server shutting down...")
+
+    if exit_code:
+        sys.exit(exit_code)
 
 
 if __name__ == '__main__':

--- a/rewrite-python/rewrite/tests/rpc/test_stdin_framing.py
+++ b/rewrite-python/rewrite/tests/rpc/test_stdin_framing.py
@@ -1,0 +1,258 @@
+"""Framing and liveness of the stdin JSON-RPC loop, held to the semantics the JS peer
+gets from ``vscode-jsonrpc``. The protocol has no shutdown message, so exiting 0 is
+itself an assertion: the host closed the stream.
+"""
+import json
+import os
+import subprocess
+import sys
+import threading
+
+import pytest
+
+import rewrite.rpc.server as server
+
+
+def _framed(msg: dict) -> bytes:
+    body = json.dumps(msg).encode('utf-8')
+    return b"Content-Length: %d\r\n\r\n" % len(body) + body
+
+
+def _header_and_body(msg: dict):
+    """The two halves a slow peer can deliver in separate writes."""
+    framed = _framed(msg)
+    split = framed.index(b"\r\n\r\n") + 4
+    return framed[:split], framed[split:]
+
+
+def _parse_frames(data: bytes) -> list:
+    messages = []
+    while data:
+        separator = data.index(b"\r\n\r\n")
+        length = int(data[:separator].split(b":")[1])
+        start = separator + 4
+        messages.append(json.loads(data[start:start + length]))
+        data = data[start + length:]
+    return messages
+
+
+def _write_later(pipe, chunks, delay=0.15):
+    """Deliver the rest of a message after the reader's deadline has passed."""
+    def run():
+        for chunk in chunks:
+            try:
+                pipe.write(chunk)
+            except (OSError, ValueError):
+                return  # the test finished early and its pipe is gone
+
+    timer = threading.Timer(delay, run)
+    timer.daemon = True
+    timer.start()
+
+
+@pytest.fixture
+def stdin_pipe(monkeypatch):
+    """Bind the module-level stdin buffer to a pipe this test writes into."""
+    read_fd, write_fd = os.pipe()
+    buffer = server._StdinBuffer()
+    buffer._fd = read_fd
+    monkeypatch.setattr(server, '_stdin_buffer', buffer)
+    writer = os.fdopen(write_fd, 'wb', buffering=0)
+    try:
+        yield writer
+    finally:
+        if not writer.closed:
+            writer.close()
+        os.close(read_fd)
+
+
+class _Stdout:
+    """A real descriptor for ``write_message``, so responses are asserted through the
+    production encoder and framing rather than around them."""
+
+    def __init__(self, path):
+        self._path = path
+        self._handle = open(path, 'wb', buffering=0)
+
+    def install(self, monkeypatch):
+        # Applied from the test body: pytest reinstalls sys.stdout when the call phase
+        # begins, so a patch made during fixture setup is discarded before main() runs.
+        monkeypatch.setattr(sys, 'stdout', self._handle)
+
+    def frames(self):
+        return _parse_frames(self._path.read_bytes())
+
+    def close(self):
+        self._handle.close()
+
+
+@pytest.fixture
+def stdout(tmp_path):
+    out = _Stdout(tmp_path / 'stdout.bin')
+    try:
+        yield out
+    finally:
+        out.close()
+
+
+@pytest.fixture(autouse=True)
+def isolated_server(monkeypatch):
+    """The server keeps its request ids and in-flight bookkeeping in module state, and
+    main() reads argv, so both are per-test rather than per-session."""
+    monkeypatch.setattr(server, '_request_id_counter', 0)
+    monkeypatch.setattr(server, '_awaiting_ids', set())
+    monkeypatch.setattr(server, '_pending_responses', {})
+    monkeypatch.setattr(sys, 'argv', ['server'])
+
+
+@pytest.fixture
+def sent(monkeypatch):
+    """Messages the server sent, for tests that care about content, not encoding."""
+    messages = []
+    monkeypatch.setattr(server, 'write_message', messages.append)
+    return messages
+
+
+LATE = {'jsonrpc': '2.0', 'id': 1, 'result': 'late'}
+NEXT_REQUEST = {'jsonrpc': '2.0', 'id': 2, 'method': 'GetLanguages', 'params': {}}
+
+
+def test_read_with_timeout_waits_for_a_body_that_arrives_after_the_deadline(stdin_pipe):
+    header, body = _header_and_body(LATE)
+    stdin_pipe.write(header)
+    _write_later(stdin_pipe, [body])
+
+    assert server.read_message_with_timeout(0.05) == LATE
+
+
+def test_stream_stays_aligned_after_a_body_arrives_late(stdin_pipe):
+    header, body = _header_and_body(LATE)
+    stdin_pipe.write(header)
+    _write_later(stdin_pipe, [body, _framed(NEXT_REQUEST)])
+
+    server.read_message_with_timeout(0.05)
+
+    assert server.read_message() == NEXT_REQUEST
+
+
+def test_main_survives_a_handler_result_that_is_not_json_serializable(stdin_pipe, stdout,
+                                                                     monkeypatch):
+    stdout.install(monkeypatch)
+    monkeypatch.setattr(server, 'handle_request', lambda method, params: {'path': {'a', 'b'}})
+
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 1, 'method': 'GetObject', 'params': {}}))
+    stdin_pipe.write(_framed(NEXT_REQUEST))
+    stdin_pipe.close()
+
+    server.main()
+
+    written = stdout.frames()
+    assert [r['id'] for r in written] == [1, 2]
+    assert 'error' in written[0]
+
+
+def test_main_exits_zero_when_the_host_closes_the_stream(stdin_pipe, stdout, monkeypatch):
+    stdout.install(monkeypatch)
+    stdin_pipe.write(_framed(NEXT_REQUEST))
+    stdin_pipe.close()
+
+    server.main()
+
+    assert [r['id'] for r in stdout.frames()] == [2]
+
+
+def test_main_exits_nonzero_on_a_corrupt_frame(stdin_pipe, stdout, monkeypatch):
+    stdout.install(monkeypatch)
+    stdin_pipe.write(b"Content-Length: not-a-number\r\n\r\n")
+    stdin_pipe.close()
+
+    with pytest.raises(SystemExit) as exit_info:
+        server.main()
+
+    assert exit_info.value.code == 8
+
+
+def test_send_request_returns_the_response_matching_its_id(stdin_pipe, sent):
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 999, 'result': 'stale'}))
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 1, 'result': 'mine'}))
+
+    assert server.send_request('GetObject', {'id': 'x'}, timeout_seconds=1.0) == 'mine'
+
+
+def test_send_request_serves_a_request_that_arrives_while_it_waits(stdin_pipe, sent):
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 'reentrant', 'method': 'GetLanguages',
+                              'params': {}}))
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 1, 'result': 'mine'}))
+
+    assert server.send_request('GetObject', {'id': 'x'}, timeout_seconds=1.0) == 'mine'
+    assert 'reentrant' in [m.get('id') for m in sent]
+
+
+def _nested_call(method, params):
+    return server.send_request('Inner', {}, timeout_seconds=1.0)
+
+
+def test_a_nested_call_does_not_discard_the_outer_calls_response(stdin_pipe, sent, monkeypatch):
+    monkeypatch.setattr(server, 'handle_request', _nested_call)
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 'reentrant', 'method': 'Visit', 'params': {}}))
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 1, 'result': 'outer'}))
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 2, 'result': 'inner'}))
+
+    assert server.send_request('Outer', {}, timeout_seconds=1.0) == 'outer'
+
+
+def test_a_protocol_error_inside_a_handler_still_exits_nonzero(stdin_pipe, stdout, monkeypatch):
+    stdout.install(monkeypatch)
+    monkeypatch.setattr(server, 'handle_request', _nested_call)
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 1, 'method': 'Visit', 'params': {}}))
+    # A frame the reader consumes whole, so main() reaches EOF rather than tripping
+    # over leftovers and reporting the fault for the wrong reason.
+    stdin_pipe.write(b"garbage\r\n")
+    stdin_pipe.close()
+
+    with pytest.raises(SystemExit) as exit_info:
+        server.main()
+
+    assert exit_info.value.code == 8
+
+
+def test_main_exits_nonzero_on_a_truncated_message(stdin_pipe, stdout, monkeypatch):
+    stdout.install(monkeypatch)
+    stdin_pipe.write(_header_and_body(NEXT_REQUEST)[0])
+    stdin_pipe.close()
+
+    with pytest.raises(SystemExit) as exit_info:
+        server.main()
+
+    assert exit_info.value.code == 8
+
+
+def test_send_request_reports_a_closed_stream_rather_than_a_timeout(stdin_pipe, sent):
+    stdin_pipe.close()
+
+    with pytest.raises(RuntimeError, match='closed'):
+        server.send_request('GetObject', {'id': 'x'}, timeout_seconds=1.0)
+
+
+def test_a_response_no_call_is_awaiting_is_not_retained(stdin_pipe, sent):
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 999, 'result': 'stale'}))
+    stdin_pipe.write(_framed({'jsonrpc': '2.0', 'id': 1, 'result': 'mine'}))
+
+    assert server.send_request('GetObject', {'id': 'x'}, timeout_seconds=1.0) == 'mine'
+    assert not server._pending_responses
+
+
+def _spawn_server(stdin_bytes, tmp_path):
+    """Exercise the exit status the Java host actually observes."""
+    proc = subprocess.run(
+        [sys.executable, '-m', 'rewrite.rpc.server', '--log-file', str(tmp_path / 'rpc.log')],
+        input=stdin_bytes, stdout=subprocess.PIPE, timeout=60)
+    return proc.returncode
+
+
+def test_the_process_exits_zero_when_the_host_closes_the_stream(tmp_path):
+    assert _spawn_server(_framed(NEXT_REQUEST), tmp_path) == 0
+
+
+def test_the_process_exits_eight_on_a_corrupt_frame(tmp_path):
+    assert _spawn_server(b"garbage\r\n", tmp_path) == 8


### PR DESCRIPTION
## Motivation

The Python RPC server hand-rolls JSON-RPC framing over stdin/stdout, and `main()` returns — so the process exits 0 — only by breaking out of its read loop. The protocol has no shutdown message, so every clean exit is either a real EOF or something the loop mistook for one. Four conditions took that second path, and each surfaced on the Java side as `IllegalStateException: RPC process shut down early with exit code 0` from `RewriteRpcProcess.getLivenessCheck`, with no indication of what actually went wrong.

The JS peer gets the right behaviour for free from `vscode-jsonrpc`: it never abandons a partially-read message, it correlates responses to requests by id, it dispatches an inbound request that arrives while a call is pending, and it distinguishes a host-closed stream (`process.exit(0)`) from a fault (`process.exit(8)`). This aligns the Python server's behaviour with that, without taking on a framing dependency.

## Summary

- The read deadline now bounds only the wait for a message to *start*. Previously it was a whole-message wall clock, so a body arriving in several chunks past the deadline was abandoned after its header had been consumed, leaving the body to be parsed as the next message's header — desynchronizing every read that followed. Header parsing is extracted into `_read_body`, shared by both readers.
- Response encoding moved inside the per-request guard. `json.dumps` ran after the `try` around the handler, so a single value JSON could not represent ended the server instead of failing that one request.
- `send_request` now matches responses by id rather than returning whatever arrived next. A response belonging to a call further out on the stack is held for it — serving an inbound request can nest a call inside an outer one — and anything no in-flight call claims is dropped rather than retained.
- `send_request` serves an inbound request that arrives while it is waiting, so the host can call us while we are calling the host.
- Exit status is classified: EOF exits 0, a stream that can no longer be framed raises `_ProtocolError` and exits `FATAL_EXIT_CODE` (8, matching the JS peer). A `Content-Length: 0` body and a truncated message are no longer mistaken for EOF, and a closed stream is reported as such instead of as a timeout.

## Test plan

- [x] New `tests/rpc/test_stdin_framing.py` (14 tests), each watched failing first, covering: a body arriving after the deadline; stream alignment afterwards; an unencodable result; id matching; a request arriving mid-call; a nested call not discarding the outer call's response; a response no call awaits not being retained; a protocol error inside a handler still being fatal; corrupt frame, truncated message, and clean EOF exit codes.
- [x] Two of those spawn `python -m rewrite.rpc.server` as a subprocess and assert the real process exit status, so the `main()`-to-exit-code mapping is covered rather than just `SystemExit`.
- [x] Full Python suite: 2022 passed, 22 skipped.
- [x] End to end under the Moderne CLI against a Python repository — LST build plus recipe runs in facade + child topology, producing correct diffs with zero framing faults logged (no `Fatal error`, `Protocol error`, `Invalid header`, `Discarding response`, or timeout entries). The zero `Discarding response` count also confirms the new correlation logic is inert on the happy path.
- [x] Exit-code contract verified on the interpreter the CLI spawns: well-formed request then EOF → 0, corrupt frame → 8, truncated body → 8, immediate EOF → 0.
