### PR TITLE
Bring the Go formatter to gofmt parity on well-formatted input

### DIFF
--- a/rewrite-go/pkg/format/auto_format.go
+++ b/rewrite-go/pkg/format/auto_format.go
@@ -30,15 +30,18 @@ import (
 //  2. BlankLinesVisitor                — collapse blank-line runs
 //  3. TabsAndIndentsVisitor            — re-indent post-newline whitespace
 //  4. SpacesVisitor                    — normalize intra-line spacing
+//  5. DocCommentVisitor                — canonicalize doc comment text
 //
 // Pass-1 runs first because pass-3 (re-indent) only touches the post-
 // newline portion of a Whitespace; if pass-1 ran later, the trailing
 // space/tabs of an earlier line could survive. Pass-2 runs before pass-3
 // because collapsing blank lines doesn't touch indents — it just
 // removes whole `\n` characters — so pass-3 still has the right
-// post-newline section to rewrite. Pass-4 runs last because changes
-// within a binary/assignment don't affect whether a line carries a
-// newline; spacing fixes can't disturb prior passes.
+// post-newline section to rewrite. Pass-4 runs after pass-3 because
+// changes within a binary/assignment don't affect whether a line carries
+// a newline; spacing fixes can't disturb prior passes. Pass-5 runs after
+// pass-3 too, because a doc comment is one that sits at column one, which
+// is only true of the right comments once indentation has been restored.
 //
 // stopAfter is forwarded to every member visitor; pass nil to format
 // the entire visited subtree.
@@ -59,5 +62,6 @@ func (v *AutoFormatVisitor) Visit(t java.Tree, p any) java.Tree {
 	v.DoAfterVisit(NewBlankLinesVisitor(v.stopAfter))
 	v.DoAfterVisit(NewTabsAndIndentsVisitor(v.stopAfter))
 	v.DoAfterVisit(NewSpacesVisitor(v.stopAfter))
+	v.DoAfterVisit(NewDocCommentVisitor(v.stopAfter))
 	return t
 }

--- a/rewrite-go/pkg/format/auto_format.go
+++ b/rewrite-go/pkg/format/auto_format.go
@@ -27,13 +27,14 @@ import (
 //
 //  1. MinimumViableSpacingVisitor      — separation the tokens require
 //  2. DocCommentVisitor                — canonical doc comment text
-//  3. SpacesVisitor                    — intra-line spacing
-//  4. TabsAndIndentsVisitor            — indentation
+//  3. BinarySpacingVisitor             — blanks around binary operators
+//  4. SpacesVisitor                    — intra-line spacing
+//  5. TabsAndIndentsVisitor            — indentation
 //
 // then the passes that decide what the lines are, once their text is final:
 //
-//  5. BlankLinesVisitor                — collapse blank-line runs
-//  6. RemoveTrailingWhitespaceVisitor  — strip trailing space/tabs
+//  6. BlankLinesVisitor                — collapse blank-line runs
+//  7. RemoveTrailingWhitespaceVisitor  — strip trailing space/tabs
 //
 // Phase two runs last because the earlier passes rewrite a line's text and can
 // add or drop whole lines, so a line structure normalized ahead of them would
@@ -56,6 +57,7 @@ func (v *AutoFormatVisitor) Visit(t java.Tree, p any) java.Tree {
 	}
 	v.DoAfterVisit(NewMinimumViableSpacingVisitor(v.stopAfter))
 	v.DoAfterVisit(NewDocCommentVisitor(v.stopAfter))
+	v.DoAfterVisit(NewBinarySpacingVisitor(v.stopAfter))
 	v.DoAfterVisit(NewSpacesVisitor(v.stopAfter))
 	v.DoAfterVisit(NewTabsAndIndentsVisitor(v.stopAfter))
 	v.DoAfterVisit(NewBlankLinesVisitor(v.stopAfter))

--- a/rewrite-go/pkg/format/auto_format.go
+++ b/rewrite-go/pkg/format/auto_format.go
@@ -25,14 +25,15 @@ import (
 // single end-to-end pipeline, in the two phases org.openrewrite.java.format.
 // AutoFormatVisitor uses. Spacing is settled first, widest scope last:
 //
-//  1. DocCommentVisitor                — canonical doc comment text
-//  2. SpacesVisitor                    — intra-line spacing
-//  3. TabsAndIndentsVisitor            — indentation
+//  1. MinimumViableSpacingVisitor      — separation the tokens require
+//  2. DocCommentVisitor                — canonical doc comment text
+//  3. SpacesVisitor                    — intra-line spacing
+//  4. TabsAndIndentsVisitor            — indentation
 //
 // then the passes that decide what the lines are, once their text is final:
 //
-//  4. BlankLinesVisitor                — collapse blank-line runs
-//  5. RemoveTrailingWhitespaceVisitor  — strip trailing space/tabs
+//  5. BlankLinesVisitor                — collapse blank-line runs
+//  6. RemoveTrailingWhitespaceVisitor  — strip trailing space/tabs
 //
 // Phase two runs last because the earlier passes rewrite a line's text and can
 // add or drop whole lines, so a line structure normalized ahead of them would
@@ -53,6 +54,7 @@ func (v *AutoFormatVisitor) Visit(t java.Tree, p any) java.Tree {
 	if t == nil {
 		return nil
 	}
+	v.DoAfterVisit(NewMinimumViableSpacingVisitor(v.stopAfter))
 	v.DoAfterVisit(NewDocCommentVisitor(v.stopAfter))
 	v.DoAfterVisit(NewSpacesVisitor(v.stopAfter))
 	v.DoAfterVisit(NewTabsAndIndentsVisitor(v.stopAfter))

--- a/rewrite-go/pkg/format/auto_format.go
+++ b/rewrite-go/pkg/format/auto_format.go
@@ -21,27 +21,22 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
-// AutoFormatVisitor composes the per-responsibility format visitors
-// into a single end-to-end pipeline. The pipeline applies passes in a
-// fixed order — each later pass relies on the structure normalized by
-// the earlier ones:
+// AutoFormatVisitor composes the per-responsibility format visitors into a
+// single end-to-end pipeline, in the two phases org.openrewrite.java.format.
+// AutoFormatVisitor uses. Spacing is settled first, widest scope last:
 //
-//  1. RemoveTrailingWhitespaceVisitor  — strip trailing spaces/tabs
-//  2. BlankLinesVisitor                — collapse blank-line runs
-//  3. TabsAndIndentsVisitor            — re-indent post-newline whitespace
-//  4. SpacesVisitor                    — normalize intra-line spacing
-//  5. DocCommentVisitor                — canonicalize doc comment text
+//  1. DocCommentVisitor                — canonical doc comment text
+//  2. SpacesVisitor                    — intra-line spacing
+//  3. TabsAndIndentsVisitor            — indentation
 //
-// Pass-1 runs first because pass-3 (re-indent) only touches the post-
-// newline portion of a Whitespace; if pass-1 ran later, the trailing
-// space/tabs of an earlier line could survive. Pass-2 runs before pass-3
-// because collapsing blank lines doesn't touch indents — it just
-// removes whole `\n` characters — so pass-3 still has the right
-// post-newline section to rewrite. Pass-4 runs after pass-3 because
-// changes within a binary/assignment don't affect whether a line carries
-// a newline; spacing fixes can't disturb prior passes. Pass-5 runs after
-// pass-3 too, because a doc comment is one that sits at column one, which
-// is only true of the right comments once indentation has been restored.
+// then the passes that decide what the lines are, once their text is final:
+//
+//  4. BlankLinesVisitor                — collapse blank-line runs
+//  5. RemoveTrailingWhitespaceVisitor  — strip trailing space/tabs
+//
+// Phase two runs last because the earlier passes rewrite a line's text and can
+// add or drop whole lines, so a line structure normalized ahead of them would
+// not stay normalized.
 //
 // stopAfter is forwarded to every member visitor; pass nil to format
 // the entire visited subtree.
@@ -58,10 +53,10 @@ func (v *AutoFormatVisitor) Visit(t java.Tree, p any) java.Tree {
 	if t == nil {
 		return nil
 	}
-	v.DoAfterVisit(NewRemoveTrailingWhitespaceVisitor(v.stopAfter))
-	v.DoAfterVisit(NewBlankLinesVisitor(v.stopAfter))
-	v.DoAfterVisit(NewTabsAndIndentsVisitor(v.stopAfter))
-	v.DoAfterVisit(NewSpacesVisitor(v.stopAfter))
 	v.DoAfterVisit(NewDocCommentVisitor(v.stopAfter))
+	v.DoAfterVisit(NewSpacesVisitor(v.stopAfter))
+	v.DoAfterVisit(NewTabsAndIndentsVisitor(v.stopAfter))
+	v.DoAfterVisit(NewBlankLinesVisitor(v.stopAfter))
+	v.DoAfterVisit(NewRemoveTrailingWhitespaceVisitor(v.stopAfter))
 	return t
 }

--- a/rewrite-go/pkg/format/binary_spacing.go
+++ b/rewrite-go/pkg/format/binary_spacing.go
@@ -96,8 +96,10 @@ func (v *BinarySpacingVisitor) VisitGoBinary(bin *golang.Binary, p any) java.J {
 // VisitParentheses undoes one level of nesting, since the parentheses already
 // group what the depth is standing in for.
 func (v *BinarySpacingVisitor) VisitParentheses(parens *java.Parentheses, p any) java.J {
+	depth := v.depth
 	out := *parens
-	out.Tree.Element = v.operand(parens.Tree.Element, reduceDepth(v.depth))
+	out.Tree.Element = v.operand(parens.Tree.Element, reduceDepth(depth))
+	v.depth = depth
 	return &out
 }
 
@@ -215,10 +217,12 @@ func (v *BinarySpacingVisitor) operand(e java.Expression, depth int) java.Expres
 }
 
 func (v *BinarySpacingVisitor) operandList(elements []java.RightPadded[java.Expression], depth int) []java.RightPadded[java.Expression] {
+	outer := v.depth
 	out := append([]java.RightPadded[java.Expression](nil), elements...)
 	for i := range out {
 		out[i].Element = v.operand(out[i].Element, depth)
 	}
+	v.depth = outer
 	return out
 }
 

--- a/rewrite-go/pkg/format/binary_spacing.go
+++ b/rewrite-go/pkg/format/binary_spacing.go
@@ -53,7 +53,10 @@ func (v *BinarySpacingVisitor) Visit(t java.Tree, p any) java.Tree {
 	// Every statement starts its expressions at the outermost depth, so a
 	// statement reached from inside an expression — a function literal's body —
 	// starts over rather than inheriting the depth around it.
-	if _, isStatement := t.(java.Statement); isStatement {
+	_, isStatement := t.(java.Statement)
+	// A call is both a statement and an expression; only something that is
+	// purely a statement begins a fresh expression.
+	if _, isExpression := t.(java.Expression); isStatement && !isExpression {
 		outer := v.depth
 		v.depth = 1
 		defer func() { v.depth = outer }()
@@ -111,6 +114,55 @@ func (v *BinarySpacingVisitor) VisitArrayAccess(access *java.ArrayAccess, p any)
 	}
 	v.depth = depth
 	return &out
+}
+
+// VisitSlice descends into the indices of a slice expression, and spaces the
+// colons: gofmt sets them off with blanks when an outermost slice has more than
+// one index and at least one of them is a binary expression, so `a[i : j+1]`
+// reads apart while `a[:n-1]` stays tight.
+func (v *BinarySpacingVisitor) VisitSlice(sl *golang.Slice, p any) java.J {
+	depth := v.depth
+	out := *sl
+	out.Indexed = v.operand(sl.Indexed, 1)
+
+	indices := []java.Expression{sl.Low.Element, sl.High.Element, sl.Max}
+	present, binaries := 0, 0
+	for _, index := range indices {
+		if isPresentIndex(index) {
+			present++
+			if operandsOf(index).prec > 0 {
+				binaries++
+			}
+		}
+	}
+	blanks := depth <= 1 && present > 1 && binaries > 0
+
+	out.Low.Element = v.operand(sl.Low.Element, depth+1)
+	out.High.Element = v.operand(sl.High.Element, depth+1)
+	out.Max = v.operand(sl.Max, depth+1)
+
+	// A colon takes a blank on the side where an index is written, and none
+	// where one is omitted.
+	out.Low.After = spaceOrNothing(out.Low.After, blanks && isPresentIndex(out.Low.Element))
+	if isPresentIndex(out.High.Element) {
+		out.High.Element = withPrefix(out.High.Element, spaceOrNothing(getPrefix(out.High.Element), blanks))
+		out.High.After = spaceOrNothing(out.High.After, blanks && out.Max != nil)
+	}
+	if isPresentIndex(out.Max) {
+		out.Max = withPrefix(out.Max, spaceOrNothing(getPrefix(out.Max), blanks))
+	}
+	v.depth = depth
+	return &out
+}
+
+// isPresentIndex reports whether a slice index is written, since an omitted one
+// is modeled as an empty expression rather than as nothing.
+func isPresentIndex(e java.Expression) bool {
+	if e == nil {
+		return false
+	}
+	_, empty := e.(*java.Empty)
+	return !empty
 }
 
 // VisitComposite prints its elements at the outermost depth however deeply the

--- a/rewrite-go/pkg/format/binary_spacing.go
+++ b/rewrite-go/pkg/format/binary_spacing.go
@@ -1,0 +1,369 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"strings"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// BinarySpacingVisitor spaces binary operators the way gofmt does: the tighter
+// an operator binds relative to its neighbours, the more likely it loses its
+// blanks, so `x*y + z` and `hi-lo` come out alongside `a + b`. What decides it
+// is the set of precedences in the expression and how deeply the expression
+// nests, which this pass carries down from the statement it starts at.
+//
+// The rule and the numbers are go/printer's binaryExpr, walkBinary and cutoff.
+type BinarySpacingVisitor struct {
+	visitor.GoVisitor
+	stopAfterTracker
+	depth int
+}
+
+// NewBinarySpacingVisitor returns a visitor configured with the given
+// stopAfter bound. Pass nil to format the entire visited tree.
+func NewBinarySpacingVisitor(stopAfter java.Tree) *BinarySpacingVisitor {
+	return visitor.Init(&BinarySpacingVisitor{
+		stopAfterTracker: stopAfterTracker{stopAfter: stopAfter},
+		depth:            1,
+	})
+}
+
+func (v *BinarySpacingVisitor) Visit(t java.Tree, p any) java.Tree {
+	if v.shouldHalt() {
+		return t
+	}
+	// Every statement starts its expressions at the outermost depth, so a
+	// statement reached from inside an expression — a function literal's body —
+	// starts over rather than inheriting the depth around it.
+	if _, isStatement := t.(java.Statement); isStatement {
+		outer := v.depth
+		v.depth = 1
+		defer func() { v.depth = outer }()
+	}
+	out := v.GoVisitor.Visit(t, p)
+	v.noteVisited(t)
+	return out
+}
+
+func (v *BinarySpacingVisitor) VisitBinary(bin *java.Binary, p any) java.J {
+	prec := javaPrecedence(bin.Operator.Element)
+	out := *bin
+	out.Operator.Before, out.Right = v.spaceOperands(
+		operandsOf(bin), prec, bin.Operator.Before, bin.Right)
+
+	depth := v.depth
+	out.Left = v.operand(bin.Left, depth+diffPrec(bin.Left, prec))
+	out.Right = v.operand(out.Right, depth+1)
+	v.depth = depth
+	return &out
+}
+
+func (v *BinarySpacingVisitor) VisitGoBinary(bin *golang.Binary, p any) java.J {
+	// `&^` is the only operator golang.Binary carries, at the tightest level.
+	const prec = 5
+	out := *bin
+	out.Operator.Before, out.Right = v.spaceOperands(
+		operandsOf(bin), prec, bin.Operator.Before, bin.Right)
+
+	depth := v.depth
+	out.Left = v.operand(bin.Left, depth+diffPrec(bin.Left, prec))
+	out.Right = v.operand(out.Right, depth+1)
+	v.depth = depth
+	return &out
+}
+
+// VisitParentheses undoes one level of nesting, since the parentheses already
+// group what the depth is standing in for.
+func (v *BinarySpacingVisitor) VisitParentheses(parens *java.Parentheses, p any) java.J {
+	out := *parens
+	out.Tree.Element = v.operand(parens.Tree.Element, reduceDepth(v.depth))
+	return &out
+}
+
+// VisitArrayAccess descends into an index one level deeper, matching the
+// nesting an index expression introduces in gofmt.
+func (v *BinarySpacingVisitor) VisitArrayAccess(access *java.ArrayAccess, p any) java.J {
+	out := *access
+	depth := v.depth
+	out.Indexed = v.operand(access.Indexed, depth)
+	if access.Dimension != nil {
+		dimension := *access.Dimension
+		dimension.Index.Element = v.operand(access.Dimension.Index.Element, depth+1)
+		out.Dimension = &dimension
+	}
+	v.depth = depth
+	return &out
+}
+
+// VisitComposite prints its elements at the outermost depth however deeply the
+// literal itself sits, which is gofmt's rule for a composite literal.
+func (v *BinarySpacingVisitor) VisitComposite(c *golang.Composite, p any) java.J {
+	depth := v.depth
+	out := *c
+	if c.TypeExpr != nil {
+		out.TypeExpr = v.operand(c.TypeExpr, depth)
+	}
+	out.Elements.Elements = v.operandList(c.Elements.Elements, 1)
+	v.depth = depth
+	return &out
+}
+
+// VisitMethodInvocation descends one level for a call that passes more than one
+// argument, which is where gofmt starts tightening the operators inside them.
+func (v *BinarySpacingVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
+	depth := v.depth
+	if len(mi.Arguments.Elements) > 1 {
+		v.depth++
+	}
+	out := v.GoVisitor.VisitMethodInvocation(mi, p)
+	v.depth = depth
+	return out
+}
+
+// VisitMultiAssignment starts one level in when both sides list more than one
+// expression, which is where gofmt tightens the operators inside them.
+func (v *BinarySpacingVisitor) VisitMultiAssignment(assign *golang.MultiAssignment, p any) java.J {
+	depth := 1
+	if len(assign.Variables) > 1 && len(assign.Values) > 1 {
+		depth = 2
+	}
+	out := *assign
+	out.Variables = v.operandList(assign.Variables, depth)
+	out.Values = v.operandList(assign.Values, depth)
+	return &out
+}
+
+func (v *BinarySpacingVisitor) operand(e java.Expression, depth int) java.Expression {
+	if e == nil {
+		return nil
+	}
+	v.depth = depth
+	if out, ok := v.Visit(e, nil).(java.Expression); ok {
+		return out
+	}
+	return e
+}
+
+func (v *BinarySpacingVisitor) operandList(elements []java.RightPadded[java.Expression], depth int) []java.RightPadded[java.Expression] {
+	out := append([]java.RightPadded[java.Expression](nil), elements...)
+	for i := range out {
+		out[i].Element = v.operand(out[i].Element, depth)
+	}
+	return out
+}
+
+// spaceOperands decides whether an operator of the given precedence keeps the
+// blanks around it, and returns the space before the operator together with the
+// right operand carrying the space after it. An operator whose right operand
+// starts on another line keeps that break and takes no blank after it.
+func (v *BinarySpacingVisitor) spaceOperands(operands binaryOperands, prec int, before java.Space, right java.Expression) (java.Space, java.Expression) {
+	blank := prec < cutoff(operands, v.depth)
+	before = spaceOrNothing(before, blank)
+	if strings.Contains(getPrefix(right).Whitespace, "\n") {
+		return before, right
+	}
+	return before, withPrefix(right, spaceOrNothing(getPrefix(right), blank))
+}
+
+func spaceOrNothing(s java.Space, blank bool) java.Space {
+	if len(s.Comments) > 0 || strings.Contains(s.Whitespace, "\n") {
+		return s
+	}
+	if blank {
+		s.Whitespace = " "
+	} else {
+		s.Whitespace = ""
+	}
+	return s
+}
+
+// binaryOperands is what cutoff needs to know about one binary expression: the
+// operator's precedence and the two operands.
+type binaryOperands struct {
+	prec        int
+	token       string
+	left, right java.Expression
+}
+
+func operandsOf(e java.Expression) binaryOperands {
+	switch b := e.(type) {
+	case *java.Binary:
+		op := b.Operator.Element
+		return binaryOperands{javaPrecedence(op), javaOperatorToken(op), b.Left, b.Right}
+	case *golang.Binary:
+		return binaryOperands{5, "&^", b.Left, b.Right}
+	}
+	return binaryOperands{}
+}
+
+// cutoff is the precedence at and above which an operator loses its blanks.
+func cutoff(e binaryOperands, depth int) int {
+	has4, has5, maxProblem := walkBinary(e)
+	if maxProblem > 0 {
+		return maxProblem + 1
+	}
+	if has4 && has5 {
+		if depth == 1 {
+			return 5
+		}
+		return 4
+	}
+	if depth == 1 {
+		return 6
+	}
+	return 4
+}
+
+// walkBinary reports which precedence levels appear in an expression, and the
+// tightest level at which writing two operators together would read as one
+// token — `/*` opening a comment, for one.
+func walkBinary(e binaryOperands) (has4, has5 bool, maxProblem int) {
+	switch e.prec {
+	case 4:
+		has4 = true
+	case 5:
+		has5 = true
+	}
+
+	if l := operandsOf(e.left); l.prec > 0 && l.prec >= e.prec {
+		h4, h5, mp := walkBinary(l)
+		has4, has5 = has4 || h4, has5 || h5
+		maxProblem = max(maxProblem, mp)
+	}
+
+	if r := operandsOf(e.right); r.prec > 0 && r.prec > e.prec {
+		h4, h5, mp := walkBinary(r)
+		has4, has5 = has4 || h4, has5 || h5
+		maxProblem = max(maxProblem, mp)
+	} else if op, ok := unaryOperator(e.right); ok {
+		switch e.token + op {
+		case "/*", "&&", "&^":
+			maxProblem = 5
+		case "++", "--":
+			maxProblem = max(maxProblem, 4)
+		}
+	}
+	return
+}
+
+// unaryOperator reports the token a unary expression writes ahead of its
+// operand, which can join the binary operator to its left.
+func unaryOperator(e java.Expression) (string, bool) {
+	u, ok := e.(*java.Unary)
+	if !ok {
+		return "", false
+	}
+	switch u.Operator.Element {
+	case java.Positive:
+		return "+", true
+	case java.Negate:
+		return "-", true
+	case java.Not:
+		return "!", true
+	case java.BitwiseNot:
+		return "^", true
+	case java.Deref:
+		return "*", true
+	case java.AddressOf:
+		return "&", true
+	case java.Receive:
+		return "<-", true
+	}
+	return "", false
+}
+
+func diffPrec(e java.Expression, prec int) int {
+	if operands := operandsOf(e); operands.prec == prec {
+		return 0
+	}
+	return 1
+}
+
+func reduceDepth(depth int) int {
+	if depth <= 1 {
+		return 1
+	}
+	return depth - 1
+}
+
+// javaOperatorToken spells an operator as Go writes it, which decides whether it
+// joins the unary operator of the operand to its right.
+func javaOperatorToken(op java.BinaryOperator) string {
+	switch op {
+	case java.LogicalOr, java.Or:
+		return "||"
+	case java.LogicalAnd, java.And:
+		return "&&"
+	case java.Equal:
+		return "=="
+	case java.NotEqual:
+		return "!="
+	case java.LessThan:
+		return "<"
+	case java.LessThanOrEqual:
+		return "<="
+	case java.GreaterThan:
+		return ">"
+	case java.GreaterThanOrEqual:
+		return ">="
+	case java.Add:
+		return "+"
+	case java.Subtract:
+		return "-"
+	case java.BitwiseOr:
+		return "|"
+	case java.BitwiseXor:
+		return "^"
+	case java.Multiply:
+		return "*"
+	case java.Divide:
+		return "/"
+	case java.Modulo:
+		return "%"
+	case java.LeftShift:
+		return "<<"
+	case java.RightShift:
+		return ">>"
+	case java.BitwiseAnd:
+		return "&"
+	case java.AndNot:
+		return "&^"
+	}
+	return ""
+}
+
+// javaPrecedence is go/token.Token.Precedence for the operators java.Binary
+// carries.
+func javaPrecedence(op java.BinaryOperator) int {
+	switch op {
+	case java.LogicalOr, java.Or:
+		return 1
+	case java.LogicalAnd, java.And:
+		return 2
+	case java.Equal, java.NotEqual, java.LessThan, java.LessThanOrEqual, java.GreaterThan, java.GreaterThanOrEqual:
+		return 3
+	case java.Add, java.Subtract, java.BitwiseOr, java.BitwiseXor:
+		return 4
+	case java.Multiply, java.Divide, java.Modulo, java.LeftShift, java.RightShift, java.BitwiseAnd, java.AndNot:
+		return 5
+	}
+	return 0
+}

--- a/rewrite-go/pkg/format/blank_lines.go
+++ b/rewrite-go/pkg/format/blank_lines.go
@@ -92,16 +92,22 @@ func adjustSpace(s java.Space, f func(string) string) java.Space {
 	return s
 }
 
-// stripLeadingBlankLines collapses any "\n\n+" run at the start to a
-// single "\n", preserving any trailing indent.
+// stripLeadingBlankLines collapses the first run of newlines in ws to a single
+// one, preserving both the trailing indent and anything ahead of that run,
+// which is the previous line's trailing whitespace.
 func stripLeadingBlankLines(ws string) string {
-	if !strings.HasPrefix(ws, "\n\n") {
+	start := strings.IndexByte(ws, '\n')
+	if start < 0 {
 		return ws
 	}
-	for strings.HasPrefix(ws, "\n\n") {
-		ws = ws[1:]
+	end := start
+	for end < len(ws) && ws[end] == '\n' {
+		end++
 	}
-	return ws
+	if end-start < 2 {
+		return ws
+	}
+	return ws[:start] + "\n" + ws[end:]
 }
 
 // capInternalBlankLines walks ws and collapses any internal run of

--- a/rewrite-go/pkg/format/blank_lines.go
+++ b/rewrite-go/pkg/format/blank_lines.go
@@ -19,6 +19,7 @@ package format
 import (
 	"strings"
 
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
@@ -28,12 +29,12 @@ import (
 //   - Any run of >1 blank line collapses to one (anywhere in the
 //     compilation unit — gofmt's `1 blank line max` rule applies
 //     uniformly inside blocks AND between top-level decls).
-//   - Block.End loses any leading blank line so the closing brace
-//     sits flush against the last statement.
-//   - The first statement of a block has no blank line above it.
+//   - A declaration list — the fields of a struct, the methods of an
+//     interface — sits flush against its braces, while a statement
+//     block keeps a blank line written against either of its own.
 //
-// The first-statement rule operates on the statement node's own Prefix —
-// the parser attaches inter-statement whitespace to the outermost element.
+// The flush rule operates on the first statement's own Prefix, since the
+// parser attaches inter-statement whitespace to the outermost element.
 type BlankLinesVisitor struct {
 	visitor.GoVisitor
 	stopAfterTracker
@@ -64,10 +65,11 @@ func (v *BlankLinesVisitor) VisitSpace(s java.Space, p any) java.Space {
 
 func (v *BlankLinesVisitor) VisitBlock(block *java.Block, p any) java.J {
 	out := v.GoVisitor.VisitBlock(block, p).(*java.Block)
+	if !v.isDeclarationList() {
+		return out
+	}
 	out = out.WithEnd(adjustSpace(out.End, stripLeadingBlankLines))
 
-	// Strip any leading blank line above the first statement, whose Prefix
-	// carries the inter-statement whitespace.
 	if len(out.Statements) > 0 && out.Statements[0].Element != nil {
 		first := out.Statements[0]
 		if updated, ok := transformPrefix(first.Element, stripLeadingBlankLinesSpace).(java.Statement); ok {
@@ -76,6 +78,21 @@ func (v *BlankLinesVisitor) VisitBlock(block *java.Block, p any) java.J {
 		}
 	}
 	return out
+}
+
+// isDeclarationList reports whether the block being visited holds declarations
+// rather than statements, which is what decides whether it sits flush against
+// its braces.
+func (v *BlankLinesVisitor) isDeclarationList() bool {
+	parent := v.Cursor().Parent()
+	if parent == nil {
+		return false
+	}
+	switch parent.Value().(type) {
+	case *golang.StructType, *golang.InterfaceType:
+		return true
+	}
+	return false
 }
 
 func stripLeadingBlankLinesSpace(s java.Space) java.Space {

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -24,7 +24,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 2098
+const canonicalDamageCeiling = 1434
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -24,7 +24,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 397
+const canonicalDamageCeiling = 146
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -24,7 +24,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 1434
+const canonicalDamageCeiling = 1045
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -1,0 +1,110 @@
+//go:build gofmtaudit
+
+package format
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// TestCanonicalInputUnchanged runs the formatter over gofmt-clean sources,
+// where the layout is already canonical and every pass must leave it alone.
+// Anything rewritten here is a disagreement with gofmt, as distinct from the
+// parity gap, which also counts layout the formatter does not reach yet.
+func TestCanonicalInputUnchanged(t *testing.T) {
+	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, false) })
+	t.Run("full pipeline", func(t *testing.T) { canonicalInputUnchanged(t, true) })
+}
+
+func canonicalInputUnchanged(t *testing.T, wholePipeline bool) {
+	var contexts []build.Context
+	for _, pair := range [][2]string{
+		{"darwin", "arm64"}, {"linux", "amd64"}, {"windows", "amd64"},
+		{"js", "wasm"}, {"plan9", "386"}, {"linux", "riscv64"}, {"aix", "ppc64"},
+	} {
+		c := build.Default
+		c.GOOS, c.GOARCH = pair[0], pair[1]
+		c.CgoEnabled = true
+		contexts = append(contexts, c)
+	}
+
+	root := filepath.Join(runtime.GOROOT(), "src")
+	var files []string
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.Contains(path, "/testdata/") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	var checked, changed int
+	var examples []string
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		src := string(content)
+		var ctx *build.Context
+		for i := range contexts {
+			if parser.MatchBuildContext(contexts[i], filepath.Base(f), src) {
+				ctx = &contexts[i]
+				break
+			}
+		}
+		if ctx == nil {
+			continue
+		}
+		// Only gofmt-clean files carry the invariant.
+		if formatted, err := gofmtSource(filepath.Base(f), src); err != nil || formatted != src {
+			continue
+		}
+		p := parser.NewGoParserWithBuildContext(*ctx)
+		p.ParseOnly = true
+		cu, err := p.Parse(filepath.Base(f), src)
+		if err != nil || printer.Print(cu) != src {
+			continue
+		}
+		checked++
+
+		var got string
+		if wholePipeline {
+			v := NewAutoFormatVisitor(nil)
+			out := v.Visit(cu, nil)
+			got = printer.Print(visitor.DrainAfterVisits(v, out.(java.Tree), nil))
+		} else {
+			v := NewDocCommentVisitor(nil)
+			got = printer.Print(v.Visit(cu, nil).(java.Tree))
+		}
+		if got == src {
+			continue
+		}
+		changed++
+		if len(examples) < 6 {
+			for i, line := range strings.Split(got, "\n") {
+				want := strings.Split(src, "\n")
+				if i < len(want) && line != want[i] {
+					examples = append(examples, filepath.Base(f)+
+						"\n         want |"+want[i]+"|\n         got  |"+line+"|")
+					break
+				}
+			}
+		}
+	}
+	t.Logf("gofmtCleanFilesChecked=%d changed=%d", checked, changed)
+	for _, e := range examples {
+		t.Logf("  %s", e)
+	}
+	if changed != 0 {
+		t.Errorf("rewrote %d already-canonical files", changed)
+	}
+}

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -24,7 +24,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 683
+const canonicalDamageCeiling = 397
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -24,7 +24,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 88
+const canonicalDamageCeiling = 31
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -20,6 +20,11 @@ import (
 // where the layout is already canonical and every pass must leave it alone.
 // Anything rewritten here is a disagreement with gofmt, as distinct from the
 // parity gap, which also counts layout the formatter does not reach yet.
+// canonicalDamageCeiling is the number of gofmt-clean standard library files
+// the whole pipeline still rewrites, all of it layout the formatter renders
+// differently from gofmt. Lower it as passes converge; it never goes up.
+const canonicalDamageCeiling = 2981
+
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, false) })
 	t.Run("full pipeline", func(t *testing.T) { canonicalInputUnchanged(t, true) })
@@ -104,7 +109,11 @@ func canonicalInputUnchanged(t *testing.T, wholePipeline bool) {
 	for _, e := range examples {
 		t.Logf("  %s", e)
 	}
-	if changed != 0 {
-		t.Errorf("rewrote %d already-canonical files", changed)
+	ceiling := 0
+	if wholePipeline {
+		ceiling = canonicalDamageCeiling
+	}
+	if changed > ceiling {
+		t.Errorf("rewrote %d already-canonical files, ceiling is %d", changed, ceiling)
 	}
 }

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -24,7 +24,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 146
+const canonicalDamageCeiling = 88
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -26,11 +26,12 @@ import (
 const canonicalDamageCeiling = 2981
 
 func TestCanonicalInputUnchanged(t *testing.T) {
-	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, false) })
-	t.Run("full pipeline", func(t *testing.T) { canonicalInputUnchanged(t, true) })
+	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })
+	t.Run("minimum spacing", func(t *testing.T) { canonicalInputUnchanged(t, "mvs") })
+	t.Run("full pipeline", func(t *testing.T) { canonicalInputUnchanged(t, "all") })
 }
 
-func canonicalInputUnchanged(t *testing.T, wholePipeline bool) {
+func canonicalInputUnchanged(t *testing.T, pass string) {
 	var contexts []build.Context
 	for _, pair := range [][2]string{
 		{"darwin", "arm64"}, {"linux", "amd64"}, {"windows", "amd64"},
@@ -82,13 +83,15 @@ func canonicalInputUnchanged(t *testing.T, wholePipeline bool) {
 		checked++
 
 		var got string
-		if wholePipeline {
+		switch pass {
+		case "all":
 			v := NewAutoFormatVisitor(nil)
 			out := v.Visit(cu, nil)
 			got = printer.Print(visitor.DrainAfterVisits(v, out.(java.Tree), nil))
-		} else {
-			v := NewDocCommentVisitor(nil)
-			got = printer.Print(v.Visit(cu, nil).(java.Tree))
+		case "mvs":
+			got = printer.Print(NewMinimumViableSpacingVisitor(nil).Visit(cu, nil))
+		default:
+			got = printer.Print(NewDocCommentVisitor(nil).Visit(cu, nil))
 		}
 		if got == src {
 			continue
@@ -110,7 +113,7 @@ func canonicalInputUnchanged(t *testing.T, wholePipeline bool) {
 		t.Logf("  %s", e)
 	}
 	ceiling := 0
-	if wholePipeline {
+	if pass == "all" {
 		ceiling = canonicalDamageCeiling
 	}
 	if changed > ceiling {

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -24,7 +24,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 1045
+const canonicalDamageCeiling = 683
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 
@@ -54,6 +55,8 @@ func canonicalInputUnchanged(t *testing.T, pass string) {
 
 	var checked, changed int
 	var examples []string
+	kinds := map[string]int{}
+	kindExamples := map[string]string{}
 	for _, f := range files {
 		content, err := os.ReadFile(f)
 		if err != nil {
@@ -97,6 +100,20 @@ func canonicalInputUnchanged(t *testing.T, pass string) {
 			continue
 		}
 		changed++
+		{
+			g, w := strings.Split(got, "\n"), strings.Split(src, "\n")
+			for i := range g {
+				if i < len(w) && g[i] != w[i] {
+					kind, _ := classifyLine(g[i], w[i])
+					kinds[kind]++
+					if _, seen := kindExamples[kind]; !seen {
+						kindExamples[kind] = filepath.Base(f) +
+							"\n         want |" + w[i] + "|\n         got  |" + g[i] + "|"
+					}
+					break
+				}
+			}
+		}
 		if len(examples) < 6 {
 			for i, line := range strings.Split(got, "\n") {
 				want := strings.Split(src, "\n")
@@ -109,6 +126,14 @@ func canonicalInputUnchanged(t *testing.T, pass string) {
 		}
 	}
 	t.Logf("gofmtCleanFilesChecked=%d changed=%d", checked, changed)
+	keys := make([]string, 0, len(kinds))
+	for k := range kinds {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return kinds[keys[i]] > kinds[keys[j]] })
+	for _, k := range keys {
+		t.Logf("  %5d files  %s\n         e.g. %s", kinds[k], k, kindExamples[k])
+	}
 	for _, e := range examples {
 		t.Logf("  %s", e)
 	}

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -23,7 +23,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 2981
+const canonicalDamageCeiling = 2098
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -1,5 +1,21 @@
 //go:build gofmtaudit
 
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package format
 
 import (

--- a/rewrite-go/pkg/format/doc_comments.go
+++ b/rewrite-go/pkg/format/doc_comments.go
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"go/doc/comment"
+	"strings"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// DocCommentVisitor rewrites doc comments into the canonical form gofmt
+// produces, delegating the text to go/doc/comment — the parser and printer
+// gofmt itself uses, so lists, code blocks, headings and links all follow.
+// Only an unindented `//` run abutting the token it documents qualifies, which
+// is gofmt's rule; every other comment keeps its text.
+type DocCommentVisitor struct {
+	visitor.GoVisitor
+	stopAfterTracker
+}
+
+// NewDocCommentVisitor returns a visitor configured with the given stopAfter
+// bound. Pass nil to format the entire visited tree.
+func NewDocCommentVisitor(stopAfter java.Tree) *DocCommentVisitor {
+	return visitor.Init(&DocCommentVisitor{
+		stopAfterTracker: stopAfterTracker{stopAfter: stopAfter},
+	})
+}
+
+func (v *DocCommentVisitor) Visit(t java.Tree, p any) java.Tree {
+	if v.shouldHalt() {
+		return t
+	}
+	out := v.GoVisitor.Visit(t, p)
+	v.noteVisited(t)
+	return out
+}
+
+// VisitCompilationUnit holds two positions out of the pass. Comments trailing
+// the last declaration document nothing, and gofmt leaves an import
+// declaration's doc comment as written — in a file that imports "C" it is the
+// cgo preamble, and its spacing is significant.
+func (v *DocCommentVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
+	// The file's own prefix is the one place a doc comment can begin at column
+	// one without a line break ahead of it.
+	if start, ok := docCommentRun(cu.Prefix, true); ok {
+		if formatted, ok := canonicalDocComment(cu.Prefix.Comments[start:]); ok {
+			prefix := cu.Prefix
+			prefix.Comments = append(append([]java.Comment(nil), prefix.Comments[:start]...), formatted...)
+			cu = cu.WithPrefix(prefix)
+		}
+	}
+	out, ok := v.GoVisitor.VisitCompilationUnit(cu, p).(*golang.CompilationUnit)
+	if !ok {
+		return cu
+	}
+	return out.WithEOF(cu.EOF).WithImports(cu.Imports)
+}
+
+func (v *DocCommentVisitor) VisitSpace(s java.Space, p any) java.Space {
+	start, ok := docCommentRun(s, false)
+	if !ok {
+		return s
+	}
+	formatted, ok := canonicalDocComment(s.Comments[start:])
+	if !ok {
+		return s
+	}
+	s.Comments = append(append([]java.Comment(nil), s.Comments[:start]...), formatted...)
+	return s
+}
+
+// docCommentRun reports the index at which the run documenting whatever
+// follows s begins. The run reaches the next token with nothing but a line
+// break between, and every line in it starts at column one.
+func docCommentRun(s java.Space, atFileStart bool) (int, bool) {
+	last := len(s.Comments) - 1
+	if last < 0 || s.Comments[last].Suffix != "\n" {
+		return 0, false
+	}
+	for start := last; ; start-- {
+		if !startsLine(s, start, atFileStart) {
+			return 0, false
+		}
+		// A run reaching the start of s, or preceded by anything other than a
+		// bare line break, is as far back as this doc comment goes.
+		if start == 0 || s.Comments[start-1].Suffix != "\n" {
+			return start, true
+		}
+	}
+}
+
+// startsLine reports whether the i-th comment of s begins a line: the text
+// ahead of it ends in a line break, or there is no text ahead of it and s sits
+// at the start of the file. A comment trailing code on the same line documents
+// nothing, and dropping it would join two tokens.
+func startsLine(s java.Space, i int, atFileStart bool) bool {
+	preceding := s.Whitespace
+	if i > 0 {
+		preceding = s.Comments[i-1].Suffix
+	}
+	if preceding == "" {
+		return atFileStart && i == 0
+	}
+	return strings.HasSuffix(preceding, "\n")
+}
+
+// canonicalDocComment reformats one doc comment run, mirroring
+// go/printer.formatDocComment. Directives keep their own text and follow the
+// prose, separated from it by a blank line. Anything that isn't a run of `//`
+// lines is reported as unformattable, since the caller should leave it be.
+func canonicalDocComment(run []java.Comment) ([]java.Comment, bool) {
+	var prose strings.Builder
+	var directives []java.Comment
+	for _, c := range run {
+		if c.Kind != java.LineComment {
+			return nil, false
+		}
+		body, found := strings.CutPrefix(c.Text, "//")
+		if !found {
+			return nil, false
+		}
+		if isDirective(body) {
+			directives = append(directives, c)
+			continue
+		}
+		prose.WriteString(strings.TrimPrefix(body, " "))
+		prose.WriteString("\n")
+	}
+	if prose.Len() == 0 {
+		return nil, false
+	}
+
+	var parser comment.Parser
+	var printer comment.Printer
+	text := string(printer.Comment(parser.Parse(prose.String())))
+
+	out := make([]java.Comment, 0, len(run)+len(directives)+1)
+	for text != "" {
+		var line string
+		line, text, _ = strings.Cut(text, "\n")
+		switch {
+		case line == "":
+			line = "//"
+		case strings.HasPrefix(line, "\t"):
+			line = "//" + line
+		default:
+			line = "// " + line
+		}
+		out = append(out, docLine(run[0], line))
+	}
+	if len(directives) > 0 {
+		out = append(out, docLine(run[0], "//"))
+		out = append(out, directives...)
+	}
+	if len(out) == 0 {
+		// A doc comment carrying no text renders as nothing, and gofmt drops
+		// it, keeping the whitespace that ran up to it.
+		return nil, true
+	}
+
+	// Every line but the last is followed by a bare line break; the last one
+	// keeps whatever separated the run from the token it documents.
+	for i := range out {
+		out[i].Suffix = "\n"
+	}
+	out[len(out)-1].Suffix = run[len(run)-1].Suffix
+	return out, true
+}
+
+// docLine builds one comment line, taking everything but the text from an
+// existing line of the same run.
+func docLine(like java.Comment, text string) java.Comment {
+	like.Text = text
+	like.Multiline = false
+	return like
+}
+
+// isDirective reports whether a comment body (with `//` already removed) is a
+// compiler directive such as `go:build`. Mirrors go/ast.isDirective.
+func isDirective(c string) bool {
+	if strings.HasPrefix(c, "line ") || strings.HasPrefix(c, "extern ") || strings.HasPrefix(c, "export ") {
+		return true
+	}
+	colon := strings.Index(c, ":")
+	if colon <= 0 || colon+1 >= len(c) {
+		return false
+	}
+	for i := 0; i <= colon+1; i++ {
+		if i == colon {
+			continue
+		}
+		b := c[i]
+		if !('a' <= b && b <= 'z' || '0' <= b && b <= '9') {
+			return false
+		}
+	}
+	return true
+}

--- a/rewrite-go/pkg/format/doc_comments.go
+++ b/rewrite-go/pkg/format/doc_comments.go
@@ -28,8 +28,11 @@ import (
 // DocCommentVisitor rewrites doc comments into the canonical form gofmt
 // produces, delegating the text to go/doc/comment — the parser and printer
 // gofmt itself uses, so lists, code blocks, headings and links all follow.
-// Only an unindented `//` run abutting the token it documents qualifies, which
-// is gofmt's rule; every other comment keeps its text.
+//
+// Only the package clause and top-level declarations carry doc comments, which
+// is what gofmt's "unindented run abutting the token" amounts to in a formatted
+// file. Taking the position from the tree rather than from the column keeps the
+// pass independent of the indentation any other pass has applied.
 type DocCommentVisitor struct {
 	visitor.GoVisitor
 	stopAfterTracker
@@ -52,29 +55,33 @@ func (v *DocCommentVisitor) Visit(t java.Tree, p any) java.Tree {
 	return out
 }
 
-// VisitCompilationUnit holds two positions out of the pass. Comments trailing
-// the last declaration document nothing, and gofmt leaves an import
-// declaration's doc comment as written — in a file that imports "C" it is the
-// cgo preamble, and its spacing is significant.
+// VisitCompilationUnit rewrites the doc comment of the package clause and of
+// each top-level declaration. An import declaration is left as written: in a
+// file that imports "C" its doc comment is the cgo preamble, whose spacing is
+// significant, and gofmt exempts it too.
 func (v *DocCommentVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
-	// The file's own prefix is the one place a doc comment can begin at column
-	// one without a line break ahead of it.
-	if start, ok := docCommentRun(cu.Prefix, true); ok {
-		if formatted, ok := canonicalDocComment(cu.Prefix.Comments[start:]); ok {
-			prefix := cu.Prefix
-			prefix.Comments = append(append([]java.Comment(nil), prefix.Comments[:start]...), formatted...)
-			cu = cu.WithPrefix(prefix)
+	out := *cu
+	// The file's own prefix is the one place a doc comment can begin the source
+	// with no line break ahead of it.
+	out.Prefix = canonicalDoc(cu.Prefix, true)
+
+	declarationDoc := func(s java.Space) java.Space { return canonicalDoc(s, false) }
+	statements := make([]java.RightPadded[java.Statement], len(cu.Statements))
+	for i, rp := range cu.Statements {
+		if rp.Element != nil {
+			if fixed, ok := transformPrefix(rp.Element, declarationDoc).(java.Statement); ok {
+				rp.Element = fixed
+			}
 		}
+		statements[i] = rp
 	}
-	out, ok := v.GoVisitor.VisitCompilationUnit(cu, p).(*golang.CompilationUnit)
-	if !ok {
-		return cu
-	}
-	return out.WithEOF(cu.EOF).WithImports(cu.Imports)
+	out.Statements = statements
+	return v.GoVisitor.VisitCompilationUnit(&out, p)
 }
 
-func (v *DocCommentVisitor) VisitSpace(s java.Space, p any) java.Space {
-	start, ok := docCommentRun(s, false)
+// canonicalDoc rewrites the doc comment run of s, if it has one.
+func canonicalDoc(s java.Space, atFileStart bool) java.Space {
+	start, ok := docCommentRun(s, atFileStart)
 	if !ok {
 		return s
 	}
@@ -88,37 +95,30 @@ func (v *DocCommentVisitor) VisitSpace(s java.Space, p any) java.Space {
 
 // docCommentRun reports the index at which the run documenting whatever
 // follows s begins. The run reaches the next token with nothing but a line
-// break between, and every line in it starts at column one.
+// break between, and begins a line — a comment trailing code documents
+// nothing, and dropping it would join two tokens. Earlier comments belong to
+// whatever preceded them.
 func docCommentRun(s java.Space, atFileStart bool) (int, bool) {
 	last := len(s.Comments) - 1
 	if last < 0 || s.Comments[last].Suffix != "\n" {
 		return 0, false
 	}
 	for start := last; ; start-- {
-		if !startsLine(s, start, atFileStart) {
-			return 0, false
-		}
 		// A run reaching the start of s, or preceded by anything other than a
 		// bare line break, is as far back as this doc comment goes.
-		if start == 0 || s.Comments[start-1].Suffix != "\n" {
+		if start == 0 {
+			if s.Whitespace == "" && !atFileStart {
+				return 0, false
+			}
+			if s.Whitespace != "" && !strings.HasSuffix(s.Whitespace, "\n") {
+				return 0, false
+			}
+			return 0, true
+		}
+		if s.Comments[start-1].Suffix != "\n" {
 			return start, true
 		}
 	}
-}
-
-// startsLine reports whether the i-th comment of s begins a line: the text
-// ahead of it ends in a line break, or there is no text ahead of it and s sits
-// at the start of the file. A comment trailing code on the same line documents
-// nothing, and dropping it would join two tokens.
-func startsLine(s java.Space, i int, atFileStart bool) bool {
-	preceding := s.Whitespace
-	if i > 0 {
-		preceding = s.Comments[i-1].Suffix
-	}
-	if preceding == "" {
-		return atFileStart && i == 0
-	}
-	return strings.HasSuffix(preceding, "\n")
 }
 
 // canonicalDocComment reformats one doc comment run, mirroring

--- a/rewrite-go/pkg/format/fuzz_test.go
+++ b/rewrite-go/pkg/format/fuzz_test.go
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	goparser "go/parser"
+	"go/scanner"
+	gotoken "go/token"
+	"math/rand"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+var fuzzSeeds = []string{
+	"package p\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nfunc main() {\n\tfmt.Println(os.Args[0])\n}\n",
+	"package p\n\ntype T struct {\n\tName string `json:\"name\"`\n\tN    int\n}\n\nfunc (t T) String() string { return t.Name }\n",
+	"package p\n\n// Doc explains things.\n//\n//   - first\n//   - second\nfunc F(i int) int {\n\tswitch i {\n\tcase 1, 2:\n\t\treturn i * 2\n\tdefault:\n\t\treturn i&0xff | 1\n\t}\n}\n",
+	"package p\n\nfunc G(c chan int) {\n\tselect {\n\tcase v := <-c:\n\t\t_ = v\n\tdefault:\n\t}\n}\n",
+	"package p\n\nvar table = []struct {\n\tname string\n\tn    int\n}{\n\t{name: \"a\", n: 1},\n\t{name: \"b\", n: 2},\n}\n",
+	"package p\n\nfunc Map[T, U any](in []T, f func(T) U) []U {\n\tout := make([]U, 0, len(in))\n\tfor _, v := range in {\n\t\tout = append(out, f(v))\n\t}\n\treturn out\n}\n",
+}
+
+// FuzzFormat re-whitespaces valid Go source and holds the formatter to the
+// properties that survive any input layout: it emits parseable Go, it moves no
+// tokens, and a second run changes nothing. Mutating whitespace rather than
+// bytes keeps every generated input valid Go, so the budget goes on layouts
+// instead of on inputs the parser rejects.
+func FuzzFormat(f *testing.F) {
+	for _, src := range fuzzSeeds {
+		for _, seed := range []int64{1, 2, 3} {
+			f.Add(src, seed)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, src string, seed int64) {
+		// The fuzzer mutates the seed bytes too, so most inputs are not Go at
+		// all; only a valid compilation unit says anything about formatting.
+		if _, err := goparser.ParseFile(gotoken.NewFileSet(), "f.go", src, goparser.ParseComments); err != nil {
+			return
+		}
+		mutated, ok := reWhitespace(src, rand.New(rand.NewSource(seed)))
+		if !ok {
+			return
+		}
+		if _, err := goparser.ParseFile(gotoken.NewFileSet(), "f.go", mutated, goparser.ParseComments); err != nil {
+			t.Fatalf("whitespace-only mutation invalidated valid Go: %v\n%s", err, mutated)
+		}
+
+		p := parser.NewGoParser()
+		p.ParseOnly = true
+		cu, err := p.Parse("f.go", mutated)
+		if err != nil || printer.Print(cu) != mutated {
+			return // a parser or printer gap, not a formatter property
+		}
+
+		formatted := runAutoFormat(cu)
+		if _, err := goparser.ParseFile(gotoken.NewFileSet(), "f.go", formatted, goparser.ParseComments); err != nil {
+			t.Fatalf("formatted output does not parse: %v\n%s", err, formatted)
+		}
+		if before, after := codeTokens(mutated), codeTokens(formatted); before != after {
+			t.Fatalf("formatting moved tokens\n  before %s\n  after  %s", before, after)
+		}
+
+		again, err := p.Parse("f.go", formatted)
+		if err != nil {
+			t.Fatalf("cannot re-parse formatted output: %v", err)
+		}
+		if twice := runAutoFormat(again); twice != formatted {
+			t.Fatalf("formatting is not idempotent\n  once %q\n  twice %q", formatted, twice)
+		}
+	})
+}
+
+func runAutoFormat(cu java.Tree) string {
+	v := NewAutoFormatVisitor(nil)
+	out := v.Visit(cu, nil)
+	return printer.Print(visitor.DrainAfterVisits(v, out.(java.Tree), nil))
+}
+
+// codeTokens renders the token stream excluding comment text, which doc
+// formatting is allowed to rewrite.
+func codeTokens(src string) string {
+	fset := gotoken.NewFileSet()
+	file := fset.AddFile("f.go", fset.Base(), len(src))
+	var s scanner.Scanner
+	s.Init(file, []byte(src), nil, 0)
+	var out strings.Builder
+	for {
+		_, tok, lit := s.Scan()
+		if tok == gotoken.EOF {
+			return out.String()
+		}
+		out.WriteString(tok.String())
+		if lit != "" && tok != gotoken.SEMICOLON {
+			out.WriteString("(" + lit + ")")
+		}
+		out.WriteByte(' ')
+	}
+}
+
+// reWhitespace rebuilds src with every gap between tokens replaced. A gap
+// holding a line break keeps one, since Go's semicolon insertion reads line
+// breaks; a gap separating two tokens keeps a space; and an empty gap stays
+// empty, since splitting a token like `<-` would change the program.
+func reWhitespace(src string, rnd *rand.Rand) (string, bool) {
+	fset := gotoken.NewFileSet()
+	file := fset.AddFile("f.go", fset.Base(), len(src))
+	var s scanner.Scanner
+	s.Init(file, []byte(src), func(gotoken.Position, string) {}, scanner.ScanComments)
+
+	var out strings.Builder
+	prevEnd := 0
+	for {
+		pos, tok, lit := s.Scan()
+		if tok == gotoken.EOF {
+			break
+		}
+		offset := file.Offset(pos)
+		if offset < prevEnd || offset > len(src) {
+			return "", false
+		}
+		width := len(lit)
+		switch {
+		case tok == gotoken.SEMICOLON && lit == "\n":
+			// Inserted for a line break rather than written, so it occupies no
+			// source text and the gap that follows carries the break.
+			width = 0
+		case lit == "":
+			width = len(tok.String())
+		}
+		if offset+width > len(src) {
+			return "", false
+		}
+
+		out.WriteString(mutateGap(src[prevEnd:offset], rnd))
+		out.WriteString(src[offset : offset+width])
+		prevEnd = offset + width
+	}
+	out.WriteString(mutateGap(src[prevEnd:], rnd))
+	return out.String(), true
+}
+
+func mutateGap(gap string, rnd *rand.Rand) string {
+	if gap == "" {
+		return ""
+	}
+	if !strings.Contains(gap, "\n") {
+		return strings.Repeat(" ", 1+rnd.Intn(3))
+	}
+	var b strings.Builder
+	for i := 0; i <= rnd.Intn(3); i++ {
+		b.WriteString("\n")
+	}
+	switch rnd.Intn(3) {
+	case 0:
+		b.WriteString(strings.Repeat("\t", rnd.Intn(4)))
+	case 1:
+		b.WriteString(strings.Repeat(" ", rnd.Intn(8)))
+	}
+	return b.String()
+}

--- a/rewrite-go/pkg/format/fuzz_test.go
+++ b/rewrite-go/pkg/format/fuzz_test.go
@@ -109,7 +109,9 @@ func runAutoFormat(cu java.Tree) string {
 }
 
 // codeTokens renders the token stream excluding comment text, which doc
-// formatting is allowed to rewrite.
+// formatting is allowed to rewrite, and excluding semicolons, which Go inserts
+// from line breaks and formatting therefore decides. That a program stays
+// well-formed is checked by parsing it.
 func codeTokens(src string) string {
 	fset := gotoken.NewFileSet()
 	file := fset.AddFile("f.go", fset.Base(), len(src))
@@ -121,8 +123,11 @@ func codeTokens(src string) string {
 		if tok == gotoken.EOF {
 			return out.String()
 		}
+		if tok == gotoken.SEMICOLON {
+			continue
+		}
 		out.WriteString(tok.String())
-		if lit != "" && tok != gotoken.SEMICOLON {
+		if lit != "" {
 			out.WriteString("(" + lit + ")")
 		}
 		out.WriteByte(' ')
@@ -160,6 +165,13 @@ func reWhitespace(src string, rnd *rand.Rand) (string, bool) {
 			width = len(tok.String())
 		}
 		if offset+width > len(src) {
+			return "", false
+		}
+		// The scanner drops carriage returns from a raw string literal, so its
+		// text can be shorter than the source it came from. Mutating around a
+		// token whose text does not match the source would move the token
+		// boundaries, so leave those sources alone.
+		if lit != "" && src[offset:offset+width] != lit {
 			return "", false
 		}
 

--- a/rewrite-go/pkg/format/fuzz_test.go
+++ b/rewrite-go/pkg/format/fuzz_test.go
@@ -41,7 +41,7 @@ var fuzzSeeds = []string{
 
 // FuzzFormat re-whitespaces valid Go source and holds the formatter to the
 // properties that survive any input layout: it emits parseable Go, it moves no
-// tokens, and a second run changes nothing. Mutating whitespace rather than
+// tokens, and a second run changes nothing wherever gofmt is itself stable. Mutating whitespace rather than
 // bytes keeps every generated input valid Go, so the budget goes on layouts
 // instead of on inputs the parser rejects.
 func FuzzFormat(f *testing.F) {
@@ -78,6 +78,18 @@ func FuzzFormat(f *testing.F) {
 		}
 		if before, after := codeTokens(mutated), codeTokens(formatted); before != after {
 			t.Fatalf("formatting moved tokens\n  before %s\n  after  %s", before, after)
+		}
+
+		// gofmt is itself not idempotent on every input: go/doc/comment reads an
+		// indented line as a code block only when a blank line precedes it, and
+		// the first pass removes the blank lines. Hold the formatter to
+		// idempotence exactly where gofmt has it.
+		once, err := gofmtSource("f.go", mutated)
+		if err != nil {
+			return
+		}
+		if twice, err := gofmtSource("f.go", once); err != nil || twice != once {
+			return
 		}
 
 		again, err := p.Parse("f.go", formatted)

--- a/rewrite-go/pkg/format/gofmt.go
+++ b/rewrite-go/pkg/format/gofmt.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"bytes"
+	goparser "go/parser"
+	goprinter "go/printer"
+	gotoken "go/token"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// gofmt's own printer settings (see cmd/gofmt and go/format).
+const (
+	gofmtMode     = goprinter.UseSpaces | goprinter.TabIndent
+	gofmtTabWidth = 8
+)
+
+// Gofmt lays out cu the way gofmt would, by printing it, running the result
+// through go/printer, and splicing that layout back in with SpliceWhitespace.
+// When target is non-nil only that subtree is re-laid-out, so a recipe's diff
+// stays limited to what the recipe touched.
+//
+// cu comes back unchanged when it is already formatted or when the printed
+// source doesn't parse.
+func Gofmt(cu *golang.CompilationUnit, target java.Tree) (*golang.CompilationUnit, error) {
+	src := printer.Print(cu)
+	formattedSrc, err := gofmtSource(cu.SourcePath, src)
+	if err != nil {
+		return cu, err
+	}
+	if formattedSrc == src {
+		return cu, nil
+	}
+	// The layout-only parse is the cheaper one but shapes a few expressions
+	// differently (see GoParser.ParseOnly), so a tree that diverges from cu is
+	// re-parsed with attribution before settling for the partial splice.
+	best := cu
+	p := parser.NewGoParser()
+	for _, parseOnly := range [...]bool{true, false} {
+		p.ParseOnly = parseOnly
+		formatted, err := p.Parse(cu.SourcePath, formattedSrc)
+		if err != nil {
+			return best, err
+		}
+		spliced, complete := SpliceWhitespace(cu, formatted, target)
+		best = spliced.(*golang.CompilationUnit)
+		if complete {
+			break
+		}
+	}
+	return best, nil
+}
+
+// GofmtVisitor applies Gofmt to every compilation unit it visits.
+type GofmtVisitor struct {
+	visitor.GoVisitor
+	target java.Tree
+}
+
+// NewGofmtVisitor returns a visitor bounded to the given target subtree. Pass
+// nil to lay out the whole file.
+func NewGofmtVisitor(target java.Tree) *GofmtVisitor {
+	return visitor.Init(&GofmtVisitor{target: target})
+}
+
+func (v *GofmtVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
+	out, err := Gofmt(cu, v.target)
+	if err != nil {
+		return cu
+	}
+	return out
+}
+
+// gofmtSource applies gofmt's layout rules and nothing else. Plain gofmt also
+// sorts imports and normalizes number literals, which rewrite tokens: a
+// whitespace splice cannot carry those, and they belong to recipes anyway.
+func gofmtSource(sourcePath, src string) (string, error) {
+	fset := gotoken.NewFileSet()
+	file, err := goparser.ParseFile(fset, sourcePath, src, goparser.ParseComments|goparser.SkipObjectResolution)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	if err := (&goprinter.Config{Mode: gofmtMode, Tabwidth: gofmtTabWidth}).Fprint(&buf, fset, file); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/rewrite-go/pkg/format/gofmt_bench_test.go
+++ b/rewrite-go/pkg/format/gofmt_bench_test.go
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	goparser "go/parser"
+	gotoken "go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+var indentPattern = regexp.MustCompile(`(?m)^[ \t]+`)
+
+// benchInput is net/http/server.go with every line's indentation stripped, so
+// both formatters face the same amount of work.
+func benchInput(b *testing.B) (*golang.CompilationUnit, string) {
+	b.Helper()
+	content, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "src", "net", "http", "server.go"))
+	if err != nil {
+		b.Skip(err)
+	}
+	mangled := indentPattern.ReplaceAllString(string(content), "")
+	cu, err := parser.NewGoParser().Parse("server.go", mangled)
+	if err != nil {
+		b.Skip(err)
+	}
+	return cu, mangled
+}
+
+func BenchmarkFormatGofmt(b *testing.B) {
+	cu, _ := benchInput(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := Gofmt(cu, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkFormatHandRolled(b *testing.B) {
+	cu, _ := benchInput(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		v := NewAutoFormatVisitor(nil)
+		out := v.Visit(cu, nil)
+		visitor.DrainAfterVisits(v, out.(java.Tree), nil)
+	}
+}
+
+func BenchmarkStagePrint(b *testing.B) {
+	cu, _ := benchInput(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		printer.Print(cu)
+	}
+}
+
+func BenchmarkStageGoPrinter(b *testing.B) {
+	_, src := benchInput(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := gofmtSource("server.go", src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStageReparseLayoutOnly(b *testing.B) {
+	_, src := benchInput(b)
+	formattedSrc, err := gofmtSource("server.go", src)
+	if err != nil {
+		b.Skip(err)
+	}
+	p := parser.NewGoParser()
+	p.ParseOnly = true
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := p.Parse("server.go", formattedSrc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStageReparseTyped(b *testing.B) {
+	_, src := benchInput(b)
+	formattedSrc, err := gofmtSource("server.go", src)
+	if err != nil {
+		b.Skip(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := parser.NewGoParser().Parse("server.go", formattedSrc); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkStageSplice(b *testing.B) {
+	cu, src := benchInput(b)
+	formattedSrc, err := gofmtSource("server.go", src)
+	if err != nil {
+		b.Skip(err)
+	}
+	formatted, err := parser.NewGoParser().Parse("server.go", formattedSrc)
+	if err != nil {
+		b.Skip(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		SpliceWhitespace(cu, formatted, nil)
+	}
+}
+
+// A recipe formatting one declaration it just synthesized, in a large file.
+
+func firstDeclaration(b *testing.B, cu *golang.CompilationUnit) java.Tree {
+	b.Helper()
+	if len(cu.Statements) == 0 {
+		b.Skip("no declarations")
+	}
+	return cu.Statements[0].Element
+}
+
+func BenchmarkSubtreeGofmt(b *testing.B) {
+	cu, _ := benchInput(b)
+	target := firstDeclaration(b, cu)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := Gofmt(cu, target); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkSubtreeHandRolled(b *testing.B) {
+	cu, _ := benchInput(b)
+	target := firstDeclaration(b, cu)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		v := NewAutoFormatVisitor(nil)
+		out := v.Visit(target, nil)
+		visitor.DrainAfterVisits(v, out.(java.Tree), nil)
+	}
+}
+
+// Go parsing on its own, to separate it from LST construction.
+func BenchmarkStageGoParseOnly(b *testing.B) {
+	_, src := benchInput(b)
+	formattedSrc, err := gofmtSource("server.go", src)
+	if err != nil {
+		b.Skip(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		fset := gotoken.NewFileSet()
+		if _, err := goparser.ParseFile(fset, "server.go", formattedSrc, goparser.ParseComments|goparser.SkipObjectResolution); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// What a call costs when the file is already formatted and nothing changes.
+func BenchmarkFormatGofmtNoOp(b *testing.B) {
+	content, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "src", "net", "http", "server.go"))
+	if err != nil {
+		b.Skip(err)
+	}
+	cu, err := parser.NewGoParser().Parse("server.go", string(content))
+	if err != nil {
+		b.Skip(err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		if _, err := Gofmt(cu, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/rewrite-go/pkg/format/minimum_spacing.go
+++ b/rewrite-go/pkg/format/minimum_spacing.go
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"strings"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// MinimumViableSpacingVisitor supplies the whitespace a tree needs to print as
+// the Go it represents. A node a recipe splices in carries no prefix, which
+// would run a keyword into the identifier after it and put two statements on one
+// line; this pass gives each the least separation that keeps the token stream
+// intact, and leaves layout to the passes after it.
+//
+// Mirrors org.openrewrite.java.format.MinimumViableSpacingVisitor.
+type MinimumViableSpacingVisitor struct {
+	visitor.GoVisitor
+	stopAfterTracker
+}
+
+// NewMinimumViableSpacingVisitor returns a visitor configured with the given
+// stopAfter bound. Pass nil to format the entire visited tree.
+func NewMinimumViableSpacingVisitor(stopAfter java.Tree) *MinimumViableSpacingVisitor {
+	return visitor.Init(&MinimumViableSpacingVisitor{
+		stopAfterTracker: stopAfterTracker{stopAfter: stopAfter},
+	})
+}
+
+func (v *MinimumViableSpacingVisitor) Visit(t java.Tree, p any) java.Tree {
+	if v.shouldHalt() {
+		return t
+	}
+	out := v.GoVisitor.Visit(t, p)
+	v.noteVisited(t)
+	return out
+}
+
+func (v *MinimumViableSpacingVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
+	out := *cu
+	if cu.PackageDecl != nil {
+		decl := *cu.PackageDecl
+		decl.Element = separateFrom("package", decl.Element)
+		out.PackageDecl = &decl
+	}
+	// Everything after the package clause is a declaration of its own, so the
+	// first one needs the same line break as the rest.
+	if cu.Imports != nil && cu.Imports.Before.IsEmpty() {
+		imports := *cu.Imports
+		imports.Before = java.Space{Whitespace: "\n"}
+		out.Imports = &imports
+	}
+	out.Statements = separateStatements(cu.Statements, true)
+	return v.GoVisitor.VisitCompilationUnit(&out, p)
+}
+
+func (v *MinimumViableSpacingVisitor) VisitBlock(block *java.Block, p any) java.J {
+	out := v.GoVisitor.VisitBlock(block, p).(*java.Block)
+	// The first statement follows `{`, which separates it already.
+	return out.WithStatements(separateStatements(out.Statements, false))
+}
+
+func (v *MinimumViableSpacingVisitor) VisitCase(c *java.Case, p any) java.J {
+	out := v.GoVisitor.VisitCase(c, p).(*java.Case)
+	copied := *out
+	if len(out.Expressions.Elements) > 0 && !isDefaultClause(out) {
+		elements := append([]java.RightPadded[java.Expression](nil), out.Expressions.Elements...)
+		elements[0].Element = separateFrom("case", elements[0].Element)
+		copied.Expressions.Elements = elements
+	}
+	copied.Body = separateStatements(out.Body, false)
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitCommClause(cc *golang.CommClause, p any) java.J {
+	out := v.GoVisitor.VisitCommClause(cc, p).(*golang.CommClause)
+	copied := *out
+	if out.Comm != nil {
+		copied.Comm = separateFrom("case", out.Comm)
+	}
+	copied.Body = separateStatements(out.Body, false)
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitReturn(ret *java.Return, p any) java.J {
+	out := v.GoVisitor.VisitReturn(ret, p).(*java.Return)
+	if out.Expression == nil {
+		return out
+	}
+	copied := *out
+	copied.Expression = separateFrom("return", out.Expression)
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitGoReturn(ret *golang.Return, p any) java.J {
+	out := v.GoVisitor.VisitGoReturn(ret, p).(*golang.Return)
+	if len(out.Expressions) == 0 {
+		return out
+	}
+	copied := *out
+	elements := append([]java.RightPadded[java.Expression](nil), out.Expressions...)
+	elements[0].Element = separateFrom("return", elements[0].Element)
+	copied.Expressions = elements
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitVariableDeclarations(vd *java.VariableDeclarations, p any) java.J {
+	out := v.GoVisitor.VisitVariableDeclarations(vd, p).(*java.VariableDeclarations)
+	copied := *out
+
+	if keyword := declarationKeyword(out.Markers); keyword != "" && len(out.Variables) > 0 {
+		variables := append([]java.RightPadded[*java.VariableDeclarator](nil), out.Variables...)
+		variables[0].Element = separateFrom(keyword, variables[0].Element)
+		copied.Variables = variables
+	}
+	// Go writes a declared type straight after the name, so their separation is
+	// the grammar's rather than the layout's. An unnamed parameter or result
+	// prints no name to separate from.
+	if out.TypeExpr != nil && out.Varargs == nil && len(out.Variables) > 0 &&
+		getPrefix(out.TypeExpr).IsEmpty() && printer.Print(out.Variables[0].Element) != "" {
+		copied.TypeExpr = withLeadingSpace(out.TypeExpr).(java.Expression)
+	}
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
+	out := v.GoVisitor.VisitTypeDecl(td, p).(*golang.TypeDecl)
+	copied := *out
+	// A spec inside `type (…)` prints no keyword of its own.
+	if out.Name != nil && out.Specs == nil && !java.HasMarker[golang.GroupedSpec](out.Markers) {
+		copied.Name = separateFrom("type", out.Name)
+	}
+	if out.Definition != nil && out.Name != nil {
+		if fusesWith(printer.Print(out.Name), printer.Print(out.Definition)) {
+			copied.Definition = withLeadingSpace(out.Definition).(java.Expression)
+		}
+	}
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitMethodDeclaration(md *java.MethodDeclaration, p any) java.J {
+	out := v.GoVisitor.VisitMethodDeclaration(md, p).(*java.MethodDeclaration)
+	copied := *out
+	if out.Name != nil && !java.HasMarker[golang.InterfaceMethod](out.Markers) {
+		copied.Name = separateFrom("func", out.Name)
+	}
+	return &copied
+}
+
+// isDefaultClause reports whether c is Go's `default:`, which the printer spells
+// as a lone identifier named default with no `case` ahead of it.
+func isDefaultClause(c *java.Case) bool {
+	if len(c.Expressions.Elements) != 1 {
+		return false
+	}
+	ident, ok := c.Expressions.Elements[0].Element.(*java.Identifier)
+	return ok && ident.Name == "default"
+}
+
+// followsAnInit reports whether the statement being visited is wrapped in an
+// init clause, in which case its condition or tag follows the init's semicolon
+// rather than the keyword.
+func (v *MinimumViableSpacingVisitor) followsAnInit() bool {
+	parent := v.Cursor().Parent()
+	if parent == nil {
+		return false
+	}
+	_, wrapped := parent.Value().(*golang.StatementWithInit)
+	return wrapped
+}
+
+// separateStatements gives each statement the line break Go requires between
+// two statements. Only a line break or a semicolon will do here, so this is not
+// spacing the later passes could supply.
+func separateStatements[T java.Tree](statements []java.RightPadded[T], separateFirst bool) []java.RightPadded[T] {
+	var out []java.RightPadded[T]
+	for i, rp := range statements {
+		if (i == 0 && !separateFirst) || !getPrefix(rp.Element).IsEmpty() {
+			continue
+		}
+		if out == nil {
+			out = append([]java.RightPadded[T](nil), statements...)
+		}
+		if fixed, ok := any(withPrefix(rp.Element, java.Space{Whitespace: "\n"})).(T); ok {
+			out[i].Element = fixed
+		}
+	}
+	if out == nil {
+		return statements
+	}
+	return out
+}
+
+// separateFrom gives t a leading space when writing it straight after keyword
+// would lex as a single token. Whether whitespace already separates them is
+// read off t's printed form, so it does not matter which of the Spaces within t
+// holds it; leading names any Space printed ahead of t by its parent.
+func separateFrom[T java.Tree](keyword string, t T, leading ...java.Space) T {
+	for _, s := range leading {
+		if !s.IsEmpty() {
+			return t
+		}
+	}
+	printed := printer.Print(t)
+	if printed == "" || printed[0] == ' ' || printed[0] == '\t' || printed[0] == '\n' {
+		return t
+	}
+	if !fusesWith(keyword, printed) {
+		return t
+	}
+	return withLeadingSpace(t).(T)
+}
+
+func withLeadingSpace(t java.Tree) java.Tree {
+	return withPrefix(t, java.Space{Whitespace: " "})
+}
+
+// fusesWith reports whether the first token of after would join the last token
+// of before, which happens when the characters either side of the join can both
+// appear inside one identifier or number.
+func fusesWith(before, after string) bool {
+	before = strings.TrimRight(before, " \t\n")
+	if before == "" || after == "" {
+		return false
+	}
+	return tokenChar(before[len(before)-1]) && tokenChar(after[0])
+}
+
+func tokenChar(b byte) bool {
+	return b == '_' || b == '.' ||
+		'a' <= b && b <= 'z' ||
+		'A' <= b && b <= 'Z' ||
+		'0' <= b && b <= '9'
+}
+
+// declarationKeyword reports the keyword a declaration prints ahead of its
+// first name, or "" for the forms that print none — a grouped spec, and the
+// parameters and struct fields that share this node type.
+func declarationKeyword(markers java.Markers) string {
+	if java.HasMarker[golang.GroupedSpec](markers) {
+		return ""
+	}
+	if java.HasMarker[golang.ConstDecl](markers) {
+		return "const"
+	}
+	if java.HasMarker[golang.VarKeyword](markers) {
+		return "var"
+	}
+	return ""
+}
+
+// VisitTypeParameter separates a type parameter from its constraint, which Go
+// writes straight after the name.
+func (v *MinimumViableSpacingVisitor) VisitTypeParameter(tp *java.TypeParameter, p any) java.J {
+	out := v.GoVisitor.VisitTypeParameter(tp, p).(*java.TypeParameter)
+	if out.Bounds == nil || len(out.Bounds.Elements) == 0 {
+		return out
+	}
+	if !out.Bounds.Before.IsEmpty() || !getPrefix(out.Bounds.Elements[0].Element).IsEmpty() {
+		return out
+	}
+	copied := *out
+	bounds := *out.Bounds
+	bounds.Before = java.Space{Whitespace: " "}
+	copied.Bounds = &bounds
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitIf(ifStmt *java.If, p any) java.J {
+	out := v.GoVisitor.VisitIf(ifStmt, p).(*java.If)
+	copied := *out
+	if !v.followsAnInit() {
+		condition := out.Condition
+		condition.Tree.Element = separateFrom("if", condition.Tree.Element, condition.Prefix)
+		copied.Condition = condition
+	}
+	if out.ElsePart != nil && out.ElsePart.Body.Element != nil {
+		elsePart := *out.ElsePart
+		elsePart.Body.Element = separateFrom("else", elsePart.Body.Element)
+		copied.ElsePart = &elsePart
+	}
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitSwitch(sw *java.Switch, p any) java.J {
+	out := v.GoVisitor.VisitSwitch(sw, p).(*java.Switch)
+	if out.Tag == nil {
+		return out
+	}
+	if v.followsAnInit() {
+		return out
+	}
+	copied := *out
+	tag := *out.Tag
+	tag.Element = separateFrom("switch", tag.Element)
+	copied.Tag = &tag
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitForEachControl(control *java.ForEachControl, p any) java.J {
+	out := v.GoVisitor.VisitForEachControl(control, p).(*java.ForEachControl)
+	copied := *out
+	copied.Variable.Element = separateFrom("for", out.Variable.Element, out.Prefix)
+	copied.Iterable.Element = separateFrom("range", out.Iterable.Element)
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitGoStmt(g *golang.GoStmt, p any) java.J {
+	out := v.GoVisitor.VisitGoStmt(g, p).(*golang.GoStmt)
+	copied := *out
+	copied.Expr = separateFrom("go", out.Expr)
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitDefer(d *golang.Defer, p any) java.J {
+	out := v.GoVisitor.VisitDefer(d, p).(*golang.Defer)
+	copied := *out
+	copied.Expr = separateFrom("defer", out.Expr)
+	return &copied
+}
+
+func (v *MinimumViableSpacingVisitor) VisitChannel(ch *golang.Channel, p any) java.J {
+	out := v.GoVisitor.VisitChannel(ch, p).(*golang.Channel)
+	copied := *out
+	copied.Value = separateFrom("chan", out.Value)
+	return &copied
+}

--- a/rewrite-go/pkg/format/minimum_spacing_test.go
+++ b/rewrite-go/pkg/format/minimum_spacing_test.go
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	goparser "go/parser"
+	gotoken "go/token"
+	"reflect"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// TestFormatsTreeWithNoWhitespace strips every Space from a parsed tree and
+// requires the formatter to rebuild valid Go from it. A recipe splicing in a
+// synthesized node leaves exactly this: elements whose prefix nothing has set.
+func TestFormatsTreeWithNoWhitespace(t *testing.T) {
+	sources := map[string]string{
+		"declarations":     "package p\n\nimport \"fmt\"\n\nvar x int = 1\n\nconst y = 2\n\ntype T struct {\n\tName string\n\tN    int\n}\n\nfunc F(a int, b string) (int, error) {\n\treturn a, nil\n}\n",
+		"statements":       "package p\n\nfunc F(xs []int) int {\n\tvar total int\n\tfor _, x := range xs {\n\t\ttotal += x\n\t}\n\tif total > 0 {\n\t\treturn total\n\t} else if total == 0 {\n\t\treturn 0\n\t}\n\tgo F(xs)\n\tdefer F(xs)\n\treturn -total\n}\n",
+		"switch and types": "package p\n\ntype I interface {\n\tM() int\n}\n\nfunc F(i int, c chan int) {\n\tswitch i {\n\tcase 1:\n\t\treturn\n\tdefault:\n\t}\n\tvar ch chan int = c\n\tvar m map[string]int\n\t_, _ = ch, m\n}\n",
+		"generics":         "package p\n\nfunc Map[T any, U any](in []T, f func(T) U) []U {\n\tvar out []U\n\tfor _, v := range in {\n\t\tout = append(out, f(v))\n\t}\n\treturn out\n}\n",
+	}
+
+	for name, src := range sources {
+		t.Run(name, func(t *testing.T) {
+			p := parser.NewGoParser()
+			p.ParseOnly = true
+			cu, err := p.Parse("t.go", src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			stripped := stripAllSpaces(reflect.ValueOf(cu)).Interface().(java.Tree)
+
+			got := runAutoFormat(stripped)
+			if _, err := goparser.ParseFile(gotoken.NewFileSet(), "t.go", got, goparser.ParseComments); err != nil {
+				t.Fatalf("output does not parse: %v\n%s", err, got)
+			}
+			if before, after := codeTokens(src), codeTokens(got); before != after {
+				t.Errorf("token stream changed\n  before %s\n  after  %s", before, after)
+			}
+		})
+	}
+}
+
+// stripAllSpaces returns v with every Space replaced by the empty one.
+func stripAllSpaces(v reflect.Value) reflect.Value {
+	d := shapeOf(v.Type())
+	if !d.carriesSpace {
+		return v
+	}
+	if d.isSpace {
+		return reflect.ValueOf(java.Space{})
+	}
+	if d.isMarkers {
+		return v
+	}
+	switch d.kind {
+	case reflect.Interface:
+		if v.IsNil() {
+			return v
+		}
+		boxed := reflect.New(v.Type()).Elem()
+		boxed.Set(stripAllSpaces(v.Elem()))
+		return boxed
+	case reflect.Pointer:
+		if v.IsNil() {
+			return v
+		}
+		elem := stripAllSpaces(v.Elem())
+		p := reflect.New(elem.Type())
+		p.Elem().Set(elem)
+		return p
+	case reflect.Struct:
+		out := reflect.New(v.Type()).Elem()
+		out.Set(v)
+		for _, i := range d.spaceFields {
+			out.Field(i).Set(stripAllSpaces(v.Field(i)))
+		}
+		return out
+	case reflect.Slice:
+		out := reflect.MakeSlice(v.Type(), v.Len(), v.Len())
+		reflect.Copy(out, v)
+		for i := 0; i < v.Len(); i++ {
+			out.Index(i).Set(stripAllSpaces(v.Index(i)))
+		}
+		return out
+	default:
+		return v
+	}
+}

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 4354
+const parityFloor = 4379
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 2145
+const parityFloor = 2292
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 4048
+const parityFloor = 4222
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The
@@ -173,12 +173,12 @@ func classifyLine(g, w string) (string, string) {
 	case strings.TrimSpace(g) == "" || strings.TrimSpace(w) == "":
 		return "blank lines", detail
 	case commentLine.MatchString(w) || commentLine.MatchString(g):
-		if collapse(g) == collapse(w) && indentOf(g) != indentOf(w) {
+		if collapse(g) == collapse(w) && leadingIndent(g) != leadingIndent(w) {
 			return "comment indentation", detail
 		}
 		return "comment layout", detail
 	case collapse(g) == collapse(w):
-		if indentOf(g) != indentOf(w) {
+		if leadingIndent(g) != leadingIndent(w) {
 			return "indentation", detail
 		}
 		return "intra-line alignment", detail
@@ -204,4 +204,4 @@ func sameIgnoringIndent(got, want string) bool {
 
 func collapse(s string) string { return spaceRun.ReplaceAllString(strings.TrimSpace(s), " ") }
 
-func indentOf(s string) string { return s[:len(s)-len(strings.TrimLeft(s, " \t"))] }
+func leadingIndent(s string) string { return s[:len(s)-len(strings.TrimLeft(s, " \t"))] }

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 4379
+const parityFloor = 4382
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 3702
+const parityFloor = 4048
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 4222
+const parityFloor = 4354
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 2099
+const parityFloor = 2110
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 3138
+const parityFloor = 3702
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -1,0 +1,207 @@
+//go:build gofmtaudit
+
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// parityFloor is the number of standard library files the hand-rolled
+// visitors render exactly as gofmt does. Raise it whenever a change earns
+// more; it never goes down.
+const parityFloor = 2099
+
+// TestParityGap measures how far the hand-rolled visitors are from gofmt,
+// using gofmtSource as the oracle, and holds the result at parityFloor. The
+// per-file counts are the reliable figure; the per-kind line counts are
+// indicative only, since one line of drift misaligns every comparison after it.
+func TestParityGap(t *testing.T) {
+	var contexts []build.Context
+	for _, pair := range [][2]string{
+		{"darwin", "arm64"}, {"linux", "amd64"}, {"windows", "amd64"},
+		{"js", "wasm"}, {"plan9", "386"}, {"linux", "riscv64"}, {"aix", "ppc64"},
+	} {
+		c := build.Default
+		c.GOOS, c.GOARCH = pair[0], pair[1]
+		c.CgoEnabled = true
+		contexts = append(contexts, c)
+	}
+
+	root := filepath.Join(runtime.GOROOT(), "src")
+	var files []string
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.Contains(path, "/testdata/") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	strip := regexp.MustCompile(`(?m)^[ \t]+`)
+	buckets := map[string]int{}
+	examples := map[string]string{}
+	var considered, exact, exactIgnoringIndent int
+	var indentOnly []string
+
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		var ctx *build.Context
+		for i := range contexts {
+			if parser.MatchBuildContext(contexts[i], filepath.Base(f), string(content)) {
+				ctx = &contexts[i]
+				break
+			}
+		}
+		if ctx == nil {
+			continue
+		}
+		mangled := strip.ReplaceAllString(string(content), "")
+
+		p := parser.NewGoParserWithBuildContext(*ctx)
+		p.ParseOnly = true
+		cu, err := p.Parse(filepath.Base(f), mangled)
+		if err != nil || printer.Print(cu) != mangled {
+			continue
+		}
+		want, err := gofmtSource(filepath.Base(f), mangled)
+		if err != nil {
+			continue
+		}
+
+		v := NewAutoFormatVisitor(nil)
+		out := v.Visit(cu, nil)
+		formatted := visitor.DrainAfterVisits(v, out.(java.Tree), nil)
+		got := printer.Print(formatted)
+
+		considered++
+		if got == want {
+			exact++
+			continue
+		}
+		if sameIgnoringIndent(got, want) {
+			exactIgnoringIndent++
+			if len(indentOnly) < 8 {
+				g, w := strings.Split(got, "\n"), strings.Split(want, "\n")
+				for i := range g {
+					if g[i] != w[i] {
+						ctx := ""
+						if i > 0 {
+							ctx = "\n         prev |" + w[i-1] + "|"
+						}
+						indentOnly = append(indentOnly, filepath.Base(f)+ctx+
+							"\n         want |"+w[i]+"|\n         got  |"+g[i]+"|")
+						break
+					}
+				}
+			}
+		}
+		g, w := strings.Split(got, "\n"), strings.Split(want, "\n")
+		for i := 0; i < len(g) && i < len(w); i++ {
+			if g[i] == w[i] {
+				continue
+			}
+			kind, detail := classifyLine(g[i], w[i])
+			buckets[kind]++
+			if _, seen := examples[kind]; !seen {
+				examples[kind] = f + "\n         " + detail
+			}
+		}
+	}
+
+	keys := make([]string, 0, len(buckets))
+	for k := range buckets {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return buckets[keys[i]] > buckets[keys[j]] })
+
+	t.Logf("considered=%d exactlyGofmt=%d wouldMatchIfIndentWereFixed=%d differ=%d",
+		considered, exact, exact+exactIgnoringIndent, considered-exact)
+	t.Logf("differing lines by kind:")
+	for _, k := range keys {
+		t.Logf("  %5d  %s\n         e.g. %s", buckets[k], k, examples[k])
+	}
+
+	t.Logf("indent-only mismatches:")
+	for _, e := range indentOnly {
+		t.Logf("  %s", e)
+	}
+
+	if exact < parityFloor {
+		t.Errorf("parity regressed: %d files render exactly as gofmt, floor is %d", exact, parityFloor)
+	}
+}
+
+var (
+	spaceRun    = regexp.MustCompile(`[ \t]+`)
+	commentLine = regexp.MustCompile(`^\s*(//|/\*|\*)`)
+)
+
+// classifyLine names one differing line.
+func classifyLine(g, w string) (string, string) {
+	detail := "want |" + w + "|\n         got  |" + g + "|"
+	switch {
+	case strings.TrimSpace(g) == "" || strings.TrimSpace(w) == "":
+		return "blank lines", detail
+	case commentLine.MatchString(w) || commentLine.MatchString(g):
+		if collapse(g) == collapse(w) && indentOf(g) != indentOf(w) {
+			return "comment indentation", detail
+		}
+		return "comment layout", detail
+	case collapse(g) == collapse(w):
+		if indentOf(g) != indentOf(w) {
+			return "indentation", detail
+		}
+		return "intra-line alignment", detail
+	default:
+		return "token spacing", detail
+	}
+}
+
+// sameIgnoringIndent reports whether the two renderings agree once every
+// line's leading whitespace is discarded.
+func sameIgnoringIndent(got, want string) bool {
+	g, w := strings.Split(got, "\n"), strings.Split(want, "\n")
+	if len(g) != len(w) {
+		return false
+	}
+	for i := range g {
+		if strings.TrimLeft(g[i], " \t") != strings.TrimLeft(w[i], " \t") {
+			return false
+		}
+	}
+	return true
+}
+
+func collapse(s string) string { return spaceRun.ReplaceAllString(strings.TrimSpace(s), " ") }
+
+func indentOf(s string) string { return s[:len(s)-len(strings.TrimLeft(s, " \t"))] }

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 2292
+const parityFloor = 3138
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 2110
+const parityFloor = 2145
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/prefix.go
+++ b/rewrite-go/pkg/format/prefix.go
@@ -82,7 +82,7 @@ func transformPrefix(t java.Tree, f func(java.Space) java.Space) java.Tree {
 	}
 	cur := getPrefix(t)
 	next := f(cur)
-	if next.Whitespace == cur.Whitespace && len(next.Comments) == len(cur.Comments) {
+	if spaceContentEqual(cur, next) {
 		return t
 	}
 	return withPrefix(t, next)

--- a/rewrite-go/pkg/format/shapeshift_audit_test.go
+++ b/rewrite-go/pkg/format/shapeshift_audit_test.go
@@ -1,0 +1,123 @@
+//go:build gofmtaudit
+
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+)
+
+// TestShapeshiftAudit enumerates every node type that maps differently with
+// and without type attribution, over the Go standard library.
+func TestShapeshiftAudit(t *testing.T) {
+	root := filepath.Join(runtime.GOROOT(), "src")
+	var files []string
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.Contains(path, "/testdata/") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	pairs := map[string]int{}
+	filesWithDivergence := 0
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		typed, err := parser.NewGoParser().Parse(filepath.Base(f), string(content))
+		if err != nil {
+			continue
+		}
+		p := parser.NewGoParser()
+		p.ParseOnly = true
+		untyped, err := p.Parse(filepath.Base(f), string(content))
+		if err != nil {
+			continue
+		}
+		found := map[string]int{}
+		collectDivergences(reflect.ValueOf(typed), reflect.ValueOf(untyped), found)
+		if len(found) > 0 {
+			filesWithDivergence++
+		}
+		for k, v := range found {
+			pairs[k] += v
+		}
+	}
+
+	keys := make([]string, 0, len(pairs))
+	for k := range pairs {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return pairs[keys[i]] > pairs[keys[j]] })
+	t.Logf("files=%d filesWithDivergence=%d distinctPairs=%d", len(files), filesWithDivergence, len(pairs))
+	for _, k := range keys {
+		t.Logf("  %6d  %s", pairs[k], k)
+	}
+}
+
+// collectDivergences records each place the two trees disagree on node type,
+// then stops descending that branch.
+func collectDivergences(a, b reflect.Value, out map[string]int) {
+	if !a.IsValid() || !b.IsValid() {
+		return
+	}
+	t := a.Type()
+	if t != b.Type() {
+		if shapeOf(t).isTree || shapeOf(b.Type()).isTree {
+			out[fmt.Sprintf("%s vs %s", t, b.Type())]++
+		}
+		return
+	}
+	d := shapeOf(t)
+	if !d.carriesSpace || d.isSpace || d.isMarkers {
+		return
+	}
+	switch d.kind {
+	case reflect.Interface, reflect.Pointer:
+		if a.IsNil() || b.IsNil() {
+			if a.IsNil() != b.IsNil() {
+				out[fmt.Sprintf("nil mismatch at %s", t)]++
+			}
+			return
+		}
+		collectDivergences(a.Elem(), b.Elem(), out)
+	case reflect.Struct:
+		for _, i := range d.spaceFields {
+			collectDivergences(a.Field(i), b.Field(i), out)
+		}
+	case reflect.Slice:
+		if a.Len() != b.Len() {
+			out[fmt.Sprintf("length mismatch at %s", t)]++
+			return
+		}
+		for i := 0; i < a.Len(); i++ {
+			collectDivergences(a.Index(i), b.Index(i), out)
+		}
+	}
+}

--- a/rewrite-go/pkg/format/spaces.go
+++ b/rewrite-go/pkg/format/spaces.go
@@ -25,7 +25,6 @@ import (
 
 // SpacesVisitor enforces gofmt's intra-line spacing rules:
 //
-//   - One space around binary operators (`a + b`, not `a+b`).
 //   - No space around unary operators (`!x`, `-y`).
 //   - One space after commas in argument/parameter lists
 //     (RightPadded.After fields don't get touched here — they precede
@@ -54,13 +53,6 @@ func (v *SpacesVisitor) Visit(t java.Tree, p any) java.Tree {
 	out := v.GoVisitor.Visit(t, p)
 	v.noteVisited(t)
 	return out
-}
-
-func (v *SpacesVisitor) VisitBinary(bin *java.Binary, p any) java.J {
-	bin = v.GoVisitor.VisitBinary(bin, p).(*java.Binary)
-	bin.Operator.Before = ensureSingleSpace(bin.Operator.Before)
-	bin = bin.WithRight(ensureLeadingSingleSpace(bin.Right))
-	return bin
 }
 
 func (v *SpacesVisitor) VisitAssignment(a *java.Assignment, p any) java.J {

--- a/rewrite-go/pkg/format/splice_shape.go
+++ b/rewrite-go/pkg/format/splice_shape.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"reflect"
+	"sync"
+)
+
+// spliceShape is what the splicer needs to know about one LST type. Every
+// answer depends only on the type, so each is computed once and shared across
+// the walk.
+type spliceShape struct {
+	kind      reflect.Kind
+	isSpace   bool
+	isMarkers bool
+	isTree    bool
+	// carriesSpace reports whether a value of this type can hold a Space at
+	// any depth. Values that can't are copied wholesale instead of walked.
+	carriesSpace bool
+	spaceFields  []int
+}
+
+var spliceShapes sync.Map // reflect.Type -> *spliceShape
+
+func shapeOf(t reflect.Type) *spliceShape {
+	if cached, ok := spliceShapes.Load(t); ok {
+		return cached.(*spliceShape)
+	}
+	d := &spliceShape{
+		kind:      t.Kind(),
+		isSpace:   t == spaceType,
+		isMarkers: t == markersType,
+		isTree:    t.Implements(treeType),
+		// LST types are mutually recursive. A type reached again while its own
+		// shape is still being computed answers "yes", keeping the walk
+		// over-inclusive rather than pruning a branch that does carry Spaces.
+		carriesSpace: true,
+	}
+	spliceShapes.Store(t, d)
+
+	switch {
+	case d.isSpace || d.isMarkers:
+		d.carriesSpace = true
+	case t.Implements(javaTypeType):
+		d.carriesSpace = false
+	default:
+		switch t.Kind() {
+		case reflect.Interface:
+			// The dynamic type decides, so assume the worst.
+			d.carriesSpace = true
+		case reflect.Pointer, reflect.Slice:
+			d.carriesSpace = shapeOf(t.Elem()).carriesSpace
+		case reflect.Struct:
+			d.carriesSpace = false
+			for i := 0; i < t.NumField(); i++ {
+				f := t.Field(i)
+				if f.PkgPath != "" {
+					continue // unexported fields ride along on the struct copy
+				}
+				if shapeOf(f.Type).carriesSpace {
+					d.spaceFields = append(d.spaceFields, i)
+					d.carriesSpace = true
+				}
+			}
+		default:
+			d.carriesSpace = false
+		}
+	}
+	return d
+}

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -19,28 +19,17 @@ package format
 import (
 	"strings"
 
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
-// TabsAndIndentsVisitor re-indents block-level whitespace to gofmt's
-// `\t × depth` convention.
+// TabsAndIndentsVisitor re-indents to gofmt's `\t × depth` convention.
 //
-// Strategy: rather than touching every Space in the tree (which would
-// rewrite continuation alignments inside multi-line argument lists),
-// the visitor drives indentation from VisitBlock explicitly:
-//
-//   - For each `Block.Statements[i].Element`, the statement's own
-//     Prefix carries the inter-statement whitespace; we rewrite its
-//     indent (the post-newline portion) to `\t × (depth+1)`.
-//   - `Block.End` (the whitespace before `}`) is re-indented to
-//     `\t × depth`.
-//   - VisitCase decrements depth around the case-clause Prefix so
-//     `case` keywords align with the enclosing `switch` (gofmt
-//     convention) while body statements remain at body depth.
-//
-// Whitespace that doesn't carry a newline, or whitespace inside an
-// expression context (continuations, alignments) is left untouched.
+// Indentation is driven from the constructs that introduce a level — blocks,
+// clause bodies, and delimited lists that wrap across lines — rather than from
+// every Space in the tree, which would also rewrite the continuation alignment
+// inside multi-line expressions.
 type TabsAndIndentsVisitor struct {
 	visitor.GoVisitor
 	stopAfterTracker
@@ -62,6 +51,114 @@ func (v *TabsAndIndentsVisitor) Visit(t java.Tree, p any) java.Tree {
 	return out
 }
 
+// VisitCompilationUnit indents the specs of a parenthesized import
+// declaration one level in, and the whitespace before its closing paren back
+// out to file level.
+func (v *TabsAndIndentsVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
+	if cu.Imports != nil {
+		grouped := java.HasMarker[golang.GroupedImport](cu.Imports.Markers)
+		elements := make([]java.RightPadded[*java.Import], len(cu.Imports.Elements))
+		for i, rp := range cu.Imports.Elements {
+			if block := java.FindMarker[golang.ImportBlock](rp.Element.Markers); block != nil {
+				grouped = block.Grouped
+				block.Before = v.reindentSpace(block.Before)
+			}
+			if grouped {
+				v.depth++
+			}
+			rp.Element = rp.Element.WithPrefix(v.reindentSpace(rp.Element.Prefix))
+			if grouped {
+				v.depth--
+			}
+			rp.After = v.reindentSpace(rp.After)
+			elements[i] = rp
+		}
+		imports := *cu.Imports
+		imports.Elements = elements
+		cu = cu.WithImports(&imports)
+	}
+	return v.GoVisitor.VisitCompilationUnit(cu, p)
+}
+
+// VisitDeclarationBlock indents the specs of a `var (…)` or `const (…)` group.
+func (v *TabsAndIndentsVisitor) VisitDeclarationBlock(db *golang.DeclarationBlock, p any) java.J {
+	if db.Specs != nil {
+		c := *db
+		c.Specs = v.indentSpecs(db.Specs)
+		db = &c
+	}
+	return v.GoVisitor.VisitDeclarationBlock(db, p)
+}
+
+// VisitTypeDecl indents the specs of a `type (…)` group. An ungrouped
+// declaration has no Specs and is indented by its enclosing block.
+func (v *TabsAndIndentsVisitor) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
+	if td.Specs != nil {
+		c := *td
+		c.Specs = v.indentSpecs(td.Specs)
+		td = &c
+	}
+	return v.GoVisitor.VisitTypeDecl(td, p)
+}
+
+// VisitComposite indents the elements of a composite literal that spans
+// lines, and the whitespace before its closing brace back out.
+func (v *TabsAndIndentsVisitor) VisitComposite(c *golang.Composite, p any) java.J {
+	println("VISIT COMPOSITE depth=", v.depth, "elems=", len(c.Elements.Elements))
+	out := *c
+	out.Elements.Elements = indentElements(v, c.Elements.Elements)
+	out.Markers = v.reindentTrailingComma(c.Markers)
+	return v.GoVisitor.VisitComposite(&out, p)
+}
+
+// reindentTrailingComma re-indents the closing delimiter of a list that ends
+// in a comma, where the space between the two rides on the marker rather than
+// on any element.
+func (v *TabsAndIndentsVisitor) reindentTrailingComma(m java.Markers) java.Markers {
+	comma := java.FindMarker[golang.TrailingComma](m)
+	if comma == nil {
+		return m
+	}
+	after := v.reindentSpace(comma.After)
+	if java.SpaceEqual(after, comma.After) {
+		return m
+	}
+	updated := *comma
+	updated.After = after
+	entries := append([]java.Marker(nil), m.Entries...)
+	for i, e := range entries {
+		if _, isComma := e.(golang.TrailingComma); isComma {
+			entries[i] = updated
+		}
+	}
+	return java.Markers{ID: m.ID, Entries: entries}
+}
+
+// indentSpecs indents the body of a parenthesized declaration group.
+func (v *TabsAndIndentsVisitor) indentSpecs(c *java.Container[java.Statement]) *java.Container[java.Statement] {
+	out := *c
+	out.Elements = indentElements(v, c.Elements)
+	return &out
+}
+
+// indentElements moves each element of a delimited list one level in, and the
+// whitespace before the closing delimiter back out. An element's After holds a
+// newline only in that closing position, so re-indenting every After at the
+// outer depth leaves the ones between elements untouched.
+func indentElements[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPadded[T]) []java.RightPadded[T] {
+	out := make([]java.RightPadded[T], len(elements))
+	for i, rp := range elements {
+		v.depth++
+		if fixed, ok := any(transformPrefix(rp.Element, v.reindentSpace)).(T); ok {
+			rp.Element = fixed
+		}
+		v.depth--
+		rp.After = v.reindentSpace(rp.After)
+		out[i] = rp
+	}
+	return out
+}
+
 // VisitBlock dispatches the body at depth+1 and re-indents each
 // statement's Prefix and the closing-brace `End`.
 func (v *TabsAndIndentsVisitor) VisitBlock(block *java.Block, p any) java.J {
@@ -79,10 +176,10 @@ func (v *TabsAndIndentsVisitor) VisitBlock(block *java.Block, p any) java.J {
 		}
 		stmts[i] = rp
 	}
-	block.Statements = stmts
 	v.depth--
 
-	block = block.WithEnd(v.reindentSpace(block.End))
+	block = block.WithStatements(stmts)
+	block = block.WithEnd(v.reindentClosing(block.End))
 	return block
 }
 
@@ -96,36 +193,117 @@ func (v *TabsAndIndentsVisitor) VisitCase(c *java.Case, p any) java.J {
 	c = c.WithPrefix(v.reindentSpace(c.Prefix))
 	v.depth++
 
-	body := make([]java.RightPadded[java.Statement], len(c.Body))
-	for i, rp := range c.Body {
+	// Expressions that wrap sit one level in from the `case` keyword, which
+	// is the depth the body already runs at.
+	exprs := make([]java.RightPadded[java.Expression], len(c.Expressions.Elements))
+	for i, rp := range c.Expressions.Elements {
+		if fixed, ok := transformPrefix(rp.Element, v.reindentSpace).(java.Expression); ok {
+			rp.Element = fixed
+		}
+		exprs[i] = rp
+	}
+
+	out := *c
+	out.Expressions.Elements = exprs
+	out.Body = indentBody(v, c.Body, p)
+	return &out
+}
+
+// VisitMethodInvocation indents arguments that wrap onto their own lines, and
+// the whitespace before the closing paren back out to the call's own level.
+func (v *TabsAndIndentsVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
+	out := *mi
+	out.Arguments.Elements = indentElements(v, mi.Arguments.Elements)
+	out.Markers = v.reindentTrailingComma(mi.Markers)
+	return v.GoVisitor.VisitMethodInvocation(&out, p)
+}
+
+// VisitCommClause aligns a select clause the way VisitCase aligns a switch
+// clause: the `case` keyword sits with the enclosing `select`, its body one
+// level in.
+func (v *TabsAndIndentsVisitor) VisitCommClause(cc *golang.CommClause, p any) java.J {
+	v.depth--
+	cc = cc.WithPrefix(v.reindentSpace(cc.Prefix))
+	v.depth++
+
+	out := *cc
+	out.Body = indentBody(v, cc.Body, p)
+	return v.GoVisitor.VisitCommClause(&out, p)
+}
+
+func indentBody(v *TabsAndIndentsVisitor, body []java.RightPadded[java.Statement], p any) []java.RightPadded[java.Statement] {
+	out := make([]java.RightPadded[java.Statement], len(body))
+	for i, rp := range body {
 		if rp.Element != nil {
-			fixed, _ := transformPrefix(rp.Element, v.reindentSpace).(java.Statement)
-			if fixed != nil {
+			if fixed, ok := transformPrefix(rp.Element, v.reindentSpace).(java.Statement); ok {
 				rp.Element = fixed
 			}
 			if next, ok := v.Visit(rp.Element, p).(java.Statement); ok {
 				rp.Element = next
 			}
 		}
-		body[i] = rp
+		out[i] = rp
 	}
-	c.Body = body
-	return c
+	return out
 }
 
-// reindentSpace rewrites the indent (post-last-newline portion) of s
-// to `\t × v.depth`. Whitespace without a newline is returned
-// unchanged. The pre-newline portion (which can hold blank lines) is
-// preserved — BlankLinesVisitor handles that.
-func (v *TabsAndIndentsVisitor) reindentSpace(s java.Space) java.Space {
-	if !strings.Contains(s.Whitespace, "\n") {
-		return s
+// reindentClosing re-indents the whitespace before a closing delimiter. Any
+// comments in it trail the body and so sit one level in, while the delimiter
+// itself returns to the outer depth.
+func (v *TabsAndIndentsVisitor) reindentClosing(s java.Space) java.Space {
+	if len(s.Comments) == 0 {
+		return v.reindentSpace(s)
 	}
-	last := strings.LastIndex(s.Whitespace, "\n")
-	want := strings.Repeat("\t", v.depth)
-	if s.Whitespace[last+1:] == want {
-		return s
+	inner := strings.Repeat("\t", v.depth+1)
+	outer := strings.Repeat("\t", v.depth)
+
+	s.Whitespace = reindentTail(s.Whitespace, inner)
+	comments := append([]java.Comment(nil), s.Comments...)
+	for i := range comments {
+		indent := inner
+		if i == len(comments)-1 {
+			indent = outer
+		}
+		comments[i].Suffix = reindentTail(comments[i].Suffix, indent)
 	}
-	s.Whitespace = s.Whitespace[:last+1] + want
+	s.Comments = comments
 	return s
+}
+
+// reindentSpace rewrites to `\t × v.depth` the indent of everything s
+// introduces: its comments, and the syntax that follows them. A Space prints
+// as Whitespace, then each comment followed by its Suffix, so every one of
+// those segments ends in the indent of whatever comes next.
+func (v *TabsAndIndentsVisitor) reindentSpace(s java.Space) java.Space {
+	want := strings.Repeat("\t", v.depth)
+	s.Whitespace = reindentTail(s.Whitespace, want)
+
+	var comments []java.Comment
+	for i, c := range s.Comments {
+		suffix := reindentTail(c.Suffix, want)
+		if suffix == c.Suffix {
+			continue
+		}
+		if comments == nil {
+			comments = append([]java.Comment(nil), s.Comments...)
+		}
+		comments[i].Suffix = suffix
+	}
+	if comments != nil {
+		s.Comments = comments
+	}
+	return s
+}
+
+// reindentTail rewrites the run of whitespace following the last newline in
+// ws, which is the indent of whatever comes next. Whitespace holding no
+// newline sits mid-line and is returned unchanged, which is what keeps a
+// trailing comment beside the code it follows. The portion before the last
+// newline can hold blank lines and is preserved — BlankLinesVisitor owns that.
+func reindentTail(ws, indent string) string {
+	last := strings.LastIndex(ws, "\n")
+	if last < 0 || ws[last+1:] == indent {
+		return ws
+	}
+	return ws[:last+1] + indent
 }

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -104,7 +104,6 @@ func (v *TabsAndIndentsVisitor) VisitTypeDecl(td *golang.TypeDecl, p any) java.J
 // VisitComposite indents the elements of a composite literal that spans
 // lines, and the whitespace before its closing brace back out.
 func (v *TabsAndIndentsVisitor) VisitComposite(c *golang.Composite, p any) java.J {
-	println("VISIT COMPOSITE depth=", v.depth, "elems=", len(c.Elements.Elements))
 	out := *c
 	out.Elements.Elements = indentElements(v, c.Elements.Elements)
 	out.Markers = v.reindentTrailingComma(c.Markers)
@@ -216,6 +215,30 @@ func (v *TabsAndIndentsVisitor) VisitMethodInvocation(mi *java.MethodInvocation,
 	out.Arguments.Elements = indentElements(v, mi.Arguments.Elements)
 	out.Markers = v.reindentTrailingComma(mi.Markers)
 	return v.GoVisitor.VisitMethodInvocation(&out, p)
+}
+
+// VisitBinary indents a right operand that continues on its own line. Both
+// operands sit at the same level however deeply the expression nests, so the
+// depth is taken from the enclosing statement rather than from the operand.
+func (v *TabsAndIndentsVisitor) VisitBinary(b *java.Binary, p any) java.J {
+	out := *b
+	v.depth++
+	if right, ok := transformPrefix(b.Right, v.reindentSpace).(java.Expression); ok {
+		out.Right = right
+	}
+	v.depth--
+	return v.GoVisitor.VisitBinary(&out, p)
+}
+
+// VisitGoBinary applies VisitBinary's rule to Go's own binary expressions.
+func (v *TabsAndIndentsVisitor) VisitGoBinary(b *golang.Binary, p any) java.J {
+	out := *b
+	v.depth++
+	if right, ok := transformPrefix(b.Right, v.reindentSpace).(java.Expression); ok {
+		out.Right = right
+	}
+	v.depth--
+	return v.GoVisitor.VisitGoBinary(&out, p)
 }
 
 // VisitCommClause aligns a select clause the way VisitCase aligns a switch

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -189,12 +189,10 @@ func eachElement[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPad
 }
 
 // VisitLabel sits a label one level out from the statements around it, and
-// leaves the statement it labels at their level.
+// leaves the statement it labels — and any comment ahead of the label — at
+// their level.
 func (v *TabsAndIndentsVisitor) VisitLabel(l *java.Label, p any) java.J {
-	depth := v.depth
-	v.depth = reduceIndentDepth(depth)
-	out := l.WithPrefix(v.reindentSpace(l.Prefix))
-	v.depth = depth
+	out := l.WithPrefix(v.reindentClauseLeadIn(l.Prefix))
 
 	copied := *out
 	statement := l.Statement
@@ -277,23 +275,41 @@ func (v *TabsAndIndentsVisitor) VisitMethodInvocation(mi *java.MethodInvocation,
 // depth is taken from the enclosing statement rather than from the operand.
 func (v *TabsAndIndentsVisitor) VisitBinary(b *java.Binary, p any) java.J {
 	out := *b
-	v.depth++
-	if right, ok := transformPrefix(b.Right, v.reindentSpace).(java.Expression); ok {
-		out.Right = right
-	}
-	v.depth--
-	return v.GoVisitor.VisitBinary(&out, p)
+	out.Left = v.visitOperand(b.Left, false, p)
+	out.Right = v.visitOperand(b.Right, true, p)
+	return &out
 }
 
 // VisitGoBinary applies VisitBinary's rule to Go's own binary expressions.
 func (v *TabsAndIndentsVisitor) VisitGoBinary(b *golang.Binary, p any) java.J {
 	out := *b
-	v.depth++
-	if right, ok := transformPrefix(b.Right, v.reindentSpace).(java.Expression); ok {
-		out.Right = right
+	out.Left = v.visitOperand(b.Left, false, p)
+	out.Right = v.visitOperand(b.Right, true, p)
+	return &out
+}
+
+// visitOperand indents an operand that continues on its own line, and descends
+// into it at that level so an operand wrapping inside one lands a level
+// further in. Only the right-hand operand can start a continuation line; the
+// left one opens the expression.
+func (v *TabsAndIndentsVisitor) visitOperand(e java.Expression, continues bool, p any) java.Expression {
+	if e == nil {
+		return nil
 	}
-	v.depth--
-	return v.GoVisitor.VisitGoBinary(&out, p)
+	wraps := continues && breaksLine(getPrefix(e))
+	if wraps {
+		v.depth++
+		if fixed, ok := transformPrefix(e, v.reindentSpace).(java.Expression); ok {
+			e = fixed
+		}
+	}
+	if next, ok := v.Visit(e, p).(java.Expression); ok {
+		e = next
+	}
+	if wraps {
+		v.depth--
+	}
+	return e
 }
 
 // VisitCommClause aligns a select clause the way VisitCase aligns a switch
@@ -333,11 +349,11 @@ func ownsItsLeadIn(t java.Tree) bool {
 	return false
 }
 
-// reindentClauseLeadIn re-indents what runs up to a `case` or `default`
-// keyword, which aligns with the enclosing `switch` or `select` one level out
-// from the clause bodies. A comment ahead of the keyword belongs to the body
-// above it and is indented with that body, unless it was written at the
-// keyword's own level, where it reads as introducing the clause and stays.
+// reindentClauseLeadIn re-indents what runs up to a keyword that sits one level
+// out from the statements around it — `case`, `default`, a label. A comment
+// ahead of the keyword belongs to those statements and is indented with them,
+// unless it was written at the keyword's own level, where it reads as
+// introducing what follows and stays.
 func (v *TabsAndIndentsVisitor) reindentClauseLeadIn(s java.Space) java.Space {
 	body := strings.Repeat("\t", v.depth)
 	keyword := strings.Repeat("\t", reduceIndentDepth(v.depth))

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -196,9 +196,12 @@ func (v *TabsAndIndentsVisitor) VisitBlock(block *java.Block, p any) java.J {
 	stmts := make([]java.RightPadded[java.Statement], len(block.Statements))
 	for i, rp := range block.Statements {
 		if rp.Element != nil {
-			fixed, _ := transformPrefix(rp.Element, v.reindentSpace).(java.Statement)
-			if fixed != nil {
-				rp.Element = fixed
+			// A clause aligns with the switch or select that encloses it and
+			// decides its own lead-in, so its prefix is left to it.
+			if !ownsItsLeadIn(rp.Element) {
+				if fixed, ok := transformPrefix(rp.Element, v.reindentSpace).(java.Statement); ok {
+					rp.Element = fixed
+				}
 			}
 			if next, ok := v.Visit(rp.Element, p).(java.Statement); ok {
 				rp.Element = next
@@ -219,9 +222,7 @@ func (v *TabsAndIndentsVisitor) VisitBlock(block *java.Block, p any) java.J {
 // blocks inside a case get their own indent fixes (the default
 // GoVisitor.VisitCase doesn't recurse into Body).
 func (v *TabsAndIndentsVisitor) VisitCase(c *java.Case, p any) java.J {
-	v.depth--
-	c = c.WithPrefix(v.reindentSpace(c.Prefix))
-	v.depth++
+	c = c.WithPrefix(v.reindentClauseLeadIn(c.Prefix))
 
 	// Expressions that wrap sit one level in from the `case` keyword, which
 	// is the depth the body already runs at.
@@ -243,9 +244,16 @@ func (v *TabsAndIndentsVisitor) VisitCase(c *java.Case, p any) java.J {
 // the whitespace before the closing paren back out to the call's own level.
 func (v *TabsAndIndentsVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
 	out := *mi
-	out.Arguments.Elements = indentElements(v, mi.Arguments.Elements)
+	out.Arguments.Elements = indentSubtrees(v, mi.Arguments.Elements, p)
 	out.Markers = v.reindentTrailingComma(mi.Markers)
-	return v.GoVisitor.VisitMethodInvocation(&out, p)
+	if mi.Select != nil {
+		selected := *mi.Select
+		if next, ok := v.Visit(selected.Element, p).(java.Expression); ok {
+			selected.Element = next
+			out.Select = &selected
+		}
+	}
+	return &out
 }
 
 // VisitBinary indents a right operand that continues on its own line. Both
@@ -276,9 +284,7 @@ func (v *TabsAndIndentsVisitor) VisitGoBinary(b *golang.Binary, p any) java.J {
 // clause: the `case` keyword sits with the enclosing `select`, its body one
 // level in.
 func (v *TabsAndIndentsVisitor) VisitCommClause(cc *golang.CommClause, p any) java.J {
-	v.depth--
-	cc = cc.WithPrefix(v.reindentSpace(cc.Prefix))
-	v.depth++
+	cc = cc.WithPrefix(v.reindentClauseLeadIn(cc.Prefix))
 
 	out := *cc
 	out.Body = indentBody(v, cc.Body, p)
@@ -299,6 +305,68 @@ func indentBody(v *TabsAndIndentsVisitor, body []java.RightPadded[java.Statement
 		out[i] = rp
 	}
 	return out
+}
+
+// ownsItsLeadIn reports whether a statement re-indents the whitespace ahead of
+// itself rather than leaving that to the block holding it.
+func ownsItsLeadIn(t java.Tree) bool {
+	switch t.(type) {
+	case *java.Case, *golang.CommClause:
+		return true
+	}
+	return false
+}
+
+// reindentClauseLeadIn re-indents what runs up to a `case` or `default`
+// keyword, which aligns with the enclosing `switch` or `select` one level out
+// from the clause bodies. A comment ahead of the keyword belongs to the body
+// above it and is indented with that body, unless it was written at the
+// keyword's own level, where it reads as introducing the clause and stays.
+func (v *TabsAndIndentsVisitor) reindentClauseLeadIn(s java.Space) java.Space {
+	body := strings.Repeat("\t", v.depth)
+	keyword := strings.Repeat("\t", reduceIndentDepth(v.depth))
+
+	segments := make([]string, 0, len(s.Comments)+1)
+	segments = append(segments, s.Whitespace)
+	for _, c := range s.Comments {
+		segments = append(segments, c.Suffix)
+	}
+	for i, segment := range segments {
+		want := body
+		if i == len(segments)-1 {
+			want = keyword
+		} else if indentOf(segment) == keyword {
+			continue
+		}
+		segments[i] = reindentTail(segment, want)
+	}
+
+	out := s
+	out.Whitespace = segments[0]
+	if len(s.Comments) > 0 {
+		comments := append([]java.Comment(nil), s.Comments...)
+		for i := range comments {
+			comments[i].Suffix = segments[i+1]
+		}
+		out.Comments = comments
+	}
+	return out
+}
+
+// indentOf reports the whitespace after the last line break in ws, which is the
+// indent of whatever follows it.
+func indentOf(ws string) string {
+	if i := strings.LastIndex(ws, "\n"); i >= 0 {
+		return ws[i+1:]
+	}
+	return ws
+}
+
+func reduceIndentDepth(depth int) int {
+	if depth <= 1 {
+		return 0
+	}
+	return depth - 1
 }
 
 // reindentClosing re-indents the whitespace before a closing delimiter. Any

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -105,9 +105,16 @@ func (v *TabsAndIndentsVisitor) VisitTypeDecl(td *golang.TypeDecl, p any) java.J
 // lines, and the whitespace before its closing brace back out.
 func (v *TabsAndIndentsVisitor) VisitComposite(c *golang.Composite, p any) java.J {
 	out := *c
-	out.Elements.Elements = indentElements(v, c.Elements.Elements)
+	// The type expression sits at the literal's own level — the fields of an
+	// inline struct type line up with the elements, not one level further in.
+	if c.TypeExpr != nil {
+		if typeExpr, ok := v.Visit(c.TypeExpr, p).(java.Expression); ok {
+			out.TypeExpr = typeExpr
+		}
+	}
+	out.Elements.Elements = indentSubtrees(v, c.Elements.Elements, p)
 	out.Markers = v.reindentTrailingComma(c.Markers)
-	return v.GoVisitor.VisitComposite(&out, p)
+	return &out
 }
 
 // reindentTrailingComma re-indents the closing delimiter of a list that ends
@@ -145,13 +152,37 @@ func (v *TabsAndIndentsVisitor) indentSpecs(c *java.Container[java.Statement]) *
 // newline only in that closing position, so re-indenting every After at the
 // outer depth leaves the ones between elements untouched.
 func indentElements[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPadded[T]) []java.RightPadded[T] {
+	return eachElement(v, elements, nil, false)
+}
+
+// indentSubtrees indents a delimited list and descends into each element at the
+// element's own level, so a list nested inside one lands a level further in.
+func indentSubtrees[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPadded[T], p any) []java.RightPadded[T] {
+	return eachElement(v, elements, p, true)
+}
+
+func eachElement[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPadded[T], p any, descend bool) []java.RightPadded[T] {
 	out := make([]java.RightPadded[T], len(elements))
 	for i, rp := range elements {
-		v.depth++
-		if fixed, ok := any(transformPrefix(rp.Element, v.reindentSpace)).(T); ok {
-			rp.Element = fixed
+		// A list contributes a level only where it breaks the line. An element
+		// written alongside the delimiter that opens the list stays on that
+		// line's level, and whatever nests inside it counts from there.
+		if breaksLine(getPrefix(rp.Element)) {
+			v.depth++
+			if fixed, ok := any(transformPrefix(rp.Element, v.reindentSpace)).(T); ok {
+				rp.Element = fixed
+			}
+			if descend {
+				if next, ok := any(v.Visit(rp.Element, p)).(T); ok {
+					rp.Element = next
+				}
+			}
+			v.depth--
+		} else if descend {
+			if next, ok := any(v.Visit(rp.Element, p)).(T); ok {
+				rp.Element = next
+			}
 		}
-		v.depth--
 		rp.After = v.reindentSpace(rp.After)
 		out[i] = rp
 	}
@@ -316,6 +347,21 @@ func (v *TabsAndIndentsVisitor) reindentSpace(s java.Space) java.Space {
 		s.Comments = comments
 	}
 	return s
+}
+
+// breaksLine reports whether s puts what follows it on a new line. The break
+// can sit in the whitespace or in the suffix of a comment s carries, as it does
+// when the previous line ends in a trailing comment.
+func breaksLine(s java.Space) bool {
+	if strings.Contains(s.Whitespace, "\n") {
+		return true
+	}
+	for _, c := range s.Comments {
+		if strings.Contains(c.Suffix, "\n") {
+			return true
+		}
+	}
+	return false
 }
 
 // reindentTail rewrites the run of whitespace following the last newline in

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -52,8 +52,7 @@ func (v *TabsAndIndentsVisitor) Visit(t java.Tree, p any) java.Tree {
 }
 
 // VisitCompilationUnit indents the specs of a parenthesized import
-// declaration one level in, and the whitespace before its closing paren back
-// out to file level.
+// declaration.
 func (v *TabsAndIndentsVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p any) java.J {
 	if cu.Imports != nil {
 		grouped := java.HasMarker[golang.GroupedImport](cu.Imports.Markers)
@@ -101,8 +100,7 @@ func (v *TabsAndIndentsVisitor) VisitTypeDecl(td *golang.TypeDecl, p any) java.J
 	return &out
 }
 
-// VisitComposite indents the elements of a composite literal that spans
-// lines, and the whitespace before its closing brace back out.
+// VisitComposite indents the elements of a composite literal.
 func (v *TabsAndIndentsVisitor) VisitComposite(c *golang.Composite, p any) java.J {
 	out := *c
 	// The type expression sits at the literal's own level — the fields of an
@@ -125,7 +123,7 @@ func (v *TabsAndIndentsVisitor) reindentTrailingComma(m java.Markers) java.Marke
 	if comma == nil {
 		return m
 	}
-	after := v.reindentSpace(comma.After)
+	after := v.reindentClosing(comma.After)
 	if java.SpaceEqual(after, comma.After) {
 		return m
 	}
@@ -147,10 +145,7 @@ func (v *TabsAndIndentsVisitor) indentSpecs(c *java.Container[java.Statement], p
 	return &out
 }
 
-// indentElements moves each element of a delimited list one level in, and the
-// whitespace before the closing delimiter back out. An element's After holds a
-// newline only in that closing position, so re-indenting every After at the
-// outer depth leaves the ones between elements untouched.
+// indentElements indents the elements of a delimited list.
 func indentElements[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPadded[T]) []java.RightPadded[T] {
 	return eachElement(v, elements, nil, false)
 }
@@ -161,6 +156,10 @@ func indentSubtrees[T java.Tree](v *TabsAndIndentsVisitor, elements []java.Right
 	return eachElement(v, elements, p, true)
 }
 
+// eachElement moves each element of a delimited list one level in and the
+// closing delimiter back out. An element's After holds a line break only in
+// that closing position, so treating every After as a closing one leaves the
+// ones between elements untouched.
 func eachElement[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPadded[T], p any, descend bool) []java.RightPadded[T] {
 	out := make([]java.RightPadded[T], len(elements))
 	for i, rp := range elements {
@@ -183,7 +182,7 @@ func eachElement[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPad
 				rp.Element = next
 			}
 		}
-		rp.After = v.reindentSpace(rp.After)
+		rp.After = v.reindentClosing(rp.After)
 		out[i] = rp
 	}
 	return out
@@ -236,11 +235,9 @@ func (v *TabsAndIndentsVisitor) VisitBlock(block *java.Block, p any) java.J {
 	return block
 }
 
-// VisitCase aligns the case keyword with the enclosing switch (one
-// tab less than the switch body's depth) while keeping the case body
-// statements at body depth. Also explicitly visits Body so nested
-// blocks inside a case get their own indent fixes (the default
-// GoVisitor.VisitCase doesn't recurse into Body).
+// VisitCase indents a switch clause: the lead-in aligns the keyword with the
+// enclosing switch, and the body one level in. It visits Body itself, which
+// GoVisitor.VisitCase does not recurse into.
 func (v *TabsAndIndentsVisitor) VisitCase(c *java.Case, p any) java.J {
 	c = c.WithPrefix(v.reindentClauseLeadIn(c.Prefix))
 
@@ -260,8 +257,7 @@ func (v *TabsAndIndentsVisitor) VisitCase(c *java.Case, p any) java.J {
 	return &out
 }
 
-// VisitMethodInvocation indents arguments that wrap onto their own lines, and
-// the whitespace before the closing paren back out to the call's own level.
+// VisitMethodInvocation indents arguments that wrap onto their own lines.
 func (v *TabsAndIndentsVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
 	out := *mi
 	out.Arguments.Elements = indentSubtrees(v, mi.Arguments.Elements, p)

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -82,23 +82,23 @@ func (v *TabsAndIndentsVisitor) VisitCompilationUnit(cu *golang.CompilationUnit,
 
 // VisitDeclarationBlock indents the specs of a `var (…)` or `const (…)` group.
 func (v *TabsAndIndentsVisitor) VisitDeclarationBlock(db *golang.DeclarationBlock, p any) java.J {
-	if db.Specs != nil {
-		c := *db
-		c.Specs = v.indentSpecs(db.Specs)
-		db = &c
+	if db.Specs == nil {
+		return v.GoVisitor.VisitDeclarationBlock(db, p)
 	}
-	return v.GoVisitor.VisitDeclarationBlock(db, p)
+	out := *db
+	out.Specs = v.indentSpecs(db.Specs, p)
+	return &out
 }
 
 // VisitTypeDecl indents the specs of a `type (…)` group. An ungrouped
 // declaration has no Specs and is indented by its enclosing block.
 func (v *TabsAndIndentsVisitor) VisitTypeDecl(td *golang.TypeDecl, p any) java.J {
-	if td.Specs != nil {
-		c := *td
-		c.Specs = v.indentSpecs(td.Specs)
-		td = &c
+	if td.Specs == nil {
+		return v.GoVisitor.VisitTypeDecl(td, p)
 	}
-	return v.GoVisitor.VisitTypeDecl(td, p)
+	out := *td
+	out.Specs = v.indentSpecs(td.Specs, p)
+	return &out
 }
 
 // VisitComposite indents the elements of a composite literal that spans
@@ -141,9 +141,9 @@ func (v *TabsAndIndentsVisitor) reindentTrailingComma(m java.Markers) java.Marke
 }
 
 // indentSpecs indents the body of a parenthesized declaration group.
-func (v *TabsAndIndentsVisitor) indentSpecs(c *java.Container[java.Statement]) *java.Container[java.Statement] {
+func (v *TabsAndIndentsVisitor) indentSpecs(c *java.Container[java.Statement], p any) *java.Container[java.Statement] {
 	out := *c
-	out.Elements = indentElements(v, c.Elements)
+	out.Elements = indentSubtrees(v, c.Elements, p)
 	return &out
 }
 
@@ -187,6 +187,26 @@ func eachElement[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPad
 		out[i] = rp
 	}
 	return out
+}
+
+// VisitLabel sits a label one level out from the statements around it, and
+// leaves the statement it labels at their level.
+func (v *TabsAndIndentsVisitor) VisitLabel(l *java.Label, p any) java.J {
+	depth := v.depth
+	v.depth = reduceIndentDepth(depth)
+	out := l.WithPrefix(v.reindentSpace(l.Prefix))
+	v.depth = depth
+
+	copied := *out
+	statement := l.Statement
+	if fixed, ok := transformPrefix(statement, v.reindentSpace).(java.Statement); ok {
+		statement = fixed
+	}
+	if next, ok := v.Visit(statement, p).(java.Statement); ok {
+		statement = next
+	}
+	copied.Statement = statement
+	return &copied
 }
 
 // VisitBlock dispatches the body at depth+1 and re-indents each
@@ -311,7 +331,7 @@ func indentBody(v *TabsAndIndentsVisitor, body []java.RightPadded[java.Statement
 // itself rather than leaving that to the block holding it.
 func ownsItsLeadIn(t java.Tree) bool {
 	switch t.(type) {
-	case *java.Case, *golang.CommClause:
+	case *java.Case, *golang.CommClause, *java.Label:
 		return true
 	}
 	return false

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/2023acf3eede0828
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/2023acf3eede0828
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A\n//\n//\n")
+int64(92)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/4c44247d4925f319
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/4c44247d4925f319
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A\ntype A struct{A`\r`}")
+int64(103)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/58ccb08cce8efe28
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/58ccb08cce8efe28
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("")
+int64(1)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/63e300e87c13c9e4
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/63e300e87c13c9e4
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A0//\n//\n//  \n//   0\nfunc A()")
+int64(78)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/809792dd3f789fab
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/809792dd3f789fab
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A\nfunc A(){switch {case 0:0;0}}")
+int64(-60)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/e89fd7339013822a
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/e89fd7339013822a
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A//\nfunc A()")
+int64(29)

--- a/rewrite-go/pkg/format/whitespace_splice.go
+++ b/rewrite-go/pkg/format/whitespace_splice.go
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"reflect"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+var (
+	spaceType    = reflect.TypeOf(java.Space{})
+	markersType  = reflect.TypeOf(java.Markers{})
+	javaTypeType = reflect.TypeOf((*java.JavaType)(nil)).Elem()
+	treeType     = reflect.TypeOf((*java.Tree)(nil)).Elem()
+)
+
+// SpliceWhitespace returns original with every Space replaced by its
+// counterpart in formatted, a tree parsed from a re-laid-out rendering of
+// original. Node ids, type attribution and everything else come from original,
+// which is rebuilt only along the paths that changed. When target is non-nil,
+// only Spaces inside that subtree are replaced.
+//
+// A node the two trees shape differently keeps its original whitespace while
+// its siblings are spliced; the second return value reports whether every node
+// was reached, distinguishing a complete splice from a partial one.
+func SpliceWhitespace(original, formatted java.Tree, target java.Tree) (java.Tree, bool) {
+	s := &splicer{target: target, active: target == nil}
+	out, changed := s.value(reflect.ValueOf(original), reflect.ValueOf(formatted))
+	if !changed {
+		return original, !s.diverged
+	}
+	return out.Interface().(java.Tree), !s.diverged
+}
+
+type splicer struct {
+	target   java.Tree
+	active   bool
+	diverged bool
+}
+
+// value walks orig and fmtd in lockstep, returning the reconciled value and
+// whether it differs from orig.
+func (s *splicer) value(orig, fmtd reflect.Value) (reflect.Value, bool) {
+	t := orig.Type()
+	d := shapeOf(t)
+	if t != fmtd.Type() {
+		// A payload the trees disagree on (the `any` behind Literal.Value, say)
+		// carries no layout, so only a node counts as a divergence.
+		if d.isTree || shapeOf(fmtd.Type()).isTree {
+			s.diverged = true
+		}
+		return orig, false
+	}
+	if !d.carriesSpace {
+		return orig, false
+	}
+
+	switch {
+	case d.isSpace:
+		if !s.active || spaceContentEqual(orig.Interface().(java.Space), fmtd.Interface().(java.Space)) {
+			return orig, false
+		}
+		return fmtd, true
+	case d.isMarkers:
+		if !s.active {
+			return orig, false
+		}
+		return s.markers(orig, fmtd)
+	}
+
+	switch d.kind {
+	case reflect.Interface:
+		if orig.IsNil() != fmtd.IsNil() {
+			s.diverged = true
+			return orig, false
+		}
+		if orig.IsNil() {
+			return orig, false
+		}
+		elem, changed := s.value(orig.Elem(), fmtd.Elem())
+		if !changed {
+			return orig, false
+		}
+		boxed := reflect.New(t).Elem()
+		boxed.Set(elem)
+		return boxed, true
+
+	case reflect.Pointer:
+		if orig.IsNil() != fmtd.IsNil() {
+			s.diverged = true
+			return orig, false
+		}
+		if orig.IsNil() {
+			return orig, false
+		}
+		outer := s.active
+		if !outer && d.isTree && orig.Interface() == s.target {
+			s.active = true
+		}
+		elem, changed := s.value(orig.Elem(), fmtd.Elem())
+		s.active = outer
+		if !changed {
+			return orig, false
+		}
+		p := reflect.New(elem.Type())
+		p.Elem().Set(elem)
+		return p, true
+
+	case reflect.Struct:
+		var out reflect.Value
+		for _, i := range d.spaceFields {
+			field, changed := s.value(orig.Field(i), fmtd.Field(i))
+			if !changed {
+				continue
+			}
+			if !out.IsValid() {
+				out = reflect.New(t).Elem()
+				out.Set(orig)
+			}
+			out.Field(i).Set(field)
+		}
+		if !out.IsValid() {
+			return orig, false
+		}
+		return out, true
+
+	case reflect.Slice:
+		if orig.Len() != fmtd.Len() {
+			if elem := shapeOf(t.Elem()); elem.isTree || elem.kind == reflect.Struct {
+				s.diverged = true
+			}
+			return orig, false
+		}
+		var out reflect.Value
+		for i := 0; i < orig.Len(); i++ {
+			elem, changed := s.value(orig.Index(i), fmtd.Index(i))
+			if !changed {
+				continue
+			}
+			if !out.IsValid() {
+				out = reflect.MakeSlice(t, orig.Len(), orig.Len())
+				reflect.Copy(out, orig)
+			}
+			out.Index(i).Set(elem)
+		}
+		if !out.IsValid() {
+			return orig, false
+		}
+		return out, true
+
+	default:
+		return orig, false
+	}
+}
+
+// markers splices the layout a marker carries: some whitespace has no Space of
+// its own and rides on a marker instead, as golang.TrailingComma holds the
+// space around a composite literal's trailing comma. Semicolon is itself
+// layout — go/printer writes a newline where an explicit `;` separated two
+// statements — so it is added or dropped to match the formatted tree.
+func (s *splicer) markers(orig, fmtd reflect.Value) (reflect.Value, bool) {
+	om := orig.Interface().(java.Markers)
+	fm := fmtd.Interface().(java.Markers)
+
+	entries := om.Entries
+	changed := false
+	copyOnWrite := func() {
+		if !changed {
+			entries = append([]java.Marker(nil), om.Entries...)
+			changed = true
+		}
+	}
+
+	oIdx, fIdx := layoutPeers(om.Entries), layoutPeers(fm.Entries)
+	if len(oIdx) == len(fIdx) {
+		for k := range oIdx {
+			ov := reflect.ValueOf(om.Entries[oIdx[k]])
+			fv := reflect.ValueOf(fm.Entries[fIdx[k]])
+			if ov.Type() != fv.Type() {
+				continue
+			}
+			spliced, ch := s.value(ov, fv)
+			if !ch {
+				continue
+			}
+			copyOnWrite()
+			entries[oIdx[k]] = spliced.Interface().(java.Marker)
+		}
+	}
+
+	if has := java.HasMarker[golang.Semicolon](om); has != java.HasMarker[golang.Semicolon](fm) {
+		copyOnWrite()
+		if has {
+			kept := entries[:0:0]
+			for _, e := range entries {
+				if _, isSemicolon := e.(golang.Semicolon); !isSemicolon {
+					kept = append(kept, e)
+				}
+			}
+			entries = kept
+		} else {
+			entries = append(entries, golang.NewSemicolon())
+		}
+	}
+
+	if !changed {
+		return orig, false
+	}
+	return reflect.ValueOf(java.Markers{ID: om.ID, Entries: entries}), true
+}
+
+// layoutPeers indexes the entries that pair up positionally between the two
+// trees. Semicolons are excluded because they are added and dropped by
+// formatting, which would misalign every marker after them.
+func layoutPeers(entries []java.Marker) []int {
+	var idx []int
+	for i, e := range entries {
+		if _, isSemicolon := e.(golang.Semicolon); !isSemicolon {
+			idx = append(idx, i)
+		}
+	}
+	return idx
+}
+
+// spaceContentEqual compares Spaces by content. java.SpaceEqual is identity
+// based on the comments slice, which would report every commented Space of a
+// freshly parsed tree as different.
+func spaceContentEqual(a, b java.Space) bool {
+	if a.Whitespace != b.Whitespace || len(a.Comments) != len(b.Comments) {
+		return false
+	}
+	for i := range a.Comments {
+		x, y := a.Comments[i], b.Comments[i]
+		if x.Kind != y.Kind || x.Text != y.Text || x.Suffix != y.Suffix || x.Multiline != y.Multiline {
+			return false
+		}
+	}
+	return true
+}

--- a/rewrite-go/pkg/parser/attachment_audit_test.go
+++ b/rewrite-go/pkg/parser/attachment_audit_test.go
@@ -1,0 +1,122 @@
+//go:build gofmtaudit
+
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+)
+
+// TestWhitespaceAttachmentAudit reports where leading whitespace sits on a
+// child that shares its parent's leading edge. It belongs to the outermost
+// element: anything reading a node's own prefix otherwise finds it empty while
+// the text in front of the node is not.
+func TestWhitespaceAttachmentAudit(t *testing.T) {
+	var contexts []build.Context
+	for _, pair := range [][2]string{
+		{"darwin", "arm64"}, {"linux", "amd64"}, {"windows", "amd64"},
+		{"js", "wasm"}, {"plan9", "386"}, {"linux", "riscv64"}, {"aix", "ppc64"},
+	} {
+		c := build.Default
+		c.GOOS, c.GOARCH = pair[0], pair[1]
+		c.CgoEnabled = true
+		contexts = append(contexts, c)
+	}
+
+	root := filepath.Join(runtime.GOROOT(), "src")
+	var files []string
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.Contains(path, "/testdata/") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	kinds := map[string]int{}
+	examples := map[string]string{}
+	var checked, withViolations int
+
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		src := string(content)
+		var ctx *build.Context
+		for i := range contexts {
+			if parser.MatchBuildContext(contexts[i], filepath.Base(f), src) {
+				ctx = &contexts[i]
+				break
+			}
+		}
+		if ctx == nil {
+			continue
+		}
+		p := parser.NewGoParserWithBuildContext(*ctx)
+		p.ParseOnly = true
+		cu, err := p.Parse(filepath.Base(f), src)
+		if err != nil {
+			continue
+		}
+		checked++
+
+		violations := test.WhitespaceAttachmentViolations(cu)
+		if len(violations) == 0 {
+			continue
+		}
+		withViolations++
+		for _, v := range violations {
+			kind := kindOf(v)
+			kinds[kind]++
+			if _, seen := examples[kind]; !seen {
+				examples[kind] = filepath.Base(f) + ": " + v
+			}
+		}
+	}
+
+	keys := make([]string, 0, len(kinds))
+	for k := range kinds {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return kinds[keys[i]] > kinds[keys[j]] })
+
+	t.Logf("filesChecked=%d filesWithViolations=%d distinctKinds=%d", checked, withViolations, len(kinds))
+	for _, k := range keys {
+		t.Logf("  %6d  %s\n         e.g. %s", kinds[k], k, examples[k])
+	}
+}
+
+// kindOf reduces a violation message to the parent-and-child pair it reports,
+// so the same modelling gap counts once however often it occurs.
+func kindOf(violation string) string {
+	parts := strings.SplitN(violation, " has child ", 2)
+	if len(parts) != 2 {
+		return violation
+	}
+	child, _, _ := strings.Cut(parts[1], " starting with whitespace")
+	return parts[0] + " -> " + child
+}

--- a/rewrite-go/pkg/parser/coverage_audit_test.go
+++ b/rewrite-go/pkg/parser/coverage_audit_test.go
@@ -1,0 +1,132 @@
+//go:build gofmtaudit
+
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package parser_test
+
+import (
+	"go/build"
+	goparser "go/parser"
+	gotoken "go/token"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+)
+
+// TestParserCoverageAudit buckets why standard library files fail to parse,
+// separating build-context exclusion from real gaps.
+func TestParserCoverageAudit(t *testing.T) {
+	root := filepath.Join(runtime.GOROOT(), "src")
+	var files []string
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.Contains(path, "/testdata/") {
+			files = append(files, path)
+		}
+		return nil
+	})
+
+	contexts := []build.Context{}
+	for _, pair := range [][2]string{
+		{"darwin", "arm64"}, {"linux", "amd64"}, {"windows", "amd64"},
+		{"js", "wasm"}, {"plan9", "386"}, {"linux", "riscv64"}, {"aix", "ppc64"},
+	} {
+		c := build.Default
+		c.GOOS, c.GOARCH = pair[0], pair[1]
+		c.CgoEnabled = true
+		contexts = append(contexts, c)
+	}
+
+	digits := regexp.MustCompile(`[0-9]+`)
+	buckets := map[string]int{}
+	examples := map[string]string{}
+	var ok, excluded, goParserRejects, rewriteRejects, roundTripFails int
+	var roundTripExamples []string
+
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		src := string(content)
+
+		// Try every build context, so files constrained to another platform
+		// are still exercised.
+		var selected *build.Context
+		for i, c := range contexts {
+			if parser.MatchBuildContext(c, filepath.Base(f), src) {
+				selected = &contexts[i]
+				break
+			}
+		}
+		if selected == nil {
+			excluded++
+			continue
+		}
+		// Does Go's own parser accept it?
+		fset := gotoken.NewFileSet()
+		if _, err := goparser.ParseFile(fset, f, src, goparser.ParseComments); err != nil {
+			goParserRejects++
+			continue
+		}
+
+		p := parser.NewGoParserWithBuildContext(*selected)
+		p.ParseOnly = true
+		cu, err := p.Parse(filepath.Base(f), src)
+		if err != nil {
+			rewriteRejects++
+			key := digits.ReplaceAllString(err.Error(), "N")
+			if i := strings.Index(key, ": "); i > 0 && strings.HasSuffix(key[:i], ".go") {
+				key = key[i+2:]
+			}
+			buckets[key]++
+			if _, seen := examples[key]; !seen {
+				examples[key] = f
+			}
+			continue
+		}
+		if printed := printer.Print(cu); printed != src {
+			roundTripFails++
+			if len(roundTripExamples) < 10 {
+				roundTripExamples = append(roundTripExamples, f)
+			}
+			continue
+		}
+		ok++
+	}
+
+	keys := make([]string, 0, len(buckets))
+	for k := range buckets {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool { return buckets[keys[i]] > buckets[keys[j]] })
+
+	t.Logf("files=%d parsedAndRoundTripped=%d buildExcluded=%d goParserRejects=%d rewriteRejects=%d roundTripFails=%d distinctCauses=%d",
+		len(files), ok, excluded, goParserRejects, rewriteRejects, roundTripFails, len(buckets))
+	for _, e := range roundTripExamples {
+		t.Logf("  roundTrip: %s", e)
+	}
+	for _, k := range keys {
+		t.Logf("  %5d  %s\n         e.g. %s", buckets[k], k, examples[k])
+	}
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -44,6 +44,13 @@ type GoParser struct {
 	// GOOS/GOARCH). Recipe authors that need cross-platform analysis can
 	// set this explicitly via NewGoParserWithBuildContext.
 	BuildContext build.Context
+
+	// ParseOnly produces trees without type attribution, for callers that read
+	// only layout off the result. Some expressions map to a different shape
+	// without types — `Map[int]` becomes an index expression rather than a
+	// generic instantiation — so a caller that compares shapes must tolerate
+	// that. Mirrors JavaScriptParser.parseOnly() in rewrite-javascript.
+	ParseOnly bool
 }
 
 func NewGoParser() *GoParser {
@@ -132,20 +139,22 @@ func (gp *GoParser) ParsePackage(files []FileInput) ([]*golang.CompilationUnit, 
 		// Used to distinguish generic instantiation from ordinary indexing.
 		Instances: make(map[*ast.Ident]types.Instance),
 	}
-	conf := types.Config{
-		Importer: gp.Importer,
-		// Don't fail on type errors — we want partial type info even when
-		// some imports can't be resolved.
-		Error: func(error) {},
-	}
+	if !gp.ParseOnly {
+		conf := types.Config{
+			Importer: gp.Importer,
+			// Don't fail on type errors — we want partial type info even when
+			// some imports can't be resolved.
+			Error: func(error) {},
+		}
 
-	// Use the first file's package name as the type-checker hint;
-	// types.Config.Check validates that all files agree.
-	pkgName := "main"
-	if asts[0].Name != nil {
-		pkgName = asts[0].Name.Name
+		// Use the first file's package name as the type-checker hint;
+		// types.Config.Check validates that all files agree.
+		pkgName := "main"
+		if asts[0].Name != nil {
+			pkgName = asts[0].Name.Name
+		}
+		_, _ = conf.Check(pkgName, fset, asts, typeInfo)
 	}
-	_, _ = conf.Check(pkgName, fset, asts, typeInfo)
 
 	mapper := newTypeMapper()
 	cus := make([]*golang.CompilationUnit, 0, len(files))

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -413,3 +413,14 @@ func TestTabsAndIndents_OutdentsLabels(t *testing.T) {
 		t.Errorf("want %q\ngot  %q", want, out)
 	}
 }
+
+func TestBinarySpacing_SiblingArgumentsKeepTheirDepth(t *testing.T) {
+	// The parenthesised argument lowers the depth for its own contents only.
+	out := applyVisitor(t,
+		"package p\n\nfunc f(g func(int, int), max int) {\n\tg(-(max - 1), max - 1)\n}\n",
+		format.NewBinarySpacingVisitor(nil))
+	want := "package p\n\nfunc f(g func(int, int), max int) {\n\tg(-(max - 1), max-1)\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -403,3 +403,13 @@ func TestTabsAndIndents_CaseLeadInComments(t *testing.T) {
 		}
 	}
 }
+
+func TestTabsAndIndents_OutdentsLabels(t *testing.T) {
+	out := applyVisitor(t,
+		"package p\n\nfunc f() {\nloop:\nfor {\nbreak loop\n}\nif true {\ninner:\nfor {\nbreak inner\n}\n}\n}\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nfunc f() {\nloop:\n\tfor {\n\t\tbreak loop\n\t}\n\tif true {\n\tinner:\n\t\tfor {\n\t\t\tbreak inner\n\t\t}\n\t}\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -384,3 +384,22 @@ func TestBlankLinesAtBlockBraces(t *testing.T) {
 		}
 	}
 }
+
+func TestTabsAndIndents_CaseLeadInComments(t *testing.T) {
+	cases := map[string][2]string{
+		"a comment at the case keyword's level stays": {
+			"package p\n\nfunc f(a, b bool) {\n\tswitch {\n\tcase a:\n\t// c\n\tcase b:\n\t\treturn\n\t}\n}\n",
+			"package p\n\nfunc f(a, b bool) {\n\tswitch {\n\tcase a:\n\t// c\n\tcase b:\n\t\treturn\n\t}\n}\n"},
+		"a comment at the body's level stays there": {
+			"package p\n\nfunc f(a, b bool) {\n\tswitch {\n\tcase a:\n\t\t// c\n\tcase b:\n\t\treturn\n\t}\n}\n",
+			"package p\n\nfunc f(a, b bool) {\n\tswitch {\n\tcase a:\n\t\t// c\n\tcase b:\n\t\treturn\n\t}\n}\n"},
+		"a comment written anywhere else moves to the body": {
+			"package p\n\nfunc f(a, b bool) {\n\tswitch {\n\tcase a:\n// c\n\tcase b:\n\t\treturn\n\t}\n}\n",
+			"package p\n\nfunc f(a, b bool) {\n\tswitch {\n\tcase a:\n\t\t// c\n\tcase b:\n\t\treturn\n\t}\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewTabsAndIndentsVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -287,3 +287,114 @@ func TestAutoFormat_FullPipelineEndToEnd(t *testing.T) {
 		t.Errorf("got %q, want %q", out, want)
 	}
 }
+
+func TestTabsAndIndents_IndentsImportBlock(t *testing.T) {
+	out := applyVisitor(t, "package p\n\nimport (\n\"fmt\"\n\"os\"\n)\n\nvar _ = fmt.Sprint(os.Args)\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nimport (\n\t\"fmt\"\n\t\"os\"\n)\n\nvar _ = fmt.Sprint(os.Args)\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}
+
+func TestTabsAndIndents_IndentsLeadingComment(t *testing.T) {
+	out := applyVisitor(t, "package p\n\nfunc f() {\n// leading\nx := 1\n_ = x\n}\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nfunc f() {\n\t// leading\n\tx := 1\n\t_ = x\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}
+
+func TestTabsAndIndents_IndentsConsecutiveComments(t *testing.T) {
+	out := applyVisitor(t, "package p\n\nfunc f() {\n// one\n// two\nx := 1\n_ = x\n}\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nfunc f() {\n\t// one\n\t// two\n\tx := 1\n\t_ = x\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}
+
+func TestTabsAndIndents_LeavesTrailingCommentOnItsLine(t *testing.T) {
+	out := applyVisitor(t, "package p\n\nfunc f() {\nx := 1 // trailing\n_ = x\n}\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nfunc f() {\n\tx := 1 // trailing\n\t_ = x\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}
+
+func TestTabsAndIndents_IndentsGroupedDeclarations(t *testing.T) {
+	cases := map[string][2]string{
+		"var group": {
+			"package p\n\nvar (\na = 1\nb = 2\n)\n",
+			"package p\n\nvar (\n\ta = 1\n\tb = 2\n)\n"},
+		"const group": {
+			"package p\n\nconst (\nA = 1\nB = 2\n)\n",
+			"package p\n\nconst (\n\tA = 1\n\tB = 2\n)\n"},
+		"type group": {
+			"package p\n\ntype (\nA int\nB string\n)\n",
+			"package p\n\ntype (\n\tA int\n\tB string\n)\n"},
+		"struct body": {
+			"package p\n\ntype T struct {\nX int\nY int\n}\n",
+			"package p\n\ntype T struct {\n\tX int\n\tY int\n}\n"},
+		"interface body": {
+			"package p\n\ntype I interface {\nFoo() int\n}\n",
+			"package p\n\ntype I interface {\n\tFoo() int\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewTabsAndIndentsVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}
+
+func TestTabsAndIndents_IndentsCompositeLiteral(t *testing.T) {
+	out := applyVisitor(t, "package p\n\nvar m = map[string]bool{\n\"a\": true,\n\"b\": false,\n}\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nvar m = map[string]bool{\n\t\"a\": true,\n\t\"b\": false,\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}
+
+func TestTabsAndIndents_IndentsTrailingComments(t *testing.T) {
+	cases := map[string][2]string{
+		"comment before closing brace": {
+			"package p\n\nfunc f() {\nx := 1\n_ = x\n// trailing note\n}\n",
+			"package p\n\nfunc f() {\n\tx := 1\n\t_ = x\n\t// trailing note\n}\n"},
+		"comment as whole case body": {
+			"package p\n\nfunc g(i int) {\nswitch i {\ndefault:\n// note\n}\n}\n",
+			"package p\n\nfunc g(i int) {\n\tswitch i {\n\tdefault:\n\t\t// note\n\t}\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewTabsAndIndentsVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}
+
+func TestTabsAndIndents_AlignsSelectCaseWithSelect(t *testing.T) {
+	out := applyVisitor(t, "package p\n\nfunc h(c chan int) {\nselect {\ncase <-c:\nreturn\n}\n}\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nfunc h(c chan int) {\n\tselect {\n\tcase <-c:\n\t\treturn\n\t}\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}
+
+func TestTabsAndIndents_IndentsWrappedLists(t *testing.T) {
+	cases := map[string][2]string{
+		"call arguments": {
+			"package p\n\nimport \"os/exec\"\n\nfunc f() {\ncmd := exec.Command(\"go\", \"tool\",\n\"-a\", \"b\",\n)\n_ = cmd\n}\n",
+			"package p\n\nimport \"os/exec\"\n\nfunc f() {\n\tcmd := exec.Command(\"go\", \"tool\",\n\t\t\"-a\", \"b\",\n\t)\n\t_ = cmd\n}\n"},
+		"case expressions": {
+			"package p\n\nfunc f(i int) {\nswitch i {\ncase 1, 2,\n3:\nreturn\n}\n}\n",
+			"package p\n\nfunc f(i int) {\n\tswitch i {\n\tcase 1, 2,\n\t\t3:\n\t\treturn\n\t}\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewTabsAndIndentsVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -381,3 +381,22 @@ func TestBinarySpacing(t *testing.T) {
 		}
 	}
 }
+
+func TestBinarySpacingInSlices(t *testing.T) {
+	cases := map[string][2]string{
+		"single index stays tight": {
+			"package p\n\nfunc f(a []int, n int) {\n\ta = a[:n - 1]\n\t_ = a\n}\n",
+			"package p\n\nfunc f(a []int, n int) {\n\ta = a[:n-1]\n\t_ = a\n}\n"},
+		"two indices with a binary set the colon off": {
+			"package p\n\nfunc f(a []int, i, j int) {\n\t_ = a[i:j + 1]\n}\n",
+			"package p\n\nfunc f(a []int, i, j int) {\n\t_ = a[i : j+1]\n}\n"},
+		"two plain indices stay tight": {
+			"package p\n\nfunc f(a []int, i, j int) {\n\t_ = a[i : j]\n}\n",
+			"package p\n\nfunc f(a []int, i, j int) {\n\t_ = a[i:j]\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewBinarySpacingVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -159,47 +159,10 @@ func main() {
 	assert.Equal(t, want, out)
 }
 
-func TestSpaces_NormalizesBinaryOperatorSpacing(t *testing.T) {
-	src := `package main
-
-func main() {
-	a := 1+2
-	_ = a
-}
-`
-	want := `package main
-
-func main() {
-	a := 1 + 2
-	_ = a
-}
-`
-	out := applyVisitor(t, src, format.NewSpacesVisitor(nil))
-	assert.Equal(t, want, out)
-}
-
 // Regression: when the right operand of `:=` is itself a Binary, the
 // leading single-space-after-`:=` lives on the leftmost leaf of the
 // Binary tree (e.g., the Literal `1` in `1+2+3`). Setting Binary.Prefix
 // directly would double the space.
-func TestSpaces_NoSpaceDoublingWithBinaryOperand(t *testing.T) {
-	src := `package main
-
-func main() {
-	a := 1+2+3
-	_ = a
-}
-`
-	want := `package main
-
-func main() {
-	a := 1 + 2 + 3
-	_ = a
-}
-`
-	out := applyVisitor(t, src, format.NewSpacesVisitor(nil))
-	assert.Equal(t, want, out)
-}
 
 // Regression: same delegation rule when the assigned expression is a
 // FieldAccess — the space-after-`:=` lives on FieldAccess.Target.Prefix.
@@ -386,6 +349,34 @@ func TestTabsAndIndents_IndentsWrappedBinary(t *testing.T) {
 	}
 	for name, io := range cases {
 		if out := applyVisitor(t, io[0], format.NewTabsAndIndentsVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}
+
+func TestBinarySpacing(t *testing.T) {
+	cases := map[string][2]string{
+		"one precedence keeps blanks": {
+			"package p\n\nfunc f() int {\n\ta := 1+2\n\treturn a\n}\n",
+			"package p\n\nfunc f() int {\n\ta := 1 + 2\n\treturn a\n}\n"},
+		"chain of one precedence keeps blanks": {
+			"package p\n\nfunc f() int {\n\ta := 1+2+3\n\treturn a\n}\n",
+			"package p\n\nfunc f() int {\n\ta := 1 + 2 + 3\n\treturn a\n}\n"},
+		"tighter operator loses them": {
+			"package p\n\nfunc f(x, y, z int) int {\n\tb := x * y + z\n\treturn b\n}\n",
+			"package p\n\nfunc f(x, y, z int) int {\n\tb := x*y + z\n\treturn b\n}\n"},
+		"both sides of a sum tighten": {
+			"package p\n\nfunc f(x, y int) int {\n\tg := 2 * x + 3 * y\n\treturn g\n}\n",
+			"package p\n\nfunc f(x, y int) int {\n\tg := 2*x + 3*y\n\treturn g\n}\n"},
+		"nesting inside an index tightens": {
+			"package p\n\nfunc f(s []int, i int) int {\n\td := s[i + 1]\n\treturn d\n}\n",
+			"package p\n\nfunc f(s []int, i int) int {\n\td := s[i+1]\n\treturn d\n}\n"},
+		"nesting inside a comparison tightens": {
+			"package p\n\nfunc f(a, b, c int) bool {\n\treturn a > b - c\n}\n",
+			"package p\n\nfunc f(a, b, c int) bool {\n\treturn a > b-c\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewBinarySpacingVisitor(nil)); out != io[1] {
 			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
 		}
 	}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -374,3 +374,19 @@ func TestTabsAndIndents_IndentsWrappedLists(t *testing.T) {
 		}
 	}
 }
+
+func TestTabsAndIndents_IndentsWrappedBinary(t *testing.T) {
+	cases := map[string][2]string{
+		"in if condition": {
+			"package p\n\nfunc f(a, b, c bool) bool {\nif a &&\nb &&\nc {\nreturn true\n}\nreturn false\n}\n",
+			"package p\n\nfunc f(a, b, c bool) bool {\n\tif a &&\n\t\tb &&\n\t\tc {\n\t\treturn true\n\t}\n\treturn false\n}\n"},
+		"in assignment": {
+			"package p\n\nfunc f(a, b bool) bool {\nx := a ||\nb\nreturn x\n}\n",
+			"package p\n\nfunc f(a, b bool) bool {\n\tx := a ||\n\t\tb\n\treturn x\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewTabsAndIndentsVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -62,47 +62,9 @@ func TestRemoveTrailingWhitespace_StripsTrailingTabsFromLines(t *testing.T) {
 // block lives on the *leftmost descendant* of that statement (e.g.
 // Variable.Prefix), not on Asg.Prefix. The visitor walks the leftmost
 // spine via transformLeftmostPrefix to find it.
-func TestBlankLines_StripsLeadingBlankLineAtBlockStart(t *testing.T) {
-	src := `package main
-
-func main() {
-
-	a := 1
-	_ = a
-}
-`
-	want := `package main
-
-func main() {
-	a := 1
-	_ = a
-}
-`
-	out := applyVisitor(t, src, format.NewBlankLinesVisitor(nil))
-	assert.Equal(t, want, out)
-}
 
 // Regression: the trailing blank line above the closing brace lives on
 // Block.End — straightforward direct manipulation.
-func TestBlankLines_StripsTrailingBlankLineAtBlockEnd(t *testing.T) {
-	src := `package main
-
-func main() {
-	a := 1
-	_ = a
-
-}
-`
-	want := `package main
-
-func main() {
-	a := 1
-	_ = a
-}
-`
-	out := applyVisitor(t, src, format.NewBlankLinesVisitor(nil))
-	assert.Equal(t, want, out)
-}
 
 func TestBlankLines_CapsRunOfBlankLinesInBlock(t *testing.T) {
 	src := `package main
@@ -222,7 +184,7 @@ func TestAutoFormat_FullPipelineEndToEnd(t *testing.T) {
 	// start of body, wrong indent on nested block + its body,
 	// missing space around `+`. Expect all four passes to fire.
 	src := "package main\n\nfunc main() {   \n\n\n\tif true {\n\ta := 1+2\n\t_ = a\n\t}\n}\n"
-	want := "package main\n\nfunc main() {\n\tif true {\n\t\ta := 1 + 2\n\t\t_ = a\n\t}\n}\n"
+	want := "package main\n\nfunc main() {\n\n\tif true {\n\t\ta := 1 + 2\n\t\t_ = a\n\t}\n}\n"
 	out := applyVisitor(t, src, format.NewAutoFormatVisitor(nil))
 	assert.Equal(t, want, out)
 }
@@ -396,6 +358,28 @@ func TestBinarySpacingInSlices(t *testing.T) {
 	}
 	for name, io := range cases {
 		if out := applyVisitor(t, io[0], format.NewBinarySpacingVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}
+
+func TestBlankLinesAtBlockBraces(t *testing.T) {
+	cases := map[string][2]string{
+		"a function body keeps one": {
+			"package p\n\nfunc f() {\n\n\ta := 1\n\t_ = a\n\n}\n",
+			"package p\n\nfunc f() {\n\n\ta := 1\n\t_ = a\n\n}\n"},
+		"a function body caps a run at one": {
+			"package p\n\nfunc f() {\n\n\n\ta := 1\n\t_ = a\n\n\n}\n",
+			"package p\n\nfunc f() {\n\n\ta := 1\n\t_ = a\n\n}\n"},
+		"a struct body sits flush": {
+			"package p\n\ntype T struct {\n\n\tA int\n\n}\n",
+			"package p\n\ntype T struct {\n\tA int\n}\n"},
+		"an interface body sits flush": {
+			"package p\n\ntype I interface {\n\n\tM() int\n\n}\n",
+			"package p\n\ntype I interface {\n\tM() int\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewBlankLinesVisitor(nil)); out != io[1] {
 			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
 		}
 	}

--- a/rewrite-go/test/doc_comment_test.go
+++ b/rewrite-go/test/doc_comment_test.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/format"
+)
+
+func TestDocComments(t *testing.T) {
+	cases := map[string][2]string{
+		"list indentation": {
+			"package p\n\n// Doc explains things.\n//\n//  - first\n//  - second\nfunc F() {}\n",
+			"package p\n\n// Doc explains things.\n//\n//   - first\n//   - second\nfunc F() {}\n"},
+		"code block": {
+			"package p\n\n// Doc with code:\n//\t\tcode()\nfunc G() {}\n",
+			"package p\n\n// Doc with code:\n//\n//\tcode()\nfunc G() {}\n"},
+		"directive is held off from the doc by a blank line": {
+			"package p\n\n// Doc text.\n//go:noinline\nfunc H() {}\n",
+			"package p\n\n// Doc text.\n//\n//go:noinline\nfunc H() {}\n"},
+		"indented field doc is left alone": {
+			"package p\n\ntype T struct {\n\t//  - field doc list\n\t//  - second\n\tX int\n}\n",
+			"package p\n\ntype T struct {\n\t//  - field doc list\n\t//  - second\n\tX int\n}\n"},
+		"body comment is left alone": {
+			"package p\n\nfunc F() {\n\t//  - body list\n\t//  - second\n\tx := 1\n\t_ = x\n}\n",
+			"package p\n\nfunc F() {\n\t//  - body list\n\t//  - second\n\tx := 1\n\t_ = x\n}\n"},
+		"comment detached by a blank line is left alone": {
+			"package p\n\n//  - detached\n\nfunc F() {}\n",
+			"package p\n\n//  - detached\n\nfunc F() {}\n"},
+		"empty doc comment is dropped": {
+			"package p\n\n//\nfunc F() {}\n",
+			"package p\n\nfunc F() {}\n"},
+		"package doc": {
+			"//  - package list\n//  - second\n//\n// Text.\npackage p\n",
+			"//   - package list\n//   - second\n//\n// Text.\npackage p\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewDocCommentVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}

--- a/rewrite-go/test/gofmt_audit_test.go
+++ b/rewrite-go/test/gofmt_audit_test.go
@@ -1,0 +1,110 @@
+//go:build gofmtaudit
+
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/format"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+)
+
+// TestGofmtAudit strips the indentation off every Go standard library file and
+// checks that the splice restores exactly what gofmt produces. It reports
+// coverage rather than asserting, so parser gaps don't read as splice failures.
+//
+// Gated behind the `gofmtaudit` build tag; run with
+// `go test -tags gofmtaudit ./test/ -run TestGofmtAudit -v`.
+func TestGofmtAudit(t *testing.T) {
+	root := filepath.Join(runtime.GOROOT(), "src")
+
+	var files []string
+	filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() || !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		if strings.Contains(path, "/testdata/") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+
+	var parsed, roundTripped, exact, mismatch, bailed int
+	var examples []string
+	for _, f := range files {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			continue
+		}
+		mangled := stripIndent(string(content))
+		want, err := gofmtBinary(t, mangled)
+		if err != nil {
+			continue
+		}
+
+		cu, err := parser.NewGoParser().Parse(filepath.Base(f), mangled)
+		if err != nil {
+			continue
+		}
+		parsed++
+		if printer.Print(cu) != mangled {
+			continue // printer round-trip gap, not a splice gap
+		}
+		roundTripped++
+
+		out, err := format.Gofmt(cu, nil)
+		if err != nil {
+			bailed++
+			continue
+		}
+		got := printer.Print(out)
+		switch {
+		case got == want:
+			exact++
+		case got == mangled:
+			bailed++
+		default:
+			mismatch++
+			if len(examples) < 10 {
+				examples = append(examples, f)
+			}
+		}
+	}
+
+	t.Logf("files=%d parsed=%d roundTripped=%d exactGofmt=%d bailed=%d mismatch=%d",
+		len(files), parsed, roundTripped, exact, bailed, mismatch)
+	for _, e := range examples {
+		t.Logf("  mismatch: %s", e)
+	}
+}
+
+func gofmtBinary(t *testing.T, src string) (string, error) {
+	t.Helper()
+	cmd := exec.Command("gofmt")
+	cmd.Stdin = strings.NewReader(src)
+	out, err := cmd.Output()
+	return string(out), err
+}

--- a/rewrite-go/test/gofmt_test.go
+++ b/rewrite-go/test/gofmt_test.go
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/format"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+func gofmtCU(t *testing.T, src string) *golang.CompilationUnit {
+	t.Helper()
+	cu, err := parser.NewGoParser().Parse("test.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := format.Gofmt(cu, nil)
+	if err != nil {
+		t.Fatalf("gofmt: %v", err)
+	}
+	return out
+}
+
+func assertGofmt(t *testing.T, before, after string) {
+	t.Helper()
+	if got := printer.Print(gofmtCU(t, before)); got != after {
+		t.Errorf("unexpected output\n--- want ---\n%s\n--- got ---\n%s", after, got)
+	}
+}
+
+func TestGofmt_AlignsStructFields(t *testing.T) {
+	assertGofmt(t,
+		"package p\n\ntype T struct {\nName string `json:\"name\"`\nVeryLongFieldName int `json:\"v\"`\n}\n",
+		"package p\n\ntype T struct {\n\tName              string `json:\"name\"`\n\tVeryLongFieldName int    `json:\"v\"`\n}\n")
+}
+
+func TestGofmt_AlignsTrailingComments(t *testing.T) {
+	assertGofmt(t,
+		"package p\n\nfunc f() {\nx := 1 // one\nyy := 22 // two\n_, _ = x, yy\n}\n",
+		"package p\n\nfunc f() {\n\tx := 1   // one\n\tyy := 22 // two\n\t_, _ = x, yy\n}\n")
+}
+
+func TestGofmt_NormalizesSpacingAndIndent(t *testing.T) {
+	assertGofmt(t,
+		"package p\n\nfunc f(a int,b int)int{\nif a>b{\nreturn a\n}\nreturn b\n}\n",
+		"package p\n\nfunc f(a int, b int) int {\n\tif a > b {\n\t\treturn a\n\t}\n\treturn b\n}\n")
+}
+
+func TestGofmt_AlreadyFormattedIsUnchanged(t *testing.T) {
+	src := "package p\n\nimport \"fmt\"\n\nfunc f() {\n\tfmt.Println(\"hi\")\n}\n"
+	cu, err := parser.NewGoParser().Parse("test.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := format.Gofmt(cu, nil)
+	if err != nil {
+		t.Fatalf("gofmt: %v", err)
+	}
+	if out != cu {
+		t.Error("expected the same tree instance back for already-formatted source")
+	}
+}
+
+func TestGofmt_PreservesIdsAndTypes(t *testing.T) {
+	src := "package main\n\nfunc main() {\nx := 42\n_ = x\n}\n"
+	cu, err := parser.NewGoParser().Parse("test.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	beforeIds, beforeTypes := identifierFacts(cu)
+	if len(beforeIds) == 0 {
+		t.Fatal("no identifiers found")
+	}
+	typed := 0
+	for _, ty := range beforeTypes {
+		if ty != nil {
+			typed++
+		}
+	}
+	if typed == 0 {
+		t.Fatal("expected at least one attributed identifier")
+	}
+
+	out, err := format.Gofmt(cu, nil)
+	if err != nil {
+		t.Fatalf("gofmt: %v", err)
+	}
+	afterIds, afterTypes := identifierFacts(out)
+
+	if len(afterIds) != len(beforeIds) {
+		t.Fatalf("identifier count changed: %d -> %d", len(beforeIds), len(afterIds))
+	}
+	for i := range beforeIds {
+		if beforeIds[i] != afterIds[i] {
+			t.Errorf("identifier %d lost its id", i)
+		}
+		if beforeTypes[i] != afterTypes[i] {
+			t.Errorf("identifier %d lost its type attribution", i)
+		}
+	}
+}
+
+func TestGofmt_TargetSubtreeOnly(t *testing.T) {
+	src := "package p\n\nfunc a() {\nx:=1\n_ = x\n}\n\nfunc b() {\ny:=2\n_ = y\n}\n"
+	cu, err := parser.NewGoParser().Parse("test.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	target := cu.Statements[1].Element // func b
+
+	out, err := format.Gofmt(cu, target)
+	if err != nil {
+		t.Fatalf("gofmt: %v", err)
+	}
+	got := printer.Print(out)
+	want := "package p\n\nfunc a() {\nx:=1\n_ = x\n}\n\nfunc b() {\n\ty := 2\n\t_ = y\n}\n"
+	if got != want {
+		t.Errorf("unexpected output\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+}
+
+func TestGofmt_FormatsAroundStructuralDivergence(t *testing.T) {
+	// go/printer drops one level of redundant parentheses, so the reparsed tree
+	// has fewer nodes than the original. The parentheses survive — a splice
+	// carries no token changes — while the rest of the file is laid out.
+	assertGofmt(t,
+		"package p\n\nfunc f() int {\nreturn ((1 + 2))\n}\n",
+		"package p\n\nfunc f() int {\n\treturn ((1 + 2))\n}\n")
+}
+
+func TestGofmt_MatchesGofmtBinaryOnCorpus(t *testing.T) {
+	gofmtBin, err := exec.LookPath("gofmt")
+	if err != nil {
+		t.Skip("gofmt binary not on PATH")
+	}
+
+	var fixtures []string
+	root := filepath.Join("testdata", "printer-corpus")
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(path, ".go") {
+			fixtures = append(fixtures, path)
+		}
+		return err
+	}); err != nil {
+		t.Fatalf("walk corpus: %v", err)
+	}
+
+	for _, f := range fixtures {
+		t.Run(filepath.Base(f), func(t *testing.T) {
+			content, err := os.ReadFile(f)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			mangled := stripIndent(string(content))
+
+			cmd := exec.Command(gofmtBin)
+			cmd.Stdin = strings.NewReader(mangled)
+			want, err := cmd.Output()
+			if err != nil {
+				t.Skipf("gofmt rejected the mangled fixture: %v", err)
+			}
+
+			cu, err := parser.NewGoParser().Parse(filepath.Base(f), mangled)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			out, err := format.Gofmt(cu, nil)
+			if err != nil {
+				t.Fatalf("gofmt: %v", err)
+			}
+			if got := printer.Print(out); got != string(want) {
+				t.Errorf("does not match gofmt\n--- want ---\n%s\n--- got ---\n%s", want, got)
+			}
+		})
+	}
+}
+
+var indentPattern = regexp.MustCompile(`(?m)^[ \t]+`)
+
+// stripIndent removes leading whitespace from every line. Line structure — and
+// so Go's implicit semicolons — is preserved, leaving the token stream intact.
+func stripIndent(src string) string {
+	return indentPattern.ReplaceAllString(src, "")
+}
+
+type identifierCollector struct {
+	visitor.GoVisitor
+	ids   []uuid.UUID
+	types []java.JavaType
+}
+
+func (v *identifierCollector) VisitIdentifier(ident *java.Identifier, p any) java.J {
+	v.ids = append(v.ids, ident.ID)
+	v.types = append(v.types, ident.Type)
+	return v.GoVisitor.VisitIdentifier(ident, p)
+}
+
+func identifierFacts(cu java.Tree) ([]uuid.UUID, []java.JavaType) {
+	c := visitor.Init(&identifierCollector{})
+	c.Visit(cu, nil)
+	return c.ids, c.types
+}
+
+func TestGofmtVisitor_FormatsCompilationUnit(t *testing.T) {
+	got := applyVisitor(t, "package p\n\nfunc f(a int,b int)int{\nreturn a+b\n}\n", format.NewGofmtVisitor(nil))
+	want := "package p\n\nfunc f(a int, b int) int {\n\treturn a + b\n}\n"
+	if got != want {
+		t.Errorf("unexpected output\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+}
+
+func BenchmarkGofmt(b *testing.B) {
+	content, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "src", "net", "http", "server.go"))
+	if err != nil {
+		b.Skip(err)
+	}
+	mangled := stripIndent(string(content))
+	cu, err := parser.NewGoParser().Parse("server.go", mangled)
+	if err != nil {
+		b.Skip(err)
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := format.Gofmt(cu, nil); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkParseOnly(b *testing.B) {
+	content, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "src", "net", "http", "server.go"))
+	if err != nil {
+		b.Skip(err)
+	}
+	src := string(content)
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := parser.NewGoParser().Parse("server.go", src); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func TestGofmt_KeepsIdentityOfUnchangedSubtrees(t *testing.T) {
+	src := "package p\n\nfunc a() {\n\tx := 1\n\t_ = x\n}\n\nfunc b() {\ny:=2\n_ = y\n}\n"
+	cu, err := parser.NewGoParser().Parse("test.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	out, err := format.Gofmt(cu, nil)
+	if err != nil {
+		t.Fatalf("gofmt: %v", err)
+	}
+	if out == cu {
+		t.Fatal("expected a new compilation unit")
+	}
+	// func a is already formatted, so nothing below it may be rebuilt.
+	if out.Statements[0].Element != cu.Statements[0].Element {
+		t.Error("untouched declaration was replaced")
+	}
+	if out.Statements[1].Element == cu.Statements[1].Element {
+		t.Error("reformatted declaration was not replaced")
+	}
+}
+
+func TestGofmt_ReformatsComments(t *testing.T) {
+	assertGofmt(t,
+		"package p\n\n// Doc explains things.\n//\n//  - first item\n//  - second item\n//\n// Example:\n//\t\tcode()\nfunc F() {\n// inner\n/* block\nsecond line\n*/\nx := 1 // trailing\n_ = x\n}\n",
+		"package p\n\n// Doc explains things.\n//\n//   - first item\n//   - second item\n//\n// Example:\n//\n//\tcode()\nfunc F() {\n\t// inner\n\t/* block\n\t   second line\n\t*/\n\tx := 1 // trailing\n\t_ = x\n}\n")
+}
+
+func TestGofmt_FormatsGenericInstantiation(t *testing.T) {
+	// Shapes that need type attribution to map: a layout-only reparse reads
+	// List[int] as an index expression, which the splice refuses.
+	assertGofmt(t,
+		"package p\n\ntype List[T any] struct{ items []T }\n\nfunc Get[T any](l List[T]) []T { return l.items }\n\nfunc f() {\nm := List[int]{}\n_ = Get[int](m)\n}\n",
+		"package p\n\ntype List[T any] struct{ items []T }\n\nfunc Get[T any](l List[T]) []T { return l.items }\n\nfunc f() {\n\tm := List[int]{}\n\t_ = Get[int](m)\n}\n")
+}


### PR DESCRIPTION
## Motivation

`rewrite-go`'s formatter rewrote code that gofmt considers already correct. Running it over the Go standard library, **2981 of 5333 gofmt-clean files came back changed** — a formatter that damages well-formatted input is worse than no formatter at all, since every recipe run would carry unrelated diff noise. The gaps were not exotic: operators spaced without regard to precedence, table-driven literals indented one level short, labels indented at all, and blank lines stripped from places gofmt keeps them.

This brings the hand-rolled visitors to **99.4% agreement with gofmt on well-formatted input** (31 of 5333 files still change), and adds the measurement apparatus that makes further work a tracked number rather than an impression.

## Examples

Operator spacing now follows gofmt's precedence and depth rule rather than forcing one space:

```go
a := 1 + 2                  // unchanged
b := x*y + z                // tighter operator loses its blanks
d := s[i+1]                 // nesting tightens
e := a[i : j+1]             // a slice colon is set off when an index is a binary
f := int(2*numEntries)      // depth carries through a conversion
```

Indentation follows the line structure of nested lists, labels sit one level out, and a comment written after the last element of a list is indented with the elements:

```go
tests := []struct{ name string }{
	{
		name: "a",
	},
	// a trailing note sits with the elements
}

loop:
	for {
		break loop
	}
```

A new `MinimumViableSpacingVisitor` supplies the separation a tree needs to print as the Go it represents, which is what a recipe splicing in a synthesized node leaves behind:

```go
// A node with no prefix would otherwise print as `varx int` or run two
// statements onto one line.
format.NewMinimumViableSpacingVisitor(nil)
```

## Summary

- **`BinarySpacingVisitor`** reproduces `go/printer`'s `binaryExpr`, `walkBinary` and `cutoff`, including the cases where two operators written together would read as one token. Depth comes down from the statement, descending for a call with more than one argument, resetting inside a composite literal, and undoing a level at parentheses. `SpacesVisitor` no longer forces a space around binary operators.
- **`MinimumViableSpacingVisitor`** gives each construct the least separation that keeps the token stream intact — a line break between statements, a single space where two tokens would lex as one — and leaves layout to later passes. Each site's condition matches what the printer emits, so `default:` gets no `case`, an interface method no `func`, and a variadic type follows `...`.
- **`DocCommentVisitor`** hands doc comment text to `go/doc/comment`, the parser and printer gofmt itself uses, so lists, code blocks and links come out canonical. A file's trailing comments and an import declaration's doc comment are exempt, the latter because it carries the cgo preamble.
- **`TabsAndIndentsVisitor`** covers parenthesized imports, `var`/`const`/`type` groups, composite literals, wrapped call arguments and case expression lists, select clauses, wrapped binary operands, and labels. A construct contributes a level only where it breaks the line, and descending into a nested one happens at its own level, so a list or an operand wrapping inside another lands a level further in. A `case`, `default` or label sits one level out from the statements around it, while a comment ahead of it stays with those statements.
- **`BlankLinesVisitor`** sits a declaration list flush against its braces while keeping a blank line written against either brace of a statement block.
- **Pipeline staged in two phases**, as `org.openrewrite.java.format.AutoFormatVisitor` does: spacing settles first, then the passes that decide what the lines are.
- **`GoParser.ParseOnly`** produces trees without type attribution, for callers that read only layout off the result.
- **`Gofmt`** formats a compilation unit by printing it, running the result through `go/printer`, and splicing that layout back into the original tree, so node ids, type attribution and markers stay put. It is not wired into the pipeline; it serves as the oracle the parity test measures against, and tracks the Go toolchain automatically.

## Test plan

- [x] `go test ./...` in `rewrite-go` — green
- [x] `TestCanonicalInputUnchanged` — the formatter changes **0** of 5333 gofmt-clean standard library files for the doc-comment and minimum-spacing passes individually, and 31 for the whole pipeline, held by a ceiling that only moves down
- [x] `TestParityGap` — 4382 of 5333 files with every indent stripped come back byte-identical to gofmt, held by a floor that only moves up
- [x] `TestGofmtAudit` — the gofmt splice reproduces gofmt exactly on 4578 of 4578 files, with no structural bail-outs
- [x] `TestParserCoverageAudit` — 5335 files across seven `GOOS`/`GOARCH` contexts parse and round-trip, with no rejects
- [x] `TestFormatsTreeWithNoWhitespace` — stripping every `Space` from a parsed tree still yields valid Go with the same token stream
- [x] `FuzzFormat` — 8M+ executions over whitespace-mutated Go: output parses, no token moves, and idempotence wherever gofmt itself has it. It found four defects during development, kept as corpus
- [x] `go vet` and `gofmt -l` clean over the touched packages

The audits are behind the `gofmtaudit` build tag so ordinary runs skip them:

```
go test -tags gofmtaudit ./pkg/format/ ./pkg/parser/ -timeout 30m
```

## Known gaps

The 31 remaining files split into indentation (16), blank lines around block comments (11) and token spacing (4). Column alignment — struct field types and tags lining up across neighbouring lines — is not implemented; it needs rendered widths, and it is the largest single piece still outstanding.

Separately, the whitespace between `var` and a declared name sits on the `Identifier` rather than on the enclosing `VariableDeclarator` whose leading edge coincides with it. `MinimumViableSpacingVisitor` reads the printed form rather than one particular `Space`, so it is unaffected, but `pkg/test/whitespace_attachment.go` cannot see the discrepancy either: it inspects `J.GetPrefix()`, and the printer emits a declarator's prefix directly rather than through `Visit`, so no capture node exists for it.
