### PR TITLE
Go: removing imports fall back to lexical matching

### DIFF
--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -68,6 +68,22 @@ func ImportPath(imp *java.Import) string {
 	return strings.Trim(raw, `"`+"`")
 }
 
+// PackageName returns the qualifier used to reference the import: its alias, else the last path segment ("" for blank/dot imports).
+func PackageName(imp *java.Import) string {
+	switch alias := AliasName(imp); alias {
+	case "":
+		path := ImportPath(imp)
+		if i := strings.LastIndex(path, "/"); i >= 0 {
+			return path[i+1:]
+		}
+		return path
+	case "_", ".":
+		return ""
+	default:
+		return alias
+	}
+}
+
 // AliasName returns the alias used by an Import: a custom identifier for
 // `import alias "path"`, "_" for blank imports, "." for dot imports, or
 // "" when the import uses the default (last segment of the path).
@@ -175,18 +191,31 @@ func IsLocal(importPath, modulePath string) bool {
 // Aliases and dot imports are handled uniformly — the package's import
 // path is what we track, regardless of how the user named it.
 func ReferencedPackages(cu *golang.CompilationUnit) map[string]bool {
-	refs := map[string]bool{}
-	if cu == nil {
-		return refs
-	}
-	v := visitor.Init(&referencedPackagesVisitor{refs: refs})
-	v.Visit(cu, nil)
+	refs, _ := referencedImports(cu)
 	return refs
+}
+
+// ReferencedQualifiers returns the identifiers used lexically as package qualifiers (left of the dot), the attribution-free signal goimports relies on.
+func ReferencedQualifiers(cu *golang.CompilationUnit) map[string]bool {
+	_, quals := referencedImports(cu)
+	return quals
+}
+
+func referencedImports(cu *golang.CompilationUnit) (refs, quals map[string]bool) {
+	refs = map[string]bool{}
+	quals = map[string]bool{}
+	if cu == nil {
+		return refs, quals
+	}
+	v := visitor.Init(&referencedPackagesVisitor{refs: refs, quals: quals})
+	v.Visit(cu, nil)
+	return refs, quals
 }
 
 type referencedPackagesVisitor struct {
 	visitor.GoVisitor
-	refs map[string]bool
+	refs  map[string]bool
+	quals map[string]bool
 }
 
 func (v *referencedPackagesVisitor) VisitIdentifier(ident *java.Identifier, p any) java.J {
@@ -206,7 +235,19 @@ func (v *referencedPackagesVisitor) VisitMethodInvocation(mi *java.MethodInvocat
 			v.refs[path] = true
 		}
 	}
+	if mi.Select != nil {
+		if id, ok := mi.Select.Element.(*java.Identifier); ok {
+			v.quals[id.Name] = true
+		}
+	}
 	return v.GoVisitor.VisitMethodInvocation(mi, p)
+}
+
+func (v *referencedPackagesVisitor) VisitFieldAccess(fa *java.FieldAccess, p any) java.J {
+	if id, ok := fa.Target.(*java.Identifier); ok {
+		v.quals[id.Name] = true
+	}
+	return v.GoVisitor.VisitFieldAccess(fa, p)
 }
 
 // pkgPathOf returns the package import path implied by an FQN. The

--- a/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
+++ b/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
@@ -59,6 +59,7 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 		return cu
 	}
 	refs := internal.ReferencedPackages(cu)
+	quals := internal.ReferencedQualifiers(cu)
 	for _, rp := range cu.Imports.Elements {
 		imp := rp.Element
 		if imp == nil {
@@ -73,9 +74,10 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 		if internal.AliasName(imp) == "." {
 			continue
 		}
-		if !refs[internal.ImportPath(imp)] {
-			cu = internal.RemoveFromBlock(cu, imp)
+		if refs[internal.ImportPath(imp)] || quals[internal.PackageName(imp)] {
+			continue
 		}
+		cu = internal.RemoveFromBlock(cu, imp)
 	}
 	return cu
 }

--- a/rewrite-go/test/import_recipes_test.go
+++ b/rewrite-go/test/import_recipes_test.go
@@ -19,11 +19,95 @@ package test
 import (
 	"testing"
 
+	"github.com/google/uuid"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	recipes "github.com/openrewrite/rewrite/rewrite-go/pkg/recipe/golang"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
 func strPtr(s string) *string { return &s }
+
+// stripQualifierAttribution rewrites `y.Hello()` into an equivalent call
+// whose qualifier identifier and method type carry no attribution,
+// mimicking a hand-built cross-package call node.
+type stripQualifierAttribution struct {
+	recipe.Base
+}
+
+func (r *stripQualifierAttribution) Name() string {
+	return "org.openrewrite.golang.test.StripQualifierAttribution"
+}
+func (r *stripQualifierAttribution) DisplayName() string { return "Strip qualifier attribution" }
+func (r *stripQualifierAttribution) Description() string {
+	return "Replaces the qualifier of `y.Hello()` with an un-attributed identifier."
+}
+
+func (r *stripQualifierAttribution) Editor() recipe.TreeVisitor {
+	return visitor.Init(&stripQualifierVisitor{})
+}
+
+type stripQualifierVisitor struct {
+	visitor.GoVisitor
+}
+
+func (v *stripQualifierVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
+	if mi.Name == nil || mi.Name.Name != "Hello" || mi.Select == nil {
+		return v.GoVisitor.VisitMethodInvocation(mi, p)
+	}
+	qualifier, ok := mi.Select.Element.(*java.Identifier)
+	if !ok {
+		return v.GoVisitor.VisitMethodInvocation(mi, p)
+	}
+	c := *mi
+	sel := *mi.Select
+	sel.Element = &java.Identifier{ID: uuid.New(), Prefix: qualifier.Prefix, Name: qualifier.Name}
+	c.Select = &sel
+	c.MethodType = nil
+	return v.GoVisitor.VisitMethodInvocation(&c, p)
+}
+
+type handBuiltCallThenRemoveUnused struct {
+	recipe.Base
+}
+
+func (r *handBuiltCallThenRemoveUnused) Name() string {
+	return "org.openrewrite.golang.test.HandBuiltCallThenRemoveUnused"
+}
+func (r *handBuiltCallThenRemoveUnused) DisplayName() string {
+	return "Hand-built call then remove unused"
+}
+func (r *handBuiltCallThenRemoveUnused) Description() string {
+	return "Strips qualifier attribution, then removes unused imports."
+}
+func (r *handBuiltCallThenRemoveUnused) RecipeList() []recipe.Recipe {
+	return []recipe.Recipe{&stripQualifierAttribution{}, &recipes.RemoveUnusedImports{}}
+}
+
+func TestRemoveUnusedImports_KeepsImportReferencedByUnattributedQualifier(t *testing.T) {
+	// given a file whose only use of `github.com/x/y` is a call whose
+	// qualifier is stripped of attribution (as a hand-built node would be)
+	// when RemoveUnusedImports runs after
+	// then the import survives on the lexical qualifier match alone
+	spec := NewRecipeSpec().WithRecipe(&handBuiltCallThenRemoveUnused{})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				"fmt"
+				"github.com/x/y"
+			)
+
+			func main() {
+				fmt.Println("hi")
+				_ = y.Hello()
+			}
+		`),
+	)
+}
 
 func TestAddImport_NoOpWhenAlreadyImported(t *testing.T) {
 	spec := NewRecipeSpec().WithRecipe(&recipes.AddImport{PackagePath: "fmt"})


### PR DESCRIPTION
## What's changed?

Amend the Remove Unused Imports logic for Go.
Fallback to lexical matching of packages when type attribution doesn't help.
Same approach we use in some of the other languages, incl. Java.

## What's your motivation?

Otherwise, when a recipe adds an import "by hand" (not using template) there might be mismatches. And Go is a language which doesn't accept dangling imports, thus it's important to match as closely as possible.