### PR TITLE
Preserve Ruby call syntax on print instead of canonicalizing it

### DIFF
--- a/rewrite-ruby/src/main/java/org/openrewrite/ruby/RubyParserVisitor.java
+++ b/rewrite-ruby/src/main/java/org/openrewrite/ruby/RubyParserVisitor.java
@@ -1465,6 +1465,11 @@ public class RubyParserVisitor extends AbstractNodeVisitor<J> {
             skip(".");
         }
 
+        // `Foo.(a)` elides the `call` that Prism still reports as the name
+        if (name.equals("call") && !peekKeywordAt("call", indexOfNextNonWhitespace(cursor))) {
+            markers = markers.add(new ImplicitCall(randomId()));
+        }
+
         J.Identifier methodName = identifier(name);
         if (name.equals("new")) {
             return new J.NewClass(
@@ -2048,17 +2053,21 @@ public class RubyParserVisitor extends AbstractNodeVisitor<J> {
     private Rb.Hash hash(Space prefix, Nodes.Node[] elements, Nodes.@Nullable Node rest) {
         AtomicReference<Markers> markers = new AtomicReference<>(Markers.EMPTY);
         Space before = whitespace();
-        boolean braces = source.startsWith("{", cursor);
+
+        List<Nodes.Node> all = new ArrayList<>(Arrays.asList(elements));
+        if (rest != null) {
+            all.add(rest);
+        }
+
+        // a brace-less hash whose first key is itself a hash (`eq({} => 0)`) also starts with `{`,
+        // so the brace only belongs to this hash when it sits ahead of the first pair
+        boolean braces = source.startsWith("{", cursor) &&
+                         (all.isEmpty() || cursor < charStart(all.get(0)));
         Markers hashMarkers = Markers.EMPTY;
         if (braces) {
             skip("{");
         } else {
             hashMarkers = hashMarkers.add(new OmitParentheses(randomId()));
-        }
-
-        List<Nodes.Node> all = new ArrayList<>(Arrays.asList(elements));
-        if (rest != null) {
-            all.add(rest);
         }
 
         List<JRightPadded<Expression>> pairs = new ArrayList<>(all.size());

--- a/rewrite-ruby/src/main/java/org/openrewrite/ruby/internal/RubyPrinter.java
+++ b/rewrite-ruby/src/main/java/org/openrewrite/ruby/internal/RubyPrinter.java
@@ -1223,7 +1223,11 @@ public class RubyPrinter<P> extends RubyVisitor<PrintOutputCapture<P>> {
                             (method.getMarkers().findFirst(Colon2.class).isPresent() ? "::" : ".");
             visitRightPadded(method.getPadding().getSelect(),
                     JRightPadded.Location.METHOD_SELECT, suffix, p);
-            visit(method.getName(), p);
+            // `Foo.()` writes no message, but a recipe that renamed it has to write the new one
+            if (!method.getMarkers().findFirst(ImplicitCall.class).isPresent() ||
+                !"call".equals(method.getSimpleName())) {
+                visit(method.getName(), p);
+            }
 
             JContainer<Expression> args = method.getPadding().getArguments();
             AtomicReference<Rb.Block> blockArg = new AtomicReference<>();
@@ -1308,7 +1312,8 @@ public class RubyPrinter<P> extends RubyVisitor<PrintOutputCapture<P>> {
             beforeSyntax(newClass, Space.Location.NEW_CLASS_PREFIX, p);
             visit(newClass.getClazz(), p);
             visitSpace(requireNonNull(newClass.getPadding().getEnclosing()).getAfter(), Space.Location.NEW_CLASS_ENCLOSING_SUFFIX, p);
-            p.append(newClass.getMarkers().findFirst(SafeNavigation.class).isPresent() ? "&." : ".");
+            p.append((newClass.getMarkers().findFirst(SafeNavigation.class).isPresent() ? "&" : "") +
+                     (newClass.getMarkers().findFirst(Colon2.class).isPresent() ? "::" : "."));
             visitSpace(newClass.getNew(), Space.Location.NEW_PREFIX, p);
             p.append("new");
             JContainer<Expression> args = newClass.getPadding().getArguments();

--- a/rewrite-ruby/src/main/java/org/openrewrite/ruby/marker/ImplicitCall.java
+++ b/rewrite-ruby/src/main/java/org/openrewrite/ruby/marker/ImplicitCall.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.ruby.marker;
+
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.marker.Marker;
+
+import java.util.UUID;
+
+/**
+ * {@code Foo.(a)} is shorthand for {@code Foo.call(a)}, written with the message elided.
+ */
+@Value
+@With
+public class ImplicitCall implements Marker {
+    UUID id;
+}

--- a/rewrite-ruby/src/test/java/org/openrewrite/ruby/tree/HashTest.java
+++ b/rewrite-ruby/src/test/java/org/openrewrite/ruby/tree/HashTest.java
@@ -156,4 +156,17 @@ public class HashTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void hashKey() {
+        rewriteRun(
+          ruby(
+            """
+              expect(metrics[0].data).to eq({} => 0)
+              expect(metrics[0].data).to eq({a: 1} => 0)
+              x = {{} => 0}
+              """
+          )
+        );
+    }
 }

--- a/rewrite-ruby/src/test/java/org/openrewrite/ruby/tree/MethodInvocationTest.java
+++ b/rewrite-ruby/src/test/java/org/openrewrite/ruby/tree/MethodInvocationTest.java
@@ -80,6 +80,57 @@ public class MethodInvocationTest implements RewriteTest {
     }
 
     @Test
+    void callSugar() {
+        rewriteRun(
+          ruby(
+            """
+              Sweep.()
+              MarkForToken.(t)
+              MarkForToken.(t, 1)
+              obj&.()
+              """
+          )
+        );
+    }
+
+    @Test
+    void callSugarWithBlock() {
+        rewriteRun(
+          ruby(
+            """
+              Sweep.() { |a| a }
+              """
+          )
+        );
+    }
+
+    @Test
+    void explicitCall() {
+        rewriteRun(
+          ruby(
+            """
+              Sweep.call()
+              Sweep.call
+              MarkForToken.call(t)
+              """
+          )
+        );
+    }
+
+    @Test
+    void colon2Call() {
+        rewriteRun(
+          ruby(
+            """
+              Nokogiri::XML(response.body)
+              WEBrick::Log::new(log_path)
+              Integer::sqrt(9)
+              """
+          )
+        );
+    }
+
+    @Test
     void noParens() {
         rewriteRun(
           ruby(


### PR DESCRIPTION
## What's changed

Three ways of writing a Ruby call parsed fine but printed back as a *different, canonical* spelling of the same call. `Parser.requirePrintEqualsInput` then rejected the file and it was dropped as a parse error. The shared root cause is the printer normalizing Ruby call syntax rather than preserving what the source actually wrote — in each case Prism reports the desugared call and the printer wrote that out.

### `Foo.()` printed as `Foo.call()`

`.()` is sugar for `.call()`, and Prism names the call `call` either way. A new `ImplicitCall` marker records that the message was elided, and `RubyPrinter` omits it. The one nuance: if a recipe has since renamed the method, the new name does have to be written out, so the printer only elides while the name is still `call`.

```ruby
User::ReputationToken.all.find_each { |t| User::ReputationPeriod::MarkForToken.(t) }
User::ReputationPeriod::Sweep.()
```

### `Foo::method()` printed as `Foo.method()`

Ruby permits `::` as a method-call delimiter, not only as constant scope resolution. The `Colon2` marker was already parsed and already honoured for ordinary invocations — `J.NewClass` just never consulted it, so only the `::new` form was affected.

```ruby
WEBrick::Log::new(log_path)   # was: WEBrick::Log.new(log_path)
```

### Cursor desync on `eq({} => 0)`

```
java.lang.IllegalStateException: Cursor desync in <file>: expected to be at offset 835
  (start of AssocNode) but was at 836
```

A brace-less hash whose first key is itself a hash also starts with `{`, and that brace was consumed as if it opened the outer hash. The brace only belongs to the hash when it sits ahead of the first pair.

## Impact

Found empirically by building a corpus of 105 real Rails applications. The first case alone accounted for roughly 85% of all Ruby parse errors across that corpus and also affects discourse, gumroad, both Basecamp apps, cyberark/conjur, diaspora and dradis-ce. Measured with `RubyCorpusTest` on `exercism/website`:

| | files | parsed | failed |
|---|---|---|---|
| before | 2826 | 1762 (62.3%) | 1064 |
| after | 2826 | 2825 (100.0%) | 1 |

The one remaining failure is `scripts/setup_part_2.rb`, which Prism itself rejects as a syntax error.

The three real-world files that produced these reports — `exercism/website/test/test_helper.rb`, `alphagov/e-petitions/features/support/ssl_server.rb` and `alphagov/email-alert-api/spec/lib/collectors/global_prometheus_collector_spec.rb` — all parse and round-trip.

## Tests

`MethodInvocationTest#callSugar`, `#callSugarWithBlock`, `#explicitCall`, `#colon2Call` and `HashTest#hashKey`, all asserting the source round-trips unchanged. `explicitCall` pins the explicitly-written `.call` form so eliding the message can't overreach. Full `:rewrite-ruby:test` is green (452 tests).
