### PR TITLE
Fix garbled "but it recipe 'X' does not exist" validation message

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -132,7 +132,7 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
                     initValidation = initValidation.and(
                             invalid(name + ".recipeList[" + i + "] (in " + source + ")",
                                     recipeFqn,
-                                    "refers to a recipe that doesn't exist.",
+                                    "refers to recipe '" + recipeFqn + "', which does not exist.",
                                     null));
                 }
             } else {

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -130,10 +130,9 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
                     result.add(subRecipe);
                 } else {
                     initValidation = initValidation.and(
-                            invalid(name + ".recipeList" +
-                                    "[" + i + "] (in " + source + ")",
+                            invalid(name + ".recipeList[" + i + "] (in " + source + ")",
                                     recipeFqn,
-                                    "recipe '" + recipeFqn + "' does not exist.",
+                                    "refers to a recipe that doesn't exist.",
                                     null));
                 }
             } else {

--- a/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
+++ b/rewrite-core/src/main/java/org/openrewrite/config/DeclarativeRecipe.java
@@ -132,7 +132,7 @@ public class DeclarativeRecipe extends ScanningRecipe<DeclarativeRecipe.Accumula
                     initValidation = initValidation.and(
                             invalid(name + ".recipeList[" + i + "] (in " + source + ")",
                                     recipeFqn,
-                                    "refers to recipe '" + recipeFqn + "', which does not exist.",
+                                    "refers to a recipe that doesn't exist.",
                                     null));
                 }
             } else {


### PR DESCRIPTION
`ValidationException` renders every failure as `[property] was '[value]' but it [message]`, so the message argument has to read as a fragment continuing "but it ". Since 5b5af79d (#1499) it has instead been a standalone sentence that repeated the recipe name, producing `... was 'org.openrewrite.xml.liberty.DetectUnsupportedJSF' but it recipe 'org.openrewrite.xml.liberty.DetectUnsupportedJSF' does not exist.`

This restores the original fragment, so the failure reads as a sentence again. #1499 added the name because rewrite-maven-plugin logged only `getProperty()` and `getMessage()`, never `getInvalidValue()`; openrewrite/rewrite-maven-plugin#1192 fixes that at the source, so the FQN no longer has to be baked into the message here. Also collapses a needlessly split string concatenation on the property above it.