### PR TITLE
Give `RemoveImport` a conditional mode and add `MaybeRemoveImport` in `rewrite-go`

### DIFF
--- a/rewrite-go/pkg/recipe/golang/import_service.go
+++ b/rewrite-go/pkg/recipe/golang/import_service.go
@@ -74,6 +74,33 @@ func MaybeAddImport(v visitor.AfterVisitsProvider, packagePath string, alias *st
 	}).Editor())
 }
 
+// MaybeRemoveImport queues a RemoveImport visitor on v unless an
+// equivalent RemoveImport is already pending. It mirrors
+// JavaVisitor.maybeRemoveImport: the import survives while the file
+// still references the package, and running on the after-visit drain is
+// what lets that check see the recipe's own edits.
+func MaybeRemoveImport(v visitor.AfterVisitsProvider, packagePath string) {
+	if v == nil {
+		return
+	}
+	if pending, ok := v.(visitor.PendingAfterVisitsProvider); ok {
+		for _, after := range pending.PendingAfterVisits() {
+			if samePendingRemoveImport(after, packagePath) {
+				return
+			}
+		}
+	}
+	v.DoAfterVisit((&RemoveImport{PackagePath: packagePath}).Editor())
+}
+
+func samePendingRemoveImport(after visitor.AfterVisitor, packagePath string) bool {
+	v, ok := after.(*removeImportVisitor)
+	if !ok || v.cfg == nil {
+		return false
+	}
+	return v.cfg.PackagePath == packagePath && !v.cfg.Force
+}
+
 func samePendingAddImport(after visitor.AfterVisitor, packagePath string, alias *string, onlyIfReferenced bool) bool {
 	v, ok := after.(*addImportVisitor)
 	if !ok || v.cfg == nil {
@@ -115,11 +142,11 @@ func (s *ImportService) AddImportVisitor(packagePath string, alias *string, only
 }
 
 // RemoveImportVisitor returns a visitor that deletes any `import` whose
-// path matches packagePath. Aliased / blank / dot forms are all
-// removed. Empty import containers are nil-ed out so the printer
-// doesn't emit an empty `import ()` block.
-func (s *ImportService) RemoveImportVisitor(packagePath string) recipe.TreeVisitor {
-	return (&RemoveImport{PackagePath: packagePath}).Editor()
+// path matches packagePath. Empty import containers are nil-ed out so
+// the printer doesn't emit an empty `import ()` block. See RemoveImport
+// for what force does.
+func (s *ImportService) RemoveImportVisitor(packagePath string, force bool) recipe.TreeVisitor {
+	return (&RemoveImport{PackagePath: packagePath, Force: force}).Editor()
 }
 
 // RemoveUnusedImportsVisitor returns a visitor that drops imports

--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -176,29 +176,26 @@ func IsLocal(importPath, modulePath string) bool {
 	return importPath == modulePath || strings.HasPrefix(importPath, modulePath+"/")
 }
 
-// ReferencedPackages walks cu and returns the set of import paths that
-// are referenced by some identifier in the file body. Used by
-// RemoveUnusedImports to drop imports whose alias is never read.
-//
-// Detection is driven by the Type attribution that the parser threads
-// onto each Identifier:
-//   - For an `Identifier` whose `Type` is a `JavaTypeClass` and whose
-//     `FullyQualifiedName` carries an import path (path-shaped FQN),
-//     that path is added to the set.
-//   - For a `MethodInvocation`, the `MethodType.DeclaringType.FullyQualifiedName`
-//     is used.
-//
-// Aliases and dot imports are handled uniformly — the package's import
-// path is what we track, regardless of how the user named it.
+// ReferencedImports walks the body of cu once and returns the two signals
+// that decide whether an import is used: refs, the import paths carried by
+// the parser's Type attribution, and quals, the identifiers used lexically
+// as package qualifiers — the attribution-free signal goimports relies on.
+// Aliases and dot imports land in refs under the package's import path.
+func ReferencedImports(cu *golang.CompilationUnit) (refs, quals map[string]bool) {
+	return referencedImports(cu)
+}
+
+// ReferencedPackages returns just the import-path set of ReferencedImports.
 func ReferencedPackages(cu *golang.CompilationUnit) map[string]bool {
 	refs, _ := referencedImports(cu)
 	return refs
 }
 
-// ReferencedQualifiers returns the identifiers used lexically as package qualifiers (left of the dot), the attribution-free signal goimports relies on.
-func ReferencedQualifiers(cu *golang.CompilationUnit) map[string]bool {
-	_, quals := referencedImports(cu)
-	return quals
+// IsReferenced reports whether imp is used by the file whose refs/quals
+// sets are passed in. Both sets come from one ReferencedImports walk per
+// file.
+func IsReferenced(imp *java.Import, refs, quals map[string]bool) bool {
+	return refs[ImportPath(imp)] || quals[PackageName(imp)]
 }
 
 func referencedImports(cu *golang.CompilationUnit) (refs, quals map[string]bool) {
@@ -216,6 +213,13 @@ type referencedPackagesVisitor struct {
 	visitor.GoVisitor
 	refs  map[string]bool
 	quals map[string]bool
+}
+
+// The alias in `import s "strings"` carries the imported package as its
+// type, so the walk stops at the import declarations and counts only uses
+// in the body.
+func (v *referencedPackagesVisitor) VisitImport(imp *java.Import, p any) java.J {
+	return imp
 }
 
 func (v *referencedPackagesVisitor) VisitIdentifier(ident *java.Identifier, p any) java.J {

--- a/rewrite-go/pkg/recipe/golang/remove_import.go
+++ b/rewrite-go/pkg/recipe/golang/remove_import.go
@@ -24,29 +24,34 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
-// Matches by import path: any form (regular, aliased, dot, or blank)
-// that imports PackagePath is removed. If the imports container becomes
-// empty as a result, it is nil-ed out so the printer doesn't emit an
-// empty `import ()` block.
+// Matches by import path, whichever form (regular, aliased, dot, or
+// blank) the import takes. If the imports container becomes empty as a
+// result, it is nil-ed out so the printer doesn't emit an empty
+// `import ()` block.
 //
-// Removing an actively-referenced import will of course break the file;
-// this recipe trusts the caller to know that. For unused-import cleanup,
-// use RemoveUnusedImports.
+// Force mirrors the Java recipe's flag of the same name. Left false, the
+// import survives while the file still references it, and blank (`_`) and
+// dot (`.`) imports survive outright under the rule RemoveUnusedImports
+// documents. Set it to remove every matching form regardless.
 type RemoveImport struct {
 	recipe.Base
 	PackagePath string
+	Force       bool
 }
 
 func (r *RemoveImport) Name() string        { return "org.openrewrite.golang.RemoveImport" }
 func (r *RemoveImport) DisplayName() string { return "Remove import" }
 func (r *RemoveImport) Description() string {
-	return "Remove an `import` statement from a Go compilation unit. Matches by import path; any form (regular, aliased, dot, blank) is removed."
+	return "Remove an `import` statement from a Go compilation unit. Matches by import path, in any form (regular, aliased, dot, blank). Unless `force` is set, an import that the file still references is kept, as are blank (`_`) and dot (`.`) imports."
 }
 
 func (r *RemoveImport) Options() []recipe.OptionDescriptor {
 	return []recipe.OptionDescriptor{
 		recipe.Option("packagePath", "Package path", "The import path to remove.").
 			WithExample("fmt").WithValue(r.PackagePath),
+		recipe.Option("force", "Force",
+			"When true, remove the import even if the file still references the package, and remove blank (`_`) and dot (`.`) imports.").
+			AsOptional().WithValue(r.Force),
 	}
 }
 
@@ -64,10 +69,24 @@ func (v *removeImportVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p
 	if v.cfg.PackagePath == "" || cu.Imports == nil {
 		return cu
 	}
+	var refs, quals map[string]bool
+	if !v.cfg.Force {
+		refs, quals = internal.ReferencedImports(cu)
+	}
 	for _, rp := range cu.Imports.Elements {
-		if internal.ImportPath(rp.Element) == v.cfg.PackagePath {
-			cu = internal.RemoveFromBlock(cu, rp.Element)
+		imp := rp.Element
+		if internal.ImportPath(imp) != v.cfg.PackagePath {
+			continue
 		}
+		if !v.cfg.Force {
+			if alias := internal.AliasName(imp); alias == "_" || alias == "." {
+				continue
+			}
+			if internal.IsReferenced(imp, refs, quals) {
+				continue
+			}
+		}
+		cu = internal.RemoveFromBlock(cu, imp)
 	}
 	return cu
 }

--- a/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
+++ b/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
@@ -34,7 +34,7 @@ import (
 // their init() side-effects, not for any user-visible reference.
 //
 // Recipe authors who want to drop blank imports should use RemoveImport
-// targeting the specific path.
+// with Force set, targeting the specific path.
 type RemoveUnusedImports struct {
 	recipe.Base
 }
@@ -58,8 +58,7 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 	if cu.Imports == nil || len(cu.Imports.Elements) == 0 {
 		return cu
 	}
-	refs := internal.ReferencedPackages(cu)
-	quals := internal.ReferencedQualifiers(cu)
+	refs, quals := internal.ReferencedImports(cu)
 	for _, rp := range cu.Imports.Elements {
 		imp := rp.Element
 		if imp == nil {
@@ -74,7 +73,7 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 		if internal.AliasName(imp) == "." {
 			continue
 		}
-		if refs[internal.ImportPath(imp)] || quals[internal.PackageName(imp)] {
+		if internal.IsReferenced(imp, refs, quals) {
 			continue
 		}
 		cu = internal.RemoveFromBlock(cu, imp)

--- a/rewrite-go/test/import_recipes_test.go
+++ b/rewrite-go/test/import_recipes_test.go
@@ -236,7 +236,7 @@ func TestAddImport_AliasedFormDoesNotMatchRegular(t *testing.T) {
 }
 
 func TestRemoveImport_DeletesMatching(t *testing.T) {
-	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "strings"})
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "strings", Force: true})
 	before := `
 		package main
 
@@ -257,6 +257,142 @@ func TestRemoveImport_DeletesMatching(t *testing.T) {
 		func main() { fmt.Println(strings.ToUpper("hi")) }
 	`
 	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestRemoveImport_KeepsStillReferenced(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "strings"})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				"fmt"
+				"strings"
+			)
+
+			func main() { fmt.Println(strings.ToUpper("hi")) }
+		`),
+	)
+}
+
+func TestRemoveImport_DeletesUnreferenced(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "strings"})
+	before := `
+		package main
+
+		import (
+			"fmt"
+			"strings"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	after := `
+		package main
+
+		import (
+			"fmt"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestRemoveImport_DeletesUnreferencedAliased(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "strings"})
+	before := `
+		package main
+
+		import (
+			"fmt"
+			s "strings"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	after := `
+		package main
+
+		import (
+			"fmt"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestRemoveImport_KeepsReferencedAliased(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "strings"})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				"fmt"
+				s "strings"
+			)
+
+			func main() { fmt.Println(s.ToUpper("hi")) }
+		`),
+	)
+}
+
+func TestRemoveImport_KeepsBlankImport(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "github.com/x/y"})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				_ "github.com/x/y"
+				"fmt"
+			)
+
+			func main() { fmt.Println("hi") }
+		`),
+	)
+}
+
+func TestRemoveImport_ForceDeletesBlankImport(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "github.com/x/y", Force: true})
+	before := `
+		package main
+
+		import (
+			_ "github.com/x/y"
+			"fmt"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	after := `
+		package main
+
+		import (
+			"fmt"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestRemoveImport_KeepsDotImport(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveImport{PackagePath: "github.com/x/y"})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				. "github.com/x/y"
+				"fmt"
+			)
+
+			func main() { fmt.Println("hi") }
+		`),
+	)
 }
 
 func TestRemoveImport_NoOpWhenAbsent(t *testing.T) {
@@ -294,6 +430,46 @@ func TestRemoveUnusedImports_DropsUnreferenced(t *testing.T) {
 		func main() { fmt.Println("hi") }
 	`
 	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestRemoveUnusedImports_DropsUnreferencedAliased(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveUnusedImports{})
+	before := `
+		package main
+
+		import (
+			"fmt"
+			s "strings"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	after := `
+		package main
+
+		import (
+			"fmt"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestRemoveUnusedImports_KeepsReferencedAliased(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveUnusedImports{})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				"fmt"
+				s "strings"
+			)
+
+			func main() { fmt.Println(s.ToUpper("hi")) }
+		`),
+	)
 }
 
 func TestRemoveUnusedImports_PreservesBlankImports(t *testing.T) {

--- a/rewrite-go/test/import_service_test.go
+++ b/rewrite-go/test/import_service_test.go
@@ -177,6 +177,93 @@ type removeFmtVisitor struct{ visitor.GoVisitor }
 func (v *removeFmtVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
 	cu = v.GoVisitor.VisitCompilationUnit(cu, p).(*golang.CompilationUnit)
 	svc := recipe.Service[*recipes.ImportService](nil)
-	v.DoAfterVisit(svc.RemoveImportVisitor("fmt"))
+	v.DoAfterVisit(svc.RemoveImportVisitor("fmt", false))
 	return cu
+}
+
+func TestMaybeRemoveImport_DeduplicatesPendingVisitors(t *testing.T) {
+	v := visitor.Init(&maybeRemoveImportPendingVisitor{})
+	recipes.MaybeRemoveImport(v, "fmt")
+	recipes.MaybeRemoveImport(v, "fmt")
+
+	if got := len(v.PendingAfterVisits()); got != 1 {
+		t.Fatalf("expected one pending RemoveImport visitor, got %d", got)
+	}
+}
+
+type maybeRemoveImportPendingVisitor struct{ visitor.GoVisitor }
+
+func TestMaybeRemoveImport_KeepsStillReferencedImport(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&maybeRemoveStringsImportRecipe{unwrap: false})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				"fmt"
+				"strings"
+			)
+
+			func main() { fmt.Println(strings.ToUpper("hi")) }
+		`),
+	)
+}
+
+func TestMaybeRemoveImport_RemovesImportOrphanedByTheSameEdit(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&maybeRemoveStringsImportRecipe{unwrap: true})
+	before := `
+		package main
+
+		import (
+			"fmt"
+			"strings"
+		)
+
+		func main() { fmt.Println(strings.ToUpper("hi")) }
+	`
+	after := `
+		package main
+
+		import (
+			"fmt"
+		)
+
+		func main() { fmt.Println("hi") }
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+// Unwraps `strings.ToUpper(x)` to `x` when unwrap is set; calls
+// MaybeRemoveImport("strings") either way.
+type maybeRemoveStringsImportRecipe struct {
+	recipe.Base
+	unwrap bool
+}
+
+func (r *maybeRemoveStringsImportRecipe) Name() string { return "test.MaybeRemoveStringsImport" }
+func (r *maybeRemoveStringsImportRecipe) DisplayName() string {
+	return "Remove strings import via MaybeRemoveImport"
+}
+func (r *maybeRemoveStringsImportRecipe) Description() string { return "Test recipe." }
+func (r *maybeRemoveStringsImportRecipe) Editor() recipe.TreeVisitor {
+	return visitor.Init(&maybeRemoveStringsVisitor{unwrap: r.unwrap})
+}
+
+type maybeRemoveStringsVisitor struct {
+	visitor.GoVisitor
+	unwrap bool
+}
+
+func (v *maybeRemoveStringsVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
+	cu = v.GoVisitor.VisitCompilationUnit(cu, p).(*golang.CompilationUnit)
+	recipes.MaybeRemoveImport(v, "strings")
+	return cu
+}
+
+func (v *maybeRemoveStringsVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
+	mi = v.GoVisitor.VisitMethodInvocation(mi, p).(*java.MethodInvocation)
+	if !v.unwrap || mi.Name == nil || mi.Name.Name != "ToUpper" || len(mi.Arguments.Elements) != 1 {
+		return mi
+	}
+	return mi.Arguments.Elements[0].Element
 }


### PR DESCRIPTION
## Motivation

`rewrite-go` exposes `MaybeAddImport` but has no removal counterpart, and its `RemoveImport` removes unconditionally. A recipe that rewrites away the last use of a package therefore has two bad options: remove the import blindly and risk emitting code that no longer compiles, or run `RemoveUnusedImports` across the whole file and touch imports the recipe never cared about. Every other language in the ecosystem offers the "maybe" form, where the import is dropped only once nothing references it.

While adding it, a second problem surfaced: the reference walk that decides whether an import is used covered the import declarations themselves. The parser attributes an import's alias identifier with the imported package (`JavaTypeClass{FullyQualifiedName: <import path>}`), so `import s "strings"` registered as a use of `strings`. No aliased import could ever be seen as unused, which silently defeated the pre-existing `RemoveUnusedImports` as well.

## Examples

`RemoveImport` gains a `Force` flag mirroring the Java recipe's:

```go
// Removes only if nothing in the file still references the package.
// Blank (`_`) and dot (`.`) imports are kept.
&golang.RemoveImport{PackagePath: "strings"}

// Removes every matching form regardless.
&golang.RemoveImport{PackagePath: "strings", Force: true}
```

`MaybeRemoveImport` queues the conditional visitor on the after-visit drain, mirroring `JavaVisitor.maybeRemoveImport`:

```go
func (v *myVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
    if shouldUnwrap(mi) {
        golang.MaybeRemoveImport(v, "strings")
        return mi.Arguments.Elements[0].Element
    }
    return mi
}
```

Because the edit runs on the drain rather than inline, the reference check sees the tree as the recipe left it — removing the last use in the same pass is enough for the import to go.

## Summary

- `RemoveImport` gains `Force bool`. Left false, the import survives while the file still references it, and blank / dot imports survive outright (a blank import has no reference to count; a dot import's names enter the local scope and can't be traced back to an import path). `Force: true` is the previous unconditional behavior.
- New `MaybeRemoveImport(v, packagePath)` free function with pending-visitor dedup, mirroring `MaybeAddImport`.
- `ImportService.RemoveImportVisitor` takes a `force` argument.
- The reference walk stops at the import declarations, so an import alias no longer counts as a use of its own package. This repairs aliased-import handling in `RemoveUnusedImports` too.
- `ReferencedImports` returns both reference sets from one walk, and `IsReferenced` gives `RemoveImport` and `RemoveUnusedImports` a single definition of "still used". The now-unused `ReferencedQualifiers` is dropped.
- `RemoveImport`'s recipe description and doc comment describe the conditional default.

Note for existing callers: `RemoveImport{PackagePath: p}` is now conditional. Anything relying on unconditional removal needs `Force: true`.

## Test plan

- [x] `RemoveImport` keeps a still-referenced import, removes an unreferenced one, and removes a referenced one under `Force`
- [x] `RemoveImport` keeps blank and dot imports by default, and removes a blank import under `Force`
- [x] `RemoveImport` and `RemoveUnusedImports` both remove an unreferenced *aliased* import and keep a referenced one (red before the walk fix, green after)
- [x] `MaybeRemoveImport` dedups repeated calls into one pending visitor
- [x] `MaybeRemoveImport` keeps a still-referenced import, and removes one orphaned by the same recipe pass (`strings.ToUpper(x)` unwrapped to `x`)
- [x] `go test ./...` green across `rewrite-go`; `go vet` clean; touched files gofmt-clean
