### PR TITLE
Python: Upgrade to `ty-types` 0.0.71 and map tuple element types

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.49",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.71",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -101,6 +101,14 @@ _PRIMITIVE_TO_PYTHON: Dict[JavaType.Primitive, str] = {
 # ty-types descriptor kinds that map to JavaType.Method
 _FUNCTION_KINDS = frozenset(('function', 'boundMethod', 'callable', 'wrapperDescriptor'))
 
+# knownInstance descriptors carry no moduleName, and most of the singletons ty
+# reports live in `typing`. These `knownInstanceKind`s are the ones that don't.
+_KNOWN_INSTANCE_FQNS: Dict[str, str] = {
+    'Range': 'range',
+    'FunctoolsPartial': 'functools.partial',
+    'FunctoolsPartialCall': 'functools.partial',
+}
+
 
 def _module_all_names(tree: ast.Module) -> Optional[Set[str]]:
     """The names ``__all__`` declares via top-level literal list/tuple assignments
@@ -438,6 +446,8 @@ class PythonTypeMapping:
             if class_name in _PYTHON_PRIMITIVES:
                 return _PYTHON_PRIMITIVES[class_name]
 
+            module_name = descriptor.get('moduleName')
+
             # Resolve base class: prefer classId (enriched with supertypes/methods)
             class_id = descriptor.get('classId')
             if class_id is None:
@@ -449,25 +459,33 @@ class PythonTypeMapping:
                 if not isinstance(base_class, JavaType.Class):
                     base_class = self._create_class_type(class_name)
             else:
-                module_name = descriptor.get('moduleName')
                 if module_name and module_name != 'builtins':
                     base_class = self._create_class_type(f"{module_name}.{class_name}")
                 else:
                     base_class = self._create_class_type(class_name)
 
-            # If typeArgs present, wrap in Parameterized
-            type_args = descriptor.get('typeArgs')
-            if type_args:
-                resolved_args = []
-                for arg_id in type_args:
-                    arg_type = self._resolve_type(arg_id)
-                    if arg_type is not None:
-                        resolved_args.append(arg_type)
-                if resolved_args:
-                    param = JavaType.Parameterized()
-                    param._type = base_class
-                    param._type_parameters = resolved_args
-                    return param
+            # `tuple` has a single generic parameter, so typeArgs conflates
+            # `tuple[int, str]` with `tuple[int | str, ...]`. Subclasses inherit
+            # elements from `tuple` without being generic, so only `tuple` takes them.
+            tuple_elements = (descriptor.get('tupleElements')
+                              if class_name == 'tuple' and module_name == 'builtins'
+                              else None)
+            if isinstance(tuple_elements, list):
+                arg_ids = [element.get('typeId') for element in tuple_elements
+                           if isinstance(element, dict)]
+            else:
+                arg_ids = descriptor.get('typeArgs') or []
+
+            resolved_args = []
+            for arg_id in arg_ids:
+                arg_type = self._resolve_type(arg_id) if arg_id is not None else None
+                if arg_type is not None:
+                    resolved_args.append(arg_type)
+            if resolved_args:
+                param = JavaType.Parameterized()
+                param._type = base_class
+                param._type_parameters = resolved_args
+                return param
 
             return base_class
 
@@ -713,10 +731,13 @@ class PythonTypeMapping:
             return _UNKNOWN
 
         elif kind == 'knownInstance':
-            class_name = descriptor.get('className', '')
-            if class_name:
-                return self._create_class_type(f"typing.{class_name}")
-            return _UNKNOWN
+            fqn = _KNOWN_INSTANCE_FQNS.get(descriptor.get('knownInstanceKind', ''))
+            if fqn is None:
+                class_name = descriptor.get('className', '')
+                if not class_name:
+                    return _UNKNOWN
+                fqn = f"typing.{class_name}"
+            return self._create_class_type(fqn)
 
         elif kind == 'typeAlias':
             # Resolve through to the underlying value type when available

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -1003,6 +1003,135 @@ class TestVariableTypes:
             _cleanup_mapping(mapping, tmpdir, client)
 
 
+class TestTupleElements:
+    """Tests for per-position tuple element types."""
+
+    @staticmethod
+    def _tuple_descriptor(elements, class_name='tuple', module_name='builtins',
+                          type_args=None):
+        return {
+            'kind': 'instance',
+            'className': class_name,
+            'moduleName': module_name,
+            'typeArgs': type_args if type_args is not None else [],
+            'tupleElements': elements,
+        }
+
+    def test_fixed_elements_become_type_parameters(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[1] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[2] = {'kind': 'instance', 'className': 'str'}
+        # typeArgs holds the collapsed union; the elements must win over it.
+        mapping._type_registry[400] = self._tuple_descriptor(
+            [{'typeId': 1, 'kind': 'fixed'}, {'typeId': 2, 'kind': 'fixed'}],
+            type_args=[3])
+        mapping._type_registry[3] = {'kind': 'union', 'members': [1, 2]}
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Parameterized)
+        assert result.fully_qualified_name == 'tuple'
+        assert result._type_parameters == [JavaType.Primitive.Int,
+                                           JavaType.Primitive.String]
+
+    def test_homogeneous_element_becomes_single_type_parameter(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[1] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[400] = self._tuple_descriptor(
+            [{'typeId': 1, 'kind': 'homogeneous'}], type_args=[1])
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Parameterized)
+        assert result._type_parameters == [JavaType.Primitive.Int]
+
+    def test_type_var_tuple_element_resolves(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[1] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[2] = {'kind': 'typeVar', 'name': 'Ts',
+                                     'typevarKind': 'TypeVarTuple'}
+        mapping._type_registry[400] = self._tuple_descriptor(
+            [{'typeId': 1, 'kind': 'fixed'}, {'typeId': 2, 'kind': 'typeVarTuple'}])
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Parameterized)
+        assert result._type_parameters[0] == JavaType.Primitive.Int
+        assert isinstance(result._type_parameters[1], JavaType.GenericTypeVariable)
+
+    def test_empty_tuple_is_not_parameterized(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[400] = self._tuple_descriptor([])
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'tuple'
+
+    def test_tuple_subclass_is_not_parameterized_by_its_elements(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[1] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[2] = {'kind': 'instance', 'className': 'str'}
+        mapping._type_registry[400] = self._tuple_descriptor(
+            [{'typeId': 1, 'kind': 'fixed'}, {'typeId': 2, 'kind': 'fixed'}],
+            class_name='MyTup', module_name='mymod')
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'mymod.MyTup'
+
+    def test_unrecognised_tuple_elements_shape_falls_back_to_type_args(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[1] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[400] = self._tuple_descriptor(
+            {'elements': []}, type_args=[1])
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Parameterized)
+        assert result._type_parameters == [JavaType.Primitive.Int]
+
+    def test_falls_back_to_type_args_without_tuple_elements(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[1] = {'kind': 'instance', 'className': 'int'}
+        mapping._type_registry[400] = {
+            'kind': 'instance', 'className': 'tuple', 'moduleName': 'builtins',
+            'typeArgs': [1],
+        }
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Parameterized)
+        assert result._type_parameters == [JavaType.Primitive.Int]
+
+
+@requires_ty_types_cli
+class TestTupleElementsWithTyTypes:
+    """End-to-end tuple element attribution using live ty-types."""
+
+    def test_fixed_length_tuple_keeps_element_order(self):
+        source = '''
+            def pair() -> tuple[int, str]: ...
+            pair()
+        '''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            result = mapping.type(tree.body[1].value)
+            assert isinstance(result, JavaType.Parameterized)
+            assert result.fully_qualified_name == 'tuple'
+            assert result._type_parameters == [JavaType.Primitive.Int,
+                                               JavaType.Primitive.String]
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_homogeneous_tuple_has_one_element(self):
+        source = '''
+            def homo() -> tuple[int, ...]: ...
+            homo()
+        '''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            result = mapping.type(tree.body[1].value)
+            assert isinstance(result, JavaType.Parameterized)
+            assert result._type_parameters == [JavaType.Primitive.Int]
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
 @requires_ty_types_cli
 class TestParameterizedTypes:
     """Tests for Parameterized type creation (e.g., list[str])."""
@@ -1881,6 +2010,33 @@ class TestKnownInstanceDescriptor:
         result = mapping._resolve_type(400)
         assert isinstance(result, JavaType.Unknown)
 
+    def test_known_instance_range_is_a_builtin(self):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[400] = {
+            'kind': 'knownInstance',
+            'className': 'range',
+            'knownInstanceKind': 'Range',
+            'isNonEmpty': True,
+        }
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'range'
+
+    @pytest.mark.parametrize('known_instance_kind',
+                             ['FunctoolsPartial', 'FunctoolsPartialCall'])
+    def test_known_instance_functools_partial(self, known_instance_kind):
+        mapping = PythonTypeMapping("", file_path=None)
+        mapping._type_registry[400] = {
+            'kind': 'knownInstance',
+            'className': 'partial',
+            'knownInstanceKind': known_instance_kind,
+        }
+
+        result = mapping._resolve_type(400)
+        assert isinstance(result, JavaType.Class)
+        assert result._fully_qualified_name == 'functools.partial'
+
 
 class TestTypeAliasDescriptor:
     """Tests for the enriched typeAlias kind."""
@@ -2051,6 +2207,37 @@ class TestNewDescriptorsWithTyTypes:
             assert result._name == 'add'
             assert result._declaring_type is not None
             assert result._declaring_type._fully_qualified_name.endswith('Calculator')
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_range_call_resolves_to_builtin_range(self):
+        source = '''
+            r = range(3)
+            r
+        '''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            result = mapping.type(tree.body[1].value)
+            assert isinstance(result, JavaType.FullyQualified)
+            assert result._fully_qualified_name == 'range'
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+    def test_functools_partial_resolves_to_partial(self):
+        source = '''
+            import functools
+
+            def f(a: int, b: str) -> bool:
+                return True
+
+            p = functools.partial(f, 1)
+            p
+        '''
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            result = mapping.type(tree.body[3].value)
+            assert isinstance(result, JavaType.FullyQualified)
+            assert result._fully_qualified_name == 'functools.partial'
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
 


### PR DESCRIPTION
## Motivation

ty-types 0.0.71 changes how `range(...)` is reported: it now arrives as a `knownInstance` rather than a nominal `instance`. The `knownInstance` branch prefixed every class name with `typing.`, so `range(3)` was attributed to `typing.range` instead of the builtin `range`. The same branch already mis-attributed `functools.partial(...)` as `typing.partial`; the new `knownInstanceKind` field makes both distinguishable.

0.0.71 also adds `tupleElements`, which carries per-position tuple element types. `typeArgs` cannot express these — `tuple` has a single generic parameter, so ty collapses `tuple[int, str]` to a single union and the element order is lost.

## Examples

```python
r = range(3)                     # was typing.range, now range
p = functools.partial(f, 1)      # was typing.partial, now functools.partial

def pair() -> tuple[int, str]: ...
pair()                           # was tuple<int | str>, now tuple<int, str>
```

## Summary

- Bump the `ty-types` requirement from `>=0.0.49` to `>=0.0.71`.
- Map `knownInstanceKind` values whose singletons do not live in `typing` (`Range` to `range`, `FunctoolsPartial`/`FunctoolsPartialCall` to `functools.partial`); everything else keeps the `typing.` default.
- Derive `tuple` type parameters from `tupleElements` when present, falling back to `typeArgs` otherwise. `homogeneous` and `typeVarTuple` segments contribute their element type, so `tuple[int, ...]` maps to `tuple<int>` and `tuple[int, *Ts, str]` to `tuple<int, Ts, str>`.
- Only `builtins.tuple` takes elements as type parameters. ty also reports `tupleElements` for tuple subclasses and named tuples, which inherit them through the MRO without being generic themselves, so those keep their plain class type.
- An empty `tupleElements` (`tuple[()]`) yields the plain `tuple` class rather than a parameterized type with no parameters.

Both branches degrade rather than raise when a field is absent or has an unexpected shape, so the client keeps working against older ty-types releases: without `knownInstanceKind` the `typing.` default applies, and without `tupleElements` the `typeArgs` path is used.

## Test plan

- [x] Full Python suite passes against the published ty-types 0.0.71: 2047 passed, 11 skipped.
- [x] Unit tests for the new `knownInstance` mapping (`Range`, both `FunctoolsPartial` kinds) and for the `typing.` fallback on descriptors without `knownInstanceKind`.
- [x] Unit tests for tuple elements: fixed, homogeneous, `TypeVarTuple`, empty, tuple subclass, and fallback to `typeArgs`.
- [x] End-to-end tests against the live CLI for `range(...)`, `functools.partial(...)`, and fixed-length and homogeneous tuple returns.
- [x] Verified against ty-types 0.0.49 that the client raises no exception and that only the `functools.partial` expectation differs, which the version bump covers.
- [x] Verified no new `ty check` diagnostics in `type_mapping.py` (37 before and after).
