### PR TITLE
Send `FileAttributes` timestamps as ISO-8601 strings

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/FileAttributes.java
+++ b/rewrite-core/src/main/java/org/openrewrite/FileAttributes.java
@@ -53,9 +53,9 @@ public class FileAttributes implements RpcCodec<FileAttributes> {
         if (Files.exists(path)) {
             try {
                 BasicFileAttributes basicFileAttributes = Files.readAttributes(path, BasicFileAttributes.class);
-                return new FileAttributes(ZonedDateTime.from(basicFileAttributes.creationTime().toInstant().atZone(ZoneId.systemDefault())),
-                        ZonedDateTime.from(basicFileAttributes.lastAccessTime().toInstant().atZone(ZoneId.systemDefault())),
-                        ZonedDateTime.from(basicFileAttributes.lastModifiedTime().toInstant().atZone(ZoneId.systemDefault())),
+                return new FileAttributes(basicFileAttributes.creationTime().toInstant().atZone(ZoneId.systemDefault()),
+                        basicFileAttributes.lastModifiedTime().toInstant().atZone(ZoneId.systemDefault()),
+                        basicFileAttributes.lastAccessTime().toInstant().atZone(ZoneId.systemDefault()),
                         Files.isReadable(path),
                         Files.isWritable(path),
                         Files.isExecutable(path),
@@ -65,23 +65,31 @@ public class FileAttributes implements RpcCodec<FileAttributes> {
         return null;
     }
 
+    /**
+     * Timestamps travel as ISO-8601 strings; the wire mapper writes a raw {@link ZonedDateTime}
+     * as an epoch number, dropping the zone and nanos. Field order is the protocol; peers mirror it.
+     */
     @Override
     public void rpcSend(FileAttributes after, RpcSendQueue q) {
-        q.getAndSend(after, FileAttributes::getCreationTime);
-        q.getAndSend(after, FileAttributes::getLastModifiedTime);
-        q.getAndSend(after, FileAttributes::getLastAccessTime);
+        q.getAndSend(after, a -> iso(a.getCreationTime()));
+        q.getAndSend(after, a -> iso(a.getLastModifiedTime()));
+        q.getAndSend(after, a -> iso(a.getLastAccessTime()));
         q.getAndSend(after, FileAttributes::isReadable);
         q.getAndSend(after, FileAttributes::isWritable);
         q.getAndSend(after, FileAttributes::isExecutable);
         q.getAndSend(after, FileAttributes::getSize);
     }
 
+    private static @Nullable String iso(@Nullable ZonedDateTime time) {
+        return time == null ? null : time.toString();
+    }
+
     @Override
     public FileAttributes rpcReceive(FileAttributes before, RpcReceiveQueue q) {
         return before
-                .withCreationTime(q.receive(before.getCreationTime()))
-                .withLastModifiedTime(q.receive(before.getLastModifiedTime()))
-                .withLastAccessTime(q.receive(before.getLastAccessTime()))
+                .withCreationTime(q.receiveAndGet(before.getCreationTime(), (String iso) -> ZonedDateTime.parse(iso)))
+                .withLastModifiedTime(q.receiveAndGet(before.getLastModifiedTime(), (String iso) -> ZonedDateTime.parse(iso)))
+                .withLastAccessTime(q.receiveAndGet(before.getLastAccessTime(), (String iso) -> ZonedDateTime.parse(iso)))
                 .withReadable(q.receive(before.isReadable()))
                 .withWritable(q.receive(before.isWritable()))
                 .withExecutable(q.receive(before.isExecutable()))

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -245,7 +245,11 @@ public class RpcSendQueue {
         @Override
         protected @Nullable String computeValue(Class<?> afterType) {
             Package pkg = afterType.getPackage();
-            if (afterType.isPrimitive() || afterType.isArray() || (pkg != null && pkg.getName().startsWith("java.lang")) ||
+            String pkgName = pkg == null ? "" : pkg.getName();
+            if (afterType.isPrimitive() || afterType.isArray() || pkgName.startsWith("java.lang") ||
+                // JDK value types have no codec on either side, so a valueType only buys the
+                // receiver a bogus Objenesis instance it discards. Send them as scalars.
+                pkgName.startsWith("java.time") || pkgName.startsWith("java.math") ||
                 afterType.equals(UUID.class) || Iterable.class.isAssignableFrom(afterType) ||
                 Map.class.isAssignableFrom(afterType)) {
                 // A plain Map (like a Collection) is serialized structurally and needs no

--- a/rewrite-core/src/test/java/org/openrewrite/FileAttributesTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/FileAttributesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FileAttributesTest {
+
+    @Test
+    void fromPathAssignsTimestampsInConstructorOrder(@TempDir Path tempDir) throws IOException {
+        Path file = Files.writeString(tempDir.resolve("hello.txt"), "hello");
+        FileTime modified = FileTime.from(Instant.parse("2020-01-02T03:04:05Z"));
+        FileTime accessed = FileTime.from(Instant.parse("2021-06-07T08:09:10Z"));
+        requireNonNull(Files.getFileAttributeView(file, BasicFileAttributeView.class)).setTimes(modified, accessed, null);
+
+        FileAttributes attributes = requireNonNull(FileAttributes.fromPath(file));
+
+        assertThat(requireNonNull(attributes.getLastModifiedTime()).toInstant()).isEqualTo(modified.toInstant());
+        assertThat(requireNonNull(attributes.getLastAccessTime()).toInstant()).isEqualTo(accessed.toInstant());
+    }
+}

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RpcReceiveQueueTest.java
@@ -27,8 +27,11 @@ import org.openrewrite.marker.Markers;
 import org.openrewrite.text.PlainText;
 
 import java.nio.file.Path;
+import java.time.ZonedDateTime;
 import java.util.*;
 
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -149,6 +152,29 @@ class RpcReceiveQueueTest {
                 .writerFor(new TypeReference<Map<String, String>>() {})
                 .writeValueAsString(after))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void fileAttributeTimestampsTravelAsStrings() {
+        ZonedDateTime created = ZonedDateTime.parse("2026-08-16T10:15:30.123456789+02:00[Europe/Berlin]");
+        FileAttributes before = new FileAttributes(created, created.plusHours(1), created.plusHours(2),
+          true, true, false, 100);
+
+        sq.send(before, null, null);
+
+        // A raw ZonedDateTime is written as a bare epoch number and arrives as a Double -- a CCE
+        // in rpcReceive, and even coerced it would have lost the zone and the nanos below.
+        List<RpcObjectData> timestamps = batches.stream().flatMap(List::stream).collect(toList()).subList(1, 4);
+        assertThat(timestamps).allSatisfy(data -> {
+            assertThat(data.getValueType()).isNull();
+            assertThat((Object) data.getValue()).isInstanceOf(String.class);
+        });
+
+        FileAttributes after = rq.receive(null);
+        assertThat(after).isEqualTo(before);
+        assertThat(after.getCreationTime()).isEqualTo(created);
+        assertThat(requireNonNull(after.getCreationTime()).getZone()).isEqualTo(created.getZone());
+        assertThat(after.getCreationTime().getNano()).isEqualTo(123456789);
     }
 
     @Test

--- a/rewrite-csharp/csharp/OpenRewrite/Core/FileAttributes.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/FileAttributes.cs
@@ -19,7 +19,7 @@ namespace OpenRewrite.Core;
 
 /// <summary>
 /// Represents file attributes. Mirrors org.openrewrite.FileAttributes.
-/// Time fields are stored as opaque objects to round-trip Java's ZonedDateTime.
+/// Time fields are stored as opaque objects to round-trip the ISO-8601 strings Java sends.
 /// </summary>
 public sealed class FileAttributes(
     object? creationTime,

--- a/rewrite-javascript/rewrite/src/tree.ts
+++ b/rewrite-javascript/rewrite/src/tree.ts
@@ -124,9 +124,10 @@ export interface Checksum {
 
 export interface FileAttributes {
     kind: typeof TreeKind.FileAttributes
-    readonly creationDate?: Date
-    readonly lastModifiedTime?: Date
-    readonly lastAccessTime?: Date
+    // ISO-8601, as sent by org.openrewrite.FileAttributes#rpcSend
+    readonly creationDate?: string
+    readonly lastModifiedTime?: string
+    readonly lastAccessTime?: string
     readonly isReadable: boolean
     readonly isWritable: boolean
     readonly isExecutable: boolean


### PR DESCRIPTION
`FileAttributes` could not survive an RPC round trip with non-null timestamps. Three things composed:

1. `FileAttributes#rpcSend` passed raw `ZonedDateTime`s to the queue.
2. `RpcSendQueue#getValueType` excludes `java.lang.*`, `UUID` and collections, but not `java.time` — so each timestamp went out as `valueType: "java.time.ZonedDateTime"`.
3. The wire mapper in `io.moderne.jsonrpc`'s `JsonMessageFormatter` registers `JavaTimeModule` but never disables `WRITE_DATES_AS_TIMESTAMPS`.

The JSON is therefore a bare number, and `RpcObjectData#getValue()` only re-maps when the value is a `Map`, so a `Double` came back raw → `ClassCastException` in `FileAttributes#rpcReceive`.

Reaching for `q.receiveAndGet` alone would not have fixed it: a double cannot hold nanosecond epoch precision, and the timestamp form drops the zone id. That would have corrupted silently instead of crashing.

## The fix

Timestamps travel as **ISO-8601 strings**, following the existing `UUID` precedent — excluded from `valueType`, sent as a string, rebuilt with `receiveAndGet` — and mirroring how `RecipeThatMadeChanges` ships its `Duration` as millis.

Peer impact is nil-to-small. The message *count* is unchanged, so no peer's queue framing moves:

| peer | change |
|---|---|
| C# | none — `FileAttributes` already stores the time fields as `object?` to round-trip them opaquely (comment updated) |
| TypeScript | the three fields were declared `Date` but have always held the raw JSON value at runtime, so the declared type was wrong today; corrected to `string` |
| Go, Python | none — neither models the payload |

## Riding along

- **Pre-existing bug**, unrelated to RPC: `FileAttributes#fromPath` passed `(creationTime, lastAccessTime, lastModifiedTime)` into a constructor declared `(creationTime, lastModifiedTime, lastAccessTime)` — the last two were swapped for **every file parsed from disk**.
- `getValueType` now also excludes `java.time` and `java.math`. Neither has a codec on either side, so a `valueType` only buys the receiver a bogus Objenesis instance that it immediately discards. A grep confirms nothing else currently sends either package over the queue, so this is purely a guardrail against a future JDK value type repeating this.

## Why this was never caught

`RpcReceiveQueueTest`'s only `FileAttributes` fixture constructs it with all-null timestamps, so the codec's interesting path never ran. The new tests:

- `RpcReceiveQueueTest#fileAttributeTimestampsTravelAsStrings` — a **non-null** zoned timestamp with nanoseconds; asserts the wire value is a `String` with no `valueType`, and that the zone id and nanos survive the round trip.
- `FileAttributesTest#fromPathAssignsTimestampsInConstructorOrder` — sets distinct mtime/atime via `BasicFileAttributeView#setTimes` so the swap is observable.

Both were confirmed to fail against the previous behavior before being kept.
