### PR TITLE
Skip the Python import-visitor RPC round trip for files it cannot change

### DIFF
--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -173,6 +173,10 @@ val pytestTest by tasks.registering(Exec::class) {
     description = "Run Python pytest tests"
 
     dependsOn(pythonInstall)
+    // Tests marked `requires_java_rpc` are skipped unless test-classpath.txt names a Java RPC
+    // server to spawn, so without this they pass by never running. Devs invoking pytest directly
+    // still need :generateTestClasspath once.
+    dependsOn(tasks.named("generateTestClasspath"))
 
     workingDir = pythonDir
     // Use relative path for python executable to avoid absolute paths in cache key
@@ -191,6 +195,10 @@ val pytestTest by tasks.registering(Exec::class) {
         .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.file(pythonDir.resolve("pyproject.toml"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    // Part of the cache key, so a Java-side change re-runs the tests that exercise it rather than
+    // replaying a cached pass against a stale classpath.
+    inputs.files(tasks.named("generateTestClasspath").map { it.outputs.files })
+        .withNormalizer(ClasspathNormalizer::class)
     outputs.file(pythonDir.resolve("build/test-results/pytest/junit.xml"))
     outputs.cacheIf { true }
 }

--- a/rewrite-python/build.gradle.kts
+++ b/rewrite-python/build.gradle.kts
@@ -173,9 +173,9 @@ val pytestTest by tasks.registering(Exec::class) {
     description = "Run Python pytest tests"
 
     dependsOn(pythonInstall)
-    // Tests marked `requires_java_rpc` are skipped unless test-classpath.txt names a Java RPC
-    // server to spawn, so without this they pass by never running. Devs invoking pytest directly
-    // still need :generateTestClasspath once.
+    // Tests marked `requires_java_rpc` run only where test-classpath.txt names a Java RPC server to
+    // spawn, so generating it is part of running the suite. Devs invoking pytest directly still
+    // need :generateTestClasspath once.
     dependsOn(tasks.named("generateTestClasspath"))
 
     workingDir = pythonDir
@@ -195,8 +195,7 @@ val pytestTest by tasks.registering(Exec::class) {
         .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.file(pythonDir.resolve("pyproject.toml"))
         .withPathSensitivity(PathSensitivity.RELATIVE)
-    // Part of the cache key, so a Java-side change re-runs the tests that exercise it rather than
-    // replaying a cached pass against a stale classpath.
+    // Part of the cache key, so a Java-side change re-runs the tests that exercise it.
     inputs.files(tasks.named("generateTestClasspath").map { it.outputs.files })
         .withNormalizer(ClasspathNormalizer::class)
     outputs.file(pythonDir.resolve("build/test-results/pytest/junit.xml"))

--- a/rewrite-python/rewrite/tests/python/_java_import_arm.py
+++ b/rewrite-python/rewrite/tests/python/_java_import_arm.py
@@ -1,0 +1,78 @@
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Drive the Java-side import visitors over RPC, so their pre-dispatch predicate runs.
+
+The Java visitor decides whether the file can change and, when it can, dispatches back to the
+Python implementation over the same connection. Both arms of the import tests therefore end in
+the same edit code, and only the Java predicate differs between them.
+"""
+
+from typing import Any, Optional
+
+from rewrite.java import J
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
+
+_ADD = 'org.openrewrite.python.service.PythonAddImportVisitor'
+_REMOVE = 'org.openrewrite.python.service.PythonRemoveImportVisitor'
+_PY_CU = 'org.openrewrite.python.tree.Py$CompilationUnit'
+
+
+class _JavaImportVisitor(PythonVisitor):
+    def __init__(self, visitor_name: str, options: dict):
+        super().__init__()
+        self._visitor_name = visitor_name
+        self._options = options
+
+    def visit_compilation_unit(self, cu: CompilationUnit, p: Any) -> J:
+        from rewrite.execution import ExecutionContext
+        from rewrite.rpc.server import (get_object_from_java, local_object, local_objects,
+                                        send_request)
+
+        tree_id = str(cu.id)
+        local_objects[tree_id] = cu
+        params = {
+            'visitor': self._visitor_name,
+            'treeId': tree_id,
+            'sourceFileType': _PY_CU,
+            'visitorOptions': self._options,
+        }
+        if isinstance(p, ExecutionContext):
+            params['p'] = local_object(p)
+
+        result = send_request('Visit', params)
+        if not (result and result.get('modified', False)):
+            return cu
+        after = get_object_from_java(tree_id, _PY_CU)
+        return after if after is not None else cu
+
+
+def java_add_import(module: str, name: Optional[str] = None, alias: Optional[str] = None,
+                    only_if_referenced: bool = False) -> PythonVisitor:
+    return _JavaImportVisitor(_ADD, {
+        'module': module,
+        'name': name,
+        'alias': alias,
+        'onlyIfReferenced': only_if_referenced,
+    })
+
+
+def java_remove_import(module: str, name: Optional[str] = None,
+                       only_if_unused: bool = True) -> PythonVisitor:
+    return _JavaImportVisitor(_REMOVE, {
+        'module': module,
+        'name': name,
+        'onlyIfUnused': only_if_unused,
+    })

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -164,6 +164,22 @@ class TestMaybeAddImport:
             )
         )
 
+    def test_only_if_referenced_finds_a_reference_in_a_comprehension(self, arm):
+        """The only reference is inside a comprehension, a Python-specific node."""
+        spec = RecipeSpec(recipe=from_visitor(
+            _add_import_visitor(arm, 'os.path', 'join', only_if_referenced=True)))
+        spec.rewrite_run(
+            python(
+                """
+                paths = [join(p) for p in ps]
+                """,
+                """
+                from os.path import join
+                paths = [join(p) for p in ps]
+                """,
+            )
+        )
+
     def test_merge_into_existing_from_import(self, arm):
         """Merge a new name into an existing 'from X import ...' statement.
 
@@ -354,22 +370,6 @@ class TestMaybeAddImport:
                 """
                 from builtins import list as _list
                 x = 1
-                """,
-            )
-        )
-
-
-class TestAddImportVisitor:
-    """Requests that must not add an import even with only_if_referenced off."""
-
-    def test_skips_builtins_import(self, arm):
-        """e.g. Java's ChangeType retargeting a type to ``builtins.list`` must
-        not add ``from builtins import list``."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'builtins', 'list')))
-        spec.rewrite_run(
-            python(
-                """
-                x: list = []
                 """,
             )
         )

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -14,12 +14,16 @@
 
 """Tests for AddImport / maybe_add_import."""
 
+import pytest
+
 from rewrite import ExecutionContext, InMemoryExecutionContext
 from rewrite.java import J
-from rewrite.python.add_import import AddImport, AddImportOptions, maybe_add_import
+from rewrite.python.add_import import AddImportOptions, maybe_add_import
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python, from_visitor
+
+from ._java_import_arm import java_add_import
 
 
 def _assert_ids_accessible(source_file):
@@ -32,15 +36,29 @@ def _assert_ids_accessible(source_file):
     IdWalker().visit(source_file, InMemoryExecutionContext())
 
 
-def _add_import_visitor(module, name=None, alias=None):
-    """Build a visitor that registers a single maybe_add_import (always added)."""
+@pytest.fixture(params=[
+    pytest.param('native'),
+    pytest.param('java', marks=pytest.mark.requires_java_rpc),
+])
+def arm(request):
+    """Run each case against the Python visitor in-process and against the Java visitor over RPC."""
+    if request.param == 'java':
+        request.getfixturevalue('java_rpc')
+    return request.param
+
+
+def _add_import_visitor(arm, module, name=None, alias=None, only_if_referenced=False):
+    """Build a visitor that registers a single add-import request."""
+    if arm == 'java':
+        return java_add_import(module, name, alias, only_if_referenced)
+
     class _V(PythonVisitor[ExecutionContext]):
         def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
             maybe_add_import(self, AddImportOptions(
                 module=module,
                 name=name,
                 alias=alias,
-                only_if_referenced=False,
+                only_if_referenced=only_if_referenced,
             ))
             return super().visit_compilation_unit(cu, p)
 
@@ -50,18 +68,9 @@ def _add_import_visitor(module, name=None, alias=None):
 class TestMaybeAddImport:
     """Tests for maybe_add_import scheduling via _after_visit."""
 
-    def test_add_from_import(self):
+    def test_add_from_import(self, arm):
         """Add 'from os.path import join' to a file that uses join."""
-        class AddJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_add_import(self, AddImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_referenced=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(AddJoinVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'os.path', 'join')))
         spec.rewrite_run(
             python(
                 """
@@ -74,17 +83,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_add_direct_import(self):
+    def test_add_direct_import(self, arm):
         """Add 'import os' to a file."""
-        class AddOsVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_add_import(self, AddImportOptions(
-                    module='os',
-                    only_if_referenced=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(AddOsVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'os')))
         spec.rewrite_run(
             python(
                 """
@@ -97,17 +98,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_no_duplicate_import(self):
+    def test_no_duplicate_import(self, arm):
         """Don't add an import that already exists."""
-        class AddOsVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_add_import(self, AddImportOptions(
-                    module='os',
-                    only_if_referenced=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(AddOsVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'os')))
         spec.rewrite_run(
             python(
                 """
@@ -117,10 +110,10 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_builtin_name_is_not_imported(self):
+    def test_builtin_name_is_not_imported(self, arm):
         """A bare builtin name (e.g. from ChangeType retargeting to `list`) is not a module;
         adding an import for it is a no-op."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('list')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'list')))
         spec.rewrite_run(
             python(
                 """
@@ -129,18 +122,10 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_only_if_referenced(self):
+    def test_only_if_referenced(self, arm):
         """Don't add import when the name is not referenced and only_if_referenced=True."""
-        class AddJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_add_import(self, AddImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_referenced=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(AddJoinVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _add_import_visitor(arm, 'os.path', 'join', only_if_referenced=True)))
         spec.rewrite_run(
             python(
                 """
@@ -149,17 +134,10 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_only_if_referenced_ignores_identifiers_in_imports(self):
+    def test_only_if_referenced_ignores_identifiers_in_imports(self, arm):
         """``pathlib`` occurs only as the module of the existing aliased import."""
-        class AddPathlibVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_add_import(self, AddImportOptions(
-                    module='pathlib',
-                    only_if_referenced=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(AddPathlibVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _add_import_visitor(arm, 'pathlib', only_if_referenced=True)))
         spec.rewrite_run(
             python(
                 """
@@ -170,13 +148,13 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_into_existing_from_import(self):
+    def test_merge_into_existing_from_import(self, arm):
         """Merge a new name into an existing 'from X import ...' statement.
 
         The new member is inserted in case-insensitive alphabetical position
         ('exists' < 'join'), not appended.
         """
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('os.path', 'exists')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'os.path', 'exists')))
         spec.rewrite_run(
             python(
                 """
@@ -190,11 +168,11 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_into_existing_import_keeps_ids_accessible(self):
+    def test_merge_into_existing_import_keeps_ids_accessible(self, arm):
         """Merging into an existing from-import rebuilds the MultiImport from the
         public `.id` property; the rebuilt node's id must remain accessible
         (regression for the 8.84.8 int-id migration)."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('os.path', 'exists')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'os.path', 'exists')))
         spec.rewrite_run(
             python(
                 """
@@ -209,9 +187,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_inserts_member_in_sorted_position(self):
+    def test_merge_inserts_member_in_sorted_position(self, arm):
         """Insert before an existing member when it sorts earlier (the reported bug)."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'ClassVar')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'typing', 'ClassVar')))
         spec.rewrite_run(
             python(
                 """
@@ -225,9 +203,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_inserts_member_in_middle(self):
+    def test_merge_inserts_member_in_middle(self, arm):
         """Insert a member between two existing, already-sorted members."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'ClassVar')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'typing', 'ClassVar')))
         spec.rewrite_run(
             python(
                 """
@@ -241,9 +219,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_appends_when_alphabetically_last(self):
+    def test_merge_appends_when_alphabetically_last(self, arm):
         """Append a member when it sorts after all existing members."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'Final')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'typing', 'Final')))
         spec.rewrite_run(
             python(
                 """
@@ -257,9 +235,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_is_case_insensitive(self):
+    def test_merge_is_case_insensitive(self, arm):
         """Ordering is case-insensitive: 'cast' sorts before 'Optional'."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'cast')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'typing', 'cast')))
         spec.rewrite_run(
             python(
                 """
@@ -273,10 +251,10 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_into_unsorted_list_still_inserts_sorted(self):
+    def test_merge_into_unsorted_list_still_inserts_sorted(self, arm):
         """When existing members are unsorted, the new member is still placed at
         its first sorted position; existing members are not reordered."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('os.path', 'exists')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'os.path', 'exists')))
         spec.rewrite_run(
             python(
                 """
@@ -290,9 +268,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_merge_aliased_member_sorted_by_alias(self):
+    def test_merge_aliased_member_sorted_by_alias(self, arm):
         """An aliased member is sorted by its alias (the bound name)."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'Final', alias='abc')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'typing', 'Final', alias='abc')))
         spec.rewrite_run(
             python(
                 """
@@ -306,10 +284,10 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_new_from_import_added_after_existing_imports(self):
+    def test_new_from_import_added_after_existing_imports(self, arm):
         """A brand-new 'from' import is placed after existing imports; import
         statements are not reordered among themselves."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('mmm', 'w')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'mmm', 'w')))
         spec.rewrite_run(
             python(
                 """
@@ -326,10 +304,10 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_skips_builtins_import(self):
+    def test_skips_builtins_import(self, arm):
         """Names from the 'builtins' module are always available, so no import
         is added (e.g. 'from builtins import list' is redundant)."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('builtins', 'list')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'builtins', 'list')))
         spec.rewrite_run(
             python(
                 """
@@ -338,9 +316,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_skips_builtins_direct_import(self):
+    def test_skips_builtins_direct_import(self, arm):
         """A direct 'import builtins' is likewise not added."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('builtins')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'builtins')))
         spec.rewrite_run(
             python(
                 """
@@ -349,9 +327,9 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_adds_aliased_builtins_import(self):
+    def test_adds_aliased_builtins_import(self, arm):
         """An explicit alias makes a builtins import meaningful, so it is added."""
-        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor('builtins', 'list', '_list')))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'builtins', 'list', '_list')))
         spec.rewrite_run(
             python(
                 """
@@ -366,14 +344,12 @@ class TestMaybeAddImport:
 
 
 class TestAddImportVisitor:
-    """Tests for AddImport constructed directly (bypassing maybe_add_import),
-    as the RPC server does for Java-initiated ``maybeAddImport`` calls."""
+    """Requests that must not add an import even with only_if_referenced off."""
 
-    def test_skips_builtins_import(self):
+    def test_skips_builtins_import(self, arm):
         """e.g. Java's ChangeType retargeting a type to ``builtins.list`` must
         not add ``from builtins import list``."""
-        spec = RecipeSpec(recipe=from_visitor(AddImport(AddImportOptions(
-            module='builtins', name='list', only_if_referenced=False))))
+        spec = RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'builtins', 'list')))
         spec.rewrite_run(
             python(
                 """
@@ -388,8 +364,8 @@ class TestCanonicalAddImportDedup:
     its canonical FQN matches (``os.path.join`` is canonically
     ``posixpath.join``), not just when its written path does."""
 
-    def test_canonical_request_matches_written_from_import(self):
-        RecipeSpec(recipe=from_visitor(_add_import_visitor('posixpath', 'join'))).rewrite_run(
+    def test_canonical_request_matches_written_from_import(self, arm):
+        RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'posixpath', 'join'))).rewrite_run(
             python(
                 """
                 from os.path import join
@@ -398,8 +374,8 @@ class TestCanonicalAddImportDedup:
             )
         )
 
-    def test_canonical_request_matches_written_class_import(self):
-        RecipeSpec(recipe=from_visitor(_add_import_visitor('typing', 'Iterable'))).rewrite_run(
+    def test_canonical_request_matches_written_class_import(self, arm):
+        RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'typing', 'Iterable'))).rewrite_run(
             python(
                 """
                 from collections.abc import Iterable
@@ -408,9 +384,9 @@ class TestCanonicalAddImportDedup:
             )
         )
 
-    def test_canonical_match_requires_same_bound_name(self):
+    def test_canonical_match_requires_same_bound_name(self, arm):
         """An aliased binding does not satisfy a request for the plain name."""
-        RecipeSpec(recipe=from_visitor(_add_import_visitor('posixpath', 'join'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'posixpath', 'join'))).rewrite_run(
             python(
                 """
                 from os.path import join as j
@@ -424,10 +400,10 @@ class TestCanonicalAddImportDedup:
             )
         )
 
-    def test_canonical_mismatch_still_adds(self):
+    def test_canonical_mismatch_still_adds(self, arm):
         """os.path.exists is canonically genericpath.exists, so a posixpath
         request is a different symbol and gets its own import."""
-        RecipeSpec(recipe=from_visitor(_add_import_visitor('posixpath', 'exists'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(_add_import_visitor(arm, 'posixpath', 'exists'))).rewrite_run(
             python(
                 """
                 from os.path import exists

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -148,6 +148,22 @@ class TestMaybeAddImport:
             )
         )
 
+    def test_only_if_referenced_adds_when_referenced(self, arm):
+        """The name is used, so the import is added."""
+        spec = RecipeSpec(recipe=from_visitor(
+            _add_import_visitor(arm, 'os.path', 'join', only_if_referenced=True)))
+        spec.rewrite_run(
+            python(
+                """
+                x = join('a', 'b')
+                """,
+                """
+                from os.path import join
+                x = join('a', 'b')
+                """,
+            )
+        )
+
     def test_merge_into_existing_from_import(self, arm):
         """Merge a new name into an existing 'from X import ...' statement.
 

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -333,12 +333,9 @@ class TestCanonicalRemoveImport:
     (``os.path.join`` is canonically ``posixpath.join``), not just by its
     written path."""
 
-    @staticmethod
-    def _remover(arm, module, name=None):
-        return _remove_import_visitor(arm, module, name, only_if_unused=False)
-
     def test_remove_reexported_function_by_canonical_fqn(self, arm):
-        RecipeSpec(recipe=from_visitor(self._remover(arm, 'posixpath', 'join'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'posixpath', 'join', only_if_unused=False))).rewrite_run(
             python(
                 """
                 from os.path import join
@@ -351,7 +348,8 @@ class TestCanonicalRemoveImport:
         )
 
     def test_remove_reexported_class_by_canonical_fqn(self, arm):
-        RecipeSpec(recipe=from_visitor(self._remover(arm, 'typing', 'Iterable'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'typing', 'Iterable', only_if_unused=False))).rewrite_run(
             python(
                 """
                 from collections.abc import Iterable
@@ -364,7 +362,8 @@ class TestCanonicalRemoveImport:
         )
 
     def test_canonical_removal_keeps_other_names(self, arm):
-        RecipeSpec(recipe=from_visitor(self._remover(arm, 'posixpath', 'join'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'posixpath', 'join', only_if_unused=False))).rewrite_run(
             python(
                 """
                 from os.path import exists, join
@@ -379,7 +378,8 @@ class TestCanonicalRemoveImport:
 
     def test_remove_module_binding_by_canonical_fqn(self, arm):
         """`from os import path` binds the module canonically named os.path."""
-        RecipeSpec(recipe=from_visitor(self._remover(arm, 'os.path'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'os.path', only_if_unused=False))).rewrite_run(
             python(
                 """
                 from os import path
@@ -393,7 +393,8 @@ class TestCanonicalRemoveImport:
 
     def test_canonical_mismatch_is_not_removed(self, arm):
         """os.path.exists is canonically genericpath.exists, not posixpath.exists."""
-        RecipeSpec(recipe=from_visitor(self._remover(arm, 'posixpath', 'exists'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'posixpath', 'exists', only_if_unused=False))).rewrite_run(
             python(
                 """
                 from os.path import exists
@@ -406,7 +407,8 @@ class TestCanonicalRemoveImport:
         """`typing` is the canonical home of many re-exports, so a whole-module
         request must match only bindings of the module itself — not every member
         that happens to be declared there."""
-        RecipeSpec(recipe=from_visitor(self._remover(arm, 'typing'))).rewrite_run(
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'typing', only_if_unused=False))).rewrite_run(
             python(
                 """
                 from collections.abc import Iterable

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -14,12 +14,16 @@
 
 """Tests for RemoveImport / maybe_remove_import."""
 
+import pytest
+
 from rewrite import ExecutionContext, InMemoryExecutionContext
 from rewrite.java import J
 from rewrite.python.remove_import import RemoveImportOptions, maybe_remove_import
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python, from_visitor
+
+from ._java_import_arm import java_remove_import
 
 
 def _assert_ids_accessible(source_file):
@@ -32,21 +36,41 @@ def _assert_ids_accessible(source_file):
     IdWalker().visit(source_file, InMemoryExecutionContext())
 
 
+@pytest.fixture(params=[
+    pytest.param('native'),
+    pytest.param('java', marks=pytest.mark.requires_java_rpc),
+])
+def arm(request):
+    """Run each case against the Python visitor in-process and against the Java visitor over RPC."""
+    if request.param == 'java':
+        request.getfixturevalue('java_rpc')
+    return request.param
+
+
+def _remove_import_visitor(arm, module, name=None, only_if_unused=True):
+    """Build a visitor that registers a single remove-import request."""
+    if arm == 'java':
+        return java_remove_import(module, name, only_if_unused)
+
+    class _V(PythonVisitor[ExecutionContext]):
+        def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
+            maybe_remove_import(self, RemoveImportOptions(
+                module=module,
+                name=name,
+                only_if_unused=only_if_unused,
+            ))
+            return super().visit_compilation_unit(cu, p)
+
+    return _V()
+
+
 class TestMaybeRemoveImport:
     """Tests for maybe_remove_import scheduling via _after_visit."""
 
-    def test_remove_unused_from_import(self):
+    def test_remove_unused_from_import(self, arm):
         """Remove 'from os.path import join' when join is not used."""
-        class RemoveJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_unused=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveJoinVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'os.path', 'join', only_if_unused=False)))
         spec.rewrite_run(
             python(
                 """
@@ -59,17 +83,10 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_remove_entire_direct_import(self):
+    def test_remove_entire_direct_import(self, arm):
         """Remove 'import os' entirely."""
-        class RemoveOsVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os',
-                    only_if_unused=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveOsVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'os', only_if_unused=False)))
         spec.rewrite_run(
             python(
                 """
@@ -82,18 +99,10 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_remove_one_name_from_multi_import(self):
+    def test_remove_one_name_from_multi_import(self, arm):
         """Remove 'join' from 'from os.path import join, exists'."""
-        class RemoveJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_unused=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveJoinVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'os.path', 'join', only_if_unused=False)))
         spec.rewrite_run(
             python(
                 """
@@ -107,18 +116,9 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_keep_import_when_used(self):
+    def test_keep_import_when_used(self, arm):
         """Don't remove an import when the name is still used and only_if_unused=True."""
-        class RemoveJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveJoinVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'os.path', 'join')))
         spec.rewrite_run(
             python(
                 """
@@ -128,18 +128,10 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_remove_import_when_only_shadowed_in_function(self):
+    def test_remove_import_when_only_shadowed_in_function(self, arm):
         """Remove import when the name is only used as a local variable shadowing it."""
-        class RemoveJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveJoinVisitor()), type_attribution=True)
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'os.path', 'join')),
+                          type_attribution=True)
         spec.rewrite_run(
             python(
                 """\
@@ -157,18 +149,10 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_keep_import_when_used_at_module_level(self):
+    def test_keep_import_when_used_at_module_level(self, arm):
         """Keep import when it's used at module level even if also shadowed in a function."""
-        class RemoveJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveJoinVisitor()), type_attribution=True)
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'os.path', 'join')),
+                          type_attribution=True)
         spec.rewrite_run(
             python(
                 """\
@@ -183,17 +167,10 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_remove_direct_import_when_only_shadowed(self):
+    def test_remove_direct_import_when_only_shadowed(self, arm):
         """Remove 'import os' when 'os' is only used as a local variable name."""
-        class RemoveOsVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveOsVisitor()), type_attribution=True)
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'os')),
+                          type_attribution=True)
         spec.rewrite_run(
             python(
                 """\
@@ -211,18 +188,10 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_no_change_when_import_not_present(self):
+    def test_no_change_when_import_not_present(self, arm):
         """No change when the import to remove doesn't exist."""
-        class RemoveJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_unused=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveJoinVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'os.path', 'join', only_if_unused=False)))
         spec.rewrite_run(
             python(
                 """
@@ -232,18 +201,9 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_keep_aliased_from_import_when_alias_used(self):
+    def test_keep_aliased_from_import_when_alias_used(self, arm):
         """Keep 'from typing import List as L' while L is used."""
-        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='typing',
-                    name='List',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
         spec.rewrite_run(
             python(
                 """
@@ -253,18 +213,9 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_remove_aliased_from_import_when_alias_unused(self):
+    def test_remove_aliased_from_import_when_alias_unused(self, arm):
         """Remove 'from typing import List as L' when L is not used."""
-        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='typing',
-                    name='List',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
         spec.rewrite_run(
             python(
                 """
@@ -277,19 +228,10 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_remove_aliased_from_import_even_when_imported_name_used(self):
+    def test_remove_aliased_from_import_even_when_imported_name_used(self, arm):
         """A use of the bare imported name is some other binding and must not
         keep the aliased import alive."""
-        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='typing',
-                    name='List',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
         spec.rewrite_run(
             python(
                 """
@@ -302,18 +244,9 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_mixed_multi_import_removes_only_unreferenced_bindings(self):
+    def test_mixed_multi_import_removes_only_unreferenced_bindings(self, arm):
         """Only the entry whose bound name is unreferenced is removed."""
-        class RemoveListVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='typing',
-                    name='List',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveListVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
         spec.rewrite_run(
             python(
                 """
@@ -327,17 +260,9 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_keep_aliased_direct_import_when_alias_used(self):
+    def test_keep_aliased_direct_import_when_alias_used(self, arm):
         """Keep 'import numpy as np' while np is used."""
-        class RemoveNumpyVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='numpy',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveNumpyVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'numpy')))
         spec.rewrite_run(
             python(
                 """
@@ -347,17 +272,9 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_remove_aliased_direct_import_when_alias_unused(self):
+    def test_remove_aliased_direct_import_when_alias_unused(self, arm):
         """Remove 'import numpy as np' when np is not used."""
-        class RemoveNumpyVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='numpy',
-                    only_if_unused=True
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveNumpyVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'numpy')))
         spec.rewrite_run(
             python(
                 """
@@ -370,20 +287,12 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_partial_from_import_removal_keeps_ids_accessible(self):
+    def test_partial_from_import_removal_keeps_ids_accessible(self, arm):
         """Removing one name from a from-import rebuilds the MultiImport from the
         public `.id` property; the rebuilt node's id must remain accessible
         (regression for the 8.84.8 int-id migration)."""
-        class RemoveJoinVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os.path',
-                    name='join',
-                    only_if_unused=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveJoinVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'os.path', 'join', only_if_unused=False)))
         spec.rewrite_run(
             python(
                 """
@@ -398,19 +307,12 @@ class TestMaybeRemoveImport:
             )
         )
 
-    def test_partial_direct_import_removal_keeps_ids_accessible(self):
+    def test_partial_direct_import_removal_keeps_ids_accessible(self, arm):
         """Removing one module from 'import X, Y' rebuilds the MultiImport from the
         public `.id` property; the rebuilt node's id must remain accessible
         (regression for the 8.84.8 int-id migration)."""
-        class RemoveOsVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module='os',
-                    only_if_unused=False
-                ))
-                return super().visit_compilation_unit(cu, p)
-
-        spec = RecipeSpec(recipe=from_visitor(RemoveOsVisitor()))
+        spec = RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'os', only_if_unused=False)))
         spec.rewrite_run(
             python(
                 """
@@ -432,17 +334,11 @@ class TestCanonicalRemoveImport:
     written path."""
 
     @staticmethod
-    def _remover(module, name=None):
-        class RemoveVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module=module, name=name, only_if_unused=False))
-                return super().visit_compilation_unit(cu, p)
+    def _remover(arm, module, name=None):
+        return _remove_import_visitor(arm, module, name, only_if_unused=False)
 
-        return RecipeSpec(recipe=from_visitor(RemoveVisitor()))
-
-    def test_remove_reexported_function_by_canonical_fqn(self):
-        self._remover('posixpath', 'join').rewrite_run(
+    def test_remove_reexported_function_by_canonical_fqn(self, arm):
+        RecipeSpec(recipe=from_visitor(self._remover(arm, 'posixpath', 'join'))).rewrite_run(
             python(
                 """
                 from os.path import join
@@ -454,8 +350,8 @@ class TestCanonicalRemoveImport:
             )
         )
 
-    def test_remove_reexported_class_by_canonical_fqn(self):
-        self._remover('typing', 'Iterable').rewrite_run(
+    def test_remove_reexported_class_by_canonical_fqn(self, arm):
+        RecipeSpec(recipe=from_visitor(self._remover(arm, 'typing', 'Iterable'))).rewrite_run(
             python(
                 """
                 from collections.abc import Iterable
@@ -467,8 +363,8 @@ class TestCanonicalRemoveImport:
             )
         )
 
-    def test_canonical_removal_keeps_other_names(self):
-        self._remover('posixpath', 'join').rewrite_run(
+    def test_canonical_removal_keeps_other_names(self, arm):
+        RecipeSpec(recipe=from_visitor(self._remover(arm, 'posixpath', 'join'))).rewrite_run(
             python(
                 """
                 from os.path import exists, join
@@ -481,9 +377,9 @@ class TestCanonicalRemoveImport:
             )
         )
 
-    def test_remove_module_binding_by_canonical_fqn(self):
+    def test_remove_module_binding_by_canonical_fqn(self, arm):
         """`from os import path` binds the module canonically named os.path."""
-        self._remover('os.path').rewrite_run(
+        RecipeSpec(recipe=from_visitor(self._remover(arm, 'os.path'))).rewrite_run(
             python(
                 """
                 from os import path
@@ -495,9 +391,9 @@ class TestCanonicalRemoveImport:
             )
         )
 
-    def test_canonical_mismatch_is_not_removed(self):
+    def test_canonical_mismatch_is_not_removed(self, arm):
         """os.path.exists is canonically genericpath.exists, not posixpath.exists."""
-        self._remover('posixpath', 'exists').rewrite_run(
+        RecipeSpec(recipe=from_visitor(self._remover(arm, 'posixpath', 'exists'))).rewrite_run(
             python(
                 """
                 from os.path import exists
@@ -506,11 +402,11 @@ class TestCanonicalRemoveImport:
             )
         )
 
-    def test_whole_module_removal_spares_canonically_related_members(self):
+    def test_whole_module_removal_spares_canonically_related_members(self, arm):
         """`typing` is the canonical home of many re-exports, so a whole-module
         request must match only bindings of the module itself — not every member
         that happens to be declared there."""
-        self._remover('typing').rewrite_run(
+        RecipeSpec(recipe=from_visitor(self._remover(arm, 'typing'))).rewrite_run(
             python(
                 """
                 from collections.abc import Iterable
@@ -525,18 +421,12 @@ class TestRemoveImportUsageScoping:
     rebind, including references that appear only in annotations."""
 
     @staticmethod
-    def _remove(module, name):
-        class RemoveVisitor(PythonVisitor[ExecutionContext]):
-            def visit_compilation_unit(self, cu: CompilationUnit, p: ExecutionContext) -> J:
-                maybe_remove_import(self, RemoveImportOptions(
-                    module=module, name=name, only_if_unused=True))
-                return super().visit_compilation_unit(cu, p)
+    def _remove(arm, module, name):
+        return from_visitor(_remove_import_visitor(arm, module, name))
 
-        return from_visitor(RemoveVisitor())
-
-    def test_keep_import_referenced_in_function_annotations(self):
+    def test_keep_import_referenced_in_function_annotations(self, arm):
         for type_attribution in (False, True):
-            spec = RecipeSpec(recipe=self._remove('typing', 'Deque'),
+            spec = RecipeSpec(recipe=self._remove(arm, 'typing', 'Deque'),
                               type_attribution=type_attribution)
             spec.rewrite_run(
                 python(
@@ -551,9 +441,9 @@ class TestRemoveImportUsageScoping:
                 )
             )
 
-    def test_keep_import_referenced_in_function_body(self):
+    def test_keep_import_referenced_in_function_body(self, arm):
         for type_attribution in (False, True):
-            spec = RecipeSpec(recipe=self._remove('os.path', 'join'),
+            spec = RecipeSpec(recipe=self._remove(arm, 'os.path', 'join'),
                               type_attribution=type_attribution)
             spec.rewrite_run(
                 python(
@@ -567,9 +457,9 @@ class TestRemoveImportUsageScoping:
                 )
             )
 
-    def test_keep_import_referenced_outside_the_shadowing_function(self):
+    def test_keep_import_referenced_outside_the_shadowing_function(self, arm):
         for type_attribution in (False, True):
-            spec = RecipeSpec(recipe=self._remove('os.path', 'join'),
+            spec = RecipeSpec(recipe=self._remove(arm, 'os.path', 'join'),
                               type_attribution=type_attribution)
             spec.rewrite_run(
                 python(
@@ -588,9 +478,9 @@ class TestRemoveImportUsageScoping:
                 )
             )
 
-    def test_remove_import_shadowed_in_every_function(self):
+    def test_remove_import_shadowed_in_every_function(self, arm):
         for type_attribution in (False, True):
-            spec = RecipeSpec(recipe=self._remove('os.path', 'join'),
+            spec = RecipeSpec(recipe=self._remove(arm, 'os.path', 'join'),
                               type_attribution=type_attribution)
             spec.rewrite_run(
                 python(
@@ -616,14 +506,15 @@ class TestRemoveImportScopeRules:
     resolves to the import keeps that import alive."""
 
     @staticmethod
-    def _keeps(source):
+    def _keeps(arm, source):
         for type_attribution in (False, True):
-            spec = RecipeSpec(recipe=TestRemoveImportUsageScoping._remove('time', 'clock'),
+            spec = RecipeSpec(recipe=TestRemoveImportUsageScoping._remove(arm, 'time', 'clock'),
                               type_attribution=type_attribution)
             spec.rewrite_run(python(source))
 
-    def test_class_attribute_does_not_hide_method_usage(self):
+    def test_class_attribute_does_not_hide_method_usage(self, arm):
         self._keeps(
+            arm,
             """\
             from time import clock
 
@@ -636,8 +527,9 @@ class TestRemoveImportScopeRules:
             """
         )
 
-    def test_attribute_assignment_does_not_hide_usage(self):
+    def test_attribute_assignment_does_not_hide_usage(self, arm):
         self._keeps(
+            arm,
             """\
             from time import clock
 
@@ -649,8 +541,9 @@ class TestRemoveImportScopeRules:
             """
         )
 
-    def test_decorator_usage_counts(self):
+    def test_decorator_usage_counts(self, arm):
         self._keeps(
+            arm,
             """\
             from time import clock
 
@@ -662,8 +555,9 @@ class TestRemoveImportScopeRules:
             """
         )
 
-    def test_parameter_default_usage_counts(self):
+    def test_parameter_default_usage_counts(self, arm):
         self._keeps(
+            arm,
             """\
             from time import clock
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonBuiltins.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonBuiltins.java
@@ -23,6 +23,8 @@ import java.util.Set;
  * The names Python's {@code builtins} module binds. A bare builtin name is not a module, so no
  * import can bind it. Generated from {@code dir(builtins)} on CPython 3.12.5; a name added in a
  * later release is not an importable module either, so the set does not need to track the runtime.
+ * The package supports Python 3.10+; {@code BaseExceptionGroup} and {@code ExceptionGroup} (3.11+)
+ * are kept in the set regardless, since a dotless module named exactly one of them is not realistic.
  */
 public final class PythonBuiltins {
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonBuiltins.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonBuiltins.java
@@ -20,11 +20,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * The names Python's {@code builtins} module binds. A bare builtin name is not a module, so no
- * import can bind it. Generated from {@code dir(builtins)} on CPython 3.12.5; a name added in a
- * later release is not an importable module either, so the set does not need to track the runtime.
- * The package supports Python 3.10+; {@code BaseExceptionGroup} and {@code ExceptionGroup} (3.11+)
- * are kept in the set regardless, since a dotless module named exactly one of them is not realistic.
+ * The names Python's {@code builtins} module binds, generated from {@code dir(builtins)} on CPython
+ * 3.12.5. The set holds across the 3.10+ the package supports: a name only a newer release binds is
+ * no more importable as a module, and no realistic module is named {@code ExceptionGroup} or
+ * {@code BaseExceptionGroup} (3.11+), which the set keeps.
  */
 public final class PythonBuiltins {
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonBuiltins.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonBuiltins.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.internal;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * The names Python's {@code builtins} module binds. A bare builtin name is not a module, so no
+ * import can bind it. Generated from {@code dir(builtins)} on CPython 3.12.5; a name added in a
+ * later release is not an importable module either, so the set does not need to track the runtime.
+ */
+public final class PythonBuiltins {
+
+    private static final Set<String> NAMES = new HashSet<>(Arrays.asList(
+            "ArithmeticError", "AssertionError", "AttributeError", "BaseException", "BaseExceptionGroup",
+            "BlockingIOError", "BrokenPipeError", "BufferError", "BytesWarning", "ChildProcessError",
+            "ConnectionAbortedError", "ConnectionError", "ConnectionRefusedError", "ConnectionResetError",
+            "DeprecationWarning", "EOFError", "Ellipsis", "EncodingWarning", "EnvironmentError", "Exception",
+            "ExceptionGroup", "False", "FileExistsError", "FileNotFoundError", "FloatingPointError",
+            "FutureWarning", "GeneratorExit", "IOError", "ImportError", "ImportWarning", "IndentationError",
+            "IndexError", "InterruptedError", "IsADirectoryError", "KeyError", "KeyboardInterrupt", "LookupError",
+            "MemoryError", "ModuleNotFoundError", "NameError", "None", "NotADirectoryError", "NotImplemented",
+            "NotImplementedError", "OSError", "OverflowError", "PendingDeprecationWarning", "PermissionError",
+            "ProcessLookupError", "RecursionError", "ReferenceError", "ResourceWarning", "RuntimeError",
+            "RuntimeWarning", "StopAsyncIteration", "StopIteration", "SyntaxError", "SyntaxWarning", "SystemError",
+            "SystemExit", "TabError", "TimeoutError", "True", "TypeError", "UnboundLocalError",
+            "UnicodeDecodeError", "UnicodeEncodeError", "UnicodeError", "UnicodeTranslateError", "UnicodeWarning",
+            "UserWarning", "ValueError", "Warning", "ZeroDivisionError", "__build_class__", "__debug__", "__doc__",
+            "__import__", "__loader__", "__name__", "__package__", "__spec__", "abs", "aiter", "all", "anext",
+            "any", "ascii", "bin", "bool", "breakpoint", "bytearray", "bytes", "callable", "chr", "classmethod",
+            "compile", "complex", "copyright", "credits", "delattr", "dict", "dir", "divmod", "enumerate", "eval",
+            "exec", "exit", "filter", "float", "format", "frozenset", "getattr", "globals", "hasattr", "hash",
+            "help", "hex", "id", "input", "int", "isinstance", "issubclass", "iter", "len", "license", "list",
+            "locals", "map", "max", "memoryview", "min", "next", "object", "oct", "open", "ord", "pow", "print",
+            "property", "quit", "range", "repr", "reversed", "round", "set", "setattr", "slice", "sorted",
+            "staticmethod", "str", "sum", "super", "tuple", "type", "vars", "zip"));
+
+    private PythonBuiltins() {
+    }
+
+    public static boolean contains(String name) {
+        return NAMES.contains(name);
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonImportNames.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/PythonImportNames.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.internal;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+/**
+ * Reads the names and types an import binds, mirroring {@code rewrite.python.import_utils}.
+ */
+public final class PythonImportNames {
+
+    private PythonImportNames() {
+    }
+
+    /**
+     * The dotted name a name tree spells, e.g. {@code os.path}. A qualid whose target is
+     * {@link J.Empty} spells just its own name, which is how a single-part import is modelled.
+     */
+    public static String nameString(@Nullable J name) {
+        if (name instanceof J.Identifier) {
+            return ((J.Identifier) name).getSimpleName();
+        }
+        if (name instanceof J.FieldAccess) {
+            J.FieldAccess fieldAccess = (J.FieldAccess) name;
+            String target = nameString(fieldAccess.getTarget());
+            String simpleName = fieldAccess.getName().getSimpleName();
+            return target.isEmpty() ? simpleName : target + "." + simpleName;
+        }
+        return "";
+    }
+
+    public static @Nullable String aliasName(J.Import imp) {
+        return imp.getAlias() == null ? null : imp.getAlias().getSimpleName();
+    }
+
+    /**
+     * The canonical fully qualified name of the symbol the import binds, which differs from the
+     * written path for re-exports: {@code from os.path import join} binds {@code posixpath.join}.
+     */
+    public static @Nullable String canonicalFqn(J.Import imp) {
+        JavaType type = imp.getQualid().getType();
+        if (type instanceof JavaType.Method) {
+            JavaType.Method method = (JavaType.Method) type;
+            JavaType.FullyQualified declaring = method.getDeclaringType();
+            if (declaring instanceof JavaType.Unknown || method.getName().isEmpty()) {
+                return null;
+            }
+            return declaring.getFullyQualifiedName() + "." + method.getName();
+        }
+        if (type instanceof JavaType.Parameterized) {
+            type = ((JavaType.Parameterized) type).getType();
+        }
+        if (type instanceof JavaType.FullyQualified && !(type instanceof JavaType.Unknown)) {
+            return ((JavaType.FullyQualified) type).getFullyQualifiedName();
+        }
+        return null;
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
@@ -140,7 +140,7 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
         AtomicBoolean found = new AtomicBoolean();
         new PythonVisitor<AtomicBoolean>() {
             // Identifiers inside an import are bindings rather than uses, so neither kind of
-            // import statement is descended into.
+            // import statement is descended into (#8409).
             @Override
             public J visitImport(J.Import imp, AtomicBoolean found) {
                 return imp;

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
@@ -19,10 +19,22 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.NameTree;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.python.PythonVisitor;
+import org.openrewrite.python.internal.PythonBuiltins;
 import org.openrewrite.python.tree.Py;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.util.Objects.requireNonNull;
+import static org.openrewrite.python.internal.PythonImportNames.aliasName;
+import static org.openrewrite.python.internal.PythonImportNames.canonicalFqn;
+import static org.openrewrite.python.internal.PythonImportNames.nameString;
 
 /**
  * Dispatches to {@code rewrite.python.add_import.AddImport}.
@@ -54,6 +66,99 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
 
     @Override
     boolean mightChange(Py.CompilationUnit cu) {
-        return true;
+        // builtins are always available; only import them under an explicit alias.
+        if ("builtins".equals(module) && alias == null) {
+            return false;
+        }
+        // A bare builtin name (e.g. `list` when ChangeType retargets a type to a builtin) is not a
+        // module, so there is no import that could bind it.
+        if (name == null && module != null && module.indexOf('.') == -1 && PythonBuiltins.contains(module)) {
+            return false;
+        }
+        if (importExists(cu)) {
+            return false;
+        }
+        return !onlyIfReferenced || isReferenced(cu);
+    }
+
+    private boolean importExists(Py.CompilationUnit cu) {
+        for (Statement statement : cu.getStatements()) {
+            if (statement instanceof J.Import) {
+                if (name == null && bindsExactly((J.Import) statement, module)) {
+                    return true;
+                }
+            } else if (statement instanceof Py.MultiImport && satisfies((Py.MultiImport) statement)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean satisfies(Py.MultiImport multi) {
+        NameTree from = multi.getFrom();
+        if (name == null) {
+            if (from != null) {
+                return false;
+            }
+            for (J.Import member : multi.getNames()) {
+                if (bindsExactly(member, module)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (from == null) {
+            return false;
+        }
+        boolean syntactic = nameString(from).equals(module);
+        String targetFqn = module + "." + name;
+        String requestedBinding = alias != null ? alias : name;
+        for (J.Import member : multi.getNames()) {
+            if (syntactic && bindsExactly(member, name)) {
+                return true;
+            }
+            // A member canonically matching the request satisfies it only when it binds the same
+            // name, so references to that name keep resolving through it.
+            if (targetFqn.equals(canonicalFqn(member))) {
+                String memberAlias = aliasName(member);
+                String bound = memberAlias != null ? memberAlias : nameString(member.getQualid());
+                if (requestedBinding.equals(bound)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private boolean bindsExactly(J.Import imp, @Nullable String expected) {
+        return nameString(imp.getQualid()).equals(expected) && Objects.equals(alias, aliasName(imp));
+    }
+
+    private boolean isReferenced(Py.CompilationUnit cu) {
+        String target = alias != null ? alias :
+                name != null ? name : requireNonNull(module).substring(module.lastIndexOf('.') + 1);
+        AtomicBoolean found = new AtomicBoolean();
+        new PythonVisitor<AtomicBoolean>() {
+            // Identifiers inside an import are bindings rather than uses, so neither kind of
+            // import statement is descended into.
+            @Override
+            public J visitImport(J.Import imp, AtomicBoolean found) {
+                return imp;
+            }
+
+            @Override
+            public J visitMultiImport(Py.MultiImport multi, AtomicBoolean found) {
+                return multi;
+            }
+
+            @Override
+            public J visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
+                if (target.equals(identifier.getSimpleName())) {
+                    found.set(true);
+                }
+                return identifier;
+            }
+        }.visit(cu, found);
+        return found.get();
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.python.tree.Py;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Dispatches to {@code rewrite.python.add_import.AddImport}.
+ */
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@Getter
+public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
+
+    private final @Nullable String module;
+    private final @Nullable String name;
+    private final @Nullable String alias;
+    private final boolean onlyIfReferenced;
+
+    @Override
+    String visitorName() {
+        return "org.openrewrite.python.AddImport";
+    }
+
+    @Override
+    Map<String, Object> options() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("module", module);
+        options.put("name", name);
+        options.put("alias", alias);
+        options.put("only_if_referenced", onlyIfReferenced);
+        return options;
+    }
+
+    @Override
+    boolean mightChange(Py.CompilationUnit cu) {
+        return true;
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static java.util.Objects.requireNonNull;
 import static org.openrewrite.python.internal.PythonImportNames.aliasName;
 import static org.openrewrite.python.internal.PythonImportNames.canonicalFqn;
 import static org.openrewrite.python.internal.PythonImportNames.nameString;
@@ -44,7 +43,7 @@ import static org.openrewrite.python.internal.PythonImportNames.nameString;
 @Getter
 public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
 
-    private final @Nullable String module;
+    private final String module;
     private final @Nullable String name;
     private final @Nullable String alias;
     private final boolean onlyIfReferenced;
@@ -72,7 +71,7 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
         }
         // A bare builtin name (e.g. `list` when ChangeType retargets a type to a builtin) is not a
         // module, so there is no import that could bind it.
-        if (name == null && module != null && module.indexOf('.') == -1 && PythonBuiltins.contains(module)) {
+        if (name == null && module.indexOf('.') == -1 && PythonBuiltins.contains(module)) {
             return false;
         }
         if (importExists(cu)) {
@@ -136,7 +135,7 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
 
     private boolean isReferenced(Py.CompilationUnit cu) {
         String target = alias != null ? alias :
-                name != null ? name : requireNonNull(module).substring(module.lastIndexOf('.') + 1);
+                name != null ? name : module.substring(module.lastIndexOf('.') + 1);
         AtomicBoolean found = new AtomicBoolean();
         new PythonVisitor<AtomicBoolean>() {
             // Identifiers inside an import are bindings rather than uses, so neither kind of

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonImportService.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonImportService.java
@@ -15,20 +15,9 @@
  */
 package org.openrewrite.python.service;
 
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
-import org.openrewrite.Cursor;
-import org.openrewrite.SourceFile;
-import org.openrewrite.Tree;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.service.ImportService;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.python.rpc.PythonRewriteRpc;
-import org.openrewrite.rpc.RewriteRpc;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Dispatches {@link org.openrewrite.java.JavaVisitor#maybeAddImport}/{@code maybeRemoveImport} to
@@ -37,21 +26,27 @@ import java.util.Map;
  */
 public class PythonImportService extends ImportService {
 
-    private static final String ADD_IMPORT_VISITOR = "org.openrewrite.python.AddImport";
-    private static final String REMOVE_IMPORT_VISITOR = "org.openrewrite.python.RemoveImport";
-
     @Override
     public <P> JavaVisitor<P> addImportVisitor(@Nullable String packageName,
                                                String typeName,
                                                @Nullable String member,
                                                @Nullable String alias,
                                                boolean onlyIfReferenced) {
-        return new PythonAddImportVisitor<>(packageName, typeName, member, alias, onlyIfReferenced);
+        // A `member` is Java's static import, whose Python equivalent imports the member from
+        // the type's own module: `from <package>.<type> import <member>`.
+        String[] moduleAndName = member == null ?
+                moduleAndName(packageName, typeName) :
+                moduleAndName(packageName == null ? typeName : packageName + "." + typeName, member);
+        return new PythonAddImportVisitor<>(moduleAndName[0], moduleAndName[1], alias, onlyIfReferenced);
     }
 
     @Override
     public <P> JavaVisitor<P> removeImportVisitor(String fullyQualifiedName) {
-        return new PythonRemoveImportVisitor<>(fullyQualifiedName);
+        int lastDot = fullyQualifiedName.lastIndexOf('.');
+        String[] moduleAndName = lastDot == -1 ?
+                moduleAndName(null, fullyQualifiedName) :
+                moduleAndName(fullyQualifiedName.substring(0, lastDot), fullyQualifiedName.substring(lastDot + 1));
+        return new PythonRemoveImportVisitor<>(moduleAndName[0], moduleAndName[1]);
     }
 
     /**
@@ -66,108 +61,9 @@ public class PythonImportService extends ImportService {
      * Splits a fully-qualified name into Python's (module, name) pair, e.g. {@code collections.abc}
      * + {@code Iterable}; a name with no dot becomes a plain {@code import <name>} with a null name.
      */
-    private static Map<String, Object> moduleAndName(@Nullable String packageName, String typeName) {
-        Map<String, Object> options = new HashMap<>();
-        if (packageName == null || packageName.isEmpty()) {
-            options.put("module", typeName);
-            options.put("name", null);
-        } else {
-            options.put("module", packageName);
-            options.put("name", typeName);
-        }
-        return options;
-    }
-
-    /**
-     * Runs one of the Python side's own import visitors over RPC, with equality on its fields so
-     * {@code maybeAddImport}/{@code maybeRemoveImport} can deduplicate the queued visitors.
-     */
-    @EqualsAndHashCode(callSuper = false)
-    private abstract static class RpcImportVisitor<P> extends JavaVisitor<P> {
-
-        abstract String visitorName();
-
-        abstract Map<String, Object> options();
-
-        @Override
-        public @Nullable J visit(@Nullable Tree tree, P p, Cursor parent) {
-            return dispatch(tree, p, parent);
-        }
-
-        @Override
-        public @Nullable J visit(@Nullable Tree tree, P p) {
-            return dispatch(tree, p, null);
-        }
-
-        private @Nullable J dispatch(@Nullable Tree tree, P p, @Nullable Cursor parent) {
-            if (!(tree instanceof SourceFile)) {
-                return (J) tree;
-            }
-            RewriteRpc rpc = PythonRewriteRpc.get();
-            if (rpc == null) {
-                // Without a process-manager handle, the peer whose request is being handled is
-                // the one that implements the import visitors; see RewriteRpc.current().
-                rpc = RewriteRpc.current();
-            }
-            if (rpc == null) {
-                return (J) tree;
-            }
-            // An import visitor never deletes the file, so a null result is an RPC desync rather than
-            // a real deletion; return the file unchanged instead of dropping it from the result set.
-            Tree result = rpc.visit(tree, visitorName(), options(), p, parent);
-            return result != null ? (J) result : (J) tree;
-        }
-    }
-
-    /**
-     * Dispatches to {@code rewrite.python.add_import.AddImport}.
-     */
-    @RequiredArgsConstructor
-    @EqualsAndHashCode(callSuper = false)
-    private static class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
-        private final @Nullable String packageName;
-        private final String typeName;
-        private final @Nullable String member;
-        private final @Nullable String alias;
-        private final boolean onlyIfReferenced;
-
-        @Override
-        String visitorName() {
-            return ADD_IMPORT_VISITOR;
-        }
-
-        @Override
-        Map<String, Object> options() {
-            // A `member` is Java's static import, whose Python equivalent imports the member from
-            // the type's own module: `from <package>.<type> import <member>`.
-            Map<String, Object> options = member == null ?
-                    moduleAndName(packageName, typeName) :
-                    moduleAndName(packageName == null ? typeName : packageName + "." + typeName, member);
-            options.put("alias", alias);
-            options.put("only_if_referenced", onlyIfReferenced);
-            return options;
-        }
-    }
-
-    /**
-     * Dispatches to {@code rewrite.python.remove_import.RemoveImport}.
-     */
-    @RequiredArgsConstructor
-    @EqualsAndHashCode(callSuper = false)
-    private static class PythonRemoveImportVisitor<P> extends RpcImportVisitor<P> {
-        private final String fullyQualifiedName;
-
-        @Override
-        String visitorName() {
-            return REMOVE_IMPORT_VISITOR;
-        }
-
-        @Override
-        Map<String, Object> options() {
-            int lastDot = fullyQualifiedName.lastIndexOf('.');
-            return lastDot == -1 ?
-                    moduleAndName(null, fullyQualifiedName) :
-                    moduleAndName(fullyQualifiedName.substring(0, lastDot), fullyQualifiedName.substring(lastDot + 1));
-        }
+    private static String[] moduleAndName(@Nullable String packageName, String typeName) {
+        return packageName == null || packageName.isEmpty() ?
+                new String[]{typeName, null} :
+                new String[]{packageName, typeName};
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonImportService.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonImportService.java
@@ -34,19 +34,22 @@ public class PythonImportService extends ImportService {
                                                boolean onlyIfReferenced) {
         // A `member` is Java's static import, whose Python equivalent imports the member from
         // the type's own module: `from <package>.<type> import <member>`.
-        String[] moduleAndName = member == null ?
-                moduleAndName(packageName, typeName) :
-                moduleAndName(packageName == null ? typeName : packageName + "." + typeName, member);
-        return new PythonAddImportVisitor<>(moduleAndName[0], moduleAndName[1], alias, onlyIfReferenced);
+        String fqType = member == null ? packageName : packageName == null ? typeName : packageName + "." + typeName;
+        String boundName = member == null ? typeName : member;
+        // A name with no dot becomes a plain `import <name>` with a null name.
+        String module = fqType == null || fqType.isEmpty() ? boundName : fqType;
+        String name = fqType == null || fqType.isEmpty() ? null : boundName;
+        return new PythonAddImportVisitor<>(module, name, alias, onlyIfReferenced);
     }
 
     @Override
     public <P> JavaVisitor<P> removeImportVisitor(String fullyQualifiedName) {
         int lastDot = fullyQualifiedName.lastIndexOf('.');
-        String[] moduleAndName = lastDot == -1 ?
-                moduleAndName(null, fullyQualifiedName) :
-                moduleAndName(fullyQualifiedName.substring(0, lastDot), fullyQualifiedName.substring(lastDot + 1));
-        return new PythonRemoveImportVisitor<>(moduleAndName[0], moduleAndName[1]);
+        String packageName = lastDot == -1 ? null : fullyQualifiedName.substring(0, lastDot);
+        String typeName = lastDot == -1 ? fullyQualifiedName : fullyQualifiedName.substring(lastDot + 1);
+        String module = packageName == null || packageName.isEmpty() ? typeName : packageName;
+        String name = packageName == null || packageName.isEmpty() ? null : typeName;
+        return new PythonRemoveImportVisitor<>(module, name);
     }
 
     /**
@@ -55,15 +58,5 @@ public class PythonImportService extends ImportService {
     @Override
     public boolean usesStatementBasedImports() {
         return true;
-    }
-
-    /**
-     * Splits a fully-qualified name into Python's (module, name) pair, e.g. {@code collections.abc}
-     * + {@code Iterable}; a name with no dot becomes a plain {@code import <name>} with a null name.
-     */
-    private static String[] moduleAndName(@Nullable String packageName, String typeName) {
-        return packageName == null || packageName.isEmpty() ?
-                new String[]{typeName, null} :
-                new String[]{packageName, typeName};
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
@@ -20,10 +20,16 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.NameTree;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.python.tree.Py;
 
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.openrewrite.python.internal.PythonImportNames.canonicalFqn;
+import static org.openrewrite.python.internal.PythonImportNames.nameString;
 
 /**
  * Dispatches to {@code rewrite.python.remove_import.RemoveImport}.
@@ -63,6 +69,55 @@ public class PythonRemoveImportVisitor<P> extends RpcImportVisitor<P> {
 
     @Override
     boolean mightChange(Py.CompilationUnit cu) {
-        return true;
+        for (Statement statement : cu.getStatements()) {
+            if (statement instanceof J.Import) {
+                if (name == null && module.equals(nameString(((J.Import) statement).getQualid()))) {
+                    return true;
+                }
+            } else if (statement instanceof Py.MultiImport && hasCandidate((Py.MultiImport) statement)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Whether any member of the statement is one the Python implementation would consider removing.
+     * {@code only_if_unused} is not evaluated here: it can only retain a candidate, so leaving it
+     * out risks a dispatch that changes nothing rather than a skip that loses a change.
+     */
+    private boolean hasCandidate(Py.MultiImport multi) {
+        NameTree from = multi.getFrom();
+        if (name == null) {
+            if (from == null) {
+                for (J.Import member : multi.getNames()) {
+                    if (module.equals(nameString(member.getQualid()))) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+            if (module.equals(nameString(from))) {
+                return !multi.getNames().isEmpty();
+            }
+            for (J.Import member : multi.getNames()) {
+                if (module.equals(canonicalFqn(member))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        if (from == null) {
+            return false;
+        }
+        boolean syntactic = module.equals(nameString(from));
+        String targetFqn = module + "." + name;
+        for (J.Import member : multi.getNames()) {
+            if (syntactic && name.equals(nameString(member.getQualid())) ||
+                    targetFqn.equals(canonicalFqn(member))) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.python.tree.Py;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Dispatches to {@code rewrite.python.remove_import.RemoveImport}.
+ */
+@RequiredArgsConstructor
+@EqualsAndHashCode(callSuper = false)
+@Getter
+public class PythonRemoveImportVisitor<P> extends RpcImportVisitor<P> {
+
+    private final String module;
+    private final @Nullable String name;
+
+    /**
+     * Mirrors the Python option of the same name. {@code removeImportVisitor} has no parameter for
+     * it, so a service-constructed visitor always leaves an import that is still referenced alone.
+     */
+    private final boolean onlyIfUnused;
+
+    @JsonIgnore
+    public PythonRemoveImportVisitor(String module, @Nullable String name) {
+        this(module, name, true);
+    }
+
+    @Override
+    String visitorName() {
+        return "org.openrewrite.python.RemoveImport";
+    }
+
+    @Override
+    Map<String, Object> options() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("module", module);
+        options.put("name", name);
+        options.put("only_if_unused", onlyIfUnused);
+        return options;
+    }
+
+    @Override
+    boolean mightChange(Py.CompilationUnit cu) {
+        return true;
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
@@ -87,6 +87,11 @@ public class PythonRemoveImportVisitor<P> extends RpcImportVisitor<P> {
      * out risks a dispatch that changes nothing rather than a skip that loses a change.
      */
     private boolean hasCandidate(Py.MultiImport multi) {
+        // A statement with no names left is deleted by the Python side whatever the request, so it
+        // is never something this predicate may rule out.
+        if (multi.getNames().isEmpty()) {
+            return true;
+        }
         NameTree from = multi.getFrom();
         if (name == null) {
             if (from == null) {
@@ -98,7 +103,7 @@ public class PythonRemoveImportVisitor<P> extends RpcImportVisitor<P> {
                 return false;
             }
             if (module.equals(nameString(from))) {
-                return !multi.getNames().isEmpty();
+                return true;
             }
             for (J.Import member : multi.getNames()) {
                 if (module.equals(canonicalFqn(member))) {

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/RpcImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/RpcImportVisitor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import lombok.EqualsAndHashCode;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.python.tree.Py;
+import org.openrewrite.rpc.RewriteRpc;
+
+import java.util.Map;
+
+/**
+ * Runs one of the Python side's own import visitors over RPC, with equality on its fields so
+ * {@code maybeAddImport}/{@code maybeRemoveImport} can deduplicate the queued visitors.
+ */
+@EqualsAndHashCode(callSuper = false)
+abstract class RpcImportVisitor<P> extends JavaVisitor<P> {
+
+    abstract String visitorName();
+
+    abstract Map<String, Object> options();
+
+    /**
+     * Whether the Python implementation could change this file. Transcribes its early returns, so
+     * a false answer means the round trip would have handed back the tree it was given.
+     */
+    abstract boolean mightChange(Py.CompilationUnit cu);
+
+    @Override
+    public @Nullable J visit(@Nullable Tree tree, P p, Cursor parent) {
+        return dispatch(tree, p, parent);
+    }
+
+    @Override
+    public @Nullable J visit(@Nullable Tree tree, P p) {
+        return dispatch(tree, p, null);
+    }
+
+    private @Nullable J dispatch(@Nullable Tree tree, P p, @Nullable Cursor parent) {
+        if (!(tree instanceof SourceFile)) {
+            return (J) tree;
+        }
+        if (tree instanceof Py.CompilationUnit && !mightChange((Py.CompilationUnit) tree)) {
+            return (J) tree;
+        }
+        RewriteRpc rpc = PythonRewriteRpc.get();
+        if (rpc == null) {
+            // Without a process-manager handle, the peer whose request is being handled is
+            // the one that implements the import visitors; see RewriteRpc.current().
+            rpc = RewriteRpc.current();
+        }
+        if (rpc == null) {
+            return (J) tree;
+        }
+        // An import visitor never deletes the file, so a null result is an RPC desync rather than
+        // a real deletion; return the file unchanged instead of dropping it from the result set.
+        Tree result = rpc.visit(tree, visitorName(), options(), p, parent);
+        return result != null ? (J) result : (J) tree;
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonImportNamesTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonImportNamesTest.java
@@ -20,8 +20,6 @@ import org.junit.jupiter.api.Test;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
-import java.util.UUID;
-
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.Tree.randomId;
@@ -89,8 +87,8 @@ class PythonImportNamesTest {
 
     @Test
     void canonicalFqnOfClassType() {
-        assertThat(PythonImportNames.canonicalFqn(imp("Iterable", null, JavaType.ShallowClass.build("typing.Iterable"))))
-                .isEqualTo("typing.Iterable");
+        assertThat(PythonImportNames.canonicalFqn(
+                imp("Iterable", null, JavaType.ShallowClass.build("typing.Iterable")))).isEqualTo("typing.Iterable");
     }
 
     @Test

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonImportNamesTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/PythonImportNamesTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.internal;
+
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+
+import java.util.UUID;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.Tree.randomId;
+
+class PythonImportNamesTest {
+
+    private static J.Identifier ident(String name) {
+        return new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), name, null, null);
+    }
+
+    private static J.FieldAccess qualid(String dotted, @Nullable JavaType type) {
+        String[] parts = dotted.split("\\.");
+        Expression target = parts.length == 1 ?
+                new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY) : ident(parts[0]);
+        for (int i = 1; i < parts.length - 1; i++) {
+            target = new J.FieldAccess(randomId(), Space.EMPTY, Markers.EMPTY, target,
+                    JLeftPadded.build(ident(parts[i])), null);
+        }
+        return new J.FieldAccess(randomId(), Space.EMPTY, Markers.EMPTY, target,
+                JLeftPadded.build(ident(parts[parts.length - 1])), type);
+    }
+
+    private static J.Import imp(String dotted, @Nullable String alias, @Nullable JavaType type) {
+        return new J.Import(randomId(), Space.EMPTY, Markers.EMPTY,
+                JLeftPadded.build(false), qualid(dotted, type),
+                alias == null ? null : JLeftPadded.build(ident(alias)));
+    }
+
+    @Test
+    void nameStringOfIdentifier() {
+        assertThat(PythonImportNames.nameString(ident("os"))).isEqualTo("os");
+    }
+
+    @Test
+    void nameStringOfDottedFieldAccess() {
+        assertThat(PythonImportNames.nameString(qualid("os.path", null))).isEqualTo("os.path");
+    }
+
+    @Test
+    void nameStringSkipsEmptyTarget() {
+        assertThat(PythonImportNames.nameString(qualid("join", null))).isEqualTo("join");
+    }
+
+    @Test
+    void nameStringOfNull() {
+        assertThat(PythonImportNames.nameString(null)).isEmpty();
+    }
+
+    @Test
+    void aliasNameIsNullWithoutAlias() {
+        assertThat(PythonImportNames.aliasName(imp("os", null, null))).isNull();
+    }
+
+    @Test
+    void aliasNameReadsTheAlias() {
+        assertThat(PythonImportNames.aliasName(imp("numpy", "np", null))).isEqualTo("np");
+    }
+
+    @Test
+    void canonicalFqnOfMethodType() {
+        JavaType.Method method = new JavaType.Method(null, 0, JavaType.ShallowClass.build("posixpath"),
+                "join", null, emptyList(), emptyList(), emptyList(), emptyList(), emptyList(), emptyList());
+        assertThat(PythonImportNames.canonicalFqn(imp("join", null, method))).isEqualTo("posixpath.join");
+    }
+
+    @Test
+    void canonicalFqnOfClassType() {
+        assertThat(PythonImportNames.canonicalFqn(imp("Iterable", null, JavaType.ShallowClass.build("typing.Iterable"))))
+                .isEqualTo("typing.Iterable");
+    }
+
+    @Test
+    void canonicalFqnIsNullWhenUnattributed() {
+        assertThat(PythonImportNames.canonicalFqn(imp("Iterable", null, null))).isNull();
+    }
+
+    @Test
+    void canonicalFqnIsNullForUnknownType() {
+        assertThat(PythonImportNames.canonicalFqn(imp("Iterable", null, JavaType.Unknown.getInstance()))).isNull();
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonAddImportVisitorTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonAddImportVisitorTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.python.tree.Py;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.python.service.PythonImports.*;
+
+class PythonAddImportVisitorTest {
+
+    private static boolean mightChange(String module, String name, String alias,
+                                       boolean onlyIfReferenced, Py.CompilationUnit cu) {
+        return new PythonAddImportVisitor<>(module, name, alias, onlyIfReferenced).mightChange(cu);
+    }
+
+    @Test
+    void skipsBuiltinsWithoutAnAlias() {
+        assertThat(mightChange("builtins", "list", null, false, cu())).isFalse();
+    }
+
+    @Test
+    void dispatchesForAnAliasedBuiltinsImport() {
+        assertThat(mightChange("builtins", "list", "_list", false, cu())).isTrue();
+    }
+
+    @Test
+    void skipsABareBuiltinName() {
+        assertThat(mightChange("list", null, null, false, cu())).isFalse();
+    }
+
+    @Test
+    void dispatchesForADottedModuleThatStartsWithABuiltinName() {
+        assertThat(mightChange("list.sub", null, null, false, cu())).isTrue();
+    }
+
+    @Test
+    void skipsWhenTheFromImportAlreadyExists() {
+        assertThat(mightChange("typing", "List", null, false,
+          cu(fromImport("typing", member("List"))))).isFalse();
+    }
+
+    @Test
+    void dispatchesWhenOnlyAnotherMemberExists() {
+        assertThat(mightChange("typing", "List", null, false,
+          cu(fromImport("typing", member("Iterable"))))).isTrue();
+    }
+
+    @Test
+    void dispatchesWhenTheExistingImportIsAliased() {
+        assertThat(mightChange("typing", "List", null, false,
+          cu(fromImport("typing", member("List", "L", null))))).isTrue();
+    }
+
+    @Test
+    void skipsWhenTheDirectImportAlreadyExists() {
+        assertThat(mightChange("os", null, null, false, cu(directImport(member("os"))))).isFalse();
+    }
+
+    @Test
+    void skipsWhenAnExistingImportCanonicallyBindsTheSameName() {
+        assertThat(mightChange("posixpath", "join", null, false,
+          cu(fromImport("os.path", member("join", null, methodType("posixpath", "join")))))).isFalse();
+    }
+
+    @Test
+    void dispatchesWhenTheCanonicalMatchBindsAnotherName() {
+        assertThat(mightChange("posixpath", "join", null, false,
+          cu(fromImport("os.path", member("join", "j", methodType("posixpath", "join")))))).isTrue();
+    }
+
+    @Test
+    void skipsAnUnreferencedNameWhenOnlyIfReferenced() {
+        assertThat(mightChange("os.path", "join", null, true, cu())).isFalse();
+    }
+
+    @Test
+    void doesNotCountAnIdentifierBoundByAnImportAsAReference() {
+        assertThat(mightChange("pathlib", null, null, true,
+          cu(directImport(member("pathlib", "o", null))))).isFalse();
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
@@ -28,8 +28,6 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.Space;
-import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.marketplace.RecipeMarketplace;
 import org.openrewrite.python.tree.Py;
@@ -38,10 +36,8 @@ import org.openrewrite.rpc.RewriteRpc;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
-import java.nio.file.Paths;
 import java.util.HashMap;
 
-import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -76,8 +72,9 @@ class PythonImportServiceRpcTest {
 
     @Test
     void dispatchesImportEditBackToRequestingPeer() {
-        Py.CompilationUnit cu = new Py.CompilationUnit(Tree.randomId(), Space.EMPTY, Markers.EMPTY,
-          Paths.get("test.py"), null, null, false, null, emptyList(), emptyList(), Space.EMPTY);
+        // The predicate only dispatches when an import could actually satisfy the request, so the
+        // tree needs one for the RemovesTypingList visitor to have anything to remove.
+        Py.CompilationUnit cu = PythonImports.cu(PythonImports.fromImport("typing", PythonImports.member("List")));
 
         // The maybeRemoveImport queued on the server dispatches org.openrewrite.python.RemoveImport
         // back to the host, where the test stand-in receives it.

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImportServiceRpcTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.python.service;
 
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import io.moderne.jsonrpc.JsonRpc;
 import io.moderne.jsonrpc.formatter.JsonMessageFormatter;
@@ -38,6 +39,7 @@ import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.nio.file.Paths;
+import java.util.HashMap;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,5 +95,36 @@ class PythonImportServiceRpcTest {
             maybeRemoveImport("typing.List");
             return tree;
         }
+    }
+
+    @Test
+    void addVisitorIsConstructibleFromAnOptionsMap() {
+        var mapper = JsonMapper.builder().addModule(new ParameterNamesModule()).build();
+        var options = new HashMap<String, Object>();
+        options.put("module", "typing");
+        options.put("name", "List");
+        options.put("alias", null);
+        options.put("onlyIfReferenced", true);
+
+        PythonAddImportVisitor<?> visitor = mapper.convertValue(options, PythonAddImportVisitor.class);
+
+        assertThat(visitor.getModule()).isEqualTo("typing");
+        assertThat(visitor.getName()).isEqualTo("List");
+        assertThat(visitor.getAlias()).isNull();
+        assertThat(visitor.isOnlyIfReferenced()).isTrue();
+    }
+
+    @Test
+    void removeVisitorIsConstructibleFromAnOptionsMap() {
+        var mapper = JsonMapper.builder().addModule(new ParameterNamesModule()).build();
+        var options = new HashMap<String, Object>();
+        options.put("module", "typing");
+        options.put("name", "List");
+        options.put("onlyIfUnused", false);
+
+        PythonRemoveImportVisitor<?> visitor = mapper.convertValue(options, PythonRemoveImportVisitor.class);
+
+        assertThat(visitor.getModule()).isEqualTo("typing");
+        assertThat(visitor.isOnlyIfUnused()).isFalse();
     }
 }

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImports.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImports.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.python.tree.Py;
+
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.openrewrite.Tree.randomId;
+
+/**
+ * Builds the import shapes the dispatch predicates read, without a Python runtime to parse them.
+ */
+final class PythonImports {
+
+    private PythonImports() {
+    }
+
+    static Py.CompilationUnit cu(Statement... statements) {
+        List<JRightPadded<Statement>> padded = new ArrayList<>();
+        for (Statement statement : statements) {
+            padded.add(JRightPadded.build(statement));
+        }
+        return new Py.CompilationUnit(randomId(), Space.EMPTY, Markers.EMPTY, Paths.get("test.py"),
+                null, null, false, null, emptyList(), padded, Space.EMPTY);
+    }
+
+    static Py.MultiImport fromImport(String from, J.Import... names) {
+        return multiImport(JRightPadded.build((NameTree) name(from)), names);
+    }
+
+    static Py.MultiImport directImport(J.Import... names) {
+        return multiImport(null, names);
+    }
+
+    static J.Import member(String dotted) {
+        return member(dotted, null, null);
+    }
+
+    /** The type an attributed function import carries, e.g. {@code posixpath.join}. */
+    static JavaType.Method methodType(String declaringType, String name) {
+        // Casts pin the List-based overload; bare nulls are ambiguous with the array-based one.
+        return new JavaType.Method(null, 0, JavaType.ShallowClass.build(declaringType), name,
+                null, (List<String>) null, (List<JavaType>) null, (List<JavaType>) null,
+                (List<JavaType.FullyQualified>) null, null, (List<String>) null);
+    }
+
+    static J.Import member(String dotted, @Nullable String alias, @Nullable JavaType type) {
+        return new J.Import(randomId(), Space.EMPTY, Markers.EMPTY, JLeftPadded.build(false),
+                qualid(dotted, type), alias == null ? null : JLeftPadded.build(identifier(alias)));
+    }
+
+    private static Py.MultiImport multiImport(@Nullable JRightPadded<NameTree> from, J.Import... names) {
+        List<JRightPadded<J.Import>> padded = new ArrayList<>();
+        for (J.Import name : Arrays.asList(names)) {
+            padded.add(JRightPadded.build(name));
+        }
+        return new Py.MultiImport(randomId(), Space.EMPTY, Markers.EMPTY, from, false,
+                JContainer.build(Space.SINGLE_SPACE, padded, Markers.EMPTY));
+    }
+
+    /** A dotted name as the parser models it outside an import qualid: no empty target. */
+    private static Expression name(String dotted) {
+        String[] parts = dotted.split("\\.");
+        Expression result = identifier(parts[0]);
+        for (int i = 1; i < parts.length; i++) {
+            result = new J.FieldAccess(randomId(), Space.EMPTY, Markers.EMPTY, result,
+                    JLeftPadded.build(identifier(parts[i])), null);
+        }
+        return result;
+    }
+
+    /** A qualid: a single-part name has a {@link J.Empty} target, as the parser emits it. */
+    private static J.FieldAccess qualid(String dotted, @Nullable JavaType type) {
+        String[] parts = dotted.split("\\.");
+        Expression target = parts.length == 1 ?
+                new J.Empty(randomId(), Space.EMPTY, Markers.EMPTY) : identifier(parts[0]);
+        for (int i = 1; i < parts.length - 1; i++) {
+            target = new J.FieldAccess(randomId(), Space.EMPTY, Markers.EMPTY, target,
+                    JLeftPadded.build(identifier(parts[i])), null);
+        }
+        return new J.FieldAccess(randomId(), Space.EMPTY, Markers.EMPTY, target,
+                JLeftPadded.build(identifier(parts[parts.length - 1])), type);
+    }
+
+    private static J.Identifier identifier(String name) {
+        return new J.Identifier(randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), name, null, null);
+    }
+}

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonRemoveImportVisitorTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonRemoveImportVisitorTest.java
@@ -51,19 +51,19 @@ class PythonRemoveImportVisitorTest {
     @Test
     void dispatchesForAMatchingMemberAmongOthers() {
         assertThat(mightChange("typing", "List",
-          cu(fromImport("typing", member("Iterable"), member("List"))))).isTrue();
+                cu(fromImport("typing", member("Iterable"), member("List"))))).isTrue();
     }
 
     @Test
     void dispatchesForACanonicalMatch() {
         assertThat(mightChange("posixpath", "join",
-          cu(fromImport("os.path", member("join", null, methodType("posixpath", "join")))))).isTrue();
+                cu(fromImport("os.path", member("join", null, methodType("posixpath", "join")))))).isTrue();
     }
 
     @Test
     void skipsWhenTheCanonicalNameDiffers() {
         assertThat(mightChange("posixpath", "exists",
-          cu(fromImport("os.path", member("exists", null, methodType("genericpath", "exists")))))).isFalse();
+                cu(fromImport("os.path", member("exists", null, methodType("genericpath", "exists")))))).isFalse();
     }
 
     @Test

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonRemoveImportVisitorTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonRemoveImportVisitorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.service;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.JavaType;
+import org.openrewrite.python.tree.Py;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.python.service.PythonImports.*;
+
+class PythonRemoveImportVisitorTest {
+
+    private static boolean mightChange(String module, String name, Py.CompilationUnit cu) {
+        return new PythonRemoveImportVisitor<>(module, name).mightChange(cu);
+    }
+
+    @Test
+    void skipsAFileWithNoImports() {
+        assertThat(mightChange("typing", "List", cu())).isFalse();
+    }
+
+    @Test
+    void skipsWhenNoImportBindsTheName() {
+        assertThat(mightChange("typing", "List", cu(fromImport("typing", member("Iterable"))))).isFalse();
+    }
+
+    @Test
+    void skipsWhenTheModuleDiffers() {
+        assertThat(mightChange("typing", "List", cu(fromImport("collections.abc", member("List"))))).isFalse();
+    }
+
+    @Test
+    void dispatchesForAMatchingFromImport() {
+        assertThat(mightChange("typing", "List", cu(fromImport("typing", member("List"))))).isTrue();
+    }
+
+    @Test
+    void dispatchesForAMatchingMemberAmongOthers() {
+        assertThat(mightChange("typing", "List",
+          cu(fromImport("typing", member("Iterable"), member("List"))))).isTrue();
+    }
+
+    @Test
+    void dispatchesForACanonicalMatch() {
+        assertThat(mightChange("posixpath", "join",
+          cu(fromImport("os.path", member("join", null, methodType("posixpath", "join")))))).isTrue();
+    }
+
+    @Test
+    void skipsWhenTheCanonicalNameDiffers() {
+        assertThat(mightChange("posixpath", "exists",
+          cu(fromImport("os.path", member("exists", null, methodType("genericpath", "exists")))))).isFalse();
+    }
+
+    @Test
+    void dispatchesForAWholeModuleDirectImport() {
+        assertThat(mightChange("os", null, cu(directImport(member("os"))))).isTrue();
+    }
+
+    @Test
+    void skipsAWholeModuleRequestAgainstADifferentDirectImport() {
+        assertThat(mightChange("os", null, cu(directImport(member("sys"))))).isFalse();
+    }
+
+    @Test
+    void dispatchesForAWholeModuleRequestAgainstAFromImport() {
+        assertThat(mightChange("typing", null, cu(fromImport("typing", member("List"))))).isTrue();
+    }
+
+    @Test
+    void skipsANamedRequestAgainstADirectImport() {
+        assertThat(mightChange("os", "path", cu(directImport(member("os"))))).isFalse();
+    }
+}


### PR DESCRIPTION
## Motivation

- `PythonImportService` implements `maybeAddImport`/`maybeRemoveImport` by shipping the entire Python source file over RPC to the Python process, running the Python visitor there, and shipping the (possibly unchanged) tree back — for every queued add/remove-import request, even when nothing in the file could change. Commit c9c70e1a8e ("Share Java service interfaces across the recipe classloader boundary", #8427, released in 8.88.3) is correct and should not be reverted: before it, `ChangeType`'s `service(ImportService.class)` resolved child-first through `RecipeClassLoader`, and the cast against the parent-loaded `PythonImportService` threw `ClassCastException` on every Python file, so this import-service work never actually ran. #8427 fixed that resolution bug and, in doing so, exposed the RPC round-trip cost that had always been latent in the design. Measured on `pallets/itsdangerous` (50 files searched): 8.88.1 baseline 726 ms/file, parent commit 499b8076b1 715 ms/file, c9c70e1a8e 885 ms/file (+24%).

The same run shows why a full round trip is wasteful: 152 extra `Visit` calls at roughly 45ms each, of which only 2 files actually changed (`filesWithFixResults: 2`), while all 569 visits together cost about 5ms of Python-side handler time. The cost is almost entirely serialization and transport, not the edit logic itself — which motivates a cheap Java-side precheck rather than porting the edit logic to Java.

This change adds a conservative Java-side predicate, `RpcImportVisitor.mightChange`, that inspects the file's existing imports and skips the RPC round trip whenever the request cannot affect the file — no matching import to remove, no already-satisfying import to add, an unreferenced name under `only_if_referenced`, and so on. When the predicate can't rule the file out, dispatch proceeds exactly as before.

## Summary

- `PythonImportNames` (Java) reads the name, alias, and canonical FQN an import binds, mirroring `rewrite.python.import_utils` closely enough that the Java predicate and the Python implementation agree on what "the same import" means, including canonical matches for re-exports (e.g. `os.path.join` canonically `posixpath.join`).
- `PythonBuiltins` lists the names Python's `builtins` module binds, so the predicate can recognize that no import statement can bind a bare builtin name.
- `PythonAddImportVisitor` and `PythonRemoveImportVisitor` are extracted from private inner classes of `PythonImportService` into public top-level classes, each with a `mightChange(Py.CompilationUnit)` hook that runs before the RPC dispatch in the shared `RpcImportVisitor` base.
- The `mightChange` predicates transcribe the early-return conditions of the Python `AddImport`/`RemoveImport` visitors: they only ever produce a `false` (skip) verdict when they can prove the Python side would have returned the tree unchanged; anything they're unsure about falls through to dispatch.
- The Python implementation itself is untouched. It remains a parallel implementation rather than delegating to the new Java code, because that would add an RPC round trip per file for Python-hosted recipes (the RPC server driving Python-native recipes today), which currently pay none — the same cost this change removes, pointed in the other direction. This is deliberate duplication with a real drift risk: the Java predicate and the Python visitor's actual behavior have to keep agreeing on what counts as a match. The two-arm test corpus below is what holds them together.
- The Python add/remove-import test corpus (`test_add_import.py`, `test_remove_import.py`) now runs every case twice via a parametrized `arm` fixture: once against the Python visitor in-process (`native`), and once against the new Java predicate + dispatch over RPC (`java`, via a small `_java_import_arm.py` helper that invokes `PythonAddImportVisitor`/`PythonRemoveImportVisitor` directly through the RPC `Visit` call). Both arms assert the same before/after source, so a predicate that diverges from the Python visitor's actual behavior fails a test immediately.
- Java-side unit tests (`PythonImportNamesTest`, `PythonAddImportVisitorTest`, `PythonRemoveImportVisitorTest`) exercise the predicates directly against hand-built `Py.CompilationUnit` trees, without needing a Python runtime. These are the part of the safety net that runs in CI.

- `:rewrite-python:pytestTest` now depends on `:rewrite-python:generateTestClasspath`, mirroring what `:rewrite-javascript:npmTest` already does. `pytestTest` already ran in CI via `check`, but nothing generated `test-classpath.txt`, so every `requires_java_rpc` case — the entire java arm, plus `tests/rpc/test_java_recipes.py` — skipped silently and the suite reported green having exercised only the Python implementation. The generated classpath is also declared as a task input with `ClasspathNormalizer`, so a Java-side change re-runs those tests instead of replaying a cached pass against a stale classpath. This adds 65 tests and roughly 8 seconds to CI.

One maintenance note: `PythonAddImportVisitor` and `PythonRemoveImportVisitor` are now addressed by fully-qualified class name from a test in another language's tree. Renaming either breaks the java arm loudly with a failed RPC request rather than silently, so this is a note rather than a risk.

`PythonAutoFormatService` has the same full-tree round-trip shape — `autoFormatVisitor` sends the whole tree to `org.openrewrite.python.format.AutoFormatVisitor` and back regardless of whether formatting would change anything — and is left alone here as follow-up rather than widening this change.

A full Java port of the add/remove-import edit logic remains available as a follow-up if the residual cost on change-heavy repos justifies it; this change's matching layer (`PythonImportNames`, the `mightChange` predicates) would be its first slice, since a port would need the same name/alias/canonical-FQN matching this already builds. The saving here scales with the fraction of files a request cannot affect — on `pallets/itsdangerous`, 150 of 152 extra round trips changed nothing, so most of the overhead is recoverable. On a repo where the request affects, say, half the files, this recovers roughly half the overhead; a full port would recover all of it.

## Test plan

- `./gradlew :rewrite-python:test` — full Java module: 1962 tests, 0 failures. This includes `ChangeTypeTest` (`@DisabledIfEnvironmentVariable(named = "CI")`, so it runs locally but not in CI), which is the JVM-hosted topology's end-to-end cover for this path and ran all 4 of its cases.
- `pytest tests/python/test_add_import.py tests/python/test_remove_import.py -v --timeout=120` in `rewrite-python/rewrite` — 108 passed (48 add + 60 remove, both arms), 0 skipped.
- `pytest tests/rpc/test_java_recipes.py -v --timeout=120` in `rewrite-python/rewrite` — the Python-hosted topology end to end through `ChangeType`, where the JVM runs the Java recipe against a tree the Python process owns; 11 passed, 0 failed. Nothing failed on the branch, so there was no failure to attribute to it.
- Comment-discipline pass over the full branch diff.
- **Outstanding**: the ms/file benchmark that motivated this change has not been re-run against this branch. To reproduce: build an LST for `pallets/itsdangerous` (50 files searched), run `org.openrewrite.python.migrate.UpgradeToPython313` from `openrewrite-migrate-python==0.11.0` (pip) with `org.openrewrite.recipe:rewrite-migrate-python:0.11.0`, `org.openrewrite:rewrite-python`, and `org.openrewrite:rewrite-java` in the CLI marketplace, and read `elapsedTimeMs`/`filesSearched` from `.moderne/run/<id>/trace.json`. Interleave the before/after arms and take medians over at least 4 runs per arm — run-to-run noise on a repo this size is roughly 1-10% against an effect of roughly 1.2x. Target: ms/file back down to the ~715-726 baseline from the ~885 measured at c9c70e1a8e.
