### PR TITLE
Send Javadoc over RPC, and measure the RPC boundary

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -31,6 +31,8 @@ import lombok.Getter;
 import lombok.Setter;
 import org.jspecify.annotations.Nullable;
 
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -45,6 +47,7 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.openrewrite.internal.StringUtils.readFully;
 
@@ -82,6 +85,13 @@ public class RewriteRpcProcess extends Thread {
 
     @Nullable
     private Thread rssSamplerThread;
+
+    @Nullable
+    private Thread byteSamplerThread;
+
+    private final AtomicLong bytesOut = new AtomicLong();
+
+    private final AtomicLong bytesIn = new AtomicLong();
 
     @Nullable
     private IOException startupFailure;
@@ -227,8 +237,18 @@ public class RewriteRpcProcess extends Thread {
         module.addSerializer(Path.class, new PathSerializer());
         module.addDeserializer(Path.class, new PathDeserializer());
         JsonMessageFormatter formatter = new JsonMessageFormatter(module);
-        MessageHandler handler = new HeaderDelimitedMessageHandler(formatter,
-                process.getInputStream(), process.getOutputStream());
+
+        // Counting the framed streams is the only place a peer's real wire volume can be read.
+        // Off unless REWRITE_RPC_BYTES_MS is set, so the common path keeps the raw streams.
+        InputStream fromPeer = process.getInputStream();
+        OutputStream toPeer = process.getOutputStream();
+        if (System.getenv("REWRITE_RPC_BYTES_MS") != null) {
+            fromPeer = new CountingInputStream(fromPeer, bytesIn);
+            toPeer = new CountingOutputStream(toPeer, bytesOut);
+            startByteSampler();
+        }
+
+        MessageHandler handler = new HeaderDelimitedMessageHandler(formatter, fromPeer, toPeer);
         if (trace) {
             handler = new TraceMessageHandler("client", handler);
         }
@@ -239,6 +259,10 @@ public class RewriteRpcProcess extends Thread {
         if (rssSamplerThread != null) {
             rssSamplerThread.interrupt();
             rssSamplerThread = null;
+        }
+        if (byteSamplerThread != null) {
+            byteSamplerThread.interrupt();
+            byteSamplerThread = null;
         }
         if (shutdownHook != null) {
             try {
@@ -302,11 +326,8 @@ public class RewriteRpcProcess extends Thread {
         if (intervalMs <= 0) {
             return;
         }
-        long pid;
-        try {
-            // Process.pid() is Java 9+, but this module compiles at Java 8 source level.
-            pid = (long) Process.class.getMethod("pid").invoke(p);
-        } catch (Exception e) {
+        long pid = processPid(p);
+        if (pid < 0) {
             return;
         }
         Path rssCsv = dir.resolve("rpc-rss-" + pid + ".csv");
@@ -332,6 +353,119 @@ public class RewriteRpcProcess extends Thread {
         sampler.setDaemon(true);
         sampler.start();
         this.rssSamplerThread = sampler;
+    }
+
+    /**
+     * Samples cumulative wire volume in each direction, symmetric with {@link #startRssSampler()}.
+     * The framed streams are the only place a peer's real byte cost can be read; everything above
+     * them counts messages, which says nothing about how large those messages were. A final row is
+     * written once the peer exits, so a total is never lost between samples.
+     */
+    private void startByteSampler() {
+        String intervalEnv = System.getenv("REWRITE_RPC_BYTES_MS");
+        Path dir = workingDirectory;
+        Process p = process;
+        if (intervalEnv == null || dir == null || p == null) {
+            return;
+        }
+        long intervalMs;
+        try {
+            intervalMs = Long.parseLong(intervalEnv.trim());
+        } catch (NumberFormatException e) {
+            return;
+        }
+        if (intervalMs <= 0) {
+            return;
+        }
+        long pid = processPid(p);
+        if (pid < 0) {
+            return;
+        }
+        Path bytesCsv = dir.resolve("rpc-bytes-" + pid + ".csv");
+        Thread sampler = new Thread(() -> {
+            try (OutputStream out = Files.newOutputStream(bytesCsv,
+                    StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING)) {
+                out.write("timestamp_ms,bytes_out,bytes_in\n".getBytes());
+                out.flush();
+                try {
+                    while (p.isAlive() && !Thread.currentThread().isInterrupted()) {
+                        writeByteSample(out);
+                        Thread.sleep(intervalMs);
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                writeByteSample(out);
+            } catch (IOException ignored) {
+                // Best-effort profiling; never disturb the run.
+            }
+        }, "rpc-bytes-sampler");
+        sampler.setDaemon(true);
+        sampler.start();
+        this.byteSamplerThread = sampler;
+    }
+
+    private void writeByteSample(OutputStream out) throws IOException {
+        out.write((System.currentTimeMillis() + "," + bytesOut.get() + "," + bytesIn.get() + "\n").getBytes());
+        out.flush();
+    }
+
+    /** {@code Process.pid()} is Java 9+, but this module compiles at Java 8 source level. */
+    private static long processPid(Process p) {
+        try {
+            return (long) Process.class.getMethod("pid").invoke(p);
+        } catch (Exception e) {
+            return -1;
+        }
+    }
+
+    private static final class CountingInputStream extends FilterInputStream {
+        private final AtomicLong count;
+
+        CountingInputStream(InputStream in, AtomicLong count) {
+            super(in);
+            this.count = count;
+        }
+
+        @Override
+        public int read() throws IOException {
+            int b = super.read();
+            if (b != -1) {
+                count.incrementAndGet();
+            }
+            return b;
+        }
+
+        @Override
+        public int read(byte[] b, int off, int len) throws IOException {
+            int n = super.read(b, off, len);
+            if (n > 0) {
+                count.addAndGet(n);
+            }
+            return n;
+        }
+    }
+
+    private static final class CountingOutputStream extends FilterOutputStream {
+        private final AtomicLong count;
+
+        CountingOutputStream(OutputStream out, AtomicLong count) {
+            super(out);
+            this.count = count;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            out.write(b);
+            count.incrementAndGet();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            // FilterOutputStream's default loops a byte at a time; delegate the whole array.
+            out.write(b, off, len);
+            count.addAndGet(len);
+        }
     }
 
     /** Resident set size of {@code pid} in KiB via {@code ps} (macOS + Linux), or -1 on failure. */

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaReceiver.java
@@ -617,6 +617,8 @@ public class JavaReceiver extends JavaVisitor<RpcReceiveQueue> {
                                 .withText(q.receive(((TextComment) c).getText()))
                                 .withSuffix(q.receive(c.getSuffix()))
                                 .withMarkers(q.receive(c.getMarkers()));
+                    } else if (c instanceof Javadoc.DocComment) {
+                        return (Comment) new JavadocReceiver(this).visit((Javadoc.DocComment) c, q);
                     }
                     return c;
                 }))

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavaSender.java
@@ -635,11 +635,15 @@ public class JavaSender extends JavaVisitor<RpcSendQueue> {
                         TextComment tc = (TextComment) c;
                         q.getAndSend(tc, TextComment::isMultiline);
                         q.getAndSend(tc, TextComment::getText);
+                        q.getAndSend(c, Comment::getSuffix);
+                        q.getAndSend(c, Comment::getMarkers);
+                    } else if (c instanceof Javadoc.DocComment) {
+                        // A doc comment is a tree, so it is decomposed rather than inlined; its own
+                        // suffix and markers travel as part of that tree, not as Comment fields.
+                        new JavadocSender(this).visit((Javadoc.DocComment) c, q);
                     } else {
                         throw new IllegalArgumentException("Unexpected comment type " + c.getClass().getName());
                     }
-                    q.getAndSend(c, Comment::getSuffix);
-                    q.getAndSend(c, Comment::getMarkers);
                 });
         q.getAndSend(space, Space::getWhitespace);
     }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavadocReceiver.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavadocReceiver.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.rpc;
+
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.JavadocVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Javadoc;
+import org.openrewrite.rpc.RpcReceiveQueue;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Rebuilds a {@link Javadoc} tree from the stream {@link JavadocSender} produces. Field order here
+ * is the mirror of that sender and must stay in lockstep with it.
+ */
+class JavadocReceiver extends JavadocVisitor<RpcReceiveQueue> {
+
+    JavadocReceiver(JavaVisitor<RpcReceiveQueue> javaVisitor) {
+        super(javaVisitor);
+    }
+
+    @Override
+    public Javadoc preVisit(Javadoc javadoc, RpcReceiveQueue q) {
+        return javadoc
+                .withId(q.receiveAndGet(javadoc.getId(), UUID::fromString))
+                .withMarkers(q.receive(javadoc.getMarkers()));
+    }
+
+    @Override
+    public Javadoc visitAttribute(Javadoc.Attribute attribute, RpcReceiveQueue q) {
+        return attribute
+                .withName(q.receive(attribute.getName()))
+                .withSpaceBeforeEqual(receiveList(attribute.getSpaceBeforeEqual(), q))
+                .withValue(receiveList(attribute.getValue(), q));
+    }
+
+    @Override
+    public Javadoc visitAuthor(Javadoc.Author author, RpcReceiveQueue q) {
+        return author.withName(receiveList(author.getName(), q));
+    }
+
+    @Override
+    public Javadoc visitDeprecated(Javadoc.Deprecated deprecated, RpcReceiveQueue q) {
+        return deprecated.withDescription(receiveList(deprecated.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitDocComment(Javadoc.DocComment docComment, RpcReceiveQueue q) {
+        return docComment
+                .withBody(receiveList(docComment.getBody(), q))
+                .withSuffix(q.receive(docComment.getSuffix()));
+    }
+
+    @Override
+    public Javadoc visitDocRoot(Javadoc.DocRoot docRoot, RpcReceiveQueue q) {
+        return docRoot.withEndBrace(receiveList(docRoot.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitDocType(Javadoc.DocType docType, RpcReceiveQueue q) {
+        return docType.withText(receiveList(docType.getText(), q));
+    }
+
+    @Override
+    public Javadoc visitEndElement(Javadoc.EndElement endElement, RpcReceiveQueue q) {
+        return endElement
+                .withName(q.receive(endElement.getName()))
+                .withSpaceBeforeEndBracket(receiveList(endElement.getSpaceBeforeEndBracket(), q));
+    }
+
+    @Override
+    public Javadoc visitErroneous(Javadoc.Erroneous erroneous, RpcReceiveQueue q) {
+        return erroneous.withText(receiveList(erroneous.getText(), q));
+    }
+
+    @Override
+    public Javadoc visitHidden(Javadoc.Hidden hidden, RpcReceiveQueue q) {
+        return hidden.withBody(receiveList(hidden.getBody(), q));
+    }
+
+    @Override
+    public Javadoc visitIndex(Javadoc.Index index, RpcReceiveQueue q) {
+        return index
+                .withSearchTerm(receiveList(index.getSearchTerm(), q))
+                .withDescription(receiveList(index.getDescription(), q))
+                .withEndBrace(receiveList(index.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitInheritDoc(Javadoc.InheritDoc inheritDoc, RpcReceiveQueue q) {
+        return inheritDoc.withEndBrace(receiveList(inheritDoc.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitInlinedValue(Javadoc.InlinedValue inlinedValue, RpcReceiveQueue q) {
+        return inlinedValue
+                .withSpaceBeforeTree(receiveList(inlinedValue.getSpaceBeforeTree(), q))
+                .withTree(q.receive(inlinedValue.getTree(), t -> javaVisitorVisit(t, q)))
+                .withEndBrace(receiveList(inlinedValue.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitLineBreak(Javadoc.LineBreak lineBreak, RpcReceiveQueue q) {
+        return lineBreak.withMargin(q.receive(lineBreak.getMargin()));
+    }
+
+    @Override
+    public Javadoc visitLink(Javadoc.Link link, RpcReceiveQueue q) {
+        return link
+                .withPlain(q.receive(link.isPlain()))
+                .withSpaceBeforeTree(receiveList(link.getSpaceBeforeTree(), q))
+                .withTree(q.receive(link.getTree(), t -> javaVisitorVisit(t, q)))
+                .withTreeReference(q.receive(link.getTreeReference(), r -> (Javadoc.Reference) visit(r, q)))
+                .withLabel(receiveList(link.getLabel(), q))
+                .withEndBrace(receiveList(link.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitLiteral(Javadoc.Literal literal, RpcReceiveQueue q) {
+        return literal
+                .withCode(q.receive(literal.isCode()))
+                .withDescription(receiveList(literal.getDescription(), q))
+                .withEndBrace(receiveList(literal.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitParameter(Javadoc.Parameter parameter, RpcReceiveQueue q) {
+        return parameter
+                .withSpaceBeforeName(receiveList(parameter.getSpaceBeforeName(), q))
+                .withName(q.receive(parameter.getName(), n -> javaVisitorVisit(n, q)))
+                .withNameReference(q.receive(parameter.getNameReference(), r -> (Javadoc.Reference) visit(r, q)))
+                .withDescription(receiveList(parameter.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitProvides(Javadoc.Provides provides, RpcReceiveQueue q) {
+        return provides
+                .withSpaceBeforeServiceType(receiveList(provides.getSpaceBeforeServiceType(), q))
+                .withServiceType(q.receive(provides.getServiceType(), t -> javaVisitorVisit(t, q)))
+                .withDescription(receiveList(provides.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitReference(Javadoc.Reference reference, RpcReceiveQueue q) {
+        return reference
+                .withTree(q.receive(reference.getTree(), t -> javaVisitorVisit(t, q)))
+                .withLineBreaks(receiveList(reference.getLineBreaks(), q));
+    }
+
+    @Override
+    public Javadoc visitReturn(Javadoc.Return aReturn, RpcReceiveQueue q) {
+        return aReturn.withDescription(receiveList(aReturn.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitSee(Javadoc.See see, RpcReceiveQueue q) {
+        return see
+                .withSpaceBeforeTree(receiveList(see.getSpaceBeforeTree(), q))
+                .withTree(q.receive(see.getTree(), t -> javaVisitorVisit(t, q)))
+                .withTreeReference(q.receive(see.getTreeReference(), r -> (Javadoc.Reference) visit(r, q)))
+                .withReference(receiveList(see.getReference(), q));
+    }
+
+    @Override
+    public Javadoc visitSerial(Javadoc.Serial serial, RpcReceiveQueue q) {
+        return serial.withDescription(receiveList(serial.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitSerialData(Javadoc.SerialData serialData, RpcReceiveQueue q) {
+        return serialData.withDescription(receiveList(serialData.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitSerialField(Javadoc.SerialField serialField, RpcReceiveQueue q) {
+        return serialField
+                .withName(q.receive(serialField.getName(), n -> (J.Identifier) javaVisitorVisit(n, q)))
+                .withType(q.receive(serialField.getType(), t -> javaVisitorVisit(t, q)))
+                .withDescription(receiveList(serialField.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitSince(Javadoc.Since since, RpcReceiveQueue q) {
+        return since.withDescription(receiveList(since.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitSnippet(Javadoc.Snippet snippet, RpcReceiveQueue q) {
+        return snippet
+                .withAttributes(receiveList(snippet.getAttributes(), q))
+                .withContent(receiveList(snippet.getContent(), q))
+                .withEndBrace(receiveList(snippet.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitStartElement(Javadoc.StartElement startElement, RpcReceiveQueue q) {
+        return startElement
+                .withName(q.receive(startElement.getName()))
+                .withAttributes(receiveList(startElement.getAttributes(), q))
+                .withSelfClosing(q.receive(startElement.isSelfClosing()))
+                .withSpaceBeforeEndBracket(receiveList(startElement.getSpaceBeforeEndBracket(), q));
+    }
+
+    @Override
+    public Javadoc visitSummary(Javadoc.Summary summary, RpcReceiveQueue q) {
+        return summary
+                .withSummary(receiveList(summary.getSummary(), q))
+                .withBeforeBrace(receiveList(summary.getBeforeBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitText(Javadoc.Text text, RpcReceiveQueue q) {
+        return text.withText(q.receive(text.getText()));
+    }
+
+    @Override
+    public Javadoc visitThrows(Javadoc.Throws aThrows, RpcReceiveQueue q) {
+        return aThrows
+                .withThrowsKeyword(q.receive(aThrows.isThrowsKeyword()))
+                .withSpaceBeforeExceptionName(receiveList(aThrows.getSpaceBeforeExceptionName(), q))
+                .withExceptionName(q.receive(aThrows.getExceptionName(), n -> javaVisitorVisit(n, q)))
+                .withDescription(receiveList(aThrows.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitUnknownBlock(Javadoc.UnknownBlock unknownBlock, RpcReceiveQueue q) {
+        return unknownBlock
+                .withName(q.receive(unknownBlock.getName()))
+                .withContent(receiveList(unknownBlock.getContent(), q));
+    }
+
+    @Override
+    public Javadoc visitUnknownInline(Javadoc.UnknownInline unknownInline, RpcReceiveQueue q) {
+        return unknownInline
+                .withName(q.receive(unknownInline.getName()))
+                .withContent(receiveList(unknownInline.getContent(), q))
+                .withEndBrace(receiveList(unknownInline.getEndBrace(), q));
+    }
+
+    @Override
+    public Javadoc visitUses(Javadoc.Uses uses, RpcReceiveQueue q) {
+        return uses
+                .withBeforeServiceType(receiveList(uses.getBeforeServiceType(), q))
+                .withServiceType(q.receive(uses.getServiceType(), t -> javaVisitorVisit(t, q)))
+                .withDescription(receiveList(uses.getDescription(), q));
+    }
+
+    @Override
+    public Javadoc visitVersion(Javadoc.Version version, RpcReceiveQueue q) {
+        return version.withBody(receiveList(version.getBody(), q));
+    }
+
+    private List<Javadoc> receiveList(List<Javadoc> before, RpcReceiveQueue q) {
+        return q.receiveList(before, d -> visit(d, q));
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavadocSender.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/rpc/JavadocSender.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.rpc;
+
+import org.openrewrite.Tree;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.JavadocVisitor;
+import org.openrewrite.java.tree.Javadoc;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.util.List;
+import java.util.function.Function;
+
+/**
+ * Decomposes a {@link Javadoc} tree over RPC, the same way {@link JavaSender} decomposes the rest
+ * of the LST, so a doc comment survives the round trip as a tree instead of being flattened back
+ * to text. Modelled on {@code CsDocCommentSender}.
+ * <p>
+ * The field lists below follow declaration order in {@link Javadoc}, <b>not</b> the traversal in
+ * {@link JavadocVisitor}: that visitor skips every scalar (it never visits {@code Text#text} or
+ * {@code LineBreak#margin}) and omits {@code markers} on roughly a third of the node types, so a
+ * sender derived from it would silently drop fields. {@link JavadocReceiver} mirrors this order.
+ */
+class JavadocSender extends JavadocVisitor<RpcSendQueue> {
+
+    JavadocSender(JavaVisitor<RpcSendQueue> javaVisitor) {
+        super(javaVisitor);
+    }
+
+    @Override
+    public Javadoc preVisit(Javadoc javadoc, RpcSendQueue q) {
+        q.getAndSend(javadoc, Tree::getId);
+        q.getAndSend(javadoc, Tree::getMarkers);
+        return javadoc;
+    }
+
+    @Override
+    public Javadoc visitAttribute(Javadoc.Attribute attribute, RpcSendQueue q) {
+        q.getAndSend(attribute, Javadoc.Attribute::getName);
+        sendList(attribute, Javadoc.Attribute::getSpaceBeforeEqual, q);
+        sendList(attribute, Javadoc.Attribute::getValue, q);
+        return attribute;
+    }
+
+    @Override
+    public Javadoc visitAuthor(Javadoc.Author author, RpcSendQueue q) {
+        sendList(author, Javadoc.Author::getName, q);
+        return author;
+    }
+
+    @Override
+    public Javadoc visitDeprecated(Javadoc.Deprecated deprecated, RpcSendQueue q) {
+        sendList(deprecated, Javadoc.Deprecated::getDescription, q);
+        return deprecated;
+    }
+
+    @Override
+    public Javadoc visitDocComment(Javadoc.DocComment docComment, RpcSendQueue q) {
+        sendList(docComment, Javadoc.DocComment::getBody, q);
+        q.getAndSend(docComment, Javadoc.DocComment::getSuffix);
+        return docComment;
+    }
+
+    @Override
+    public Javadoc visitDocRoot(Javadoc.DocRoot docRoot, RpcSendQueue q) {
+        sendList(docRoot, Javadoc.DocRoot::getEndBrace, q);
+        return docRoot;
+    }
+
+    @Override
+    public Javadoc visitDocType(Javadoc.DocType docType, RpcSendQueue q) {
+        sendList(docType, Javadoc.DocType::getText, q);
+        return docType;
+    }
+
+    @Override
+    public Javadoc visitEndElement(Javadoc.EndElement endElement, RpcSendQueue q) {
+        q.getAndSend(endElement, Javadoc.EndElement::getName);
+        sendList(endElement, Javadoc.EndElement::getSpaceBeforeEndBracket, q);
+        return endElement;
+    }
+
+    @Override
+    public Javadoc visitErroneous(Javadoc.Erroneous erroneous, RpcSendQueue q) {
+        sendList(erroneous, Javadoc.Erroneous::getText, q);
+        return erroneous;
+    }
+
+    @Override
+    public Javadoc visitHidden(Javadoc.Hidden hidden, RpcSendQueue q) {
+        sendList(hidden, Javadoc.Hidden::getBody, q);
+        return hidden;
+    }
+
+    @Override
+    public Javadoc visitIndex(Javadoc.Index index, RpcSendQueue q) {
+        sendList(index, Javadoc.Index::getSearchTerm, q);
+        sendList(index, Javadoc.Index::getDescription, q);
+        sendList(index, Javadoc.Index::getEndBrace, q);
+        return index;
+    }
+
+    @Override
+    public Javadoc visitInheritDoc(Javadoc.InheritDoc inheritDoc, RpcSendQueue q) {
+        sendList(inheritDoc, Javadoc.InheritDoc::getEndBrace, q);
+        return inheritDoc;
+    }
+
+    @Override
+    public Javadoc visitInlinedValue(Javadoc.InlinedValue inlinedValue, RpcSendQueue q) {
+        sendList(inlinedValue, Javadoc.InlinedValue::getSpaceBeforeTree, q);
+        q.getAndSend(inlinedValue, Javadoc.InlinedValue::getTree, t -> javaVisitorVisit(t, q));
+        sendList(inlinedValue, Javadoc.InlinedValue::getEndBrace, q);
+        return inlinedValue;
+    }
+
+    @Override
+    public Javadoc visitLineBreak(Javadoc.LineBreak lineBreak, RpcSendQueue q) {
+        // `margin` is declared ahead of `markers`, but preVisit has already sent id and markers
+        // for every node; the receiver reads them in the same hoisted order.
+        q.getAndSend(lineBreak, Javadoc.LineBreak::getMargin);
+        return lineBreak;
+    }
+
+    @Override
+    public Javadoc visitLink(Javadoc.Link link, RpcSendQueue q) {
+        q.getAndSend(link, Javadoc.Link::isPlain);
+        sendList(link, Javadoc.Link::getSpaceBeforeTree, q);
+        q.getAndSend(link, Javadoc.Link::getTree, t -> javaVisitorVisit(t, q));
+        q.getAndSend(link, Javadoc.Link::getTreeReference, r -> visit(r, q));
+        sendList(link, Javadoc.Link::getLabel, q);
+        sendList(link, Javadoc.Link::getEndBrace, q);
+        return link;
+    }
+
+    @Override
+    public Javadoc visitLiteral(Javadoc.Literal literal, RpcSendQueue q) {
+        q.getAndSend(literal, Javadoc.Literal::isCode);
+        sendList(literal, Javadoc.Literal::getDescription, q);
+        sendList(literal, Javadoc.Literal::getEndBrace, q);
+        return literal;
+    }
+
+    @Override
+    public Javadoc visitParameter(Javadoc.Parameter parameter, RpcSendQueue q) {
+        sendList(parameter, Javadoc.Parameter::getSpaceBeforeName, q);
+        q.getAndSend(parameter, Javadoc.Parameter::getName, n -> javaVisitorVisit(n, q));
+        q.getAndSend(parameter, Javadoc.Parameter::getNameReference, r -> visit(r, q));
+        sendList(parameter, Javadoc.Parameter::getDescription, q);
+        return parameter;
+    }
+
+    @Override
+    public Javadoc visitProvides(Javadoc.Provides provides, RpcSendQueue q) {
+        sendList(provides, Javadoc.Provides::getSpaceBeforeServiceType, q);
+        q.getAndSend(provides, Javadoc.Provides::getServiceType, t -> javaVisitorVisit(t, q));
+        sendList(provides, Javadoc.Provides::getDescription, q);
+        return provides;
+    }
+
+    @Override
+    public Javadoc visitReference(Javadoc.Reference reference, RpcSendQueue q) {
+        q.getAndSend(reference, Javadoc.Reference::getTree, t -> javaVisitorVisit(t, q));
+        sendList(reference, Javadoc.Reference::getLineBreaks, q);
+        return reference;
+    }
+
+    @Override
+    public Javadoc visitReturn(Javadoc.Return aReturn, RpcSendQueue q) {
+        sendList(aReturn, Javadoc.Return::getDescription, q);
+        return aReturn;
+    }
+
+    @Override
+    public Javadoc visitSee(Javadoc.See see, RpcSendQueue q) {
+        sendList(see, Javadoc.See::getSpaceBeforeTree, q);
+        q.getAndSend(see, Javadoc.See::getTree, t -> javaVisitorVisit(t, q));
+        q.getAndSend(see, Javadoc.See::getTreeReference, r -> visit(r, q));
+        sendList(see, Javadoc.See::getReference, q);
+        return see;
+    }
+
+    @Override
+    public Javadoc visitSerial(Javadoc.Serial serial, RpcSendQueue q) {
+        sendList(serial, Javadoc.Serial::getDescription, q);
+        return serial;
+    }
+
+    @Override
+    public Javadoc visitSerialData(Javadoc.SerialData serialData, RpcSendQueue q) {
+        sendList(serialData, Javadoc.SerialData::getDescription, q);
+        return serialData;
+    }
+
+    @Override
+    public Javadoc visitSerialField(Javadoc.SerialField serialField, RpcSendQueue q) {
+        q.getAndSend(serialField, Javadoc.SerialField::getName, n -> javaVisitorVisit(n, q));
+        q.getAndSend(serialField, Javadoc.SerialField::getType, t -> javaVisitorVisit(t, q));
+        sendList(serialField, Javadoc.SerialField::getDescription, q);
+        return serialField;
+    }
+
+    @Override
+    public Javadoc visitSince(Javadoc.Since since, RpcSendQueue q) {
+        sendList(since, Javadoc.Since::getDescription, q);
+        return since;
+    }
+
+    @Override
+    public Javadoc visitSnippet(Javadoc.Snippet snippet, RpcSendQueue q) {
+        sendList(snippet, Javadoc.Snippet::getAttributes, q);
+        sendList(snippet, Javadoc.Snippet::getContent, q);
+        sendList(snippet, Javadoc.Snippet::getEndBrace, q);
+        return snippet;
+    }
+
+    @Override
+    public Javadoc visitStartElement(Javadoc.StartElement startElement, RpcSendQueue q) {
+        q.getAndSend(startElement, Javadoc.StartElement::getName);
+        sendList(startElement, Javadoc.StartElement::getAttributes, q);
+        q.getAndSend(startElement, Javadoc.StartElement::isSelfClosing);
+        sendList(startElement, Javadoc.StartElement::getSpaceBeforeEndBracket, q);
+        return startElement;
+    }
+
+    @Override
+    public Javadoc visitSummary(Javadoc.Summary summary, RpcSendQueue q) {
+        sendList(summary, Javadoc.Summary::getSummary, q);
+        sendList(summary, Javadoc.Summary::getBeforeBrace, q);
+        return summary;
+    }
+
+    @Override
+    public Javadoc visitText(Javadoc.Text text, RpcSendQueue q) {
+        q.getAndSend(text, Javadoc.Text::getText);
+        return text;
+    }
+
+    @Override
+    public Javadoc visitThrows(Javadoc.Throws aThrows, RpcSendQueue q) {
+        q.getAndSend(aThrows, Javadoc.Throws::isThrowsKeyword);
+        sendList(aThrows, Javadoc.Throws::getSpaceBeforeExceptionName, q);
+        q.getAndSend(aThrows, Javadoc.Throws::getExceptionName, n -> javaVisitorVisit(n, q));
+        sendList(aThrows, Javadoc.Throws::getDescription, q);
+        return aThrows;
+    }
+
+    @Override
+    public Javadoc visitUnknownBlock(Javadoc.UnknownBlock unknownBlock, RpcSendQueue q) {
+        q.getAndSend(unknownBlock, Javadoc.UnknownBlock::getName);
+        sendList(unknownBlock, Javadoc.UnknownBlock::getContent, q);
+        return unknownBlock;
+    }
+
+    @Override
+    public Javadoc visitUnknownInline(Javadoc.UnknownInline unknownInline, RpcSendQueue q) {
+        q.getAndSend(unknownInline, Javadoc.UnknownInline::getName);
+        sendList(unknownInline, Javadoc.UnknownInline::getContent, q);
+        sendList(unknownInline, Javadoc.UnknownInline::getEndBrace, q);
+        return unknownInline;
+    }
+
+    @Override
+    public Javadoc visitUses(Javadoc.Uses uses, RpcSendQueue q) {
+        sendList(uses, Javadoc.Uses::getBeforeServiceType, q);
+        q.getAndSend(uses, Javadoc.Uses::getServiceType, t -> javaVisitorVisit(t, q));
+        sendList(uses, Javadoc.Uses::getDescription, q);
+        return uses;
+    }
+
+    @Override
+    public Javadoc visitVersion(Javadoc.Version version, RpcSendQueue q) {
+        sendList(version, Javadoc.Version::getBody, q);
+        return version;
+    }
+
+    private <T extends Javadoc> void sendList(T parent, Function<T, List<Javadoc>> values, RpcSendQueue q) {
+        q.getAndSendList(parent, values, Tree::getId, d -> visit(d, q));
+    }
+}

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavadocRpcTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavadocRpcTest.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.internal.rpc;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Cursor;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.tree.Comment;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Javadoc;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.rpc.RpcObjectData;
+import org.openrewrite.rpc.RpcReceiveQueue;
+import org.openrewrite.rpc.RpcSendQueue;
+
+import java.nio.file.Path;
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Every {@link Javadoc} node is {@code @EqualsAndHashCode(onlyExplicitlyIncluded = true)} on
+ * {@code id} alone, so two doc comments compare equal no matter how badly their contents were
+ * mangled in between. Every assertion here compares printed output instead.
+ * <p>
+ * The doc comment is round-tripped on its own rather than as part of its compilation unit: a whole
+ * {@code J.CompilationUnit} does not survive this harness yet for an unrelated reason (enums are
+ * still sent as objects, which is why {@code JavaSendReceiveTest.sendReceiveIdempotence} is
+ * disabled), and that would mask what is under test here.
+ */
+class JavadocRpcTest {
+
+    private Deque<List<RpcObjectData>> batches;
+    private RpcSendQueue sq;
+    private RpcReceiveQueue rq;
+
+    @BeforeEach
+    void setUp() {
+        batches = new ArrayDeque<>();
+        String sourceFileType = J.CompilationUnit.class.getName();
+        sq = new RpcSendQueue(1, e -> batches.addLast(encode(e)), new IdentityHashMap<>(), sourceFileType, false);
+        rq = new RpcReceiveQueue(new HashMap<>(), batches::removeFirst, sourceFileType, null);
+    }
+
+    @Test
+    void blockTagsRoundTrip() {
+        assertRoundTrip(
+          """
+            /**
+             * A summary sentence.
+             *
+             * @param name the name
+             * @return nothing
+             */
+            class Foo {
+                void bar(String name) {
+                }
+            }
+            """
+        );
+    }
+
+    @Test
+    void inlineTagsAndReferencesRoundTrip() {
+        assertRoundTrip(
+          """
+            /**
+             * See {@link Foo#bar(String)} and {@linkplain Foo plain}.
+             * A {@code literal} and a {@literal <b>raw</b>} value.
+             * {@inheritDoc}
+             *
+             * @see Foo#bar(String)
+             * @since 1.0
+             * @deprecated use something else
+             */
+            class Foo {
+                void bar(String name) {
+                }
+            }
+            """
+        );
+    }
+
+    @Test
+    void htmlElementsAndUnknownTagsRoundTrip() {
+        assertRoundTrip(
+          """
+            /**
+             * <p>A paragraph with <b>bold</b> and an <img src="x.png"/> element.</p>
+             *
+             * @author Jon
+             * @version 2
+             * @customTag whatever this is
+             */
+            class Foo {
+            }
+            """
+        );
+    }
+
+    @Test
+    void throwsTagsRoundTrip() {
+        assertRoundTrip(
+          """
+            class Foo {
+                /**
+                 * @throws IllegalStateException when broken
+                 * @exception RuntimeException also when broken
+                 */
+                void bar() {
+                }
+            }
+            """
+        );
+    }
+
+    private void assertRoundTrip(@Language("java") String source) {
+        SourceFile cu = JavaParser.fromJavaVersion().build()
+          .parse(new InMemoryExecutionContext(), source)
+          .findFirst()
+          .orElseThrow();
+
+        Javadoc.DocComment before = findDocComment(cu);
+        Cursor cursor = new Cursor(null, cu);
+        String expected = before.printComment(cursor);
+        assertThat(expected).as("the fixture must actually contain a doc comment").contains("@");
+
+        JavaVisitor<RpcSendQueue> sender = new JavaSender();
+        sq.send(before, null, () -> new JavadocSender(sender).visit(before, sq));
+        sq.flush();
+
+        JavaVisitor<RpcReceiveQueue> receiver = new JavaReceiver();
+        Javadoc.DocComment after = rq.receive(null,
+          d -> (Javadoc.DocComment) new JavadocReceiver(receiver).visit(d, rq));
+
+        assertThat(after.printComment(cursor)).isEqualTo(expected);
+    }
+
+    private Javadoc.DocComment findDocComment(SourceFile cu) {
+        List<Javadoc.DocComment> found = new ArrayList<>();
+        new JavaVisitor<Integer>() {
+            @Override
+            public Space visitSpace(Space space, Space.Location loc, Integer p) {
+                for (Comment comment : space.getComments()) {
+                    if (comment instanceof Javadoc.DocComment) {
+                        found.add((Javadoc.DocComment) comment);
+                    }
+                }
+                return space;
+            }
+        }.visit(cu, 0);
+        assertThat(found).as("fixture should parse to exactly one doc comment").hasSize(1);
+        return found.get(0);
+    }
+
+    private List<RpcObjectData> encode(List<RpcObjectData> batch) {
+        List<RpcObjectData> encoded = new ArrayList<>();
+        for (RpcObjectData data : batch) {
+            // The wire carries a UUID or Path as a string, as the transport's JSON encoding would.
+            if (data.getValue() instanceof UUID || data.getValue() instanceof Path) {
+                encoded.add(new RpcObjectData(data.getState(), data.getValueType(),
+                  data.getValue().toString(), data.getRef(), false));
+            } else {
+                encoded.add(data);
+            }
+        }
+        return encoded;
+    }
+}

--- a/rewrite-javascript/rewrite/src/rpc/request/metrics.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/metrics.ts
@@ -17,7 +17,9 @@ import * as fs from 'fs';
 import * as rpc from "vscode-jsonrpc/node";
 import {Cursor, isSourceFile, SourceFile} from "../../tree";
 
-const CSV_HEADER = 'request,target,durationMs,memoryUsedBytes,memoryMaxBytes,localObjects,remoteObjects,refs';
+// `timestamp` leads, as it does in the Go, Python and C# writers, so a profile can align this
+// peer's residency against samples taken outside it (RSS, GC, the host's own metrics).
+const CSV_HEADER = 'timestamp,request,target,durationMs,memoryUsedBytes,memoryMaxBytes,localObjects,remoteObjects,refs';
 
 // Optional provider of current RPC cache sizes, appended to each metrics row so a profile
 // shows cache residency (flat with per-file Evict, monotonic without). Set by RewriteRpc.
@@ -172,7 +174,7 @@ function recordMetrics(
     const memoryMaxBytes = memEnd.heapTotal;
     const cache = cacheSizeProvider?.() ?? {local: 0, remote: 0, refs: 0};
 
-    const csvRow = `${request},${target},${durationMs},${memoryUsedBytes},${memoryMaxBytes},${cache.local},${cache.remote},${cache.refs}\n`;
+    const csvRow = `${new Date(endTime).toISOString()},${request},${target},${durationMs},${memoryUsedBytes},${memoryMaxBytes},${cache.local},${cache.remote},${cache.refs}\n`;
 
     try {
         fs.appendFileSync(metricsCsv, csvRow);


### PR DESCRIPTION
- > Stacked on #8512 — review that one first. This PR's own diff is the last two commits: the RPC instrumentation, and Javadoc.

- Two things that #8512 needs in order to be *verified* rather than just merged.

## Javadoc over RPC

A doc comment is a tree, and `JavaSender.visitSpace` had no case for it. Any `Space` carrying a `Javadoc.DocComment` threw:

```
IllegalArgumentException: Unexpected comment type ...Javadoc$DocComment
```

That is why `J$CompilationUnit` is still commented out of the JavaScript peer's advertised languages, and it is not a theoretical edge: a spring-boot run with Java compilation units enabled died on it after about 7,700 files.

`JavadocSender` / `JavadocReceiver` decompose the tree node by node across all 33 node types, modelled on `CsDocCommentSender` / `CsDocCommentReceiver`, which the C# side already uses for exactly this job.

**The field lists follow declaration order in `Javadoc`, deliberately not the traversal in `JavadocVisitor`.** That visitor is not a serialization order:

- it never visits a scalar — `Text#text` and `LineBreak#margin` are both invisible to it;
- it omits `markers` on roughly a third of the node types.

A sender derived from it would drop fields while looking complete. `id` and `markers` are hoisted into `preVisit` for every node, the way `JavaSender.preVisit` already does, and the receiver reads them in that same hoisted order — which is what keeps `LineBreak` symmetric despite declaring `margin` ahead of `markers`.

### Verified by printing, never by `equals`

Every Javadoc node is `@EqualsAndHashCode(onlyExplicitlyIncluded = true)` on `id` alone, so two doc comments compare equal no matter how badly the contents were mangled in between. `JavadocRpcTest` compares `printComment` output across block tags, inline tags and references, HTML elements and unknown tags, and throws clauses. **Deleting a single field from the sender fails all four tests.**

The comment is round-tripped on its own rather than inside its compilation unit: a whole `J.CompilationUnit` does not survive that harness yet for an unrelated reason — enums still travel as objects, which is why `JavaSendReceiveTest.sendReceiveIdempotence` is disabled — and that would have masked what is under test.

### End-to-end

Re-running the spring-boot corpus with `J$CompilationUnit` enabled, the "Unexpected comment type" failure is gone and **5,820 Java compilation units cross the boundary**. This PR does not flip the language list: the TypeScript mirror of these codecs is still missing, and enabling Java compilation units without it would just move the failure across the wire.

## Instrumentation at the RPC boundary

Nothing in the RPC stack measured wire volume. Everything above the framed streams counts *messages*, which says nothing about how large they were, and the only alternative — the size of a `--trace-rpc-messages` log — is an overhead-inflated upper bound rather than a boundary measurement.

`RewriteRpcProcess` now wraps the two process streams in counting decorators and samples cumulative totals to `rpc-bytes-<pid>.csv` (`timestamp_ms,bytes_out,bytes_in`), symmetric with the existing `rpc-rss-<pid>.csv` sampler and gated the same way, on `REWRITE_RPC_BYTES_MS`. Unset, the raw streams are used and nothing is wrapped. A final row is written when the peer exits so a total is never lost between samples.

`FilterOutputStream.write(byte[], int, int)` loops a byte at a time, so the decorator overrides it to delegate the whole array; inheriting that default would have made every write O(n) syscalls.

The JavaScript metrics CSV also grew a leading `timestamp` column, as the Go, Python and C# writers already have. Without it this peer's residency series cannot be aligned against anything sampled outside it — RSS, GC, or the host's own metrics.

## What this unblocks, and what it doesn't

With Javadoc landed, Java compilation units reach the JavaScript peer for the first time. That immediately surfaced the **next** wall, which is worth stating plainly rather than discovering later: the peer exhausts its 4 GB heap after ~5,820 compilation units, with its ref map at **9.3M entries**.

- I can't yet attribute that to #8512. The A/B switch I used sets an environment variable that the CLI does not forward to the spawned peer, so the "before" arm applied on the Java side only — both arms therefore ran with the peer's refs retained, and both OOM'd at the same point. Fixing that plumbing is the next step before any before/after claim about peer memory is meaningful.
