### PR TITLE
Stop an undescribed category from shadowing a description

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
+++ b/rewrite-core/src/main/java/org/openrewrite/marketplace/RecipeMarketplace.java
@@ -16,7 +16,6 @@
 package org.openrewrite.marketplace;
 
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Incubating;
@@ -134,16 +133,31 @@ public class RecipeMarketplace {
     }
 
     @Getter
-    @RequiredArgsConstructor
     public class Category {
         @NlsRewrite.DisplayName
         private final String displayName;
 
         @NlsRewrite.DisplayName
-        private final String description;
+        private String description;
 
         private final List<Category> categories = new ArrayList<>();
         private final List<RecipeListing> recipes = new ArrayList<>();
+
+        public Category(@NlsRewrite.DisplayName String displayName, @NlsRewrite.DisplayName String description) {
+            this.displayName = displayName;
+            this.description = description;
+        }
+
+        /**
+         * Categories are keyed by display name, so the first artifact to install one owns the
+         * node and later descriptors for the same name are discarded. When the winner carried no
+         * description, adopt the first one offered rather than leaving the category undescribed.
+         */
+        private void describeIfBlank(@Nullable String candidate) {
+            if (StringUtils.isBlank(description) && !StringUtils.isBlank(candidate)) {
+                description = candidate;
+            }
+        }
 
         /**
          * A view, not a copy. Structural change goes through {@link #install} and
@@ -187,6 +201,7 @@ public class RecipeMarketplace {
                     }
                 }
                 if (existingSubCategory != null) {
+                    existingSubCategory.describeIfBlank(subCategory.description);
                     existingSubCategory.merge(subCategory, alreadyInstalled, added);
                 } else {
                     Category copy = new Category(subCategory.displayName, subCategory.description);
@@ -268,6 +283,7 @@ public class RecipeMarketplace {
         private Category findOrCreateCategory(CategoryDescriptor categoryDescriptor) {
             for (Category category : categories) {
                 if (category.getDisplayName().equalsIgnoreCase(categoryDescriptor.getDisplayName())) {
+                    category.describeIfBlank(categoryDescriptor.getDescription());
                     return category;
                 }
             }

--- a/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/marketplace/RecipeMarketplaceInstallTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.marketplace;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Recipe;
 import org.openrewrite.config.CategoryDescriptor;
@@ -220,5 +221,72 @@ class RecipeMarketplaceInstallTest {
                 .isNotNull()
                 .extracting(l -> l.getBundle().getPackageName())
                 .isEqualTo("org.example:b");
+    }
+
+    private static CategoryDescriptor category(String name, String description) {
+        return new CategoryDescriptor(name, "", description, emptySet(), false, 0, false);
+    }
+
+    private static RecipeListing listing(String name) {
+        return new RecipeListing(null, name, name, name + ".", null, emptyList(), emptyList(), 1,
+                new RecipeBundle("maven", "org.example:a", "1.0.0", "1.0.0", null));
+    }
+
+    private static RecipeMarketplace.@Nullable Category child(RecipeMarketplace marketplace, String displayName) {
+        for (RecipeMarketplace.Category c : marketplace.getRoot().getCategories()) {
+            if (c.getDisplayName().equals(displayName)) {
+                return c;
+            }
+        }
+        return null;
+    }
+
+    @Test
+    void anUndescribedCategoryDoesNotShadowADescriptionOfferedLater() {
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+
+        // Two artifacts name the same category. The first says nothing about it; without this
+        // the second one's description is discarded and the category renders bare forever.
+        marketplace.install(listing("com.foo.Bar"), List.of(category("Spring Boot 2.x", "")));
+        marketplace.install(listing("com.foo.Baz"), List.of(category("Spring Boot 2.x", "Recipes for Spring Boot 2.")));
+
+        assertThat(marketplace.getRoot().getCategories()).hasSize(1);
+        assertThat(child(marketplace, "Spring Boot 2.x"))
+                .isNotNull()
+                .extracting(RecipeMarketplace.Category::getDescription)
+                .isEqualTo("Recipes for Spring Boot 2.");
+    }
+
+    @Test
+    void aDescribedCategoryIsNotOverwrittenByALaterOne() {
+        RecipeMarketplace marketplace = new RecipeMarketplace();
+
+        marketplace.install(listing("com.foo.Bar"), List.of(category("Spring Boot 2.x", "The first description.")));
+        marketplace.install(listing("com.foo.Baz"), List.of(category("Spring Boot 2.x", "A competing description.")));
+
+        assertThat(child(marketplace, "Spring Boot 2.x"))
+                .isNotNull()
+                .extracting(RecipeMarketplace.Category::getDescription)
+                .as("first-wins still applies once a category actually says something")
+                .isEqualTo("The first description.");
+    }
+
+    @Test
+    void mergeFillsInADescriptionTheExistingCategoryLacks() {
+        // Regenerating a marketplace CSV merges into what is already on disk. A category read
+        // back from a CSV written before its descriptor existed has no description, and would
+        // otherwise keep suppressing the one the freshly scanned marketplace supplies.
+        RecipeMarketplace onDisk = new RecipeMarketplace();
+        onDisk.install(listing("com.foo.Bar"), List.of(category("Gradle", "")));
+
+        RecipeMarketplace scanned = new RecipeMarketplace();
+        scanned.install(listing("com.foo.Baz"), List.of(category("Gradle", "Recipes to transform Gradle builds.")));
+
+        onDisk.merge(scanned);
+
+        assertThat(child(onDisk, "Gradle"))
+                .isNotNull()
+                .extracting(RecipeMarketplace.Category::getDescription)
+                .isEqualTo("Recipes to transform Gradle builds.");
     }
 }


### PR DESCRIPTION
Categories in `RecipeMarketplace` are keyed by display name — `findOrCreateCategory`
and `Category.merge` both match on `equalsIgnoreCase(displayName)` and keep the
node that is already there. Every later descriptor for that name is discarded,
description included. So if the first artifact to claim a name carried no
description, the category renders bare no matter how many other artifacts
describe it.

That is a live bug, not a hypothetical. `org.openrewrite.java.spring.boot2`
declared `Spring Boot 2.x` with a name and no description, which silently
suppressed the description `io.moderne.java.spring.boot2` supplies for the same
category — text that has never reached users, and that no change to the
downstream artifact could have surfaced. I only found it by asserting that every
descriptor declaring a description actually reaches the generated CSV.

Both call sites now adopt the first non-blank description offered for an
otherwise undescribed category. A category that already says something keeps
what it has, so first-wins precedence is unchanged wherever it was meaningful.

This also removes a sharp edge in `recipeCsvGenerate`, which merges into an
existing `recipes.csv` rather than replacing it: a category read back from a CSV
written *before* its descriptor existed used to suppress the description on every
subsequent regeneration. That behaviour produced several incomplete CSVs across
the recipe repos, and was convincing enough to make me conclude twice that
descriptors were not binding at all.

### Tests

Three added to `RecipeMarketplaceInstallTest`, covering the install path, the
merge path, and a guard that an existing description is never overwritten.

I verified they actually catch the bug rather than merely passing: with the two
`describeIfBlank` calls removed, `anUndescribedCategoryDoesNotShadowADescriptionOfferedLater`
and `mergeFillsInADescriptionTheExistingCategoryLacks` both fail, while the guard
test and the seven pre-existing tests still pass.

Full `rewrite-core` suite: 1254 tests, no failures.

### Note on the field

`Category.description` becomes non-final and the Lombok `@RequiredArgsConstructor`
is replaced with an explicit two-arg constructor, since the whole point is to fill
it in later. `Category` is `@Incubating`, and the public getter is unchanged.