### PR TITLE
Python: decide import shadowing by scope instead of `field_type`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -1,4 +1,5 @@
 import ast
+import contextlib
 import dataclasses
 import sys
 import token
@@ -94,6 +95,7 @@ class ParserVisitor(ast.NodeVisitor):
             tokenize(BytesIO(tokenizer_source.encode('utf-8')).readline)
         )
         self._token_idx = 1  # Skip ENCODING token
+        self._type_context_depth = 0
 
     def _byte_offset_to_char_offset(self, lineno: int, byte_offset: int) -> int:
         """Convert a byte offset to a character offset for a given line."""
@@ -1059,7 +1061,8 @@ class ParserVisitor(ast.NodeVisitor):
         expr_type, field_type = self._type_mapping.attribute_type_info(node, receiver_type)
 
         if isinstance(name_ident, j.Identifier):
-            name_ident = dataclasses.replace(name_ident, _type=expr_type, _field_type=field_type)
+            name_ident = dataclasses.replace(name_ident, _type=expr_type,
+                                             _field_type=self.__binding_field_type(field_type))
 
         return j.FieldAccess(
             random_id(),
@@ -2222,11 +2225,14 @@ class ParserVisitor(ast.NodeVisitor):
         if node.returns is None:
             return_type = None
         else:
+            arrow = self.__source_before('->')
+            with self.__type_context():
+                returns = self.__convert(node.returns)
             return_type = py.TypeHint(
                 random_id(),
-                self.__source_before('->'),
+                arrow,
                 Markers.EMPTY,
-                self.__convert(node.returns),
+                returns,
                 self._type_mapping.type(node.returns)
             )
         body = self.__convert_block(node.body)
@@ -2601,6 +2607,20 @@ class ParserVisitor(ast.NodeVisitor):
         # Parsing complete - all tokens should be consumed
         return cu
 
+    @contextlib.contextmanager
+    def __type_context(self):
+        self._type_context_depth += 1
+        try:
+            yield
+        finally:
+            self._type_context_depth -= 1
+
+    def __binding_field_type(self, field_type):
+        """``field_type`` describes the variable an identifier resolves to, and a
+        type position names a type rather than binding one. ty's descriptors cannot
+        draw this line: the annotation ``int`` and a variable holding an int share one."""
+        return None if self._type_context_depth else field_type
+
     def visit_Name(self, node):
         space, actual_name = self.__consume_identifier(node.id)
         expr_type, field_type = self._type_mapping.name_type_info(node)
@@ -2611,7 +2631,7 @@ class ParserVisitor(ast.NodeVisitor):
             _EMPTY_LIST,
             actual_name,
             expr_type,
-            field_type
+            self.__binding_field_type(field_type)
         )
 
     def visit_NamedExpr(self, node):
@@ -2849,7 +2869,8 @@ class ParserVisitor(ast.NodeVisitor):
 
     def __convert_type(self, node) -> Optional[TypeTree]:
         prefix = self.__whitespace()
-        converted_type = self.__convert_internal(node, self.__convert_type, self.__convert_type_mapper)
+        with self.__type_context():
+            converted_type = self.__convert_internal(node, self.__convert_type, self.__convert_type_mapper)
         if isinstance(converted_type, TypeTree):
             return converted_type.replace(prefix=prefix)  # TypeTree base class doesn't have replace
         else:

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
@@ -24,8 +24,9 @@ from rewrite.marketplace import Python
 from rewrite.recipe import option
 from rewrite.java import J
 from rewrite.java.support_types import JavaType
-from rewrite.java.tree import FieldAccess, Identifier, Import, MethodDeclaration, MethodInvocation
+from rewrite.java.tree import FieldAccess, Identifier, Import, MethodInvocation
 from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name
+from rewrite.python.scope_utils import LocalBindings
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
 from rewrite.python.add_import import AddImportOptions, maybe_add_import
@@ -142,6 +143,7 @@ class ChangeImport(Recipe):
             module_alias: Optional[str] = None
             rewrote_qualified_refs: bool = False
             new_module_type: Optional[JavaType.Class] = None
+            local_bindings: LocalBindings  # a fresh instance per compilation unit
 
             def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
                 self.has_old_import = False
@@ -150,6 +152,7 @@ class ChangeImport(Recipe):
                 self.module_alias = None
                 self.rewrote_qualified_refs = False
                 self.new_module_type = None
+                self.local_bindings = LocalBindings()
 
                 # Single pass: detect old imports and direct module imports
                 for stmt in cu.statements:
@@ -259,14 +262,13 @@ class ChangeImport(Recipe):
                 # Skip identifiers inside import statements
                 if self.cursor.first_enclosing(Import):
                     return ident
-                # Skip local variables that shadow the imported name.
-                # Only check field_type inside function scopes — at module level,
-                # bare references to the imported name always need renaming.
-                # When ty is unavailable, field_type is None for all identifiers
-                # and shadowed locals may be incorrectly renamed.
-                if self.cursor.first_enclosing(MethodDeclaration) is not None:
-                    if ident.field_type is not None:
-                        return ident
+                # An attribute name resolves against its target object;
+                # visit_field_access handles the qualified references.
+                parent = self.cursor.parent_tree_cursor().value
+                if isinstance(parent, FieldAccess) and parent.name.id == ident.id:
+                    return ident
+                if self.local_bindings.is_bound(self.cursor, old_ref_name):
+                    return ident
                 return ident.replace(_simple_name=new_ref_name)
 
             def visit_method_invocation(self, method: MethodInvocation, p: ExecutionContext) -> J:

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -19,8 +19,9 @@ from typing import Optional, Set
 
 from rewrite.java import J
 from rewrite.java.support_types import JContainer, JRightPadded
-from rewrite.java.tree import Identifier, Import, MethodDeclaration, Space
+from rewrite.java.tree import Identifier, Import, Space
 from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name, get_canonical_fqn
+from rewrite.python.scope_utils import LocalBindings
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
 
@@ -142,6 +143,7 @@ class RemoveImport(PythonVisitor):
     def _collect_used_identifiers(self, cu: CompilationUnit) -> Set[str]:
         """Collect all identifiers used in the code (excluding imports)."""
         used: Set[str] = set()
+        bindings = LocalBindings()
 
         class UsageCollector(PythonVisitor):
             def __init__(self):
@@ -165,12 +167,7 @@ class RemoveImport(PythonVisitor):
                     self.in_import = False
 
             def visit_identifier(self, ident: Identifier, p) -> J:
-                if not self.in_import:
-                    # Inside a function scope, identifiers with field_type are
-                    # local variables (shadowing the import), not actual uses.
-                    if self.cursor.first_enclosing(MethodDeclaration) is not None:
-                        if ident.field_type is not None:
-                            return ident
+                if not self.in_import and not bindings.is_bound(self.cursor, ident.simple_name):
                     used.add(ident.simple_name)
                 return ident
 

--- a/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
@@ -1,0 +1,218 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Which names a Python scope binds, for telling a local apart from an import reference."""
+
+from typing import Any, Dict, List, Optional, Set
+
+from rewrite import Cursor
+from rewrite.java import J
+from rewrite.java.tree import (Assignment, AssignmentOperation, ClassDeclaration, ForEachLoop,
+                               Identifier, Import, Lambda, MethodDeclaration, Parentheses,
+                               VariableDeclarations)
+from rewrite.python.import_utils import get_alias_name, get_qualid_name
+from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ComprehensionExpression,
+                                 ExpressionStatement, MultiImport, Star, TypeHintedExpression,
+                                 VariableScope)
+from rewrite.python.visitor import PythonVisitor
+
+# The module scope is excluded so that module-level references stay attributable
+# to the import that binds them.
+_SCOPES = (MethodDeclaration, Lambda, ClassDeclaration, ComprehensionExpression)
+
+
+class LocalBindings:
+    """Whether an identifier is a local of some enclosing scope rather than a
+    reference to a module-level import.
+
+    Syntactic, because ``field_type`` cannot decide it: it is unset for every
+    identifier when type attribution is unavailable. Caches per scope, so one
+    instance serves a whole compilation unit.
+    """
+
+    def __init__(self) -> None:
+        self._by_scope: Dict[Any, Set[str]] = {}
+
+    def is_bound(self, cursor: Cursor, name: str) -> bool:
+        return any(name in self._names(scope) for scope in _enclosing_scopes(cursor))
+
+    def _names(self, scope: J) -> Set[str]:
+        names = self._by_scope.get(scope.id)
+        if names is None:
+            names = _BindingScan(scope).run()
+            self._by_scope[scope.id] = names
+        return names
+
+
+def _enclosing_scopes(cursor: Optional[Cursor]) -> List[J]:
+    """The scopes a reference resolves through, innermost first.
+
+    A scope covers only the region Python evaluates inside it: a ``def``'s
+    decorators, annotations and parameter defaults belong to the scope enclosing
+    it. A class body is reachable only from directly within it, never from a
+    function nested in it.
+    """
+    path = _tree_path(cursor)
+    scopes: List[J] = []
+    for i, node in enumerate(path):
+        if not isinstance(node, _SCOPES):
+            continue
+        child = path[i - 1] if i else None
+        if not _governs(node, child, path[i - 2] if i > 1 else None, path):
+            continue
+        if isinstance(node, ClassDeclaration) and scopes:
+            continue
+        scopes.append(node)
+    return scopes
+
+
+def _tree_path(cursor: Optional[Cursor]) -> List[Any]:
+    """The tree nodes from the cursor outwards, skipping padding wrappers."""
+    path = []
+    while cursor is not None:
+        value = cursor.value
+        if isinstance(value, (J, ComprehensionExpression.Clause)):
+            path.append(value)
+        cursor = cursor.parent
+    return path
+
+
+def _governs(scope: J, child: Any, grandchild: Any, path: List[Any]) -> bool:
+    if isinstance(scope, MethodDeclaration):
+        return child is scope.body or (isinstance(child, VariableDeclarations) and _is_parameter_name(path))
+    if isinstance(scope, Lambda):
+        return child is scope.body or (child is scope.parameters and _is_parameter_name(path))
+    if isinstance(scope, ClassDeclaration):
+        return child is scope.body
+    # A comprehension's leading iterable is evaluated before its targets exist.
+    clauses = scope.clauses if isinstance(scope, ComprehensionExpression) else None
+    return not (clauses and child is clauses[0] and grandchild is clauses[0].iterated_list)
+
+
+def _is_parameter_name(path: List[Any]) -> bool:
+    return (len(path) > 1 and isinstance(path[1], VariableDeclarations.NamedVariable)
+            and path[1].name is path[0])
+
+
+def _bound_import_name(imp: Import, from_: Optional[Any]) -> str:
+    """The name an import binds: its alias, else the member for ``from X import
+    Y``, else the root package of a dotted ``import a.b.c``."""
+    alias = get_alias_name(imp)
+    if alias:
+        return alias
+    qualid = get_qualid_name(imp.qualid)
+    return qualid if from_ is not None else qualid.split('.')[0]
+
+
+class _BindingScan(PythonVisitor[Any]):
+    """The names ``scope`` binds directly: assignment targets, parameters, loop and
+    comprehension targets, ``as`` clauses, imports, and nested ``def``/``class`` names.
+    """
+
+    def __init__(self, scope: J) -> None:
+        super().__init__()
+        self._scope = scope
+        self._names: Set[str] = set()
+        self._declared_elsewhere: Set[str] = set()
+
+    def run(self) -> Set[str]:
+        self.visit(self._scope, None)
+        return self._names - self._declared_elsewhere
+
+    def _bind(self, target: Optional[J]) -> None:
+        """Bind the names a target expression introduces. Attribute and subscript
+        targets (``self.x``, ``d[k]``) assign through an object without binding."""
+        if isinstance(target, Identifier):
+            self._names.add(target.simple_name)
+        elif isinstance(target, ExpressionStatement):
+            self._bind(target.expression)
+        elif isinstance(target, TypeHintedExpression):
+            self._bind(target.expression)
+        elif isinstance(target, Parentheses):
+            self._bind(target.tree)
+        elif isinstance(target, Star):
+            self._bind(target.expression)
+        elif isinstance(target, CollectionLiteral):
+            for element in target.elements:
+                self._bind(element)
+
+    def _is_nested(self, scope: J, name: Optional[Identifier] = None) -> bool:
+        """True once past the scope being scanned, binding the nested scope's own
+        name (a ``def``/``class``) in the scope that encloses it."""
+        if scope is self._scope:
+            return False
+        self._bind(name)
+        return True
+
+    def visit_method_declaration(self, method: MethodDeclaration, p: Any) -> J:
+        if self._is_nested(method, method.name):
+            return method
+        return super().visit_method_declaration(method, p)
+
+    def visit_class_declaration(self, class_decl: ClassDeclaration, p: Any) -> J:
+        if self._is_nested(class_decl, class_decl.name):
+            return class_decl
+        return super().visit_class_declaration(class_decl, p)
+
+    def visit_lambda(self, lambda_: Lambda, p: Any) -> J:
+        if self._is_nested(lambda_):
+            return lambda_
+        return super().visit_lambda(lambda_, p)
+
+    def visit_comprehension_expression(self, comp: ComprehensionExpression, p: Any) -> J:
+        if self._is_nested(comp):
+            return comp
+        return super().visit_comprehension_expression(comp, p)
+
+    def visit_variable_scope(self, scope: VariableScope, p: Any) -> J:
+        for name in scope.names:
+            self._declared_elsewhere.add(name.simple_name)
+        return scope
+
+    def visit_import(self, import_: Import, p: Any) -> J:
+        if not isinstance(import_, MultiImport):
+            self._names.add(_bound_import_name(import_, None))
+        return import_
+
+    def visit_multi_import(self, multi: MultiImport, p: Any) -> J:
+        for imp in multi.names:
+            self._names.add(_bound_import_name(imp, multi.from_))
+        return multi
+
+    def visit_variable_declarations(self, var_decls: VariableDeclarations, p: Any) -> J:
+        for variable in var_decls.variables:
+            self._bind(variable.name)
+        return super().visit_variable_declarations(var_decls, p)
+
+    def visit_assignment(self, assignment: Assignment, p: Any) -> J:
+        self._bind(assignment.variable)
+        return super().visit_assignment(assignment, p)
+
+    def visit_assignment_operation(self, assign_op: AssignmentOperation, p: Any) -> J:
+        self._bind(assign_op.variable)
+        return super().visit_assignment_operation(assign_op, p)
+
+    def visit_chained_assignment(self, chained: ChainedAssignment, p: Any) -> J:
+        for variable in chained.variables:
+            self._bind(variable)
+        return super().visit_chained_assignment(chained, p)
+
+    def visit_for_each_control(self, control: ForEachLoop.Control, p: Any) -> J:
+        self._bind(control.variable)
+        return super().visit_for_each_control(control, p)
+
+    def visit_comprehension_clause(self, clause: ComprehensionExpression.Clause,
+                                   p: Any) -> ComprehensionExpression.Clause:
+        self._bind(clause.iterator_variable)
+        return super().visit_comprehension_clause(clause, p)

--- a/rewrite-python/rewrite/tests/python/all/tree/method_declaration_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/method_declaration_test.py
@@ -283,3 +283,37 @@ def test_param_identifier_field_type():
         after_recipe=check_types,
     ))
     assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+def test_type_name_identifier_has_no_field_type():
+    """Mirrors J.Identifier.fieldType, which Java populates only from a VarSymbol."""
+    errors = []
+
+    def check_types(source_file):
+        assert isinstance(source_file, CompilationUnit)
+
+        class TypeChecker(PythonVisitor):
+            def visit_identifier(self, ident, p):
+                if ident.simple_name in ('Deque', 'int') and ident.field_type is not None:
+                    errors.append(
+                        f"type name '{ident.simple_name}' has field_type "
+                        f"{ident.field_type}, expected None")
+                elif ident.simple_name in ('q', 'local') and ident.field_type is None:
+                    errors.append(f"variable '{ident.simple_name}' has field_type=None")
+                return ident
+
+        TypeChecker().visit(source_file, None)
+
+    # language=python
+    RecipeSpec(type_attribution=True).rewrite_run(python(
+        """\
+        from typing import Deque
+
+
+        def f(q: Deque[int]) -> Deque[int]:
+            local: Deque[int] = q
+            return local
+        """,
+        after_recipe=check_types,
+    ))
+    assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -518,3 +518,158 @@ class TestCanonicalRemoveImport:
                 """,
             )
         )
+
+
+class TestRemoveImportUsageScoping:
+    """``only_if_unused`` counts every reference the enclosing scopes do not
+    rebind, including references that appear only in annotations."""
+
+    @staticmethod
+    def _remove(module, name):
+        class RemoveVisitor(PythonVisitor[ExecutionContext]):
+            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+                maybe_remove_import(self, RemoveImportOptions(
+                    module=module, name=name, only_if_unused=True))
+                return super().visit_compilation_unit(cu, p)
+
+        return from_visitor(RemoveVisitor())
+
+    def test_keep_import_referenced_in_function_annotations(self):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=self._remove('typing', 'Deque'),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from typing import Deque
+
+
+                    def f(q: Deque[int]) -> Deque[int]:
+                        local: Deque[int] = q
+                        return local
+                    """,
+                )
+            )
+
+    def test_keep_import_referenced_in_function_body(self):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=self._remove('os.path', 'join'),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from os.path import join
+
+
+                    def f():
+                        return join("a", "b")
+                    """,
+                )
+            )
+
+    def test_keep_import_referenced_outside_the_shadowing_function(self):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=self._remove('os.path', 'join'),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from os.path import join
+
+
+                    def shadows():
+                        join = "not a function"
+                        return join
+
+
+                    def uses():
+                        return join("a", "b")
+                    """,
+                )
+            )
+
+    def test_remove_import_shadowed_in_every_function(self):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=self._remove('os.path', 'join'),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from os.path import join
+
+
+                    def f():
+                        join = "not a function"
+                        return join
+                    """,
+                    """\
+                    def f():
+                        join = "not a function"
+                        return join
+                    """,
+                )
+            )
+
+
+class TestRemoveImportScopeRules:
+    """Usage counting follows Python's scoping, so a reference the interpreter
+    resolves to the import keeps that import alive."""
+
+    @staticmethod
+    def _keeps(source):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=TestRemoveImportUsageScoping._remove('time', 'clock'),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(python(source))
+
+    def test_class_attribute_does_not_hide_method_usage(self):
+        self._keeps(
+            """\
+            from time import clock
+
+
+            class C:
+                clock = 1
+
+                def m(self):
+                    return clock()
+            """
+        )
+
+    def test_attribute_assignment_does_not_hide_usage(self):
+        self._keeps(
+            """\
+            from time import clock
+
+
+            class C:
+                def m(self):
+                    self.clock = 1
+                    return clock()
+            """
+        )
+
+    def test_decorator_usage_counts(self):
+        self._keeps(
+            """\
+            from time import clock
+
+
+            @clock
+            def f():
+                clock = 1
+                return clock
+            """
+        )
+
+    def test_parameter_default_usage_counts(self):
+        self._keeps(
+            """\
+            from time import clock
+
+
+            def f(x=clock):
+                clock = 1
+                return clock, x
+            """
+        )

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -628,3 +628,364 @@ class TestChangeImportLeavesUnrelatedImports:
                 """,
             )
         )
+
+
+class TestChangeImportFunctionScopedReferences:
+    """References inside a function body are renamed unless the enclosing scope
+    binds the name itself."""
+
+    def test_rename_annotation_references_in_function(self):
+        """Annotations are references to the imported name, not bindings of it,
+        so they are renamed along with the import."""
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=ChangeImport(
+                old_module='typing',
+                old_name='Deque',
+                new_module='collections',
+                new_name='deque',
+            ), type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from typing import Deque
+
+
+                    def f(q: Deque[int]) -> Deque[int]:
+                        local: Deque[int] = q
+                        return local
+                    """,
+                    """\
+                    from collections import deque
+
+
+                    def f(q: deque[int]) -> deque[int]:
+                        local: deque[int] = q
+                        return local
+                    """,
+                )
+            )
+
+    def test_rename_plain_references_in_function(self):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=ChangeImport(
+                old_module='time',
+                old_name='clock',
+                new_module='time',
+                new_name='perf_counter',
+            ), type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from time import clock
+
+
+                    def f():
+                        return clock()
+                    """,
+                    """\
+                    from time import perf_counter
+
+
+                    def f():
+                        return perf_counter()
+                    """,
+                )
+            )
+
+    def test_no_rename_of_names_bound_in_the_same_function(self):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=ChangeImport(
+                old_module='time',
+                old_name='clock',
+                new_module='time',
+                new_name='perf_counter',
+            ), type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from time import clock
+
+
+                    def assigned():
+                        clock = 1
+                        return clock
+
+
+                    def parameter(clock):
+                        return clock
+
+
+                    def loop_target():
+                        for clock in range(3):
+                            print(clock)
+
+
+                    def as_clause():
+                        with open("f") as clock:
+                            return clock
+
+
+                    def nested_def():
+                        def clock():
+                            pass
+                        return clock
+
+
+                    def uses_import():
+                        return clock()
+                    """,
+                    """\
+                    from time import perf_counter
+
+
+                    def assigned():
+                        clock = 1
+                        return clock
+
+
+                    def parameter(clock):
+                        return clock
+
+
+                    def loop_target():
+                        for clock in range(3):
+                            print(clock)
+
+
+                    def as_clause():
+                        with open("f") as clock:
+                            return clock
+
+
+                    def nested_def():
+                        def clock():
+                            pass
+                        return clock
+
+
+                    def uses_import():
+                        return perf_counter()
+                    """,
+                )
+            )
+
+    def test_nested_function_shadowing_does_not_leak_outward(self):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=ChangeImport(
+                old_module='time',
+                old_name='clock',
+                new_module='time',
+                new_name='perf_counter',
+            ), type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from time import clock
+
+
+                    def outer():
+                        def inner():
+                            clock = 1
+                            return clock
+                        return clock() + inner()
+                    """,
+                    """\
+                    from time import perf_counter
+
+
+                    def outer():
+                        def inner():
+                            clock = 1
+                            return clock
+                        return perf_counter() + inner()
+                    """,
+                )
+            )
+
+
+class TestChangeImportPythonScopeRules:
+    """Renaming follows Python's own scoping: a name is a local only where the
+    interpreter would resolve it to one."""
+
+    @staticmethod
+    def _run(before, after=None):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=ChangeImport(
+                old_module='time',
+                old_name='clock',
+                new_module='time',
+                new_name='perf_counter',
+            ), type_attribution=type_attribution)
+            spec.rewrite_run(python(before, after) if after else python(before))
+
+    def test_class_attribute_does_not_shadow_inside_methods(self):
+        """A class body is not part of the scope chain of its methods."""
+        self._run(
+            """\
+            from time import clock
+
+
+            class C:
+                clock = 1
+
+                def m(self):
+                    return clock()
+            """,
+            """\
+            from time import perf_counter
+
+
+            class C:
+                clock = 1
+
+                def m(self):
+                    return perf_counter()
+            """,
+        )
+
+    def test_class_attribute_shadows_within_the_class_body(self):
+        self._run(
+            """\
+            from time import clock
+
+
+            class C:
+                clock = 1
+                alias = clock
+            """,
+            """\
+            from time import perf_counter
+
+
+            class C:
+                clock = 1
+                alias = clock
+            """,
+        )
+
+    def test_attribute_and_subscript_targets_do_not_bind(self):
+        """``self.clock = 1`` and ``d[clock] = 1`` assign through an object."""
+        self._run(
+            """\
+            from time import clock
+
+
+            class C:
+                def m(self, d):
+                    self.clock = 1
+                    d[clock] = 2
+                    return clock()
+            """,
+            """\
+            from time import perf_counter
+
+
+            class C:
+                def m(self, d):
+                    self.clock = 1
+                    d[perf_counter] = 2
+                    return perf_counter()
+            """,
+        )
+
+    def test_tuple_unpacking_binds(self):
+        self._run(
+            """\
+            from time import clock
+
+
+            def f(pair):
+                clock, other = pair
+                return clock
+            """,
+            """\
+            from time import perf_counter
+
+
+            def f(pair):
+                clock, other = pair
+                return clock
+            """,
+        )
+
+    def test_function_local_import_shadows(self):
+        self._run(
+            """\
+            from time import clock
+
+
+            def f():
+                from mymod import clock
+                return clock()
+            """,
+            """\
+            from time import perf_counter
+
+
+            def f():
+                from mymod import clock
+                return clock()
+            """,
+        )
+
+    def test_decorator_resolves_in_the_enclosing_scope(self):
+        self._run(
+            """\
+            from time import clock
+
+
+            @clock
+            def f():
+                clock = 1
+                return clock
+            """,
+            """\
+            from time import perf_counter
+
+
+            @perf_counter
+            def f():
+                clock = 1
+                return clock
+            """,
+        )
+
+    def test_parameter_default_resolves_in_the_enclosing_scope(self):
+        self._run(
+            """\
+            from time import clock
+
+
+            def f(x=clock):
+                clock = 1
+                return clock, x
+            """,
+            """\
+            from time import perf_counter
+
+
+            def f(x=perf_counter):
+                clock = 1
+                return clock, x
+            """,
+        )
+
+    def test_global_declaration_is_not_a_local_binding(self):
+        self._run(
+            """\
+            from time import clock
+
+
+            def f():
+                global clock
+                clock = 1
+            """,
+            """\
+            from time import perf_counter
+
+
+            def f():
+                global perf_counter
+                perf_counter = 1
+            """,
+        )


### PR DESCRIPTION
## Motivation

The Python SDK decided whether an identifier inside a function was a shadowed local by checking `ident.field_type is not None`. Type attribution sets `field_type` on *every* in-function reference, including plain module-level imports used in annotations, so that check misread every such reference. Two sites relied on it, and together they emitted non-importable Python: `ChangeImport` rewrote the import statement while leaving its usages untouched, and `RemoveImport`'s `only_if_unused` check could not see in-function references, so `maybe_remove_import` deleted imports that were still referenced. `UpgradeToPython39`'s renaming `ChangeImport` moves (`Deque`→`deque`, `DefaultDict`→`defaultdict`, `ContextManager`→`AbstractContextManager`, and friends) all produced broken files.

Root-causing this turned up two independent defects.

**The type mapper violated the `fieldType` contract.** In rewrite-java, `J.Identifier.fieldType` comes from `typeMapping.variableType(ident.sym)` (`ReloadableJava21ParserVisitor.java:819`), which returns non-null only for a `Symbol.VarSymbol` — fields, locals, parameters. A type-name identifier gets `null`. The Python mapper instead inferred "is a variable" from ty's *type descriptor kind* (`_is_variable_descriptor`), which can never work: a descriptor describes the type, not the binding, so the annotation `int` and a variable holding an int share one descriptor. Widening the excluded-kind list backfires too — `x: type[Foo] = Foo` gives `x` kind `subclassOf`, yet `x` really is a variable. The discriminator has to be syntactic, matching Java, where the symbol of a type name is never a `VarSymbol`.

**`field_type` was the wrong oracle regardless.** Shadowing is a scoping question. `field_type` is `None` for *every* identifier when the type checker is unavailable, silently inverting the rule, and a global merely read inside a function carries the same `JavaType.Variable` as a local that shadows it.

## Examples

Given `ChangeImport(old_module="typing", old_name="Deque", new_module="collections", new_name="deque")`:

```python
from typing import Deque


def f(q: Deque[int]) -> Deque[int]:
    local: Deque[int] = q
    return local
```

Before, the import was rewritten and every usage left behind, producing `NameError: name 'Deque' is not defined`:

```python
from collections import deque


def f(q: Deque[int]) -> Deque[int]:
    local: Deque[int] = q
    return local
```

After, the file imports and executes:

```python
from collections import deque


def f(q: deque[int]) -> deque[int]:
    local: deque[int] = q
    return local
```

Genuinely shadowed names are still left alone, and now without depending on type attribution being present:

```python
from time import clock


def shadows():
    clock = 1
    return clock


def uses_import():
    return clock()
```

renames only the second function's reference.

## Summary

- Added `python/scope_utils.py` with `LocalBindings.is_bound(cursor, name)`, a per-scope-cached syntactic scan answering whether an enclosing scope binds a name. It follows Python's actual scoping rules:
  - A class body is not in the scope chain of its methods, so a class attribute does not shadow an import inside `def m`; a class scope counts only as the innermost governing scope.
  - Attribute and subscript targets bind nothing — `self.x = 1` and `d[k] = 1` assign through an object. Binding targets are bare identifiers, recursing through tuple/list unpacking, `*rest`, parentheses, and annotated targets.
  - A `def`'s decorators, parameter defaults, and annotations are evaluated in the *enclosing* scope; only the body and the parameter names belong to the function.
  - Function-local imports bind (alias, else the `from X import Y` member, else the root package of `import a.b.c`).
  - `global`/`nonlocal` names are not local bindings.
  - A comprehension's leading iterable is evaluated before its targets exist.
  - The module scope is deliberately excluded, so module-level references stay attributable to the import that binds them.
- `recipes/change_import.py` and `remove_import.py` now consult it instead of `field_type`.
- `ChangeImport.visit_identifier` no longer renames a `FieldAccess`'s name (`obj.clock`), which resolves against the target object; `visit_field_access` already handles the qualified references that do concern the recipe.
- `_parser_visitor.py` tracks type positions through a `__type_context()` guard around `__convert_type` and the return-annotation conversion, and leaves `field_type` unset inside them, restoring the `fieldType` contract.

### Known limitation

The type-position guard covers all of `__convert_type`, so a *value* expression nested in a type position — `dep` in `x: Annotated[int, dep]`, or `var` in `class C(dict, metaclass=var)` — also loses its `field_type`. Closing this needs reliable `Annotated` detection across aliased, dotted, and re-exported spellings, which is fragile enough that getting it wrong would be worse than the narrowing. The affected identifiers are variables referenced inside annotations, which are rare; function references such as FastAPI's `Depends`/`get_db` were already `None` via the existing function-kind exclusion.

Separately, ty-types 0.0.49 returns a bare `{"kind": "specialForm", "name": "typing.Deque"}` for the deprecated `typing` aliases, with no `classId`, members, or supertypes, so they can only be mapped to a `ShallowClass`. Real classes in annotation position (`list`, `deque`, `collections.abc.Sequence`) come back as full `classLiteral`s. ty does resolve the alias internally — the parameter `a: Deque[int]` types as `Parameterized` over `collections.deque` — it just is not exposed on the identifier's own descriptor. Worth raising upstream; it does not affect this change, since the written `typing.Deque` name is what `ChangeImport` matches on.

## Test plan

- [x] `test_type_name_identifier_has_no_field_type` asserts type-name identifiers (`Deque`, `int`) in parameter, return, and annotated-assignment positions carry no `field_type`, while the variables `q`/`local` still do.
- [x] `TestChangeImportFunctionScopedReferences` covers function-scoped references renamed in annotations and in plain code, names bound by assignment/parameter/loop target/`as` clause/nested `def` left alone, and a nested `def`'s binding not leaking outward.
- [x] `TestChangeImportPythonScopeRules` covers each scoping rule: class attribute vs. method scope, class attribute within the class body, attribute and subscript targets, tuple unpacking, function-local imports, decorators, parameter defaults, and `global`.
- [x] `TestRemoveImportUsageScoping` and `TestRemoveImportScopeRules` assert an import is never removed while references remain — including references appearing only in annotations, and references outside a function that shadows the name — and that it is still removed when every scope shadows it.
- [x] Every new recipe test runs under both `type_attribution=False` and `type_attribution=True`, since the previous heuristic behaved differently (and wrongly) in each.
- [x] The recipe output for the reported case was executed, not just string-compared, to confirm it imports and runs.
- [x] Full `rewrite-python` suite green, including the RPC tests: 2045 passed, 7 skipped.
