### PR TITLE
Size static wildcard imports by their static members in `Autodetect`

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
@@ -664,6 +664,43 @@ class AutodetectTest implements RewriteTest {
     }
 
     @Test
+    void staticStarImportCountsFoldedMembersNotVariablesOfThatType() {
+        var cus = jp().parse(
+          """
+            package org.openrewrite.test;
+
+            public class Outer {
+                public enum Measure {
+                    One, Two, Three, Four, Five, Six
+                }
+            }
+            """,
+          """
+            package org.openrewrite.test;
+
+            import java.util.List;
+
+            import static org.openrewrite.test.Outer.Measure.*;
+
+            class OuterTest {
+                List<Object> used() {
+                    return List.of(One, Two, Three, Four, Five);
+                }
+
+                void parameterized(Outer.Measure measure) {
+                }
+            }
+            """
+        );
+
+        var detector = Autodetect.detector();
+        cus.forEach(detector::sample);
+        var importLayout = detector.build().getStyle(ImportLayoutStyle.class);
+
+        assertThat(importLayout.getNameCountToUseStarImport()).isEqualTo(5);
+    }
+
+    @Test
     void detectMethodArgs() {
         var cus = jp().parse(
           """

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/style/AutodetectTest.java
@@ -671,7 +671,9 @@ class AutodetectTest implements RewriteTest {
 
             public class Outer {
                 public enum Measure {
-                    One, Two, Three, Four, Five, Six
+                    One, Two, Three, Four, Five, Six;
+
+                    public int label;
                 }
             }
             """,
@@ -687,7 +689,8 @@ class AutodetectTest implements RewriteTest {
                     return List.of(One, Two, Three, Four, Five);
                 }
 
-                void parameterized(Outer.Measure measure) {
+                int parameterized(Outer.Measure measure) {
+                    return measure.label;
                 }
             }
             """

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -1001,13 +1001,20 @@ public class Autodetect extends NamedStyles {
 
                 if ("*".equals(anImport.getQualid().getSimpleName())) {
                     if (anImport.isStatic()) {
-                        int count = 0;
+                        Set<String> staticMembers = new HashSet<>();
                         for (JavaType.Variable variable : cu.getTypesInUse().getVariables()) {
-                            JavaType.FullyQualified fq = TypeUtils.asFullyQualified(variable.getType());
-                            if (fq != null && anImport.getTypeName().equals(fq.getFullyQualifiedName())) {
-                                count++;
+                            JavaType.FullyQualified owner = TypeUtils.asFullyQualified(variable.getOwner());
+                            if (owner != null && anImport.getTypeName().equals(owner.getFullyQualifiedName())) {
+                                staticMembers.add(variable.getName());
                             }
                         }
+                        for (JavaType.Method method : cu.getTypesInUse().getUsedMethods()) {
+                            if (method.hasFlags(Flag.Static) &&
+                                anImport.getTypeName().equals(method.getDeclaringType().getFullyQualifiedName())) {
+                                staticMembers.add(method.getName());
+                            }
+                        }
+                        int count = staticMembers.size();
 
                         importLayoutStatistics.minimumFoldedStaticImports = Math.min(
                                 importLayoutStatistics.minimumFoldedStaticImports,

--- a/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/style/Autodetect.java
@@ -1001,24 +1001,25 @@ public class Autodetect extends NamedStyles {
 
                 if ("*".equals(anImport.getQualid().getSimpleName())) {
                     if (anImport.isStatic()) {
+                        String importedTypeName = anImport.getTypeName();
                         Set<String> staticMembers = new HashSet<>();
                         for (JavaType.Variable variable : cu.getTypesInUse().getVariables()) {
                             JavaType.FullyQualified owner = TypeUtils.asFullyQualified(variable.getOwner());
-                            if (owner != null && anImport.getTypeName().equals(owner.getFullyQualifiedName())) {
+                            if (variable.hasFlags(Flag.Static) &&
+                                owner != null && importedTypeName.equals(owner.getFullyQualifiedName())) {
                                 staticMembers.add(variable.getName());
                             }
                         }
                         for (JavaType.Method method : cu.getTypesInUse().getUsedMethods()) {
                             if (method.hasFlags(Flag.Static) &&
-                                anImport.getTypeName().equals(method.getDeclaringType().getFullyQualifiedName())) {
+                                importedTypeName.equals(method.getDeclaringType().getFullyQualifiedName())) {
                                 staticMembers.add(method.getName());
                             }
                         }
-                        int count = staticMembers.size();
 
                         importLayoutStatistics.minimumFoldedStaticImports = Math.min(
                                 importLayoutStatistics.minimumFoldedStaticImports,
-                                count
+                                staticMembers.size()
                         );
                     } else {
                         Set<String> fqns = new HashSet<>();


### PR DESCRIPTION
`Autodetect` sized a static wildcard import by counting variables whose *type* was the imported type, whereas `RemoveUnusedImports` counts members whose *owner* is that type. A file that also declares a variable of the imported enum type — such as a `Measure measure` test parameter — inflated the detected `nameCountToUseStarImport` past the number of names the wildcard actually folds, so `RemoveUnusedImports` unfolded a wildcard that `OrderImports` would fold straight back.

Because `minimumFoldedStaticImports` is a minimum across the files that currently hold a wildcard, unfolding one file raised the threshold for the next, so a repository like [moderneinc/rewrite-devcenter](https://github.com/moderneinc/rewrite-devcenter) produced a fresh no-op import change on every nightly run — verified by iterating `mod build` / `mod run` over a clone.

The count is now the set of distinct static members of the imported type that the file actually uses: variables matched by `getOwner()` and filtered on `Flag.Static` (instance fields would inflate the count the same way), plus statically imported methods, which were previously ignored entirely and pinned the threshold to 3 for any file using `import static ...Assertions.*`.

Not addressed here: `minimumFoldedImports` / `minimumFoldedStaticImports` stay at `Integer.MAX_VALUE` when a repository has no wildcard imports at all, so `Math.max(..., 5)` / `Math.max(..., 3)` act as an infinite ceiling rather than a floor; changing that would start introducing wildcard imports into repositories that have none.