### PR TITLE
Size static wildcard imports by their static members in Kotlin `Autodetect`

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/style/Autodetect.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/style/Autodetect.java
@@ -999,17 +999,25 @@ public class Autodetect extends NamedStyles {
 
                 if ("*".equals(anImport.getQualid().getSimpleName())) {
                     if (anImport.isStatic()) {
-                        int count = 0;
+                        String importedTypeName = anImport.getTypeName();
+                        Set<String> staticMembers = new HashSet<>();
                         for (JavaType.Variable variable : cu.getTypesInUse().getVariables()) {
-                            JavaType.FullyQualified fq = TypeUtils.asFullyQualified(variable.getType());
-                            if (fq != null && anImport.getTypeName().equals(fq.getFullyQualifiedName())) {
-                                count++;
+                            JavaType.FullyQualified owner = TypeUtils.asFullyQualified(variable.getOwner());
+                            if (variable.hasFlags(Flag.Static) &&
+                                owner != null && importedTypeName.equals(owner.getFullyQualifiedName())) {
+                                staticMembers.add(variable.getName());
+                            }
+                        }
+                        for (JavaType.Method method : cu.getTypesInUse().getUsedMethods()) {
+                            if (method.hasFlags(Flag.Static) &&
+                                importedTypeName.equals(method.getDeclaringType().getFullyQualifiedName())) {
+                                staticMembers.add(method.getName());
                             }
                         }
 
                         importLayoutStatistics.minimumFoldedStaticImports = Math.min(
                                 importLayoutStatistics.minimumFoldedStaticImports,
-                                count
+                                staticMembers.size()
                         );
                     } else {
                         Set<String> fqns = new HashSet<>();

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/style/AutodetectTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/style/AutodetectTest.java
@@ -674,6 +674,70 @@ class AutodetectTest implements RewriteTest {
         assertThat(importLayout.getJavaStaticsAndEnumsToUseStarImport()).isEqualTo(3);
     }
 
+    @Disabled("Detector.build() uses FindImportLayout.getImportLayoutStyle(), which never reaches the star import " +
+              "counting in ImportLayoutStatistics; enable once the two are connected, as for detectStarImport()")
+    @Test
+    void staticStarImportCountsFoldedMembersNotVariablesOfThatType() {
+        var cus = kp().parse(
+          """
+            package org.openrewrite.test
+
+            class Outer {
+                enum class Measure(val label: Int) {
+                    One(1), Two(2), Three(3), Four(4), Five(5), Six(6)
+                }
+            }
+            """,
+          """
+            package org.openrewrite.test
+
+            import org.openrewrite.test.Outer.Measure.*
+
+            class OuterTest {
+                fun used(): List<Any> {
+                    return listOf(One, Two, Three, Four, Five)
+                }
+
+                fun parameterized(measure: Outer.Measure): Int {
+                    return measure.label
+                }
+            }
+            """
+        );
+
+        var detector = Autodetect.detector();
+        cus.forEach(detector::sample);
+        var importLayout = NamedStyles.merge(ImportLayoutStyle.class, singletonList(detector.build()));
+
+        assertThat(importLayout.getJavaStaticsAndEnumsToUseStarImport()).isEqualTo(5);
+    }
+
+    @Disabled("Detector.build() uses FindImportLayout.getImportLayoutStyle(), which never reaches the star import " +
+              "counting in ImportLayoutStatistics; enable once the two are connected, as for detectStarImport()")
+    @Test
+    void staticStarImportCountsStaticallyImportedMethods() {
+        var cus = kp().parse(
+          """
+            package org.openrewrite.test
+
+            import java.util.Objects.*
+
+            class StaticMethods {
+                fun check(a: Any?, b: Any?): Boolean {
+                    requireNonNull(a)
+                    return equals(a, b) && hash(a, b) != 0 && isNull(b)
+                }
+            }
+            """
+        );
+
+        var detector = Autodetect.detector();
+        cus.forEach(detector::sample);
+        var importLayout = NamedStyles.merge(ImportLayoutStyle.class, singletonList(detector.build()));
+
+        assertThat(importLayout.getJavaStaticsAndEnumsToUseStarImport()).isEqualTo(4);
+    }
+
     @Test
     void detectMethodArgs() {
         var cus = kp().parse(


### PR DESCRIPTION
- Ports openrewrite/rewrite#8487 to the `rewrite-kotlin` copy of `Autodetect`, which carried the same counting bug verbatim: a static wildcard import was sized by counting variables whose *type* was the imported type, rather than the members the wildcard actually folds. A file that also declares a variable of the imported enum type inflates the count, and statically imported methods were not counted at all.

The count is now the set of distinct static members of the imported type that the file actually uses: variables matched by `getOwner()` and filtered on `Flag.Static`, plus statically imported methods, deduped by name. Kept textually parallel to the Java version, since the two are maintained as copies.

### What this changes for users: nothing, today

`rewrite-kotlin` has two `getImportLayoutStyle()` implementations. `Detector.build()` calls `FindImportLayout.getImportLayoutStyle()` — the Kotlin-specific, import-weight-based builder, which never sets `topLevelSymbolsToUseStarImport` or `javaStaticsAndEnumsToUseStarImport`. The Java-derived `ImportLayoutStatistics.getImportLayoutStyle()`, which is where `minimumFoldedStaticImports` is consumed, is reached only through `aggregate()`, and `aggregate()` has no callers in the module. (On the Java side, `Detector.build()` calls `findImportLayout.aggregate().getImportLayoutStyle()`.)

So the counted value is computed and discarded: `Autodetect` on Kotlin sources always yields the IntelliJ defaults of 5 / 3. The pre-existing `@Disabled detectStarImport()` test in `AutodetectTest` is the non-static counterpart of the same gap.

This is a parity fix so the copies do not drift, and so the counting is right whenever the two halves are connected. Connecting them is a behaviour change (`ImportLayoutStyle.addImport`, which `AddImport` uses, does consume `javaStaticsAndEnumsToUseStarImport <= sameCount`) and is deliberately not done here.

### Verification

The two new tests are `@Disabled` for the reason above. With `Detector.build()` temporarily pointed at `findImportLayout.aggregate().getImportLayoutStyle()`, they pass with this change and fail without it:

| fixture | before | after |
| --- | --- | --- |
| enum wildcard folding 5 constants, plus a `Measure` parameter and an instance-property read | 7 | 5 |
| `import java.util.Objects.*` with 4 static methods used | 3 (the `Math.max(…, 3)` floor) | 4 |

Dropping only the `Flag.Static` filter gives 6 on the first fixture, so both halves of the guard matter.

Confirmed against parsed fixtures rather than by reading: Kotlin member/enum imports do set `J.Import#isStatic`; enum entries carry `Flag.Static` with `getOwner()` = the enum; statically imported Java methods carry `Flag.Static` with the right declaring type.

- The fold/unfold ping-pong that motivated #8487 cannot occur on the Kotlin side: `org.openrewrite.java.RemoveUnusedImports` does its work in `visitCompilationUnit(J.CompilationUnit)` and there is no `K.CompilationUnit` equivalent, and `ImportLayoutStyle.orderImports` still hard-disables folding via `disableFoldingImports = true` (openrewrite/rewrite-kotlin#370) with no unfolding branch at all.

### Downstream

Zero impact, for two independent reasons: the code path is unreachable, and no static wildcard import exists in the Kotlin repositories sampled (`recipes-kotlin`, `rewrite-migrate-kotlin`, `rewrite-migrate-kotlin-v2`, `kotlin-recipe-starter`, and `rewrite-kotlin`'s own sources) — every `import …*` found there is a package import, which takes the non-static branch.

- Not addressed here, as in #8487: `minimumFoldedImports` / `minimumFoldedStaticImports` stay at `Integer.MAX_VALUE` when a repository has no wildcard imports, so the `Math.max(…, 5)` / `Math.max(…, 3)` fallbacks act as an infinite ceiling rather than a floor.
