### PR TITLE
Go: adopt Testify testing library

### DIFF
--- a/rewrite-go/cmd/rpc/cross_ecosystem_test.go
+++ b/rewrite-go/cmd/rpc/cross_ecosystem_test.go
@@ -21,6 +21,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 )
 
@@ -54,13 +58,9 @@ func (*goCompositeWithJavaChild) RecipeList() []recipe.Recipe {
 func prepareOK(t *testing.T, s *server, id string) prepareRecipeResponse {
 	t.Helper()
 	params, err := json.Marshal(prepareRecipeRequest{ID: id})
-	if err != nil {
-		t.Fatalf("marshal prepare request: %v", err)
-	}
+	require.NoError(t, err)
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	if rpcErr != nil {
-		t.Fatalf("handlePrepareRecipe error: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	return resp.(prepareRecipeResponse)
 }
 
@@ -72,9 +72,7 @@ func TestPrepareRecipeRootDelegatesToJavaRecipe(t *testing.T) {
 
 	pr := prepareOK(t, s, "org.openrewrite.go.test.Delegating")
 
-	if pr.DelegatesTo == nil {
-		t.Fatal("expected delegatesTo to be set, got nil")
-	}
+	require.NotNil(t, pr.DelegatesTo)
 	if got := pr.DelegatesTo.RecipeName; got != "org.openrewrite.java.ChangeType" {
 		t.Errorf("delegatesTo.recipeName = %q, want org.openrewrite.java.ChangeType", got)
 	}
@@ -82,12 +80,8 @@ func TestPrepareRecipeRootDelegatesToJavaRecipe(t *testing.T) {
 		"oldFullyQualifiedTypeName": "a.A",
 		"newFullyQualifiedTypeName": "b.B",
 	}
-	if !reflect.DeepEqual(pr.DelegatesTo.Options, want) {
-		t.Errorf("delegatesTo.options = %+v, want %+v", pr.DelegatesTo.Options, want)
-	}
-	if len(pr.RecipeList) != 0 {
-		t.Errorf("a delegating recipe carries no child tree, got %d children", len(pr.RecipeList))
-	}
+	assert.True(t, reflect.DeepEqual(pr.DelegatesTo.Options, want))
+	assert.Len(t, pr.RecipeList, 0)
 }
 
 // A composite's child that delegates to a Java recipe is emitted inside the prepared recipeList as
@@ -100,16 +94,10 @@ func TestPrepareRecipeCompositeChildDelegatesToJavaRecipe(t *testing.T) {
 
 	pr := prepareOK(t, s, "org.openrewrite.go.test.CompositeWithJavaChild")
 
-	if pr.DelegatesTo != nil {
-		t.Errorf("the composite itself should not delegate, got %+v", pr.DelegatesTo)
-	}
-	if len(pr.RecipeList) != 1 {
-		t.Fatalf("expected 1 prepared child, got %d: %+v", len(pr.RecipeList), pr.RecipeList)
-	}
+	assert.Nil(t, pr.DelegatesTo)
+	require.Len(t, pr.RecipeList, 1)
 	child := pr.RecipeList[0]
-	if child.DelegatesTo == nil {
-		t.Fatal("expected the child to carry delegatesTo, got nil")
-	}
+	require.NotNil(t, child.DelegatesTo)
 	if got := child.DelegatesTo.RecipeName; got != "org.openrewrite.java.ChangeType" {
 		t.Errorf("child delegatesTo.recipeName = %q, want org.openrewrite.java.ChangeType", got)
 	}

--- a/rewrite-go/cmd/rpc/cross_ecosystem_test.go
+++ b/rewrite-go/cmd/rpc/cross_ecosystem_test.go
@@ -58,9 +58,9 @@ func (*goCompositeWithJavaChild) RecipeList() []recipe.Recipe {
 func prepareOK(t *testing.T, s *server, id string) prepareRecipeResponse {
 	t.Helper()
 	params, err := json.Marshal(prepareRecipeRequest{ID: id})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal prepare request")
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "handlePrepareRecipe error")
 	return resp.(prepareRecipeResponse)
 }
 
@@ -72,7 +72,7 @@ func TestPrepareRecipeRootDelegatesToJavaRecipe(t *testing.T) {
 
 	pr := prepareOK(t, s, "org.openrewrite.go.test.Delegating")
 
-	require.NotNil(t, pr.DelegatesTo)
+	require.NotNil(t, pr.DelegatesTo, "expected delegatesTo to be set, got nil")
 	if got := pr.DelegatesTo.RecipeName; got != "org.openrewrite.java.ChangeType" {
 		t.Errorf("delegatesTo.recipeName = %q, want org.openrewrite.java.ChangeType", got)
 	}
@@ -80,8 +80,8 @@ func TestPrepareRecipeRootDelegatesToJavaRecipe(t *testing.T) {
 		"oldFullyQualifiedTypeName": "a.A",
 		"newFullyQualifiedTypeName": "b.B",
 	}
-	assert.True(t, reflect.DeepEqual(pr.DelegatesTo.Options, want))
-	assert.Len(t, pr.RecipeList, 0)
+	assert.True(t, reflect.DeepEqual(pr.DelegatesTo.Options, want), "delegatesTo.options")
+	assert.Lenf(t, pr.RecipeList, 0, "a delegating recipe carries no child tree, got %d children", len(pr.RecipeList))
 }
 
 // A composite's child that delegates to a Java recipe is emitted inside the prepared recipeList as
@@ -94,10 +94,10 @@ func TestPrepareRecipeCompositeChildDelegatesToJavaRecipe(t *testing.T) {
 
 	pr := prepareOK(t, s, "org.openrewrite.go.test.CompositeWithJavaChild")
 
-	assert.Nil(t, pr.DelegatesTo)
-	require.Len(t, pr.RecipeList, 1)
+	assert.Nil(t, pr.DelegatesTo, "the composite itself should not delegate")
+	require.Len(t, pr.RecipeList, 1, "expected 1 prepared child")
 	child := pr.RecipeList[0]
-	require.NotNil(t, child.DelegatesTo)
+	require.NotNil(t, child.DelegatesTo, "expected the child to carry delegatesTo, got nil")
 	if got := child.DelegatesTo.RecipeName; got != "org.openrewrite.java.ChangeType" {
 		t.Errorf("child delegatesTo.recipeName = %q, want org.openrewrite.java.ChangeType", got)
 	}

--- a/rewrite-go/cmd/rpc/exported_types_test.go
+++ b/rewrite-go/cmd/rpc/exported_types_test.go
@@ -26,6 +26,10 @@ import (
 
 	"golang.org/x/mod/module"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	goparser "github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/rpc"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -61,17 +65,11 @@ func TestHandleExportedTypes(t *testing.T) {
 
 	s, _ := newTestServer(t)
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/foo", Version: "v1.0.0"})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 	result, rpcErr := s.handleDependencyTypes(params)
-	if rpcErr != nil {
-		t.Fatalf("ExportedTypes failed: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	data := result.([]rpc.RpcObjectData)
-	if len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject {
-		t.Fatalf("expected a batch ending in END_OF_OBJECT, got %d items", len(data))
-	}
+	require.False(t, len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject)
 
 	// The own-FQN list is sent first and must name every enumerated type, so the
 	// caller can tell defined types from references before the first type arrives.
@@ -128,10 +126,7 @@ func TestHandleExportedTypes(t *testing.T) {
 	if !ok {
 		t.Fatalf("io.Writer reference is %T, want *java.JavaTypeShallowClass", out)
 	}
-	if sc.FullyQualifiedName != "io.Writer" || len(sc.Members) != 0 || len(sc.Methods) != 0 {
-		t.Errorf("shallow ref = %s (members=%d methods=%d); want io.Writer with an empty body",
-			sc.FullyQualifiedName, len(sc.Members), len(sc.Methods))
-	}
+	assert.False(t, sc.FullyQualifiedName != "io.Writer" || len(sc.Members) != 0 || len(sc.Methods) != 0)
 	sawShallowTag := false
 	for _, d := range data {
 		if d.ValueType != nil && *d.ValueType == java.JavaTypeShallowClassKind {
@@ -139,9 +134,7 @@ func TestHandleExportedTypes(t *testing.T) {
 			break
 		}
 	}
-	if !sawShallowTag {
-		t.Error("no JavaType$ShallowClass valueType tag on the wire")
-	}
+	assert.True(t, sawShallowTag)
 }
 
 // Covers the enumerator's correctness fixes: an alias to an external type is not
@@ -177,12 +170,8 @@ func (g *Greeter) Greet() string { return g.Name }
 	if greeter == nil {
 		t.Fatalf("Greeter not enumerated; got %v", keys(byFqn))
 	}
-	if !hasMethod(greeter, "Greet") {
-		t.Errorf("Greeter missing Greet method")
-	}
-	if !hasMember(greeter, "Name") {
-		t.Errorf("Greeter missing Name field")
-	}
+	assert.True(t, hasMethod(greeter, "Greet"))
+	assert.True(t, hasMember(greeter, "Name"))
 	if _, ok := byFqn["io.Reader"]; ok {
 		t.Errorf("external alias target io.Reader was collected as an owned type")
 	}
@@ -199,12 +188,8 @@ func (g *Greeter) Greet() string { return g.Name }
 	if config == nil {
 		t.Fatalf("Config not enumerated; got %v", keys(byFqn))
 	}
-	if !hasMember(config, "Linux") {
-		t.Errorf("Config missing Linux field (fixed linux/amd64 context)")
-	}
-	if hasMember(config, "Windows") {
-		t.Errorf("Config has Windows field; _windows.go should be filtered out")
-	}
+	assert.True(t, hasMember(config, "Linux"))
+	assert.False(t, hasMember(config, "Windows"))
 }
 
 // A subdirectory with its own go.mod is a separate module; its files must not be
@@ -246,16 +231,12 @@ func TestExportedTypes_StdlibPackage(t *testing.T) {
 	if stringer == nil {
 		t.Fatalf("fmt.Stringer not enumerated; got %v", keys(byFqn))
 	}
-	if !hasMethod(stringer, "String") {
-		t.Errorf("fmt.Stringer missing String method")
-	}
+	assert.True(t, hasMethod(stringer, "String"))
 	pkg := byFqn["fmt"]
 	if pkg == nil {
 		t.Fatalf("synthetic fmt package class not enumerated; got %v", keys(byFqn))
 	}
-	if !hasMethod(pkg, "Sprintf") {
-		t.Errorf("fmt package class missing Sprintf; got %v", pkg.Methods)
-	}
+	assert.True(t, hasMethod(pkg, "Sprintf"))
 	// A stdlib package's cross-package references are shallow too.
 	for _, m := range pkg.Methods {
 		if m.Name != "Fprintf" {
@@ -282,17 +263,11 @@ func TestHandleDependencyTypes_StdlibCoordinate(t *testing.T) {
 	s, _ := newTestServer(t)
 	s.batchSize = 1 << 20
 	params, err := json.Marshal(dependencyRequest{ModulePath: "fmt"})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 	result, rpcErr := s.handleDependencyTypes(params)
-	if rpcErr != nil {
-		t.Fatalf("stdlib DependencyTypes failed: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	data := result.([]rpc.RpcObjectData)
-	if len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject {
-		t.Fatalf("expected a batch ending in END_OF_OBJECT, got %d items", len(data))
-	}
+	require.False(t, len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject)
 	fqns := map[string]bool{}
 	for _, f := range receiveFqnList(t, data) {
 		fqns[f] = true
@@ -313,21 +288,15 @@ func TestHandleDependencyTypes_VendorTree(t *testing.T) {
 
 	s, _ := newTestServer(t)
 	pp, err := json.Marshal(parseProjectRequest{ProjectPath: proj})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 	if _, rpcErr := s.handleParseProject(pp); rpcErr != nil {
 		t.Fatalf("ParseProject failed: %+v", rpcErr)
 	}
 
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/foo", Version: "v1.0.0"})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 	result, rpcErr := s.handleDependencyTypes(params)
-	if rpcErr != nil {
-		t.Fatalf("vendored DependencyTypes failed: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	byFqn := map[string]*java.JavaTypeClass{}
 	for _, ty := range receiveTypeList(t, result.([]rpc.RpcObjectData)) {
 		if cls, ok := ty.(*java.JavaTypeClass); ok {
@@ -345,9 +314,7 @@ func TestHandleDependencyTypes_UnresolvableCoordinate(t *testing.T) {
 	t.Setenv("GOMODCACHE", t.TempDir())
 	s, _ := newTestServer(t)
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/missing", Version: "v9.9.9"})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 	if _, rpcErr := s.handleDependencyTypes(params); rpcErr == nil {
 		t.Fatal("expected an error for an unresolvable coordinate")
 	}
@@ -363,21 +330,15 @@ func TestExportedTypes_Paginates(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "greeter.go"), greeterModule)
 
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/foo", Version: "v1.0.0"})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Single-shot reference run with a batch large enough to hold the whole table.
 	single, _ := newTestServer(t)
 	single.batchSize = 1 << 20
 	oneShot, rpcErr := single.handleDependencyTypes(params)
-	if rpcErr != nil {
-		t.Fatalf("single-shot ExportedTypes failed: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	want := oneShot.([]rpc.RpcObjectData)
-	if len(want) == 0 || want[len(want)-1].State != rpc.EndOfObject {
-		t.Fatalf("single-shot must end in END_OF_OBJECT; got %d items", len(want))
-	}
+	require.False(t, len(want) == 0 || want[len(want)-1].State != rpc.EndOfObject)
 
 	// Paginated run: same params, tiny batch, drained across repeated calls.
 	s, _ := newTestServer(t)
@@ -388,9 +349,7 @@ func TestExportedTypes_Paginates(t *testing.T) {
 			t.Fatalf("pagination did not terminate after %d calls", calls)
 		}
 		result, rpcErr := s.handleDependencyTypes(params)
-		if rpcErr != nil {
-			t.Fatalf("paginated ExportedTypes failed: %+v", rpcErr)
-		}
+		require.Nil(t, rpcErr)
 		batch := result.([]rpc.RpcObjectData)
 		if len(batch) > s.batchSize {
 			t.Fatalf("batch of %d exceeds batchSize %d", len(batch), s.batchSize)
@@ -401,9 +360,7 @@ func TestExportedTypes_Paginates(t *testing.T) {
 		}
 	}
 
-	if len(s.pendingDependencyTypes) != 0 {
-		t.Errorf("cache not freed after drain: %d entries remain", len(s.pendingDependencyTypes))
-	}
+	assert.Len(t, s.pendingDependencyTypes, 0)
 	if len(got) != len(want) {
 		t.Fatalf("paginated total %d != single-shot %d", len(got), len(want))
 	}
@@ -437,13 +394,9 @@ func exportedTypesByFqn(t *testing.T, modulePath, version string) map[string]*ja
 	t.Helper()
 	s, _ := newTestServer(t)
 	params, err := json.Marshal(dependencyRequest{ModulePath: modulePath, Version: version})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 	result, rpcErr := s.handleDependencyTypes(params)
-	if rpcErr != nil {
-		t.Fatalf("ExportedTypes failed: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	byFqn := map[string]*java.JavaTypeClass{}
 	for _, ty := range receiveTypeList(t, result.([]rpc.RpcObjectData)) {
 		if cls, ok := ty.(*java.JavaTypeClass); ok {

--- a/rewrite-go/cmd/rpc/exported_types_test.go
+++ b/rewrite-go/cmd/rpc/exported_types_test.go
@@ -65,11 +65,11 @@ func TestHandleExportedTypes(t *testing.T) {
 
 	s, _ := newTestServer(t)
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/foo", Version: "v1.0.0"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 	result, rpcErr := s.handleDependencyTypes(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "ExportedTypes failed")
 	data := result.([]rpc.RpcObjectData)
-	require.False(t, len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject)
+	require.Falsef(t, len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject, "expected a batch ending in END_OF_OBJECT, got %d items", len(data))
 
 	// The own-FQN list is sent first and must name every enumerated type, so the
 	// caller can tell defined types from references before the first type arrives.
@@ -77,9 +77,7 @@ func TestHandleExportedTypes(t *testing.T) {
 	for _, f := range receiveFqnList(t, data) {
 		fqnSet[f] = true
 	}
-	if !fqnSet["example.com/foo.Greeter"] || !fqnSet["example.com/foo"] {
-		t.Errorf("own-FQN list missing enumerated FQNs; got %v", fqnSet)
-	}
+	assert.Falsef(t, !fqnSet["example.com/foo.Greeter"] || !fqnSet["example.com/foo"], "own-FQN list missing enumerated FQNs; got %v", fqnSet)
 
 	types := receiveTypeList(t, data)
 	if len(types) == 0 {
@@ -94,9 +92,7 @@ func TestHandleExportedTypes(t *testing.T) {
 	}
 
 	greeter := byFqn["example.com/foo.Greeter"]
-	if greeter == nil {
-		t.Fatalf("Greeter type not enumerated; got %v", keys(byFqn))
-	}
+	require.NotNilf(t, greeter, "Greeter type not enumerated; got %v", keys(byFqn))
 	if len(greeter.Methods) == 0 {
 		t.Error("Greeter.Methods is empty; expected Greet")
 	}
@@ -105,9 +101,7 @@ func TestHandleExportedTypes(t *testing.T) {
 	}
 
 	pkg := byFqn["example.com/foo"]
-	if pkg == nil {
-		t.Fatalf("synthetic package class not enumerated; got %v", keys(byFqn))
-	}
+	require.NotNilf(t, pkg, "synthetic package class not enumerated; got %v", keys(byFqn))
 	if len(pkg.Methods) == 0 {
 		t.Error("package class Methods is empty; expected NewGreeter")
 	}
@@ -123,10 +117,8 @@ func TestHandleExportedTypes(t *testing.T) {
 		}
 	}
 	sc, ok := out.(*java.JavaTypeShallowClass)
-	if !ok {
-		t.Fatalf("io.Writer reference is %T, want *java.JavaTypeShallowClass", out)
-	}
-	assert.False(t, sc.FullyQualifiedName != "io.Writer" || len(sc.Members) != 0 || len(sc.Methods) != 0)
+	require.Truef(t, ok, "io.Writer reference is %T, want *java.JavaTypeShallowClass", out)
+	assert.Falsef(t, sc.FullyQualifiedName != "io.Writer" || len(sc.Members) != 0 || len(sc.Methods) != 0, "shallow ref = %s (members=%d methods=%d); want io.Writer with an empty body", sc.FullyQualifiedName, len(sc.Members), len(sc.Methods))
 	sawShallowTag := false
 	for _, d := range data {
 		if d.ValueType != nil && *d.ValueType == java.JavaTypeShallowClassKind {
@@ -134,7 +126,7 @@ func TestHandleExportedTypes(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, sawShallowTag)
+	assert.True(t, sawShallowTag, "no JavaType$ShallowClass valueType tag on the wire")
 }
 
 // Covers the enumerator's correctness fixes: an alias to an external type is not
@@ -167,11 +159,9 @@ func (g *Greeter) Greet() string { return g.Name }
 	byFqn := exportedTypesByFqn(t, "example.com/foo", "v1.0.0")
 
 	greeter := byFqn["example.com/foo.Greeter"]
-	if greeter == nil {
-		t.Fatalf("Greeter not enumerated; got %v", keys(byFqn))
-	}
-	assert.True(t, hasMethod(greeter, "Greet"))
-	assert.True(t, hasMember(greeter, "Name"))
+	require.NotNilf(t, greeter, "Greeter not enumerated; got %v", keys(byFqn))
+	assert.True(t, hasMethod(greeter, "Greet"), "Greeter missing Greet method")
+	assert.True(t, hasMember(greeter, "Name"), "Greeter missing Name field")
 	if _, ok := byFqn["io.Reader"]; ok {
 		t.Errorf("external alias target io.Reader was collected as an owned type")
 	}
@@ -185,11 +175,9 @@ func (g *Greeter) Greet() string { return g.Name }
 		t.Errorf("bar package class missing NewBar; got %v", barPkg)
 	}
 	config := byFqn["example.com/foo.Config"]
-	if config == nil {
-		t.Fatalf("Config not enumerated; got %v", keys(byFqn))
-	}
-	assert.True(t, hasMember(config, "Linux"))
-	assert.False(t, hasMember(config, "Windows"))
+	require.NotNilf(t, config, "Config not enumerated; got %v", keys(byFqn))
+	assert.True(t, hasMember(config, "Linux"), "Config missing Linux field (fixed linux/amd64 context)")
+	assert.False(t, hasMember(config, "Windows"), "Config has Windows field; _windows.go should be filtered out")
 }
 
 // A subdirectory with its own go.mod is a separate module; its files must not be
@@ -228,15 +216,11 @@ func TestExportedTypes_StdlibPackage(t *testing.T) {
 	}
 
 	stringer := byFqn["fmt.Stringer"]
-	if stringer == nil {
-		t.Fatalf("fmt.Stringer not enumerated; got %v", keys(byFqn))
-	}
-	assert.True(t, hasMethod(stringer, "String"))
+	require.NotNilf(t, stringer, "fmt.Stringer not enumerated; got %v", keys(byFqn))
+	assert.True(t, hasMethod(stringer, "String"), "fmt.Stringer missing String method")
 	pkg := byFqn["fmt"]
-	if pkg == nil {
-		t.Fatalf("synthetic fmt package class not enumerated; got %v", keys(byFqn))
-	}
-	assert.True(t, hasMethod(pkg, "Sprintf"))
+	require.NotNilf(t, pkg, "synthetic fmt package class not enumerated; got %v", keys(byFqn))
+	assert.True(t, hasMethod(pkg, "Sprintf"), "fmt package class missing Sprintf")
 	// A stdlib package's cross-package references are shallow too.
 	for _, m := range pkg.Methods {
 		if m.Name != "Fprintf" {
@@ -263,18 +247,16 @@ func TestHandleDependencyTypes_StdlibCoordinate(t *testing.T) {
 	s, _ := newTestServer(t)
 	s.batchSize = 1 << 20
 	params, err := json.Marshal(dependencyRequest{ModulePath: "fmt"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 	result, rpcErr := s.handleDependencyTypes(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "stdlib DependencyTypes failed")
 	data := result.([]rpc.RpcObjectData)
-	require.False(t, len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject)
+	require.Falsef(t, len(data) == 0 || data[len(data)-1].State != rpc.EndOfObject, "expected a batch ending in END_OF_OBJECT, got %d items", len(data))
 	fqns := map[string]bool{}
 	for _, f := range receiveFqnList(t, data) {
 		fqns[f] = true
 	}
-	if !fqns["fmt"] || !fqns["fmt.Stringer"] {
-		t.Errorf("own-FQN list missing fmt package FQNs; got %d FQNs", len(fqns))
-	}
+	assert.Falsef(t, !fqns["fmt"] || !fqns["fmt.Stringer"], "own-FQN list missing fmt package FQNs; got %d FQNs", len(fqns))
 }
 
 // A versioned coordinate resolves against the parsed project's vendor/ tree before the module
@@ -288,24 +270,22 @@ func TestHandleDependencyTypes_VendorTree(t *testing.T) {
 
 	s, _ := newTestServer(t)
 	pp, err := json.Marshal(parseProjectRequest{ProjectPath: proj})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 	if _, rpcErr := s.handleParseProject(pp); rpcErr != nil {
 		t.Fatalf("ParseProject failed: %+v", rpcErr)
 	}
 
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/foo", Version: "v1.0.0"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 	result, rpcErr := s.handleDependencyTypes(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "vendored DependencyTypes failed")
 	byFqn := map[string]*java.JavaTypeClass{}
 	for _, ty := range receiveTypeList(t, result.([]rpc.RpcObjectData)) {
 		if cls, ok := ty.(*java.JavaTypeClass); ok {
 			byFqn[cls.FullyQualifiedName] = cls
 		}
 	}
-	if byFqn["example.com/foo.Greeter"] == nil {
-		t.Errorf("vendored Greeter not enumerated; got %v", keys(byFqn))
-	}
+	assert.NotNilf(t,byFqn["example.com/foo.Greeter"], "vendored Greeter not enumerated; got %v", keys(byFqn))
 }
 
 // A coordinate found in neither the vendor tree nor the module cache is a per-dependency
@@ -314,7 +294,7 @@ func TestHandleDependencyTypes_UnresolvableCoordinate(t *testing.T) {
 	t.Setenv("GOMODCACHE", t.TempDir())
 	s, _ := newTestServer(t)
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/missing", Version: "v9.9.9"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 	if _, rpcErr := s.handleDependencyTypes(params); rpcErr == nil {
 		t.Fatal("expected an error for an unresolvable coordinate")
 	}
@@ -330,15 +310,15 @@ func TestExportedTypes_Paginates(t *testing.T) {
 	writeFile(t, filepath.Join(dir, "greeter.go"), greeterModule)
 
 	params, err := json.Marshal(dependencyRequest{ModulePath: "example.com/foo", Version: "v1.0.0"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 
 	// Single-shot reference run with a batch large enough to hold the whole table.
 	single, _ := newTestServer(t)
 	single.batchSize = 1 << 20
 	oneShot, rpcErr := single.handleDependencyTypes(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "single-shot ExportedTypes failed")
 	want := oneShot.([]rpc.RpcObjectData)
-	require.False(t, len(want) == 0 || want[len(want)-1].State != rpc.EndOfObject)
+	require.Falsef(t, len(want) == 0 || want[len(want)-1].State != rpc.EndOfObject, "single-shot must end in END_OF_OBJECT; got %d items", len(want))
 
 	// Paginated run: same params, tiny batch, drained across repeated calls.
 	s, _ := newTestServer(t)
@@ -349,7 +329,7 @@ func TestExportedTypes_Paginates(t *testing.T) {
 			t.Fatalf("pagination did not terminate after %d calls", calls)
 		}
 		result, rpcErr := s.handleDependencyTypes(params)
-		require.Nil(t, rpcErr)
+		require.Nil(t, rpcErr, "paginated ExportedTypes failed")
 		batch := result.([]rpc.RpcObjectData)
 		if len(batch) > s.batchSize {
 			t.Fatalf("batch of %d exceeds batchSize %d", len(batch), s.batchSize)
@@ -360,14 +340,12 @@ func TestExportedTypes_Paginates(t *testing.T) {
 		}
 	}
 
-	assert.Len(t, s.pendingDependencyTypes, 0)
+	assert.Lenf(t, s.pendingDependencyTypes, 0, "cache not freed after drain: %d entries remain", len(s.pendingDependencyTypes))
 	if len(got) != len(want) {
 		t.Fatalf("paginated total %d != single-shot %d", len(got), len(want))
 	}
 	for i := range want {
-		if !reflect.DeepEqual(got[i], want[i]) {
-			t.Fatalf("item %d differs between paginated and single-shot runs:\n paginated=%+v\n single=%+v", i, got[i], want[i])
-		}
+		require.Truef(t, reflect.DeepEqual(got[i], want[i]), "item %d differs between paginated and single-shot runs:\n paginated=%+v\n single=%+v", i, got[i], want[i])
 	}
 }
 
@@ -378,13 +356,9 @@ func modCacheDir(t *testing.T, modulePath, version string) string {
 	cache := t.TempDir()
 	t.Setenv("GOMODCACHE", cache)
 	esc, err := module.EscapePath(modulePath)
-	if err != nil {
-		t.Fatalf("escape %q: %v", modulePath, err)
-	}
+	require.NoErrorf(t, err, "escape %q", modulePath)
 	escVer, err := module.EscapeVersion(version)
-	if err != nil {
-		t.Fatalf("escape %q: %v", version, err)
-	}
+	require.NoErrorf(t, err, "escape %q", version)
 	return filepath.Join(cache, filepath.FromSlash(esc)+"@"+escVer)
 }
 
@@ -394,9 +368,9 @@ func exportedTypesByFqn(t *testing.T, modulePath, version string) map[string]*ja
 	t.Helper()
 	s, _ := newTestServer(t)
 	params, err := json.Marshal(dependencyRequest{ModulePath: modulePath, Version: version})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 	result, rpcErr := s.handleDependencyTypes(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "ExportedTypes failed")
 	byFqn := map[string]*java.JavaTypeClass{}
 	for _, ty := range receiveTypeList(t, result.([]rpc.RpcObjectData)) {
 		if cls, ok := ty.(*java.JavaTypeClass); ok {

--- a/rewrite-go/cmd/rpc/get_object_test.go
+++ b/rewrite-go/cmd/rpc/get_object_test.go
@@ -20,6 +20,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	goparser "github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/rpc"
@@ -29,18 +31,14 @@ import (
 func getObjectParams(t *testing.T, id string) json.RawMessage {
 	t.Helper()
 	params, err := json.Marshal(getObjectRequest{ID: id})
-	if err != nil {
-		t.Fatalf("marshal GetObject params: %v", err)
-	}
+	require.NoError(t, err)
 	return params
 }
 
 func getObjectBatchForTest(t *testing.T, s *server, params json.RawMessage) []rpc.RpcObjectData {
 	t.Helper()
 	result, rpcErr := s.handleGetObject(params)
-	if rpcErr != nil {
-		t.Fatalf("GetObject failed: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	return result.([]rpc.RpcObjectData)
 }
 
@@ -60,9 +58,7 @@ func getCompleteObjectForTest(t *testing.T, s *server, id string) []rpc.RpcObjec
 func getObjectTreeForTest(t *testing.T) java.Tree {
 	t.Helper()
 	cu, err := goparser.NewGoParser().Parse("main.go", "package main\n")
-	if err != nil {
-		t.Fatalf("parse test source: %v", err)
-	}
+	require.NoError(t, err)
 	return cu
 }
 
@@ -76,9 +72,7 @@ func TestHandleGetObjectReturnsOneBatchPerRequest(t *testing.T) {
 	params := getObjectParams(t, id)
 
 	first := getObjectBatchForTest(t, s, params)
-	if len(first) != s.batchSize || first[0].State != rpc.Add {
-		t.Fatalf("first batch = %+v, want a full batch beginning with ADD", first)
-	}
+	require.False(t, len(first) != s.batchSize || first[0].State != rpc.Add)
 	if _, complete := s.remoteObjects[id]; complete {
 		t.Fatal("remote baseline was updated before END_OF_OBJECT was delivered")
 	}
@@ -153,9 +147,7 @@ func TestHandleGetObjectReusesReferencesAcrossTransfers(t *testing.T) {
 
 	getCompleteObjectForTest(t, s, "first")
 	refsAfterFirst := s.localRefs.Len()
-	if refsAfterFirst == 0 {
-		t.Fatal("first transfer did not retain any references")
-	}
+	require.NotEqual(t, 0, refsAfterFirst)
 
 	second := getCompleteObjectForTest(t, s, "second")
 	if got := s.localRefs.Len(); got != refsAfterFirst {
@@ -196,9 +188,7 @@ func TestHandleGetObjectRejectsInterleavedTransfers(t *testing.T) {
 			break
 		}
 	}
-	if len(s.inProgressGetObjects) != 0 {
-		t.Fatalf("in-progress GetObjects after completion = %d, want 0", len(s.inProgressGetObjects))
-	}
+	require.Len(t, s.inProgressGetObjects, 0)
 	getCompleteObjectForTest(t, s, "second")
 }
 
@@ -212,10 +202,6 @@ func TestResetCancelsInProgressGetObject(t *testing.T) {
 	_ = getObjectBatchForTest(t, s, params)
 
 	s.handleReset()
-	if len(s.inProgressGetObjects) != 0 {
-		t.Fatalf("in-progress transfers after Reset = %d, want 0", len(s.inProgressGetObjects))
-	}
-	if len(s.localObjects) != 0 || len(s.remoteObjects) != 0 {
-		t.Fatal("Reset did not clear object state")
-	}
+	require.Len(t, s.inProgressGetObjects, 0)
+	require.False(t, len(s.localObjects) != 0 || len(s.remoteObjects) != 0)
 }

--- a/rewrite-go/cmd/rpc/get_object_test.go
+++ b/rewrite-go/cmd/rpc/get_object_test.go
@@ -31,14 +31,14 @@ import (
 func getObjectParams(t *testing.T, id string) json.RawMessage {
 	t.Helper()
 	params, err := json.Marshal(getObjectRequest{ID: id})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal GetObject params")
 	return params
 }
 
 func getObjectBatchForTest(t *testing.T, s *server, params json.RawMessage) []rpc.RpcObjectData {
 	t.Helper()
 	result, rpcErr := s.handleGetObject(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "GetObject failed")
 	return result.([]rpc.RpcObjectData)
 }
 
@@ -58,7 +58,7 @@ func getCompleteObjectForTest(t *testing.T, s *server, id string) []rpc.RpcObjec
 func getObjectTreeForTest(t *testing.T) java.Tree {
 	t.Helper()
 	cu, err := goparser.NewGoParser().Parse("main.go", "package main\n")
-	require.NoError(t, err)
+	require.NoError(t, err, "parse test source")
 	return cu
 }
 
@@ -72,7 +72,7 @@ func TestHandleGetObjectReturnsOneBatchPerRequest(t *testing.T) {
 	params := getObjectParams(t, id)
 
 	first := getObjectBatchForTest(t, s, params)
-	require.False(t, len(first) != s.batchSize || first[0].State != rpc.Add)
+	require.Falsef(t, len(first) != s.batchSize || first[0].State != rpc.Add, "first batch = %+v, want a full batch beginning with ADD", first)
 	if _, complete := s.remoteObjects[id]; complete {
 		t.Fatal("remote baseline was updated before END_OF_OBJECT was delivered")
 	}
@@ -122,9 +122,7 @@ func TestHandleGetObjectBatchesAreConsumedByReceiveQueue(t *testing.T) {
 		return v
 	})
 	gotTree, ok := got.(java.Tree)
-	if !ok {
-		t.Fatalf("received object = %T, want java.Tree", got)
-	}
+	require.Truef(t, ok, "received object = %T, want java.Tree", got)
 	if printed := printer.Print(gotTree); printed != want {
 		t.Fatalf("received source = %q, want %q", printed, want)
 	}
@@ -147,7 +145,7 @@ func TestHandleGetObjectReusesReferencesAcrossTransfers(t *testing.T) {
 
 	getCompleteObjectForTest(t, s, "first")
 	refsAfterFirst := s.localRefs.Len()
-	require.NotEqual(t, 0, refsAfterFirst)
+	require.NotEqual(t, 0, refsAfterFirst, "first transfer did not retain any references")
 
 	second := getCompleteObjectForTest(t, s, "second")
 	if got := s.localRefs.Len(); got != refsAfterFirst {
@@ -188,7 +186,7 @@ func TestHandleGetObjectRejectsInterleavedTransfers(t *testing.T) {
 			break
 		}
 	}
-	require.Len(t, s.inProgressGetObjects, 0)
+	require.Len(t, s.inProgressGetObjects, 0, "in-progress GetObjects after completion")
 	getCompleteObjectForTest(t, s, "second")
 }
 
@@ -202,6 +200,6 @@ func TestResetCancelsInProgressGetObject(t *testing.T) {
 	_ = getObjectBatchForTest(t, s, params)
 
 	s.handleReset()
-	require.Len(t, s.inProgressGetObjects, 0)
-	require.False(t, len(s.localObjects) != 0 || len(s.remoteObjects) != 0)
+	require.Len(t, s.inProgressGetObjects, 0, "in-progress transfers after Reset")
+	require.False(t, len(s.localObjects) != 0 || len(s.remoteObjects) != 0, "Reset did not clear object state")
 }

--- a/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
+++ b/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -42,9 +44,7 @@ func TestParseProjectRelativizesGoModSourcePath(t *testing.T) {
 		ProjectPath: projectDir,
 		RelativeTo:  &relativeTo,
 	})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -59,19 +59,13 @@ func TestParseProjectRelativizesGoModSourcePath(t *testing.T) {
 			break
 		}
 	}
-	if gm == nil {
-		t.Fatal("expected a GoMod object to be produced")
-	}
-	if gm.SourcePath != "go.mod" {
-		t.Fatalf("expected GoMod SourcePath relativized to %q, got %q", "go.mod", gm.SourcePath)
-	}
+	require.NotNil(t, gm)
+	require.Equal(t, "go.mod", gm.SourcePath)
 }
 
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
 	}
@@ -97,9 +91,7 @@ func TestParseProjectRelativizesGoResolutionResultPath(t *testing.T) {
 		ProjectPath: projectDir,
 		RelativeTo:  &relativeTo,
 	})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -122,9 +114,7 @@ func TestParseProjectRelativizesGoResolutionResultPath(t *testing.T) {
 			}
 		}
 	}
-	if onGoMod != 2 || onGoSum != 1 {
-		t.Fatalf("expected markers on 2 go.mod and 1 go.sum, got %d and %d", onGoMod, onGoSum)
-	}
+	require.False(t, onGoMod != 2 || onGoSum != 1)
 }
 
 func resolutionResults(entries []java.Marker) []golang.GoResolutionResult {

--- a/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
+++ b/rewrite-go/cmd/rpc/gomod_sourcepath_test.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -44,7 +46,7 @@ func TestParseProjectRelativizesGoModSourcePath(t *testing.T) {
 		ProjectPath: projectDir,
 		RelativeTo:  &relativeTo,
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -59,16 +61,14 @@ func TestParseProjectRelativizesGoModSourcePath(t *testing.T) {
 			break
 		}
 	}
-	require.NotNil(t, gm)
-	require.Equal(t, "go.mod", gm.SourcePath)
+	require.NotNil(t, gm, "expected a GoMod object to be produced")
+	require.Equalf(t, "go.mod", gm.SourcePath, "expected GoMod SourcePath relativized to %q", "go.mod")
 }
 
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
-	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755), "mkdir")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0644), "write")
 }
 
 // TestParseProjectRelativizesGoResolutionResultPath pins down that the GoResolutionResult
@@ -91,7 +91,7 @@ func TestParseProjectRelativizesGoResolutionResultPath(t *testing.T) {
 		ProjectPath: projectDir,
 		RelativeTo:  &relativeTo,
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -114,7 +114,7 @@ func TestParseProjectRelativizesGoResolutionResultPath(t *testing.T) {
 			}
 		}
 	}
-	require.False(t, onGoMod != 2 || onGoSum != 1)
+	require.Falsef(t, onGoMod != 2 || onGoSum != 1, "expected markers on 2 go.mod and 1 go.sum, got %d and", onGoMod)
 }
 
 func resolutionResults(entries []java.Marker) []golang.GoResolutionResult {
@@ -129,7 +129,5 @@ func resolutionResults(entries []java.Marker) []golang.GoResolutionResult {
 
 func assertMarkerPath(t *testing.T, got, want, attachedTo string) {
 	t.Helper()
-	if got != want {
-		t.Errorf("marker on %q has Path %q, want %q", attachedTo, got, want)
-	}
+	assert.Equalf(t, want, got, "marker on %q has Path", attachedTo)
 }

--- a/rewrite-go/cmd/rpc/metrics_test.go
+++ b/rewrite-go/cmd/rpc/metrics_test.go
@@ -52,11 +52,11 @@ func newTestServer(t *testing.T) (*server, string) {
 func readMetricsCSV(t *testing.T, path string) (header []string, rows [][]string) {
 	t.Helper()
 	f, err := os.Open(path)
-	require.NoError(t, err)
+	require.NoError(t, err, "open metrics csv")
 	defer f.Close()
 	r := csv.NewReader(f)
 	all, err := r.ReadAll()
-	require.NoError(t, err)
+	require.NoError(t, err, "parse metrics csv")
 	if len(all) == 0 {
 		t.Fatal("metrics csv is empty (no header)")
 	}
@@ -77,7 +77,7 @@ func TestMetricsCSVHeaderWritten(t *testing.T) {
 			t.Errorf("header[%d]: want %q, got %q", i, col, header[i])
 		}
 	}
-	assert.Len(t, rows, 0)
+	assert.Len(t, rows, 0, "want no rows before any RPC")
 }
 
 func TestMetricsCSVRowPerRequest(t *testing.T) {
@@ -129,7 +129,7 @@ func TestMetricsCSVCapturesErrors(t *testing.T) {
 	s.closeMetrics()
 
 	_, rows := readMetricsCSV(t, csvPath)
-	require.Len(t, rows, 1)
+	require.Len(t, rows, 1, "rows")
 	if rows[0][1] != "BogusMethodThatDoesNotExist" {
 		t.Errorf("method: %q", rows[0][1])
 	}
@@ -168,15 +168,13 @@ func TestMetricsCSVConcurrentLoad(t *testing.T) {
 	s.closeMetrics()
 
 	_, rows := readMetricsCSV(t, csvPath)
-	require.Len(t, rows, total)
+	require.Len(t, rows, total, "rows")
 	// Every row must have 9 columns and a parseable timestamp+duration.
 	// If writes interleaved, csv.NewReader.ReadAll above would fail or
 	// produce malformed rows; we re-validate here in case ReadAll silently
 	// padded.
 	for i, row := range rows {
-		if len(row) != 9 {
-			t.Fatalf("row[%d] columns: want 9, got %d (%v)", i, len(row), row)
-		}
+		require.Lenf(t, row, 9, "row[%d] columns", i)
 		if row[1] != "GetLanguages" {
 			t.Errorf("row[%d].method: want GetLanguages, got %q", i, row[1])
 		}
@@ -198,5 +196,5 @@ func TestMetricsCSVDisabledWhenFlagEmpty(t *testing.T) {
 
 	// Should be a no-op; if writer-or-file leaks it would panic on close.
 	s.safeHandleRequest(&jsonRPCRequest{JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "GetLanguages"})
-	assert.False(t, s.metricsWriter != nil || s.metricsFile != nil)
+	assert.Falsef(t, s.metricsWriter != nil || s.metricsFile != nil, "metrics writer should be nil when flag empty (writer=%v file", s.metricsWriter)
 }

--- a/rewrite-go/cmd/rpc/metrics_test.go
+++ b/rewrite-go/cmd/rpc/metrics_test.go
@@ -26,6 +26,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 // newTestServer wires a server pointed at a temp metrics CSV. Cleanup is
@@ -50,15 +52,11 @@ func newTestServer(t *testing.T) (*server, string) {
 func readMetricsCSV(t *testing.T, path string) (header []string, rows [][]string) {
 	t.Helper()
 	f, err := os.Open(path)
-	if err != nil {
-		t.Fatalf("open metrics csv: %v", err)
-	}
+	require.NoError(t, err)
 	defer f.Close()
 	r := csv.NewReader(f)
 	all, err := r.ReadAll()
-	if err != nil {
-		t.Fatalf("parse metrics csv: %v", err)
-	}
+	require.NoError(t, err)
 	if len(all) == 0 {
 		t.Fatal("metrics csv is empty (no header)")
 	}
@@ -79,9 +77,7 @@ func TestMetricsCSVHeaderWritten(t *testing.T) {
 			t.Errorf("header[%d]: want %q, got %q", i, col, header[i])
 		}
 	}
-	if len(rows) != 0 {
-		t.Errorf("want no rows before any RPC, got %d", len(rows))
-	}
+	assert.Len(t, rows, 0)
 }
 
 func TestMetricsCSVRowPerRequest(t *testing.T) {
@@ -133,9 +129,7 @@ func TestMetricsCSVCapturesErrors(t *testing.T) {
 	s.closeMetrics()
 
 	_, rows := readMetricsCSV(t, csvPath)
-	if len(rows) != 1 {
-		t.Fatalf("rows: want 1, got %d", len(rows))
-	}
+	require.Len(t, rows, 1)
 	if rows[0][1] != "BogusMethodThatDoesNotExist" {
 		t.Errorf("method: %q", rows[0][1])
 	}
@@ -174,9 +168,7 @@ func TestMetricsCSVConcurrentLoad(t *testing.T) {
 	s.closeMetrics()
 
 	_, rows := readMetricsCSV(t, csvPath)
-	if len(rows) != total {
-		t.Fatalf("rows: want %d, got %d", total, len(rows))
-	}
+	require.Len(t, rows, total)
 	// Every row must have 9 columns and a parseable timestamp+duration.
 	// If writes interleaved, csv.NewReader.ReadAll above would fail or
 	// produce malformed rows; we re-validate here in case ReadAll silently
@@ -206,7 +198,5 @@ func TestMetricsCSVDisabledWhenFlagEmpty(t *testing.T) {
 
 	// Should be a no-op; if writer-or-file leaks it would panic on close.
 	s.safeHandleRequest(&jsonRPCRequest{JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "GetLanguages"})
-	if s.metricsWriter != nil || s.metricsFile != nil {
-		t.Errorf("metrics writer should be nil when flag empty (writer=%v file=%v)", s.metricsWriter, s.metricsFile)
-	}
+	assert.False(t, s.metricsWriter != nil || s.metricsFile != nil)
 }

--- a/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -50,7 +52,7 @@ func TestParseProjectExcludesGitIgnored(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -65,14 +67,10 @@ func TestParseProjectExcludesGitIgnored(t *testing.T) {
 		}
 	}
 	for _, want := range []string{"probe.go", "pkg/build/legit.go"} {
-		if !parsed[want] {
-			t.Errorf("expected %q to be parsed, but it was not", want)
-		}
+		assert.Truef(t,parsed[want], "expected %q to be parsed, but it was not", want)
 	}
 	for _, unwanted := range []string{"build/generated/rootbuild.go", "sub/build/generated/subbuild.go"} {
-		if parsed[unwanted] {
-			t.Errorf("expected gitignored %q to be excluded, but it was parsed", unwanted)
-		}
+		assert.Falsef(t, parsed[unwanted], "expected gitignored %q to be excluded, but it was parsed", unwanted)
 	}
 }
 

--- a/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 )
 
@@ -48,9 +50,7 @@ func TestParseProjectExcludesGitIgnored(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {

--- a/rewrite-go/cmd/rpc/parse_project_resolve_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_resolve_test.go
@@ -47,7 +47,7 @@ func TestParseProjectResolvesModuleGraph(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -63,10 +63,8 @@ func TestParseProjectResolvesModuleGraph(t *testing.T) {
 			main = &mrr.ResolvedDependencies[i]
 		}
 	}
-	if main == nil {
-		t.Fatalf("main module missing from resolved build list: %+v", mrr.ResolvedDependencies)
-	}
-	assert.True(t, main.Main)
+	require.NotNilf(t, main, "main module missing from resolved build list: %+v", mrr.ResolvedDependencies)
+	assert.True(t, main.Main, "main module should have Main=true")
 
 	var sawStdlib, sawMainPkg bool
 	for _, p := range mrr.PackageModules {
@@ -77,12 +75,8 @@ func TestParseProjectResolvesModuleGraph(t *testing.T) {
 			sawMainPkg = true
 		}
 	}
-	if !sawStdlib {
-		t.Errorf("expected stdlib package fmt (Standard) in PackageModules: %+v", mrr.PackageModules)
-	}
-	if !sawMainPkg {
-		t.Errorf("expected the main package mapped to its module in PackageModules: %+v", mrr.PackageModules)
-	}
+	assert.Truef(t, sawStdlib, "expected stdlib package fmt (Standard) in PackageModules: %+v", mrr.PackageModules)
+	assert.Truef(t, sawMainPkg, "expected the main package mapped to its module in PackageModules: %+v", mrr.PackageModules)
 }
 
 func TestParseProjectResolvesTestOnlyDependency(t *testing.T) {
@@ -105,7 +99,7 @@ func TestParseProjectResolvesTestOnlyDependency(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -121,9 +115,7 @@ func TestParseProjectResolvesTestOnlyDependency(t *testing.T) {
 			sawTestDep = true
 		}
 	}
-	if !sawTestDep {
-		t.Errorf("expected test-only dependency example.com/bar in PackageModules: %+v", mrr.PackageModules)
-	}
+	assert.Truef(t, sawTestDep, "expected test-only dependency example.com/bar in PackageModules: %+v", mrr.PackageModules)
 }
 
 func findGoResolutionResult(t *testing.T, s *server) golang.GoResolutionResult {

--- a/rewrite-go/cmd/rpc/parse_project_resolve_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_resolve_test.go
@@ -22,6 +22,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 )
 
@@ -43,9 +47,7 @@ func TestParseProjectResolvesModuleGraph(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -64,9 +66,7 @@ func TestParseProjectResolvesModuleGraph(t *testing.T) {
 	if main == nil {
 		t.Fatalf("main module missing from resolved build list: %+v", mrr.ResolvedDependencies)
 	}
-	if !main.Main {
-		t.Errorf("main module should have Main=true: %+v", main)
-	}
+	assert.True(t, main.Main)
 
 	var sawStdlib, sawMainPkg bool
 	for _, p := range mrr.PackageModules {
@@ -105,9 +105,7 @@ func TestParseProjectResolvesTestOnlyDependency(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {

--- a/rewrite-go/cmd/rpc/parse_project_test_files_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_test_files_test.go
@@ -20,6 +20,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
@@ -49,9 +53,7 @@ func TestParseProjectParsesTestFiles(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	if err != nil {
-		t.Fatalf("marshal params: %v", err)
-	}
+	require.NoError(t, err)
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -75,9 +77,7 @@ func TestParseProjectParsesTestFiles(t *testing.T) {
 	// holds if the file was type-checked as its own `foo_test` package rather
 	// than lumped in with the co-located `package foo` sources.
 	blackBox := cusByPath["foo/foo_test.go"]
-	if blackBox == nil {
-		t.Fatal("black-box test CU missing; cannot check attribution")
-	}
+	require.NotNil(t, blackBox)
 	var attributed bool
 	visitor.Walk(blackBox, func(tr java.Tree) bool {
 		if mi, ok := tr.(*java.MethodInvocation); ok && mi.Name != nil &&
@@ -87,7 +87,5 @@ func TestParseProjectParsesTestFiles(t *testing.T) {
 		}
 		return true
 	})
-	if !attributed {
-		t.Error("expected helper() in the black-box test package to be type-attributed")
-	}
+	assert.True(t, attributed)
 }

--- a/rewrite-go/cmd/rpc/parse_project_test_files_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_test_files_test.go
@@ -53,7 +53,7 @@ func TestParseProjectParsesTestFiles(t *testing.T) {
 
 	relativeTo := projectDir
 	params, err := json.Marshal(parseProjectRequest{ProjectPath: projectDir, RelativeTo: &relativeTo})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal params")
 
 	// when
 	if _, rpcErr := s.handleParseProject(params); rpcErr != nil {
@@ -77,7 +77,7 @@ func TestParseProjectParsesTestFiles(t *testing.T) {
 	// holds if the file was type-checked as its own `foo_test` package rather
 	// than lumped in with the co-located `package foo` sources.
 	blackBox := cusByPath["foo/foo_test.go"]
-	require.NotNil(t, blackBox)
+	require.NotNil(t, blackBox, "black-box test CU missing; cannot check attribution")
 	var attributed bool
 	visitor.Walk(blackBox, func(tr java.Tree) bool {
 		if mi, ok := tr.(*java.MethodInvocation); ok && mi.Name != nil &&
@@ -87,5 +87,5 @@ func TestParseProjectParsesTestFiles(t *testing.T) {
 		}
 		return true
 	})
-	assert.True(t, attributed)
+	assert.True(t, attributed, "expected helper() in the black-box test package to be type-attributed")
 }

--- a/rewrite-go/cmd/rpc/prepare_recipe_test.go
+++ b/rewrite-go/cmd/rpc/prepare_recipe_test.go
@@ -23,22 +23,24 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 )
 
 func prepareRecipe(t *testing.T, s *server, id string) string {
 	t.Helper()
 	params, err := json.Marshal(prepareRecipeRequest{ID: id})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal prepare request")
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "handlePrepareRecipe returned error")
 	return resp.(prepareRecipeResponse).ID
 }
 
 func visit(t *testing.T, s *server, visitor string) (any, *rpcError) {
 	t.Helper()
 	params, err := json.Marshal(visitRequest{Visitor: visitor, TreeID: "tree-1", SourceFileType: "Go"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal visit request")
 	return s.handleVisit(params)
 }
 
@@ -63,14 +65,8 @@ func TestVisitMetadataOnlyRecipeFailsLoudly(t *testing.T) {
 		resp, rpcErr := visit(t, s, phase+":"+recipeID)
 
 		// then
-		if rpcErr == nil {
-			t.Fatalf("%s: expected an rpcError, got success response %+v", phase, resp)
-		}
-		if !strings.Contains(rpcErr.Message, recipeName) {
-			t.Errorf("%s: error message %q does not name the recipe %q", phase, rpcErr.Message, recipeName)
-		}
-		if !strings.Contains(rpcErr.Message, "stale or missing") {
-			t.Errorf("%s: error message %q does not explain the stale/missing binary cause", phase, rpcErr.Message)
-		}
+		require.NotNilf(t, rpcErr, "%s: expected an rpcError, got success response %+v", phase, resp)
+		assert.Truef(t, strings.Contains(rpcErr.Message, recipeName), "%s: error message %q does not name the recipe", phase, rpcErr.Message)
+		assert.Truef(t, strings.Contains(rpcErr.Message, "stale or missing"), "%s: error message %q does not explain the stale/missing binary cause", phase, rpcErr.Message)
 	}
 }

--- a/rewrite-go/cmd/rpc/prepare_recipe_test.go
+++ b/rewrite-go/cmd/rpc/prepare_recipe_test.go
@@ -21,28 +21,24 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 )
 
 func prepareRecipe(t *testing.T, s *server, id string) string {
 	t.Helper()
 	params, err := json.Marshal(prepareRecipeRequest{ID: id})
-	if err != nil {
-		t.Fatalf("marshal prepare request: %v", err)
-	}
+	require.NoError(t, err)
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	if rpcErr != nil {
-		t.Fatalf("handlePrepareRecipe returned error: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	return resp.(prepareRecipeResponse).ID
 }
 
 func visit(t *testing.T, s *server, visitor string) (any, *rpcError) {
 	t.Helper()
 	params, err := json.Marshal(visitRequest{Visitor: visitor, TreeID: "tree-1", SourceFileType: "Go"})
-	if err != nil {
-		t.Fatalf("marshal visit request: %v", err)
-	}
+	require.NoError(t, err)
 	return s.handleVisit(params)
 }
 

--- a/rewrite-go/cmd/rpc/receive_resilience_test.go
+++ b/rewrite-go/cmd/rpc/receive_resilience_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
+	"github.com/stretchr/testify/require"
 )
 
 // frameReverseGetObjectReply renders one Content-Length framed JSON-RPC
@@ -35,9 +36,7 @@ func frameReverseGetObjectReply(t *testing.T, result any) []byte {
 		"id":      "go-GetObject",
 		"result":  result,
 	})
-	if err != nil {
-		t.Fatalf("marshal reply: %v", err)
-	}
+	require.NoError(t, err)
 	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))), body...)
 }
 
@@ -88,9 +87,7 @@ func TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs(t *testing.T) {
 		s.getObjectFromJava(id, "")
 		return false
 	}()
-	if !panicked {
-		t.Fatal("transfer 1: expected a panic mid-receive, got none")
-	}
+	require.True(t, panicked)
 
 	// Containment: the diverged per-id baseline is dropped.
 	if v, ok := s.reverseRemoteObjects[id]; ok {

--- a/rewrite-go/cmd/rpc/receive_resilience_test.go
+++ b/rewrite-go/cmd/rpc/receive_resilience_test.go
@@ -36,7 +36,7 @@ func frameReverseGetObjectReply(t *testing.T, result any) []byte {
 		"id":      "go-GetObject",
 		"result":  result,
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal reply")
 	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))), body...)
 }
 
@@ -87,7 +87,7 @@ func TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs(t *testing.T) {
 		s.getObjectFromJava(id, "")
 		return false
 	}()
-	require.True(t, panicked)
+	require.True(t, panicked, "transfer 1: expected a panic mid-receive, got none")
 
 	// Containment: the diverged per-id baseline is dropped.
 	if v, ok := s.reverseRemoteObjects[id]; ok {

--- a/rewrite-go/cmd/rpc/set_data_table_store_test.go
+++ b/rewrite-go/cmd/rpc/set_data_table_store_test.go
@@ -49,12 +49,8 @@ func TestParseOrderedColumnsPreservesOrder(t *testing.T) {
 func TestParseOrderedColumnsEmptyAndNull(t *testing.T) {
 	for _, raw := range []json.RawMessage{nil, json.RawMessage("null"), json.RawMessage("{}")} {
 		cols, err := parseOrderedColumns(raw)
-		if err != nil {
-			t.Fatalf("unexpected error for %q: %v", string(raw), err)
-		}
-		if len(cols) != 0 {
-			t.Errorf("expected no columns for %q, got %+v", string(raw), cols)
-		}
+		require.NoErrorf(t, err, "unexpected error for %q", string(raw))
+		assert.Lenf(t, cols, 0, "expected no columns for %q", string(raw))
 	}
 }
 
@@ -90,10 +86,8 @@ func TestParseSetDataTableStoreSelectsVariantByKind(t *testing.T) {
 		`{"kind":"CSV","outputDir":"/tmp/dt","prefixColumns":{"repositoryOrigin":"acme"}}`))
 	require.NoError(t, err)
 	c, ok := csv.(*csvDataTableStore)
-	if !ok {
-		t.Fatalf("CSV: expected *csvDataTableStore, got %T", csv)
-	}
-	assert.Equal(t, "/tmp/dt", c.OutputDir)
+	require.Truef(t, ok, "CSV: expected *csvDataTableStore, got %T", csv)
+	assert.Equalf(t, "/tmp/dt", c.OutputDir, "OutputDir = %q, want /tmp/dt", c.OutputDir)
 
 	noop, err := parseSetDataTableStore(json.RawMessage(`{"kind":"NOOP"}`))
 	require.NoError(t, err)
@@ -108,7 +102,7 @@ func TestHandleSetDataTableStoreInstallsConfiguredStore(t *testing.T) {
 
 	params, _ := json.Marshal(map[string]string{"kind": "CSV", "outputDir": dir})
 	result, rpcErr := s.handleSetDataTableStore(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "unexpected rpc error")
 	if result != true {
 		t.Errorf("expected result true, got %v", result)
 	}
@@ -119,7 +113,7 @@ func TestHandleSetDataTableStoreInstallsConfiguredStore(t *testing.T) {
 	ctx := recipe.NewExecutionContext()
 	s.installDataTableStore(ctx)
 	installed, ok := ctx.GetMessage(recipe.DataTableStoreKey)
-	require.True(t, ok)
+	require.True(t, ok, "expected a store installed on the ctx")
 	if installed != s.configuredDataTableStore {
 		t.Errorf("installed store %p != configured store %p", installed, s.configuredDataTableStore)
 	}

--- a/rewrite-go/cmd/rpc/set_data_table_store_test.go
+++ b/rewrite-go/cmd/rpc/set_data_table_store_test.go
@@ -20,15 +20,17 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 )
 
 func TestParseOrderedColumnsPreservesOrder(t *testing.T) {
 	raw := json.RawMessage(`{"zeta":"1","alpha":"2","mike":"3"}`)
 	cols, err := parseOrderedColumns(raw)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	want := []recipe.ColumnValue{
 		{Name: "zeta", Value: "1"},
 		{Name: "alpha", Value: "2"},
@@ -65,25 +67,19 @@ func TestToDataTableStoreKinds(t *testing.T) {
 		SuffixColumns: json.RawMessage(`{"organization":"acme"}`),
 	}
 	store, err := csv.toDataTableStore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if _, ok := store.(*recipe.CsvDataTableStore); !ok {
 		t.Fatalf("CSV kind: expected *CsvDataTableStore, got %T", store)
 	}
 
 	store, err = (noOpDataTableStore{}).toDataTableStore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if _, ok := store.(*recipe.InMemoryDataTableStore); !ok {
 		t.Fatalf("NOOP kind: expected *InMemoryDataTableStore, got %T", store)
 	}
 
 	store, err = (&csvDataTableStore{}).toDataTableStore()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if _, ok := store.(*recipe.InMemoryDataTableStore); !ok {
 		t.Fatalf("under-specified CSV: expected *InMemoryDataTableStore, got %T", store)
 	}
@@ -92,21 +88,15 @@ func TestToDataTableStoreKinds(t *testing.T) {
 func TestParseSetDataTableStoreSelectsVariantByKind(t *testing.T) {
 	csv, err := parseSetDataTableStore(json.RawMessage(
 		`{"kind":"CSV","outputDir":"/tmp/dt","prefixColumns":{"repositoryOrigin":"acme"}}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	c, ok := csv.(*csvDataTableStore)
 	if !ok {
 		t.Fatalf("CSV: expected *csvDataTableStore, got %T", csv)
 	}
-	if c.OutputDir != "/tmp/dt" {
-		t.Errorf("OutputDir = %q, want /tmp/dt", c.OutputDir)
-	}
+	assert.Equal(t, "/tmp/dt", c.OutputDir)
 
 	noop, err := parseSetDataTableStore(json.RawMessage(`{"kind":"NOOP"}`))
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if _, ok := noop.(noOpDataTableStore); !ok {
 		t.Fatalf("NOOP: expected noOpDataTableStore, got %T", noop)
 	}
@@ -118,9 +108,7 @@ func TestHandleSetDataTableStoreInstallsConfiguredStore(t *testing.T) {
 
 	params, _ := json.Marshal(map[string]string{"kind": "CSV", "outputDir": dir})
 	result, rpcErr := s.handleSetDataTableStore(params)
-	if rpcErr != nil {
-		t.Fatalf("unexpected rpc error: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 	if result != true {
 		t.Errorf("expected result true, got %v", result)
 	}
@@ -131,9 +119,7 @@ func TestHandleSetDataTableStoreInstallsConfiguredStore(t *testing.T) {
 	ctx := recipe.NewExecutionContext()
 	s.installDataTableStore(ctx)
 	installed, ok := ctx.GetMessage(recipe.DataTableStoreKey)
-	if !ok {
-		t.Fatal("expected a store installed on the ctx")
-	}
+	require.True(t, ok)
 	if installed != s.configuredDataTableStore {
 		t.Errorf("installed store %p != configured store %p", installed, s.configuredDataTableStore)
 	}

--- a/rewrite-go/cmd/rpc/whole_tree_test.go
+++ b/rewrite-go/cmd/rpc/whole_tree_test.go
@@ -66,7 +66,7 @@ func (*goCompositeInvalidChild) RecipeList() []recipe.Recipe {
 func prepareErr(t *testing.T, s *server, id string) *rpcError {
 	t.Helper()
 	params, err := json.Marshal(prepareRecipeRequest{ID: id})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal prepare request")
 	_, rpcErr := s.handlePrepareRecipe(params)
 	return rpcErr
 }
@@ -77,8 +77,8 @@ func TestPrepareRecipeRejectsMissingRequiredOption(t *testing.T) {
 
 	rpcErr := prepareErr(t, s, "org.openrewrite.go.test.RequiresOpt")
 
-	require.NotNil(t, rpcErr)
-	assert.False(t, !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text"))
+	require.NotNil(t, rpcErr, "expected a missing-required-option error, got success")
+	assert.Falsef(t, !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text"), "error %q does not report the missing `text` option", rpcErr.Message)
 }
 
 // Validation recurses through the whole prepared tree (like the C#, JS, and Python servers).
@@ -88,8 +88,8 @@ func TestPrepareRecipeValidatesChildRequiredOptions(t *testing.T) {
 
 	rpcErr := prepareErr(t, s, "org.openrewrite.go.test.CompositeInvalid")
 
-	require.NotNil(t, rpcErr)
-	assert.False(t, !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text"))
+	require.NotNil(t, rpcErr, "expected a missing-required-option error for the child, got success")
+	assert.Falsef(t, !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text"), "error %q does not report the child's missing `text` option", rpcErr.Message)
 }
 
 func TestPrepareRecipeReturnsWholeChildTree(t *testing.T) {
@@ -97,12 +97,12 @@ func TestPrepareRecipeReturnsWholeChildTree(t *testing.T) {
 	s.registry.Register(&goCompositeRecipe{})
 
 	params, err := json.Marshal(prepareRecipeRequest{ID: "org.openrewrite.go.test.Composite"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal prepare request")
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "handlePrepareRecipe error")
 
 	pr := resp.(prepareRecipeResponse)
-	require.Len(t, pr.RecipeList, 1)
+	require.Len(t, pr.RecipeList, 1, "expected 1 prepared child")
 	if got := pr.RecipeList[0].Descriptor.Name; got != "org.openrewrite.go.test.Leaf" {
 		t.Errorf("expected child Leaf, got %q", got)
 	}
@@ -143,12 +143,12 @@ func TestPrepareRecipeSameTypeChildrenPreserveDistinctOptions(t *testing.T) {
 	s.registry.Register(&goCompositeSameType{})
 
 	params, err := json.Marshal(prepareRecipeRequest{ID: "org.openrewrite.go.test.CompositeSameType"})
-	require.NoError(t, err)
+	require.NoError(t, err, "marshal prepare request")
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	require.Nil(t, rpcErr)
+	require.Nil(t, rpcErr, "handlePrepareRecipe error")
 
 	pr := resp.(prepareRecipeResponse)
-	require.Len(t, pr.RecipeList, 3)
+	require.Len(t, pr.RecipeList, 3, "expected 3 prepared children")
 
 	ids := map[string]bool{}
 	var texts []any
@@ -165,8 +165,8 @@ func TestPrepareRecipeSameTypeChildrenPreserveDistinctOptions(t *testing.T) {
 	}
 
 	// Each child is prepared as its own instance (distinct id)...
-	assert.Len(t, ids, 3)
+	assert.Len(t, ids, 3, "expected 3 distinct child ids")
 	// ...retaining its own distinct option value, in the order the composite declared them.
 	want := []any{"a", "b", "c"}
-	assert.True(t, reflect.DeepEqual(texts, want))
+	assert.True(t, reflect.DeepEqual(texts, want), "expected child option values")
 }

--- a/rewrite-go/cmd/rpc/whole_tree_test.go
+++ b/rewrite-go/cmd/rpc/whole_tree_test.go
@@ -22,6 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 )
 
@@ -62,9 +66,7 @@ func (*goCompositeInvalidChild) RecipeList() []recipe.Recipe {
 func prepareErr(t *testing.T, s *server, id string) *rpcError {
 	t.Helper()
 	params, err := json.Marshal(prepareRecipeRequest{ID: id})
-	if err != nil {
-		t.Fatalf("marshal prepare request: %v", err)
-	}
+	require.NoError(t, err)
 	_, rpcErr := s.handlePrepareRecipe(params)
 	return rpcErr
 }
@@ -75,12 +77,8 @@ func TestPrepareRecipeRejectsMissingRequiredOption(t *testing.T) {
 
 	rpcErr := prepareErr(t, s, "org.openrewrite.go.test.RequiresOpt")
 
-	if rpcErr == nil {
-		t.Fatal("expected a missing-required-option error, got success")
-	}
-	if !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text") {
-		t.Errorf("error %q does not report the missing `text` option", rpcErr.Message)
-	}
+	require.NotNil(t, rpcErr)
+	assert.False(t, !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text"))
 }
 
 // Validation recurses through the whole prepared tree (like the C#, JS, and Python servers).
@@ -90,12 +88,8 @@ func TestPrepareRecipeValidatesChildRequiredOptions(t *testing.T) {
 
 	rpcErr := prepareErr(t, s, "org.openrewrite.go.test.CompositeInvalid")
 
-	if rpcErr == nil {
-		t.Fatal("expected a missing-required-option error for the child, got success")
-	}
-	if !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text") {
-		t.Errorf("error %q does not report the child's missing `text` option", rpcErr.Message)
-	}
+	require.NotNil(t, rpcErr)
+	assert.False(t, !strings.Contains(rpcErr.Message, "Missing required option") || !strings.Contains(rpcErr.Message, "text"))
 }
 
 func TestPrepareRecipeReturnsWholeChildTree(t *testing.T) {
@@ -103,18 +97,12 @@ func TestPrepareRecipeReturnsWholeChildTree(t *testing.T) {
 	s.registry.Register(&goCompositeRecipe{})
 
 	params, err := json.Marshal(prepareRecipeRequest{ID: "org.openrewrite.go.test.Composite"})
-	if err != nil {
-		t.Fatalf("marshal prepare request: %v", err)
-	}
+	require.NoError(t, err)
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	if rpcErr != nil {
-		t.Fatalf("handlePrepareRecipe error: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 
 	pr := resp.(prepareRecipeResponse)
-	if len(pr.RecipeList) != 1 {
-		t.Fatalf("expected 1 prepared child, got %d: %+v", len(pr.RecipeList), pr.RecipeList)
-	}
+	require.Len(t, pr.RecipeList, 1)
 	if got := pr.RecipeList[0].Descriptor.Name; got != "org.openrewrite.go.test.Leaf" {
 		t.Errorf("expected child Leaf, got %q", got)
 	}
@@ -155,18 +143,12 @@ func TestPrepareRecipeSameTypeChildrenPreserveDistinctOptions(t *testing.T) {
 	s.registry.Register(&goCompositeSameType{})
 
 	params, err := json.Marshal(prepareRecipeRequest{ID: "org.openrewrite.go.test.CompositeSameType"})
-	if err != nil {
-		t.Fatalf("marshal prepare request: %v", err)
-	}
+	require.NoError(t, err)
 	resp, rpcErr := s.handlePrepareRecipe(params)
-	if rpcErr != nil {
-		t.Fatalf("handlePrepareRecipe error: %+v", rpcErr)
-	}
+	require.Nil(t, rpcErr)
 
 	pr := resp.(prepareRecipeResponse)
-	if len(pr.RecipeList) != 3 {
-		t.Fatalf("expected 3 prepared children, got %d", len(pr.RecipeList))
-	}
+	require.Len(t, pr.RecipeList, 3)
 
 	ids := map[string]bool{}
 	var texts []any
@@ -183,12 +165,8 @@ func TestPrepareRecipeSameTypeChildrenPreserveDistinctOptions(t *testing.T) {
 	}
 
 	// Each child is prepared as its own instance (distinct id)...
-	if len(ids) != 3 {
-		t.Errorf("expected 3 distinct child ids, got %d", len(ids))
-	}
+	assert.Len(t, ids, 3)
 	// ...retaining its own distinct option value, in the order the composite declared them.
 	want := []any{"a", "b", "c"}
-	if !reflect.DeepEqual(texts, want) {
-		t.Errorf("expected child option values %v, got %v", want, texts)
-	}
+	assert.True(t, reflect.DeepEqual(texts, want))
 }

--- a/rewrite-go/go.mod
+++ b/rewrite-go/go.mod
@@ -5,10 +5,16 @@ go 1.25.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/grafana/pyroscope-go v1.2.8
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/mod v0.35.0
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // indirect
 	github.com/klauspost/compress v1.17.8 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/rogpeppe/go-internal v1.16.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/rewrite-go/go.sum
+++ b/rewrite-go/go.sum
@@ -1,3 +1,4 @@
+github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -8,13 +9,22 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.9 h1:c1Us8i6eSmkW+Ez05d3co8kasn
 github.com/grafana/pyroscope-go/godeltaprof v0.1.9/go.mod h1:2+l7K7twW49Ct4wFluZD3tZ6e0SjanjcUUBPVD/UuGU=
 github.com/klauspost/compress v1.17.8 h1:YcnTYrq7MikUT7k0Yb5eceMmALQPYBW/Xltxn0NAMnU=
 github.com/klauspost/compress v1.17.8/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.16.0 h1:O9DK+vNMDVGLr2BeZqmpLeMjiMNkuXfcqntWbZV6S5g=
+github.com/rogpeppe/go-internal v1.16.0/go.mod h1:DrUVZyrJU+txYW5/1kwtXQSMFio52ZOxX7yM1VHvnxs=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/rewrite-go/pkg/matcher/matcher_test.go
+++ b/rewrite-go/pkg/matcher/matcher_test.go
@@ -19,6 +19,10 @@ package matcher
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
@@ -47,12 +51,8 @@ func TestGetFullyQualifiedName(t *testing.T) {
 
 func TestIsOfClassType(t *testing.T) {
 	cls := &java.JavaTypeClass{FullyQualifiedName: "time.Time"}
-	if !IsOfClassType(cls, "time.Time") {
-		t.Error("expected true for exact match")
-	}
-	if IsOfClassType(cls, "time.Duration") {
-		t.Error("expected false for different type")
-	}
+	assert.True(t, IsOfClassType(cls, "time.Time"))
+	assert.False(t, IsOfClassType(cls, "time.Duration"))
 }
 
 func TestIsAssignableTo(t *testing.T) {
@@ -62,34 +62,20 @@ func TestIsAssignableTo(t *testing.T) {
 		Interfaces:         []java.FullyQualified{stringer},
 	}
 
-	if !IsAssignableTo(myType, "main.MyType") {
-		t.Error("type should be assignable to itself")
-	}
-	if !IsAssignableTo(myType, "fmt.Stringer") {
-		t.Error("type should be assignable to its interface")
-	}
-	if IsAssignableTo(myType, "io.Reader") {
-		t.Error("type should not be assignable to unrelated interface")
-	}
+	assert.True(t, IsAssignableTo(myType, "main.MyType"))
+	assert.True(t, IsAssignableTo(myType, "fmt.Stringer"))
+	assert.False(t, IsAssignableTo(myType, "io.Reader"))
 }
 
 func TestIsError(t *testing.T) {
 	errType := &java.JavaTypeClass{FullyQualifiedName: "error"}
-	if !IsError(errType) {
-		t.Error("expected true for error type")
-	}
-	if IsError(&java.JavaTypeClass{FullyQualifiedName: "string"}) {
-		t.Error("expected false for non-error type")
-	}
+	assert.True(t, IsError(errType))
+	assert.False(t, IsError(&java.JavaTypeClass{FullyQualifiedName: "string"}))
 }
 
 func TestIsString(t *testing.T) {
-	if !IsString(&java.JavaTypePrimitive{Keyword: "String"}) {
-		t.Error("expected true for String primitive")
-	}
-	if IsString(&java.JavaTypePrimitive{Keyword: "int"}) {
-		t.Error("expected false for int")
-	}
+	assert.True(t, IsString(&java.JavaTypePrimitive{Keyword: "String"}))
+	assert.False(t, IsString(&java.JavaTypePrimitive{Keyword: "int"}))
 }
 
 func TestIsInt(t *testing.T) {
@@ -107,9 +93,7 @@ func TestIsInt(t *testing.T) {
 		&java.JavaTypeClass{FullyQualifiedName: "uintptr"},
 	}
 	for _, typ := range intLike {
-		if !IsInt(typ) {
-			t.Errorf("IsInt(%q) = false, want true", GetFullyQualifiedName(typ))
-		}
+		assert.True(t, IsInt(typ))
 	}
 	notInt := []java.JavaType{
 		&java.JavaTypePrimitive{Keyword: "double"},
@@ -118,9 +102,7 @@ func TestIsInt(t *testing.T) {
 		nil,
 	}
 	for _, typ := range notInt {
-		if IsInt(typ) {
-			t.Errorf("IsInt(%q) = true, want false", GetFullyQualifiedName(typ))
-		}
+		assert.False(t, IsInt(typ))
 	}
 }
 
@@ -143,16 +125,10 @@ func TestIsNumeric(t *testing.T) {
 		&java.JavaTypeClass{FullyQualifiedName: "uintptr"},
 	}
 	for _, typ := range numeric {
-		if !IsNumeric(typ) {
-			t.Errorf("IsNumeric(%q) = false, want true", GetFullyQualifiedName(typ))
-		}
+		assert.True(t, IsNumeric(typ))
 	}
-	if IsNumeric(&java.JavaTypePrimitive{Keyword: "String"}) {
-		t.Error("IsNumeric(String) = true, want false")
-	}
-	if IsNumeric(nil) {
-		t.Error("IsNumeric(nil) = true, want false")
-	}
+	assert.False(t, IsNumeric(&java.JavaTypePrimitive{Keyword: "String"}))
+	assert.False(t, IsNumeric(nil))
 }
 
 // Pattern type names must resolve to the same signature the type mapper
@@ -180,9 +156,7 @@ func TestAsClass(t *testing.T) {
 	if AsClass(param) != cls {
 		t.Error("AsClass should unwrap parameterized types")
 	}
-	if AsClass(&java.JavaTypePrimitive{Keyword: "int"}) != nil {
-		t.Error("AsClass should return nil for non-class types")
-	}
+	assert.Nil(t, AsClass(&java.JavaTypePrimitive{Keyword: "int"}))
 }
 
 func TestGlobToRegexp(t *testing.T) {
@@ -208,23 +182,15 @@ func TestGlobToRegexp(t *testing.T) {
 	for _, tt := range tests {
 		re := globToRegexp(tt.pattern)
 		got := re.MatchString(tt.input)
-		if got != tt.want {
-			t.Errorf("globToRegexp(%q).MatchString(%q) = %v, want %v", tt.pattern, tt.input, got, tt.want)
-		}
+		assert.Equal(t, tt.want, got)
 	}
 }
 
 func TestMethodMatcherParsing(t *testing.T) {
 	mm := NewMethodMatcher("fmt Sprintf(string, ..)")
-	if mm.declaringTypePattern == nil {
-		t.Fatal("expected declaringTypePattern")
-	}
-	if mm.methodNamePattern == nil {
-		t.Fatal("expected methodNamePattern")
-	}
-	if !mm.matchesAnyArgs {
-		t.Error("expected matchesAnyArgs for .. pattern")
-	}
+	require.NotNil(t, mm.declaringTypePattern)
+	require.NotNil(t, mm.methodNamePattern)
+	assert.True(t, mm.matchesAnyArgs)
 }
 
 func TestMethodMatcherMatchesAnyArgs(t *testing.T) {
@@ -235,9 +201,7 @@ func TestMethodMatcherMatchesAnyArgs(t *testing.T) {
 		},
 		Name: &java.Identifier{Name: "Println"},
 	}
-	if !mm.Matches(mi) {
-		t.Error("expected match for fmt.Println with any args")
-	}
+	assert.True(t, mm.Matches(mi))
 }
 
 func TestMethodMatcherNoMatchWrongName(t *testing.T) {
@@ -248,9 +212,7 @@ func TestMethodMatcherNoMatchWrongName(t *testing.T) {
 		},
 		Name: &java.Identifier{Name: "Sprintf"},
 	}
-	if mm.Matches(mi) {
-		t.Error("expected no match for wrong method name")
-	}
+	assert.False(t, mm.Matches(mi))
 }
 
 func TestMethodMatcherNoMatchWrongPackage(t *testing.T) {
@@ -261,9 +223,7 @@ func TestMethodMatcherNoMatchWrongPackage(t *testing.T) {
 		},
 		Name: &java.Identifier{Name: "Println"},
 	}
-	if mm.Matches(mi) {
-		t.Error("expected no match for wrong package")
-	}
+	assert.False(t, mm.Matches(mi))
 }
 
 func TestMethodMatcherWildcardType(t *testing.T) {
@@ -276,9 +236,7 @@ func TestMethodMatcherWildcardType(t *testing.T) {
 	}
 	// With just an identifier "t" as select, DeclaringTypeFQN returns "t"
 	// which matches "*" pattern
-	if !mm.Matches(mi) {
-		t.Error("expected match for wildcard declaring type")
-	}
+	assert.True(t, mm.Matches(mi))
 }
 
 func TestMethodMatcherWithTypeInfo(t *testing.T) {
@@ -294,9 +252,7 @@ func TestMethodMatcherWithTypeInfo(t *testing.T) {
 			Name:          "Sprintf",
 		},
 	}
-	if !mm.Matches(mi) {
-		t.Error("expected match with type info")
-	}
+	assert.True(t, mm.Matches(mi))
 }
 
 func TestMethodMatcherMatchesMethod(t *testing.T) {
@@ -305,9 +261,7 @@ func TestMethodMatcherMatchesMethod(t *testing.T) {
 		DeclaringType: &java.JavaTypeClass{FullyQualifiedName: "time.Time"},
 		Name:          "Sub",
 	}
-	if !mm.MatchesMethod(mt) {
-		t.Error("expected match for time.Time Sub(..)")
-	}
+	assert.True(t, mm.MatchesMethod(mt))
 }
 
 func TestMethodMatcherOnParsedCode(t *testing.T) {
@@ -321,9 +275,7 @@ func main() {
 	fmt.Sprintf("%d", 42)
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	printlnMatcher := NewMethodMatcher("fmt Println(..)")
 	sprintfMatcher := NewMethodMatcher("fmt Sprintf(..)")
@@ -341,12 +293,8 @@ func main() {
 	})
 	v.Visit(cu, nil)
 
-	if printlnCount != 1 {
-		t.Errorf("expected 1 Println match, got %d", printlnCount)
-	}
-	if sprintfCount != 1 {
-		t.Errorf("expected 1 Sprintf match, got %d", sprintfCount)
-	}
+	assert.Equal(t, 1, printlnCount)
+	assert.Equal(t, 1, sprintfCount)
 }
 
 func TestMethodMatcherNoMatchOnParsedCode(t *testing.T) {
@@ -359,9 +307,7 @@ func main() {
 	log.Println("hello")
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	fmtPrintln := NewMethodMatcher("fmt Println(..)")
 
@@ -372,9 +318,7 @@ func main() {
 	})
 	v.Visit(cu, nil)
 
-	if count != 0 {
-		t.Errorf("expected 0 matches for fmt.Println in log code, got %d", count)
-	}
+	assert.Equal(t, 0, count)
 }
 
 // Test helper visitor that counts method matcher hits.

--- a/rewrite-go/pkg/matcher/matcher_test.go
+++ b/rewrite-go/pkg/matcher/matcher_test.go
@@ -51,8 +51,8 @@ func TestGetFullyQualifiedName(t *testing.T) {
 
 func TestIsOfClassType(t *testing.T) {
 	cls := &java.JavaTypeClass{FullyQualifiedName: "time.Time"}
-	assert.True(t, IsOfClassType(cls, "time.Time"))
-	assert.False(t, IsOfClassType(cls, "time.Duration"))
+	assert.True(t, IsOfClassType(cls, "time.Time"), "expected true for exact match")
+	assert.False(t, IsOfClassType(cls, "time.Duration"), "expected false for different type")
 }
 
 func TestIsAssignableTo(t *testing.T) {
@@ -62,20 +62,20 @@ func TestIsAssignableTo(t *testing.T) {
 		Interfaces:         []java.FullyQualified{stringer},
 	}
 
-	assert.True(t, IsAssignableTo(myType, "main.MyType"))
-	assert.True(t, IsAssignableTo(myType, "fmt.Stringer"))
-	assert.False(t, IsAssignableTo(myType, "io.Reader"))
+	assert.True(t, IsAssignableTo(myType, "main.MyType"), "type should be assignable to itself")
+	assert.True(t, IsAssignableTo(myType, "fmt.Stringer"), "type should be assignable to its interface")
+	assert.False(t, IsAssignableTo(myType, "io.Reader"), "type should not be assignable to unrelated interface")
 }
 
 func TestIsError(t *testing.T) {
 	errType := &java.JavaTypeClass{FullyQualifiedName: "error"}
-	assert.True(t, IsError(errType))
-	assert.False(t, IsError(&java.JavaTypeClass{FullyQualifiedName: "string"}))
+	assert.True(t, IsError(errType), "expected true for error type")
+	assert.False(t, IsError(&java.JavaTypeClass{FullyQualifiedName: "string"}), "expected false for non-error type")
 }
 
 func TestIsString(t *testing.T) {
-	assert.True(t, IsString(&java.JavaTypePrimitive{Keyword: "String"}))
-	assert.False(t, IsString(&java.JavaTypePrimitive{Keyword: "int"}))
+	assert.True(t, IsString(&java.JavaTypePrimitive{Keyword: "String"}), "expected true for String primitive")
+	assert.False(t, IsString(&java.JavaTypePrimitive{Keyword: "int"}), "expected false for int")
 }
 
 func TestIsInt(t *testing.T) {
@@ -93,7 +93,7 @@ func TestIsInt(t *testing.T) {
 		&java.JavaTypeClass{FullyQualifiedName: "uintptr"},
 	}
 	for _, typ := range intLike {
-		assert.True(t, IsInt(typ))
+		assert.Truef(t, IsInt(typ), "IsInt(%q) = false, want true", GetFullyQualifiedName(typ))
 	}
 	notInt := []java.JavaType{
 		&java.JavaTypePrimitive{Keyword: "double"},
@@ -102,7 +102,7 @@ func TestIsInt(t *testing.T) {
 		nil,
 	}
 	for _, typ := range notInt {
-		assert.False(t, IsInt(typ))
+		assert.Falsef(t, IsInt(typ), "IsInt(%q) = true, want false", GetFullyQualifiedName(typ))
 	}
 }
 
@@ -125,10 +125,10 @@ func TestIsNumeric(t *testing.T) {
 		&java.JavaTypeClass{FullyQualifiedName: "uintptr"},
 	}
 	for _, typ := range numeric {
-		assert.True(t, IsNumeric(typ))
+		assert.Truef(t, IsNumeric(typ), "IsNumeric(%q) = false, want true", GetFullyQualifiedName(typ))
 	}
-	assert.False(t, IsNumeric(&java.JavaTypePrimitive{Keyword: "String"}))
-	assert.False(t, IsNumeric(nil))
+	assert.False(t, IsNumeric(&java.JavaTypePrimitive{Keyword: "String"}), "IsNumeric(String) = true, want false")
+	assert.False(t, IsNumeric(nil), "IsNumeric(nil) = true, want false")
 }
 
 // Pattern type names must resolve to the same signature the type mapper
@@ -156,7 +156,7 @@ func TestAsClass(t *testing.T) {
 	if AsClass(param) != cls {
 		t.Error("AsClass should unwrap parameterized types")
 	}
-	assert.Nil(t, AsClass(&java.JavaTypePrimitive{Keyword: "int"}))
+	assert.Nil(t, AsClass(&java.JavaTypePrimitive{Keyword: "int"}), "AsClass should return nil for non-class types")
 }
 
 func TestGlobToRegexp(t *testing.T) {
@@ -182,15 +182,15 @@ func TestGlobToRegexp(t *testing.T) {
 	for _, tt := range tests {
 		re := globToRegexp(tt.pattern)
 		got := re.MatchString(tt.input)
-		assert.Equal(t, tt.want, got)
+		assert.Equalf(t, tt.want, got, "globToRegexp(%q).MatchString", tt.pattern)
 	}
 }
 
 func TestMethodMatcherParsing(t *testing.T) {
 	mm := NewMethodMatcher("fmt Sprintf(string, ..)")
-	require.NotNil(t, mm.declaringTypePattern)
-	require.NotNil(t, mm.methodNamePattern)
-	assert.True(t, mm.matchesAnyArgs)
+	require.NotNil(t, mm.declaringTypePattern, "expected declaringTypePattern")
+	require.NotNil(t, mm.methodNamePattern, "expected methodNamePattern")
+	assert.True(t, mm.matchesAnyArgs, "expected matchesAnyArgs for .. pattern")
 }
 
 func TestMethodMatcherMatchesAnyArgs(t *testing.T) {
@@ -201,7 +201,7 @@ func TestMethodMatcherMatchesAnyArgs(t *testing.T) {
 		},
 		Name: &java.Identifier{Name: "Println"},
 	}
-	assert.True(t, mm.Matches(mi))
+	assert.True(t, mm.Matches(mi), "expected match for fmt.Println with any args")
 }
 
 func TestMethodMatcherNoMatchWrongName(t *testing.T) {
@@ -212,7 +212,7 @@ func TestMethodMatcherNoMatchWrongName(t *testing.T) {
 		},
 		Name: &java.Identifier{Name: "Sprintf"},
 	}
-	assert.False(t, mm.Matches(mi))
+	assert.False(t, mm.Matches(mi), "expected no match for wrong method name")
 }
 
 func TestMethodMatcherNoMatchWrongPackage(t *testing.T) {
@@ -223,7 +223,7 @@ func TestMethodMatcherNoMatchWrongPackage(t *testing.T) {
 		},
 		Name: &java.Identifier{Name: "Println"},
 	}
-	assert.False(t, mm.Matches(mi))
+	assert.False(t, mm.Matches(mi), "expected no match for wrong package")
 }
 
 func TestMethodMatcherWildcardType(t *testing.T) {
@@ -236,7 +236,7 @@ func TestMethodMatcherWildcardType(t *testing.T) {
 	}
 	// With just an identifier "t" as select, DeclaringTypeFQN returns "t"
 	// which matches "*" pattern
-	assert.True(t, mm.Matches(mi))
+	assert.True(t, mm.Matches(mi), "expected match for wildcard declaring type")
 }
 
 func TestMethodMatcherWithTypeInfo(t *testing.T) {
@@ -252,7 +252,7 @@ func TestMethodMatcherWithTypeInfo(t *testing.T) {
 			Name:          "Sprintf",
 		},
 	}
-	assert.True(t, mm.Matches(mi))
+	assert.True(t, mm.Matches(mi), "expected match with type info")
 }
 
 func TestMethodMatcherMatchesMethod(t *testing.T) {
@@ -261,7 +261,7 @@ func TestMethodMatcherMatchesMethod(t *testing.T) {
 		DeclaringType: &java.JavaTypeClass{FullyQualifiedName: "time.Time"},
 		Name:          "Sub",
 	}
-	assert.True(t, mm.MatchesMethod(mt))
+	assert.True(t, mm.MatchesMethod(mt), "expected match for time.Time Sub(..)")
 }
 
 func TestMethodMatcherOnParsedCode(t *testing.T) {
@@ -293,8 +293,8 @@ func main() {
 	})
 	v.Visit(cu, nil)
 
-	assert.Equal(t, 1, printlnCount)
-	assert.Equal(t, 1, sprintfCount)
+	assert.Equal(t, 1, printlnCount, "expected 1 Println match")
+	assert.Equal(t, 1, sprintfCount, "expected 1 Sprintf match")
 }
 
 func TestMethodMatcherNoMatchOnParsedCode(t *testing.T) {
@@ -318,7 +318,7 @@ func main() {
 	})
 	v.Visit(cu, nil)
 
-	assert.Equal(t, 0, count)
+	assert.Equal(t, 0, count, "expected 0 matches for fmt.Println in log code")
 }
 
 // Test helper visitor that counts method matcher hits.

--- a/rewrite-go/pkg/parser/basic_lit_test.go
+++ b/rewrite-go/pkg/parser/basic_lit_test.go
@@ -20,9 +20,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -34,9 +34,7 @@ func litRHS(t *testing.T, src string) *java.Literal {
 	t.Helper()
 	rhs := firstAssignRHS(t, src)
 	lit, ok := rhs.(*java.Literal)
-	if !ok {
-		t.Fatalf("expected *java.Literal, got %T", rhs)
-	}
+	require.Truef(t, ok, "expected *java.Literal, got %T", rhs)
 	return lit
 }
 
@@ -73,7 +71,7 @@ func TestBasicLitDecodedValue(t *testing.T) {
 			if lit.Value != tc.wantValue {
 				t.Errorf("Value = %#v (%T), want %#v (%T)", lit.Value, lit.Value, tc.wantValue, tc.wantValue)
 			}
-			assert.Equal(t, lit.Source, tc.wantSource)
+			assert.Equal(t, lit.Source, tc.wantSource, "Source")
 		})
 	}
 }
@@ -83,7 +81,7 @@ func TestBasicLitDecodedValue(t *testing.T) {
 func firstLiteralOfType(t *testing.T, src, keyword string) *java.Literal {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("g.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	var found *java.Literal
 	visitor.Walk(cu, func(n java.Tree) bool {
 		if lit, ok := n.(*java.Literal); ok {
@@ -94,9 +92,7 @@ func firstLiteralOfType(t *testing.T, src, keyword string) *java.Literal {
 		}
 		return true
 	})
-	if found == nil {
-		t.Fatalf("no *java.Literal of primitive type %q found", keyword)
-	}
+	require.NotNilf(t, found, "no *java.Literal of primitive type %q found", keyword)
 	return found
 }
 

--- a/rewrite-go/pkg/parser/basic_lit_test.go
+++ b/rewrite-go/pkg/parser/basic_lit_test.go
@@ -20,6 +20,10 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
@@ -69,9 +73,7 @@ func TestBasicLitDecodedValue(t *testing.T) {
 			if lit.Value != tc.wantValue {
 				t.Errorf("Value = %#v (%T), want %#v (%T)", lit.Value, lit.Value, tc.wantValue, tc.wantValue)
 			}
-			if lit.Source != tc.wantSource {
-				t.Errorf("Source = %q, want %q", lit.Source, tc.wantSource)
-			}
+			assert.Equal(t, lit.Source, tc.wantSource)
 		})
 	}
 }
@@ -81,9 +83,7 @@ func TestBasicLitDecodedValue(t *testing.T) {
 func firstLiteralOfType(t *testing.T, src, keyword string) *java.Literal {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("g.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	var found *java.Literal
 	visitor.Walk(cu, func(n java.Tree) bool {
 		if lit, ok := n.(*java.Literal); ok {

--- a/rewrite-go/pkg/parser/for_control_test.go
+++ b/rewrite-go/pkg/parser/for_control_test.go
@@ -30,9 +30,7 @@ import (
 func forControl(t *testing.T, src string) *java.ForControl {
 	t.Helper()
 	loop, ok := firstStatementInBody(t, src).(*java.ForLoop)
-	if !ok {
-		t.Fatalf("expected first statement to be *java.ForLoop, got %T", firstStatementInBody(t, src))
-	}
+	require.Truef(t, ok, "expected first statement to be *java.ForLoop, got %T", firstStatementInBody(t, src))
 	return &loop.Control
 }
 
@@ -47,16 +45,16 @@ func TestConditionOnlyForHasEmptyInitAndUpdate(t *testing.T) {
 	control := forControl(t, src)
 
 	// then
-	require.NotNil(t, control.Init)
+	require.NotNil(t, control.Init, "Init must not be nil for a condition-only for")
 	if _, ok := control.Init.Element.(*java.Empty); !ok {
 		t.Fatalf("Init element must be *java.Empty, got %T", control.Init.Element)
 	}
-	require.NotNil(t, control.Update)
+	require.NotNil(t, control.Update, "Update must not be nil for a condition-only for")
 	if _, ok := control.Update.Element.(*java.Empty); !ok {
 		t.Fatalf("Update element must be *java.Empty, got %T", control.Update.Element)
 	}
-	require.NotNil(t, control.Condition)
-	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
+	require.NotNil(t, control.Condition, "Condition must be the real condition, got nil")
+	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers), "expected golang.ImplicitForClauses marker on the control")
 }
 
 // An infinite `for {}` has no condition, but its init/update placeholders must
@@ -69,13 +67,13 @@ func TestInfiniteForHasEmptyInitAndUpdate(t *testing.T) {
 	control := forControl(t, src)
 
 	// then
-	require.NotNil(t, control.Init)
+	require.NotNil(t, control.Init, "Init must not be nil for an infinite for")
 	if _, ok := control.Init.Element.(*java.Empty); !ok {
 		t.Fatalf("Init element must be *java.Empty, got %T", control.Init.Element)
 	}
-	require.NotNil(t, control.Update)
-	require.Nil(t, control.Condition)
-	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
+	require.NotNil(t, control.Update, "Update must not be nil for an infinite for")
+	require.Nil(t, control.Condition, "infinite for must have no condition")
+	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers), "expected golang.ImplicitForClauses marker on the control")
 }
 
 // A genuine 3-clause for keeps its real init and is NOT marked implicit; an
@@ -89,12 +87,12 @@ func TestThreeClauseForIsNotMarkedImplicit(t *testing.T) {
 	control := forControl(t, src)
 
 	// then
-	require.Nil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
-	require.NotNil(t, control.Init)
+	require.Nil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers), "a 3-clause for must not carry the ImplicitForClauses marker")
+	require.NotNil(t, control.Init, "Init must not be nil")
 	if _, ok := control.Init.Element.(*java.Empty); ok {
 		t.Fatalf("Init element must be the real init statement, not J.Empty")
 	}
-	require.NotNil(t, control.Update)
+	require.NotNil(t, control.Update, "Update must not be nil for a 3-clause for without an update clause")
 	if _, ok := control.Update.Element.(*java.Empty); !ok {
 		t.Fatalf("omitted update must be a *java.Empty placeholder, got %T", control.Update.Element)
 	}

--- a/rewrite-go/pkg/parser/for_control_test.go
+++ b/rewrite-go/pkg/parser/for_control_test.go
@@ -19,6 +19,8 @@ package parser_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -45,24 +47,16 @@ func TestConditionOnlyForHasEmptyInitAndUpdate(t *testing.T) {
 	control := forControl(t, src)
 
 	// then
-	if control.Init == nil {
-		t.Fatalf("Init must not be nil for a condition-only for")
-	}
+	require.NotNil(t, control.Init)
 	if _, ok := control.Init.Element.(*java.Empty); !ok {
 		t.Fatalf("Init element must be *java.Empty, got %T", control.Init.Element)
 	}
-	if control.Update == nil {
-		t.Fatalf("Update must not be nil for a condition-only for")
-	}
+	require.NotNil(t, control.Update)
 	if _, ok := control.Update.Element.(*java.Empty); !ok {
 		t.Fatalf("Update element must be *java.Empty, got %T", control.Update.Element)
 	}
-	if control.Condition == nil {
-		t.Fatalf("Condition must be the real condition, got nil")
-	}
-	if java.FindMarker[golang.ImplicitForClauses](control.Markers) == nil {
-		t.Fatalf("expected golang.ImplicitForClauses marker on the control")
-	}
+	require.NotNil(t, control.Condition)
+	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
 }
 
 // An infinite `for {}` has no condition, but its init/update placeholders must
@@ -75,21 +69,13 @@ func TestInfiniteForHasEmptyInitAndUpdate(t *testing.T) {
 	control := forControl(t, src)
 
 	// then
-	if control.Init == nil {
-		t.Fatalf("Init must not be nil for an infinite for")
-	}
+	require.NotNil(t, control.Init)
 	if _, ok := control.Init.Element.(*java.Empty); !ok {
 		t.Fatalf("Init element must be *java.Empty, got %T", control.Init.Element)
 	}
-	if control.Update == nil {
-		t.Fatalf("Update must not be nil for an infinite for")
-	}
-	if control.Condition != nil {
-		t.Fatalf("infinite for must have no condition, got %+v", control.Condition)
-	}
-	if java.FindMarker[golang.ImplicitForClauses](control.Markers) == nil {
-		t.Fatalf("expected golang.ImplicitForClauses marker on the control")
-	}
+	require.NotNil(t, control.Update)
+	require.Nil(t, control.Condition)
+	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
 }
 
 // A genuine 3-clause for keeps its real init and is NOT marked implicit; an
@@ -103,18 +89,12 @@ func TestThreeClauseForIsNotMarkedImplicit(t *testing.T) {
 	control := forControl(t, src)
 
 	// then
-	if java.FindMarker[golang.ImplicitForClauses](control.Markers) != nil {
-		t.Fatalf("a 3-clause for must not carry the ImplicitForClauses marker")
-	}
-	if control.Init == nil {
-		t.Fatalf("Init must not be nil")
-	}
+	require.Nil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
+	require.NotNil(t, control.Init)
 	if _, ok := control.Init.Element.(*java.Empty); ok {
 		t.Fatalf("Init element must be the real init statement, not J.Empty")
 	}
-	if control.Update == nil {
-		t.Fatalf("Update must not be nil for a 3-clause for without an update clause")
-	}
+	require.NotNil(t, control.Update)
 	if _, ok := control.Update.Element.(*java.Empty); !ok {
 		t.Fatalf("omitted update must be a *java.Empty placeholder, got %T", control.Update.Element)
 	}

--- a/rewrite-go/pkg/parser/for_range_test.go
+++ b/rewrite-go/pkg/parser/for_range_test.go
@@ -19,6 +19,8 @@ package parser_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -29,16 +31,12 @@ import (
 func nthStatementInBody(t *testing.T, src string, n int) java.Statement {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("body.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	fn, ok := cu.Statements[0].Element.(*java.MethodDeclaration)
 	if !ok {
 		t.Fatalf("expected first statement to be *java.MethodDeclaration, got %T", cu.Statements[0].Element)
 	}
-	if fn.Body == nil || len(fn.Body.Statements) <= n {
-		t.Fatalf("function body has fewer than %d statements", n+1)
-	}
+	require.False(t, fn.Body == nil || len(fn.Body.Statements) <= n)
 	return fn.Body.Statements[n].Element
 }
 
@@ -83,12 +81,8 @@ func TestForRangeTwoVarsDefineUsesMultiAssignment(t *testing.T) {
 	if !ok {
 		t.Fatalf("range head Variable must be *golang.MultiAssignment, got %T", control.Variable.Element)
 	}
-	if len(ma.Variables) != 2 {
-		t.Fatalf("expected 2 loop targets, got %d", len(ma.Variables))
-	}
-	if java.FindMarker[golang.ShortVarDecl](ma.Markers) == nil {
-		t.Fatalf("`:=` range must carry a ShortVarDecl marker")
-	}
+	require.Len(t, ma.Variables, 2)
+	require.NotNil(t, java.FindMarker[golang.ShortVarDecl](ma.Markers))
 }
 
 // `for k, v = range expr {}` uses `=`, so the MultiAssignment must NOT carry a
@@ -110,9 +104,7 @@ func TestForRangeAssignHasNoShortVarDeclMarker(t *testing.T) {
 	}
 
 	// then
-	if java.FindMarker[golang.ShortVarDecl](ma.Markers) != nil {
-		t.Fatalf("`=` range must NOT carry a ShortVarDecl marker")
-	}
+	require.Nil(t, java.FindMarker[golang.ShortVarDecl](ma.Markers))
 }
 
 // Every for-range variant must round-trip parse → print byte-for-byte.

--- a/rewrite-go/pkg/parser/for_range_test.go
+++ b/rewrite-go/pkg/parser/for_range_test.go
@@ -31,12 +31,10 @@ import (
 func nthStatementInBody(t *testing.T, src string, n int) java.Statement {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("body.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	fn, ok := cu.Statements[0].Element.(*java.MethodDeclaration)
-	if !ok {
-		t.Fatalf("expected first statement to be *java.MethodDeclaration, got %T", cu.Statements[0].Element)
-	}
-	require.False(t, fn.Body == nil || len(fn.Body.Statements) <= n)
+	require.Truef(t, ok, "expected first statement to be *java.MethodDeclaration, got %T", cu.Statements[0].Element)
+	require.Falsef(t, fn.Body == nil || len(fn.Body.Statements) <= n, "function body has fewer than %d statements", n+1)
 	return fn.Body.Statements[n].Element
 }
 
@@ -46,9 +44,7 @@ func forEachControlOf(t *testing.T, src string) *java.ForEachControl {
 	t.Helper()
 	stmt := firstStatementInBody(t, src)
 	loop, ok := stmt.(*java.ForEachLoop)
-	if !ok {
-		t.Fatalf("expected first statement to be *java.ForEachLoop, got %T", stmt)
-	}
+	require.Truef(t, ok, "expected first statement to be *java.ForEachLoop, got %T", stmt)
 	return &loop.Control
 }
 
@@ -78,11 +74,9 @@ func TestForRangeTwoVarsDefineUsesMultiAssignment(t *testing.T) {
 
 	// then
 	ma, ok := control.Variable.Element.(*golang.MultiAssignment)
-	if !ok {
-		t.Fatalf("range head Variable must be *golang.MultiAssignment, got %T", control.Variable.Element)
-	}
-	require.Len(t, ma.Variables, 2)
-	require.NotNil(t, java.FindMarker[golang.ShortVarDecl](ma.Markers))
+	require.Truef(t, ok, "range head Variable must be *golang.MultiAssignment, got %T", control.Variable.Element)
+	require.Len(t, ma.Variables, 2, "expected 2 loop targets")
+	require.NotNil(t, java.FindMarker[golang.ShortVarDecl](ma.Markers), "`:=` range must carry a ShortVarDecl marker")
 }
 
 // `for k, v = range expr {}` uses `=`, so the MultiAssignment must NOT carry a
@@ -95,16 +89,12 @@ func TestForRangeAssignHasNoShortVarDeclMarker(t *testing.T) {
 	// when
 	stmt := nthStatementInBody(t, src, 1) // the for-range, after `var k, v int`
 	loop, ok := stmt.(*java.ForEachLoop)
-	if !ok {
-		t.Fatalf("expected *java.ForEachLoop, got %T", stmt)
-	}
+	require.Truef(t, ok, "expected *java.ForEachLoop, got %T", stmt)
 	ma, ok := loop.Control.Variable.Element.(*golang.MultiAssignment)
-	if !ok {
-		t.Fatalf("range head Variable must be *golang.MultiAssignment, got %T", loop.Control.Variable.Element)
-	}
+	require.Truef(t, ok, "range head Variable must be *golang.MultiAssignment, got %T", loop.Control.Variable.Element)
 
 	// then
-	require.Nil(t, java.FindMarker[golang.ShortVarDecl](ma.Markers))
+	require.Nil(t, java.FindMarker[golang.ShortVarDecl](ma.Markers), "`=` range must NOT carry a ShortVarDecl marker")
 }
 
 // Every for-range variant must round-trip parse → print byte-for-byte.

--- a/rewrite-go/pkg/parser/func_decl_test.go
+++ b/rewrite-go/pkg/parser/func_decl_test.go
@@ -19,6 +19,8 @@ package parser_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -29,9 +31,7 @@ import (
 func firstDeclaration(t *testing.T, src string) java.Statement {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("decl.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	if len(cu.Statements) == 0 {
 		t.Fatalf("no top-level statements parsed")
 	}
@@ -71,19 +71,11 @@ func TestMethodWithReceiverIsWrapped(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *golang.MethodDeclaration, got %T", decl)
 	}
-	if wrapper.Declaration == nil {
-		t.Fatalf("wrapper must carry the inner *java.MethodDeclaration")
-	}
-	if len(wrapper.Receiver.Elements) != 1 {
-		t.Fatalf("expected a single receiver element, got %d", len(wrapper.Receiver.Elements))
-	}
+	require.NotNil(t, wrapper.Declaration)
+	require.Len(t, wrapper.Receiver.Elements, 1)
 	// The prefix (the blank line before `func`) belongs on the outermost node.
-	if wrapper.Prefix.Whitespace != "\n\n" {
-		t.Fatalf("expected wrapper to carry the prefix %q, got %q", "\n\n", wrapper.Prefix.Whitespace)
-	}
-	if wrapper.Declaration.Prefix.Whitespace != "" || len(wrapper.Declaration.Prefix.Comments) != 0 {
-		t.Fatalf("inner declaration must be prefix-less, got %+v", wrapper.Declaration.Prefix)
-	}
+	require.Equal(t, "\n\n", wrapper.Prefix.Whitespace)
+	require.False(t, wrapper.Declaration.Prefix.Whitespace != "" || len(wrapper.Declaration.Prefix.Comments) != 0)
 }
 
 // With the prefix on the wrapper but `//go:` directives still on the inner

--- a/rewrite-go/pkg/parser/func_decl_test.go
+++ b/rewrite-go/pkg/parser/func_decl_test.go
@@ -31,7 +31,7 @@ import (
 func firstDeclaration(t *testing.T, src string) java.Statement {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("decl.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	if len(cu.Statements) == 0 {
 		t.Fatalf("no top-level statements parsed")
 	}
@@ -68,14 +68,12 @@ func TestMethodWithReceiverIsWrapped(t *testing.T) {
 
 	// then
 	wrapper, ok := decl.(*golang.MethodDeclaration)
-	if !ok {
-		t.Fatalf("expected *golang.MethodDeclaration, got %T", decl)
-	}
-	require.NotNil(t, wrapper.Declaration)
-	require.Len(t, wrapper.Receiver.Elements, 1)
+	require.Truef(t, ok, "expected *golang.MethodDeclaration, got %T", decl)
+	require.NotNil(t, wrapper.Declaration, "wrapper must carry the inner *java.MethodDeclaration")
+	require.Len(t, wrapper.Receiver.Elements, 1, "expected a single receiver element")
 	// The prefix (the blank line before `func`) belongs on the outermost node.
-	require.Equal(t, "\n\n", wrapper.Prefix.Whitespace)
-	require.False(t, wrapper.Declaration.Prefix.Whitespace != "" || len(wrapper.Declaration.Prefix.Comments) != 0)
+	require.Equalf(t, "\n\n", wrapper.Prefix.Whitespace, "expected wrapper to carry the prefix %q", "\n\n")
+	require.False(t, wrapper.Declaration.Prefix.Whitespace != "" || len(wrapper.Declaration.Prefix.Comments) != 0, "inner declaration must be prefix-less")
 }
 
 // With the prefix on the wrapper but `//go:` directives still on the inner

--- a/rewrite-go/pkg/parser/generic_call_test.go
+++ b/rewrite-go/pkg/parser/generic_call_test.go
@@ -19,6 +19,10 @@ package parser_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -28,9 +32,7 @@ import (
 func firstAssignRHS(t *testing.T, src string) java.Expression {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("g.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	for _, rp := range cu.Statements {
 		md, ok := rp.Element.(*java.MethodDeclaration)
 		if !ok || md.Body == nil {
@@ -63,27 +65,15 @@ func TestGenericFuncCallSingleTypeArg(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected RHS to be *java.MethodInvocation, got %T", rhs)
 	}
-	if mi.Select != nil {
-		t.Errorf("expected Select to be nil for a free generic function call, got %T", mi.Select.Element)
-	}
-	if mi.Name == nil || mi.Name.Name != "Map" {
-		t.Errorf("expected Name == %q, got %q", "Map", nameOrEmpty(mi.Name))
-	}
-	if mi.TypeParameters == nil {
-		t.Fatalf("expected TypeParameters to be non-nil")
-	}
-	if len(mi.TypeParameters.Elements) != 1 {
-		t.Fatalf("expected 1 type argument, got %d", len(mi.TypeParameters.Elements))
-	}
+	assert.Nil(t, mi.Select)
+	assert.False(t, mi.Name == nil || mi.Name.Name != "Map")
+	require.NotNil(t, mi.TypeParameters)
+	require.Len(t, mi.TypeParameters.Elements, 1)
 	if id, ok := mi.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "int" {
 		t.Errorf("expected type argument Identifier(int), got %T", mi.TypeParameters.Elements[0].Element)
 	}
-	if len(mi.Arguments.Elements) != 1 {
-		t.Errorf("expected 1 call argument, got %d", len(mi.Arguments.Elements))
-	}
-	if mi.MethodType == nil {
-		t.Errorf("expected MethodType to be attributed")
-	}
+	assert.Len(t, mi.Arguments.Elements, 1)
+	assert.NotNil(t, mi.MethodType)
 
 	assertRoundTrip(t, src)
 }
@@ -96,9 +86,7 @@ func TestGenericFuncCallMultipleTypeArgs(t *testing.T) {
 
 	// when
 	ccu, err := parser.NewGoParser().Parse("g.go", callSrc)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 
 	// then
 	var mi *java.MethodInvocation
@@ -113,15 +101,9 @@ func TestGenericFuncCallMultipleTypeArgs(t *testing.T) {
 			}
 		}
 	}
-	if mi == nil {
-		t.Fatalf("no MethodInvocation found")
-	}
-	if mi.Name == nil || mi.Name.Name != "Pair" {
-		t.Errorf("expected Name == %q, got %q", "Pair", nameOrEmpty(mi.Name))
-	}
-	if mi.TypeParameters == nil || len(mi.TypeParameters.Elements) != 2 {
-		t.Fatalf("expected 2 type arguments, got %v", mi.TypeParameters)
-	}
+	require.NotNil(t, mi)
+	assert.False(t, mi.Name == nil || mi.Name.Name != "Pair")
+	require.False(t, mi.TypeParameters == nil || len(mi.TypeParameters.Elements) != 2)
 	assertRoundTrip(t, callSrc)
 }
 
@@ -134,9 +116,7 @@ func TestFuncValueIndexCallIsNotGeneric(t *testing.T) {
 
 	// when
 	cu, err := parser.NewGoParser().Parse("g.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 
 	// then
 	var mi *java.MethodInvocation
@@ -151,15 +131,9 @@ func TestFuncValueIndexCallIsNotGeneric(t *testing.T) {
 			}
 		}
 	}
-	if mi == nil {
-		t.Fatalf("no MethodInvocation found")
-	}
-	if mi.TypeParameters != nil {
-		t.Errorf("expected TypeParameters to be nil for func-value index call")
-	}
-	if mi.Select == nil {
-		t.Fatalf("expected Select to be present")
-	}
+	require.NotNil(t, mi)
+	assert.Nil(t, mi.TypeParameters)
+	require.NotNil(t, mi.Select)
 	if _, ok := mi.Select.Element.(*java.ArrayAccess); !ok {
 		t.Errorf("expected Select to be *java.ArrayAccess, got %T", mi.Select.Element)
 	}

--- a/rewrite-go/pkg/parser/generic_call_test.go
+++ b/rewrite-go/pkg/parser/generic_call_test.go
@@ -32,7 +32,7 @@ import (
 func firstAssignRHS(t *testing.T, src string) java.Expression {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("g.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	for _, rp := range cu.Statements {
 		md, ok := rp.Element.(*java.MethodDeclaration)
 		if !ok || md.Body == nil {
@@ -62,18 +62,16 @@ func TestGenericFuncCallSingleTypeArg(t *testing.T) {
 
 	// then
 	mi, ok := rhs.(*java.MethodInvocation)
-	if !ok {
-		t.Fatalf("expected RHS to be *java.MethodInvocation, got %T", rhs)
-	}
-	assert.Nil(t, mi.Select)
-	assert.False(t, mi.Name == nil || mi.Name.Name != "Map")
-	require.NotNil(t, mi.TypeParameters)
-	require.Len(t, mi.TypeParameters.Elements, 1)
+	require.Truef(t, ok, "expected RHS to be *java.MethodInvocation, got %T", rhs)
+	assert.Nil(t, mi.Select, "expected Select to be nil for a free generic function call")
+	assert.Falsef(t, mi.Name == nil || mi.Name.Name != "Map", "expected Name == %q", "Map")
+	require.NotNil(t, mi.TypeParameters, "expected TypeParameters to be non-nil")
+	require.Len(t, mi.TypeParameters.Elements, 1, "expected 1 type argument")
 	if id, ok := mi.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "int" {
 		t.Errorf("expected type argument Identifier(int), got %T", mi.TypeParameters.Elements[0].Element)
 	}
-	assert.Len(t, mi.Arguments.Elements, 1)
-	assert.NotNil(t, mi.MethodType)
+	assert.Len(t, mi.Arguments.Elements, 1, "expected 1 call argument")
+	assert.NotNil(t, mi.MethodType, "expected MethodType to be attributed")
 
 	assertRoundTrip(t, src)
 }
@@ -86,7 +84,7 @@ func TestGenericFuncCallMultipleTypeArgs(t *testing.T) {
 
 	// when
 	ccu, err := parser.NewGoParser().Parse("g.go", callSrc)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 
 	// then
 	var mi *java.MethodInvocation
@@ -101,9 +99,9 @@ func TestGenericFuncCallMultipleTypeArgs(t *testing.T) {
 			}
 		}
 	}
-	require.NotNil(t, mi)
-	assert.False(t, mi.Name == nil || mi.Name.Name != "Pair")
-	require.False(t, mi.TypeParameters == nil || len(mi.TypeParameters.Elements) != 2)
+	require.NotNil(t, mi, "no MethodInvocation found")
+	assert.Falsef(t, mi.Name == nil || mi.Name.Name != "Pair", "expected Name == %q", "Pair")
+	require.False(t, mi.TypeParameters == nil || len(mi.TypeParameters.Elements) != 2, "expected 2 type arguments")
 	assertRoundTrip(t, callSrc)
 }
 
@@ -116,7 +114,7 @@ func TestFuncValueIndexCallIsNotGeneric(t *testing.T) {
 
 	// when
 	cu, err := parser.NewGoParser().Parse("g.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 
 	// then
 	var mi *java.MethodInvocation
@@ -131,9 +129,9 @@ func TestFuncValueIndexCallIsNotGeneric(t *testing.T) {
 			}
 		}
 	}
-	require.NotNil(t, mi)
-	assert.Nil(t, mi.TypeParameters)
-	require.NotNil(t, mi.Select)
+	require.NotNil(t, mi, "no MethodInvocation found")
+	assert.Nil(t, mi.TypeParameters, "expected TypeParameters to be nil for func-value index call")
+	require.NotNil(t, mi.Select, "expected Select to be present")
 	if _, ok := mi.Select.Element.(*java.ArrayAccess); !ok {
 		t.Errorf("expected Select to be *java.ArrayAccess, got %T", mi.Select.Element)
 	}

--- a/rewrite-go/pkg/parser/gomod_lst_test.go
+++ b/rewrite-go/pkg/parser/gomod_lst_test.go
@@ -18,6 +18,8 @@ package parser
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 )
 
@@ -26,13 +28,9 @@ import (
 func roundTrip(t *testing.T, content string) {
 	t.Helper()
 	gm, err := ParseGoModFile("go.mod", content)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	got := printer.PrintGoMod(gm)
-	if got != content {
-		t.Fatalf("not lossless\n--- want ---\n%q\n--- got ---\n%q", content, got)
-	}
+	require.Equal(t, content, got)
 }
 
 func TestGoModLossless(t *testing.T) {

--- a/rewrite-go/pkg/parser/gomod_lst_test.go
+++ b/rewrite-go/pkg/parser/gomod_lst_test.go
@@ -28,9 +28,9 @@ import (
 func roundTrip(t *testing.T, content string) {
 	t.Helper()
 	gm, err := ParseGoModFile("go.mod", content)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	got := printer.PrintGoMod(gm)
-	require.Equal(t, content, got)
+	require.Equal(t, content, got, "not lossless")
 }
 
 func TestGoModLossless(t *testing.T) {

--- a/rewrite-go/pkg/parser/gomod_resolve_test.go
+++ b/rewrite-go/pkg/parser/gomod_resolve_test.go
@@ -22,6 +22,10 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 )
 
@@ -40,19 +44,11 @@ func TestMergeResolvedDependencies(t *testing.T) {
 	merged := MergeResolvedDependencies(fromSum, fromList)
 
 	// then: the build-list node is authoritative and inherits the go.sum hashes
-	if len(merged) != 2 {
-		t.Fatalf("want 2 entries (1 build-list + 1 stale sum), got %d: %+v", len(merged), merged)
-	}
+	require.Len(t, merged, 2)
 	got := merged[0]
-	if got.ModulePath != "github.com/a/b" || got.Version != "v1.0.0" {
-		t.Fatalf("first entry should be the selected build-list node, got %+v", got)
-	}
-	if !got.Indirect || got.ModuleGoVersion != "1.20" || len(got.Deps) != 1 {
-		t.Errorf("build-list metadata not preserved: %+v", got)
-	}
-	if got.ModuleHash != "h1:mod=" || got.GoModHash != "h1:gomod=" {
-		t.Errorf("go.sum hashes not inherited onto build-list node: %+v", got)
-	}
+	require.False(t, got.ModulePath != "github.com/a/b" || got.Version != "v1.0.0")
+	assert.False(t, !got.Indirect || got.ModuleGoVersion != "1.20" || len(got.Deps) != 1)
+	assert.False(t, got.ModuleHash != "h1:mod=" || got.GoModHash != "h1:gomod=")
 	// and: the superseded go.sum row is preserved
 	if merged[1].Version != "v0.9.0" || merged[1].ModuleHash != "h1:stale=" {
 		t.Errorf("stale go.sum row should be preserved, got %+v", merged[1])
@@ -65,9 +61,7 @@ func TestMergeResolvedDependenciesEmpty(t *testing.T) {
 
 	// then
 	merged := MergeResolvedDependencies(fromSum, nil)
-	if len(merged) != 1 || merged[0].ModuleHash != "h1:x=" {
-		t.Fatalf("go.sum-only merge should pass through, got %+v", merged)
-	}
+	require.False(t, len(merged) != 1 || merged[0].ModuleHash != "h1:x=")
 	if got := MergeResolvedDependencies(nil, nil); len(got) != 0 {
 		t.Errorf("empty inputs should yield empty, got %+v", got)
 	}
@@ -119,9 +113,7 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 
 	// when
 	mods, pkgs, err := ResolveModuleGraph(dir)
-	if err != nil {
-		t.Fatalf("resolve failed: %v", err)
-	}
+	require.NoError(t, err)
 
 	// then: the build list contains the main module
 	var main *golang.GoResolvedDependency
@@ -133,9 +125,7 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 	if main == nil {
 		t.Fatalf("main module missing from build list: %+v", mods)
 	}
-	if !main.Main {
-		t.Errorf("main module should have Main=true: %+v", main)
-	}
+	assert.True(t, main.Main)
 
 	// and: the package map classifies stdlib and the main package
 	var sawStdlib, sawMain bool

--- a/rewrite-go/pkg/parser/gomod_resolve_test.go
+++ b/rewrite-go/pkg/parser/gomod_resolve_test.go
@@ -44,15 +44,13 @@ func TestMergeResolvedDependencies(t *testing.T) {
 	merged := MergeResolvedDependencies(fromSum, fromList)
 
 	// then: the build-list node is authoritative and inherits the go.sum hashes
-	require.Len(t, merged, 2)
+	require.Len(t, merged, 2, "want 2 entries (1 build-list + 1 stale sum")
 	got := merged[0]
-	require.False(t, got.ModulePath != "github.com/a/b" || got.Version != "v1.0.0")
-	assert.False(t, !got.Indirect || got.ModuleGoVersion != "1.20" || len(got.Deps) != 1)
-	assert.False(t, got.ModuleHash != "h1:mod=" || got.GoModHash != "h1:gomod=")
+	require.False(t, got.ModulePath != "github.com/a/b" || got.Version != "v1.0.0", "first entry should be the selected build-list node")
+	assert.False(t, !got.Indirect || got.ModuleGoVersion != "1.20" || len(got.Deps) != 1, "build-list metadata not preserved")
+	assert.False(t, got.ModuleHash != "h1:mod=" || got.GoModHash != "h1:gomod=", "go.sum hashes not inherited onto build-list node")
 	// and: the superseded go.sum row is preserved
-	if merged[1].Version != "v0.9.0" || merged[1].ModuleHash != "h1:stale=" {
-		t.Errorf("stale go.sum row should be preserved, got %+v", merged[1])
-	}
+	assert.Falsef(t, merged[1].Version != "v0.9.0" || merged[1].ModuleHash != "h1:stale=", "stale go.sum row should be preserved, got %+v", merged[1])
 }
 
 func TestMergeResolvedDependenciesEmpty(t *testing.T) {
@@ -61,7 +59,7 @@ func TestMergeResolvedDependenciesEmpty(t *testing.T) {
 
 	// then
 	merged := MergeResolvedDependencies(fromSum, nil)
-	require.False(t, len(merged) != 1 || merged[0].ModuleHash != "h1:x=")
+	require.False(t, len(merged) != 1 || merged[0].ModuleHash != "h1:x=", "go.sum-only merge should pass through")
 	if got := MergeResolvedDependencies(nil, nil); len(got) != 0 {
 		t.Errorf("empty inputs should yield empty, got %+v", got)
 	}
@@ -82,12 +80,8 @@ func TestAttachEdges(t *testing.T) {
 	attachEdges(mods, edges)
 
 	// then
-	if len(mods[0].Deps) != 1 || mods[0].Deps[0].ModulePath != "github.com/a/b" {
-		t.Fatalf("edge not attached to source node: %+v", mods[0].Deps)
-	}
-	if len(mods[1].Deps) != 0 {
-		t.Errorf("node with no outgoing edges should have no Deps: %+v", mods[1].Deps)
-	}
+	require.Falsef(t, len(mods[0].Deps) != 1 || mods[0].Deps[0].ModulePath != "github.com/a/b", "edge not attached to source node: %+v", mods[0].Deps)
+	assert.Lenf(t, mods[1].Deps, 0, "node with no outgoing edges should have no Deps: %+v", mods[1].Deps)
 }
 
 func TestSplitModuleVersion(t *testing.T) {
@@ -113,7 +107,7 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 
 	// when
 	mods, pkgs, err := ResolveModuleGraph(dir)
-	require.NoError(t, err)
+	require.NoError(t, err, "resolve failed")
 
 	// then: the build list contains the main module
 	var main *golang.GoResolvedDependency
@@ -122,10 +116,8 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 			main = &mods[i]
 		}
 	}
-	if main == nil {
-		t.Fatalf("main module missing from build list: %+v", mods)
-	}
-	assert.True(t, main.Main)
+	require.NotNilf(t, main, "main module missing from build list: %+v", mods)
+	assert.True(t, main.Main, "main module should have Main=true")
 
 	// and: the package map classifies stdlib and the main package
 	var sawStdlib, sawMain bool
@@ -137,17 +129,11 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 			sawMain = true
 		}
 	}
-	if !sawStdlib {
-		t.Errorf("expected stdlib package fmt with Standard=true in %+v", pkgs)
-	}
-	if !sawMain {
-		t.Errorf("expected the main package mapped to its module in %+v", pkgs)
-	}
+	assert.Truef(t, sawStdlib, "expected stdlib package fmt with Standard=true in %+v", pkgs)
+	assert.Truef(t, sawMain, "expected the main package mapped to its module in %+v", pkgs)
 }
 
 func writeFile(t *testing.T, dir, name, content string) {
 	t.Helper()
-	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
-		t.Fatalf("write %s: %v", name, err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644), "write")
 }

--- a/rewrite-go/pkg/parser/gosum_lst_test.go
+++ b/rewrite-go/pkg/parser/gosum_lst_test.go
@@ -18,19 +18,17 @@ package parser
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 )
 
 func roundTripSum(t *testing.T, content string) {
 	t.Helper()
 	gs, err := ParseGoSumFile("go.sum", content)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	got := printer.PrintGoSum(gs)
-	if got != content {
-		t.Fatalf("not lossless\n--- want ---\n%q\n--- got ---\n%q", content, got)
-	}
+	require.Equal(t, content, got)
 }
 
 func TestGoSumLossless(t *testing.T) {
@@ -81,22 +79,14 @@ func TestGoSumFields(t *testing.T) {
 
 	// when
 	gs, err := ParseGoSumFile("go.sum", content)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// then
-	if len(gs.Lines) != 2 {
-		t.Fatalf("expected 2 lines, got %d", len(gs.Lines))
-	}
+	require.Len(t, gs.Lines, 2)
 	zip := gs.Lines[0].Element
-	if zip.ModulePath != "github.com/a/b" || zip.Version != "v1.0.0" || zip.GoMod || zip.Hash != "h1:zip=" {
-		t.Fatalf("zip line fields wrong: %#v", zip)
-	}
+	require.False(t, zip.ModulePath != "github.com/a/b" || zip.Version != "v1.0.0" || zip.GoMod || zip.Hash != "h1:zip=")
 	mod := gs.Lines[1].Element
-	if !mod.GoMod || mod.Hash != "h1:mod=" {
-		t.Fatalf("go.mod line fields wrong: %#v", mod)
-	}
+	require.False(t, !mod.GoMod || mod.Hash != "h1:mod=")
 }
 
 func TestGoSumMalformedLineErrors(t *testing.T) {

--- a/rewrite-go/pkg/parser/gosum_lst_test.go
+++ b/rewrite-go/pkg/parser/gosum_lst_test.go
@@ -26,9 +26,9 @@ import (
 func roundTripSum(t *testing.T, content string) {
 	t.Helper()
 	gs, err := ParseGoSumFile("go.sum", content)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	got := printer.PrintGoSum(gs)
-	require.Equal(t, content, got)
+	require.Equal(t, content, got, "not lossless")
 }
 
 func TestGoSumLossless(t *testing.T) {
@@ -79,14 +79,14 @@ func TestGoSumFields(t *testing.T) {
 
 	// when
 	gs, err := ParseGoSumFile("go.sum", content)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 
 	// then
-	require.Len(t, gs.Lines, 2)
+	require.Len(t, gs.Lines, 2, "expected 2 lines")
 	zip := gs.Lines[0].Element
-	require.False(t, zip.ModulePath != "github.com/a/b" || zip.Version != "v1.0.0" || zip.GoMod || zip.Hash != "h1:zip=")
+	require.False(t, zip.ModulePath != "github.com/a/b" || zip.Version != "v1.0.0" || zip.GoMod || zip.Hash != "h1:zip=", "zip line fields wrong")
 	mod := gs.Lines[1].Element
-	require.False(t, !mod.GoMod || mod.Hash != "h1:mod=")
+	require.False(t, !mod.GoMod || mod.Hash != "h1:mod=", "go.mod line fields wrong")
 }
 
 func TestGoSumMalformedLineErrors(t *testing.T) {

--- a/rewrite-go/pkg/parser/if_init_test.go
+++ b/rewrite-go/pkg/parser/if_init_test.go
@@ -31,15 +31,13 @@ import (
 func firstStatementInBody(t *testing.T, src string) java.Statement {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("body.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	if len(cu.Statements) == 0 {
 		t.Fatalf("no top-level statements parsed")
 	}
 	fn, ok := cu.Statements[0].Element.(*java.MethodDeclaration)
-	if !ok {
-		t.Fatalf("expected first statement to be *java.MethodDeclaration, got %T", cu.Statements[0].Element)
-	}
-	require.False(t, fn.Body == nil || len(fn.Body.Statements) == 0)
+	require.Truef(t, ok, "expected first statement to be *java.MethodDeclaration, got %T", cu.Statements[0].Element)
+	require.False(t, fn.Body == nil || len(fn.Body.Statements) == 0, "function body is empty")
 	return fn.Body.Statements[0].Element
 }
 
@@ -69,10 +67,10 @@ func TestIfConditionIsControlParentheses(t *testing.T) {
 
 	// when
 	ifStmt, ok := firstStatementInBody(t, src).(*java.If)
-	require.True(t, ok)
+	require.True(t, ok, "expected *java.If")
 
 	// then
-	require.NotNil(t, ifStmt.Condition)
+	require.NotNil(t, ifStmt.Condition, "condition must be a *java.ControlParentheses, got nil")
 	if _, ok := ifStmt.Condition.Tree.Element.(*java.Identifier); !ok {
 		t.Fatalf("expected the condition to wrap the bare *java.Identifier, got %T", ifStmt.Condition.Tree.Element)
 	}
@@ -89,15 +87,13 @@ func TestIfWithInitIsWrapped(t *testing.T) {
 
 	// then
 	wrapper, ok := stmt.(*golang.StatementWithInit)
-	if !ok {
-		t.Fatalf("expected *golang.StatementWithInit, got %T", stmt)
-	}
-	require.NotNil(t, wrapper.Init.Element)
+	require.Truef(t, ok, "expected *golang.StatementWithInit, got %T", stmt)
+	require.NotNil(t, wrapper.Init.Element, "wrapper must carry the init statement")
 	if _, ok := wrapper.Statement.(*java.If); !ok {
 		t.Fatalf("wrapper must hold the inner *java.If, got %T", wrapper.Statement)
 	}
 	// The prefix (whitespace before `if`) belongs on the outermost node.
-	require.Equal(t, "\n\t", wrapper.Prefix.Whitespace)
+	require.Equalf(t, "\n\t", wrapper.Prefix.Whitespace, "expected wrapper to carry the prefix %q", "\n\t")
 	if inner := wrapper.Statement.(*java.If); inner.Prefix.Whitespace != "" || len(inner.Prefix.Comments) != 0 {
 		t.Fatalf("inner if must be prefix-less, got %+v", inner.Prefix)
 	}
@@ -114,9 +110,7 @@ func TestSwitchWithInitIsWrapped(t *testing.T) {
 
 	// then
 	wrapper, ok := stmt.(*golang.StatementWithInit)
-	if !ok {
-		t.Fatalf("expected *golang.StatementWithInit, got %T", stmt)
-	}
+	require.Truef(t, ok, "expected *golang.StatementWithInit, got %T", stmt)
 	if _, ok := wrapper.Statement.(*java.Switch); !ok {
 		t.Fatalf("wrapper must hold the inner *java.Switch, got %T", wrapper.Statement)
 	}

--- a/rewrite-go/pkg/parser/if_init_test.go
+++ b/rewrite-go/pkg/parser/if_init_test.go
@@ -19,6 +19,8 @@ package parser_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -29,9 +31,7 @@ import (
 func firstStatementInBody(t *testing.T, src string) java.Statement {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("body.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	if len(cu.Statements) == 0 {
 		t.Fatalf("no top-level statements parsed")
 	}
@@ -39,9 +39,7 @@ func firstStatementInBody(t *testing.T, src string) java.Statement {
 	if !ok {
 		t.Fatalf("expected first statement to be *java.MethodDeclaration, got %T", cu.Statements[0].Element)
 	}
-	if fn.Body == nil || len(fn.Body.Statements) == 0 {
-		t.Fatalf("function body is empty")
-	}
+	require.False(t, fn.Body == nil || len(fn.Body.Statements) == 0)
 	return fn.Body.Statements[0].Element
 }
 
@@ -71,14 +69,10 @@ func TestIfConditionIsControlParentheses(t *testing.T) {
 
 	// when
 	ifStmt, ok := firstStatementInBody(t, src).(*java.If)
-	if !ok {
-		t.Fatalf("expected *java.If")
-	}
+	require.True(t, ok)
 
 	// then
-	if ifStmt.Condition == nil {
-		t.Fatalf("condition must be a *java.ControlParentheses, got nil")
-	}
+	require.NotNil(t, ifStmt.Condition)
 	if _, ok := ifStmt.Condition.Tree.Element.(*java.Identifier); !ok {
 		t.Fatalf("expected the condition to wrap the bare *java.Identifier, got %T", ifStmt.Condition.Tree.Element)
 	}
@@ -98,16 +92,12 @@ func TestIfWithInitIsWrapped(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected *golang.StatementWithInit, got %T", stmt)
 	}
-	if wrapper.Init.Element == nil {
-		t.Fatalf("wrapper must carry the init statement")
-	}
+	require.NotNil(t, wrapper.Init.Element)
 	if _, ok := wrapper.Statement.(*java.If); !ok {
 		t.Fatalf("wrapper must hold the inner *java.If, got %T", wrapper.Statement)
 	}
 	// The prefix (whitespace before `if`) belongs on the outermost node.
-	if wrapper.Prefix.Whitespace != "\n\t" {
-		t.Fatalf("expected wrapper to carry the prefix %q, got %q", "\n\t", wrapper.Prefix.Whitespace)
-	}
+	require.Equal(t, "\n\t", wrapper.Prefix.Whitespace)
 	if inner := wrapper.Statement.(*java.If); inner.Prefix.Whitespace != "" || len(inner.Prefix.Comments) != 0 {
 		t.Fatalf("inner if must be prefix-less, got %+v", inner.Prefix)
 	}

--- a/rewrite-go/pkg/parser/type_constraints_test.go
+++ b/rewrite-go/pkg/parser/type_constraints_test.go
@@ -34,7 +34,7 @@ import (
 func interfaceBodyTypeExpr(t *testing.T, src string) java.Expression {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("constraints.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	for _, rp := range cu.Statements {
 		td, ok := rp.Element.(*golang.TypeDecl)
 		if !ok {
@@ -44,11 +44,9 @@ func interfaceBodyTypeExpr(t *testing.T, src string) java.Expression {
 		if !ok {
 			continue
 		}
-		require.Len(t, it.Body.Statements, 1)
+		require.Len(t, it.Body.Statements, 1, "expected 1 interface body element")
 		vd, ok := it.Body.Statements[0].Element.(*java.VariableDeclarations)
-		if !ok {
-			t.Fatalf("expected body element to be *java.VariableDeclarations, got %T", it.Body.Statements[0].Element)
-		}
+		require.Truef(t, ok, "expected body element to be *java.VariableDeclarations, got %T", it.Body.Statements[0].Element)
 		return vd.TypeExpr
 	}
 	t.Fatalf("no interface type declaration found")
@@ -58,7 +56,7 @@ func interfaceBodyTypeExpr(t *testing.T, src string) java.Expression {
 func assertRoundTrip(t *testing.T, src string) {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("constraints.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	if printed := printer.Print(cu); printed != src {
 		t.Errorf("round-trip mismatch\n--- expected ---\n%q\n--- actual ---\n%q", src, printed)
 	}
@@ -72,15 +70,11 @@ func TestUnionConstraintIsUnionType(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	union, ok := typeExpr.(*golang.Union)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
-	}
-	require.Len(t, union.Types, 3)
+	require.Truef(t, ok, "expected TypeExpr to be *golang.Union, got %T", typeExpr)
+	require.Len(t, union.Types, 3, "expected 3 union terms")
 	for i, term := range union.Types {
 		ut, ok := term.Element.(*golang.UnderlyingType)
-		if !ok {
-			t.Fatalf("term %d: expected *golang.UnderlyingType, got %T", i, term.Element)
-		}
+		require.Truef(t, ok, "term %d: expected *golang.UnderlyingType, got %T", i, term.Element)
 		if _, ok := ut.Element.(*java.Identifier); !ok {
 			t.Fatalf("term %d: expected underlying *java.Identifier, got %T", i, ut.Element)
 		}
@@ -94,9 +88,7 @@ func TestStandaloneApproximationIsUnderlyingType(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	ut, ok := typeExpr.(*golang.UnderlyingType)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.UnderlyingType, got %T", typeExpr)
-	}
+	require.Truef(t, ok, "expected TypeExpr to be *golang.UnderlyingType, got %T", typeExpr)
 	if id, ok := ut.Element.(*java.Identifier); !ok || id.Name != "int" {
 		t.Fatalf("expected underlying Identifier(int), got %T (%v)", ut.Element, fmt.Sprintf("%v", ut.Element))
 	}
@@ -110,10 +102,8 @@ func TestUnionOfNamedConstraints(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	union, ok := typeExpr.(*golang.Union)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
-	}
-	require.Len(t, union.Types, 2)
+	require.Truef(t, ok, "expected TypeExpr to be *golang.Union, got %T", typeExpr)
+	require.Len(t, union.Types, 2, "expected 2 union terms")
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*java.Identifier); !ok {
 			t.Fatalf("term %d: expected *java.Identifier, got %T", i, term.Element)
@@ -129,14 +119,10 @@ func TestApproximationOverSliceType(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	union, ok := typeExpr.(*golang.Union)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
-	}
-	require.Len(t, union.Types, 2)
+	require.Truef(t, ok, "expected TypeExpr to be *golang.Union, got %T", typeExpr)
+	require.Len(t, union.Types, 2, "expected 2 union terms")
 	first, ok := union.Types[0].Element.(*golang.UnderlyingType)
-	if !ok {
-		t.Fatalf("term 0: expected *golang.UnderlyingType, got %T", union.Types[0].Element)
-	}
+	require.Truef(t, ok, "term 0: expected *golang.UnderlyingType, got %T", union.Types[0].Element)
 	if _, ok := first.Element.(*java.ArrayType); !ok {
 		t.Fatalf("term 0: expected underlying *java.ArrayType (slice), got %T", first.Element)
 	}
@@ -150,10 +136,8 @@ func TestUnionOfPointerTypes(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	union, ok := typeExpr.(*golang.Union)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
-	}
-	require.Len(t, union.Types, 2)
+	require.Truef(t, ok, "expected TypeExpr to be *golang.Union, got %T", typeExpr)
+	require.Len(t, union.Types, 2, "expected 2 union terms")
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*golang.PointerType); !ok {
 			t.Fatalf("term %d: expected *golang.PointerType, got %T", i, term.Element)
@@ -169,10 +153,8 @@ func TestUnionOfQualifiedNames(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	union, ok := typeExpr.(*golang.Union)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
-	}
-	require.Len(t, union.Types, 2)
+	require.Truef(t, ok, "expected TypeExpr to be *golang.Union, got %T", typeExpr)
+	require.Len(t, union.Types, 2, "expected 2 union terms")
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*java.FieldAccess); !ok {
 			t.Fatalf("term %d: expected *java.FieldAccess, got %T", i, term.Element)
@@ -188,10 +170,8 @@ func TestPlainUnionOfPrimitives(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	union, ok := typeExpr.(*golang.Union)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
-	}
-	require.Len(t, union.Types, 10)
+	require.Truef(t, ok, "expected TypeExpr to be *golang.Union, got %T", typeExpr)
+	require.Len(t, union.Types, 10, "expected 10 union terms")
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*java.Identifier); !ok {
 			t.Fatalf("term %d: expected *java.Identifier, got %T", i, term.Element)
@@ -207,10 +187,8 @@ func TestUnionOfQualifiedNameAndSlice(t *testing.T) {
 	typeExpr := interfaceBodyTypeExpr(t, src)
 
 	union, ok := typeExpr.(*golang.Union)
-	if !ok {
-		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
-	}
-	require.Len(t, union.Types, 2)
+	require.Truef(t, ok, "expected TypeExpr to be *golang.Union, got %T", typeExpr)
+	require.Len(t, union.Types, 2, "expected 2 union terms")
 	if _, ok := union.Types[0].Element.(*java.FieldAccess); !ok {
 		t.Fatalf("term 0: expected *java.FieldAccess (qualified name), got %T", union.Types[0].Element)
 	}

--- a/rewrite-go/pkg/parser/type_constraints_test.go
+++ b/rewrite-go/pkg/parser/type_constraints_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -32,9 +34,7 @@ import (
 func interfaceBodyTypeExpr(t *testing.T, src string) java.Expression {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("constraints.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	for _, rp := range cu.Statements {
 		td, ok := rp.Element.(*golang.TypeDecl)
 		if !ok {
@@ -44,9 +44,7 @@ func interfaceBodyTypeExpr(t *testing.T, src string) java.Expression {
 		if !ok {
 			continue
 		}
-		if len(it.Body.Statements) != 1 {
-			t.Fatalf("expected 1 interface body element, got %d", len(it.Body.Statements))
-		}
+		require.Len(t, it.Body.Statements, 1)
 		vd, ok := it.Body.Statements[0].Element.(*java.VariableDeclarations)
 		if !ok {
 			t.Fatalf("expected body element to be *java.VariableDeclarations, got %T", it.Body.Statements[0].Element)
@@ -60,9 +58,7 @@ func interfaceBodyTypeExpr(t *testing.T, src string) java.Expression {
 func assertRoundTrip(t *testing.T, src string) {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("constraints.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	if printed := printer.Print(cu); printed != src {
 		t.Errorf("round-trip mismatch\n--- expected ---\n%q\n--- actual ---\n%q", src, printed)
 	}
@@ -79,9 +75,7 @@ func TestUnionConstraintIsUnionType(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
 	}
-	if len(union.Types) != 3 {
-		t.Fatalf("expected 3 union terms, got %d", len(union.Types))
-	}
+	require.Len(t, union.Types, 3)
 	for i, term := range union.Types {
 		ut, ok := term.Element.(*golang.UnderlyingType)
 		if !ok {
@@ -119,9 +113,7 @@ func TestUnionOfNamedConstraints(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
 	}
-	if len(union.Types) != 2 {
-		t.Fatalf("expected 2 union terms, got %d", len(union.Types))
-	}
+	require.Len(t, union.Types, 2)
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*java.Identifier); !ok {
 			t.Fatalf("term %d: expected *java.Identifier, got %T", i, term.Element)
@@ -140,9 +132,7 @@ func TestApproximationOverSliceType(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
 	}
-	if len(union.Types) != 2 {
-		t.Fatalf("expected 2 union terms, got %d", len(union.Types))
-	}
+	require.Len(t, union.Types, 2)
 	first, ok := union.Types[0].Element.(*golang.UnderlyingType)
 	if !ok {
 		t.Fatalf("term 0: expected *golang.UnderlyingType, got %T", union.Types[0].Element)
@@ -163,9 +153,7 @@ func TestUnionOfPointerTypes(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
 	}
-	if len(union.Types) != 2 {
-		t.Fatalf("expected 2 union terms, got %d", len(union.Types))
-	}
+	require.Len(t, union.Types, 2)
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*golang.PointerType); !ok {
 			t.Fatalf("term %d: expected *golang.PointerType, got %T", i, term.Element)
@@ -184,9 +172,7 @@ func TestUnionOfQualifiedNames(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
 	}
-	if len(union.Types) != 2 {
-		t.Fatalf("expected 2 union terms, got %d", len(union.Types))
-	}
+	require.Len(t, union.Types, 2)
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*java.FieldAccess); !ok {
 			t.Fatalf("term %d: expected *java.FieldAccess, got %T", i, term.Element)
@@ -205,9 +191,7 @@ func TestPlainUnionOfPrimitives(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
 	}
-	if len(union.Types) != 10 {
-		t.Fatalf("expected 10 union terms, got %d", len(union.Types))
-	}
+	require.Len(t, union.Types, 10)
 	for i, term := range union.Types {
 		if _, ok := term.Element.(*java.Identifier); !ok {
 			t.Fatalf("term %d: expected *java.Identifier, got %T", i, term.Element)
@@ -226,9 +210,7 @@ func TestUnionOfQualifiedNameAndSlice(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected TypeExpr to be *golang.Union, got %T", typeExpr)
 	}
-	if len(union.Types) != 2 {
-		t.Fatalf("expected 2 union terms, got %d", len(union.Types))
-	}
+	require.Len(t, union.Types, 2)
 	if _, ok := union.Types[0].Element.(*java.FieldAccess); !ok {
 		t.Fatalf("term 0: expected *java.FieldAccess (qualified name), got %T", union.Types[0].Element)
 	}

--- a/rewrite-go/pkg/preconditions/preconditions_test.go
+++ b/rewrite-go/pkg/preconditions/preconditions_test.go
@@ -19,6 +19,8 @@ package preconditions
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -56,12 +58,8 @@ func TestCheckRunsEditorWhenConditionMarks(t *testing.T) {
 	wrapped := Check(cond, editor)
 	wrapped.Visit(newSourceFile(), nil)
 
-	if cond.calls != 1 {
-		t.Errorf("condition calls = %d, want 1", cond.calls)
-	}
-	if editor.calls != 1 {
-		t.Errorf("editor calls = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, cond.calls)
+	assert.Equal(t, 1, editor.calls)
 }
 
 func TestCheckSkipsEditorWhenConditionReturnsIdentity(t *testing.T) {
@@ -71,12 +69,8 @@ func TestCheckSkipsEditorWhenConditionReturnsIdentity(t *testing.T) {
 	wrapped := Check(cond, editor)
 	wrapped.Visit(newSourceFile(), nil)
 
-	if cond.calls != 1 {
-		t.Errorf("condition calls = %d, want 1", cond.calls)
-	}
-	if editor.calls != 0 {
-		t.Errorf("editor calls = %d, want 0 (gate did not match)", editor.calls)
-	}
+	assert.Equal(t, 1, cond.calls)
+	assert.Equal(t, 0, editor.calls)
 }
 
 func TestOrShortCircuitsOnFirstMatch(t *testing.T) {
@@ -86,15 +80,9 @@ func TestOrShortCircuitsOnFirstMatch(t *testing.T) {
 
 	Check(Or(matching, nonMatching), editor).Visit(newSourceFile(), nil)
 
-	if matching.calls != 1 {
-		t.Errorf("matching calls = %d, want 1", matching.calls)
-	}
-	if nonMatching.calls != 0 {
-		t.Errorf("nonMatching calls = %d, want 0 (Or should short-circuit)", nonMatching.calls)
-	}
-	if editor.calls != 1 {
-		t.Errorf("editor calls = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, matching.calls)
+	assert.Equal(t, 0, nonMatching.calls)
+	assert.Equal(t, 1, editor.calls)
 }
 
 func TestOrSkipsEditorWhenNoOperandMatches(t *testing.T) {
@@ -104,12 +92,8 @@ func TestOrSkipsEditorWhenNoOperandMatches(t *testing.T) {
 
 	Check(Or(a, b), editor).Visit(newSourceFile(), nil)
 
-	if a.calls != 1 || b.calls != 1 {
-		t.Errorf("operand calls = %d / %d, want 1 / 1", a.calls, b.calls)
-	}
-	if editor.calls != 0 {
-		t.Errorf("editor calls = %d, want 0", editor.calls)
-	}
+	assert.False(t, a.calls != 1 || b.calls != 1)
+	assert.Equal(t, 0, editor.calls)
 }
 
 func TestAndRunsEditorOnlyWhenAllMatch(t *testing.T) {
@@ -117,29 +101,21 @@ func TestAndRunsEditorOnlyWhenAllMatch(t *testing.T) {
 	b := &markingVisitor{}
 	editor := &recordingVisitor{}
 	Check(And(a, b), editor).Visit(newSourceFile(), nil)
-	if editor.calls != 1 {
-		t.Errorf("editor calls (all match) = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, editor.calls)
 
 	editor2 := &recordingVisitor{}
 	Check(And(a, &recordingVisitor{}), editor2).Visit(newSourceFile(), nil)
-	if editor2.calls != 0 {
-		t.Errorf("editor2 calls (one non-matching) = %d, want 0", editor2.calls)
-	}
+	assert.Equal(t, 0, editor2.calls)
 }
 
 func TestNotInvertsMatch(t *testing.T) {
 	editor1 := &recordingVisitor{}
 	Check(Not(&markingVisitor{}), editor1).Visit(newSourceFile(), nil)
-	if editor1.calls != 0 {
-		t.Errorf("not(matching): editor calls = %d, want 0", editor1.calls)
-	}
+	assert.Equal(t, 0, editor1.calls)
 
 	editor2 := &recordingVisitor{}
 	Check(Not(&recordingVisitor{}), editor2).Visit(newSourceFile(), nil)
-	if editor2.calls != 1 {
-		t.Errorf("not(non-matching): editor calls = %d, want 1", editor2.calls)
-	}
+	assert.Equal(t, 1, editor2.calls)
 }
 
 func TestBareRecipeRefShortCircuitsToMatch(t *testing.T) {
@@ -152,9 +128,7 @@ func TestBareRecipeRefShortCircuitsToMatch(t *testing.T) {
 		Options:    map[string]any{"methodPattern": "*..* nope(..)"},
 	}
 	Check(bare, editor).Visit(newSourceFile(), nil)
-	if editor.calls != 1 {
-		t.Errorf("editor calls (bare RecipeRef) = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, editor.calls)
 }
 
 func TestRecipeRefWithLocalVisitorEvaluatesForReal(t *testing.T) {
@@ -164,28 +138,16 @@ func TestRecipeRefWithLocalVisitorEvaluatesForReal(t *testing.T) {
 	// fails and the editor is skipped.
 	editor := &recordingVisitor{}
 	Check(UsesMethod("*..* tostring(..)"), editor).Visit(newSourceFile(), nil)
-	if editor.calls != 0 {
-		t.Errorf("editor calls (RecipeRef with LocalVisitor) = %d, want 0", editor.calls)
-	}
+	assert.Equal(t, 0, editor.calls)
 }
 
 func TestHelpersPopulateLocalVisitor(t *testing.T) {
 	// Spot-check that helpers bundle a TreeVisitor for offline eval.
-	if HasSourcePath("**/*.go").LocalVisitor == nil {
-		t.Errorf("HasSourcePath did not populate LocalVisitor")
-	}
-	if UsesMethod("*..* a(..)").LocalVisitor == nil {
-		t.Errorf("UsesMethod did not populate LocalVisitor")
-	}
-	if UsesType("foo.Bar").LocalVisitor == nil {
-		t.Errorf("UsesType did not populate LocalVisitor")
-	}
-	if FindMethods("*..* a(..)").LocalVisitor == nil {
-		t.Errorf("FindMethods did not populate LocalVisitor")
-	}
-	if FindTypes("foo.Bar").LocalVisitor == nil {
-		t.Errorf("FindTypes did not populate LocalVisitor")
-	}
+	assert.NotNil(t, HasSourcePath("**/*.go").LocalVisitor)
+	assert.NotNil(t, UsesMethod("*..* a(..)").LocalVisitor)
+	assert.NotNil(t, UsesType("foo.Bar").LocalVisitor)
+	assert.NotNil(t, FindMethods("*..* a(..)").LocalVisitor)
+	assert.NotNil(t, FindTypes("foo.Bar").LocalVisitor)
 }
 
 func TestHasSourcePathMatchesCompilationUnit(t *testing.T) {
@@ -197,16 +159,12 @@ func TestHasSourcePathMatchesCompilationUnit(t *testing.T) {
 	Check(HasSourcePath("**/*.go"), editor).Visit(cu, nil)
 
 	// then the editor runs
-	if editor.calls != 1 {
-		t.Errorf("editor calls (matching path) = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, editor.calls)
 
 	// and when the glob does not match
 	editor2 := &recordingVisitor{}
 	Check(HasSourcePath("**/*.java"), editor2).Visit(cu, nil)
-	if editor2.calls != 0 {
-		t.Errorf("editor calls (non-matching path) = %d, want 0", editor2.calls)
-	}
+	assert.Equal(t, 0, editor2.calls)
 }
 
 func TestHasSourcePathMatchesGoMod(t *testing.T) {
@@ -218,17 +176,13 @@ func TestHasSourcePathMatchesGoMod(t *testing.T) {
 	Check(HasSourcePath("**/go.mod"), editor).Visit(mod, nil)
 
 	// then the editor runs even though GoMod is not a java.SourceFile
-	if editor.calls != 1 {
-		t.Errorf("editor calls (go.mod) = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, editor.calls)
 
 	// and a non-matching glob must actually filter the GoMod out, rather
 	// than the gate being bypassed because GoMod is not a java.SourceFile.
 	editor2 := &recordingVisitor{}
 	Check(HasSourcePath("**/*.go"), editor2).Visit(mod, nil)
-	if editor2.calls != 0 {
-		t.Errorf("editor calls (go.mod, non-matching) = %d, want 0", editor2.calls)
-	}
+	assert.Equal(t, 0, editor2.calls)
 }
 
 func TestUsesMethodMatchesInvocationInTree(t *testing.T) {
@@ -246,16 +200,12 @@ func TestUsesMethodMatchesInvocationInTree(t *testing.T) {
 	Check(UsesMethod("fmt Println(..)"), editor).Visit(cu, nil)
 
 	// then the editor runs
-	if editor.calls != 1 {
-		t.Errorf("editor calls (matching method) = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, editor.calls)
 
 	// and a non-matching pattern skips the editor
 	editor2 := &recordingVisitor{}
 	Check(UsesMethod("fmt Printf(..)"), editor2).Visit(cu, nil)
-	if editor2.calls != 0 {
-		t.Errorf("editor calls (non-matching method) = %d, want 0", editor2.calls)
-	}
+	assert.Equal(t, 0, editor2.calls)
 }
 
 func TestUsesTypeMatchesAttributionInTree(t *testing.T) {
@@ -274,16 +224,12 @@ func TestUsesTypeMatchesAttributionInTree(t *testing.T) {
 	Check(UsesType("tarfile"), editor).Visit(cu, nil)
 
 	// then the editor runs
-	if editor.calls != 1 {
-		t.Errorf("editor calls (matching type) = %d, want 1", editor.calls)
-	}
+	assert.Equal(t, 1, editor.calls)
 
 	// and an unrelated type skips the editor
 	editor2 := &recordingVisitor{}
 	Check(UsesType("zipfile"), editor2).Visit(cu, nil)
-	if editor2.calls != 0 {
-		t.Errorf("editor calls (non-matching type) = %d, want 0", editor2.calls)
-	}
+	assert.Equal(t, 0, editor2.calls)
 }
 
 func TestOrRequiresAtLeastTwoOperands(t *testing.T) {

--- a/rewrite-go/pkg/preconditions/preconditions_test.go
+++ b/rewrite-go/pkg/preconditions/preconditions_test.go
@@ -58,8 +58,8 @@ func TestCheckRunsEditorWhenConditionMarks(t *testing.T) {
 	wrapped := Check(cond, editor)
 	wrapped.Visit(newSourceFile(), nil)
 
-	assert.Equal(t, 1, cond.calls)
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, cond.calls, "condition calls")
+	assert.Equal(t, 1, editor.calls, "editor calls")
 }
 
 func TestCheckSkipsEditorWhenConditionReturnsIdentity(t *testing.T) {
@@ -69,8 +69,8 @@ func TestCheckSkipsEditorWhenConditionReturnsIdentity(t *testing.T) {
 	wrapped := Check(cond, editor)
 	wrapped.Visit(newSourceFile(), nil)
 
-	assert.Equal(t, 1, cond.calls)
-	assert.Equal(t, 0, editor.calls)
+	assert.Equal(t, 1, cond.calls, "condition calls")
+	assert.Equalf(t, 0, editor.calls, "editor calls = %d, want 0 (gate did not match)", editor.calls)
 }
 
 func TestOrShortCircuitsOnFirstMatch(t *testing.T) {
@@ -80,9 +80,9 @@ func TestOrShortCircuitsOnFirstMatch(t *testing.T) {
 
 	Check(Or(matching, nonMatching), editor).Visit(newSourceFile(), nil)
 
-	assert.Equal(t, 1, matching.calls)
-	assert.Equal(t, 0, nonMatching.calls)
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, matching.calls, "matching calls")
+	assert.Equalf(t, 0, nonMatching.calls, "nonMatching calls = %d, want 0 (Or should short-circuit)", nonMatching.calls)
+	assert.Equal(t, 1, editor.calls, "editor calls")
 }
 
 func TestOrSkipsEditorWhenNoOperandMatches(t *testing.T) {
@@ -92,8 +92,8 @@ func TestOrSkipsEditorWhenNoOperandMatches(t *testing.T) {
 
 	Check(Or(a, b), editor).Visit(newSourceFile(), nil)
 
-	assert.False(t, a.calls != 1 || b.calls != 1)
-	assert.Equal(t, 0, editor.calls)
+	assert.False(t, a.calls != 1 || b.calls != 1, "operand calls")
+	assert.Equal(t, 0, editor.calls, "editor calls")
 }
 
 func TestAndRunsEditorOnlyWhenAllMatch(t *testing.T) {
@@ -101,21 +101,21 @@ func TestAndRunsEditorOnlyWhenAllMatch(t *testing.T) {
 	b := &markingVisitor{}
 	editor := &recordingVisitor{}
 	Check(And(a, b), editor).Visit(newSourceFile(), nil)
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, editor.calls, "editor calls (all match")
 
 	editor2 := &recordingVisitor{}
 	Check(And(a, &recordingVisitor{}), editor2).Visit(newSourceFile(), nil)
-	assert.Equal(t, 0, editor2.calls)
+	assert.Equal(t, 0, editor2.calls, "editor2 calls (one non-matching")
 }
 
 func TestNotInvertsMatch(t *testing.T) {
 	editor1 := &recordingVisitor{}
 	Check(Not(&markingVisitor{}), editor1).Visit(newSourceFile(), nil)
-	assert.Equal(t, 0, editor1.calls)
+	assert.Equal(t, 0, editor1.calls, "not(matching): editor calls")
 
 	editor2 := &recordingVisitor{}
 	Check(Not(&recordingVisitor{}), editor2).Visit(newSourceFile(), nil)
-	assert.Equal(t, 1, editor2.calls)
+	assert.Equal(t, 1, editor2.calls, "not(non-matching): editor calls")
 }
 
 func TestBareRecipeRefShortCircuitsToMatch(t *testing.T) {
@@ -128,7 +128,7 @@ func TestBareRecipeRefShortCircuitsToMatch(t *testing.T) {
 		Options:    map[string]any{"methodPattern": "*..* nope(..)"},
 	}
 	Check(bare, editor).Visit(newSourceFile(), nil)
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, editor.calls, "editor calls (bare RecipeRef")
 }
 
 func TestRecipeRefWithLocalVisitorEvaluatesForReal(t *testing.T) {
@@ -138,16 +138,16 @@ func TestRecipeRefWithLocalVisitorEvaluatesForReal(t *testing.T) {
 	// fails and the editor is skipped.
 	editor := &recordingVisitor{}
 	Check(UsesMethod("*..* tostring(..)"), editor).Visit(newSourceFile(), nil)
-	assert.Equal(t, 0, editor.calls)
+	assert.Equal(t, 0, editor.calls, "editor calls (RecipeRef with LocalVisitor")
 }
 
 func TestHelpersPopulateLocalVisitor(t *testing.T) {
 	// Spot-check that helpers bundle a TreeVisitor for offline eval.
-	assert.NotNil(t, HasSourcePath("**/*.go").LocalVisitor)
-	assert.NotNil(t, UsesMethod("*..* a(..)").LocalVisitor)
-	assert.NotNil(t, UsesType("foo.Bar").LocalVisitor)
-	assert.NotNil(t, FindMethods("*..* a(..)").LocalVisitor)
-	assert.NotNil(t, FindTypes("foo.Bar").LocalVisitor)
+	assert.NotNil(t, HasSourcePath("**/*.go").LocalVisitor, "HasSourcePath did not populate LocalVisitor")
+	assert.NotNil(t, UsesMethod("*..* a(..)").LocalVisitor, "UsesMethod did not populate LocalVisitor")
+	assert.NotNil(t, UsesType("foo.Bar").LocalVisitor, "UsesType did not populate LocalVisitor")
+	assert.NotNil(t, FindMethods("*..* a(..)").LocalVisitor, "FindMethods did not populate LocalVisitor")
+	assert.NotNil(t, FindTypes("foo.Bar").LocalVisitor, "FindTypes did not populate LocalVisitor")
 }
 
 func TestHasSourcePathMatchesCompilationUnit(t *testing.T) {
@@ -159,12 +159,12 @@ func TestHasSourcePathMatchesCompilationUnit(t *testing.T) {
 	Check(HasSourcePath("**/*.go"), editor).Visit(cu, nil)
 
 	// then the editor runs
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, editor.calls, "editor calls (matching path")
 
 	// and when the glob does not match
 	editor2 := &recordingVisitor{}
 	Check(HasSourcePath("**/*.java"), editor2).Visit(cu, nil)
-	assert.Equal(t, 0, editor2.calls)
+	assert.Equal(t, 0, editor2.calls, "editor calls (non-matching path")
 }
 
 func TestHasSourcePathMatchesGoMod(t *testing.T) {
@@ -176,13 +176,13 @@ func TestHasSourcePathMatchesGoMod(t *testing.T) {
 	Check(HasSourcePath("**/go.mod"), editor).Visit(mod, nil)
 
 	// then the editor runs even though GoMod is not a java.SourceFile
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, editor.calls, "editor calls (go.mod")
 
 	// and a non-matching glob must actually filter the GoMod out, rather
 	// than the gate being bypassed because GoMod is not a java.SourceFile.
 	editor2 := &recordingVisitor{}
 	Check(HasSourcePath("**/*.go"), editor2).Visit(mod, nil)
-	assert.Equal(t, 0, editor2.calls)
+	assert.Equal(t, 0, editor2.calls, "editor calls (go.mod, non-matching")
 }
 
 func TestUsesMethodMatchesInvocationInTree(t *testing.T) {
@@ -200,12 +200,12 @@ func TestUsesMethodMatchesInvocationInTree(t *testing.T) {
 	Check(UsesMethod("fmt Println(..)"), editor).Visit(cu, nil)
 
 	// then the editor runs
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, editor.calls, "editor calls (matching method")
 
 	// and a non-matching pattern skips the editor
 	editor2 := &recordingVisitor{}
 	Check(UsesMethod("fmt Printf(..)"), editor2).Visit(cu, nil)
-	assert.Equal(t, 0, editor2.calls)
+	assert.Equal(t, 0, editor2.calls, "editor calls (non-matching method")
 }
 
 func TestUsesTypeMatchesAttributionInTree(t *testing.T) {
@@ -224,12 +224,12 @@ func TestUsesTypeMatchesAttributionInTree(t *testing.T) {
 	Check(UsesType("tarfile"), editor).Visit(cu, nil)
 
 	// then the editor runs
-	assert.Equal(t, 1, editor.calls)
+	assert.Equal(t, 1, editor.calls, "editor calls (matching type")
 
 	// and an unrelated type skips the editor
 	editor2 := &recordingVisitor{}
 	Check(UsesType("zipfile"), editor2).Visit(cu, nil)
-	assert.Equal(t, 0, editor2.calls)
+	assert.Equal(t, 0, editor2.calls, "editor calls (non-matching type")
 }
 
 func TestOrRequiresAtLeastTwoOperands(t *testing.T) {

--- a/rewrite-go/pkg/recipe/installer/installer_test.go
+++ b/rewrite-go/pkg/recipe/installer/installer_test.go
@@ -21,6 +21,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIsProxyFetchError(t *testing.T) {
@@ -55,18 +57,14 @@ func TestIsProxyFetchError(t *testing.T) {
 		got := isProxyFetchError(tc.err)
 
 		// then
-		if got != tc.want {
-			t.Errorf("isProxyFetchError(%q) = %v, want %v", tc.err, got, tc.want)
-		}
+		assert.Equal(t, tc.want, got)
 	}
 }
 
 func writeGoMod(t *testing.T, contents string) string {
 	t.Helper()
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(contents), 0o644); err != nil {
-		t.Fatalf("write go.mod: %v", err)
-	}
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(contents), 0o644))
 	return dir
 }
 
@@ -98,9 +96,7 @@ require (
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	if got != "v1.2.3" {
-		t.Errorf("expected v1.2.3, got %q", got)
-	}
+	assert.Equal(t, "v1.2.3", got)
 }
 
 func TestReadResolvedVersion_IndirectRequireInBlock(t *testing.T) {
@@ -119,9 +115,7 @@ require (
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	if got != "v1.2.3" {
-		t.Errorf("expected v1.2.3, got %q", got)
-	}
+	assert.Equal(t, "v1.2.3", got)
 }
 
 func TestReadResolvedVersion_SingleLineRequire(t *testing.T) {
@@ -138,9 +132,7 @@ require github.com/foo/bar v1.2.3
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	if got != "v1.2.3" {
-		t.Errorf("expected v1.2.3, got %q", got)
-	}
+	assert.Equal(t, "v1.2.3", got)
 }
 
 func TestReadResolvedVersion_PrefixCollision(t *testing.T) {
@@ -160,7 +152,5 @@ require (
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	if got != "v1.2.3" {
-		t.Errorf("expected v1.2.3 (the exact match, not the prefix-collision sibling), got %q", got)
-	}
+	assert.Equal(t, "v1.2.3", got)
 }

--- a/rewrite-go/pkg/recipe/installer/installer_test.go
+++ b/rewrite-go/pkg/recipe/installer/installer_test.go
@@ -57,14 +57,14 @@ func TestIsProxyFetchError(t *testing.T) {
 		got := isProxyFetchError(tc.err)
 
 		// then
-		assert.Equal(t, tc.want, got)
+		assert.Equal(t, tc.want, got, "isProxyFetchError")
 	}
 }
 
 func writeGoMod(t *testing.T, contents string) string {
 	t.Helper()
 	dir := t.TempDir()
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(contents), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "go.mod"), []byte(contents), 0o644), "write go.mod")
 	return dir
 }
 
@@ -96,7 +96,7 @@ require (
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	assert.Equal(t, "v1.2.3", got)
+	assert.Equal(t, "v1.2.3", got, "expected v")
 }
 
 func TestReadResolvedVersion_IndirectRequireInBlock(t *testing.T) {
@@ -115,7 +115,7 @@ require (
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	assert.Equal(t, "v1.2.3", got)
+	assert.Equal(t, "v1.2.3", got, "expected v")
 }
 
 func TestReadResolvedVersion_SingleLineRequire(t *testing.T) {
@@ -132,7 +132,7 @@ require github.com/foo/bar v1.2.3
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	assert.Equal(t, "v1.2.3", got)
+	assert.Equal(t, "v1.2.3", got, "expected v")
 }
 
 func TestReadResolvedVersion_PrefixCollision(t *testing.T) {
@@ -152,5 +152,5 @@ require (
 	got := inst.readResolvedVersion("github.com/foo/bar")
 
 	// then
-	assert.Equal(t, "v1.2.3", got)
+	assert.Equal(t, "v1.2.3", got, "expected v1.2.3 (the exact match, not the prefix-collision sibling")
 }

--- a/rewrite-go/pkg/recipe/registry_test.go
+++ b/rewrite-go/pkg/recipe/registry_test.go
@@ -18,6 +18,7 @@ package recipe
 
 import (
 	"testing"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,14 +68,10 @@ func TestRegisterResolvesCompositeChildren(t *testing.T) {
 	// Children with '$' in their names resolve and round-trip correctly.
 	for _, child := range []string{"com.example.Composite$Keep", "com.example.Composite$Negate"} {
 		reg, ok := r.FindRecipe(child)
-		if !ok {
-			t.Fatalf("expected child recipe %q to resolve via FindRecipe", child)
-		}
+		require.Truef(t, ok, "expected child recipe %q to resolve via FindRecipe", child)
 		inst := reg.Constructor(nil)
-		if inst == nil {
-			t.Fatalf("expected child recipe %q constructor to return an instance", child)
-		}
-		assert.Equal(t, inst.Name(), child)
+		require.NotNilf(t, inst, "expected child recipe %q constructor to return an instance", child)
+		assert.Equalf(t, inst.Name(), child, "child %q resolved to instance with name", child)
 	}
 }
 
@@ -91,23 +88,17 @@ func TestCompositeChildrenNotInMarketplace(t *testing.T) {
 	}
 
 	for _, reg := range r.AllRegistrations() {
-		if childNames[reg.Descriptor.Name] {
-			t.Errorf("child recipe %q must not appear in AllRegistrations (marketplace)", reg.Descriptor.Name)
-		}
+		assert.Falsef(t, childNames[reg.Descriptor.Name], "child recipe %q must not appear in AllRegistrations (marketplace)", reg.Descriptor.Name)
 	}
 	for _, desc := range r.AllRecipes() {
-		if childNames[desc.Name] {
-			t.Errorf("child recipe %q must not appear in AllRecipes", desc.Name)
-		}
+		assert.Falsef(t, childNames[desc.Name], "child recipe %q must not appear in AllRecipes", desc.Name)
 	}
 
 	// And not in the category tree.
 	var walk func(c *Category)
 	walk = func(c *Category) {
 		for _, reg := range c.Recipes {
-			if childNames[reg.Descriptor.Name] {
-				t.Errorf("child recipe %q must not appear in the category tree", reg.Descriptor.Name)
-			}
+			assert.Falsef(t, childNames[reg.Descriptor.Name], "child recipe %q must not appear in the category tree", reg.Descriptor.Name)
 		}
 		for _, sub := range c.Subcategories {
 			walk(sub)

--- a/rewrite-go/pkg/recipe/registry_test.go
+++ b/rewrite-go/pkg/recipe/registry_test.go
@@ -16,7 +16,10 @@
 
 package recipe
 
-import "testing"
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
 
 // leafRecipe is a minimal standalone recipe used as a composite child.
 type leafRecipe struct {
@@ -71,9 +74,7 @@ func TestRegisterResolvesCompositeChildren(t *testing.T) {
 		if inst == nil {
 			t.Fatalf("expected child recipe %q constructor to return an instance", child)
 		}
-		if inst.Name() != child {
-			t.Errorf("child %q resolved to instance with name %q", child, inst.Name())
-		}
+		assert.Equal(t, inst.Name(), child)
 	}
 }
 

--- a/rewrite-go/pkg/rpc/annotation_rpc_test.go
+++ b/rewrite-go/pkg/rpc/annotation_rpc_test.go
@@ -93,17 +93,13 @@ func TestAnnotationRpcRoundTrip_BasicTag(t *testing.T) {
 		t.Errorf("ID: got %s, want %s", got.ID, annID)
 	}
 	gotType, ok := got.AnnotationType.(*java.Identifier)
-	if !ok {
-		t.Fatalf("AnnotationType: got %T, want *Identifier", got.AnnotationType)
-	}
-	assert.Equal(t, "json", gotType.Name)
-	require.NotNil(t, got.Arguments)
-	require.Len(t, got.Arguments.Elements, 1)
+	require.Truef(t, ok, "AnnotationType: got %T, want *Identifier", got.AnnotationType)
+	assert.Equalf(t, "json", gotType.Name, "AnnotationType.Name: got %q, want %q", gotType.Name, "json")
+	require.NotNil(t, got.Arguments, "Arguments: got nil, want non-nil")
+	require.Len(t, got.Arguments.Elements, 1, "Arguments.Elements")
 	gotLit, ok := got.Arguments.Elements[0].Element.(*java.Literal)
-	if !ok {
-		t.Fatalf("Arguments[0]: got %T, want *Literal", got.Arguments.Elements[0].Element)
-	}
-	assert.Equal(t, `"name"`, gotLit.Source)
+	require.Truef(t, ok, "Arguments[0]: got %T, want *Literal", got.Arguments.Elements[0].Element)
+	assert.Equalf(t, `"name"`, gotLit.Source, "Arguments[0].Source: got %q, want %q", gotLit.Source, `"name"`)
 	if v, _ := gotLit.Value.(string); v != "name" {
 		t.Errorf("Arguments[0].Value: got %v, want %q", gotLit.Value, "name")
 	}
@@ -123,10 +119,8 @@ func TestAnnotationRpcRoundTrip_NoArguments(t *testing.T) {
 	seed := &java.Annotation{ID: annID}
 	got := roundTripNode(t, before, seed).(*java.Annotation)
 
-	assert.Nil(t, got.Arguments)
-	if !reflect.DeepEqual(got.AnnotationType.(*java.Identifier).Name, "go:noinline") {
-		t.Errorf("AnnotationType.Name: got %q, want %q", got.AnnotationType.(*java.Identifier).Name, "go:noinline")
-	}
+	assert.Nilf(t, got.Arguments, "Arguments: got %+v, want nil", got.Arguments)
+	assert.Truef(t, reflect.DeepEqual(got.AnnotationType.(*java.Identifier).Name, "go:noinline"), "AnnotationType.Name: got %q, want %q", got.AnnotationType.(*java.Identifier).Name, "go:noinline")
 }
 
 func TestAnnotationRpcRoundTrip_PrefixPreserved(t *testing.T) {
@@ -151,5 +145,5 @@ func TestAnnotationRpcRoundTrip_PrefixPreserved(t *testing.T) {
 	seed := &java.Annotation{ID: annID}
 	got := roundTripNode(t, before, seed).(*java.Annotation)
 
-	assert.Equal(t, " ", got.Prefix.Whitespace)
+	assert.Equalf(t, " ", got.Prefix.Whitespace, "Prefix.Whitespace: got %q, want %q", got.Prefix.Whitespace, " ")
 }

--- a/rewrite-go/pkg/rpc/annotation_rpc_test.go
+++ b/rewrite-go/pkg/rpc/annotation_rpc_test.go
@@ -22,6 +22,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
@@ -92,22 +96,14 @@ func TestAnnotationRpcRoundTrip_BasicTag(t *testing.T) {
 	if !ok {
 		t.Fatalf("AnnotationType: got %T, want *Identifier", got.AnnotationType)
 	}
-	if gotType.Name != "json" {
-		t.Errorf("AnnotationType.Name: got %q, want %q", gotType.Name, "json")
-	}
-	if got.Arguments == nil {
-		t.Fatal("Arguments: got nil, want non-nil")
-	}
-	if len(got.Arguments.Elements) != 1 {
-		t.Fatalf("Arguments.Elements: got %d, want 1", len(got.Arguments.Elements))
-	}
+	assert.Equal(t, "json", gotType.Name)
+	require.NotNil(t, got.Arguments)
+	require.Len(t, got.Arguments.Elements, 1)
 	gotLit, ok := got.Arguments.Elements[0].Element.(*java.Literal)
 	if !ok {
 		t.Fatalf("Arguments[0]: got %T, want *Literal", got.Arguments.Elements[0].Element)
 	}
-	if gotLit.Source != `"name"` {
-		t.Errorf("Arguments[0].Source: got %q, want %q", gotLit.Source, `"name"`)
-	}
+	assert.Equal(t, `"name"`, gotLit.Source)
 	if v, _ := gotLit.Value.(string); v != "name" {
 		t.Errorf("Arguments[0].Value: got %v, want %q", gotLit.Value, "name")
 	}
@@ -127,9 +123,7 @@ func TestAnnotationRpcRoundTrip_NoArguments(t *testing.T) {
 	seed := &java.Annotation{ID: annID}
 	got := roundTripNode(t, before, seed).(*java.Annotation)
 
-	if got.Arguments != nil {
-		t.Errorf("Arguments: got %+v, want nil", got.Arguments)
-	}
+	assert.Nil(t, got.Arguments)
 	if !reflect.DeepEqual(got.AnnotationType.(*java.Identifier).Name, "go:noinline") {
 		t.Errorf("AnnotationType.Name: got %q, want %q", got.AnnotationType.(*java.Identifier).Name, "go:noinline")
 	}
@@ -157,7 +151,5 @@ func TestAnnotationRpcRoundTrip_PrefixPreserved(t *testing.T) {
 	seed := &java.Annotation{ID: annID}
 	got := roundTripNode(t, before, seed).(*java.Annotation)
 
-	if got.Prefix.Whitespace != " " {
-		t.Errorf("Prefix.Whitespace: got %q, want %q", got.Prefix.Whitespace, " ")
-	}
+	assert.Equal(t, " ", got.Prefix.Whitespace)
 }

--- a/rewrite-go/pkg/rpc/array_type_length_rpc_test.go
+++ b/rewrite-go/pkg/rpc/array_type_length_rpc_test.go
@@ -34,7 +34,7 @@ func TestArrayTypeLengthSurvivesPrintRoundTrip(t *testing.T) {
 	// given: a Go file using a fixed-size array type `[5]int`
 	src := "package main\n\nfunc process(data [5]int) {\n}\n"
 	cu, err := parser.NewGoParser().Parse("a.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	if got := printer.Print(cu); got != src {
 		t.Fatalf("parse-print idempotence failed:\n got=%q\nwant=%q", got, src)
 	}

--- a/rewrite-go/pkg/rpc/array_type_length_rpc_test.go
+++ b/rewrite-go/pkg/rpc/array_type_length_rpc_test.go
@@ -19,6 +19,8 @@ package rpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -32,9 +34,7 @@ func TestArrayTypeLengthSurvivesPrintRoundTrip(t *testing.T) {
 	// given: a Go file using a fixed-size array type `[5]int`
 	src := "package main\n\nfunc process(data [5]int) {\n}\n"
 	cu, err := parser.NewGoParser().Parse("a.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	if got := printer.Print(cu); got != src {
 		t.Fatalf("parse-print idempotence failed:\n got=%q\nwant=%q", got, src)
 	}

--- a/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
+++ b/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
@@ -96,8 +96,8 @@ func TestParameterizedTypeRoundTrip_TypeParametersNoChange(t *testing.T) {
 	got := roundTripNodeWithBefore(t, after, before, seed).(*java.ParameterizedType)
 
 	// then: TypeParameters stays a *Container[Expression] with its element intact.
-	require.NotNil(t, got.TypeParameters)
-	require.Len(t, got.TypeParameters.Elements, 1)
+	require.NotNil(t, got.TypeParameters, "TypeParameters: got nil, want non-nil *Container[Expression]")
+	require.Len(t, got.TypeParameters.Elements, 1, "TypeParameters.Elements")
 	if id, ok := got.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "string" {
 		t.Errorf("TypeParameters[0]: got %+v, want Identifier{string}", got.TypeParameters.Elements[0].Element)
 	}
@@ -119,8 +119,8 @@ func TestParameterizedTypeRoundTrip_TypeParametersChange(t *testing.T) {
 
 	got := roundTripNode(t, before, seed).(*java.ParameterizedType)
 
-	require.NotNil(t, got.TypeParameters)
-	require.Len(t, got.TypeParameters.Elements, 1)
+	require.NotNil(t, got.TypeParameters, "TypeParameters: got nil, want non-nil")
+	require.Len(t, got.TypeParameters.Elements, 1, "TypeParameters.Elements")
 	if id, ok := got.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "int" {
 		t.Errorf("TypeParameters[0]: got %+v, want Identifier{int}", got.TypeParameters.Elements[0].Element)
 	}
@@ -133,7 +133,7 @@ func TestParameterizedTypeRoundTrip_NilTypeParameters(t *testing.T) {
 	seed := &java.ParameterizedType{ID: ptID}
 
 	got := roundTripNode(t, before, seed).(*java.ParameterizedType)
-	assert.Nil(t, got.TypeParameters)
+	assert.Nilf(t, got.TypeParameters, "TypeParameters: got %+v, want nil", got.TypeParameters)
 }
 
 func TestCompositeRoundTrip_ElementsNoChange(t *testing.T) {
@@ -163,7 +163,7 @@ func TestCompositeRoundTrip_ElementsNoChange(t *testing.T) {
 
 	got := roundTripNodeWithBefore(t, after, before, seed).(*golang.Composite)
 
-	require.Len(t, got.Elements.Elements, 1)
+	require.Len(t, got.Elements.Elements, 1, "Elements")
 	if id, ok := got.Elements.Elements[0].Element.(*java.Identifier); !ok || id.Name != "a" {
 		t.Errorf("Elements[0]: got %+v, want Identifier{a}", got.Elements.Elements[0].Element)
 	}

--- a/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
+++ b/rewrite-go/pkg/rpc/container_pointer_rpc_test.go
@@ -21,6 +21,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -92,12 +96,8 @@ func TestParameterizedTypeRoundTrip_TypeParametersNoChange(t *testing.T) {
 	got := roundTripNodeWithBefore(t, after, before, seed).(*java.ParameterizedType)
 
 	// then: TypeParameters stays a *Container[Expression] with its element intact.
-	if got.TypeParameters == nil {
-		t.Fatal("TypeParameters: got nil, want non-nil *Container[Expression]")
-	}
-	if len(got.TypeParameters.Elements) != 1 {
-		t.Fatalf("TypeParameters.Elements: got %d, want 1", len(got.TypeParameters.Elements))
-	}
+	require.NotNil(t, got.TypeParameters)
+	require.Len(t, got.TypeParameters.Elements, 1)
 	if id, ok := got.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "string" {
 		t.Errorf("TypeParameters[0]: got %+v, want Identifier{string}", got.TypeParameters.Elements[0].Element)
 	}
@@ -119,12 +119,8 @@ func TestParameterizedTypeRoundTrip_TypeParametersChange(t *testing.T) {
 
 	got := roundTripNode(t, before, seed).(*java.ParameterizedType)
 
-	if got.TypeParameters == nil {
-		t.Fatal("TypeParameters: got nil, want non-nil")
-	}
-	if len(got.TypeParameters.Elements) != 1 {
-		t.Fatalf("TypeParameters.Elements: got %d, want 1", len(got.TypeParameters.Elements))
-	}
+	require.NotNil(t, got.TypeParameters)
+	require.Len(t, got.TypeParameters.Elements, 1)
 	if id, ok := got.TypeParameters.Elements[0].Element.(*java.Identifier); !ok || id.Name != "int" {
 		t.Errorf("TypeParameters[0]: got %+v, want Identifier{int}", got.TypeParameters.Elements[0].Element)
 	}
@@ -137,9 +133,7 @@ func TestParameterizedTypeRoundTrip_NilTypeParameters(t *testing.T) {
 	seed := &java.ParameterizedType{ID: ptID}
 
 	got := roundTripNode(t, before, seed).(*java.ParameterizedType)
-	if got.TypeParameters != nil {
-		t.Errorf("TypeParameters: got %+v, want nil", got.TypeParameters)
-	}
+	assert.Nil(t, got.TypeParameters)
 }
 
 func TestCompositeRoundTrip_ElementsNoChange(t *testing.T) {
@@ -169,9 +163,7 @@ func TestCompositeRoundTrip_ElementsNoChange(t *testing.T) {
 
 	got := roundTripNodeWithBefore(t, after, before, seed).(*golang.Composite)
 
-	if len(got.Elements.Elements) != 1 {
-		t.Fatalf("Elements: got %d, want 1", len(got.Elements.Elements))
-	}
+	require.Len(t, got.Elements.Elements, 1)
 	if id, ok := got.Elements.Elements[0].Element.(*java.Identifier); !ok || id.Name != "a" {
 		t.Errorf("Elements[0]: got %+v, want Identifier{a}", got.Elements.Elements[0].Element)
 	}

--- a/rewrite-go/pkg/rpc/decode_batch_edge_test.go
+++ b/rewrite-go/pkg/rpc/decode_batch_edge_test.go
@@ -16,7 +16,10 @@
 
 package rpc
 
-import "testing"
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+)
 
 func TestDecodeBatch_EmptyArray(t *testing.T) {
 	// given
@@ -26,12 +29,8 @@ func TestDecodeBatch_EmptyArray(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(batch) != 0 {
-		t.Fatalf("expected empty batch, got %d", len(batch))
-	}
+	require.NoError(t, err)
+	require.Len(t, batch, 0)
 }
 
 func TestDecodeBatch_NullPayload(t *testing.T) {
@@ -42,12 +41,8 @@ func TestDecodeBatch_NullPayload(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(batch) != 0 {
-		t.Fatalf("expected empty batch for null, got %d", len(batch))
-	}
+	require.NoError(t, err)
+	require.Len(t, batch, 0)
 }
 
 func TestDecodeBatch_NonArrayIsError(t *testing.T) {
@@ -58,9 +53,7 @@ func TestDecodeBatch_NonArrayIsError(t *testing.T) {
 	_, err := DecodeBatch(data, nil)
 
 	// then
-	if err == nil {
-		t.Fatalf("expected error for non-array payload")
-	}
+	require.Error(t, err)
 }
 
 func TestDecodeBatch_StreamsManyMessages(t *testing.T) {
@@ -71,12 +64,8 @@ func TestDecodeBatch_StreamsManyMessages(t *testing.T) {
 	batch, err := DecodeBatch(data, make(map[string]string))
 
 	// then
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(batch) != 500 {
-		t.Fatalf("expected 500 messages, got %d", len(batch))
-	}
+	require.NoError(t, err)
+	require.Len(t, batch, 500)
 	if positions, ok := batch[2].Value.([]any); !ok || len(positions) != 5 {
 		t.Fatalf("message 2 positions not decoded as a list: %#v", batch[2].Value)
 	}

--- a/rewrite-go/pkg/rpc/decode_batch_edge_test.go
+++ b/rewrite-go/pkg/rpc/decode_batch_edge_test.go
@@ -29,8 +29,8 @@ func TestDecodeBatch_EmptyArray(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	require.NoError(t, err)
-	require.Len(t, batch, 0)
+	require.NoError(t, err, "unexpected error")
+	require.Len(t, batch, 0, "expected empty batch")
 }
 
 func TestDecodeBatch_NullPayload(t *testing.T) {
@@ -41,8 +41,8 @@ func TestDecodeBatch_NullPayload(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	require.NoError(t, err)
-	require.Len(t, batch, 0)
+	require.NoError(t, err, "unexpected error")
+	require.Len(t, batch, 0, "expected empty batch for null")
 }
 
 func TestDecodeBatch_NonArrayIsError(t *testing.T) {
@@ -53,7 +53,7 @@ func TestDecodeBatch_NonArrayIsError(t *testing.T) {
 	_, err := DecodeBatch(data, nil)
 
 	// then
-	require.Error(t, err)
+	require.Error(t, err, "expected error for non-array payload")
 }
 
 func TestDecodeBatch_StreamsManyMessages(t *testing.T) {
@@ -64,8 +64,8 @@ func TestDecodeBatch_StreamsManyMessages(t *testing.T) {
 	batch, err := DecodeBatch(data, make(map[string]string))
 
 	// then
-	require.NoError(t, err)
-	require.Len(t, batch, 500)
+	require.NoError(t, err, "unexpected error")
+	require.Len(t, batch, 500, "expected 500 messages")
 	if positions, ok := batch[2].Value.([]any); !ok || len(positions) != 5 {
 		t.Fatalf("message 2 positions not decoded as a list: %#v", batch[2].Value)
 	}

--- a/rewrite-go/pkg/rpc/for_control_rpc_test.go
+++ b/rewrite-go/pkg/rpc/for_control_rpc_test.go
@@ -45,7 +45,7 @@ func TestImplicitForClausesSurvivesRpcRoundTrip(t *testing.T) {
 		t.Run(src, func(t *testing.T) {
 			// given: a parsed for-loop that already prints back to its source
 			cu, err := parser.NewGoParser().Parse("f.go", src)
-			require.NoError(t, err)
+			require.NoError(t, err, "parse")
 			if got := printer.Print(cu); got != src {
 				t.Fatalf("parse-print idempotence failed:\n got=%q\nwant=%q", got, src)
 			}
@@ -61,9 +61,9 @@ func TestImplicitForClausesSurvivesRpcRoundTrip(t *testing.T) {
 			}
 			// ...and the control still carries the placeholders and the marker
 			control := firstForControl(t, rt)
-			assert.NotNil(t, control.Init)
-			assert.NotNil(t, control.Update)
-			assert.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
+			assert.NotNil(t, control.Init, "Init placeholder lost on round-trip")
+			assert.NotNil(t, control.Update, "Update placeholder lost on round-trip")
+			assert.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers), "ImplicitForClauses marker lost on round-trip")
 		})
 	}
 }
@@ -72,9 +72,7 @@ func TestImplicitForClausesSurvivesRpcRoundTrip(t *testing.T) {
 func firstForControl(t *testing.T, tree java.Tree) *java.ForControl {
 	t.Helper()
 	cu, ok := tree.(*golang.CompilationUnit)
-	if !ok {
-		t.Fatalf("expected *golang.CompilationUnit, got %T", tree)
-	}
+	require.Truef(t, ok, "expected *golang.CompilationUnit, got %T", tree)
 	for _, st := range cu.Statements {
 		fn, ok := st.Element.(*java.MethodDeclaration)
 		if !ok || fn.Body == nil {

--- a/rewrite-go/pkg/rpc/for_control_rpc_test.go
+++ b/rewrite-go/pkg/rpc/for_control_rpc_test.go
@@ -19,6 +19,10 @@ package rpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -41,9 +45,7 @@ func TestImplicitForClausesSurvivesRpcRoundTrip(t *testing.T) {
 		t.Run(src, func(t *testing.T) {
 			// given: a parsed for-loop that already prints back to its source
 			cu, err := parser.NewGoParser().Parse("f.go", src)
-			if err != nil {
-				t.Fatalf("parse: %v", err)
-			}
+			require.NoError(t, err)
 			if got := printer.Print(cu); got != src {
 				t.Fatalf("parse-print idempotence failed:\n got=%q\nwant=%q", got, src)
 			}
@@ -59,15 +61,9 @@ func TestImplicitForClausesSurvivesRpcRoundTrip(t *testing.T) {
 			}
 			// ...and the control still carries the placeholders and the marker
 			control := firstForControl(t, rt)
-			if control.Init == nil {
-				t.Errorf("Init placeholder lost on round-trip")
-			}
-			if control.Update == nil {
-				t.Errorf("Update placeholder lost on round-trip")
-			}
-			if java.FindMarker[golang.ImplicitForClauses](control.Markers) == nil {
-				t.Errorf("ImplicitForClauses marker lost on round-trip")
-			}
+			assert.NotNil(t, control.Init)
+			assert.NotNil(t, control.Update)
+			assert.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers))
 		})
 	}
 }

--- a/rewrite-go/pkg/rpc/go_receiver_imports_test.go
+++ b/rewrite-go/pkg/rpc/go_receiver_imports_test.go
@@ -85,7 +85,7 @@ func TestCoerceRightPaddedTyped_NonMatchingElementFallsBack(t *testing.T) {
 	var wire any = java.RightPadded[java.Expression]{Element: makeIdent("x"), After: java.EmptySpace, Markers: java.Markers{}}
 
 	got := coerceRightPaddedTyped[*java.Import](wire)
-	assert.Nil(t, got.Element)
+	assert.Nil(t, got.Element, "want nil Element on fallback")
 }
 
 func TestRawCastPanics_ContainerImportFromExpression(t *testing.T) {
@@ -113,8 +113,8 @@ func TestCompilationUnitRoundTrip_EmptyImports(t *testing.T) {
 	got := roundTripNode(t, before, seed).(*golang.CompilationUnit)
 
 	// then: Imports stays a *Container[*Import].
-	require.NotNil(t, got.Imports)
-	assert.Len(t, got.Imports.Elements, 0)
+	require.NotNil(t, got.Imports, "Imports: got nil, want empty *Container[*Import]")
+	assert.Len(t, got.Imports.Elements, 0, "Imports.Elements")
 }
 
 func TestCompilationUnitRoundTrip_WithImports(t *testing.T) {
@@ -136,10 +136,10 @@ func TestCompilationUnitRoundTrip_WithImports(t *testing.T) {
 	got := roundTripNode(t, before, seed).(*golang.CompilationUnit)
 
 	// then: both imports survive, typed as *Import.
-	require.NotNil(t, got.Imports)
-	require.Len(t, got.Imports.Elements, 2)
+	require.NotNil(t, got.Imports, "Imports: got nil, want non-nil")
+	require.Len(t, got.Imports.Elements, 2, "Imports.Elements")
 	gotImp0 := got.Imports.Elements[0].Element
-	require.NotNil(t, gotImp0)
+	require.NotNil(t, gotImp0, "Imports[0]: got nil *Import")
 	if lit, ok := gotImp0.Qualid.(*java.Literal); !ok || lit.Value != "fmt" {
 		t.Errorf("Imports[0].Qualid: got %+v, want literal \"fmt\"", gotImp0.Qualid)
 	}
@@ -152,5 +152,5 @@ func TestCompilationUnitRoundTrip_NilImports(t *testing.T) {
 	seed := &golang.CompilationUnit{ID: cuID}
 
 	got := roundTripNode(t, before, seed).(*golang.CompilationUnit)
-	assert.Nil(t, got.Imports)
+	assert.Nilf(t, got.Imports, "Imports: got %+v, want nil", got.Imports)
 }

--- a/rewrite-go/pkg/rpc/go_receiver_imports_test.go
+++ b/rewrite-go/pkg/rpc/go_receiver_imports_test.go
@@ -21,6 +21,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -81,9 +85,7 @@ func TestCoerceRightPaddedTyped_NonMatchingElementFallsBack(t *testing.T) {
 	var wire any = java.RightPadded[java.Expression]{Element: makeIdent("x"), After: java.EmptySpace, Markers: java.Markers{}}
 
 	got := coerceRightPaddedTyped[*java.Import](wire)
-	if got.Element != nil {
-		t.Errorf("want nil Element on fallback, got %+v", got.Element)
-	}
+	assert.Nil(t, got.Element)
 }
 
 func TestRawCastPanics_ContainerImportFromExpression(t *testing.T) {
@@ -111,12 +113,8 @@ func TestCompilationUnitRoundTrip_EmptyImports(t *testing.T) {
 	got := roundTripNode(t, before, seed).(*golang.CompilationUnit)
 
 	// then: Imports stays a *Container[*Import].
-	if got.Imports == nil {
-		t.Fatal("Imports: got nil, want empty *Container[*Import]")
-	}
-	if len(got.Imports.Elements) != 0 {
-		t.Errorf("Imports.Elements: got %d, want 0", len(got.Imports.Elements))
-	}
+	require.NotNil(t, got.Imports)
+	assert.Len(t, got.Imports.Elements, 0)
 }
 
 func TestCompilationUnitRoundTrip_WithImports(t *testing.T) {
@@ -138,16 +136,10 @@ func TestCompilationUnitRoundTrip_WithImports(t *testing.T) {
 	got := roundTripNode(t, before, seed).(*golang.CompilationUnit)
 
 	// then: both imports survive, typed as *Import.
-	if got.Imports == nil {
-		t.Fatal("Imports: got nil, want non-nil")
-	}
-	if len(got.Imports.Elements) != 2 {
-		t.Fatalf("Imports.Elements: got %d, want 2", len(got.Imports.Elements))
-	}
+	require.NotNil(t, got.Imports)
+	require.Len(t, got.Imports.Elements, 2)
 	gotImp0 := got.Imports.Elements[0].Element
-	if gotImp0 == nil {
-		t.Fatal("Imports[0]: got nil *Import")
-	}
+	require.NotNil(t, gotImp0)
 	if lit, ok := gotImp0.Qualid.(*java.Literal); !ok || lit.Value != "fmt" {
 		t.Errorf("Imports[0].Qualid: got %+v, want literal \"fmt\"", gotImp0.Qualid)
 	}
@@ -160,7 +152,5 @@ func TestCompilationUnitRoundTrip_NilImports(t *testing.T) {
 	seed := &golang.CompilationUnit{ID: cuID}
 
 	got := roundTripNode(t, before, seed).(*golang.CompilationUnit)
-	if got.Imports != nil {
-		t.Errorf("Imports: got %+v, want nil", got.Imports)
-	}
+	assert.Nil(t, got.Imports)
 }

--- a/rewrite-go/pkg/rpc/gomod_codec_test.go
+++ b/rewrite-go/pkg/rpc/gomod_codec_test.go
@@ -18,6 +18,8 @@ package rpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -41,9 +43,7 @@ func TestGoModRPCRoundTrip(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// given: a parsed GoMod LST
 			before, err := parser.ParseGoModFile("go.mod", content)
-			if err != nil {
-				t.Fatalf("parse error: %v", err)
-			}
+			require.NoError(t, err)
 
 			// when: round-tripped through the RPC sender/receiver
 			seed := &golang.GoMod{Ident: before.Ident}
@@ -66,13 +66,9 @@ func TestGoModRPCRoundTrip(t *testing.T) {
 func TestGoModRPCPreservesResolutionMarker(t *testing.T) {
 	content := "module example.com/foo\n\ngo 1.21\n\nrequire github.com/x/y v1.2.3\n"
 	before, err := parser.ParseGoModFile("go.mod", content)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	mrr, err := parser.ParseGoMod("go.mod", content)
-	if err != nil {
-		t.Fatalf("marker parse error: %v", err)
-	}
+	require.NoError(t, err)
 	before.Markers.Entries = append(before.Markers.Entries, *mrr)
 
 	seed := &golang.GoMod{Ident: before.Ident}
@@ -87,7 +83,5 @@ func TestGoModRPCPreservesResolutionMarker(t *testing.T) {
 	if found == nil {
 		t.Fatalf("GoResolutionResult marker lost in round-trip; markers=%#v", got.Markers.Entries)
 	}
-	if found.ModulePath != "example.com/foo" || len(found.Requires) != 1 {
-		t.Fatalf("marker fields not preserved: %#v", found)
-	}
+	require.False(t, found.ModulePath != "example.com/foo" || len(found.Requires) != 1)
 }

--- a/rewrite-go/pkg/rpc/gomod_codec_test.go
+++ b/rewrite-go/pkg/rpc/gomod_codec_test.go
@@ -43,7 +43,7 @@ func TestGoModRPCRoundTrip(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// given: a parsed GoMod LST
 			before, err := parser.ParseGoModFile("go.mod", content)
-			require.NoError(t, err)
+			require.NoError(t, err, "parse error")
 
 			// when: round-tripped through the RPC sender/receiver
 			seed := &golang.GoMod{Ident: before.Ident}
@@ -51,9 +51,7 @@ func TestGoModRPCRoundTrip(t *testing.T) {
 
 			// then: the received tree prints identically to the original
 			gm, ok := got.(*golang.GoMod)
-			if !ok {
-				t.Fatalf("expected *golang.GoMod, got %T", got)
-			}
+			require.Truef(t, ok, "expected *golang.GoMod, got %T", got)
 			if printed := printer.PrintGoMod(gm); printed != content {
 				t.Fatalf("RPC round-trip not lossless\n--- want ---\n%q\n--- got ---\n%q", content, printed)
 			}
@@ -66,9 +64,9 @@ func TestGoModRPCRoundTrip(t *testing.T) {
 func TestGoModRPCPreservesResolutionMarker(t *testing.T) {
 	content := "module example.com/foo\n\ngo 1.21\n\nrequire github.com/x/y v1.2.3\n"
 	before, err := parser.ParseGoModFile("go.mod", content)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	mrr, err := parser.ParseGoMod("go.mod", content)
-	require.NoError(t, err)
+	require.NoError(t, err, "marker parse error")
 	before.Markers.Entries = append(before.Markers.Entries, *mrr)
 
 	seed := &golang.GoMod{Ident: before.Ident}
@@ -80,8 +78,6 @@ func TestGoModRPCPreservesResolutionMarker(t *testing.T) {
 			found = &r
 		}
 	}
-	if found == nil {
-		t.Fatalf("GoResolutionResult marker lost in round-trip; markers=%#v", got.Markers.Entries)
-	}
-	require.False(t, found.ModulePath != "example.com/foo" || len(found.Requires) != 1)
+	require.NotNilf(t, found, "GoResolutionResult marker lost in round-trip; markers=%#v", got.Markers.Entries)
+	require.False(t, found.ModulePath != "example.com/foo" || len(found.Requires) != 1, "marker fields not preserved")
 }

--- a/rewrite-go/pkg/rpc/gosum_codec_test.go
+++ b/rewrite-go/pkg/rpc/gosum_codec_test.go
@@ -41,7 +41,7 @@ func TestGoSumRPCRoundTrip(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// given: a parsed GoSum LST
 			before, err := parser.ParseGoSumFile("go.sum", content)
-			require.NoError(t, err)
+			require.NoError(t, err, "parse error")
 
 			// when: round-tripped through the RPC sender/receiver
 			seed := &golang.GoSum{Ident: before.Ident}
@@ -49,9 +49,7 @@ func TestGoSumRPCRoundTrip(t *testing.T) {
 
 			// then: the received tree prints identically to the original
 			gs, ok := got.(*golang.GoSum)
-			if !ok {
-				t.Fatalf("expected *golang.GoSum, got %T", got)
-			}
+			require.Truef(t, ok, "expected *golang.GoSum, got %T", got)
 			if printed := printer.PrintGoSum(gs); printed != content {
 				t.Fatalf("RPC round-trip not lossless\n--- want ---\n%q\n--- got ---\n%q", content, printed)
 			}
@@ -63,9 +61,9 @@ func TestGoSumRPCPreservesResolutionMarker(t *testing.T) {
 	content := "github.com/x/y v1.2.3 h1:aaaa=\n" +
 		"github.com/x/y v1.2.3/go.mod h1:bbbb=\n"
 	before, err := parser.ParseGoSumFile("go.sum", content)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\nrequire github.com/x/y v1.2.3\n")
-	require.NoError(t, err)
+	require.NoError(t, err, "marker parse error")
 	before.Markers.Entries = append(before.Markers.Entries, *mrr)
 
 	seed := &golang.GoSum{Ident: before.Ident}
@@ -77,8 +75,6 @@ func TestGoSumRPCPreservesResolutionMarker(t *testing.T) {
 			found = &r
 		}
 	}
-	if found == nil {
-		t.Fatalf("GoResolutionResult marker lost in round-trip; markers=%#v", got.Markers.Entries)
-	}
-	require.False(t, found.ModulePath != "example.com/foo" || len(found.Requires) != 1)
+	require.NotNilf(t, found, "GoResolutionResult marker lost in round-trip; markers=%#v", got.Markers.Entries)
+	require.False(t, found.ModulePath != "example.com/foo" || len(found.Requires) != 1, "marker fields not preserved")
 }

--- a/rewrite-go/pkg/rpc/gosum_codec_test.go
+++ b/rewrite-go/pkg/rpc/gosum_codec_test.go
@@ -18,6 +18,8 @@ package rpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -39,9 +41,7 @@ func TestGoSumRPCRoundTrip(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			// given: a parsed GoSum LST
 			before, err := parser.ParseGoSumFile("go.sum", content)
-			if err != nil {
-				t.Fatalf("parse error: %v", err)
-			}
+			require.NoError(t, err)
 
 			// when: round-tripped through the RPC sender/receiver
 			seed := &golang.GoSum{Ident: before.Ident}
@@ -63,13 +63,9 @@ func TestGoSumRPCPreservesResolutionMarker(t *testing.T) {
 	content := "github.com/x/y v1.2.3 h1:aaaa=\n" +
 		"github.com/x/y v1.2.3/go.mod h1:bbbb=\n"
 	before, err := parser.ParseGoSumFile("go.sum", content)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\nrequire github.com/x/y v1.2.3\n")
-	if err != nil {
-		t.Fatalf("marker parse error: %v", err)
-	}
+	require.NoError(t, err)
 	before.Markers.Entries = append(before.Markers.Entries, *mrr)
 
 	seed := &golang.GoSum{Ident: before.Ident}
@@ -84,7 +80,5 @@ func TestGoSumRPCPreservesResolutionMarker(t *testing.T) {
 	if found == nil {
 		t.Fatalf("GoResolutionResult marker lost in round-trip; markers=%#v", got.Markers.Entries)
 	}
-	if found.ModulePath != "example.com/foo" || len(found.Requires) != 1 {
-		t.Fatalf("marker fields not preserved: %#v", found)
-	}
+	require.False(t, found.ModulePath != "example.com/foo" || len(found.Requires) != 1)
 }

--- a/rewrite-go/pkg/rpc/java_receiver_if_test.go
+++ b/rewrite-go/pkg/rpc/java_receiver_if_test.go
@@ -54,8 +54,8 @@ func TestJavaReceiverVisitIfUsesExistingElsePartAsReceiveBaseline(t *testing.T) 
 
 	got := NewGoReceiver().VisitIf(before, q).(*java.If)
 
-	require.NotNil(t, got.ElsePart)
-	require.True(t, reflect.DeepEqual(got.ElsePart.Prefix, beforeElsePadding))
+	require.NotNil(t, got.ElsePart, "ElsePart: got nil, want non-nil")
+	require.True(t, reflect.DeepEqual(got.ElsePart.Prefix, beforeElsePadding), "ElsePart.Prefix")
 	if got.ElsePart.Body.Element != beforeElseBody {
 		t.Fatalf("ElsePart.Body.Element: got %p, want existing body %p", got.ElsePart.Body.Element, beforeElseBody)
 	}

--- a/rewrite-go/pkg/rpc/java_receiver_if_test.go
+++ b/rewrite-go/pkg/rpc/java_receiver_if_test.go
@@ -20,6 +20,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
@@ -52,12 +54,8 @@ func TestJavaReceiverVisitIfUsesExistingElsePartAsReceiveBaseline(t *testing.T) 
 
 	got := NewGoReceiver().VisitIf(before, q).(*java.If)
 
-	if got.ElsePart == nil {
-		t.Fatal("ElsePart: got nil, want non-nil")
-	}
-	if !reflect.DeepEqual(got.ElsePart.Prefix, beforeElsePadding) {
-		t.Fatalf("ElsePart.Prefix: got %+v, want %+v", got.ElsePart.Prefix, beforeElsePadding)
-	}
+	require.NotNil(t, got.ElsePart)
+	require.True(t, reflect.DeepEqual(got.ElsePart.Prefix, beforeElsePadding))
 	if got.ElsePart.Body.Element != beforeElseBody {
 		t.Fatalf("ElsePart.Body.Element: got %p, want existing body %p", got.ElsePart.Body.Element, beforeElseBody)
 	}

--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -62,16 +62,14 @@ func TestGoProjectMarkerRoundTrip(t *testing.T) {
 	before := java.Markers{ID: uuid.New(), Entries: []java.Marker{gp}}
 
 	after := roundTripMarkers(t, before)
-	require.Len(t, after.Entries, 1)
+	require.Len(t, after.Entries, 1, "entries")
 	got, ok := after.Entries[0].(golang.GoProject)
-	if !ok {
-		t.Fatalf("entry is %T, want golang.GoProject", after.Entries[0])
-	}
+	require.Truef(t, ok, "entry is %T, want golang.GoProject", after.Entries[0])
 	if got.Ident != id {
 		t.Errorf("Ident: want %s, got %s", id, got.Ident)
 	}
-	assert.Equal(t, "example/foo", got.ProjectName)
-	assert.Equal(t, "example.com/foo", got.ModulePath)
+	assert.Equalf(t, "example/foo", got.ProjectName, "ProjectName: want %q", "example/foo")
+	assert.Equalf(t, "example.com/foo", got.ModulePath, "ModulePath: want %q", "example.com/foo")
 }
 
 func TestGoResolutionResultMarkerRoundTrip(t *testing.T) {
@@ -120,12 +118,10 @@ func TestGoResolutionResultMarkerRoundTrip(t *testing.T) {
 	before := java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}
 
 	after := roundTripMarkers(t, before)
-	require.Len(t, after.Entries, 1)
+	require.Len(t, after.Entries, 1, "entries")
 	got, ok := after.Entries[0].(golang.GoResolutionResult)
-	if !ok {
-		t.Fatalf("entry is %T, want golang.GoResolutionResult", after.Entries[0])
-	}
-	assert.True(t, reflect.DeepEqual(mrr, got))
+	require.Truef(t, ok, "entry is %T, want golang.GoResolutionResult", after.Entries[0])
+	assert.Truef(t, reflect.DeepEqual(mrr, got), "round-trip mismatch\nbefore: %+v\nafter", mrr)
 }
 
 func TestGoResolutionResultEmptyListsRoundTrip(t *testing.T) {
@@ -146,7 +142,7 @@ func TestGoResolutionResultEmptyListsRoundTrip(t *testing.T) {
 
 	after := roundTripMarkers(t, before)
 	got := after.Entries[0].(golang.GoResolutionResult)
-	assert.Equal(t, "example.com/empty", got.ModulePath)
+	assert.Equalf(t, "example.com/empty", got.ModulePath, "ModulePath: want %q", "example.com/empty")
 }
 
 // diffRoundTripMarkers serializes `after` as a delta against `before` and
@@ -187,11 +183,9 @@ func TestChangedCodecLessMarkerRoundTrip(t *testing.T) {
 	after := java.Markers{ID: markersID, Entries: []java.Marker{mk("8.0")}}
 
 	got := diffRoundTripMarkers(t, before, after)
-	require.Len(t, got.Entries, 1)
+	require.Len(t, got.Entries, 1, "entries")
 	gm, ok := got.Entries[0].(java.GenericMarker)
-	if !ok {
-		t.Fatalf("entry is %T, want java.GenericMarker", got.Entries[0])
-	}
+	require.Truef(t, ok, "entry is %T, want java.GenericMarker", got.Entries[0])
 	if gm.Data["version"] != "8.0" {
 		t.Errorf("version: want %q, got %v", "8.0", gm.Data["version"])
 	}

--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -22,6 +22,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
@@ -58,9 +62,7 @@ func TestGoProjectMarkerRoundTrip(t *testing.T) {
 	before := java.Markers{ID: uuid.New(), Entries: []java.Marker{gp}}
 
 	after := roundTripMarkers(t, before)
-	if len(after.Entries) != 1 {
-		t.Fatalf("entries: want 1, got %d", len(after.Entries))
-	}
+	require.Len(t, after.Entries, 1)
 	got, ok := after.Entries[0].(golang.GoProject)
 	if !ok {
 		t.Fatalf("entry is %T, want golang.GoProject", after.Entries[0])
@@ -68,12 +70,8 @@ func TestGoProjectMarkerRoundTrip(t *testing.T) {
 	if got.Ident != id {
 		t.Errorf("Ident: want %s, got %s", id, got.Ident)
 	}
-	if got.ProjectName != "example/foo" {
-		t.Errorf("ProjectName: want %q, got %q", "example/foo", got.ProjectName)
-	}
-	if got.ModulePath != "example.com/foo" {
-		t.Errorf("ModulePath: want %q, got %q", "example.com/foo", got.ModulePath)
-	}
+	assert.Equal(t, "example/foo", got.ProjectName)
+	assert.Equal(t, "example.com/foo", got.ModulePath)
 }
 
 func TestGoResolutionResultMarkerRoundTrip(t *testing.T) {
@@ -122,16 +120,12 @@ func TestGoResolutionResultMarkerRoundTrip(t *testing.T) {
 	before := java.Markers{ID: uuid.New(), Entries: []java.Marker{mrr}}
 
 	after := roundTripMarkers(t, before)
-	if len(after.Entries) != 1 {
-		t.Fatalf("entries: want 1, got %d", len(after.Entries))
-	}
+	require.Len(t, after.Entries, 1)
 	got, ok := after.Entries[0].(golang.GoResolutionResult)
 	if !ok {
 		t.Fatalf("entry is %T, want golang.GoResolutionResult", after.Entries[0])
 	}
-	if !reflect.DeepEqual(mrr, got) {
-		t.Errorf("round-trip mismatch\nbefore: %+v\nafter:  %+v", mrr, got)
-	}
+	assert.True(t, reflect.DeepEqual(mrr, got))
 }
 
 func TestGoResolutionResultEmptyListsRoundTrip(t *testing.T) {
@@ -152,9 +146,7 @@ func TestGoResolutionResultEmptyListsRoundTrip(t *testing.T) {
 
 	after := roundTripMarkers(t, before)
 	got := after.Entries[0].(golang.GoResolutionResult)
-	if got.ModulePath != "example.com/empty" {
-		t.Errorf("ModulePath: want %q, got %q", "example.com/empty", got.ModulePath)
-	}
+	assert.Equal(t, "example.com/empty", got.ModulePath)
 }
 
 // diffRoundTripMarkers serializes `after` as a delta against `before` and
@@ -195,9 +187,7 @@ func TestChangedCodecLessMarkerRoundTrip(t *testing.T) {
 	after := java.Markers{ID: markersID, Entries: []java.Marker{mk("8.0")}}
 
 	got := diffRoundTripMarkers(t, before, after)
-	if len(got.Entries) != 1 {
-		t.Fatalf("entries: want 1, got %d", len(got.Entries))
-	}
+	require.Len(t, got.Entries, 1)
 	gm, ok := got.Entries[0].(java.GenericMarker)
 	if !ok {
 		t.Fatalf("entry is %T, want java.GenericMarker", got.Entries[0])

--- a/rewrite-go/pkg/rpc/padding_rpc_test.go
+++ b/rewrite-go/pkg/rpc/padding_rpc_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
@@ -74,9 +76,7 @@ func TestCoerceToStatementRP_AcceptsExpressionVariant(t *testing.T) {
 	got := coerceToStatementRP(wire)
 
 	// then: the element survives, now typed as Statement
-	if got.Element == nil {
-		t.Fatal("Element nil after coerce")
-	}
+	require.NotNil(t, got.Element)
 	if got.Element.(*java.MethodInvocation) != mi {
 		t.Errorf("Element identity lost: want %p, got %p", mi, got.Element)
 	}

--- a/rewrite-go/pkg/rpc/padding_rpc_test.go
+++ b/rewrite-go/pkg/rpc/padding_rpc_test.go
@@ -76,7 +76,7 @@ func TestCoerceToStatementRP_AcceptsExpressionVariant(t *testing.T) {
 	got := coerceToStatementRP(wire)
 
 	// then: the element survives, now typed as Statement
-	require.NotNil(t, got.Element)
+	require.NotNil(t, got.Element, "Element nil after coerce")
 	if got.Element.(*java.MethodInvocation) != mi {
 		t.Errorf("Element identity lost: want %p, got %p", mi, got.Element)
 	}

--- a/rewrite-go/pkg/rpc/receive_value_test.go
+++ b/rewrite-go/pkg/rpc/receive_value_test.go
@@ -19,6 +19,8 @@ package rpc
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
@@ -50,7 +52,5 @@ func TestReceiveValue_DeleteReturnsNil(t *testing.T) {
 	before := makeIdent("x")
 	got := receiveValue(queueOf(RpcObjectData{State: Delete}), java.Expression(before),
 		func(e java.Expression) any { return e })
-	if got != nil {
-		t.Errorf("DELETE: want nil, got %v", got)
-	}
+	assert.Nil(t, got)
 }

--- a/rewrite-go/pkg/rpc/receive_value_test.go
+++ b/rewrite-go/pkg/rpc/receive_value_test.go
@@ -52,5 +52,5 @@ func TestReceiveValue_DeleteReturnsNil(t *testing.T) {
 	before := makeIdent("x")
 	got := receiveValue(queueOf(RpcObjectData{State: Delete}), java.Expression(before),
 		func(e java.Expression) any { return e })
-	assert.Nil(t, got)
+	assert.Nil(t, got, "DELETE: want nil")
 }

--- a/rewrite-go/pkg/rpc/reference_test.go
+++ b/rewrite-go/pkg/rpc/reference_test.go
@@ -27,7 +27,7 @@ func TestReferenceMapReusesStrongIdentity(t *testing.T) {
 	refs := NewReferenceMap()
 
 	firstID, existed := refs.GetOrCreate(shared)
-	require.False(t, existed || firstID != 1)
+	require.Falsef(t, existed || firstID != 1, "first allocation = (%d, %v), want (1, false)", firstID, existed)
 	if got := refs.Len(); got != 1 {
 		t.Fatalf("reference count = %d, want 1", got)
 	}

--- a/rewrite-go/pkg/rpc/reference_test.go
+++ b/rewrite-go/pkg/rpc/reference_test.go
@@ -16,7 +16,10 @@
 
 package rpc
 
-import "testing"
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+)
 
 func TestReferenceMapReusesStrongIdentity(t *testing.T) {
 	type object struct{ value int }
@@ -24,9 +27,7 @@ func TestReferenceMapReusesStrongIdentity(t *testing.T) {
 	refs := NewReferenceMap()
 
 	firstID, existed := refs.GetOrCreate(shared)
-	if existed || firstID != 1 {
-		t.Fatalf("first allocation = (%d, %v), want (1, false)", firstID, existed)
-	}
+	require.False(t, existed || firstID != 1)
 	if got := refs.Len(); got != 1 {
 		t.Fatalf("reference count = %d, want 1", got)
 	}

--- a/rewrite-go/pkg/rpc/rpc_object_data_test.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data_test.go
@@ -34,20 +34,14 @@ func TestDecodeBatch_DecodesTypedFields(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	require.NoError(t, err)
-	require.Len(t, batch, 3)
-	if batch[0].State != Add || batch[0].ValueType == nil || *batch[0].ValueType != "org.openrewrite.marker.SearchResult" || batch[0].Ref == nil || *batch[0].Ref != 7 {
-		t.Fatalf("message 0 decoded wrong: %+v", batch[0])
-	}
+	require.NoError(t, err, "unexpected error")
+	require.Len(t, batch, 3, "expected 3 messages")
+	require.Falsef(t, batch[0].State != Add || batch[0].ValueType == nil || *batch[0].ValueType != "org.openrewrite.marker.SearchResult" || batch[0].Ref == nil || *batch[0].Ref != 7, "message 0 decoded wrong: %+v", batch[0])
 	if m, ok := batch[0].Value.(map[string]any); !ok || m["id"] != "x" {
 		t.Fatalf("message 0 value not a decoded map: %#v", batch[0].Value)
 	}
-	if batch[1].State != NoChange || batch[1].Value != nil {
-		t.Fatalf("message 1 decoded wrong: %+v", batch[1])
-	}
-	if batch[2].State != Change || batch[2].Value != " " {
-		t.Fatalf("message 2 decoded wrong: %+v", batch[2])
-	}
+	require.Falsef(t, batch[1].State != NoChange || batch[1].Value != nil, "message 1 decoded wrong: %+v", batch[1])
+	require.Falsef(t, batch[2].State != Change || batch[2].Value != " ", "message 2 decoded wrong: %+v", batch[2])
 }
 
 func TestDecodeBatch_InternsDuplicateStrings(t *testing.T) {
@@ -63,13 +57,13 @@ func TestDecodeBatch_InternsDuplicateStrings(t *testing.T) {
 	batch, err := DecodeBatch(data, intern)
 
 	// then
-	require.NoError(t, err)
+	require.NoError(t, err, "unexpected error")
 	s0 := batch[0].Value.(string)
 	s1 := batch[1].Value.(string)
 	nested := batch[2].Value.(map[string]any)
 	sa := nested["a"].(string)
 	sb := nested["b"].(string)
-	require.False(t, s0 != "\n\t" || s1 != "\n\t" || sa != "\n\t" || sb != "\n\t")
+	require.False(t, s0 != "\n\t" || s1 != "\n\t" || sa != "\n\t" || sb != "\n\t", "interning corrupted values")
 	for _, s := range []string{s1, sa, sb} {
 		if strData(s0) != strData(s) {
 			t.Fatalf("duplicate string not interned to shared backing")
@@ -85,8 +79,8 @@ func TestDecodeBatch_NilInternKeepsDistinctBacking(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	require.NoError(t, err)
-	require.False(t, batch[0].Value.(string) != "dup" || batch[1].Value.(string) != "dup")
+	require.NoError(t, err, "unexpected error")
+	require.False(t, batch[0].Value.(string) != "dup" || batch[1].Value.(string) != "dup", "values decoded wrong without interning")
 }
 
 func strData(s string) unsafe.Pointer {

--- a/rewrite-go/pkg/rpc/rpc_object_data_test.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data_test.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"testing"
 	"unsafe"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDecodeBatch_DecodesTypedFields(t *testing.T) {
@@ -33,12 +34,8 @@ func TestDecodeBatch_DecodesTypedFields(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if len(batch) != 3 {
-		t.Fatalf("expected 3 messages, got %d", len(batch))
-	}
+	require.NoError(t, err)
+	require.Len(t, batch, 3)
 	if batch[0].State != Add || batch[0].ValueType == nil || *batch[0].ValueType != "org.openrewrite.marker.SearchResult" || batch[0].Ref == nil || *batch[0].Ref != 7 {
 		t.Fatalf("message 0 decoded wrong: %+v", batch[0])
 	}
@@ -66,17 +63,13 @@ func TestDecodeBatch_InternsDuplicateStrings(t *testing.T) {
 	batch, err := DecodeBatch(data, intern)
 
 	// then
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+	require.NoError(t, err)
 	s0 := batch[0].Value.(string)
 	s1 := batch[1].Value.(string)
 	nested := batch[2].Value.(map[string]any)
 	sa := nested["a"].(string)
 	sb := nested["b"].(string)
-	if s0 != "\n\t" || s1 != "\n\t" || sa != "\n\t" || sb != "\n\t" {
-		t.Fatalf("interning corrupted values: %q %q %q %q", s0, s1, sa, sb)
-	}
+	require.False(t, s0 != "\n\t" || s1 != "\n\t" || sa != "\n\t" || sb != "\n\t")
 	for _, s := range []string{s1, sa, sb} {
 		if strData(s0) != strData(s) {
 			t.Fatalf("duplicate string not interned to shared backing")
@@ -92,12 +85,8 @@ func TestDecodeBatch_NilInternKeepsDistinctBacking(t *testing.T) {
 	batch, err := DecodeBatch(data, nil)
 
 	// then
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if batch[0].Value.(string) != "dup" || batch[1].Value.(string) != "dup" {
-		t.Fatalf("values decoded wrong without interning")
-	}
+	require.NoError(t, err)
+	require.False(t, batch[0].Value.(string) != "dup" || batch[1].Value.(string) != "dup")
 }
 
 func strData(s string) unsafe.Pointer {

--- a/rewrite-go/pkg/rpc/send_queue_ref_test.go
+++ b/rewrite-go/pkg/rpc/send_queue_ref_test.go
@@ -36,16 +36,12 @@ func TestChangedRefSlotIsReAddedInsteadOfChanged(t *testing.T) {
 	// A repeat of the same transition dedups against the ref registered by the re-add
 	q.Send(AsRef(t2), AsRef(t1), nil)
 
-	require.Len(t, q.batch, 3)
+	require.Len(t, q.batch, 3, "batch length")
 	for i, d := range q.batch {
 		if d.State != Add {
 			t.Fatalf("batch[%d].State = %v, want Add", i, d.State)
 		}
 	}
-	if *q.batch[0].Ref != 1 || *q.batch[1].Ref != 2 {
-		t.Fatalf("refs = %d, %d, want 1, 2", *q.batch[0].Ref, *q.batch[1].Ref)
-	}
-	if q.batch[2].Ref == nil || *q.batch[2].Ref != 2 || q.batch[2].Value != nil {
-		t.Fatalf("batch[2] = %+v, want ref-only ADD with ref 2", q.batch[2])
-	}
+	require.Falsef(t, *q.batch[0].Ref != 1 || *q.batch[1].Ref != 2, "refs = %d, %d, want 1, 2", *q.batch[0].Ref, *q.batch[1].Ref)
+	require.Falsef(t, q.batch[2].Ref == nil || *q.batch[2].Ref != 2 || q.batch[2].Value != nil, "batch[2] = %+v, want ref-only ADD with ref 2", q.batch[2])
 }

--- a/rewrite-go/pkg/rpc/send_queue_ref_test.go
+++ b/rewrite-go/pkg/rpc/send_queue_ref_test.go
@@ -16,7 +16,10 @@
 
 package rpc
 
-import "testing"
+import (
+	"testing"
+	"github.com/stretchr/testify/require"
+)
 
 // A changed ref-deduplicated slot is re-added under a fresh ref, never CHANGEd
 // (see Send for why).
@@ -33,9 +36,7 @@ func TestChangedRefSlotIsReAddedInsteadOfChanged(t *testing.T) {
 	// A repeat of the same transition dedups against the ref registered by the re-add
 	q.Send(AsRef(t2), AsRef(t1), nil)
 
-	if len(q.batch) != 3 {
-		t.Fatalf("batch length = %d, want 3", len(q.batch))
-	}
+	require.Len(t, q.batch, 3)
 	for i, d := range q.batch {
 		if d.State != Add {
 			t.Fatalf("batch[%d].State = %v, want Add", i, d.State)

--- a/rewrite-go/pkg/template/placeholder_test.go
+++ b/rewrite-go/pkg/template/placeholder_test.go
@@ -29,14 +29,12 @@ func TestToPlaceholder(t *testing.T) {
 
 func TestFromPlaceholder(t *testing.T) {
 	name, ok := FromPlaceholder("__plh_expr__")
-	assert.False(t, !ok || name != "expr")
+	assert.Falsef(t, !ok || name != "expr", "FromPlaceholder(\"__plh_expr__\") = (%q, %v), want (\"expr\", true)", name, ok)
 }
 
 func TestFromPlaceholderNotPlaceholder(t *testing.T) {
 	name, ok := FromPlaceholder("notPlaceholder")
-	if ok {
-		t.Errorf("FromPlaceholder(\"notPlaceholder\") = (%q, %v), want (\"\", false)", name, ok)
-	}
+	assert.Falsef(t, ok, "FromPlaceholder(\"notPlaceholder\") = (%q, %v), want (\"\", false)", name, ok)
 }
 
 func TestIsPlaceholder(t *testing.T) {

--- a/rewrite-go/pkg/template/placeholder_test.go
+++ b/rewrite-go/pkg/template/placeholder_test.go
@@ -16,7 +16,10 @@
 
 package template
 
-import "testing"
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestToPlaceholder(t *testing.T) {
 	if got := ToPlaceholder("expr"); got != "__plh_expr__" {
@@ -26,9 +29,7 @@ func TestToPlaceholder(t *testing.T) {
 
 func TestFromPlaceholder(t *testing.T) {
 	name, ok := FromPlaceholder("__plh_expr__")
-	if !ok || name != "expr" {
-		t.Errorf("FromPlaceholder(\"__plh_expr__\") = (%q, %v), want (\"expr\", true)", name, ok)
-	}
+	assert.False(t, !ok || name != "expr")
 }
 
 func TestFromPlaceholderNotPlaceholder(t *testing.T) {

--- a/rewrite-go/pkg/template/template_recipe_test.go
+++ b/rewrite-go/pkg/template/template_recipe_test.go
@@ -265,10 +265,10 @@ func TestNewRecipeMetadata(t *testing.T) {
 		WithAfter(`y`),
 	)
 
-	assert.Equal(t, "org.openrewrite.golang.MyRecipe", r.Name())
-	assert.Equal(t, "My Recipe", r.DisplayName())
-	assert.Equal(t, "Does something useful.", r.Description())
-	assert.False(t, len(r.Tags()) != 2 || r.Tags()[0] != "cleanup")
+	assert.Equal(t, "org.openrewrite.golang.MyRecipe", r.Name(), "Name")
+	assert.Equal(t, "My Recipe", r.DisplayName(), "DisplayName")
+	assert.Equal(t, "Does something useful.", r.Description(), "Description")
+	assert.False(t, len(r.Tags()) != 2 || r.Tags()[0] != "cleanup", "Tags")
 }
 
 type myRecipe struct {

--- a/rewrite-go/pkg/template/template_recipe_test.go
+++ b/rewrite-go/pkg/template/template_recipe_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 )
 
@@ -263,18 +265,10 @@ func TestNewRecipeMetadata(t *testing.T) {
 		WithAfter(`y`),
 	)
 
-	if r.Name() != "org.openrewrite.golang.MyRecipe" {
-		t.Errorf("Name() = %q", r.Name())
-	}
-	if r.DisplayName() != "My Recipe" {
-		t.Errorf("DisplayName() = %q", r.DisplayName())
-	}
-	if r.Description() != "Does something useful." {
-		t.Errorf("Description() = %q", r.Description())
-	}
-	if len(r.Tags()) != 2 || r.Tags()[0] != "cleanup" {
-		t.Errorf("Tags() = %v", r.Tags())
-	}
+	assert.Equal(t, "org.openrewrite.golang.MyRecipe", r.Name())
+	assert.Equal(t, "My Recipe", r.DisplayName())
+	assert.Equal(t, "Does something useful.", r.Description())
+	assert.False(t, len(r.Tags()) != 2 || r.Tags()[0] != "cleanup")
 }
 
 type myRecipe struct {

--- a/rewrite-go/pkg/template/template_test.go
+++ b/rewrite-go/pkg/template/template_test.go
@@ -20,6 +20,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
@@ -31,9 +35,7 @@ import (
 
 func TestScaffoldExpression(t *testing.T) {
 	source, _ := buildScaffold("1 + 2", nil, nil, ScaffoldExpression)
-	if source == "" {
-		t.Fatal("expected non-empty scaffold source")
-	}
+	require.NotEqual(t, "", source)
 
 	p := parser.NewGoParser()
 	_, err := p.Parse("test.go", source)
@@ -44,9 +46,7 @@ func TestScaffoldExpression(t *testing.T) {
 
 func TestScaffoldStatement(t *testing.T) {
 	source, _ := buildScaffold("x = 1", nil, nil, ScaffoldStatement)
-	if source == "" {
-		t.Fatal("expected non-empty scaffold source")
-	}
+	require.NotEqual(t, "", source)
 
 	p := parser.NewGoParser()
 	_, err := p.Parse("test.go", source)
@@ -58,9 +58,7 @@ func TestScaffoldStatement(t *testing.T) {
 func TestScaffoldWithCaptures(t *testing.T) {
 	caps := captureMap([]*Capture{Expr("x")})
 	source, count := buildScaffold(fmt.Sprintf("%s + 1", Expr("x")), caps, nil, ScaffoldExpression)
-	if count != 1 {
-		t.Errorf("expected preamble count 1, got %d", count)
-	}
+	assert.Equal(t, 1, count)
 
 	p := parser.NewGoParser()
 	_, err := p.Parse("test.go", source)
@@ -71,27 +69,19 @@ func TestScaffoldWithCaptures(t *testing.T) {
 
 func TestParseScaffoldExpression(t *testing.T) {
 	node, err := parseScaffold("1 + 2", nil, nil, ScaffoldExpression)
-	if err != nil {
-		t.Fatalf("parseScaffold error: %v", err)
-	}
-	if node == nil {
-		t.Fatal("expected non-nil node")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, node)
 	bin, ok := node.(*java.Binary)
 	if !ok {
 		t.Fatalf("expected *java.Binary, got %T", node)
 	}
-	if bin.Left == nil || bin.Right == nil {
-		t.Fatal("binary should have left and right")
-	}
+	require.False(t, bin.Left == nil || bin.Right == nil)
 }
 
 func TestPatternMatchIdentifier(t *testing.T) {
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", "package main\n\nvar y = x\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	pat := Expression("x").Build()
 
@@ -99,22 +89,16 @@ func TestPatternMatchIdentifier(t *testing.T) {
 	v := visitor.Init(&identFinder{target: "x", found: &found})
 	v.Visit(cu, nil)
 
-	if found == nil {
-		t.Fatal("could not find identifier 'x' in parsed tree")
-	}
+	require.NotNil(t, found)
 
 	result := pat.Match(found, nil)
-	if result == nil {
-		t.Error("pattern should match identifier 'x'")
-	}
+	assert.NotNil(t, result)
 }
 
 func TestPatternNoMatch(t *testing.T) {
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", "package main\n\nvar z = y\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	pat := Expression("x").Build()
 
@@ -122,22 +106,16 @@ func TestPatternNoMatch(t *testing.T) {
 	v := visitor.Init(&identFinder{target: "y", found: &found})
 	v.Visit(cu, nil)
 
-	if found == nil {
-		t.Fatal("could not find identifier 'y'")
-	}
+	require.NotNil(t, found)
 
 	result := pat.Match(found, nil)
-	if result != nil {
-		t.Error("pattern 'x' should not match identifier 'y'")
-	}
+	assert.Nil(t, result)
 }
 
 func TestPatternMatchWithCapture(t *testing.T) {
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", "package main\n\nvar x = 1 + 2\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	expr := Expr("expr")
 	pat := Expression(fmt.Sprintf("%s + 2", expr)).
@@ -148,26 +126,18 @@ func TestPatternMatchWithCapture(t *testing.T) {
 	v := visitor.Init(&binaryFinder{found: &found})
 	v.Visit(cu, nil)
 
-	if found == nil {
-		t.Fatal("could not find binary expression")
-	}
+	require.NotNil(t, found)
 
 	result := pat.Match(found, nil)
-	if result == nil {
-		t.Fatal("pattern should match binary expression")
-	}
+	require.NotNil(t, result)
 
 	captured := result.Get("expr")
-	if captured == nil {
-		t.Fatal("expected capture 'expr' to be bound")
-	}
+	require.NotNil(t, captured)
 	lit, ok := captured.(*java.Literal)
 	if !ok {
 		t.Fatalf("expected captured value to be *java.Literal, got %T", captured)
 	}
-	if lit.Source != "1" {
-		t.Errorf("expected captured literal source '1', got %q", lit.Source)
-	}
+	assert.Equal(t, "1", lit.Source)
 }
 
 func TestRewriteVisitor(t *testing.T) {
@@ -259,37 +229,27 @@ func TestRewritePreservesFormatting(t *testing.T) {
 	src := "package main\n\nvar a = x\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx := recipe.NewExecutionContext()
 	result := rewriter.Visit(cu, ctx)
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
+	require.NotNil(t, result)
 
 	actual := printer.Print(result)
 	expected := "package main\n\nvar a = y\n"
-	if actual != expected {
-		t.Errorf("formatting not preserved\nexpected: %q\nactual:   %q", expected, actual)
-	}
+	assert.Equal(t, expected, actual)
 }
 
 func TestPatternMatchGoUnary(t *testing.T) {
 	// given a Go-specific unary (address-of) expression `&b` in the source
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", "package main\n\nfunc f(b int) { g(&b) }\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	var found java.J
 	v := visitor.Init(&goUnaryFinder{found: &found})
 	v.Visit(cu, nil)
-	if found == nil {
-		t.Fatal("could not find golang.Unary '&b' in parsed tree")
-	}
+	require.NotNil(t, found)
 
 	// when matching a pattern that captures the operand of `&<expr>`
 	expr := Expr("expr")
@@ -299,13 +259,9 @@ func TestPatternMatchGoUnary(t *testing.T) {
 
 	// then the pattern matches (regression: golang.Unary had no comparator case)
 	result := pat.Match(found, nil)
-	if result == nil {
-		t.Fatal("pattern '&<expr>' should match golang.Unary '&b'")
-	}
+	require.NotNil(t, result)
 	captured := result.Get("expr")
-	if captured == nil {
-		t.Fatal("expected capture 'expr' to be bound")
-	}
+	require.NotNil(t, captured)
 	ident, ok := captured.(*java.Identifier)
 	if !ok || ident.Name != "b" {
 		t.Fatalf("expected captured identifier 'b', got %T %v", captured, captured)

--- a/rewrite-go/pkg/template/template_test.go
+++ b/rewrite-go/pkg/template/template_test.go
@@ -35,47 +35,39 @@ import (
 
 func TestScaffoldExpression(t *testing.T) {
 	source, _ := buildScaffold("1 + 2", nil, nil, ScaffoldExpression)
-	require.NotEqual(t, "", source)
+	require.NotEqual(t, "", source, "expected non-empty scaffold source")
 
 	p := parser.NewGoParser()
 	_, err := p.Parse("test.go", source)
-	if err != nil {
-		t.Fatalf("scaffold should parse: %v\nsource:\n%s", err, source)
-	}
+	require.NoErrorf(t, err, "scaffold should parse: %v\nsource:\n%s", err, source)
 }
 
 func TestScaffoldStatement(t *testing.T) {
 	source, _ := buildScaffold("x = 1", nil, nil, ScaffoldStatement)
-	require.NotEqual(t, "", source)
+	require.NotEqual(t, "", source, "expected non-empty scaffold source")
 
 	p := parser.NewGoParser()
 	_, err := p.Parse("test.go", source)
-	if err != nil {
-		t.Fatalf("scaffold should parse: %v\nsource:\n%s", err, source)
-	}
+	require.NoErrorf(t, err, "scaffold should parse: %v\nsource:\n%s", err, source)
 }
 
 func TestScaffoldWithCaptures(t *testing.T) {
 	caps := captureMap([]*Capture{Expr("x")})
 	source, count := buildScaffold(fmt.Sprintf("%s + 1", Expr("x")), caps, nil, ScaffoldExpression)
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 1, count, "expected preamble count")
 
 	p := parser.NewGoParser()
 	_, err := p.Parse("test.go", source)
-	if err != nil {
-		t.Fatalf("scaffold with captures should parse: %v\nsource:\n%s", err, source)
-	}
+	require.NoErrorf(t, err, "scaffold with captures should parse: %v\nsource:\n%s", err, source)
 }
 
 func TestParseScaffoldExpression(t *testing.T) {
 	node, err := parseScaffold("1 + 2", nil, nil, ScaffoldExpression)
-	require.NoError(t, err)
-	require.NotNil(t, node)
+	require.NoError(t, err, "parseScaffold error")
+	require.NotNil(t, node, "expected non-nil node")
 	bin, ok := node.(*java.Binary)
-	if !ok {
-		t.Fatalf("expected *java.Binary, got %T", node)
-	}
-	require.False(t, bin.Left == nil || bin.Right == nil)
+	require.Truef(t, ok, "expected *java.Binary, got %T", node)
+	require.False(t, bin.Left == nil || bin.Right == nil, "binary should have left and right")
 }
 
 func TestPatternMatchIdentifier(t *testing.T) {
@@ -89,10 +81,10 @@ func TestPatternMatchIdentifier(t *testing.T) {
 	v := visitor.Init(&identFinder{target: "x", found: &found})
 	v.Visit(cu, nil)
 
-	require.NotNil(t, found)
+	require.NotNil(t, found, "could not find identifier 'x' in parsed tree")
 
 	result := pat.Match(found, nil)
-	assert.NotNil(t, result)
+	assert.NotNil(t, result, "pattern should match identifier 'x'")
 }
 
 func TestPatternNoMatch(t *testing.T) {
@@ -106,10 +98,10 @@ func TestPatternNoMatch(t *testing.T) {
 	v := visitor.Init(&identFinder{target: "y", found: &found})
 	v.Visit(cu, nil)
 
-	require.NotNil(t, found)
+	require.NotNil(t, found, "could not find identifier 'y'")
 
 	result := pat.Match(found, nil)
-	assert.Nil(t, result)
+	assert.Nil(t, result, "pattern 'x' should not match identifier 'y'")
 }
 
 func TestPatternMatchWithCapture(t *testing.T) {
@@ -126,18 +118,16 @@ func TestPatternMatchWithCapture(t *testing.T) {
 	v := visitor.Init(&binaryFinder{found: &found})
 	v.Visit(cu, nil)
 
-	require.NotNil(t, found)
+	require.NotNil(t, found, "could not find binary expression")
 
 	result := pat.Match(found, nil)
-	require.NotNil(t, result)
+	require.NotNil(t, result, "pattern should match binary expression")
 
 	captured := result.Get("expr")
-	require.NotNil(t, captured)
+	require.NotNil(t, captured, "expected capture 'expr' to be bound")
 	lit, ok := captured.(*java.Literal)
-	if !ok {
-		t.Fatalf("expected captured value to be *java.Literal, got %T", captured)
-	}
-	assert.Equal(t, "1", lit.Source)
+	require.Truef(t, ok, "expected captured value to be *java.Literal, got %T", captured)
+	assert.Equal(t, "1", lit.Source, "expected captured literal source")
 }
 
 func TestRewriteVisitor(t *testing.T) {
@@ -233,11 +223,11 @@ func TestRewritePreservesFormatting(t *testing.T) {
 
 	ctx := recipe.NewExecutionContext()
 	result := rewriter.Visit(cu, ctx)
-	require.NotNil(t, result)
+	require.NotNil(t, result, "expected non-nil result")
 
 	actual := printer.Print(result)
 	expected := "package main\n\nvar a = y\n"
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected, actual, "formatting not preserved")
 }
 
 func TestPatternMatchGoUnary(t *testing.T) {
@@ -249,7 +239,7 @@ func TestPatternMatchGoUnary(t *testing.T) {
 	var found java.J
 	v := visitor.Init(&goUnaryFinder{found: &found})
 	v.Visit(cu, nil)
-	require.NotNil(t, found)
+	require.NotNil(t, found, "could not find golang.Unary '&b' in parsed tree")
 
 	// when matching a pattern that captures the operand of `&<expr>`
 	expr := Expr("expr")
@@ -259,13 +249,11 @@ func TestPatternMatchGoUnary(t *testing.T) {
 
 	// then the pattern matches (regression: golang.Unary had no comparator case)
 	result := pat.Match(found, nil)
-	require.NotNil(t, result)
+	require.NotNil(t, result, "pattern '&<expr>' should match golang.Unary '&b'")
 	captured := result.Get("expr")
-	require.NotNil(t, captured)
+	require.NotNil(t, captured, "expected capture 'expr' to be bound")
 	ident, ok := captured.(*java.Identifier)
-	if !ok || ident.Name != "b" {
-		t.Fatalf("expected captured identifier 'b', got %T %v", captured, captured)
-	}
+	require.Falsef(t, !ok || ident.Name != "b", "expected captured identifier 'b', got %T %v", captured, captured)
 }
 
 type rewriteRecipeWithVisitor struct {

--- a/rewrite-go/pkg/test/expect_type.go
+++ b/rewrite-go/pkg/test/expect_type.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
@@ -34,16 +38,10 @@ func ExpectType(t *testing.T, root java.Tree, name string, expectedFQN string) {
 	t.Helper()
 	c := visitor.Init(&identifierTypeCollector{name: name})
 	c.Visit(root, nil)
-	if !c.found {
-		t.Fatalf("ExpectType(%q): no identifier with that name in tree", name)
-	}
-	if c.typ == nil {
-		t.Fatalf("ExpectType(%q): identifier has nil Type", name)
-	}
+	require.Truef(t, c.found, "ExpectType(%q): no identifier with that name in tree", name)
+	require.NotNilf(t, c.typ, "ExpectType(%q): identifier has nil Type", name)
 	fq, ok := c.typ.(java.FullyQualified)
-	if !ok {
-		t.Fatalf("ExpectType(%q): identifier Type is %T, want FullyQualified", name, c.typ)
-	}
+	require.Truef(t, ok, "ExpectType(%q): identifier Type is %T, want FullyQualified", name, c.typ)
 	if got := fq.GetFullyQualifiedName(); got != expectedFQN {
 		t.Errorf("ExpectType(%q): FQN = %q, want %q", name, got, expectedFQN)
 	}
@@ -56,19 +54,11 @@ func ExpectPrimitiveType(t *testing.T, root java.Tree, name string, expectedKeyw
 	t.Helper()
 	c := visitor.Init(&identifierTypeCollector{name: name})
 	c.Visit(root, nil)
-	if !c.found {
-		t.Fatalf("ExpectPrimitiveType(%q): no identifier with that name in tree", name)
-	}
-	if c.typ == nil {
-		t.Fatalf("ExpectPrimitiveType(%q): identifier has nil Type", name)
-	}
+	require.Truef(t, c.found, "ExpectPrimitiveType(%q): no identifier with that name in tree", name)
+	require.NotNilf(t, c.typ, "ExpectPrimitiveType(%q): identifier has nil Type", name)
 	prim, ok := c.typ.(*java.JavaTypePrimitive)
-	if !ok {
-		t.Fatalf("ExpectPrimitiveType(%q): identifier Type is %T, want *JavaTypePrimitive", name, c.typ)
-	}
-	if prim.Keyword != expectedKeyword {
-		t.Errorf("ExpectPrimitiveType(%q): keyword = %q, want %q", name, prim.Keyword, expectedKeyword)
-	}
+	require.Truef(t, ok, "ExpectPrimitiveType(%q): identifier Type is %T, want *JavaTypePrimitive", name, c.typ)
+	assert.Equalf(t, prim.Keyword, expectedKeyword, "ExpectPrimitiveType(%q): keyword", name)
 }
 
 // ExpectMethodType walks the tree rooted at root and asserts that the
@@ -84,15 +74,9 @@ func ExpectMethodType(t *testing.T, root java.Tree, name string, expectedDeclari
 	t.Helper()
 	c := visitor.Init(&methodTypeCollector{name: name})
 	c.Visit(root, nil)
-	if !c.found {
-		t.Fatalf("ExpectMethodType(%q): no method with that name in tree", name)
-	}
-	if c.methodType == nil {
-		t.Fatalf("ExpectMethodType(%q): method has nil MethodType", name)
-	}
-	if c.methodType.DeclaringType == nil {
-		t.Fatalf("ExpectMethodType(%q): method has nil DeclaringType", name)
-	}
+	require.Truef(t, c.found, "ExpectMethodType(%q): no method with that name in tree", name)
+	require.NotNilf(t, c.methodType, "ExpectMethodType(%q): method has nil MethodType", name)
+	require.NotNilf(t, c.methodType.DeclaringType, "ExpectMethodType(%q): method has nil DeclaringType", name)
 	if got := c.methodType.DeclaringType.GetFullyQualifiedName(); got != expectedDeclaringFQN {
 		t.Errorf("ExpectMethodType(%q): declaring FQN = %q, want %q", name, got, expectedDeclaringFQN)
 	}

--- a/rewrite-go/pkg/test/expect_type_test.go
+++ b/rewrite-go/pkg/test/expect_type_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 )
 
@@ -36,9 +38,7 @@ func main() {
 	_ = p
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ExpectType(t, cu, "p", "main.Point")
 }
 
@@ -53,9 +53,7 @@ func main() {
 	_ = y
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ExpectPrimitiveType(t, cu, "x", "int")
 	ExpectPrimitiveType(t, cu, "y", "String")
 }
@@ -70,9 +68,7 @@ func main() {
 	fmt.Println("hello")
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ExpectMethodType(t, cu, "Println", "fmt")
 }
 
@@ -84,8 +80,6 @@ func add(a int, b int) int {
 	return a + b
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ExpectMethodType(t, cu, "add", "main")
 }

--- a/rewrite-go/pkg/test/java_rpc.go
+++ b/rewrite-go/pkg/test/java_rpc.go
@@ -86,12 +86,12 @@ func StartJavaRpcClient(t *testing.T, recipes []RecipeEntry) *JavaRpcClient {
 	)
 
 	stdin, err := cmd.StdinPipe()
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to get stdin pipe")
 	stdout, err := cmd.StdoutPipe()
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to get stdout pipe")
 	cmd.Stderr = os.Stderr
 
-	require.NoError(t, cmd.Start())
+	require.NoError(t, cmd.Start(), "failed to start Java RPC server")
 
 	client := &JavaRpcClient{
 		process: cmd,
@@ -278,7 +278,7 @@ func writeMarketplaceCSV(t *testing.T, recipes []RecipeEntry) string {
 	t.Helper()
 
 	tmpFile, err := os.CreateTemp("", "marketplace-*.csv")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to create marketplace CSV")
 	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
 
 	w := csv.NewWriter(tmpFile)

--- a/rewrite-go/pkg/test/java_rpc.go
+++ b/rewrite-go/pkg/test/java_rpc.go
@@ -32,6 +32,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"github.com/stretchr/testify/require"
 )
 
 // JavaRpcClient communicates with a Java RPC server process
@@ -85,18 +86,12 @@ func StartJavaRpcClient(t *testing.T, recipes []RecipeEntry) *JavaRpcClient {
 	)
 
 	stdin, err := cmd.StdinPipe()
-	if err != nil {
-		t.Fatalf("failed to get stdin pipe: %v", err)
-	}
+	require.NoError(t, err)
 	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		t.Fatalf("failed to get stdout pipe: %v", err)
-	}
+	require.NoError(t, err)
 	cmd.Stderr = os.Stderr
 
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("failed to start Java RPC server: %v", err)
-	}
+	require.NoError(t, cmd.Start())
 
 	client := &JavaRpcClient{
 		process: cmd,
@@ -283,9 +278,7 @@ func writeMarketplaceCSV(t *testing.T, recipes []RecipeEntry) string {
 	t.Helper()
 
 	tmpFile, err := os.CreateTemp("", "marketplace-*.csv")
-	if err != nil {
-		t.Fatalf("failed to create marketplace CSV: %v", err)
-	}
+	require.NoError(t, err)
 	t.Cleanup(func() { os.Remove(tmpFile.Name()) })
 
 	w := csv.NewWriter(tmpFile)

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -277,9 +277,7 @@ func parsePackageGroups(t *testing.T, p *parser.GoParser, flat []SourceSpec) map
 			continue
 		}
 		cus, err := p.ParsePackage(files)
-		if err != nil {
-			t.Fatalf("parse error in package %s: %v", dir, err)
-		}
+		require.NoErrorf(t, err, "parse error in package %s", dir)
 		for i, cu := range cus {
 			out[included[i].idx] = cu
 		}
@@ -608,7 +606,7 @@ func (spec *RecipeSpec) parseGoSource(t *testing.T, p *parser.GoParser, parsedBy
 		// parse this file in isolation so two bare specs sharing a
 		// default Path don't clobber each other.
 		parsed, err := p.Parse(src.Path, src.Before)
-		require.NoError(t, err)
+		require.NoError(t, err, "parse error")
 		cu = parsed
 	}
 
@@ -651,7 +649,7 @@ func (spec *RecipeSpec) parseGoMod(t *testing.T, src SourceSpec) *golang.GoMod {
 	t.Helper()
 
 	gm, err := parser.ParseGoModFile(src.Path, src.Before)
-	require.NoError(t, err)
+	require.NoError(t, err, "go.mod parse error")
 
 	// Attach any markers contributed by GoProject(...) wrappers (e.g. the
 	// GoResolutionResult / GoProject markers) so recipes can read them.
@@ -673,7 +671,7 @@ func (spec *RecipeSpec) parseGoSum(t *testing.T, src SourceSpec) *golang.GoSum {
 	t.Helper()
 
 	gs, err := parser.ParseGoSumFile(src.Path, src.Before)
-	require.NoError(t, err)
+	require.NoError(t, err, "go.sum parse error")
 
 	for _, m := range src.Markers {
 		gs = gs.WithMarkers(java.AddMarker(gs.Markers, m))
@@ -694,17 +692,17 @@ func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
 	src := ps.spec
 
 	if ps.tree == nil {
-		assert.False(t, src.After != nil && *src.After != src.Before)
+		assert.Falsef(t, src.After != nil && *src.After != src.Before, "non-Go source %q: harness cannot apply recipes to it yet", src.Path)
 		return
 	}
 
 	if spec.Recipe == nil {
-		assert.Nil(t, src.After)
+		assert.Nil(t, src.After, "after state specified but no recipe configured")
 		return
 	}
 
 	if ps.result == nil {
-		assert.Nil(t, src.After)
+		assert.Nil(t, src.After, "recipe returned nil (deleted source file) but expected an after state")
 		return
 	}
 
@@ -717,7 +715,7 @@ func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
 		return
 	}
 	// No after state: expect no changes.
-	assert.Equal(t, src.Before, actual)
+	assert.Equal(t, src.Before, actual, "recipe made unexpected changes\n\nexpected (no change")
 }
 
 func (spec *RecipeSpec) compareGenerated(t *testing.T, specs []SourceSpec, generated []java.Tree) {
@@ -742,14 +740,10 @@ func (spec *RecipeSpec) compareGenerated(t *testing.T, specs []SourceSpec, gener
 			}
 			break
 		}
-		if !found {
-			t.Errorf("expected recipe to generate file %q, but it was not generated", gs.Path)
-		}
+		assert.Truef(t, found, "expected recipe to generate file %q, but it was not generated", gs.Path)
 	}
 	for j, gt := range generated {
-		if !matched[j] && gt != nil {
-			t.Errorf("recipe generated an unexpected file %q; add a test.Generated(...) spec to assert it", generatedSourcePath(gt))
-		}
+		assert.Falsef(t, !matched[j] && gt != nil, "recipe generated an unexpected file %q; add a test.Generated(...) spec to assert it", generatedSourcePath(gt))
 	}
 }
 

--- a/rewrite-go/pkg/test/spec.go
+++ b/rewrite-go/pkg/test/spec.go
@@ -22,6 +22,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
@@ -604,9 +608,7 @@ func (spec *RecipeSpec) parseGoSource(t *testing.T, p *parser.GoParser, parsedBy
 		// parse this file in isolation so two bare specs sharing a
 		// default Path don't clobber each other.
 		parsed, err := p.Parse(src.Path, src.Before)
-		if err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
+		require.NoError(t, err)
 		cu = parsed
 	}
 
@@ -649,9 +651,7 @@ func (spec *RecipeSpec) parseGoMod(t *testing.T, src SourceSpec) *golang.GoMod {
 	t.Helper()
 
 	gm, err := parser.ParseGoModFile(src.Path, src.Before)
-	if err != nil {
-		t.Fatalf("go.mod parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// Attach any markers contributed by GoProject(...) wrappers (e.g. the
 	// GoResolutionResult / GoProject markers) so recipes can read them.
@@ -673,9 +673,7 @@ func (spec *RecipeSpec) parseGoSum(t *testing.T, src SourceSpec) *golang.GoSum {
 	t.Helper()
 
 	gs, err := parser.ParseGoSumFile(src.Path, src.Before)
-	if err != nil {
-		t.Fatalf("go.sum parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	for _, m := range src.Markers {
 		gs = gs.WithMarkers(java.AddMarker(gs.Markers, m))
@@ -696,23 +694,17 @@ func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
 	src := ps.spec
 
 	if ps.tree == nil {
-		if src.After != nil && *src.After != src.Before {
-			t.Errorf("non-Go source %q: harness cannot apply recipes to it yet", src.Path)
-		}
+		assert.False(t, src.After != nil && *src.After != src.Before)
 		return
 	}
 
 	if spec.Recipe == nil {
-		if src.After != nil {
-			t.Error("after state specified but no recipe configured")
-		}
+		assert.Nil(t, src.After)
 		return
 	}
 
 	if ps.result == nil {
-		if src.After != nil {
-			t.Error("recipe returned nil (deleted source file) but expected an after state")
-		}
+		assert.Nil(t, src.After)
 		return
 	}
 
@@ -725,9 +717,7 @@ func (spec *RecipeSpec) compareSource(t *testing.T, ps parsedSource) {
 		return
 	}
 	// No after state: expect no changes.
-	if actual != src.Before {
-		t.Errorf("recipe made unexpected changes\n\nexpected (no change):\n%s\n\nactual:\n%s", src.Before, actual)
-	}
+	assert.Equal(t, src.Before, actual)
 }
 
 func (spec *RecipeSpec) compareGenerated(t *testing.T, specs []SourceSpec, generated []java.Tree) {

--- a/rewrite-go/test/annotation_service_test.go
+++ b/rewrite-go/test/annotation_service_test.go
@@ -21,6 +21,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
@@ -36,45 +40,31 @@ import (
 
 func TestAnnotationService_Registered(t *testing.T) {
 	svc := recipe.Service[*recipes.AnnotationService](nil)
-	if svc == nil {
-		t.Fatal("expected AnnotationService to be registered")
-	}
+	require.NotNil(t, svc)
 }
 
 func TestAnnotationService_IsAnnotatedWith_StructTag(t *testing.T) {
 	src := "package main\n\ntype User struct {\n\tName string `json:\"name\"`\n}\n"
 	field := parseStructAndFindField(t, src, "Name")
 	svc := &recipes.AnnotationService{}
-	if !svc.IsAnnotatedWith(field, "json") {
-		t.Errorf("expected struct field with json tag to match \"json\"")
-	}
-	if svc.IsAnnotatedWith(field, "validate") {
-		t.Errorf("did not expect match for absent tag \"validate\"")
-	}
+	assert.True(t, svc.IsAnnotatedWith(field, "json"))
+	assert.False(t, svc.IsAnnotatedWith(field, "validate"))
 }
 
 func TestAnnotationService_IsAnnotatedWith_Directive(t *testing.T) {
 	src := "package main\n\n//go:noinline\nfunc slow() {}\n"
 	md := parseAndFindMethod(t, src, "slow")
 	svc := &recipes.AnnotationService{}
-	if !svc.IsAnnotatedWith(md, "go:noinline") {
-		t.Errorf("expected method with go:noinline to match")
-	}
+	assert.True(t, svc.IsAnnotatedWith(md, "go:noinline"))
 }
 
 func TestAnnotationService_IsAnnotatedWith_WildcardPrefix(t *testing.T) {
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() {}\n"
 	md := parseAndFindMethod(t, src, "slow")
 	svc := &recipes.AnnotationService{}
-	if !svc.IsAnnotatedWith(md, "go:*") {
-		t.Errorf("expected method with go: directives to match \"go:*\"")
-	}
-	if !svc.IsAnnotatedWith(md, "*") {
-		t.Errorf("expected universal match \"*\" to succeed")
-	}
-	if svc.IsAnnotatedWith(md, "lint:*") {
-		t.Errorf("did not expect match for \"lint:*\" on go-only directives")
-	}
+	assert.True(t, svc.IsAnnotatedWith(md, "go:*"))
+	assert.True(t, svc.IsAnnotatedWith(md, "*"))
+	assert.False(t, svc.IsAnnotatedWith(md, "lint:*"))
 }
 
 func TestAnnotationService_FindAnnotations(t *testing.T) {
@@ -83,9 +73,7 @@ func TestAnnotationService_FindAnnotations(t *testing.T) {
 	svc := &recipes.AnnotationService{}
 
 	jsonAnns := svc.FindAnnotations(field, "json")
-	if len(jsonAnns) != 1 {
-		t.Fatalf("expected 1 json annotation, got %d", len(jsonAnns))
-	}
+	require.Len(t, jsonAnns, 1)
 	if v, _ := jsonAnns[0].Arguments.Elements[0].Element.(*java.Literal).Value.(string); v != "email" {
 		t.Errorf("json value: got %q, want \"email\"", v)
 	}
@@ -98,9 +86,7 @@ func TestAnnotationService_AllAnnotations_ViaCursor(t *testing.T) {
 
 	c := buildCursor(md)
 	anns := svc.AllAnnotations(c)
-	if len(anns) != 1 {
-		t.Fatalf("AllAnnotations: got %d, want 1", len(anns))
-	}
+	require.Len(t, anns, 1)
 	if anns[0].AnnotationType.(*java.Identifier).Name != "go:noinline" {
 		t.Errorf("annotation: got %+v", anns[0].AnnotationType)
 	}
@@ -109,9 +95,7 @@ func TestAnnotationService_AllAnnotations_ViaCursor(t *testing.T) {
 func TestAnnotationService_AddAnnotationVisitor_OnFunc(t *testing.T) {
 	src := "package main\n\nfunc slow() { _ = 1 }\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	svc := &recipes.AnnotationService{}
 	ann := &java.Annotation{
@@ -136,9 +120,7 @@ func TestAnnotationService_RemoveAnnotationVisitor(t *testing.T) {
 	// Start with two go: directives, remove one specifically.
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() {}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	svc := &recipes.AnnotationService{}
 	v := svc.RemoveAnnotationVisitor("go:nosplit")
@@ -155,12 +137,8 @@ func TestAnnotationService_Matches_ViaCursor(t *testing.T) {
 	md := parseAndFindMethod(t, src, "slow")
 	c := buildCursor(md)
 	svc := &recipes.AnnotationService{}
-	if !svc.Matches(c, recipes.NewAnnotationMatcher("go:noinline")) {
-		t.Error("expected matcher \"go:noinline\" to match")
-	}
-	if svc.Matches(c, recipes.NewAnnotationMatcher("go:nosplit")) {
-		t.Error("did not expect matcher \"go:nosplit\" to match")
-	}
+	assert.True(t, svc.Matches(c, recipes.NewAnnotationMatcher("go:noinline")))
+	assert.False(t, svc.Matches(c, recipes.NewAnnotationMatcher("go:nosplit")))
 }
 
 // buildCursor wraps a node in a single-element cursor for testing

--- a/rewrite-go/test/annotation_service_test.go
+++ b/rewrite-go/test/annotation_service_test.go
@@ -40,31 +40,31 @@ import (
 
 func TestAnnotationService_Registered(t *testing.T) {
 	svc := recipe.Service[*recipes.AnnotationService](nil)
-	require.NotNil(t, svc)
+	require.NotNil(t, svc, "expected AnnotationService to be registered")
 }
 
 func TestAnnotationService_IsAnnotatedWith_StructTag(t *testing.T) {
 	src := "package main\n\ntype User struct {\n\tName string `json:\"name\"`\n}\n"
 	field := parseStructAndFindField(t, src, "Name")
 	svc := &recipes.AnnotationService{}
-	assert.True(t, svc.IsAnnotatedWith(field, "json"))
-	assert.False(t, svc.IsAnnotatedWith(field, "validate"))
+	assert.True(t, svc.IsAnnotatedWith(field, "json"), "expected struct field with json tag to match \"json\"")
+	assert.False(t, svc.IsAnnotatedWith(field, "validate"), "did not expect match for absent tag \"validate\"")
 }
 
 func TestAnnotationService_IsAnnotatedWith_Directive(t *testing.T) {
 	src := "package main\n\n//go:noinline\nfunc slow() {}\n"
 	md := parseAndFindMethod(t, src, "slow")
 	svc := &recipes.AnnotationService{}
-	assert.True(t, svc.IsAnnotatedWith(md, "go:noinline"))
+	assert.True(t, svc.IsAnnotatedWith(md, "go:noinline"), "expected method with go:noinline to match")
 }
 
 func TestAnnotationService_IsAnnotatedWith_WildcardPrefix(t *testing.T) {
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() {}\n"
 	md := parseAndFindMethod(t, src, "slow")
 	svc := &recipes.AnnotationService{}
-	assert.True(t, svc.IsAnnotatedWith(md, "go:*"))
-	assert.True(t, svc.IsAnnotatedWith(md, "*"))
-	assert.False(t, svc.IsAnnotatedWith(md, "lint:*"))
+	assert.True(t, svc.IsAnnotatedWith(md, "go:*"), "expected method with go: directives to match \"go:*\"")
+	assert.True(t, svc.IsAnnotatedWith(md, "*"), "expected universal match \"*\" to succeed")
+	assert.False(t, svc.IsAnnotatedWith(md, "lint:*"), "did not expect match for \"lint:*\" on go-only directives")
 }
 
 func TestAnnotationService_FindAnnotations(t *testing.T) {
@@ -73,7 +73,7 @@ func TestAnnotationService_FindAnnotations(t *testing.T) {
 	svc := &recipes.AnnotationService{}
 
 	jsonAnns := svc.FindAnnotations(field, "json")
-	require.Len(t, jsonAnns, 1)
+	require.Len(t, jsonAnns, 1, "expected 1 json annotation")
 	if v, _ := jsonAnns[0].Arguments.Elements[0].Element.(*java.Literal).Value.(string); v != "email" {
 		t.Errorf("json value: got %q, want \"email\"", v)
 	}
@@ -86,16 +86,14 @@ func TestAnnotationService_AllAnnotations_ViaCursor(t *testing.T) {
 
 	c := buildCursor(md)
 	anns := svc.AllAnnotations(c)
-	require.Len(t, anns, 1)
-	if anns[0].AnnotationType.(*java.Identifier).Name != "go:noinline" {
-		t.Errorf("annotation: got %+v", anns[0].AnnotationType)
-	}
+	require.Len(t, anns, 1, "AllAnnotations")
+	assert.Equalf(t, "go:noinline", anns[0].AnnotationType.(*java.Identifier).Name, "annotation: got %+v", anns[0].AnnotationType)
 }
 
 func TestAnnotationService_AddAnnotationVisitor_OnFunc(t *testing.T) {
 	src := "package main\n\nfunc slow() { _ = 1 }\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 
 	svc := &recipes.AnnotationService{}
 	ann := &java.Annotation{
@@ -120,7 +118,7 @@ func TestAnnotationService_RemoveAnnotationVisitor(t *testing.T) {
 	// Start with two go: directives, remove one specifically.
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() {}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 
 	svc := &recipes.AnnotationService{}
 	v := svc.RemoveAnnotationVisitor("go:nosplit")
@@ -137,8 +135,8 @@ func TestAnnotationService_Matches_ViaCursor(t *testing.T) {
 	md := parseAndFindMethod(t, src, "slow")
 	c := buildCursor(md)
 	svc := &recipes.AnnotationService{}
-	assert.True(t, svc.Matches(c, recipes.NewAnnotationMatcher("go:noinline")))
-	assert.False(t, svc.Matches(c, recipes.NewAnnotationMatcher("go:nosplit")))
+	assert.True(t, svc.Matches(c, recipes.NewAnnotationMatcher("go:noinline")), "expected matcher \"go:noinline\" to match")
+	assert.False(t, svc.Matches(c, recipes.NewAnnotationMatcher("go:nosplit")), "did not expect matcher \"go:nosplit\" to match")
 }
 
 // buildCursor wraps a node in a single-element cursor for testing

--- a/rewrite-go/test/annotation_test.go
+++ b/rewrite-go/test/annotation_test.go
@@ -90,7 +90,7 @@ func TestAnnotation_VisitorRoundtripIdentity(t *testing.T) {
 
 	v := visitor.Init(&visitor.GoVisitor{})
 	out := v.Visit(ann, nil)
-	require.NotNil(t, out)
+	require.NotNil(t, out, "visitor returned nil")
 	got := printer.Print(out.(java.Tree))
 	want := ` json:"user_id"`
 	assert.Equal(t, want, got)

--- a/rewrite-go/test/annotation_test.go
+++ b/rewrite-go/test/annotation_test.go
@@ -21,6 +21,10 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
@@ -53,9 +57,7 @@ func TestAnnotation_PrintsBasicTagShape(t *testing.T) {
 	ann := newJSONTagAnnotation("json", "name")
 	out := printer.Print(ann)
 	want := `json:"name"`
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestAnnotation_PrintsWithoutArguments(t *testing.T) {
@@ -67,9 +69,7 @@ func TestAnnotation_PrintsWithoutArguments(t *testing.T) {
 	}
 	out := printer.Print(ann)
 	want := `go:noinline`
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestAnnotation_PrintsPrefixWhitespace(t *testing.T) {
@@ -79,9 +79,7 @@ func TestAnnotation_PrintsPrefixWhitespace(t *testing.T) {
 	ann.Prefix = java.Space{Whitespace: " "}
 	out := printer.Print(ann)
 	want := ` validate:"required"`
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestAnnotation_VisitorRoundtripIdentity(t *testing.T) {
@@ -92,14 +90,10 @@ func TestAnnotation_VisitorRoundtripIdentity(t *testing.T) {
 
 	v := visitor.Init(&visitor.GoVisitor{})
 	out := v.Visit(ann, nil)
-	if out == nil {
-		t.Fatal("visitor returned nil")
-	}
+	require.NotNil(t, out)
 	got := printer.Print(out.(java.Tree))
 	want := ` json:"user_id"`
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestAnnotation_VisitorReachesAnnotationType(t *testing.T) {
@@ -111,9 +105,7 @@ func TestAnnotation_VisitorReachesAnnotationType(t *testing.T) {
 
 	got := printer.Print(out)
 	want := `yaml:"x"`
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 func TestAnnotation_VisitorReachesArguments(t *testing.T) {
@@ -125,9 +117,7 @@ func TestAnnotation_VisitorReachesArguments(t *testing.T) {
 
 	got := printer.Print(out)
 	want := `json:"y"`
-	if got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
+	assert.Equal(t, want, got)
 }
 
 type renamingVisitor struct {

--- a/rewrite-go/test/assignment_test.go
+++ b/rewrite-go/test/assignment_test.go
@@ -157,5 +157,5 @@ func TestMultiAssignmentVisitsRHSMethodInvocation(t *testing.T) {
 	v.Visit(ma, nil)
 
 	// then
-	assert.False(t, len(rec.visited) != 1 || rec.visited[0] != "ReadAll")
+	assert.Falsef(t, len(rec.visited) != 1 || rec.visited[0] != "ReadAll", "expected RHS method invocation %q to be visited", "ReadAll")
 }

--- a/rewrite-go/test/assignment_test.go
+++ b/rewrite-go/test/assignment_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/assert"
+
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -155,7 +157,5 @@ func TestMultiAssignmentVisitsRHSMethodInvocation(t *testing.T) {
 	v.Visit(ma, nil)
 
 	// then
-	if len(rec.visited) != 1 || rec.visited[0] != "ReadAll" {
-		t.Errorf("expected RHS method invocation %q to be visited, got %v", "ReadAll", rec.visited)
-	}
+	assert.False(t, len(rec.visited) != 1 || rec.visited[0] != "ReadAll")
 }

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -38,9 +38,9 @@ func applyVisitor(t *testing.T, src string, v recipe.TreeVisitor) string {
 	t.Helper()
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	result := v.Visit(cu, nil)
-	require.NotNil(t, result)
+	require.NotNil(t, result, "visit returned nil")
 
 	final := visitor.DrainAfterVisits(v, result.(java.Tree), nil)
 	return printer.Print(final)
@@ -48,7 +48,7 @@ func applyVisitor(t *testing.T, src string, v recipe.TreeVisitor) string {
 
 func TestAutoFormatService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.AutoFormatService](nil)
-	require.NotNil(t, svc)
+	require.NotNil(t, svc, "expected AutoFormatService to be registered, got nil")
 }
 
 func TestRemoveTrailingWhitespace_StripsTrailingTabsFromLines(t *testing.T) {

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/format"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
@@ -34,13 +38,9 @@ func applyVisitor(t *testing.T, src string, v recipe.TreeVisitor) string {
 	t.Helper()
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	result := v.Visit(cu, nil)
-	if result == nil {
-		t.Fatal("visit returned nil")
-	}
+	require.NotNil(t, result)
 
 	final := visitor.DrainAfterVisits(v, result.(java.Tree), nil)
 	return printer.Print(final)
@@ -48,18 +48,14 @@ func applyVisitor(t *testing.T, src string, v recipe.TreeVisitor) string {
 
 func TestAutoFormatService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.AutoFormatService](nil)
-	if svc == nil {
-		t.Fatal("expected AutoFormatService to be registered, got nil")
-	}
+	require.NotNil(t, svc)
 }
 
 func TestRemoveTrailingWhitespace_StripsTrailingTabsFromLines(t *testing.T) {
 	src := "package main   \n\nfunc main() {}\n"
 	out := applyVisitor(t, src, format.NewRemoveTrailingWhitespaceVisitor(nil))
 	want := "package main\n\nfunc main() {}\n"
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 // Regression: the leading blank line above the first statement of a
@@ -83,9 +79,7 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewBlankLinesVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 // Regression: the trailing blank line above the closing brace lives on
@@ -107,9 +101,7 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewBlankLinesVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestBlankLines_CapsRunOfBlankLinesInBlock(t *testing.T) {
@@ -134,18 +126,14 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewBlankLinesVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestTabsAndIndents_ReindentsFunctionBody(t *testing.T) {
 	src := "package main\n\nfunc main() {\n\t\t   a := 1\n\t_ = a\n}\n"
 	want := "package main\n\nfunc main() {\n\ta := 1\n\t_ = a\n}\n"
 	out := applyVisitor(t, src, format.NewTabsAndIndentsVisitor(nil))
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestTabsAndIndents_NestedBlockGetsTwoTabs(t *testing.T) {
@@ -168,9 +156,7 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewTabsAndIndentsVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestSpaces_NormalizesBinaryOperatorSpacing(t *testing.T) {
@@ -189,9 +175,7 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewSpacesVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 // Regression: when the right operand of `:=` is itself a Binary, the
@@ -214,9 +198,7 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewSpacesVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 // Regression: same delegation rule when the assigned expression is a
@@ -239,9 +221,7 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewSpacesVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 // Regression: TabsAndIndentsVisitor places `case` clauses at the
@@ -271,9 +251,7 @@ func main() {
 }
 `
 	out := applyVisitor(t, src, format.NewTabsAndIndentsVisitor(nil))
-	if out != want {
-		t.Errorf("got:\n%s\nwant:\n%s", out, want)
-	}
+	assert.Equal(t, want, out)
 }
 
 func TestAutoFormat_FullPipelineEndToEnd(t *testing.T) {
@@ -283,7 +261,5 @@ func TestAutoFormat_FullPipelineEndToEnd(t *testing.T) {
 	src := "package main\n\nfunc main() {   \n\n\n\tif true {\n\ta := 1+2\n\t_ = a\n\t}\n}\n"
 	want := "package main\n\nfunc main() {\n\tif true {\n\t\ta := 1 + 2\n\t\t_ = a\n\t}\n}\n"
 	out := applyVisitor(t, src, format.NewAutoFormatVisitor(nil))
-	if out != want {
-		t.Errorf("got %q, want %q", out, want)
-	}
+	assert.Equal(t, want, out)
 }

--- a/rewrite-go/test/build_tags_test.go
+++ b/rewrite-go/test/build_tags_test.go
@@ -35,7 +35,7 @@ func parsedNames(t *testing.T, buildCtx build.Context, files []parser.FileInput)
 	t.Helper()
 	p := parser.NewGoParserWithBuildContext(buildCtx)
 	cus, err := p.ParsePackage(files)
-	require.NoError(t, err)
+	require.NoError(t, err, "ParsePackage")
 	out := make([]string, 0, len(cus))
 	for _, cu := range cus {
 		out = append(out, cu.SourcePath)
@@ -76,11 +76,11 @@ func TestBuildTags_FilenameSuffix(t *testing.T) {
 	}
 	got := parsedNames(t, ctx("linux", "amd64"), files)
 	want := []string{"extra_amd64.go", "extra_linux.go", "extra_linux_amd64.go", "main.go"}
-	assert.True(t, equal(got, want))
+	assert.True(t, equal(got, want), "on linux/amd")
 
 	got = parsedNames(t, ctx("darwin", "arm64"), files)
 	want = []string{"main.go"}
-	assert.True(t, equal(got, want))
+	assert.True(t, equal(got, want), "on darwin/arm")
 }
 
 // Case 3: combined constraints — `//go:build linux && amd64`.

--- a/rewrite-go/test/build_tags_test.go
+++ b/rewrite-go/test/build_tags_test.go
@@ -21,6 +21,10 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 )
 
@@ -31,9 +35,7 @@ func parsedNames(t *testing.T, buildCtx build.Context, files []parser.FileInput)
 	t.Helper()
 	p := parser.NewGoParserWithBuildContext(buildCtx)
 	cus, err := p.ParsePackage(files)
-	if err != nil {
-		t.Fatalf("ParsePackage: %v", err)
-	}
+	require.NoError(t, err)
 	out := make([]string, 0, len(cus))
 	for _, cu := range cus {
 		out = append(out, cu.SourcePath)
@@ -74,15 +76,11 @@ func TestBuildTags_FilenameSuffix(t *testing.T) {
 	}
 	got := parsedNames(t, ctx("linux", "amd64"), files)
 	want := []string{"extra_amd64.go", "extra_linux.go", "extra_linux_amd64.go", "main.go"}
-	if !equal(got, want) {
-		t.Errorf("on linux/amd64: got %v, want %v", got, want)
-	}
+	assert.True(t, equal(got, want))
 
 	got = parsedNames(t, ctx("darwin", "arm64"), files)
 	want = []string{"main.go"}
-	if !equal(got, want) {
-		t.Errorf("on darwin/arm64: got %v, want %v", got, want)
-	}
+	assert.True(t, equal(got, want))
 }
 
 // Case 3: combined constraints — `//go:build linux && amd64`.

--- a/rewrite-go/test/comment_rpc_test.go
+++ b/rewrite-go/test/comment_rpc_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/rpc"
 )
@@ -26,9 +28,7 @@ import (
 func TestCommentSendsTextCommentValueType(t *testing.T) {
 	// given
 	cu, err := parser.NewGoParser().Parse("test.go", "package main\n\n// hello\nfunc hello() {\n}\n")
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	// when
 	var messages []rpc.RpcObjectData
@@ -54,7 +54,5 @@ func TestCommentSendsTextCommentValueType(t *testing.T) {
 			foundTextComment = true
 		}
 	}
-	if !foundTextComment {
-		t.Fatal("expected at least one RPC message with valueType org.openrewrite.java.tree.TextComment")
-	}
+	require.True(t, foundTextComment)
 }

--- a/rewrite-go/test/comment_rpc_test.go
+++ b/rewrite-go/test/comment_rpc_test.go
@@ -28,7 +28,7 @@ import (
 func TestCommentSendsTextCommentValueType(t *testing.T) {
 	// given
 	cu, err := parser.NewGoParser().Parse("test.go", "package main\n\n// hello\nfunc hello() {\n}\n")
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 
 	// when
 	var messages []rpc.RpcObjectData
@@ -54,5 +54,5 @@ func TestCommentSendsTextCommentValueType(t *testing.T) {
 			foundTextComment = true
 		}
 	}
-	require.True(t, foundTextComment)
+	require.True(t, foundTextComment, "expected at least one RPC message with valueType org.openrewrite.java.tree.TextComment")
 }

--- a/rewrite-go/test/cross_package_generics_test.go
+++ b/rewrite-go/test/cross_package_generics_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -36,12 +38,8 @@ func genericsScaffold(t *testing.T, files map[string]string, modulePath, mainRel
 	root := t.TempDir()
 	for rel, content := range files {
 		full := filepath.Join(root, rel)
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", full, err)
-		}
-		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
-			t.Fatalf("write %s: %v", full, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755), "mkdir")
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644), "write")
 	}
 	pi := parser.NewProjectImporter(modulePath, nil)
 	pi.SetProjectRoot(root)
@@ -53,9 +51,7 @@ func genericsScaffold(t *testing.T, files map[string]string, modulePath, mainRel
 
 	mainContent := files[mainRel]
 	cu, err := p.Parse(mainRel, mainContent)
-	if err != nil {
-		t.Fatalf("parse %s: %v", mainRel, err)
-	}
+	require.NoErrorf(t, err, "parse %s", mainRel)
 	return cu
 }
 

--- a/rewrite-go/test/cursor_messages_test.go
+++ b/rewrite-go/test/cursor_messages_test.go
@@ -88,8 +88,8 @@ func TestCursorComputeMessageIfAbsent(t *testing.T) {
 		calls++
 		return "second"
 	})
-	require.False(t, v1 != "computed" || v2 != "computed")
-	require.Equal(t, 1, calls)
+	require.Falsef(t, v1 != "computed" || v2 != "computed", "expected stable computed value, got v1=%v v", v1)
+	require.Equal(t, 1, calls, "expected supplier to fire once, fired")
 }
 
 func TestCursorPutMessageOnFirstEnclosing(t *testing.T) {

--- a/rewrite-go/test/cursor_messages_test.go
+++ b/rewrite-go/test/cursor_messages_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -28,9 +30,7 @@ import (
 func threeFrameCursor(t *testing.T) (*visitor.Cursor, *visitor.Cursor, *visitor.Cursor) {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	root := visitor.NewCursor(nil, cu)
 	mid := visitor.NewCursor(root, cu)
 	leaf := visitor.NewCursor(mid, cu)
@@ -88,12 +88,8 @@ func TestCursorComputeMessageIfAbsent(t *testing.T) {
 		calls++
 		return "second"
 	})
-	if v1 != "computed" || v2 != "computed" {
-		t.Fatalf("expected stable computed value, got v1=%v v2=%v", v1, v2)
-	}
-	if calls != 1 {
-		t.Fatalf("expected supplier to fire once, fired %d", calls)
-	}
+	require.False(t, v1 != "computed" || v2 != "computed")
+	require.Equal(t, 1, calls)
 }
 
 func TestCursorPutMessageOnFirstEnclosing(t *testing.T) {

--- a/rewrite-go/test/cursor_test.go
+++ b/rewrite-go/test/cursor_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -28,18 +30,12 @@ import (
 
 func TestCursorBuildChain(t *testing.T) {
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	chain := visitor.BuildChain([]java.Tree{cu})
-	if chain == nil || chain.Value() != cu || chain.Parent() != nil {
-		t.Fatalf("expected single-element chain rooted at cu; got parent=%v value=%v", chain.Parent(), chain.Value())
-	}
+	require.False(t, chain == nil || chain.Value() != cu || chain.Parent() != nil)
 
 	chain2 := visitor.BuildChain(nil)
-	if chain2 != nil {
-		t.Fatalf("expected nil chain for empty input, got %v", chain2)
-	}
+	require.Nil(t, chain2)
 }
 
 // TestVisitorCursorState confirms that GoVisitor exposes its cursor as
@@ -48,9 +44,7 @@ func TestCursorBuildChain(t *testing.T) {
 // it from inside any Visit* override.
 func TestVisitorCursorState(t *testing.T) {
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\nfunc f(){}\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	v := &cursorObservingVisitor{}
 	visitor.Init(v)
@@ -62,12 +56,8 @@ func TestVisitorCursorState(t *testing.T) {
 	}
 
 	v.Visit(cu, recipe.NewExecutionContext())
-	if !v.observedCU {
-		t.Fatal("VisitCompilationUnit was never invoked")
-	}
-	if v.cuCursor == nil || v.cuCursor.Value() != cu {
-		t.Fatalf("expected v.Cursor().Value() == cu inside VisitCompilationUnit; got %v", v.cuCursor)
-	}
+	require.True(t, v.observedCU)
+	require.False(t, v.cuCursor == nil || v.cuCursor.Value() != cu)
 }
 
 type cursorObservingVisitor struct {

--- a/rewrite-go/test/cursor_test.go
+++ b/rewrite-go/test/cursor_test.go
@@ -32,10 +32,10 @@ func TestCursorBuildChain(t *testing.T) {
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\n")
 	require.NoError(t, err)
 	chain := visitor.BuildChain([]java.Tree{cu})
-	require.False(t, chain == nil || chain.Value() != cu || chain.Parent() != nil)
+	require.Falsef(t, chain == nil || chain.Value() != cu || chain.Parent() != nil, "expected single-element chain rooted at cu; got parent=%v value", chain.Parent())
 
 	chain2 := visitor.BuildChain(nil)
-	require.Nil(t, chain2)
+	require.Nil(t, chain2, "expected nil chain for empty input")
 }
 
 // TestVisitorCursorState confirms that GoVisitor exposes its cursor as
@@ -56,8 +56,8 @@ func TestVisitorCursorState(t *testing.T) {
 	}
 
 	v.Visit(cu, recipe.NewExecutionContext())
-	require.True(t, v.observedCU)
-	require.False(t, v.cuCursor == nil || v.cuCursor.Value() != cu)
+	require.True(t, v.observedCU, "VisitCompilationUnit was never invoked")
+	require.False(t, v.cuCursor == nil || v.cuCursor.Value() != cu, "expected v.Cursor().Value() == cu inside VisitCompilationUnit")
 }
 
 type cursorObservingVisitor struct {

--- a/rewrite-go/test/directive_test.go
+++ b/rewrite-go/test/directive_test.go
@@ -38,7 +38,7 @@ import (
 func parseAndFindMethod(t *testing.T, src, name string) *java.MethodDeclaration {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	for _, rp := range cu.Statements {
 		if md, ok := rp.Element.(*java.MethodDeclaration); ok && md.Name != nil && md.Name.Name == name {
 			return md
@@ -51,7 +51,7 @@ func parseAndFindMethod(t *testing.T, src, name string) *java.MethodDeclaration 
 func parseAndFindType(t *testing.T, src, name string) *golang.TypeDecl {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	for _, rp := range cu.Statements {
 		if td, ok := rp.Element.(*golang.TypeDecl); ok && td.Name != nil && td.Name.Name == name {
 			return td
@@ -64,7 +64,7 @@ func parseAndFindType(t *testing.T, src, name string) *golang.TypeDecl {
 func parseAndFindVar(t *testing.T, src string) *java.VariableDeclarations {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	for _, rp := range cu.Statements {
 		if vd, ok := rp.Element.(*java.VariableDeclarations); ok {
 			return vd
@@ -84,7 +84,7 @@ func TestDirective_BareGoNoinline(t *testing.T) {
 	if id, _ := ann.AnnotationType.(*java.Identifier); id == nil || id.Name != "go:noinline" {
 		t.Errorf("AnnotationType: got %+v, want Identifier{Name:\"go:noinline\"}", ann.AnnotationType)
 	}
-	assert.Nil(t, ann.Arguments)
+	assert.Nilf(t, ann.Arguments, "Arguments: got %+v, want nil for bare directive", ann.Arguments)
 }
 
 func TestDirective_GoLinknameWithArgs(t *testing.T) {
@@ -97,9 +97,9 @@ func TestDirective_GoLinknameWithArgs(t *testing.T) {
 	if id, _ := ann.AnnotationType.(*java.Identifier); id == nil || id.Name != "go:linkname" {
 		t.Errorf("AnnotationType: got %+v, want Identifier{Name:\"go:linkname\"}", ann.AnnotationType)
 	}
-	require.False(t, ann.Arguments == nil || len(ann.Arguments.Elements) != 1)
+	require.Falsef(t, ann.Arguments == nil || len(ann.Arguments.Elements) != 1, "Arguments: got %+v, want one Literal", ann.Arguments)
 	lit, _ := ann.Arguments.Elements[0].Element.(*java.Literal)
-	assert.False(t, lit == nil || lit.Source != "x runtime.x")
+	assert.Falsef(t, lit == nil || lit.Source != "x runtime.x", "Args: got %+v, want \"x runtime.x\"", lit)
 }
 
 func TestDirective_MultipleDirectivesOnFunc(t *testing.T) {
@@ -108,12 +108,8 @@ func TestDirective_MultipleDirectivesOnFunc(t *testing.T) {
 	if got := len(md.LeadingAnnotations); got != 2 {
 		t.Fatalf("LeadingAnnotations: got %d, want 2", got)
 	}
-	if md.LeadingAnnotations[0].AnnotationType.(*java.Identifier).Name != "go:noinline" {
-		t.Errorf("[0]: got %+v", md.LeadingAnnotations[0].AnnotationType)
-	}
-	if md.LeadingAnnotations[1].AnnotationType.(*java.Identifier).Name != "go:nosplit" {
-		t.Errorf("[1]: got %+v", md.LeadingAnnotations[1].AnnotationType)
-	}
+	assert.Equalf(t, "go:noinline", md.LeadingAnnotations[0].AnnotationType.(*java.Identifier).Name, "[0]: got %+v", md.LeadingAnnotations[0].AnnotationType)
+	assert.Equalf(t, "go:nosplit", md.LeadingAnnotations[1].AnnotationType.(*java.Identifier).Name, "[1]: got %+v", md.LeadingAnnotations[1].AnnotationType)
 }
 
 func TestDirective_LintIgnoreOnType(t *testing.T) {
@@ -123,10 +119,8 @@ func TestDirective_LintIgnoreOnType(t *testing.T) {
 		t.Fatalf("LeadingAnnotations: got %d, want 1", got)
 	}
 	ann := td.LeadingAnnotations[0]
-	if ann.AnnotationType.(*java.Identifier).Name != "lint:ignore" {
-		t.Errorf("AnnotationType: got %+v", ann.AnnotationType)
-	}
-	require.NotNil(t, ann.Arguments)
+	assert.Equalf(t, "lint:ignore", ann.AnnotationType.(*java.Identifier).Name, "AnnotationType: got %+v", ann.AnnotationType)
+	require.NotNil(t, ann.Arguments, "Arguments: got nil")
 	if got := ann.Arguments.Elements[0].Element.(*java.Literal).Source; got != "U1000 unused but kept" {
 		t.Errorf("Args: got %q, want %q", got, "U1000 unused but kept")
 	}
@@ -166,7 +160,7 @@ func TestDirective_RegularCommentBeforeDirectiveStops(t *testing.T) {
 func TestDirective_RoundtripFunc(t *testing.T) {
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() {}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}
@@ -175,7 +169,7 @@ func TestDirective_RoundtripFunc(t *testing.T) {
 func TestDirective_RoundtripType(t *testing.T) {
 	src := "package main\n\n//go:generate go run gen.go\ntype Foo struct{}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}
@@ -184,7 +178,7 @@ func TestDirective_RoundtripType(t *testing.T) {
 func TestDirective_RoundtripVar(t *testing.T) {
 	src := "package main\n\n//go:linkname x runtime.x\nvar x int = 1\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}
@@ -193,7 +187,7 @@ func TestDirective_RoundtripVar(t *testing.T) {
 func TestDirective_RoundtripMixed(t *testing.T) {
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() { _ = 1 }\n\n//go:generate go run gen.go\ntype Foo struct{}\n\n//go:linkname x runtime.x\nvar x int = 1\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}

--- a/rewrite-go/test/directive_test.go
+++ b/rewrite-go/test/directive_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -34,9 +38,7 @@ import (
 func parseAndFindMethod(t *testing.T, src, name string) *java.MethodDeclaration {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	for _, rp := range cu.Statements {
 		if md, ok := rp.Element.(*java.MethodDeclaration); ok && md.Name != nil && md.Name.Name == name {
 			return md
@@ -49,9 +51,7 @@ func parseAndFindMethod(t *testing.T, src, name string) *java.MethodDeclaration 
 func parseAndFindType(t *testing.T, src, name string) *golang.TypeDecl {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	for _, rp := range cu.Statements {
 		if td, ok := rp.Element.(*golang.TypeDecl); ok && td.Name != nil && td.Name.Name == name {
 			return td
@@ -64,9 +64,7 @@ func parseAndFindType(t *testing.T, src, name string) *golang.TypeDecl {
 func parseAndFindVar(t *testing.T, src string) *java.VariableDeclarations {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	for _, rp := range cu.Statements {
 		if vd, ok := rp.Element.(*java.VariableDeclarations); ok {
 			return vd
@@ -86,9 +84,7 @@ func TestDirective_BareGoNoinline(t *testing.T) {
 	if id, _ := ann.AnnotationType.(*java.Identifier); id == nil || id.Name != "go:noinline" {
 		t.Errorf("AnnotationType: got %+v, want Identifier{Name:\"go:noinline\"}", ann.AnnotationType)
 	}
-	if ann.Arguments != nil {
-		t.Errorf("Arguments: got %+v, want nil for bare directive", ann.Arguments)
-	}
+	assert.Nil(t, ann.Arguments)
 }
 
 func TestDirective_GoLinknameWithArgs(t *testing.T) {
@@ -101,13 +97,9 @@ func TestDirective_GoLinknameWithArgs(t *testing.T) {
 	if id, _ := ann.AnnotationType.(*java.Identifier); id == nil || id.Name != "go:linkname" {
 		t.Errorf("AnnotationType: got %+v, want Identifier{Name:\"go:linkname\"}", ann.AnnotationType)
 	}
-	if ann.Arguments == nil || len(ann.Arguments.Elements) != 1 {
-		t.Fatalf("Arguments: got %+v, want one Literal", ann.Arguments)
-	}
+	require.False(t, ann.Arguments == nil || len(ann.Arguments.Elements) != 1)
 	lit, _ := ann.Arguments.Elements[0].Element.(*java.Literal)
-	if lit == nil || lit.Source != "x runtime.x" {
-		t.Errorf("Args: got %+v, want \"x runtime.x\"", lit)
-	}
+	assert.False(t, lit == nil || lit.Source != "x runtime.x")
 }
 
 func TestDirective_MultipleDirectivesOnFunc(t *testing.T) {
@@ -134,9 +126,7 @@ func TestDirective_LintIgnoreOnType(t *testing.T) {
 	if ann.AnnotationType.(*java.Identifier).Name != "lint:ignore" {
 		t.Errorf("AnnotationType: got %+v", ann.AnnotationType)
 	}
-	if ann.Arguments == nil {
-		t.Fatal("Arguments: got nil")
-	}
+	require.NotNil(t, ann.Arguments)
 	if got := ann.Arguments.Elements[0].Element.(*java.Literal).Source; got != "U1000 unused but kept" {
 		t.Errorf("Args: got %q, want %q", got, "U1000 unused but kept")
 	}
@@ -176,9 +166,7 @@ func TestDirective_RegularCommentBeforeDirectiveStops(t *testing.T) {
 func TestDirective_RoundtripFunc(t *testing.T) {
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() {}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}
@@ -187,9 +175,7 @@ func TestDirective_RoundtripFunc(t *testing.T) {
 func TestDirective_RoundtripType(t *testing.T) {
 	src := "package main\n\n//go:generate go run gen.go\ntype Foo struct{}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}
@@ -198,9 +184,7 @@ func TestDirective_RoundtripType(t *testing.T) {
 func TestDirective_RoundtripVar(t *testing.T) {
 	src := "package main\n\n//go:linkname x runtime.x\nvar x int = 1\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}
@@ -209,9 +193,7 @@ func TestDirective_RoundtripVar(t *testing.T) {
 func TestDirective_RoundtripMixed(t *testing.T) {
 	src := "package main\n\n//go:noinline\n//go:nosplit\nfunc slow() { _ = 1 }\n\n//go:generate go run gen.go\ntype Foo struct{}\n\n//go:linkname x runtime.x\nvar x int = 1\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	if got := printer.Print(cu); got != src {
 		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
 	}

--- a/rewrite-go/test/generics_rpc_test.go
+++ b/rewrite-go/test/generics_rpc_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/rpc"
@@ -56,9 +60,7 @@ func TestGenericFuncTypeParametersSurviveRpc(t *testing.T) {
 	} {
 		// given
 		cu, err := parser.NewGoParser().Parse("x.go", src)
-		if err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
+		require.NoError(t, err)
 
 		// when
 		got := rpcRoundTrip(t, cu)
@@ -86,9 +88,7 @@ func TestGenericCallTypeArgumentsSurviveRpc(t *testing.T) {
 	} {
 		// given
 		cu, err := parser.NewGoParser().Parse("x.go", tc.src)
-		if err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
+		require.NoError(t, err)
 
 		// when
 		got := rpcRoundTrip(t, cu)
@@ -98,9 +98,7 @@ func TestGenericCallTypeArgumentsSurviveRpc(t *testing.T) {
 		if mi.TypeParameters == nil {
 			t.Fatalf("call-site type arguments lost over RPC for %q", tc.src)
 		}
-		if len(mi.TypeParameters.Elements) != tc.count {
-			t.Errorf("expected %d type arguments, got %d for %q", tc.count, len(mi.TypeParameters.Elements), tc.src)
-		}
+		assert.Len(t, mi.TypeParameters.Elements, tc.count)
 		if printed := printer.Print(got); printed != tc.src {
 			t.Errorf("RPC round-trip mismatch\nexpected:\n%s\nactual:\n%s", tc.src, printed)
 		}
@@ -139,9 +137,7 @@ func TestGenericTypeDeclTypeParametersSurviveRpc(t *testing.T) {
 	} {
 		// given
 		cu, err := parser.NewGoParser().Parse("x.go", src)
-		if err != nil {
-			t.Fatalf("parse error: %v", err)
-		}
+		require.NoError(t, err)
 
 		// when
 		got := rpcRoundTrip(t, cu)

--- a/rewrite-go/test/generics_rpc_test.go
+++ b/rewrite-go/test/generics_rpc_test.go
@@ -60,16 +60,14 @@ func TestGenericFuncTypeParametersSurviveRpc(t *testing.T) {
 	} {
 		// given
 		cu, err := parser.NewGoParser().Parse("x.go", src)
-		require.NoError(t, err)
+		require.NoError(t, err, "parse error")
 
 		// when
 		got := rpcRoundTrip(t, cu)
 
 		// then
 		md := got.Statements[0].Element.(*java.MethodDeclaration)
-		if md.TypeParameters == nil {
-			t.Fatalf("type parameters lost over RPC for %q", src)
-		}
+		require.NotNilf(t, md.TypeParameters, "type parameters lost over RPC for %q", src)
 		if printed := printer.Print(got); printed != src {
 			t.Errorf("RPC round-trip mismatch\nexpected:\n%s\nactual:\n%s", src, printed)
 		}
@@ -88,17 +86,15 @@ func TestGenericCallTypeArgumentsSurviveRpc(t *testing.T) {
 	} {
 		// given
 		cu, err := parser.NewGoParser().Parse("x.go", tc.src)
-		require.NoError(t, err)
+		require.NoError(t, err, "parse error")
 
 		// when
 		got := rpcRoundTrip(t, cu)
 
 		// then
 		mi := findFirstCallInMain(t, got)
-		if mi.TypeParameters == nil {
-			t.Fatalf("call-site type arguments lost over RPC for %q", tc.src)
-		}
-		assert.Len(t, mi.TypeParameters.Elements, tc.count)
+		require.NotNilf(t, mi.TypeParameters, "call-site type arguments lost over RPC for %q", tc.src)
+		assert.Lenf(t, mi.TypeParameters.Elements, tc.count, "expected %d type arguments, got %d for", tc.count, len(mi.TypeParameters.Elements))
 		if printed := printer.Print(got); printed != tc.src {
 			t.Errorf("RPC round-trip mismatch\nexpected:\n%s\nactual:\n%s", tc.src, printed)
 		}
@@ -137,16 +133,14 @@ func TestGenericTypeDeclTypeParametersSurviveRpc(t *testing.T) {
 	} {
 		// given
 		cu, err := parser.NewGoParser().Parse("x.go", src)
-		require.NoError(t, err)
+		require.NoError(t, err, "parse error")
 
 		// when
 		got := rpcRoundTrip(t, cu)
 
 		// then
 		td := got.Statements[0].Element.(*golang.TypeDecl)
-		if td.TypeParameters == nil {
-			t.Fatalf("type parameters lost over RPC for %q", src)
-		}
+		require.NotNilf(t, td.TypeParameters, "type parameters lost over RPC for %q", src)
 		if printed := printer.Print(got); printed != src {
 			t.Errorf("RPC round-trip mismatch\nexpected:\n%s\nactual:\n%s", src, printed)
 		}

--- a/rewrite-go/test/go_project_test.go
+++ b/rewrite-go/test/go_project_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -37,12 +39,8 @@ func TestGoProjectTagsGoSiblingsButNotMod(t *testing.T) {
 	goSrc.AfterRecipe = func(t *testing.T, cu *golang.CompilationUnit) {
 		t.Helper()
 		project, ok := findGoProject(cu.Markers)
-		if !ok {
-			t.Fatal("expected GoProject marker on .go file but none was attached")
-		}
-		if project.ProjectName != "foo" {
-			t.Fatalf("expected GoProject name=%q, got %q", "foo", project.ProjectName)
-		}
+		require.True(t, ok)
+		require.Equal(t, "foo", project.ProjectName)
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/go_project_test.go
+++ b/rewrite-go/test/go_project_test.go
@@ -39,8 +39,8 @@ func TestGoProjectTagsGoSiblingsButNotMod(t *testing.T) {
 	goSrc.AfterRecipe = func(t *testing.T, cu *golang.CompilationUnit) {
 		t.Helper()
 		project, ok := findGoProject(cu.Markers)
-		require.True(t, ok)
-		require.Equal(t, "foo", project.ProjectName)
+		require.True(t, ok, "expected GoProject marker on .go file but none was attached")
+		require.Equalf(t, "foo", project.ProjectName, "expected GoProject name=%q", "foo")
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/gomod_conformance_test.go
+++ b/rewrite-go/test/gomod_conformance_test.go
@@ -137,7 +137,7 @@ func nilIfEmpty(s string) *string {
 func TestGoModConformanceCorpus(t *testing.T) {
 	corpusDir := filepath.Join("..", "src", "test", "resources", "gomod-conformance")
 	entries, err := os.ReadDir(corpusDir)
-	require.NoError(t, err)
+	require.NoError(t, err, "read corpus dir")
 	cases := 0
 	for _, ent := range entries {
 		if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".gomod") {
@@ -148,7 +148,7 @@ func TestGoModConformanceCorpus(t *testing.T) {
 		t.Run(caseName, func(t *testing.T) {
 			modContent := mustRead(t, filepath.Join(corpusDir, ent.Name()))
 			mrr, err := parser.ParseGoMod("go.mod", modContent)
-			require.NoError(t, err)
+			require.NoError(t, err, "parse")
 			if sumPath := filepath.Join(corpusDir, caseName+".gosum"); fileExists(sumPath) {
 				mrr.ResolvedDependencies = parser.ParseGoSum(mustRead(t, sumPath))
 			}
@@ -156,7 +156,7 @@ func TestGoModConformanceCorpus(t *testing.T) {
 
 			goldenContent := mustRead(t, filepath.Join(corpusDir, caseName+".gomod.json"))
 			var expected conformanceShape
-			require.NoError(t, json.Unmarshal([]byte(goldenContent), &expected))
+			require.NoError(t, json.Unmarshal([]byte(goldenContent), &expected), "unmarshal golden")
 			normalize(&expected)
 
 			if !reflect.DeepEqual(actual, expected) {
@@ -167,7 +167,7 @@ func TestGoModConformanceCorpus(t *testing.T) {
 			}
 		})
 	}
-	require.NotEqual(t, 0, cases)
+	require.NotEqual(t, 0, cases, "no .gomod cases found in corpus")
 }
 
 // normalize replaces nil slices with empty slices so reflect.DeepEqual
@@ -193,9 +193,7 @@ func normalize(c *conformanceShape) {
 func mustRead(t *testing.T, path string) string {
 	t.Helper()
 	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
+	require.NoErrorf(t, err, "read %s", path)
 	return string(b)
 }
 

--- a/rewrite-go/test/gomod_conformance_test.go
+++ b/rewrite-go/test/gomod_conformance_test.go
@@ -24,6 +24,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 )
@@ -135,9 +137,7 @@ func nilIfEmpty(s string) *string {
 func TestGoModConformanceCorpus(t *testing.T) {
 	corpusDir := filepath.Join("..", "src", "test", "resources", "gomod-conformance")
 	entries, err := os.ReadDir(corpusDir)
-	if err != nil {
-		t.Fatalf("read corpus dir: %v", err)
-	}
+	require.NoError(t, err)
 	cases := 0
 	for _, ent := range entries {
 		if ent.IsDir() || !strings.HasSuffix(ent.Name(), ".gomod") {
@@ -148,9 +148,7 @@ func TestGoModConformanceCorpus(t *testing.T) {
 		t.Run(caseName, func(t *testing.T) {
 			modContent := mustRead(t, filepath.Join(corpusDir, ent.Name()))
 			mrr, err := parser.ParseGoMod("go.mod", modContent)
-			if err != nil {
-				t.Fatalf("parse: %v", err)
-			}
+			require.NoError(t, err)
 			if sumPath := filepath.Join(corpusDir, caseName+".gosum"); fileExists(sumPath) {
 				mrr.ResolvedDependencies = parser.ParseGoSum(mustRead(t, sumPath))
 			}
@@ -158,9 +156,7 @@ func TestGoModConformanceCorpus(t *testing.T) {
 
 			goldenContent := mustRead(t, filepath.Join(corpusDir, caseName+".gomod.json"))
 			var expected conformanceShape
-			if err := json.Unmarshal([]byte(goldenContent), &expected); err != nil {
-				t.Fatalf("unmarshal golden: %v", err)
-			}
+			require.NoError(t, json.Unmarshal([]byte(goldenContent), &expected))
 			normalize(&expected)
 
 			if !reflect.DeepEqual(actual, expected) {
@@ -171,9 +167,7 @@ func TestGoModConformanceCorpus(t *testing.T) {
 			}
 		})
 	}
-	if cases == 0 {
-		t.Fatal("no .gomod cases found in corpus")
-	}
+	require.NotEqual(t, 0, cases)
 }
 
 // normalize replaces nil slices with empty slices so reflect.DeepEqual

--- a/rewrite-go/test/gomod_parser_test.go
+++ b/rewrite-go/test/gomod_parser_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 )
@@ -42,36 +46,20 @@ exclude github.com/bad v0.0.1
 retract v0.0.5 // accidentally deleted main.go
 retract [v1.0.0, v1.0.5]
 `)
-	if err != nil {
-		t.Fatalf("parse failed: %v", err)
-	}
-	if mrr.ModulePath != "example.com/foo" {
-		t.Errorf("ModulePath: want %q, got %q", "example.com/foo", mrr.ModulePath)
-	}
-	if mrr.GoVersion != "1.22" {
-		t.Errorf("GoVersion: want %q, got %q", "1.22", mrr.GoVersion)
-	}
-	if mrr.Toolchain != "go1.22.3" {
-		t.Errorf("Toolchain: want %q, got %q", "go1.22.3", mrr.Toolchain)
-	}
-	if len(mrr.Requires) != 2 {
-		t.Fatalf("Requires len: want 2, got %d", len(mrr.Requires))
-	}
+	require.NoError(t, err)
+	assert.Equal(t, "example.com/foo", mrr.ModulePath)
+	assert.Equal(t, "1.22", mrr.GoVersion)
+	assert.Equal(t, "go1.22.3", mrr.Toolchain)
+	require.Len(t, mrr.Requires, 2)
 	if mrr.Requires[0].ModulePath != "github.com/x/y" || mrr.Requires[0].Version != "v1.2.3" || mrr.Requires[0].Indirect {
 		t.Errorf("Requires[0]: %+v", mrr.Requires[0])
 	}
 	if mrr.Requires[1].ModulePath != "github.com/z/w" || !mrr.Requires[1].Indirect {
 		t.Errorf("Requires[1]: %+v", mrr.Requires[1])
 	}
-	if len(mrr.Replaces) != 1 || mrr.Replaces[0].OldPath != "github.com/x/y" || mrr.Replaces[0].NewVersion != "v1.2.4" {
-		t.Errorf("Replaces: %+v", mrr.Replaces)
-	}
-	if len(mrr.Excludes) != 1 || mrr.Excludes[0].ModulePath != "github.com/bad" {
-		t.Errorf("Excludes: %+v", mrr.Excludes)
-	}
-	if len(mrr.Retracts) != 2 {
-		t.Fatalf("Retracts len: want 2, got %d", len(mrr.Retracts))
-	}
+	assert.False(t, len(mrr.Replaces) != 1 || mrr.Replaces[0].OldPath != "github.com/x/y" || mrr.Replaces[0].NewVersion != "v1.2.4")
+	assert.False(t, len(mrr.Excludes) != 1 || mrr.Excludes[0].ModulePath != "github.com/bad")
+	require.Len(t, mrr.Retracts, 2)
 	if mrr.Retracts[0].VersionRange != "v0.0.5" || mrr.Retracts[0].Rationale == "" {
 		t.Errorf("Retracts[0]: %+v", mrr.Retracts[0])
 	}
@@ -89,12 +77,8 @@ func TestGoModSourceSpecCarriesParsedMarker(t *testing.T) {
 		require github.com/x/y v1.2.3
 	`)
 	mrr := test.FindGoResolutionResult(spec)
-	if mrr == nil {
-		t.Fatal("expected GoResolutionResult marker on the GoMod SourceSpec")
-	}
-	if mrr.ModulePath != "example.com/foo" {
-		t.Errorf("ModulePath: want %q, got %q", "example.com/foo", mrr.ModulePath)
-	}
+	require.NotNil(t, mrr)
+	assert.Equal(t, "example.com/foo", mrr.ModulePath)
 	if r := mrr.FindRequire("github.com/x/y"); r == nil || r.Version != "v1.2.3" {
 		t.Errorf("FindRequire: %+v", r)
 	}
@@ -113,19 +97,11 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 `)
-	if len(resolved) != 2 {
-		t.Fatalf("ParseGoSum: want 2 entries, got %d (%+v)", len(resolved), resolved)
-	}
+	require.Len(t, resolved, 2)
 	uuid := resolved[0]
-	if uuid.ModulePath != "github.com/google/uuid" || uuid.Version != "v1.6.0" {
-		t.Errorf("entry[0]: want github.com/google/uuid@v1.6.0, got %+v", uuid)
-	}
-	if uuid.ModuleHash != "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=" {
-		t.Errorf("entry[0].ModuleHash: %q", uuid.ModuleHash)
-	}
-	if uuid.GoModHash != "h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=" {
-		t.Errorf("entry[0].GoModHash: %q", uuid.GoModHash)
-	}
+	assert.False(t, uuid.ModulePath != "github.com/google/uuid" || uuid.Version != "v1.6.0")
+	assert.Equal(t, "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=", uuid.ModuleHash)
+	assert.Equal(t, "h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=", uuid.GoModHash)
 	if mod := resolved[1]; mod.ModulePath != "golang.org/x/mod" || mod.Version != "v0.35.0" {
 		t.Errorf("entry[1]: want golang.org/x/mod@v0.35.0, got %+v", mod)
 	}
@@ -138,9 +114,7 @@ func TestParseGoSumOnlyGoModHashRecorded(t *testing.T) {
 	// build graph knows about.
 	resolved := parser.ParseGoSum(`example.com/indirect v1.0.0/go.mod h1:abc123=
 `)
-	if len(resolved) != 1 {
-		t.Fatalf("want 1 entry, got %d", len(resolved))
-	}
+	require.Len(t, resolved, 1)
 	if resolved[0].ModuleHash != "" {
 		t.Errorf("ModuleHash: want empty, got %q", resolved[0].ModuleHash)
 	}
@@ -156,9 +130,7 @@ func TestParseGoSumMalformedLineSkipped(t *testing.T) {
 this is not a valid go.sum line
 github.com/c/d v2.0.0 h1:hashC=
 `)
-	if len(resolved) != 2 {
-		t.Fatalf("want 2 entries (malformed skipped), got %d (%+v)", len(resolved), resolved)
-	}
+	require.Len(t, resolved, 2)
 	if resolved[0].ModulePath != "github.com/a/b" || resolved[1].ModulePath != "github.com/c/d" {
 		t.Errorf("unexpected modules: %+v", resolved)
 	}
@@ -169,12 +141,8 @@ func TestParseGoSumEmptyInput(t *testing.T) {
 	// directly to GoResolutionResult.ResolvedDependencies, and a nil slice
 	// would be serialized as a null list and break the LST write.
 	got := parser.ParseGoSum("")
-	if got == nil {
-		t.Error("want non-nil empty slice for empty input, got nil")
-	}
-	if len(got) != 0 {
-		t.Errorf("want empty slice for empty input, got %+v", got)
-	}
+	assert.NotNil(t, got)
+	assert.Len(t, got, 0)
 }
 
 func TestGoProjectMergesGoSumIntoGoModMarker(t *testing.T) {
@@ -201,23 +169,13 @@ func TestGoProjectMergesGoSumIntoGoModMarker(t *testing.T) {
 			modSpec = &expanded[i]
 		}
 	}
-	if modSpec == nil {
-		t.Fatal("no go.mod spec in expanded project")
-	}
+	require.NotNil(t, modSpec)
 	mrr := test.FindGoResolutionResult(*modSpec)
-	if mrr == nil {
-		t.Fatal("no GoResolutionResult marker on go.mod")
-	}
-	if len(mrr.ResolvedDependencies) != 1 {
-		t.Fatalf("want 1 resolved dep, got %d (%+v)", len(mrr.ResolvedDependencies), mrr.ResolvedDependencies)
-	}
+	require.NotNil(t, mrr)
+	require.Len(t, mrr.ResolvedDependencies, 1)
 	rd := mrr.ResolvedDependencies[0]
-	if rd.ModulePath != "github.com/google/uuid" || rd.Version != "v1.6.0" {
-		t.Errorf("unexpected resolved dep: %+v", rd)
-	}
-	if rd.ModuleHash == "" || rd.GoModHash == "" {
-		t.Errorf("expected both ModuleHash and GoModHash populated: %+v", rd)
-	}
+	assert.False(t, rd.ModulePath != "github.com/google/uuid" || rd.Version != "v1.6.0")
+	assert.False(t, rd.ModuleHash == "" || rd.GoModHash == "")
 }
 
 // TestParseGoModDirectiveListsNeverNil guards the root cause of the Moderne CLI
@@ -227,24 +185,12 @@ func TestGoProjectMergesGoSumIntoGoModMarker(t *testing.T) {
 // reflective binary LST serializer then NPEs calling items.size() on it.
 func TestParseGoModDirectiveListsNeverNil(t *testing.T) {
 	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\ngo 1.22\n")
-	if err != nil {
-		t.Fatalf("parse failed: %v", err)
-	}
-	if mrr.Requires == nil {
-		t.Error("Requires is nil; want non-nil empty slice")
-	}
-	if mrr.Replaces == nil {
-		t.Error("Replaces is nil; want non-nil empty slice")
-	}
-	if mrr.Excludes == nil {
-		t.Error("Excludes is nil; want non-nil empty slice")
-	}
-	if mrr.Retracts == nil {
-		t.Error("Retracts is nil; want non-nil empty slice")
-	}
-	if mrr.ResolvedDependencies == nil {
-		t.Error("ResolvedDependencies is nil; want non-nil empty slice")
-	}
+	require.NoError(t, err)
+	assert.NotNil(t, mrr.Requires)
+	assert.NotNil(t, mrr.Replaces)
+	assert.NotNil(t, mrr.Excludes)
+	assert.NotNil(t, mrr.Retracts)
+	assert.NotNil(t, mrr.ResolvedDependencies)
 }
 
 // TestParseGoModRequireButNoReplace covers the gin/cobra/zap failure shape: a
@@ -252,22 +198,10 @@ func TestParseGoModDirectiveListsNeverNil(t *testing.T) {
 // must still be non-nil empty slices.
 func TestParseGoModRequireButNoReplace(t *testing.T) {
 	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\ngo 1.22\n\nrequire github.com/x/y v1.2.3\n")
-	if err != nil {
-		t.Fatalf("parse failed: %v", err)
-	}
-	if len(mrr.Requires) != 1 {
-		t.Fatalf("Requires len: want 1, got %d", len(mrr.Requires))
-	}
-	if mrr.Replaces == nil {
-		t.Error("Replaces is nil; want non-nil empty slice")
-	}
-	if mrr.Excludes == nil {
-		t.Error("Excludes is nil; want non-nil empty slice")
-	}
-	if mrr.Retracts == nil {
-		t.Error("Retracts is nil; want non-nil empty slice")
-	}
-	if mrr.ResolvedDependencies == nil {
-		t.Error("ResolvedDependencies is nil; want non-nil empty slice")
-	}
+	require.NoError(t, err)
+	require.Len(t, mrr.Requires, 1)
+	assert.NotNil(t, mrr.Replaces)
+	assert.NotNil(t, mrr.Excludes)
+	assert.NotNil(t, mrr.Retracts)
+	assert.NotNil(t, mrr.ResolvedDependencies)
 }

--- a/rewrite-go/test/gomod_parser_test.go
+++ b/rewrite-go/test/gomod_parser_test.go
@@ -46,26 +46,18 @@ exclude github.com/bad v0.0.1
 retract v0.0.5 // accidentally deleted main.go
 retract [v1.0.0, v1.0.5]
 `)
-	require.NoError(t, err)
-	assert.Equal(t, "example.com/foo", mrr.ModulePath)
-	assert.Equal(t, "1.22", mrr.GoVersion)
-	assert.Equal(t, "go1.22.3", mrr.Toolchain)
-	require.Len(t, mrr.Requires, 2)
-	if mrr.Requires[0].ModulePath != "github.com/x/y" || mrr.Requires[0].Version != "v1.2.3" || mrr.Requires[0].Indirect {
-		t.Errorf("Requires[0]: %+v", mrr.Requires[0])
-	}
-	if mrr.Requires[1].ModulePath != "github.com/z/w" || !mrr.Requires[1].Indirect {
-		t.Errorf("Requires[1]: %+v", mrr.Requires[1])
-	}
-	assert.False(t, len(mrr.Replaces) != 1 || mrr.Replaces[0].OldPath != "github.com/x/y" || mrr.Replaces[0].NewVersion != "v1.2.4")
-	assert.False(t, len(mrr.Excludes) != 1 || mrr.Excludes[0].ModulePath != "github.com/bad")
-	require.Len(t, mrr.Retracts, 2)
-	if mrr.Retracts[0].VersionRange != "v0.0.5" || mrr.Retracts[0].Rationale == "" {
-		t.Errorf("Retracts[0]: %+v", mrr.Retracts[0])
-	}
-	if mrr.Retracts[1].VersionRange != "[v1.0.0, v1.0.5]" {
-		t.Errorf("Retracts[1] range: %+v", mrr.Retracts[1])
-	}
+	require.NoError(t, err, "parse failed")
+	assert.Equalf(t, "example.com/foo", mrr.ModulePath, "ModulePath: want %q", "example.com/foo")
+	assert.Equalf(t, "1.22", mrr.GoVersion, "GoVersion: want %q", "1.22")
+	assert.Equalf(t, "go1.22.3", mrr.Toolchain, "Toolchain: want %q", "go1.22.3")
+	require.Len(t, mrr.Requires, 2, "Requires len")
+	assert.Falsef(t, mrr.Requires[0].ModulePath != "github.com/x/y" || mrr.Requires[0].Version != "v1.2.3" || mrr.Requires[0].Indirect, "Requires[0]: %+v", mrr.Requires[0])
+	assert.Falsef(t, mrr.Requires[1].ModulePath != "github.com/z/w" || !mrr.Requires[1].Indirect, "Requires[1]: %+v", mrr.Requires[1])
+	assert.False(t, len(mrr.Replaces) != 1 || mrr.Replaces[0].OldPath != "github.com/x/y" || mrr.Replaces[0].NewVersion != "v1.2.4", "Replaces")
+	assert.False(t, len(mrr.Excludes) != 1 || mrr.Excludes[0].ModulePath != "github.com/bad", "Excludes")
+	require.Len(t, mrr.Retracts, 2, "Retracts len")
+	assert.Falsef(t, mrr.Retracts[0].VersionRange != "v0.0.5" || mrr.Retracts[0].Rationale == "", "Retracts[0]: %+v", mrr.Retracts[0])
+	assert.Equalf(t, "[v1.0.0, v1.0.5]", mrr.Retracts[1].VersionRange, "Retracts[1] range: %+v", mrr.Retracts[1])
 }
 
 func TestGoModSourceSpecCarriesParsedMarker(t *testing.T) {
@@ -77,8 +69,8 @@ func TestGoModSourceSpecCarriesParsedMarker(t *testing.T) {
 		require github.com/x/y v1.2.3
 	`)
 	mrr := test.FindGoResolutionResult(spec)
-	require.NotNil(t, mrr)
-	assert.Equal(t, "example.com/foo", mrr.ModulePath)
+	require.NotNil(t, mrr, "expected GoResolutionResult marker on the GoMod SourceSpec")
+	assert.Equalf(t, "example.com/foo", mrr.ModulePath, "ModulePath: want %q", "example.com/foo")
 	if r := mrr.FindRequire("github.com/x/y"); r == nil || r.Version != "v1.2.3" {
 		t.Errorf("FindRequire: %+v", r)
 	}
@@ -97,11 +89,11 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 golang.org/x/mod v0.35.0 h1:Ww1D637e6Pg+Zb2KrWfHQUnH2dQRLBQyAtpr/haaJeM=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
 `)
-	require.Len(t, resolved, 2)
+	require.Len(t, resolved, 2, "ParseGoSum: want 2 entries")
 	uuid := resolved[0]
-	assert.False(t, uuid.ModulePath != "github.com/google/uuid" || uuid.Version != "v1.6.0")
-	assert.Equal(t, "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=", uuid.ModuleHash)
-	assert.Equal(t, "h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=", uuid.GoModHash)
+	assert.False(t, uuid.ModulePath != "github.com/google/uuid" || uuid.Version != "v1.6.0", "entry[0]: want github.com/google/uuid@v")
+	assert.Equal(t, "h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=", uuid.ModuleHash, "entry[0].ModuleHash")
+	assert.Equal(t, "h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=", uuid.GoModHash, "entry[0].GoModHash")
 	if mod := resolved[1]; mod.ModulePath != "golang.org/x/mod" || mod.Version != "v0.35.0" {
 		t.Errorf("entry[1]: want golang.org/x/mod@v0.35.0, got %+v", mod)
 	}
@@ -114,13 +106,9 @@ func TestParseGoSumOnlyGoModHashRecorded(t *testing.T) {
 	// build graph knows about.
 	resolved := parser.ParseGoSum(`example.com/indirect v1.0.0/go.mod h1:abc123=
 `)
-	require.Len(t, resolved, 1)
-	if resolved[0].ModuleHash != "" {
-		t.Errorf("ModuleHash: want empty, got %q", resolved[0].ModuleHash)
-	}
-	if resolved[0].GoModHash != "h1:abc123=" {
-		t.Errorf("GoModHash: %q", resolved[0].GoModHash)
-	}
+	require.Len(t, resolved, 1, "want 1 entry")
+	assert.Equalf(t, "", resolved[0].ModuleHash, "ModuleHash: want empty, got %q", resolved[0].ModuleHash)
+	assert.Equalf(t, "h1:abc123=", resolved[0].GoModHash, "GoModHash: %q", resolved[0].GoModHash)
 }
 
 func TestParseGoSumMalformedLineSkipped(t *testing.T) {
@@ -130,10 +118,8 @@ func TestParseGoSumMalformedLineSkipped(t *testing.T) {
 this is not a valid go.sum line
 github.com/c/d v2.0.0 h1:hashC=
 `)
-	require.Len(t, resolved, 2)
-	if resolved[0].ModulePath != "github.com/a/b" || resolved[1].ModulePath != "github.com/c/d" {
-		t.Errorf("unexpected modules: %+v", resolved)
-	}
+	require.Len(t, resolved, 2, "want 2 entries (malformed skipped")
+	assert.Falsef(t, resolved[0].ModulePath != "github.com/a/b" || resolved[1].ModulePath != "github.com/c/d", "unexpected modules: %+v", resolved)
 }
 
 func TestParseGoSumEmptyInput(t *testing.T) {
@@ -141,8 +127,8 @@ func TestParseGoSumEmptyInput(t *testing.T) {
 	// directly to GoResolutionResult.ResolvedDependencies, and a nil slice
 	// would be serialized as a null list and break the LST write.
 	got := parser.ParseGoSum("")
-	assert.NotNil(t, got)
-	assert.Len(t, got, 0)
+	assert.NotNil(t, got, "want non-nil empty slice for empty input, got nil")
+	assert.Len(t, got, 0, "want empty slice for empty input")
 }
 
 func TestGoProjectMergesGoSumIntoGoModMarker(t *testing.T) {
@@ -169,13 +155,13 @@ func TestGoProjectMergesGoSumIntoGoModMarker(t *testing.T) {
 			modSpec = &expanded[i]
 		}
 	}
-	require.NotNil(t, modSpec)
+	require.NotNil(t, modSpec, "no go.mod spec in expanded project")
 	mrr := test.FindGoResolutionResult(*modSpec)
-	require.NotNil(t, mrr)
-	require.Len(t, mrr.ResolvedDependencies, 1)
+	require.NotNil(t, mrr, "no GoResolutionResult marker on go.mod")
+	require.Len(t, mrr.ResolvedDependencies, 1, "want 1 resolved dep")
 	rd := mrr.ResolvedDependencies[0]
-	assert.False(t, rd.ModulePath != "github.com/google/uuid" || rd.Version != "v1.6.0")
-	assert.False(t, rd.ModuleHash == "" || rd.GoModHash == "")
+	assert.False(t, rd.ModulePath != "github.com/google/uuid" || rd.Version != "v1.6.0", "unexpected resolved dep")
+	assert.False(t, rd.ModuleHash == "" || rd.GoModHash == "", "expected both ModuleHash and GoModHash populated")
 }
 
 // TestParseGoModDirectiveListsNeverNil guards the root cause of the Moderne CLI
@@ -185,12 +171,12 @@ func TestGoProjectMergesGoSumIntoGoModMarker(t *testing.T) {
 // reflective binary LST serializer then NPEs calling items.size() on it.
 func TestParseGoModDirectiveListsNeverNil(t *testing.T) {
 	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\ngo 1.22\n")
-	require.NoError(t, err)
-	assert.NotNil(t, mrr.Requires)
-	assert.NotNil(t, mrr.Replaces)
-	assert.NotNil(t, mrr.Excludes)
-	assert.NotNil(t, mrr.Retracts)
-	assert.NotNil(t, mrr.ResolvedDependencies)
+	require.NoError(t, err, "parse failed")
+	assert.NotNil(t, mrr.Requires, "Requires is nil; want non-nil empty slice")
+	assert.NotNil(t, mrr.Replaces, "Replaces is nil; want non-nil empty slice")
+	assert.NotNil(t, mrr.Excludes, "Excludes is nil; want non-nil empty slice")
+	assert.NotNil(t, mrr.Retracts, "Retracts is nil; want non-nil empty slice")
+	assert.NotNil(t, mrr.ResolvedDependencies, "ResolvedDependencies is nil; want non-nil empty slice")
 }
 
 // TestParseGoModRequireButNoReplace covers the gin/cobra/zap failure shape: a
@@ -198,10 +184,10 @@ func TestParseGoModDirectiveListsNeverNil(t *testing.T) {
 // must still be non-nil empty slices.
 func TestParseGoModRequireButNoReplace(t *testing.T) {
 	mrr, err := parser.ParseGoMod("go.mod", "module example.com/foo\n\ngo 1.22\n\nrequire github.com/x/y v1.2.3\n")
-	require.NoError(t, err)
-	require.Len(t, mrr.Requires, 1)
-	assert.NotNil(t, mrr.Replaces)
-	assert.NotNil(t, mrr.Excludes)
-	assert.NotNil(t, mrr.Retracts)
-	assert.NotNil(t, mrr.ResolvedDependencies)
+	require.NoError(t, err, "parse failed")
+	require.Len(t, mrr.Requires, 1, "Requires len")
+	assert.NotNil(t, mrr.Replaces, "Replaces is nil; want non-nil empty slice")
+	assert.NotNil(t, mrr.Excludes, "Excludes is nil; want non-nil empty slice")
+	assert.NotNil(t, mrr.Retracts, "Retracts is nil; want non-nil empty slice")
+	assert.NotNil(t, mrr.ResolvedDependencies, "ResolvedDependencies is nil; want non-nil empty slice")
 }

--- a/rewrite-go/test/immutability_test.go
+++ b/rewrite-go/test/immutability_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -51,9 +53,7 @@ var immutabilitySamples = map[string]string{
 func TestVisitDoesNotMutateOriginal(t *testing.T) {
 	for name, src := range immutabilitySamples {
 		cu, err := parser.NewGoParser().Parse("p.go", src)
-		if err != nil {
-			t.Fatalf("%s: parse: %v", name, err)
-		}
+		require.NoErrorf(t, err, "%s: parse", name)
 		before := printer.Print(cu)
 		r := &renamer{}
 		visitor.Init(r)
@@ -71,9 +71,7 @@ func TestVisitDoesNotMutateOriginal(t *testing.T) {
 func TestNoOpVisitPreservesIdentity(t *testing.T) {
 	for name, src := range immutabilitySamples {
 		cu, err := parser.NewGoParser().Parse("p.go", src)
-		if err != nil {
-			t.Fatalf("%s: parse: %v", name, err)
-		}
+		require.NoErrorf(t, err, "%s: parse", name)
 		v := &visitor.GoVisitor{}
 		visitor.Init(v)
 		got := v.Visit(cu, nil)

--- a/rewrite-go/test/import_cycle_test.go
+++ b/rewrite-go/test/import_cycle_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 )
 
@@ -66,9 +68,7 @@ func TestProjectImporter_DirectImportCycle(t *testing.T) {
 	pi.AddSource("b/b.go", "package b\n\nimport \"example.com/foo/a\"\n\nfunc B() string { return a.A() }\n")
 
 	pkg := importWithTimeout(t, pi, "example.com/foo/a")
-	if pkg.Path() != "example.com/foo/a" {
-		t.Errorf("expected package path %q, got %q", "example.com/foo/a", pkg.Path())
-	}
+	assert.Equal(t, "example.com/foo/a", pkg.Path())
 }
 
 // A longer cycle (a -> b -> c -> a) exercises the same guard across more than
@@ -81,7 +81,5 @@ func TestProjectImporter_TransitiveImportCycle(t *testing.T) {
 	pi.AddSource("c/c.go", "package c\n\nimport \"example.com/foo/a\"\n\nfunc C() string { return a.A() }\n")
 
 	pkg := importWithTimeout(t, pi, "example.com/foo/a")
-	if pkg.Path() != "example.com/foo/a" {
-		t.Errorf("expected package path %q, got %q", "example.com/foo/a", pkg.Path())
-	}
+	assert.Equal(t, "example.com/foo/a", pkg.Path())
 }

--- a/rewrite-go/test/import_cycle_test.go
+++ b/rewrite-go/test/import_cycle_test.go
@@ -68,7 +68,7 @@ func TestProjectImporter_DirectImportCycle(t *testing.T) {
 	pi.AddSource("b/b.go", "package b\n\nimport \"example.com/foo/a\"\n\nfunc B() string { return a.A() }\n")
 
 	pkg := importWithTimeout(t, pi, "example.com/foo/a")
-	assert.Equal(t, "example.com/foo/a", pkg.Path())
+	assert.Equalf(t, "example.com/foo/a", pkg.Path(), "expected package path %q", "example.com/foo/a")
 }
 
 // A longer cycle (a -> b -> c -> a) exercises the same guard across more than
@@ -81,5 +81,5 @@ func TestProjectImporter_TransitiveImportCycle(t *testing.T) {
 	pi.AddSource("c/c.go", "package c\n\nimport \"example.com/foo/a\"\n\nfunc C() string { return a.A() }\n")
 
 	pkg := importWithTimeout(t, pi, "example.com/foo/a")
-	assert.Equal(t, "example.com/foo/a", pkg.Path())
+	assert.Equalf(t, "example.com/foo/a", pkg.Path(), "expected package path %q", "example.com/foo/a")
 }

--- a/rewrite-go/test/import_service_test.go
+++ b/rewrite-go/test/import_service_test.go
@@ -33,7 +33,7 @@ import (
 // pkg/recipe/golang triggers registration of *golang.ImportService.
 func TestImportService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.ImportService](nil)
-	require.NotNil(t, svc)
+	require.NotNil(t, svc, "recipe.Service returned nil for *golang.ImportService")
 }
 
 // addStringsImportRecipe is a recipe that uses ImportService via

--- a/rewrite-go/test/import_service_test.go
+++ b/rewrite-go/test/import_service_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	recipes "github.com/openrewrite/rewrite/rewrite-go/pkg/recipe/golang"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
@@ -31,9 +33,7 @@ import (
 // pkg/recipe/golang triggers registration of *golang.ImportService.
 func TestImportService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.ImportService](nil)
-	if svc == nil {
-		t.Fatal("recipe.Service returned nil for *golang.ImportService")
-	}
+	require.NotNil(t, svc)
 }
 
 // addStringsImportRecipe is a recipe that uses ImportService via

--- a/rewrite-go/test/method_matcher_width_test.go
+++ b/rewrite-go/test/method_matcher_width_test.go
@@ -19,6 +19,8 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/matcher"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -41,9 +43,7 @@ func main() {
 	_ = strconv.Itoa(i)
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	calls := map[string]*java.MethodInvocation{}
 	visitor.Walk(cu, func(n java.Tree) bool {

--- a/rewrite-go/test/method_matcher_width_test.go
+++ b/rewrite-go/test/method_matcher_width_test.go
@@ -71,9 +71,7 @@ func main() {
 
 	for _, tc := range cases {
 		mi, ok := calls[tc.call]
-		if !ok {
-			t.Fatalf("no invocation of %q found in parsed tree", tc.call)
-		}
+		require.Truef(t, ok, "no invocation of %q found in parsed tree", tc.call)
 		if got := matcher.NewMethodMatcher(tc.pattern).Matches(mi); got != tc.want {
 			t.Errorf("NewMethodMatcher(%q).Matches(%s call) = %v, want %v", tc.pattern, tc.call, got, tc.want)
 		}

--- a/rewrite-go/test/multi_file_package_test.go
+++ b/rewrite-go/test/multi_file_package_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -33,17 +37,11 @@ func TestParsePackageResolvesCrossFileSymbols(t *testing.T) {
 		{Path: "main.go", Content: "package main\n\nfunc main() { helper() }\n"},
 		{Path: "helper.go", Content: "package main\n\nfunc helper() {}\n"},
 	})
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
-	if len(cus) != 2 {
-		t.Fatalf("expected 2 CUs, got %d", len(cus))
-	}
+	require.NoError(t, err)
+	require.Len(t, cus, 2)
 
 	mainTypes := collectIdentTypes(cus[0])
-	if mainTypes["helper"] == nil {
-		t.Errorf("expected `helper` reference in main.go to have a non-nil Type after multi-file parse; got nil (cross-file resolution still broken)")
-	}
+	assert.NotNil(t,mainTypes["helper"])
 }
 
 // TestGoProjectMultiFilePackageResolves is the harness-level integration:
@@ -58,9 +56,7 @@ func TestGoProjectMultiFilePackageResolves(t *testing.T) {
 	mainSrc.AfterRecipe = func(t *testing.T, cu *golang.CompilationUnit) {
 		t.Helper()
 		ids := collectIdentTypes(cu)
-		if ids["helper"] == nil {
-			t.Errorf("`helper` reference should have a resolved Type when parsed alongside helper.go; got nil")
-		}
+		assert.NotNil(t,ids["helper"])
 	}
 
 	helperSrc := test.Golang(`

--- a/rewrite-go/test/multi_file_package_test.go
+++ b/rewrite-go/test/multi_file_package_test.go
@@ -37,11 +37,11 @@ func TestParsePackageResolvesCrossFileSymbols(t *testing.T) {
 		{Path: "main.go", Content: "package main\n\nfunc main() { helper() }\n"},
 		{Path: "helper.go", Content: "package main\n\nfunc helper() {}\n"},
 	})
-	require.NoError(t, err)
-	require.Len(t, cus, 2)
+	require.NoError(t, err, "parse error")
+	require.Len(t, cus, 2, "expected 2 CUs")
 
 	mainTypes := collectIdentTypes(cus[0])
-	assert.NotNil(t,mainTypes["helper"])
+	assert.NotNil(t,mainTypes["helper"], "expected `helper` reference in main.go to have a non-nil Type after multi-file parse; got nil (cross-file resolution still broken)")
 }
 
 // TestGoProjectMultiFilePackageResolves is the harness-level integration:
@@ -56,7 +56,7 @@ func TestGoProjectMultiFilePackageResolves(t *testing.T) {
 	mainSrc.AfterRecipe = func(t *testing.T, cu *golang.CompilationUnit) {
 		t.Helper()
 		ids := collectIdentTypes(cu)
-		assert.NotNil(t,ids["helper"])
+		assert.NotNil(t,ids["helper"], "`helper` reference should have a resolved Type when parsed alongside helper.go; got nil")
 	}
 
 	helperSrc := test.Golang(`

--- a/rewrite-go/test/naming_service_test.go
+++ b/rewrite-go/test/naming_service_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestNamingService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.NamingService](nil)
-	require.NotNil(t, svc)
+	require.NotNil(t, svc, "recipe.Service returned nil for *golang.NamingService")
 }
 
 func TestNamingService_ToPascalCase(t *testing.T) {
@@ -109,9 +109,9 @@ func TestNamingService_IsValidIdentifier(t *testing.T) {
 func TestNamingService_IsPredeclared(t *testing.T) {
 	svc := &recipes.NamingService{}
 	for _, name := range []string{"int", "string", "true", "false", "nil", "iota", "len", "make", "new", "any", "comparable", "min", "max", "clear", "error"} {
-		assert.True(t, svc.IsPredeclared(name))
+		assert.Truef(t, svc.IsPredeclared(name), "IsPredeclared(%q) = false, want true", name)
 	}
 	for _, name := range []string{"Foo", "foo", "MyType", "Println", "func", "if"} {
-		assert.False(t, svc.IsPredeclared(name))
+		assert.Falsef(t, svc.IsPredeclared(name), "IsPredeclared(%q) = true, want false", name)
 	}
 }

--- a/rewrite-go/test/naming_service_test.go
+++ b/rewrite-go/test/naming_service_test.go
@@ -19,15 +19,17 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	recipes "github.com/openrewrite/rewrite/rewrite-go/pkg/recipe/golang"
 )
 
 func TestNamingService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.NamingService](nil)
-	if svc == nil {
-		t.Fatal("recipe.Service returned nil for *golang.NamingService")
-	}
+	require.NotNil(t, svc)
 }
 
 func TestNamingService_ToPascalCase(t *testing.T) {
@@ -107,13 +109,9 @@ func TestNamingService_IsValidIdentifier(t *testing.T) {
 func TestNamingService_IsPredeclared(t *testing.T) {
 	svc := &recipes.NamingService{}
 	for _, name := range []string{"int", "string", "true", "false", "nil", "iota", "len", "make", "new", "any", "comparable", "min", "max", "clear", "error"} {
-		if !svc.IsPredeclared(name) {
-			t.Errorf("IsPredeclared(%q) = false, want true", name)
-		}
+		assert.True(t, svc.IsPredeclared(name))
 	}
 	for _, name := range []string{"Foo", "foo", "MyType", "Println", "func", "if"} {
-		if svc.IsPredeclared(name) {
-			t.Errorf("IsPredeclared(%q) = true, want false", name)
-		}
+		assert.False(t, svc.IsPredeclared(name))
 	}
 }

--- a/rewrite-go/test/project_type_attribution_test.go
+++ b/rewrite-go/test/project_type_attribution_test.go
@@ -52,9 +52,9 @@ func TestProjectImporterResolvesIntraProjectImport(t *testing.T) {
 	pi.AddSource("sub/sub.go", "package sub\n\nfunc Hello() string { return \"hi\" }\n")
 
 	pkg, err := pi.Import("example.com/foo/sub")
-	require.NoError(t, err)
-	require.NotNil(t, pkg)
-	assert.Equal(t, "sub", pkg.Name())
+	require.NoError(t, err, "Import returned error")
+	require.NotNil(t, pkg, "Import returned nil package")
+	assert.Equalf(t, "sub", pkg.Name(), "package name: want %q", "sub")
 	if hello := pkg.Scope().Lookup("Hello"); hello == nil {
 		t.Fatal("expected sub.Hello to be defined in the resolved package")
 	}
@@ -66,8 +66,8 @@ func TestProjectImporterResolvesIntraProjectImport(t *testing.T) {
 func TestProjectImporterFallsBackToStdlib(t *testing.T) {
 	pi := parser.NewProjectImporter("example.com/foo", nil)
 	pkg, err := pi.Import("fmt")
-	require.NoError(t, err)
-	require.False(t, pkg == nil || pkg.Name() != "fmt")
+	require.NoError(t, err, "stdlib fallback failed")
+	require.False(t, pkg == nil || pkg.Name() != "fmt", "expected pkg=fmt")
 }
 
 // TestGoProjectWiresImporterIntoHarness is the integration assertion: a
@@ -88,8 +88,8 @@ func TestGoProjectWiresImporterIntoHarness(t *testing.T) {
 		// these would all be nil because importer.Default() doesn't know
 		// about example.com/foo/sub.
 		identTypes := collectIdentTypes(cu)
-		assert.NotNil(t,identTypes["sub"])
-		assert.NotNil(t,identTypes["Hello"])
+		assert.NotNil(t,identTypes["sub"], "expected `sub` identifier in main.go to have a resolved Type, got nil")
+		assert.NotNil(t,identTypes["Hello"], "expected `Hello` identifier in main.go to have a resolved Type, got nil")
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/project_type_attribution_test.go
+++ b/rewrite-go/test/project_type_attribution_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -48,15 +52,9 @@ func TestProjectImporterResolvesIntraProjectImport(t *testing.T) {
 	pi.AddSource("sub/sub.go", "package sub\n\nfunc Hello() string { return \"hi\" }\n")
 
 	pkg, err := pi.Import("example.com/foo/sub")
-	if err != nil {
-		t.Fatalf("Import returned error: %v", err)
-	}
-	if pkg == nil {
-		t.Fatal("Import returned nil package")
-	}
-	if pkg.Name() != "sub" {
-		t.Errorf("package name: want %q, got %q", "sub", pkg.Name())
-	}
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+	assert.Equal(t, "sub", pkg.Name())
 	if hello := pkg.Scope().Lookup("Hello"); hello == nil {
 		t.Fatal("expected sub.Hello to be defined in the resolved package")
 	}
@@ -68,12 +66,8 @@ func TestProjectImporterResolvesIntraProjectImport(t *testing.T) {
 func TestProjectImporterFallsBackToStdlib(t *testing.T) {
 	pi := parser.NewProjectImporter("example.com/foo", nil)
 	pkg, err := pi.Import("fmt")
-	if err != nil {
-		t.Fatalf("stdlib fallback failed: %v", err)
-	}
-	if pkg == nil || pkg.Name() != "fmt" {
-		t.Fatalf("expected pkg=fmt, got %v", pkg)
-	}
+	require.NoError(t, err)
+	require.False(t, pkg == nil || pkg.Name() != "fmt")
 }
 
 // TestGoProjectWiresImporterIntoHarness is the integration assertion: a
@@ -94,12 +88,8 @@ func TestGoProjectWiresImporterIntoHarness(t *testing.T) {
 		// these would all be nil because importer.Default() doesn't know
 		// about example.com/foo/sub.
 		identTypes := collectIdentTypes(cu)
-		if identTypes["sub"] == nil {
-			t.Errorf("expected `sub` identifier in main.go to have a resolved Type, got nil")
-		}
-		if identTypes["Hello"] == nil {
-			t.Errorf("expected `Hello` identifier in main.go to have a resolved Type, got nil")
-		}
+		assert.NotNil(t,identTypes["sub"])
+		assert.NotNil(t,identTypes["Hello"])
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/recipe_test.go
+++ b/rewrite-go/test/recipe_test.go
@@ -154,23 +154,23 @@ func TestSearchRecipeWithMarkerPrinting(t *testing.T) {
 	// Print with default marker printer — should show search result comment
 	output := printer.PrintWithMarkers(result, printer.DefaultMarkerPrinter)
 	expected := "package main\n\nfunc /*~~(found foo)~~>*/foo() {\n}\n"
-	assert.Equal(t, expected, output)
+	assert.Equal(t, expected, output, "marker output mismatch")
 
 	// Print without markers — should be original source
 	plain := printer.Print(result)
-	assert.Equal(t, plain, src)
+	assert.Equal(t, plain, src, "plain print should match original source")
 
 	// Print with sanitized printer — should strip markers
 	sanitized := printer.PrintWithMarkers(result, printer.SanitizedMarkerPrinter)
-	assert.Equal(t, sanitized, src)
+	assert.Equal(t, sanitized, src, "sanitized print should match original source")
 }
 
 func TestRecipeDescriptor(t *testing.T) {
 	r := &findFoo{}
 	desc := recipe.Describe(r)
 
-	assert.Equal(t, "org.openrewrite.golang.test.FindFoo", desc.Name)
-	assert.Equal(t, "Find foo identifiers", desc.DisplayName)
+	assert.Equalf(t, "org.openrewrite.golang.test.FindFoo", desc.Name, "expected name %q", "org.openrewrite.golang.test.FindFoo")
+	assert.Equalf(t, "Find foo identifiers", desc.DisplayName, "expected displayName %q", "Find foo identifiers")
 	if desc.EstimatedEffortPerOccurrence != 5*time.Minute {
 		t.Errorf("expected 5 minute default effort, got %v", desc.EstimatedEffortPerOccurrence)
 	}
@@ -193,28 +193,20 @@ func TestRegistryActivate(t *testing.T) {
 	reg.Activate(activateSearch, activateRefactoring)
 
 	found, ok := reg.FindRecipe("org.openrewrite.golang.test.FindFoo")
-	require.True(t, ok)
-	assert.Equal(t, "Find foo identifiers", found.Descriptor.DisplayName)
+	require.True(t, ok, "expected to find FindFoo recipe")
+	assert.Equalf(t, "Find foo identifiers", found.Descriptor.DisplayName, "expected displayName %q", "Find foo identifiers")
 
 	// All recipes
 	all := reg.AllRecipes()
-	assert.Len(t, all, 2)
+	assert.Len(t, all, 2, "expected 2 recipes")
 
 	// Categories
 	cats := reg.Categories()
-	require.Len(t, cats, 1)
-	if cats[0].DisplayName != "Go" {
-		t.Errorf("expected top-level category 'Go', got %q", cats[0].DisplayName)
-	}
-	if len(cats[0].Recipes) != 1 {
-		t.Errorf("expected 1 recipe directly in Go category, got %d", len(cats[0].Recipes))
-	}
-	if len(cats[0].Subcategories) != 1 {
-		t.Fatalf("expected 1 subcategory in Go, got %d", len(cats[0].Subcategories))
-	}
-	if cats[0].Subcategories[0].DisplayName != "Search" {
-		t.Errorf("expected subcategory 'Search', got %q", cats[0].Subcategories[0].DisplayName)
-	}
+	require.Len(t, cats, 1, "expected 1 top-level category")
+	assert.Equalf(t, "Go", cats[0].DisplayName, "expected top-level category 'Go', got %q", cats[0].DisplayName)
+	assert.Lenf(t, cats[0].Recipes, 1, "expected 1 recipe directly in Go category, got %d", len(cats[0].Recipes))
+	require.Lenf(t, cats[0].Subcategories, 1, "expected 1 subcategory in Go, got %d", len(cats[0].Subcategories))
+	assert.Equalf(t, "Search", cats[0].Subcategories[0].DisplayName, "expected subcategory 'Search', got %q", cats[0].Subcategories[0].DisplayName)
 }
 
 func TestRegistryReflectConstructor(t *testing.T) {
@@ -225,11 +217,11 @@ func TestRegistryReflectConstructor(t *testing.T) {
 	})
 
 	found, ok := reg.FindRecipe("org.openrewrite.golang.test.RenameFooToBar")
-	require.True(t, ok)
+	require.True(t, ok, "expected to find recipe")
 
 	// Constructor auto-derived from prototype via reflection
 	instance := found.Constructor(nil)
-	assert.Equal(t, "org.openrewrite.golang.test.RenameFooToBar", instance.Name())
+	assert.Equal(t, "org.openrewrite.golang.test.RenameFooToBar", instance.Name(), "unexpected name")
 }
 
 func TestFencedMarkerPrinting(t *testing.T) {
@@ -246,7 +238,7 @@ func TestFencedMarkerPrinting(t *testing.T) {
 
 	// Print with fenced printer — should show {{uuid}} delimiters
 	output := printer.PrintWithMarkers(result, printer.FencedMarkerPrinter)
-	assert.NotEqual(t, output, src)
+	assert.NotEqual(t, output, src, "expected fenced markers in output, but output is unchanged")
 	// Fenced output should contain UUID-style markers
 	if len(output) <= len(src) {
 		t.Error("fenced output should be longer than original source")

--- a/rewrite-go/test/recipe_test.go
+++ b/rewrite-go/test/recipe_test.go
@@ -20,6 +20,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
@@ -142,9 +146,7 @@ func TestSearchRecipeWithMarkerPrinting(t *testing.T) {
 	src := "package main\n\nfunc foo() {\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx := recipe.NewExecutionContext()
 	result := editor.Visit(cu, ctx)
@@ -152,33 +154,23 @@ func TestSearchRecipeWithMarkerPrinting(t *testing.T) {
 	// Print with default marker printer — should show search result comment
 	output := printer.PrintWithMarkers(result, printer.DefaultMarkerPrinter)
 	expected := "package main\n\nfunc /*~~(found foo)~~>*/foo() {\n}\n"
-	if output != expected {
-		t.Errorf("marker output mismatch\nexpected: %q\nactual:   %q", expected, output)
-	}
+	assert.Equal(t, expected, output)
 
 	// Print without markers — should be original source
 	plain := printer.Print(result)
-	if plain != src {
-		t.Errorf("plain print should match original source\nexpected: %q\nactual:   %q", src, plain)
-	}
+	assert.Equal(t, plain, src)
 
 	// Print with sanitized printer — should strip markers
 	sanitized := printer.PrintWithMarkers(result, printer.SanitizedMarkerPrinter)
-	if sanitized != src {
-		t.Errorf("sanitized print should match original source\nexpected: %q\nactual:   %q", src, sanitized)
-	}
+	assert.Equal(t, sanitized, src)
 }
 
 func TestRecipeDescriptor(t *testing.T) {
 	r := &findFoo{}
 	desc := recipe.Describe(r)
 
-	if desc.Name != "org.openrewrite.golang.test.FindFoo" {
-		t.Errorf("expected name %q, got %q", "org.openrewrite.golang.test.FindFoo", desc.Name)
-	}
-	if desc.DisplayName != "Find foo identifiers" {
-		t.Errorf("expected displayName %q, got %q", "Find foo identifiers", desc.DisplayName)
-	}
+	assert.Equal(t, "org.openrewrite.golang.test.FindFoo", desc.Name)
+	assert.Equal(t, "Find foo identifiers", desc.DisplayName)
 	if desc.EstimatedEffortPerOccurrence != 5*time.Minute {
 		t.Errorf("expected 5 minute default effort, got %v", desc.EstimatedEffortPerOccurrence)
 	}
@@ -201,24 +193,16 @@ func TestRegistryActivate(t *testing.T) {
 	reg.Activate(activateSearch, activateRefactoring)
 
 	found, ok := reg.FindRecipe("org.openrewrite.golang.test.FindFoo")
-	if !ok {
-		t.Fatal("expected to find FindFoo recipe")
-	}
-	if found.Descriptor.DisplayName != "Find foo identifiers" {
-		t.Errorf("expected displayName %q, got %q", "Find foo identifiers", found.Descriptor.DisplayName)
-	}
+	require.True(t, ok)
+	assert.Equal(t, "Find foo identifiers", found.Descriptor.DisplayName)
 
 	// All recipes
 	all := reg.AllRecipes()
-	if len(all) != 2 {
-		t.Errorf("expected 2 recipes, got %d", len(all))
-	}
+	assert.Len(t, all, 2)
 
 	// Categories
 	cats := reg.Categories()
-	if len(cats) != 1 {
-		t.Fatalf("expected 1 top-level category, got %d", len(cats))
-	}
+	require.Len(t, cats, 1)
 	if cats[0].DisplayName != "Go" {
 		t.Errorf("expected top-level category 'Go', got %q", cats[0].DisplayName)
 	}
@@ -241,15 +225,11 @@ func TestRegistryReflectConstructor(t *testing.T) {
 	})
 
 	found, ok := reg.FindRecipe("org.openrewrite.golang.test.RenameFooToBar")
-	if !ok {
-		t.Fatal("expected to find recipe")
-	}
+	require.True(t, ok)
 
 	// Constructor auto-derived from prototype via reflection
 	instance := found.Constructor(nil)
-	if instance.Name() != "org.openrewrite.golang.test.RenameFooToBar" {
-		t.Errorf("unexpected name: %s", instance.Name())
-	}
+	assert.Equal(t, "org.openrewrite.golang.test.RenameFooToBar", instance.Name())
 }
 
 func TestFencedMarkerPrinting(t *testing.T) {
@@ -259,18 +239,14 @@ func TestFencedMarkerPrinting(t *testing.T) {
 	src := "package main\n\nfunc foo() {\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx := recipe.NewExecutionContext()
 	result := editor.Visit(cu, ctx)
 
 	// Print with fenced printer — should show {{uuid}} delimiters
 	output := printer.PrintWithMarkers(result, printer.FencedMarkerPrinter)
-	if output == src {
-		t.Error("expected fenced markers in output, but output is unchanged")
-	}
+	assert.NotEqual(t, output, src)
 	// Fenced output should contain UUID-style markers
 	if len(output) <= len(src) {
 		t.Error("fenced output should be longer than original source")

--- a/rewrite-go/test/require_resolution_test.go
+++ b/rewrite-go/test/require_resolution_test.go
@@ -33,10 +33,10 @@ func TestProjectImporterStubsRequiredModule(t *testing.T) {
 	pi.AddRequire("github.com/x/y")
 
 	pkg, err := pi.Import("github.com/x/y")
-	require.NoError(t, err)
-	require.NotNil(t, pkg)
-	assert.Equal(t, "github.com/x/y", pkg.Path())
-	assert.Equal(t, "y", pkg.Name())
+	require.NoError(t, err, "Import returned error")
+	require.NotNil(t, pkg, "expected stub package, got nil")
+	assert.Equalf(t, "github.com/x/y", pkg.Path(), "Path: want %q", "github.com/x/y")
+	assert.Equalf(t, "y", pkg.Name(), "Name: want %q", "y")
 }
 
 func TestProjectImporterStubMatchesSubPath(t *testing.T) {
@@ -46,9 +46,9 @@ func TestProjectImporterStubMatchesSubPath(t *testing.T) {
 	// `import "github.com/x/y/sub"` should also stub-resolve, because the
 	// require covers the whole module subtree.
 	pkg, err := pi.Import("github.com/x/y/sub")
-	require.NoError(t, err)
-	require.NotNil(t, pkg)
-	assert.Equal(t, "sub", pkg.Name())
+	require.NoError(t, err, "Import returned error")
+	require.NotNil(t, pkg, "expected stub package for sub-path, got nil")
+	assert.Equalf(t, "sub", pkg.Name(), "Name: want %q", "sub")
 }
 
 func TestProjectImporterUnknownPathFallsThroughToError(t *testing.T) {
@@ -76,7 +76,7 @@ func TestGoProjectThirdPartyImportResolves(t *testing.T) {
 		// identifier should now have a non-nil Type. Without require-driven
 		// stubbing this would be nil.
 		ids := collectIdentTypes(cu)
-		assert.NotNil(t,ids["y"])
+		assert.NotNil(t,ids["y"], "expected `y` import identifier to have a non-nil Type via the require stub; got nil")
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/require_resolution_test.go
+++ b/rewrite-go/test/require_resolution_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -29,18 +33,10 @@ func TestProjectImporterStubsRequiredModule(t *testing.T) {
 	pi.AddRequire("github.com/x/y")
 
 	pkg, err := pi.Import("github.com/x/y")
-	if err != nil {
-		t.Fatalf("Import returned error: %v", err)
-	}
-	if pkg == nil {
-		t.Fatal("expected stub package, got nil")
-	}
-	if pkg.Path() != "github.com/x/y" {
-		t.Errorf("Path: want %q, got %q", "github.com/x/y", pkg.Path())
-	}
-	if pkg.Name() != "y" {
-		t.Errorf("Name: want %q, got %q", "y", pkg.Name())
-	}
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+	assert.Equal(t, "github.com/x/y", pkg.Path())
+	assert.Equal(t, "y", pkg.Name())
 }
 
 func TestProjectImporterStubMatchesSubPath(t *testing.T) {
@@ -50,15 +46,9 @@ func TestProjectImporterStubMatchesSubPath(t *testing.T) {
 	// `import "github.com/x/y/sub"` should also stub-resolve, because the
 	// require covers the whole module subtree.
 	pkg, err := pi.Import("github.com/x/y/sub")
-	if err != nil {
-		t.Fatalf("Import returned error: %v", err)
-	}
-	if pkg == nil {
-		t.Fatal("expected stub package for sub-path, got nil")
-	}
-	if pkg.Name() != "sub" {
-		t.Errorf("Name: want %q, got %q", "sub", pkg.Name())
-	}
+	require.NoError(t, err)
+	require.NotNil(t, pkg)
+	assert.Equal(t, "sub", pkg.Name())
 }
 
 func TestProjectImporterUnknownPathFallsThroughToError(t *testing.T) {
@@ -86,9 +76,7 @@ func TestGoProjectThirdPartyImportResolves(t *testing.T) {
 		// identifier should now have a non-nil Type. Without require-driven
 		// stubbing this would be nil.
 		ids := collectIdentTypes(cu)
-		if ids["y"] == nil {
-			t.Errorf("expected `y` import identifier to have a non-nil Type via the require stub; got nil")
-		}
+		assert.NotNil(t,ids["y"])
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/search_walker_test.go
+++ b/rewrite-go/test/search_walker_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -42,9 +44,7 @@ func (v *markBinaryVisitor) VisitBinary(bin *java.Binary, p any) java.J {
 
 func TestCollectSearchResultIDsEmpty(t *testing.T) {
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	if got := visitor.CollectSearchResultIDs(cu); len(got) != 0 {
 		t.Fatalf("expected no search results, got %v", got)
 	}
@@ -52,18 +52,14 @@ func TestCollectSearchResultIDsEmpty(t *testing.T) {
 
 func TestCollectSearchResultIDsAfterMark(t *testing.T) {
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\n\nvar x = 1 + 2\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	mark := java.NewSearchResult("found a binary expr")
 	v := &markBinaryVisitor{marker: mark}
 	visitor.Init(v)
 
 	result := v.Visit(cu, recipe.NewExecutionContext()).(java.Tree)
 	ids := visitor.CollectSearchResultIDs(result)
-	if len(ids) != 1 {
-		t.Fatalf("expected exactly one search result id, got %d (%v)", len(ids), ids)
-	}
+	require.Len(t, ids, 1)
 	if ids[0] != mark.Ident {
 		t.Fatalf("collected id %v does not match marker id %v", ids[0], mark.Ident)
 	}
@@ -114,9 +110,7 @@ func (v *rewriteMarkerVisitor) VisitMarker(m java.Marker, p any) java.Marker {
 func TestVisitMarkerRewritesInPlace(t *testing.T) {
 	// given
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\n\nvar x = 1 + 2\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	marked := visitor.Init(&markBinaryVisitor{marker: java.NewSearchResult("orig")}).
 		Visit(cu, recipe.NewExecutionContext()).(java.Tree)
 
@@ -134,9 +128,7 @@ func TestVisitMarkerRewritesInPlace(t *testing.T) {
 
 func TestCollectSearchResultIDsDedupes(t *testing.T) {
 	cu, err := parser.NewGoParser().Parse("a.go", "package main\n\nvar x = 1 + 2 + 3\n")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	// Same marker (same UUID) attached to two binary expressions: collector
 	// should only return it once.
 	mark := java.NewSearchResult("dup")
@@ -145,7 +137,5 @@ func TestCollectSearchResultIDsDedupes(t *testing.T) {
 
 	result := v.Visit(cu, recipe.NewExecutionContext()).(java.Tree)
 	ids := visitor.CollectSearchResultIDs(result)
-	if len(ids) != 1 {
-		t.Fatalf("expected dedup to produce 1 id, got %d (%v)", len(ids), ids)
-	}
+	require.Len(t, ids, 1)
 }

--- a/rewrite-go/test/search_walker_test.go
+++ b/rewrite-go/test/search_walker_test.go
@@ -59,7 +59,7 @@ func TestCollectSearchResultIDsAfterMark(t *testing.T) {
 
 	result := v.Visit(cu, recipe.NewExecutionContext()).(java.Tree)
 	ids := visitor.CollectSearchResultIDs(result)
-	require.Len(t, ids, 1)
+	require.Len(t, ids, 1, "expected exactly one search result id")
 	if ids[0] != mark.Ident {
 		t.Fatalf("collected id %v does not match marker id %v", ids[0], mark.Ident)
 	}
@@ -86,9 +86,7 @@ func TestCollectSearchResultIDsOnGoModNode(t *testing.T) {
 	ids := visitor.CollectSearchResultIDs(gm)
 
 	// then
-	if len(ids) != 1 || ids[0] != mark.Ident {
-		t.Fatalf("expected [%v], got %v", mark.Ident, ids)
-	}
+	require.Falsef(t, len(ids) != 1 || ids[0] != mark.Ident, "expected [%v", mark.Ident)
 }
 
 // rewriteMarkerVisitor swaps the ID of every SearchResult it encounters via
@@ -121,9 +119,7 @@ func TestVisitMarkerRewritesInPlace(t *testing.T) {
 
 	// then
 	ids := visitor.CollectSearchResultIDs(rewritten)
-	if len(ids) != 1 || ids[0] != newID {
-		t.Fatalf("expected VisitMarker to rewrite the id to %v, got %v", newID, ids)
-	}
+	require.Falsef(t, len(ids) != 1 || ids[0] != newID, "expected VisitMarker to rewrite the id to %v", newID)
 }
 
 func TestCollectSearchResultIDsDedupes(t *testing.T) {
@@ -137,5 +133,5 @@ func TestCollectSearchResultIDsDedupes(t *testing.T) {
 
 	result := v.Visit(cu, recipe.NewExecutionContext()).(java.Tree)
 	ids := visitor.CollectSearchResultIDs(result)
-	require.Len(t, ids, 1)
+	require.Len(t, ids, 1, "expected dedup to produce 1 id")
 }

--- a/rewrite-go/test/selfparse_test.go
+++ b/rewrite-go/test/selfparse_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestSelfParseGoParser(t *testing.T) {
 	data, err := os.ReadFile("../pkg/parser/go_parser.go")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to read file")
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -37,7 +37,7 @@ func TestSelfParseGoParser(t *testing.T) {
 
 func TestSelfParseGoPrinter(t *testing.T) {
 	data, err := os.ReadFile("../pkg/printer/go_printer.go")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to read file")
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -45,7 +45,7 @@ func TestSelfParseGoPrinter(t *testing.T) {
 
 func TestSelfParseGoVisitor(t *testing.T) {
 	data, err := os.ReadFile("../pkg/visitor/go_visitor.go")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to read file")
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -53,7 +53,7 @@ func TestSelfParseGoVisitor(t *testing.T) {
 
 func TestSelfParseJTree(t *testing.T) {
 	data, err := os.ReadFile("../pkg/tree/java/j.go")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to read file")
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -61,7 +61,7 @@ func TestSelfParseJTree(t *testing.T) {
 
 func TestSelfParseGoTree(t *testing.T) {
 	data, err := os.ReadFile("../pkg/tree/golang/go.go")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to read file")
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -69,7 +69,7 @@ func TestSelfParseGoTree(t *testing.T) {
 
 func TestSelfParseSpec(t *testing.T) {
 	data, err := os.ReadFile("../pkg/test/spec.go")
-	require.NoError(t, err)
+	require.NoError(t, err, "failed to read file")
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)

--- a/rewrite-go/test/selfparse_test.go
+++ b/rewrite-go/test/selfparse_test.go
@@ -22,14 +22,14 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 )
 
 func TestSelfParseGoParser(t *testing.T) {
 	data, err := os.ReadFile("../pkg/parser/go_parser.go")
-	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
-	}
+	require.NoError(t, err)
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -37,9 +37,7 @@ func TestSelfParseGoParser(t *testing.T) {
 
 func TestSelfParseGoPrinter(t *testing.T) {
 	data, err := os.ReadFile("../pkg/printer/go_printer.go")
-	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
-	}
+	require.NoError(t, err)
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -47,9 +45,7 @@ func TestSelfParseGoPrinter(t *testing.T) {
 
 func TestSelfParseGoVisitor(t *testing.T) {
 	data, err := os.ReadFile("../pkg/visitor/go_visitor.go")
-	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
-	}
+	require.NoError(t, err)
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -57,9 +53,7 @@ func TestSelfParseGoVisitor(t *testing.T) {
 
 func TestSelfParseJTree(t *testing.T) {
 	data, err := os.ReadFile("../pkg/tree/java/j.go")
-	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
-	}
+	require.NoError(t, err)
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -67,9 +61,7 @@ func TestSelfParseJTree(t *testing.T) {
 
 func TestSelfParseGoTree(t *testing.T) {
 	data, err := os.ReadFile("../pkg/tree/golang/go.go")
-	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
-	}
+	require.NoError(t, err)
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)
@@ -77,9 +69,7 @@ func TestSelfParseGoTree(t *testing.T) {
 
 func TestSelfParseSpec(t *testing.T) {
 	data, err := os.ReadFile("../pkg/test/spec.go")
-	if err != nil {
-		t.Fatalf("failed to read file: %v", err)
-	}
+	require.NoError(t, err)
 	NewRecipeSpec().RewriteRun(t,
 		GolangRaw(string(data)),
 	)

--- a/rewrite-go/test/struct_tag_test.go
+++ b/rewrite-go/test/struct_tag_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -34,9 +38,7 @@ import (
 func parseStructAndFindField(t *testing.T, src, fieldName string) *java.VariableDeclarations {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	for _, rp := range cu.Statements {
 		td, ok := rp.Element.(*golang.TypeDecl)
 		if !ok {
@@ -73,16 +75,12 @@ func TestStructTag_SingleKeyParsesIntoOneAnnotation(t *testing.T) {
 	if id, ok := ann.AnnotationType.(*java.Identifier); !ok || id.Name != "json" {
 		t.Errorf("AnnotationType: got %+v, want Identifier{Name:\"json\"}", ann.AnnotationType)
 	}
-	if ann.Arguments == nil || len(ann.Arguments.Elements) != 1 {
-		t.Fatalf("Arguments: got %+v, want 1 element", ann.Arguments)
-	}
+	require.False(t, ann.Arguments == nil || len(ann.Arguments.Elements) != 1)
 	lit, ok := ann.Arguments.Elements[0].Element.(*java.Literal)
 	if !ok {
 		t.Fatalf("Arguments[0]: got %T, want *Literal", ann.Arguments.Elements[0].Element)
 	}
-	if lit.Source != `"name"` {
-		t.Errorf("Arguments[0].Source: got %q, want %q", lit.Source, `"name"`)
-	}
+	assert.Equal(t, `"name"`, lit.Source)
 	if v, _ := lit.Value.(string); v != "name" {
 		t.Errorf("Arguments[0].Value: got %v, want %q", lit.Value, "name")
 	}
@@ -112,9 +110,7 @@ func TestStructTag_MultipleKeysParseIntoMultipleAnnotations(t *testing.T) {
 		t.Errorf("[1] Source: got %q, want %q", lit.Source, `"email_address"`)
 	}
 	// Inter-pair whitespace lives on the second annotation's Prefix.
-	if second.Prefix.Whitespace != " " {
-		t.Errorf("[1] Prefix.Whitespace: got %q, want %q", second.Prefix.Whitespace, " ")
-	}
+	assert.Equal(t, " ", second.Prefix.Whitespace)
 }
 
 func TestStructTag_NoMarkerLeftBehind(t *testing.T) {
@@ -131,39 +127,27 @@ func TestStructTag_NoMarkerLeftBehind(t *testing.T) {
 func TestStructTag_RoundtripGofmtdInput(t *testing.T) {
 	src := "package main\n\ntype User struct {\n\tName  string `json:\"name\"`\n\tEmail string `json:\"email,omitempty\" db:\"email_address\"`\n\tID    int    `json:\"-\"`\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	got := printer.Print(cu)
-	if got != src {
-		t.Errorf("roundtrip mismatch\nexpected:\n%s\nactual:\n%s", src, got)
-	}
+	assert.Equal(t, src, got)
 }
 
 func TestStructTag_RoundtripWithEscapes(t *testing.T) {
 	// A backslash-escaped quote inside the value must roundtrip.
 	src := "package main\n\ntype X struct {\n\tField string `json:\"a\\\"b\"`\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	got := printer.Print(cu)
-	if got != src {
-		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
-	}
+	assert.Equal(t, src, got)
 }
 
 func TestStructTag_DashValueRoundtrip(t *testing.T) {
 	// `json:"-"` is the convention for "skip this field".
 	src := "package main\n\ntype X struct {\n\tField string `json:\"-\"`\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	got := printer.Print(cu)
-	if got != src {
-		t.Errorf("roundtrip mismatch\nexpected: %q\nactual:   %q", src, got)
-	}
+	assert.Equal(t, src, got)
 	vd := parseStructAndFindField(t, src, "Field")
 	lit := vd.LeadingAnnotations[0].Arguments.Elements[0].Element.(*java.Literal)
 	if v, _ := lit.Value.(string); v != "-" {
@@ -176,9 +160,7 @@ func TestStructTag_NonStructDoesNotEmitAnnotations(t *testing.T) {
 	// the parser should not emit any LeadingAnnotations on them.
 	src := "package main\n\nvar x int = 1\n\nfunc f() {\n\ty := 2\n\t_ = y\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	for _, rp := range cu.Statements {
 		if vd, ok := rp.Element.(*java.VariableDeclarations); ok {
 			if len(vd.LeadingAnnotations) > 0 {

--- a/rewrite-go/test/struct_tag_test.go
+++ b/rewrite-go/test/struct_tag_test.go
@@ -38,7 +38,7 @@ import (
 func parseStructAndFindField(t *testing.T, src, fieldName string) *java.VariableDeclarations {
 	t.Helper()
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	for _, rp := range cu.Statements {
 		td, ok := rp.Element.(*golang.TypeDecl)
 		if !ok {
@@ -75,12 +75,10 @@ func TestStructTag_SingleKeyParsesIntoOneAnnotation(t *testing.T) {
 	if id, ok := ann.AnnotationType.(*java.Identifier); !ok || id.Name != "json" {
 		t.Errorf("AnnotationType: got %+v, want Identifier{Name:\"json\"}", ann.AnnotationType)
 	}
-	require.False(t, ann.Arguments == nil || len(ann.Arguments.Elements) != 1)
+	require.Falsef(t, ann.Arguments == nil || len(ann.Arguments.Elements) != 1, "Arguments: got %+v, want 1 element", ann.Arguments)
 	lit, ok := ann.Arguments.Elements[0].Element.(*java.Literal)
-	if !ok {
-		t.Fatalf("Arguments[0]: got %T, want *Literal", ann.Arguments.Elements[0].Element)
-	}
-	assert.Equal(t, `"name"`, lit.Source)
+	require.Truef(t, ok, "Arguments[0]: got %T, want *Literal", ann.Arguments.Elements[0].Element)
+	assert.Equalf(t, `"name"`, lit.Source, "Arguments[0].Source: got %q, want %q", lit.Source, `"name"`)
 	if v, _ := lit.Value.(string); v != "name" {
 		t.Errorf("Arguments[0].Value: got %v, want %q", lit.Value, "name")
 	}
@@ -110,7 +108,7 @@ func TestStructTag_MultipleKeysParseIntoMultipleAnnotations(t *testing.T) {
 		t.Errorf("[1] Source: got %q, want %q", lit.Source, `"email_address"`)
 	}
 	// Inter-pair whitespace lives on the second annotation's Prefix.
-	assert.Equal(t, " ", second.Prefix.Whitespace)
+	assert.Equalf(t, " ", second.Prefix.Whitespace, "[1] Prefix.Whitespace: got %q, want %q", second.Prefix.Whitespace, " ")
 }
 
 func TestStructTag_NoMarkerLeftBehind(t *testing.T) {
@@ -127,27 +125,27 @@ func TestStructTag_NoMarkerLeftBehind(t *testing.T) {
 func TestStructTag_RoundtripGofmtdInput(t *testing.T) {
 	src := "package main\n\ntype User struct {\n\tName  string `json:\"name\"`\n\tEmail string `json:\"email,omitempty\" db:\"email_address\"`\n\tID    int    `json:\"-\"`\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	got := printer.Print(cu)
-	assert.Equal(t, src, got)
+	assert.Equal(t, src, got, "roundtrip mismatch")
 }
 
 func TestStructTag_RoundtripWithEscapes(t *testing.T) {
 	// A backslash-escaped quote inside the value must roundtrip.
 	src := "package main\n\ntype X struct {\n\tField string `json:\"a\\\"b\"`\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	got := printer.Print(cu)
-	assert.Equal(t, src, got)
+	assert.Equal(t, src, got, "roundtrip mismatch")
 }
 
 func TestStructTag_DashValueRoundtrip(t *testing.T) {
 	// `json:"-"` is the convention for "skip this field".
 	src := "package main\n\ntype X struct {\n\tField string `json:\"-\"`\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	got := printer.Print(cu)
-	assert.Equal(t, src, got)
+	assert.Equal(t, src, got, "roundtrip mismatch")
 	vd := parseStructAndFindField(t, src, "Field")
 	lit := vd.LeadingAnnotations[0].Arguments.Elements[0].Element.(*java.Literal)
 	if v, _ := lit.Value.(string); v != "-" {
@@ -160,7 +158,7 @@ func TestStructTag_NonStructDoesNotEmitAnnotations(t *testing.T) {
 	// the parser should not emit any LeadingAnnotations on them.
 	src := "package main\n\nvar x int = 1\n\nfunc f() {\n\ty := 2\n\t_ = y\n}\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	for _, rp := range cu.Statements {
 		if vd, ok := rp.Element.(*java.VariableDeclarations); ok {
 			if len(vd.LeadingAnnotations) > 0 {

--- a/rewrite-go/test/type_attribution_test.go
+++ b/rewrite-go/test/type_attribution_test.go
@@ -74,7 +74,7 @@ func main() {
 	// "x" should be an int type
 	if xType, ok := v.identTypes["x"]; ok {
 		if prim, ok := xType.(*java.JavaTypePrimitive); ok {
-			assert.Equal(t, "int", prim.Keyword)
+			assert.Equal(t, "int", prim.Keyword, "expected x to be int")
 		} else {
 			t.Errorf("expected x to be primitive, got %T", xType)
 		}
@@ -85,7 +85,7 @@ func main() {
 	// "y" should be a string type (mapped as Primitive "String")
 	if yType, ok := v.identTypes["y"]; ok {
 		if prim, ok := yType.(*java.JavaTypePrimitive); ok {
-			assert.Equal(t, "String", prim.Keyword)
+			assert.Equal(t, "String", prim.Keyword, "expected y to be String")
 		} else {
 			t.Errorf("expected y to be primitive, got %T", yType)
 		}
@@ -108,11 +108,11 @@ func add(a int, b int) int {
 	v.Visit(cu, nil)
 
 	addType, ok := v.methodTypes["add"]
-	require.True(t, ok)
-	assert.Equal(t, "add", addType.Name)
-	assert.Len(t, addType.ParameterTypes, 2)
+	require.True(t, ok, "no method type for add()")
+	assert.Equal(t, "add", addType.Name, "expected method name 'add")
+	assert.Len(t, addType.ParameterTypes, 2, "expected 2 parameters")
 	if ret, ok := addType.ReturnType.(*java.JavaTypePrimitive); ok {
-		assert.Equal(t, "int", ret.Keyword)
+		assert.Equal(t, "int", ret.Keyword, "expected return type int")
 	} else {
 		t.Errorf("expected primitive return type, got %T", addType.ReturnType)
 	}
@@ -135,22 +135,18 @@ func divmod(a int, b int) (int, int) {
 
 	// then
 	mt, ok := v.methodTypes["divmod"]
-	require.True(t, ok)
+	require.True(t, ok, "no method type for divmod()")
 	param, ok := mt.ReturnType.(*java.JavaTypeParameterized)
-	if !ok {
-		t.Fatalf("expected parameterized return type, got %T", mt.ReturnType)
-	}
-	assert.False(t, param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple")
-	require.Len(t, param.TypeParameters, 2)
+	require.Truef(t, ok, "expected parameterized return type, got %T", mt.ReturnType)
+	assert.False(t, param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple", "expected tuple FQN 'go.tuple")
+	require.Len(t, param.TypeParameters, 2, "expected 2 tuple type parameters")
 	for i, tp := range param.TypeParameters {
 		prim, ok := tp.(*java.JavaTypePrimitive)
 		if !ok {
 			t.Errorf("tuple element %d: expected primitive, got %T", i, tp)
 			continue
 		}
-		if prim.Keyword != "int" {
-			t.Errorf("tuple element %d: expected int, got %s", i, prim.Keyword)
-		}
+		assert.Equalf(t, "int", prim.Keyword, "tuple element %d: expected int", i)
 	}
 }
 
@@ -171,13 +167,11 @@ func split() (string, int, bool) {
 
 	// then
 	mt, ok := v.methodTypes["split"]
-	require.True(t, ok)
+	require.True(t, ok, "no method type for split()")
 	param, ok := mt.ReturnType.(*java.JavaTypeParameterized)
-	if !ok {
-		t.Fatalf("expected parameterized return type, got %T", mt.ReturnType)
-	}
-	assert.False(t, param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple")
-	require.Len(t, param.TypeParameters, 3)
+	require.Truef(t, ok, "expected parameterized return type, got %T", mt.ReturnType)
+	assert.False(t, param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple", "expected tuple FQN 'go.tuple")
+	require.Len(t, param.TypeParameters, 3, "expected 3 tuple type parameters")
 	expectedKeywords := []string{"String", "int", "boolean"}
 	for i, want := range expectedKeywords {
 		prim, ok := param.TypeParameters[i].(*java.JavaTypePrimitive)
@@ -185,9 +179,7 @@ func split() (string, int, bool) {
 			t.Errorf("tuple element %d: expected primitive, got %T", i, param.TypeParameters[i])
 			continue
 		}
-		if prim.Keyword != want {
-			t.Errorf("tuple element %d: expected %s, got %s", i, want, prim.Keyword)
-		}
+		assert.Equalf(t, want, prim.Keyword, "tuple element %d", i)
 	}
 }
 
@@ -237,5 +229,5 @@ func main() {
 `)
 	// Parser should still succeed
 	require.NoError(t, err)
-	require.NotNil(t, cu)
+	require.NotNil(t, cu, "expected non-nil compilation unit")
 }

--- a/rewrite-go/test/type_attribution_test.go
+++ b/rewrite-go/test/type_attribution_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -62,9 +66,7 @@ func main() {
 	_ = y
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	v := visitor.Init(&typeCollector{identTypes: make(map[string]java.JavaType)})
 	v.Visit(cu, nil)
@@ -72,9 +74,7 @@ func main() {
 	// "x" should be an int type
 	if xType, ok := v.identTypes["x"]; ok {
 		if prim, ok := xType.(*java.JavaTypePrimitive); ok {
-			if prim.Keyword != "int" {
-				t.Errorf("expected x to be int, got %s", prim.Keyword)
-			}
+			assert.Equal(t, "int", prim.Keyword)
 		} else {
 			t.Errorf("expected x to be primitive, got %T", xType)
 		}
@@ -85,9 +85,7 @@ func main() {
 	// "y" should be a string type (mapped as Primitive "String")
 	if yType, ok := v.identTypes["y"]; ok {
 		if prim, ok := yType.(*java.JavaTypePrimitive); ok {
-			if prim.Keyword != "String" {
-				t.Errorf("expected y to be String, got %s", prim.Keyword)
-			}
+			assert.Equal(t, "String", prim.Keyword)
 		} else {
 			t.Errorf("expected y to be primitive, got %T", yType)
 		}
@@ -104,27 +102,17 @@ func add(a int, b int) int {
 	return a + b
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	v := visitor.Init(&methodTypeCollector{methodTypes: make(map[string]*java.JavaTypeMethod)})
 	v.Visit(cu, nil)
 
 	addType, ok := v.methodTypes["add"]
-	if !ok {
-		t.Fatal("no method type for add()")
-	}
-	if addType.Name != "add" {
-		t.Errorf("expected method name 'add', got '%s'", addType.Name)
-	}
-	if len(addType.ParameterTypes) != 2 {
-		t.Errorf("expected 2 parameters, got %d", len(addType.ParameterTypes))
-	}
+	require.True(t, ok)
+	assert.Equal(t, "add", addType.Name)
+	assert.Len(t, addType.ParameterTypes, 2)
 	if ret, ok := addType.ReturnType.(*java.JavaTypePrimitive); ok {
-		if ret.Keyword != "int" {
-			t.Errorf("expected return type int, got %s", ret.Keyword)
-		}
+		assert.Equal(t, "int", ret.Keyword)
 	} else {
 		t.Errorf("expected primitive return type, got %T", addType.ReturnType)
 	}
@@ -139,9 +127,7 @@ func divmod(a int, b int) (int, int) {
 	return a / b, a % b
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// when
 	v := visitor.Init(&methodTypeCollector{methodTypes: make(map[string]*java.JavaTypeMethod)})
@@ -149,19 +135,13 @@ func divmod(a int, b int) (int, int) {
 
 	// then
 	mt, ok := v.methodTypes["divmod"]
-	if !ok {
-		t.Fatal("no method type for divmod()")
-	}
+	require.True(t, ok)
 	param, ok := mt.ReturnType.(*java.JavaTypeParameterized)
 	if !ok {
 		t.Fatalf("expected parameterized return type, got %T", mt.ReturnType)
 	}
-	if param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple" {
-		t.Errorf("expected tuple FQN 'go.tuple', got %+v", param.Type)
-	}
-	if len(param.TypeParameters) != 2 {
-		t.Fatalf("expected 2 tuple type parameters, got %d", len(param.TypeParameters))
-	}
+	assert.False(t, param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple")
+	require.Len(t, param.TypeParameters, 2)
 	for i, tp := range param.TypeParameters {
 		prim, ok := tp.(*java.JavaTypePrimitive)
 		if !ok {
@@ -183,9 +163,7 @@ func split() (string, int, bool) {
 	return "x", 1, true
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// when
 	v := visitor.Init(&methodTypeCollector{methodTypes: make(map[string]*java.JavaTypeMethod)})
@@ -193,19 +171,13 @@ func split() (string, int, bool) {
 
 	// then
 	mt, ok := v.methodTypes["split"]
-	if !ok {
-		t.Fatal("no method type for split()")
-	}
+	require.True(t, ok)
 	param, ok := mt.ReturnType.(*java.JavaTypeParameterized)
 	if !ok {
 		t.Fatalf("expected parameterized return type, got %T", mt.ReturnType)
 	}
-	if param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple" {
-		t.Errorf("expected tuple FQN 'go.tuple', got %+v", param.Type)
-	}
-	if len(param.TypeParameters) != 3 {
-		t.Fatalf("expected 3 tuple type parameters, got %d", len(param.TypeParameters))
-	}
+	assert.False(t, param.Type == nil || param.Type.GetFullyQualifiedName() != "go.tuple")
+	require.Len(t, param.TypeParameters, 3)
 	expectedKeywords := []string{"String", "int", "boolean"}
 	for i, want := range expectedKeywords {
 		prim, ok := param.TypeParameters[i].(*java.JavaTypePrimitive)
@@ -229,9 +201,7 @@ func main() {
 	fmt.Println("hello")
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ExpectMethodType(t, cu, "Println", "fmt")
 }
@@ -250,9 +220,7 @@ func main() {
 	_ = p
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ExpectType(t, cu, "p", "main.Point")
 }
@@ -268,10 +236,6 @@ func main() {
 }
 `)
 	// Parser should still succeed
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cu == nil {
-		t.Fatal("expected non-nil compilation unit")
-	}
+	require.NoError(t, err)
+	require.NotNil(t, cu)
 }

--- a/rewrite-go/test/type_width_attribution_test.go
+++ b/rewrite-go/test/type_width_attribution_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -60,9 +64,7 @@ func main() {
 	_ = f64
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// Signed widths and floats map to distinct primitive keywords.
 	ExpectPrimitiveType(t, cu, "i", "int")
@@ -94,9 +96,7 @@ func main() {
 	_ = b
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ExpectPrimitiveType(t, cu, "b", "int")
 }
 
@@ -112,9 +112,7 @@ func main() {
 	_ = c
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	ExpectType(t, cu, "c", "unsafe.Pointer")
 }
 
@@ -128,22 +126,16 @@ func main() {
 	_ = a
 }
 `)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	v := visitor.Init(&typeCollector{identTypes: make(map[string]java.JavaType)})
 	v.Visit(cu, nil)
 
 	typ, ok := v.identTypes["a"]
-	if !ok {
-		t.Fatal("no type attribution for a")
-	}
+	require.True(t, ok)
 	cls, ok := typ.(*java.JavaTypeClass)
 	if !ok {
 		t.Fatalf("any: type is %T, want *JavaTypeClass (empty interface)", typ)
 	}
-	if cls.Kind != "Interface" {
-		t.Errorf("any: Kind = %q, want %q", cls.Kind, "Interface")
-	}
+	assert.Equal(t, "Interface", cls.Kind)
 }

--- a/rewrite-go/test/type_width_attribution_test.go
+++ b/rewrite-go/test/type_width_attribution_test.go
@@ -132,10 +132,8 @@ func main() {
 	v.Visit(cu, nil)
 
 	typ, ok := v.identTypes["a"]
-	require.True(t, ok)
+	require.True(t, ok, "no type attribution for a")
 	cls, ok := typ.(*java.JavaTypeClass)
-	if !ok {
-		t.Fatalf("any: type is %T, want *JavaTypeClass (empty interface)", typ)
-	}
-	assert.Equal(t, "Interface", cls.Kind)
+	require.Truef(t, ok, "any: type is %T, want *JavaTypeClass (empty interface)", typ)
+	assert.Equalf(t, "Interface", cls.Kind, "any: Kind = %q, want %q", cls.Kind, "Interface")
 }

--- a/rewrite-go/test/var_test.go
+++ b/rewrite-go/test/var_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
@@ -136,9 +140,7 @@ func TestParseVarPointerType(t *testing.T) {
 				fn := cu.Statements[0].Element.(*java.MethodDeclaration)
 				varDecl := fn.Body.Statements[0].Element.(*java.VariableDeclarations)
 
-				if varDecl.TypeExpr == nil {
-					t.Fatal("expected TypeExpr to be set for 'var x *int'")
-				}
+				require.NotNil(t, varDecl.TypeExpr)
 				pt, ok := varDecl.TypeExpr.(*golang.PointerType)
 				if !ok {
 					t.Fatalf("expected TypeExpr to be *golang.PointerType, got %T", varDecl.TypeExpr)
@@ -147,9 +149,7 @@ func TestParseVarPointerType(t *testing.T) {
 				if !ok {
 					t.Fatalf("expected PointerType.Elem to be *java.Identifier, got %T", pt.Elem)
 				}
-				if ident.Name != "int" {
-					t.Errorf("expected PointerType.Elem name to be 'int', got %q", ident.Name)
-				}
+				assert.Equal(t, "int", ident.Name)
 			},
 		})
 }

--- a/rewrite-go/test/var_test.go
+++ b/rewrite-go/test/var_test.go
@@ -140,16 +140,12 @@ func TestParseVarPointerType(t *testing.T) {
 				fn := cu.Statements[0].Element.(*java.MethodDeclaration)
 				varDecl := fn.Body.Statements[0].Element.(*java.VariableDeclarations)
 
-				require.NotNil(t, varDecl.TypeExpr)
+				require.NotNil(t, varDecl.TypeExpr, "expected TypeExpr to be set for 'var x *int'")
 				pt, ok := varDecl.TypeExpr.(*golang.PointerType)
-				if !ok {
-					t.Fatalf("expected TypeExpr to be *golang.PointerType, got %T", varDecl.TypeExpr)
-				}
+				require.Truef(t, ok, "expected TypeExpr to be *golang.PointerType, got %T", varDecl.TypeExpr)
 				ident, ok := pt.Elem.(*java.Identifier)
-				if !ok {
-					t.Fatalf("expected PointerType.Elem to be *java.Identifier, got %T", pt.Elem)
-				}
-				assert.Equal(t, "int", ident.Name)
+				require.Truef(t, ok, "expected PointerType.Elem to be *java.Identifier, got %T", pt.Elem)
+				assert.Equal(t, "int", ident.Name, "expected PointerType.Elem name to be 'int")
 			},
 		})
 }

--- a/rewrite-go/test/vendor_walker_test.go
+++ b/rewrite-go/test/vendor_walker_test.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
@@ -59,9 +61,7 @@ func parseInProject(t *testing.T, root string, modulePath string, requires []str
 	p := parser.NewGoParser()
 	p.Importer = pi
 	cu, err := p.Parse(sourcePath, src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	return cu
 }
 

--- a/rewrite-go/test/vendor_walker_test.go
+++ b/rewrite-go/test/vendor_walker_test.go
@@ -34,12 +34,8 @@ func vendorScaffold(t *testing.T, root string, files map[string]string) {
 	t.Helper()
 	for rel, content := range files {
 		full := filepath.Join(root, rel)
-		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
-			t.Fatalf("mkdir %s: %v", full, err)
-		}
-		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
-			t.Fatalf("write %s: %v", full, err)
-		}
+		require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755), "mkdir")
+		require.NoError(t, os.WriteFile(full, []byte(content), 0o644), "write")
 	}
 }
 
@@ -61,7 +57,7 @@ func parseInProject(t *testing.T, root string, modulePath string, requires []str
 	p := parser.NewGoParser()
 	p.Importer = pi
 	cu, err := p.Parse(sourcePath, src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	return cu
 }
 

--- a/rewrite-go/test/visitor_test.go
+++ b/rewrite-go/test/visitor_test.go
@@ -40,12 +40,12 @@ func TestVisitorReturningNilDoesNotPanic(t *testing.T) {
 	src := "package main\n\nfunc foo() int {\n\treturn 1\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 
 	v := visitor.Init(&deletingVisitor{})
 	// This should not panic even though VisitReturn returns nil.
 	result := v.Visit(cu, nil)
-	require.NotNil(t, result)
+	require.NotNil(t, result, "visitor returned nil for compilation unit")
 }
 
 type importCountingVisitor struct {
@@ -62,11 +62,11 @@ func TestVisitorVisitsImports(t *testing.T) {
 	src := "package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nfunc main() {\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 
 	v := visitor.Init(&importCountingVisitor{})
 	v.Visit(cu, nil)
-	assert.Equal(t, 2, v.count)
+	assert.Equal(t, 2, v.count, "expected 2 imports visited")
 }
 
 type identCountingVisitor struct {
@@ -85,7 +85,7 @@ func TestVisitorVisitsPackageDecl(t *testing.T) {
 	src := "package pkg\n\nfunc foo() {\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 
 	v := visitor.Init(&identCountingVisitor{})
 	v.Visit(cu, nil)
@@ -97,7 +97,5 @@ func TestVisitorVisitsPackageDecl(t *testing.T) {
 			break
 		}
 	}
-	if !found {
-		t.Errorf("visitor did not visit package decl identifier 'pkg'; visited: %v", v.names)
-	}
+	assert.Truef(t, found, "visitor did not visit package decl identifier 'pkg'; visited: %v", v.names)
 }

--- a/rewrite-go/test/visitor_test.go
+++ b/rewrite-go/test/visitor_test.go
@@ -19,6 +19,10 @@ package test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
@@ -36,16 +40,12 @@ func TestVisitorReturningNilDoesNotPanic(t *testing.T) {
 	src := "package main\n\nfunc foo() int {\n\treturn 1\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	v := visitor.Init(&deletingVisitor{})
 	// This should not panic even though VisitReturn returns nil.
 	result := v.Visit(cu, nil)
-	if result == nil {
-		t.Fatal("visitor returned nil for compilation unit")
-	}
+	require.NotNil(t, result)
 }
 
 type importCountingVisitor struct {
@@ -62,15 +62,11 @@ func TestVisitorVisitsImports(t *testing.T) {
 	src := "package main\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nfunc main() {\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	v := visitor.Init(&importCountingVisitor{})
 	v.Visit(cu, nil)
-	if v.count != 2 {
-		t.Errorf("expected 2 imports visited, got %d", v.count)
-	}
+	assert.Equal(t, 2, v.count)
 }
 
 type identCountingVisitor struct {
@@ -89,9 +85,7 @@ func TestVisitorVisitsPackageDecl(t *testing.T) {
 	src := "package pkg\n\nfunc foo() {\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 
 	v := visitor.Init(&identCountingVisitor{})
 	v.Visit(cu, nil)

--- a/rewrite-go/test/whitespace_collapse_repro_test.go
+++ b/rewrite-go/test/whitespace_collapse_repro_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
@@ -59,9 +60,7 @@ func locateIfThenBlock(t *testing.T, root java.Tree) *java.Block {
 	t.Helper()
 	loc := visitor.Init(&ifThenBlockLocator{})
 	loc.Visit(root, nil)
-	if loc.block == nil {
-		t.Fatal("could not locate the if-then block in the parsed tree")
-	}
+	require.NotNil(t, loc.block)
 	return loc.block
 }
 
@@ -72,9 +71,7 @@ func TestNoOpVisitPreservesUntouchedBlockIdentity(t *testing.T) {
 	// given
 	p := parser.NewGoParser()
 	cu, err := p.Parse("bind.go", collapseReproSrc)
-	if err != nil {
-		t.Fatalf("parse error: %v", err)
-	}
+	require.NoError(t, err)
 	before := locateIfThenBlock(t, cu)
 
 	// when

--- a/rewrite-go/test/whitespace_collapse_repro_test.go
+++ b/rewrite-go/test/whitespace_collapse_repro_test.go
@@ -60,7 +60,7 @@ func locateIfThenBlock(t *testing.T, root java.Tree) *java.Block {
 	t.Helper()
 	loc := visitor.Init(&ifThenBlockLocator{})
 	loc.Visit(root, nil)
-	require.NotNil(t, loc.block)
+	require.NotNil(t, loc.block, "could not locate the if-then block in the parsed tree")
 	return loc.block
 }
 
@@ -71,7 +71,7 @@ func TestNoOpVisitPreservesUntouchedBlockIdentity(t *testing.T) {
 	// given
 	p := parser.NewGoParser()
 	cu, err := p.Parse("bind.go", collapseReproSrc)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse error")
 	before := locateIfThenBlock(t, cu)
 
 	// when

--- a/rewrite-go/test/whitespace_validation_service_test.go
+++ b/rewrite-go/test/whitespace_validation_service_test.go
@@ -35,7 +35,7 @@ import (
 // importing pkg/recipe/golang registers the service.
 func TestWhitespaceValidationService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.WhitespaceValidationService](nil)
-	require.NotNil(t, svc)
+	require.NotNil(t, svc, "recipe.Service returned nil for *golang.WhitespaceValidationService")
 }
 
 // TestWhitespaceValidationService_CleanTree confirms a freshly parsed
@@ -44,12 +44,12 @@ func TestWhitespaceValidationService_CleanTree(t *testing.T) {
 	src := "package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	require.NoError(t, err)
+	require.NoError(t, err, "parse")
 	svc := &recipes.WhitespaceValidationService{}
 	if errs := svc.Validate(cu); len(errs) != 0 {
 		t.Fatalf("expected clean tree to validate, got %d errs:\n%s", len(errs), strings.Join(errs, "\n"))
 	}
-	assert.True(t, svc.IsValid(cu))
+	assert.True(t, svc.IsValid(cu), "IsValid disagrees with Validate on a clean tree")
 }
 
 // TestWhitespaceValidationService_DetectsCorruption hand-crafts a tree
@@ -64,10 +64,8 @@ func TestWhitespaceValidationService_DetectsCorruption(t *testing.T) {
 	if len(errs) == 0 {
 		t.Fatal("expected validator to flag non-whitespace in Space.Whitespace")
 	}
-	if !strings.Contains(errs[0], "non-whitespace") {
-		t.Errorf("error should mention non-whitespace, got: %s", errs[0])
-	}
-	assert.False(t, svc.IsValid(cu))
+	assert.Truef(t, strings.Contains(errs[0], "non-whitespace"), "error should mention non-whitespace, got: %s", errs[0])
+	assert.False(t, svc.IsValid(cu), "IsValid should be false when Validate returned errors")
 }
 
 // TestWhitespaceValidationService_DetectsBadComment crafts a Comment

--- a/rewrite-go/test/whitespace_validation_service_test.go
+++ b/rewrite-go/test/whitespace_validation_service_test.go
@@ -20,6 +20,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	recipes "github.com/openrewrite/rewrite/rewrite-go/pkg/recipe/golang"
@@ -31,9 +35,7 @@ import (
 // importing pkg/recipe/golang registers the service.
 func TestWhitespaceValidationService_RegisteredOnInit(t *testing.T) {
 	svc := recipe.Service[*recipes.WhitespaceValidationService](nil)
-	if svc == nil {
-		t.Fatal("recipe.Service returned nil for *golang.WhitespaceValidationService")
-	}
+	require.NotNil(t, svc)
 }
 
 // TestWhitespaceValidationService_CleanTree confirms a freshly parsed
@@ -42,16 +44,12 @@ func TestWhitespaceValidationService_CleanTree(t *testing.T) {
 	src := "package main\n\nfunc main() {\n\tprintln(\"hi\")\n}\n"
 	p := parser.NewGoParser()
 	cu, err := p.Parse("test.go", src)
-	if err != nil {
-		t.Fatalf("parse: %v", err)
-	}
+	require.NoError(t, err)
 	svc := &recipes.WhitespaceValidationService{}
 	if errs := svc.Validate(cu); len(errs) != 0 {
 		t.Fatalf("expected clean tree to validate, got %d errs:\n%s", len(errs), strings.Join(errs, "\n"))
 	}
-	if !svc.IsValid(cu) {
-		t.Error("IsValid disagrees with Validate on a clean tree")
-	}
+	assert.True(t, svc.IsValid(cu))
 }
 
 // TestWhitespaceValidationService_DetectsCorruption hand-crafts a tree
@@ -69,9 +67,7 @@ func TestWhitespaceValidationService_DetectsCorruption(t *testing.T) {
 	if !strings.Contains(errs[0], "non-whitespace") {
 		t.Errorf("error should mention non-whitespace, got: %s", errs[0])
 	}
-	if svc.IsValid(cu) {
-		t.Error("IsValid should be false when Validate returned errors")
-	}
+	assert.False(t, svc.IsValid(cu))
 }
 
 // TestWhitespaceValidationService_DetectsBadComment crafts a Comment


### PR DESCRIPTION
## What's changed?

Adopting the Testify testing library in our own rewrite-go test code.

## What's your motivation?

- Test out (dogfood) the Testify migration recipe
- Simplify the test code we own and maintain
