### PR TITLE
Consume a source file’s `fileAttributes` sub-fields in Go and Python

### DIFF
--- a/rewrite-go/pkg/rpc/file_attributes_rpc_test.go
+++ b/rewrite-go/pkg/rpc/file_attributes_rpc_test.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"strings"
+	"testing"
+)
+
+const fileAttributesType = "org.openrewrite.FileAttributes"
+
+// A source file's fileAttributes is a codec field, not a marker, so it arrives as a typed ADD
+// followed by one message per sub-field. Consuming only the ADD leaves the rest to be read as
+// whatever field comes next.
+func TestReceiveFileAttributesConsumesEverySubField(t *testing.T) {
+	valueType := fileAttributesType
+	q := queueOf(
+		RpcObjectData{State: Add, ValueType: &valueType},
+		RpcObjectData{State: Add, Value: "2026-08-16T10:15:30.123456789+02:00[Europe/Berlin]"},
+		RpcObjectData{State: NoChange},
+		RpcObjectData{State: NoChange},
+		RpcObjectData{State: Add, Value: true},
+		RpcObjectData{State: Add, Value: true},
+		RpcObjectData{State: Add, Value: false},
+		RpcObjectData{State: Add, Value: float64(42)},
+		RpcObjectData{State: Add, Value: "the next field"},
+	)
+
+	receiveFileAttributes(q)
+
+	if got := q.Receive(nil, nil); got != "the next field" {
+		t.Fatalf("next field after fileAttributes = %v, want %q", got, "the next field")
+	}
+}
+
+// A null fileAttributes is a single NO_CHANGE with no sub-fields, so the drain must not run.
+func TestReceiveFileAttributesNoChangeConsumesOneMessage(t *testing.T) {
+	q := queueOf(
+		RpcObjectData{State: NoChange},
+		RpcObjectData{State: Add, Value: "the next field"},
+	)
+
+	receiveFileAttributes(q)
+
+	if got := q.Receive(nil, nil); got != "the next field" {
+		t.Fatalf("next field after fileAttributes = %v, want %q", got, "the next field")
+	}
+}
+
+func TestReceiveChecksumConsumesEverySubField(t *testing.T) {
+	valueType := "org.openrewrite.Checksum"
+	q := queueOf(
+		RpcObjectData{State: Add, ValueType: &valueType},
+		RpcObjectData{State: Add, Value: "SHA-256"},
+		RpcObjectData{State: Add, Value: "cafebabe"},
+		RpcObjectData{State: Add, Value: "the next field"},
+	)
+
+	receiveChecksum(q)
+
+	if got := q.Receive(nil, nil); got != "the next field" {
+		t.Fatalf("next field after checksum = %v, want %q", got, "the next field")
+	}
+}
+
+// Go used to answer a typed ADD it had no codec for by returning the shell and consuming
+// nothing, so the sub-fields were read as later fields and the tree came out quietly wrong.
+func TestReceiveWithoutCodecPanicsRatherThanDesyncing(t *testing.T) {
+	valueType := fileAttributesType
+	q := queueOf(RpcObjectData{State: Add, ValueType: &valueType})
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("want a panic naming the missing codec, got none")
+		}
+		if msg, ok := r.(string); !ok || !strings.Contains(msg, "no RPC codec registered on the Go side") {
+			t.Fatalf("panic = %v, want the missing-codec diagnostic", r)
+		}
+	}()
+
+	q.Receive(nil, nil)
+}

--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -80,8 +80,8 @@ func (r *GoReceiver) receiveParseError(pe *java.ParseError, q *ReceiveQueue) *ja
 	pe.SourcePath = receiveScalar[string](q, pe.SourcePath)
 	pe.CharsetName = receiveScalar[string](q, pe.CharsetName)
 	pe.CharsetBomMarked = receiveScalar[bool](q, pe.CharsetBomMarked)
-	q.Receive(nil, nil) // checksum
-	q.Receive(nil, nil) // fileAttributes
+	receiveChecksum(q)
+	receiveFileAttributes(q)
 	pe.Text = receiveScalar[string](q, pe.Text)
 	return pe
 }
@@ -93,23 +93,8 @@ func (r *GoReceiver) VisitCompilationUnit(cu *golang.CompilationUnit, p any) jav
 	cu.SourcePath = receiveScalar[string](q, cu.SourcePath)
 	q.Receive(nil, nil) // charset
 	q.Receive(nil, nil) // charsetBomMarked
-	// checksum — Checksum.rpcSend sends: algorithm (string), value (byte[])
-	q.Receive(nil, func(v any) any {
-		receiveScalar[string](q, "") // algorithm
-		q.Receive(nil, nil)          // value
-		return nil
-	})
-	// fileAttributes — FileAttributes.rpcSend sends 7 sub-fields
-	q.Receive(nil, func(v any) any {
-		q.Receive(nil, nil) // creationTime
-		q.Receive(nil, nil) // lastModifiedTime
-		q.Receive(nil, nil) // lastAccessTime
-		q.Receive(nil, nil) // isReadable
-		q.Receive(nil, nil) // isWritable
-		q.Receive(nil, nil) // isExecutable
-		q.Receive(nil, nil) // size
-		return nil
-	})
+	receiveChecksum(q)
+	receiveFileAttributes(q)
 	// packageDecl
 	var beforePkgDecl any
 	if cu.PackageDecl != nil {

--- a/rewrite-go/pkg/rpc/gomod_codec.go
+++ b/rewrite-go/pkg/rpc/gomod_codec.go
@@ -127,8 +127,8 @@ func receiveGoMod(gm *golang.GoMod, q *ReceiveQueue) *golang.GoMod {
 	gm.SourcePath = receiveScalar[string](q, gm.SourcePath)
 	gm.Charset = receiveScalar[string](q, gm.Charset)
 	gm.CharsetBomMarked = receiveScalar[bool](q, gm.CharsetBomMarked)
-	q.Receive(nil, nil) // checksum
-	q.Receive(nil, nil) // fileAttributes
+	receiveChecksum(q)
+	receiveFileAttributes(q)
 	gm.Statements = recvGoModStmtList(q, gm.Statements)
 	gm.Eof = recvGoModSpace(q, gm.Eof)
 	return gm

--- a/rewrite-go/pkg/rpc/gosum_codec.go
+++ b/rewrite-go/pkg/rpc/gosum_codec.go
@@ -80,8 +80,8 @@ func receiveGoSum(gs *golang.GoSum, q *ReceiveQueue) *golang.GoSum {
 	gs.SourcePath = receiveScalar[string](q, gs.SourcePath)
 	gs.Charset = receiveScalar[string](q, gs.Charset)
 	gs.CharsetBomMarked = receiveScalar[bool](q, gs.CharsetBomMarked)
-	q.Receive(nil, nil) // checksum
-	q.Receive(nil, nil) // fileAttributes
+	receiveChecksum(q)
+	receiveFileAttributes(q)
 	gs.Lines = recvGoSumLineList(q, gs.Lines)
 	gs.Eof = recvGoModSpace(q, gs.Eof)
 	return gs

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -125,17 +125,26 @@ func (q *ReceiveQueue) Receive(before any, onChange func(any) any) any {
 			before = newObj(*msg.ValueType)
 		}
 		before = hydrateGenericMarker(before, msg.Value)
+		// The remote inlines a value only when it has no codec for the type, so a typed ADD with
+		// no value means sub-field messages follow. Anything that reaches a branch below without
+		// consuming them leaves the queue desynchronized, and Go is the one peer where that used
+		// to happen silently — every other receiver already fails loudly here.
+		codecExpected := msg.State == Add && msg.ValueType != nil && msg.Value == nil
 		var after any
 		if onChange != nil {
 			after = onChange(before)
 		} else if !isNilValue(before) && getValueType(before) != nil {
 			if t, ok := before.(java.Tree); ok {
 				after = defaultReceiver.Visit(t, q)
+			} else if codecExpected {
+				panic(missingCodec(*msg.ValueType))
 			} else {
 				after = before
 			}
 		} else if msg.Value != nil {
 			after = msg.Value
+		} else if codecExpected {
+			panic(missingCodec(*msg.ValueType))
 		} else {
 			after = before
 		}
@@ -150,6 +159,12 @@ func (q *ReceiveQueue) Receive(before any, onChange func(any) any) any {
 	default:
 		panic(fmt.Sprintf("unsupported state: %v", msg.State))
 	}
+}
+
+func missingCodec(valueType string) string {
+	return fmt.Sprintf("no RPC codec registered on the Go side for %q. "+
+		"The remote side has a codec and sent property messages that will not be consumed, "+
+		"causing RPC queue desynchronization.", valueType)
 }
 
 // hydrateGenericMarker applies a message's inline data map to a codec-less

--- a/rewrite-go/pkg/rpc/space_rpc.go
+++ b/rewrite-go/pkg/rpc/space_rpc.go
@@ -127,6 +127,34 @@ func SendMarkersCodec(m java.Markers, q *SendQueue) {
 		func(v any) { sendMarkerCodecFields(v, q) })
 }
 
+// fileAttributesFields is the field order org.openrewrite.FileAttributes#rpcSend uses, and the
+// number of sub-field messages it emits. Both the marker path and the source-file field path
+// (see receiveFileAttributes) depend on it.
+var fileAttributesFields = []string{"creationTime", "lastModifiedTime", "lastAccessTime",
+	"isReadable", "isWritable", "isExecutable", "size"}
+
+// receiveFileAttributes consumes the sub-fields of a source file's fileAttributes and discards
+// them. No Go tree models file attributes, and because the send side reports NO_CHANGE for the
+// field, the peer keeps its own value rather than having it overwritten with an empty one.
+func receiveFileAttributes(q *ReceiveQueue) {
+	q.Receive(nil, func(any) any {
+		for range fileAttributesFields {
+			q.Receive(nil, nil)
+		}
+		return nil
+	})
+}
+
+// receiveChecksum consumes the two sub-fields org.openrewrite.Checksum#rpcSend emits, on the
+// same terms as receiveFileAttributes.
+func receiveChecksum(q *ReceiveQueue) {
+	q.Receive(nil, func(any) any {
+		q.Receive(nil, nil) // algorithm
+		q.Receive(nil, nil) // value
+		return nil
+	})
+}
+
 // hasGenericMarkerCodec reports whether sendMarkerCodecFields will dispatch
 // sub-field messages for a java.GenericMarker with the given Java FQN.
 // Markers not listed here have no RpcCodec on either side and must travel
@@ -233,7 +261,7 @@ func sendMarkerCodecFields(v any, q *SendQueue) {
 				return nil
 			}, nil)
 		case "org.openrewrite.FileAttributes":
-			for _, key := range []string{"creationTime", "lastModifiedTime", "lastAccessTime", "isReadable", "isWritable", "isExecutable", "size"} {
+			for _, key := range fileAttributesFields {
 				k := key
 				q.GetAndSend(m, func(_ any) any {
 					if d != nil {
@@ -503,7 +531,7 @@ func receiveMarkersCodec(q *ReceiveQueue, before java.Markers) java.Markers {
 				}
 			case "org.openrewrite.FileAttributes":
 				m.Data = map[string]any{}
-				for _, key := range []string{"creationTime", "lastModifiedTime", "lastAccessTime", "isReadable", "isWritable", "isExecutable", "size"} {
+				for _, key := range fileAttributesFields {
 					m.Data[key] = q.Receive(nil, nil)
 				}
 			case "org.openrewrite.marker.Markup$Error",

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -18,6 +18,7 @@ Python RPC Receiver that mirrors Java's PythonReceiver structure.
 This uses the visitor pattern with pre_visit handling common fields (id, prefix, markers)
 and type-specific visit methods handling only additional fields.
 """
+from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Optional, Type, TypeVar
@@ -991,6 +992,51 @@ def _register_marker_codecs():
         _receive_omit_parentheses,
         lambda: OmitParentheses(random_id()),
         _send_omit_parentheses
+    )
+
+
+def _register_file_attributes_codec():
+    """A source file's ``file_attributes`` is a codec field on the Java side, so it arrives as a
+    typed ADD followed by one message per sub-field. Consuming only the ADD leaves the rest to be
+    read as whatever field comes next.
+
+    The sub-fields are consumed and discarded rather than parsed. Java sends timestamps with
+    nanosecond precision and a zone id; ``datetime`` holds neither, so keeping the value would
+    degrade it and then hand the degraded form back on the return leg. Discarding leaves
+    ``file_attributes`` at None, which the sender reports as NO_CHANGE, so the peer keeps its own.
+    """
+    from rewrite.tree import FileAttributes
+    from rewrite.rpc.receive_queue import register_codec_with_both_names
+    from rewrite.rpc.send_queue import RpcSendQueue
+
+    def _local_iso(value: Optional[datetime]) -> Optional[str]:
+        # Java's FileAttributes.fromPath stamps the system zone, so a naive datetime (what
+        # FileAttributes.from_path builds) has to acquire one or ZonedDateTime.parse rejects it.
+        if value is None:
+            return None
+        return (value if value.tzinfo else value.astimezone()).isoformat()
+
+    def _receive_file_attributes(_attrs: FileAttributes, q: RpcReceiveQueue) -> None:
+        for _field in ('creation_time', 'last_modified_time', 'last_access_time',
+                       'is_readable', 'is_writable', 'is_executable', 'size'):
+            q.receive(None)
+        return None
+
+    def _send_file_attributes(attrs: FileAttributes, q: RpcSendQueue) -> None:
+        q.get_and_send(attrs, lambda a: _local_iso(a.creation_time))
+        q.get_and_send(attrs, lambda a: _local_iso(a.last_modified_time))
+        q.get_and_send(attrs, lambda a: _local_iso(a.last_access_time))
+        q.get_and_send(attrs, lambda a: a.is_readable)
+        q.get_and_send(attrs, lambda a: a.is_writable)
+        q.get_and_send(attrs, lambda a: a.is_executable)
+        q.get_and_send(attrs, lambda a: a.size)
+
+    register_codec_with_both_names(
+        'org.openrewrite.FileAttributes',
+        FileAttributes,
+        _receive_file_attributes,
+        lambda: FileAttributes(None, None, None, False, False, False, 0),
+        _send_file_attributes
     )
 
 
@@ -2124,4 +2170,5 @@ _register_style_codecs()
 _register_parse_error_codec()  # ParseError handling
 _register_python_marker_codecs()  # Python-specific markers including PrintSyntax, ExecSyntax
 _register_python_resolution_result_codecs()  # PythonResolutionResult and nested types
+_register_file_attributes_codec()  # Consumes the source-file fileAttributes sub-fields
 _register_execution_context_codec()

--- a/rewrite-python/rewrite/tests/rpc/test_file_attributes_wire.py
+++ b/rewrite-python/rewrite/tests/rpc/test_file_attributes_wire.py
@@ -1,0 +1,60 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A source file's fileAttributes is a codec field, so it arrives as a typed ADD followed by one
+message per sub-field. Consuming only the ADD leaves the rest to be read as later fields."""
+import rewrite.rpc.python_receiver  # noqa: F401  (registers the codec under test)
+from rewrite.rpc.receive_queue import RpcReceiveQueue
+
+_FILE_ATTRIBUTES = 'org.openrewrite.FileAttributes'
+
+
+def _queue(batch):
+    remaining = batch[:]
+
+    def pull():
+        out = remaining[:]
+        remaining.clear()
+        return out
+
+    return RpcReceiveQueue({}, None, pull)
+
+
+def test_file_attributes_consumes_every_sub_field():
+    q = _queue([
+        {'state': 'ADD', 'valueType': _FILE_ATTRIBUTES},
+        {'state': 'ADD', 'value': '2026-08-16T10:15:30.123456789+02:00[Europe/Berlin]'},
+        {'state': 'NO_CHANGE'},
+        {'state': 'NO_CHANGE'},
+        {'state': 'ADD', 'value': True},
+        {'state': 'ADD', 'value': True},
+        {'state': 'ADD', 'value': False},
+        {'state': 'ADD', 'value': 42},
+        {'state': 'ADD', 'value': 'the next field'},
+    ])
+
+    # Discarded rather than parsed: datetime holds neither Java's nanoseconds nor its zone id,
+    # so keeping the value would only degrade it (see _register_file_attributes_codec).
+    assert q.receive(None) is None
+    assert q.receive(None) == 'the next field'
+
+
+def test_null_file_attributes_consumes_one_message():
+    q = _queue([
+        {'state': 'NO_CHANGE'},
+        {'state': 'ADD', 'value': 'the next field'},
+    ])
+
+    assert q.receive(None) is None
+    assert q.receive(None) == 'the next field'


### PR DESCRIPTION
- > Stacked on #8511 — review that one first; the diff here is the second commit. The Python send codec emits the ISO-8601 form #8511 introduces. The Go side is independent of it.

`FileAttributes` implements `RpcCodec`, so it crosses the wire as a typed ADD followed by **one message per sub-field**. Four receivers consumed only the ADD and then read the seven that followed as whatever field came next.

## Go had it right in exactly one place

| site | consumed | should consume |
|---|---|---|
| `go_receiver.go` `VisitCompilationUnit` | 1 + 7 ✅ | 1 + 7 |
| `go_receiver.go` `receiveParseError` | 1 ❌ | 1 + 7 |
| `gomod_codec.go` | 1 ❌ | 1 + 7 |
| `gosum_codec.go` | 1 ❌ | 1 + 7 |

The CU path drains all seven behind an explicit comment; the other three did a bare `q.Receive(nil, nil)`. The same split applied to `checksum` and its two sub-fields.

Both drains are now shared helpers (`receiveFileAttributes`, `receiveChecksum`) used by all four sites, and the seven-field list is single-sourced with the marker path that already depended on it — Go's `hasGenericMarkerCodec` has handled `org.openrewrite.FileAttributes` as a *marker* for a while; it was only the source-file *field* that was wrong.

Python consumed one message with no codec registered at all.

## Python still doesn't model the payload, on purpose

Java sends timestamps with nanosecond precision and a zone id. `datetime` holds neither:

```
>>> datetime.fromisoformat('2026-08-16T10:15:30.123456789+02:00[Europe/Berlin]')
ValueError: Invalid isoformat string
>>> datetime.fromisoformat('2026-08-16T10:15:30.123456789+02:00')
datetime(2026, 8, 16, 10, 15, 30, 123456, ...)   # 789ns gone
```

Parsing it would degrade the value and then hand the degraded form back on the return leg, quietly overwriting the peer's good one. Discarding leaves `file_attributes` at None, which the sender reports as NO_CHANGE, so the peer keeps its own. The comment in the codec says so, to stop someone "finishing the job" later.

The Python **send** codec is real, for the direction where Python owns the data — including attaching the system zone to the naive `datetime` that `FileAttributes.from_path` builds, since `ZonedDateTime.parse` rejects an offset-less string.

## Go gets the missing-codec guard

A typed ADD with no inline value means sub-field messages follow. If nothing consumes them the queue is desynchronized — and Go was the only peer that answered by returning the shell and carrying on. Java, TypeScript, C# and Python have all failed loudly here for a while; Go now panics with the same diagnostic.

Two branches needed it, not one: a `GenericMarker` shell reaches a different arm than a bare typed value, and both fell through to `after = before`.

## Was any of this live?

Not that I can find. It needs Java to hold a Go/Py source file with non-null attributes, and those trees originate from the peers themselves, which send `nil`/`None`; the CLI's V3 format early-returns on null, so null round-trips as null; and the `FileAttributes.fromPath` calls in `GoRewriteRpc`/`PythonRewriteRpc` attach attributes only to `Quark`, which is in neither peer's advertised language list.

So this is a latent bug resting on a thin, undocumented invariant — with Go positioned to fail silently the moment it broke. The guard is the part that makes that no longer possible.

## Verification

Adding the guard surfaced **no other** latent under-consumption, which is the main thing I wanted to learn from it: `go build`, `go vet`, the full Go unit suite, the Java↔Go integration suite, and all 2072 Python tests pass with it in place.

New tests, each confirmed to fail before the fix:

- `file_attributes_rpc_test.go` — asserts the drain lands on the *next* field, for both `fileAttributes` and `checksum`, plus the null case (one message, no drain), plus the guard panicking instead of desyncing.
- `test_file_attributes_wire.py` — the same drain assertion; without the codec it fails with *"No RPC codec registered on the Python side"*.
