### PR TITLE
Reach loop headers, operator spaces and untyped composite prefixes

### DIFF
--- a/rewrite-go/pkg/parser/composite_lit_test.go
+++ b/rewrite-go/pkg/parser/composite_lit_test.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// compositesOf parses src and returns every golang.Composite in source order.
+func compositesOf(t *testing.T, src string) (*golang.CompilationUnit, []*golang.Composite) {
+	t.Helper()
+	cu, err := parser.NewGoParser().Parse("composite.go", src)
+	require.NoError(t, err, "parse")
+
+	var found []*golang.Composite
+	visitor.Walk(cu, func(n java.Tree) bool {
+		if c, ok := n.(*golang.Composite); ok {
+			found = append(found, c)
+		}
+		return true
+	})
+	return cu, found
+}
+
+// The table-driven test idiom, whose inner elements are untyped composites.
+const tableDrivenSrc = "package main\n\nfunc f() {\n\ttests := []struct {\n\t\tname string\n\t}{\n\t\t{name: \"a\"},\n\t}\n\t_ = tests\n}\n"
+
+// Leading whitespace belongs on the outermost element, so an untyped composite
+// carries it on its own Prefix. Elements.Before covers only what a typed
+// composite writes between its type expression and `{`.
+func TestUntypedCompositeCarriesLeadingWhitespaceOnPrefix(t *testing.T) {
+	// given
+	_, composites := compositesOf(t, tableDrivenSrc)
+	require.Len(t, composites, 2, "outer slice literal and inner element")
+
+	// when
+	inner := composites[1]
+
+	// then
+	require.Nil(t, inner.TypeExpr, "inner element is an untyped composite")
+	require.Equal(t, "\n\t\t", inner.Prefix.Whitespace, "leading whitespace on Prefix")
+	require.True(t, inner.Elements.Before.IsEmpty(), "Elements.Before must not hold leading whitespace")
+}
+
+// A typed composite's Prefix sits ahead of its type expression.
+func TestTypedCompositeKeepsPrefixAheadOfTypeExpr(t *testing.T) {
+	// given
+	_, composites := compositesOf(t, tableDrivenSrc)
+
+	// when
+	outer := composites[0]
+
+	// then
+	require.NotNil(t, outer.TypeExpr, "outer literal is typed")
+	require.Equal(t, " ", outer.Prefix.Whitespace, "space after `:=`")
+	require.True(t, outer.Elements.Before.IsEmpty(), "nothing between the type and `{`")
+}
+
+// The printer emits Prefix ahead of `{`, so the source survives the round trip
+// and the tree satisfies the whitespace-attachment objective.
+func TestUntypedCompositeRoundTrips(t *testing.T) {
+	// given
+	cu, _ := compositesOf(t, tableDrivenSrc)
+
+	// then
+	require.Equal(t, tableDrivenSrc, printer.Print(cu))
+	require.Empty(t, test.WhitespaceAttachmentViolations(cu))
+}
+
+// An untyped composite nested in a map literal keeps the same contract.
+func TestUntypedCompositeInMapLiteral(t *testing.T) {
+	// given
+	src := "package main\n\ntype p struct{ x int }\n\nfunc f() {\n\tm := map[string]p{\n\t\t\"a\": {x: 1},\n\t}\n\t_ = m\n}\n"
+
+	// when
+	cu, composites := compositesOf(t, src)
+
+	// then
+	require.Len(t, composites, 2)
+	inner := composites[1]
+	require.Nil(t, inner.TypeExpr)
+	require.Equal(t, " ", inner.Prefix.Whitespace, "space after the key's `:`")
+	require.True(t, inner.Elements.Before.IsEmpty())
+	require.Equal(t, src, printer.Print(cu))
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -2529,6 +2529,10 @@ func (ctx *parseContext) mapCompositeLit(expr *ast.CompositeLit) java.Expression
 	}
 	lbracePrefix := ctx.prefix(expr.Lbrace)
 	ctx.skip(1) // "{"
+	if expr.Type == nil {
+		// Nothing precedes `{`, so that whitespace is the composite's own.
+		prefix, lbracePrefix = lbracePrefix, java.EmptySpace
+	}
 
 	var elements []java.RightPadded[java.Expression]
 	for i, elt := range expr.Elts {

--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -247,7 +247,7 @@ type Composite struct {
 	Prefix   java.Space
 	Markers  java.Markers
 	TypeExpr java.Expression                 // nil for untyped composite literals
-	Elements java.Container[java.Expression] // Before = space before `{`, elements, last After = space before `}`
+	Elements java.Container[java.Expression] // Before = space between TypeExpr and `{`, empty when untyped; last After = space before `}`
 }
 
 func (*Composite) IsTree()       {}

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -497,11 +497,22 @@ func (v *GoVisitor) VisitLiteral(lit *java.Literal, p any) java.J {
 }
 
 func (v *GoVisitor) VisitBinary(bin *java.Binary, p any) java.J {
-	bin = bin.WithPrefix(v.self().VisitSpace(bin.Prefix, p))
-	bin = bin.WithMarkers(v.visitMarkers(bin.Markers, p))
-	bin = bin.WithLeft(visitExpression(v, bin.Left, p))
-	bin = bin.WithRight(visitExpression(v, bin.Right, p))
-	return bin
+	prefix := v.self().VisitSpace(bin.Prefix, p)
+	markers := v.visitMarkers(bin.Markers, p)
+	left := visitExpression(v, bin.Left, p)
+	opBefore := v.self().VisitSpace(bin.Operator.Before, p)
+	right := visitExpression(v, bin.Right, p)
+	if java.SpaceEqual(prefix, bin.Prefix) && java.MarkersEqual(markers, bin.Markers) &&
+		left == bin.Left && java.SpaceEqual(opBefore, bin.Operator.Before) && right == bin.Right {
+		return bin
+	}
+	c := *bin
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Left = left
+	c.Operator.Before = opBefore
+	c.Right = right
+	return &c
 }
 
 func (v *GoVisitor) VisitBlock(block *java.Block, p any) java.J {
@@ -801,10 +812,17 @@ func (v *GoVisitor) VisitVariableDeclarations(vd *java.VariableDeclarations, p a
 	if typeExpr != nil {
 		typeExpr = visitExpression(v, typeExpr, p)
 	}
+	varargs := vd.Varargs
+	if varargs != nil {
+		visited := v.self().VisitSpace(*varargs, p)
+		if !java.SpaceEqual(visited, *varargs) {
+			varargs = &visited
+		}
+	}
 	variables := visitRightPaddedList(v, vd.Variables, p)
 	if java.SpaceEqual(prefix, vd.Prefix) && java.MarkersEqual(markers, vd.Markers) &&
 		java.SameSlice(anns, vd.LeadingAnnotations) && typeExpr == vd.TypeExpr &&
-		java.SameSlice(variables, vd.Variables) {
+		varargs == vd.Varargs && java.SameSlice(variables, vd.Variables) {
 		return vd
 	}
 	c := *vd
@@ -812,6 +830,7 @@ func (v *GoVisitor) VisitVariableDeclarations(vd *java.VariableDeclarations, p a
 	c.Markers = markers
 	c.LeadingAnnotations = anns
 	c.TypeExpr = typeExpr
+	c.Varargs = varargs
 	c.Variables = variables
 	return &c
 }
@@ -898,34 +917,67 @@ func (v *GoVisitor) VisitImport(imp *java.Import, p any) java.J {
 }
 
 func (v *GoVisitor) VisitUnary(unary *java.Unary, p any) java.J {
-	unary = unary.WithPrefix(v.self().VisitSpace(unary.Prefix, p))
-	unary = unary.WithMarkers(v.visitMarkers(unary.Markers, p))
-	unary = unary.WithOperand(visitExpression(v, unary.Operand, p))
-	return unary
+	prefix := v.self().VisitSpace(unary.Prefix, p)
+	markers := v.visitMarkers(unary.Markers, p)
+	opBefore := v.self().VisitSpace(unary.Operator.Before, p)
+	operand := visitExpression(v, unary.Operand, p)
+	if java.SpaceEqual(prefix, unary.Prefix) && java.MarkersEqual(markers, unary.Markers) &&
+		java.SpaceEqual(opBefore, unary.Operator.Before) && operand == unary.Operand {
+		return unary
+	}
+	c := *unary
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Operator.Before = opBefore
+	c.Operand = operand
+	return &c
 }
 
 func (v *GoVisitor) VisitAssignmentOperation(ao *java.AssignmentOperation, p any) java.J {
 	prefix := v.self().VisitSpace(ao.Prefix, p)
 	markers := v.visitMarkers(ao.Markers, p)
 	variable := visitExpression(v, ao.Variable, p)
+	opBefore := v.self().VisitSpace(ao.Operator.Before, p)
 	assignment := visitExpression(v, ao.Assignment, p)
 	if java.SpaceEqual(prefix, ao.Prefix) && java.MarkersEqual(markers, ao.Markers) &&
-		variable == ao.Variable && assignment == ao.Assignment {
+		variable == ao.Variable && java.SpaceEqual(opBefore, ao.Operator.Before) &&
+		assignment == ao.Assignment {
 		return ao
 	}
 	c := *ao
 	c.Prefix = prefix
 	c.Markers = markers
 	c.Variable = variable
+	c.Operator.Before = opBefore
 	c.Assignment = assignment
 	return &c
 }
 
 func (v *GoVisitor) VisitSwitch(sw *java.Switch, p any) java.J {
-	sw = sw.WithPrefix(v.self().VisitSpace(sw.Prefix, p))
-	sw = sw.WithMarkers(v.visitMarkers(sw.Markers, p))
-	sw = sw.WithBody(visitAndCast[*java.Block](v, sw.Body, p))
-	return sw
+	prefix := v.self().VisitSpace(sw.Prefix, p)
+	markers := v.visitMarkers(sw.Markers, p)
+	tag := sw.Tag
+	if tag != nil {
+		elem := visitExpression(v, tag.Element, p)
+		after := v.self().VisitSpace(tag.After, p)
+		if elem != tag.Element || !java.SpaceEqual(after, tag.After) {
+			c := *tag
+			c.Element = elem
+			c.After = after
+			tag = &c
+		}
+	}
+	body := visitAndCast[*java.Block](v, sw.Body, p)
+	if java.SpaceEqual(prefix, sw.Prefix) && java.MarkersEqual(markers, sw.Markers) &&
+		tag == sw.Tag && body == sw.Body {
+		return sw
+	}
+	c := *sw
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Tag = tag
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitCase(cse *java.Case, p any) java.J {
@@ -952,6 +1004,10 @@ func (v *GoVisitor) VisitForLoop(forLoop *java.ForLoop, p any) java.J {
 	prefix := v.self().VisitSpace(forLoop.Prefix, p)
 	markers := v.visitMarkers(forLoop.Markers, p)
 	ctrl := visitAndCast[*java.ForControl](v, &forLoop.Control, p)
+	if ctrl == nil {
+		// Control is a value field, so a pruned control has no deleted form.
+		ctrl = &forLoop.Control
+	}
 	body := visitAndCast[*java.Block](v, forLoop.Body, p)
 	if java.SpaceEqual(prefix, forLoop.Prefix) && java.MarkersEqual(markers, forLoop.Markers) &&
 		ctrl == &forLoop.Control && body == forLoop.Body {
@@ -1015,10 +1071,23 @@ func (v *GoVisitor) VisitForControl(control *java.ForControl, p any) java.J {
 }
 
 func (v *GoVisitor) VisitForEachLoop(forEach *java.ForEachLoop, p any) java.J {
-	forEach = forEach.WithPrefix(v.self().VisitSpace(forEach.Prefix, p))
-	forEach = forEach.WithMarkers(v.visitMarkers(forEach.Markers, p))
-	forEach = forEach.WithBody(visitAndCast[*java.Block](v, forEach.Body, p))
-	return forEach
+	prefix := v.self().VisitSpace(forEach.Prefix, p)
+	markers := v.visitMarkers(forEach.Markers, p)
+	ctrl := visitAndCast[*java.ForEachControl](v, &forEach.Control, p)
+	if ctrl == nil {
+		ctrl = &forEach.Control
+	}
+	body := visitAndCast[*java.Block](v, forEach.Body, p)
+	if java.SpaceEqual(prefix, forEach.Prefix) && java.MarkersEqual(markers, forEach.Markers) &&
+		ctrl == &forEach.Control && body == forEach.Body {
+		return forEach
+	}
+	c := *forEach
+	c.Prefix = prefix
+	c.Markers = markers
+	c.Control = *ctrl
+	c.Body = body
+	return &c
 }
 
 func (v *GoVisitor) VisitForEachControl(control *java.ForEachControl, p any) java.J {
@@ -1240,8 +1309,15 @@ func (v *GoVisitor) VisitFallthrough(f *golang.Fallthrough, p any) java.J {
 }
 
 func (v *GoVisitor) VisitEmpty(empty *java.Empty, p any) java.J {
-	empty = empty.WithPrefix(v.self().VisitSpace(empty.Prefix, p))
-	return empty
+	prefix := v.self().VisitSpace(empty.Prefix, p)
+	markers := v.visitMarkers(empty.Markers, p)
+	if java.SpaceEqual(prefix, empty.Prefix) && java.MarkersEqual(markers, empty.Markers) {
+		return empty
+	}
+	c := *empty
+	c.Prefix = prefix
+	c.Markers = markers
+	return &c
 }
 
 func (v *GoVisitor) VisitAnnotation(ann *java.Annotation, p any) java.J {

--- a/rewrite-go/pkg/visitor/traversal_test.go
+++ b/rewrite-go/pkg/visitor/traversal_test.go
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package visitor_test
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// reachedKinds parses src and returns how many nodes of each type the visitor
+// reaches, keyed by "package.TypeName" (e.g. "java.ForEachControl").
+func reachedKinds(t *testing.T, src string) map[string]int {
+	t.Helper()
+	cu, err := parser.NewGoParser().Parse("traversal.go", src)
+	require.NoError(t, err, "parse")
+
+	kinds := map[string]int{}
+	visitor.Walk(cu, func(n java.Tree) bool {
+		kinds[strings.TrimPrefix(reflect.TypeOf(n).String(), "*")]++
+		return true
+	})
+	return kinds
+}
+
+type spaceCollector struct {
+	visitor.GoVisitor
+	spaces []string
+}
+
+func (c *spaceCollector) VisitSpace(space java.Space, p any) java.Space {
+	c.spaces = append(c.spaces, space.Whitespace)
+	return c.GoVisitor.VisitSpace(space, p)
+}
+
+// visitedSpaces parses src and returns every whitespace string reachable
+// through VisitSpace. Callers widen the gap under test to a distinctive width
+// so the assertion names exactly one slot.
+func visitedSpaces(t *testing.T, src string) []string {
+	t.Helper()
+	cu, err := parser.NewGoParser().Parse("spaces.go", src)
+	require.NoError(t, err, "parse")
+
+	c := visitor.Init(&spaceCollector{})
+	c.Visit(cu, nil)
+	return c.spaces
+}
+
+// The space ahead of an operator is printed, so a visitor has to be able to
+// read and rewrite it — otherwise a formatter cannot set operator spacing.
+func TestOperatorSpaceIsVisited(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+	}{
+		{"binary", "package main\n\nfunc f(a, b int) int {\n\treturn a   + b\n}\n"},
+		{"unary", "package main\n\nfunc f() {\n\tx := 0\n\tx   ++\n}\n"},
+		{"assignment operation", "package main\n\nfunc f() {\n\tx := 0\n\tx   += 1\n}\n"},
+		{"variadic parameter", "package main\n\nfunc f(a   ...int) {\n\t_ = a\n}\n"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			spaces := visitedSpaces(t, tc.src)
+
+			// then
+			require.Contains(t, spaces, "   ", "the widened gap must reach VisitSpace")
+		})
+	}
+}
+
+// Everything in a `for … range` header — the loop targets and the iterated
+// expression — has to be reachable, or recipes searching a range clause find
+// nothing and rewrites of it silently no-op.
+func TestForEachLoopHeaderIsTraversed(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f() {\n\tfor _, s := range []string{\"a\"} {\n\t\t_ = s\n\t}\n}\n"
+
+	// when
+	kinds := reachedKinds(t, src)
+
+	// then
+	require.Equal(t, 1, kinds["java.ForEachLoop"], "the loop itself")
+	require.Equal(t, 1, kinds["java.ForEachControl"], "loop header")
+	require.Equal(t, 1, kinds["golang.MultiAssignment"], "loop targets")
+	require.Equal(t, 1, kinds["golang.Composite"], "iterated composite literal")
+	require.Equal(t, 1, kinds["java.ArrayType"], "iterated composite literal's type")
+	require.Equal(t, 1, kinds["java.Literal"], `the "a" element`)
+}
+
+// A recipe matching method invocations depends on the iterated expression.
+func TestForEachLoopIteratedCallIsTraversed(t *testing.T) {
+	// given
+	src := "package main\n\nfunc items() []int { return nil }\n\nfunc f() {\n\tfor i := range items() {\n\t\t_ = i\n\t}\n}\n"
+
+	// when
+	kinds := reachedKinds(t, src)
+
+	// then
+	require.Equal(t, 1, kinds["java.MethodInvocation"], "iterated call")
+}
+
+func TestForLoopHeaderIsTraversed(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f() {\n\tfor i := 0; i < 3; i++ {\n\t\t_ = i\n\t}\n}\n"
+
+	// when
+	kinds := reachedKinds(t, src)
+
+	// then
+	require.Equal(t, 1, kinds["java.ForControl"], "loop header")
+	require.Equal(t, 1, kinds["java.Binary"], "condition")
+	require.Equal(t, 1, kinds["java.Unary"], "update")
+}
+
+// A switch's tag expression is a header the same way a loop control is.
+func TestSwitchTagIsTraversed(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f(x int) {\n\tswitch x + 1 {\n\tcase 2:\n\t}\n}\n"
+
+	// when
+	kinds := reachedKinds(t, src)
+
+	// then
+	require.Equal(t, 1, kinds["java.Switch"], "the switch itself")
+	require.Equal(t, 1, kinds["java.Binary"], "tag expression")
+}
+
+// A type switch is a java.Switch whose tag holds the guard, so the guard rides
+// the same slot as an ordinary switch tag.
+func TestTypeSwitchGuardIsTraversed(t *testing.T) {
+	// given
+	bare := "package main\n\nfunc f(v any) {\n\tswitch v.(type) {\n\tcase int:\n\t}\n}\n"
+	assigning := "package main\n\nfunc f(v any) {\n\tswitch x := v.(type) {\n\tcase int:\n\t\t_ = x\n\t}\n}\n"
+
+	// when
+	bareKinds := reachedKinds(t, bare)
+	assigningKinds := reachedKinds(t, assigning)
+
+	// then
+	require.Equal(t, 1, bareKinds["golang.TypeAssertion"], "bare guard")
+	// The assigning form spells the guard as an assignment in the tag slot; the
+	// second java.Assignment is the case body's `_ = x`.
+	require.Equal(t, 1, assigningKinds["golang.TypeAssertion"], "assigning guard's assertion")
+	require.Equal(t, 2, assigningKinds["java.Assignment"], "assigning guard")
+}
+
+func TestSelectClausesAreTraversed(t *testing.T) {
+	// given
+	src := "package main\n\nfunc f(c chan int) {\n\tselect {\n\tcase <-c:\n\t}\n}\n"
+
+	// when
+	kinds := reachedKinds(t, src)
+
+	// then
+	require.Equal(t, 1, kinds["golang.CommClause"], "comm clause")
+	require.Equal(t, 1, kinds["golang.Unary"], "receive expression")
+}
+
+type pruningVisitor struct {
+	visitor.GoVisitor
+	prune func(java.Tree) bool
+}
+
+func (v *pruningVisitor) PreVisit(t java.Tree, p any) java.Tree {
+	if v.prune(t) {
+		return nil
+	}
+	return t
+}
+
+// Returning nil from PreVisit prunes a subtree.
+func TestPrunedLoopControlKeepsOriginal(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		is   func(java.Tree) bool
+	}{
+		{"for", "package main\n\nfunc f() {\n\tfor i := 0; i < 3; i++ {\n\t\t_ = i\n\t}\n}\n",
+			func(n java.Tree) bool { _, ok := n.(*java.ForControl); return ok }},
+		{"for range", "package main\n\nfunc f(items []int) {\n\tfor _, s := range items {\n\t\t_ = s\n\t}\n}\n",
+			func(n java.Tree) bool { _, ok := n.(*java.ForEachControl); return ok }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// given
+			cu, err := parser.NewGoParser().Parse("prune.go", tc.src)
+			require.NoError(t, err, "parse")
+
+			// when
+			v := visitor.Init(&pruningVisitor{prune: tc.is})
+			var got java.Tree
+			require.NotPanics(t, func() { got = v.Visit(cu, nil) })
+
+			// then
+			require.Equal(t, tc.src, printer.Print(got))
+		})
+	}
+}
+
+// java.Empty backs a keyless `for range` target, so a marker unreachable here
+// is a marker unreachable inside a loop header.
+func TestEmptyMarkersAreVisited(t *testing.T) {
+	// given
+	found := uuid.New()
+	empty := &java.Empty{
+		ID: uuid.New(),
+		Markers: java.Markers{
+			ID:      uuid.New(),
+			Entries: []java.Marker{java.SearchResult{Ident: found}},
+		},
+	}
+
+	// when
+	ids := visitor.CollectSearchResultIDs(empty)
+
+	// then
+	require.Equal(t, []uuid.UUID{found}, ids)
+}


### PR DESCRIPTION
## Motivation

Two LST-level defects in `rewrite-go`, both independent of formatting. The first affects every recipe: `GoVisitor.VisitForEachLoop` visited a loop's prefix, markers and body but never its `Control`, so nothing inside `for _, s := range expr` was traversed — neither the loop variables nor the iterated expression. Any recipe searching a range clause for method calls, types or literals silently missed them, and any visitor rewriting them silently no-opped. Auditing the other 69 J-returning visitor methods against their struct fields turned up four more slots in the same state, plus a nil-deref panic on the pruning path. The second defect is narrower: an untyped composite literal parked its leading whitespace on `Elements.Before` rather than `Prefix`, breaking the convention that leading whitespace belongs to the outermost element, so nothing driving off `GetPrefix()` could read or set that element's indentation.

## Examples

Every node in a loop or switch header is now reachable:

```go
for _, s := range []string{"a"} { _ = s }   // the []string{"a"} composite is now visited
switch x + 1 { case 2: }                    // the x + 1 tag is now visited
a + b                                       // the space before + is now visited
```

The table-driven test idiom, whose inner elements are untyped composites, now carries its indentation where recipes and formatters look for it:

```go
tests := []struct {
	name string
}{
	{name: "a"},   // "\n\t" is on Prefix; Elements.Before is empty
}
```

## Summary

- `VisitForEachLoop` visits `Control`, and `VisitSwitch` visits `Tag` (which carries both an ordinary switch tag and a type-switch guard).
- `VisitBinary`, `VisitUnary` and `VisitAssignmentOperation` visit `Operator.Before` — the printed space ahead of `+`, `++` and `+=`. The `golang.*` operator visitors already did this; the `java.*` ones were inconsistent with their own siblings.
- `VisitVariableDeclarations` visits `Varargs`, the printed space ahead of `...`.
- `VisitEmpty` visits `Markers`.
- `VisitForLoop` and `VisitForEachLoop` no longer panic when a visitor prunes the control by returning nil from `PreVisit`. `Control` is a value field with no deleted form, so they fall back to the parsed control.
- `mapCompositeLit` puts an untyped composite's leading whitespace on `Prefix` and leaves `Elements.Before` empty; the field comment on `Composite.Elements` is updated to match. The printer needed no change and output is byte-identical.
- `Annotations` on `Identifier`, `TypeParameters` and `TypeParameter` remain deliberately unvisited: the Go parser never populates them, the printer never emits them and RPC never sends them. They mirror rewrite-java's struct shape only.

Measured against the in-flight gofmt formatter branch, the two fixes move gofmt parity from 2110 to 2256 standard library files rendered exactly as gofmt. The residual indent-only mismatches there are still the untyped-composite shape: the LST now exposes that whitespace on `Prefix`, but `tabs_and_indents` does not yet act on it, so closing that gap is formatter work rather than LST work.

The RPC wire format is unaffected — `prefix` is a shared `J` field and `Elements` ships as a whole container, so the composite's tree-shape change is invisible to the codecs. The Java peer is unaffected too: there is no Java-side Go printer, and `GolangVisitor` inherits `JavaVisitor`'s loop and switch handling, which already visits controls.

## Test plan

- [x] New `pkg/visitor/traversal_test.go` asserts every node in a `for`, `for … range`, `switch`, type-switch and `select` header is reached, that operator and variadic spaces reach `VisitSpace`, that markers on `java.Empty` are visited, and that pruning a loop control does not panic.
- [x] New `pkg/parser/composite_lit_test.go` pins the untyped-composite prefix contract, the typed form, the round trip and a map-literal nesting.
- [x] Every new test confirmed to fail before its fix and pass after (verified by stashing the fixes and re-running).
- [x] `go test ./...` green.
- [x] `make parity` green.
- [x] Corpus sweep over 35,427 files across 8 repositories, clean baseline vs. fixed with fresh journals: identical at 33,467 sound / 7 unsound / 151 parse error.
- [x] `gofmt` and `go vet` clean on all changed files.
- [x] `TestParserCoverageAudit` and `TestParityGap`, the two build-tagged audits that live on the in-flight gofmt formatter branch, run on a scratch worktree at that branch's `f45c534a1e` with this branch merged in (clean merge, no conflicts).
- [x] Coverage audit holds its floor: `files=6494 parsedAndRoundTripped=5335 buildExcluded=1159 goParserRejects=0 rewriteRejects=0 roundTripFails=0 distinctCauses=0`.
- [x] Parity audit improves: `considered=5333 exactlyGofmt=2256 differ=3077`, against an `exactlyGofmt=2110 differ=3223` baseline on that branch alone — 146 more files match gofmt exactly.
