### PR TITLE
Honor Go's compiler build tag and GOOS aliases in `rewrite-go`

### DIFF
--- a/rewrite-go/pkg/parser/build_tags.go
+++ b/rewrite-go/pkg/parser/build_tags.go
@@ -30,6 +30,7 @@ import (
 //
 // The constraint evaluator recognizes:
 //   - GOOS/GOARCH name tags (matches when ctx.GOOS == tag etc.)
+//   - the compiler name in buildCtx.Compiler ("gc" or "gccgo")
 //   - "cgo" if buildCtx.CgoEnabled is true
 //   - language version tags (e.g. "go1.21") if at or below the configured
 //     release; falls back to true to avoid spurious exclusions
@@ -133,6 +134,8 @@ func matchTag(buildCtx build.Context, tag string) bool {
 	case buildCtx.GOOS:
 		return true
 	case buildCtx.GOARCH:
+		return true
+	case buildCtx.Compiler:
 		return true
 	case "cgo":
 		return buildCtx.CgoEnabled

--- a/rewrite-go/pkg/parser/build_tags.go
+++ b/rewrite-go/pkg/parser/build_tags.go
@@ -29,7 +29,8 @@ import (
 // have file content in-memory rather than on disk.
 //
 // The constraint evaluator recognizes:
-//   - GOOS/GOARCH name tags (matches when ctx.GOOS == tag etc.)
+//   - GOOS/GOARCH name tags (matches when ctx.GOOS == tag etc.), plus the
+//     aliases android→linux, ios→darwin and illumos→solaris
 //   - the compiler name in buildCtx.Compiler ("gc" or "gccgo")
 //   - "cgo" if buildCtx.CgoEnabled is true
 //   - language version tags (e.g. "go1.21") if at or below the configured
@@ -85,14 +86,13 @@ func matchOSArchFilename(buildCtx build.Context, name string) bool {
 		prev = parts[n-2]
 	}
 
+	// Suffixes resolve through matchTag, so the GOOS aliases reach filenames
+	// too: foo_linux.go builds for android.
 	if knownOS(prev) && knownArch(last) {
-		return prev == buildCtx.GOOS && last == buildCtx.GOARCH
+		return matchTag(buildCtx, prev) && matchTag(buildCtx, last)
 	}
-	if knownOS(last) {
-		return last == buildCtx.GOOS
-	}
-	if knownArch(last) {
-		return last == buildCtx.GOARCH
+	if knownOS(last) || knownArch(last) {
+		return matchTag(buildCtx, last)
 	}
 	return true
 }
@@ -137,10 +137,19 @@ func matchTag(buildCtx build.Context, tag string) bool {
 		return true
 	case buildCtx.Compiler:
 		return true
+	case "linux":
+		return buildCtx.GOOS == "android"
+	case "darwin":
+		return buildCtx.GOOS == "ios"
+	case "solaris":
+		return buildCtx.GOOS == "illumos"
 	case "cgo":
 		return buildCtx.CgoEnabled
 	case "unix":
 		return knownUnixOS(buildCtx.GOOS)
+	case "boringcrypto":
+		// Legacy spelling of the goexperiment tag.
+		tag = "goexperiment.boringcrypto"
 	}
 	for _, t := range buildCtx.BuildTags {
 		if t == tag {

--- a/rewrite-go/pkg/parser/build_tags_test.go
+++ b/rewrite-go/pkg/parser/build_tags_test.go
@@ -104,6 +104,22 @@ func TestMatchBuildContextCompilerTag(t *testing.T) {
 	}
 }
 
+const constrainedName = "constrained.go"
+
+// matchFile asks go/build itself, which needs the source on disk.
+func matchFile(t *testing.T, ctx build.Context, name, content string) bool {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	want, err := ctx.MatchFile(dir, name)
+	if err != nil {
+		t.Fatalf("MatchFile: %v", err)
+	}
+	return want
+}
+
 func TestMatchBuildContextAgreesWithGoBuild(t *testing.T) {
 	ctx := gcContext()
 	for _, content := range []string{
@@ -112,17 +128,52 @@ func TestMatchBuildContextAgreesWithGoBuild(t *testing.T) {
 		"//go:build gc && !purego\n\npackage p\n",
 		"// +build gc\n\npackage p\n",
 	} {
-		dir := t.TempDir()
-		const name = "constrained.go"
-		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
-			t.Fatalf("write fixture: %v", err)
+		if got := parser.MatchBuildContext(ctx, constrainedName, content); got != matchFile(t, ctx, constrainedName, content) {
+			t.Errorf("MatchBuildContext(%q) = %v, go/build disagrees", content, got)
 		}
-		want, err := ctx.MatchFile(dir, name)
-		if err != nil {
-			t.Fatalf("MatchFile: %v", err)
+	}
+}
+
+// TestMatchBuildContextAgreesWithGoBuildAcrossGOOS exercises the GOOS aliases
+// (android implies linux, ios implies darwin, illumos implies solaris), which a
+// linux-only context leaves invisible. go/build applies them to constraint tags
+// and filename suffixes alike, so both are swept here.
+func TestMatchBuildContextAgreesWithGoBuildAcrossGOOS(t *testing.T) {
+	names := []string{
+		"constrained.go",
+		"foo_linux.go", "foo_darwin.go", "foo_solaris.go",
+		"foo_android.go", "foo_ios.go", "foo_illumos.go", "foo_windows.go",
+		"foo_linux_amd64.go", "foo_darwin_arm64.go",
+		"foo_amd64.go", "foo_handler.go",
+	}
+	contents := []string{
+		"package p\n",
+		"//go:build gc\n\npackage p\n",
+		"//go:build linux\n\npackage p\n",
+		"//go:build darwin\n\npackage p\n",
+		"//go:build solaris\n\npackage p\n",
+		"//go:build unix\n\npackage p\n",
+	}
+	for _, goos := range []string{"linux", "android", "darwin", "ios", "solaris", "illumos", "windows"} {
+		for _, goarch := range []string{"amd64", "arm64"} {
+			for _, name := range names {
+				for _, content := range contents {
+					ctx := gcContext()
+					ctx.GOOS, ctx.GOARCH = goos, goarch
+					if got := parser.MatchBuildContext(ctx, name, content); got != matchFile(t, ctx, name, content) {
+						t.Errorf("%s/%s %s %q = %v, go/build disagrees", goos, goarch, name, content, got)
+					}
+				}
+			}
 		}
-		if got := parser.MatchBuildContext(ctx, name, content); got != want {
-			t.Errorf("MatchBuildContext(%q) = %v, go/build says %v", content, got, want)
-		}
+	}
+}
+
+func TestMatchBuildContextBoringcryptoAliasesGoexperiment(t *testing.T) {
+	ctx := gcContext()
+	ctx.ToolTags = append(append([]string{}, ctx.ToolTags...), "goexperiment.boringcrypto")
+	const content = "//go:build boringcrypto\n\npackage p\n"
+	if got := parser.MatchBuildContext(ctx, constrainedName, content); got != matchFile(t, ctx, constrainedName, content) {
+		t.Errorf("MatchBuildContext(%q) = %v, go/build disagrees", content, got)
 	}
 }

--- a/rewrite-go/pkg/parser/build_tags_test.go
+++ b/rewrite-go/pkg/parser/build_tags_test.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+)
+
+// gcContext pins GOOS/GOARCH so that on any host the cases below turn on
+// Compiler alone.
+func gcContext() build.Context {
+	ctx := build.Default
+	ctx.GOOS = "linux"
+	ctx.GOARCH = "amd64"
+	ctx.Compiler = "gc"
+	return ctx
+}
+
+func TestMatchBuildContextCompilerTag(t *testing.T) {
+	gccgo := gcContext()
+	gccgo.Compiler = "gccgo"
+
+	tests := []struct {
+		name    string
+		ctx     build.Context
+		content string
+		want    bool
+	}{
+		{
+			name:    "gc constraint under gc compiler",
+			ctx:     gcContext(),
+			content: "//go:build gc\n\npackage build\n",
+			want:    true,
+		},
+		{
+			name:    "gccgo constraint under gc compiler",
+			ctx:     gcContext(),
+			content: "//go:build gccgo\n\npackage build\n",
+			want:    false,
+		},
+		{
+			name:    "gccgo constraint under gccgo compiler",
+			ctx:     gccgo,
+			content: "//go:build gccgo\n\npackage build\n",
+			want:    true,
+		},
+		{
+			name:    "gc constraint under gccgo compiler",
+			ctx:     gccgo,
+			content: "//go:build gc\n\npackage build\n",
+			want:    false,
+		},
+		{
+			name:    "gc and not purego",
+			ctx:     gcContext(),
+			content: "//go:build gc && !purego\n\npackage chacha20\n",
+			want:    true,
+		},
+		{
+			name:    "linux and gc",
+			ctx:     gcContext(),
+			content: "//go:build linux && gc\n\npackage issue9400\n",
+			want:    true,
+		},
+		{
+			name:    "legacy plus-build gc",
+			ctx:     gcContext(),
+			content: "// +build gc\n\npackage build\n",
+			want:    true,
+		},
+		{
+			name:    "zero-value context does not satisfy gc",
+			ctx:     build.Context{},
+			content: "//go:build gc\n\npackage build\n",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parser.MatchBuildContext(tt.ctx, "constrained.go", tt.content); got != tt.want {
+				t.Errorf("MatchBuildContext() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMatchBuildContextAgreesWithGoBuild(t *testing.T) {
+	ctx := gcContext()
+	for _, content := range []string{
+		"//go:build gc\n\npackage p\n",
+		"//go:build gccgo\n\npackage p\n",
+		"//go:build gc && !purego\n\npackage p\n",
+		"// +build gc\n\npackage p\n",
+	} {
+		dir := t.TempDir()
+		const name = "constrained.go"
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+		want, err := ctx.MatchFile(dir, name)
+		if err != nil {
+			t.Fatalf("MatchFile: %v", err)
+		}
+		if got := parser.MatchBuildContext(ctx, name, content); got != want {
+			t.Errorf("MatchBuildContext(%q) = %v, go/build says %v", content, got, want)
+		}
+	}
+}

--- a/rewrite-go/pkg/parser/exported_types.go
+++ b/rewrite-go/pkg/parser/exported_types.go
@@ -269,13 +269,14 @@ func containsGoMod(dir string) bool {
 	return err == nil
 }
 
-// goBuildContext pins GOOS/GOARCH/CgoEnabled so table content is deterministic
-// across build machines; captures the linux/amd64 view.
+// goBuildContext captures the linux/amd64 gc view, pinned so that table
+// content is deterministic across build machines.
 func goBuildContext() build.Context {
 	ctx := build.Default
 	ctx.GOOS = "linux"
 	ctx.GOARCH = "amd64"
 	ctx.CgoEnabled = false
+	ctx.Compiler = "gc"
 	return ctx
 }
 

--- a/rewrite-go/pkg/parser/exported_types_test.go
+++ b/rewrite-go/pkg/parser/exported_types_test.go
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser
+
+import "testing"
+
+func TestGoBuildContextIsHostIndependent(t *testing.T) {
+	ctx := goBuildContext()
+	for _, f := range []struct{ field, got, want string }{
+		{"GOOS", ctx.GOOS, "linux"},
+		{"GOARCH", ctx.GOARCH, "amd64"},
+		{"Compiler", ctx.Compiler, "gc"},
+	} {
+		if f.got != f.want {
+			t.Errorf("%s = %q, want %q", f.field, f.got, f.want)
+		}
+	}
+	if ctx.CgoEnabled {
+		t.Error("CgoEnabled = true, want false")
+	}
+}


### PR DESCRIPTION
## Motivation

`rewrite-go` re-implements Go's build-constraint evaluation in `parser.MatchBuildContext` for callers that hold file content in memory rather than on disk. It diverged from `go/build` in two ways, both of which cause valid files to be excluded from a parse.

**The compiler tag.** `matchTag` recognized GOOS, GOARCH, `cgo`, `unix` and the configured build/tool/release tags — but not the compiler name. Go's `(*build.Context).matchTag` treats `Compiler` (`"gc"` or `"gccgo"`) as a satisfied tag, so the two disagreed about every file guarded by `//go:build gc`.

**The GOOS aliases.** `go/build` also treats `linux` as satisfied under GOOS=android, `darwin` under ios, and `solaris` under illumos — and `goodOSArchFile` resolves *filename suffixes* through that same `matchTag`, so the aliases cover `foo_linux.go` just as much as `//go:build linux`. `matchOSArchFilename` compared the suffix against GOOS/GOARCH directly, which excluded most of the platform layer when analysing Android or iOS code.

The consequences run deeper than the rejected file. Rejected files are filtered out before parsing, so a group containing only such a file produces no compilation unit and the caller reports `no compilation unit produced` — a parse failure on a file `go build` compiles without complaint. Worse, dropping a file from a package leaves the *surviving* files referencing declarations that no longer exist: `go/build/gc.go` declares `getToolDir()`, and `build.go` has `var ToolDir = getToolDir()`. The package stops type-checking, so attribution can degrade across all of it, with no error anywhere — the failure mode recipes silently under-apply on.

Measured against `go/build` itself over all 7709 `.go` files in `$(go env GOROOT)/src`, disagreement with `Context.MatchFile` before these fixes ran at 11 files under linux/amd64, 122 under android and 56 under ios; afterwards every GOOS/GOARCH context sits at the same 2-3 (see the test plan). `gc` is not an exotic tag: it marks the files that exist *because* the gc toolchain has an assembly implementation, i.e. the performance-critical and runtime-adjacent code.

## Summary

- `matchTag` matches `buildCtx.Compiler`, the three GOOS aliases (android→linux, ios→darwin, illumos→solaris), and `boringcrypto` as a spelling of `goexperiment.boringcrypto` — mirroring `go/build`.
- `matchOSArchFilename` resolves filename suffixes through `matchTag` instead of comparing them to GOOS/GOARCH, so the aliases reach filenames as `goodOSArchFile` does.
- `goBuildContext` pins `Compiler = "gc"` alongside GOOS/GOARCH/CgoEnabled, so the dependency type table stays deterministic rather than varying with the toolchain that built the parser.
- New `build_tags_test.go` pins `MatchBuildContext` against `build.Context.MatchFile` — the authority the two must not diverge from — swept across GOOS, GOARCH, filenames and constraint bodies, so the next such gap fails a test rather than waiting for an audit.
- New `exported_types_test.go` asserts `goBuildContext` is host-independent.

## Test plan

- [x] `TestMatchBuildContextCompilerTag` — `//go:build gc`, `//go:build gccgo` (each under both a `gc` and a `gccgo` context), `gc && !purego`, `linux && gc`, legacy `// +build gc`, and a zero-value `build.Context`. 5 of 8 cases failed before the fix.
- [x] `TestMatchBuildContextAgreesWithGoBuild` — compares against `Context.MatchFile` on the compiler-tag bodies. Failed on 3 of 4 inputs before the fix.
- [x] `TestMatchBuildContextAgreesWithGoBuildAcrossGOOS` — 7 GOOS × 2 GOARCH × 12 filenames × 6 constraint bodies against `Context.MatchFile`. Failed on the android/ios/illumos alias combinations, for both tags and filename suffixes, before the fix.
- [x] `TestMatchBuildContextBoringcryptoAliasesGoexperiment` — failed before the fix.
- [x] `TestGoBuildContextIsHostIndependent` — verified it has teeth by deleting the GOOS pin and watching it fail (`GOOS = "darwin", want "linux"` on the dev machine). The `Compiler` assertion cannot fail on a gc-built binary; it encodes the contract and guards a gccgo host.
- [x] Ad-hoc full-stdlib sweep (not committed): `MatchBuildContext` vs `Context.MatchFile` over 7709 files under 7 GOOS × 2 GOARCH. Residual disagreement is 2-3 files, identical in every context and all pre-existing — two dot-prefixed `.h.go` testdata files that `go/build` skips by filename, and one file whose package doc quotes a `//go:build` line inside a `/* */` block (tracked separately; `buildConstraintLines` has no block-comment awareness).
- [x] `make test` green for the whole `rewrite-go` module; `go vet ./...` and `gofmt` clean.