### PR TITLE
Close the remaining gofmt formatting gaps

### DIFF
--- a/rewrite-go/pkg/format/binary_spacing.go
+++ b/rewrite-go/pkg/format/binary_spacing.go
@@ -118,6 +118,20 @@ func (v *BinarySpacingVisitor) VisitArrayAccess(access *java.ArrayAccess, p any)
 	return &out
 }
 
+// VisitGoUnary starts a dereferenced operand at the outermost depth. gofmt
+// prints the operand of `*x` as an expression in its own right, while every
+// other unary operator carries the depth around it into its operand.
+func (v *BinarySpacingVisitor) VisitGoUnary(u *golang.Unary, p any) java.J {
+	if u.Operator.Element != golang.Indirection {
+		return v.GoVisitor.VisitGoUnary(u, p)
+	}
+	depth := v.depth
+	out := *u
+	out.Expression = v.operand(u.Expression, 1)
+	v.depth = depth
+	return &out
+}
+
 // VisitSlice descends into the indices of a slice expression, and spaces the
 // colons: gofmt sets them off with blanks when an outermost slice has more than
 // one index and at least one of them is a binary expression, so `a[i : j+1]`

--- a/rewrite-go/pkg/format/blank_lines.go
+++ b/rewrite-go/pkg/format/blank_lines.go
@@ -31,7 +31,9 @@ import (
 //     uniformly inside blocks AND between top-level decls).
 //   - A declaration list — the fields of a struct, the methods of an
 //     interface — sits flush against its braces, while a statement
-//     block keeps a blank line written against either of its own.
+//     block keeps a blank line written against either of its own. A
+//     comment against a brace keeps the blank line separating it either
+//     way, since the separation reads as the comment's own.
 //
 // The flush rule operates on the first statement's own Prefix, since the
 // parser attaches inter-statement whitespace to the outermost element.
@@ -68,9 +70,12 @@ func (v *BlankLinesVisitor) VisitBlock(block *java.Block, p any) java.J {
 	if !v.isDeclarationList() {
 		return out
 	}
-	out = out.WithEnd(adjustSpace(out.End, stripLeadingBlankLines))
+	if len(out.End.Comments) == 0 {
+		out = out.WithEnd(adjustSpace(out.End, stripLeadingBlankLines))
+	}
 
-	if len(out.Statements) > 0 && out.Statements[0].Element != nil {
+	if len(out.Statements) > 0 && out.Statements[0].Element != nil &&
+		len(getPrefix(out.Statements[0].Element).Comments) == 0 {
 		first := out.Statements[0]
 		if updated, ok := transformPrefix(first.Element, stripLeadingBlankLinesSpace).(java.Statement); ok {
 			first.Element = updated

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -40,7 +40,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 9
+const canonicalDamageCeiling = 3
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/canonical_input_test.go
+++ b/rewrite-go/pkg/format/canonical_input_test.go
@@ -40,7 +40,7 @@ import (
 // canonicalDamageCeiling is the number of gofmt-clean standard library files
 // the whole pipeline still rewrites, all of it layout the formatter renders
 // differently from gofmt. Lower it as passes converge; it never goes up.
-const canonicalDamageCeiling = 31
+const canonicalDamageCeiling = 9
 
 func TestCanonicalInputUnchanged(t *testing.T) {
 	t.Run("doc comments", func(t *testing.T) { canonicalInputUnchanged(t, "doc") })

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 4382
+const parityFloor = 4403
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/parity_gap_test.go
+++ b/rewrite-go/pkg/format/parity_gap_test.go
@@ -37,7 +37,7 @@ import (
 // parityFloor is the number of standard library files the hand-rolled
 // visitors render exactly as gofmt does. Raise it whenever a change earns
 // more; it never goes down.
-const parityFloor = 4403
+const parityFloor = 4405
 
 // TestParityGap measures how far the hand-rolled visitors are from gofmt,
 // using gofmtSource as the oracle, and holds the result at parityFloor. The

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -164,10 +164,9 @@ func eachElement[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPad
 	outer := v.depth
 	out := make([]java.RightPadded[T], len(elements))
 	for i, rp := range elements {
-		// A list contributes a level from the first element that breaks the
-		// line. Elements written alongside the delimiter that opens the list
-		// stay on that line's level, and once a later element has started a
-		// line of its own, its own siblings share the level it set.
+		// Elements written alongside the delimiter that opens the list stay on
+		// that line's level; from the first element to start a line of its own,
+		// the rest share the level it set.
 		if breaksLine(getPrefix(rp.Element)) {
 			v.depth = outer + 1
 			if fixed, ok := any(transformPrefix(rp.Element, v.reindentSpace)).(T); ok {
@@ -194,8 +193,12 @@ func (v *TabsAndIndentsVisitor) VisitLabel(l *java.Label, p any) java.J {
 
 	copied := *out
 	statement := l.Statement
-	if fixed, ok := transformPrefix(statement, v.reindentSpace).(java.Statement); ok {
-		statement = fixed
+	// An empty labelled statement prints nothing, so the whitespace ahead of it
+	// closes the block rather than opening a line of its own.
+	if _, empty := statement.(*java.Empty); !empty {
+		if fixed, ok := transformPrefix(statement, v.reindentSpace).(java.Statement); ok {
+			statement = fixed
+		}
 	}
 	if next, ok := v.Visit(statement, p).(java.Statement); ok {
 		statement = next

--- a/rewrite-go/pkg/format/tabs_and_indents.go
+++ b/rewrite-go/pkg/format/tabs_and_indents.go
@@ -161,30 +161,28 @@ func indentSubtrees[T java.Tree](v *TabsAndIndentsVisitor, elements []java.Right
 // that closing position, so treating every After as a closing one leaves the
 // ones between elements untouched.
 func eachElement[T java.Tree](v *TabsAndIndentsVisitor, elements []java.RightPadded[T], p any, descend bool) []java.RightPadded[T] {
+	outer := v.depth
 	out := make([]java.RightPadded[T], len(elements))
 	for i, rp := range elements {
-		// A list contributes a level only where it breaks the line. An element
-		// written alongside the delimiter that opens the list stays on that
-		// line's level, and whatever nests inside it counts from there.
+		// A list contributes a level from the first element that breaks the
+		// line. Elements written alongside the delimiter that opens the list
+		// stay on that line's level, and once a later element has started a
+		// line of its own, its own siblings share the level it set.
 		if breaksLine(getPrefix(rp.Element)) {
-			v.depth++
+			v.depth = outer + 1
 			if fixed, ok := any(transformPrefix(rp.Element, v.reindentSpace)).(T); ok {
 				rp.Element = fixed
 			}
-			if descend {
-				if next, ok := any(v.Visit(rp.Element, p)).(T); ok {
-					rp.Element = next
-				}
-			}
-			v.depth--
-		} else if descend {
+		}
+		if descend {
 			if next, ok := any(v.Visit(rp.Element, p)).(T); ok {
 				rp.Element = next
 			}
 		}
-		rp.After = v.reindentClosing(rp.After)
+		rp.After = v.reindentClosingAt(rp.After, outer)
 		out[i] = rp
 	}
+	v.depth = outer
 	return out
 }
 
@@ -405,11 +403,21 @@ func reduceIndentDepth(depth int) int {
 // comments in it trail the body and so sit one level in, while the delimiter
 // itself returns to the outer depth.
 func (v *TabsAndIndentsVisitor) reindentClosing(s java.Space) java.Space {
+	return v.reindentClosingAt(s, v.depth)
+}
+
+// reindentClosingAt re-indents a closing delimiter that sits at the given
+// depth, whatever level the elements ahead of it reached.
+func (v *TabsAndIndentsVisitor) reindentClosingAt(s java.Space, depth int) java.Space {
 	if len(s.Comments) == 0 {
-		return v.reindentSpace(s)
+		saved := v.depth
+		v.depth = depth
+		out := v.reindentSpace(s)
+		v.depth = saved
+		return out
 	}
-	inner := strings.Repeat("\t", v.depth+1)
-	outer := strings.Repeat("\t", v.depth)
+	inner := strings.Repeat("\t", depth+1)
+	outer := strings.Repeat("\t", depth)
 
 	s.Whitespace = reindentTail(s.Whitespace, inner)
 	comments := append([]java.Comment(nil), s.Comments...)

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -424,3 +424,22 @@ func TestBinarySpacing_SiblingArgumentsKeepTheirDepth(t *testing.T) {
 		t.Errorf("want %q\ngot  %q", want, out)
 	}
 }
+
+func TestBlankLinesAroundCommentsInDeclarationLists(t *testing.T) {
+	cases := map[string][2]string{
+		"a bare field sits flush": {
+			"package p\n\ntype A struct {\n\n\tX int\n\n}\n",
+			"package p\n\ntype A struct {\n\tX int\n}\n"},
+		"a leading comment keeps its separation": {
+			"package p\n\ntype B struct {\n\n\t// doc\n\tX int\n}\n",
+			"package p\n\ntype B struct {\n\n\t// doc\n\tX int\n}\n"},
+		"a trailing comment keeps its separation": {
+			"package p\n\ntype C struct {\n\tX int\n\n\t// trailing\n}\n",
+			"package p\n\ntype C struct {\n\tX int\n\n\t// trailing\n}\n"},
+	}
+	for name, io := range cases {
+		if out := applyVisitor(t, io[0], format.NewBlankLinesVisitor(nil)); out != io[1] {
+			t.Errorf("%s:\n  want %q\n  got  %q", name, io[1], out)
+		}
+	}
+}

--- a/rewrite-go/test/auto_format_test.go
+++ b/rewrite-go/test/auto_format_test.go
@@ -443,3 +443,13 @@ func TestBlankLinesAroundCommentsInDeclarationLists(t *testing.T) {
 		}
 	}
 }
+
+func TestTabsAndIndents_LabelBeforeAClosingBrace(t *testing.T) {
+	out := applyVisitor(t,
+		"package p\n\nfunc f(xs []int) {\n\tfor _, x := range xs {\n\t\t_ = x\n\tA:\n\t}\n\treturn\n}\n",
+		format.NewTabsAndIndentsVisitor(nil))
+	want := "package p\n\nfunc f(xs []int) {\n\tfor _, x := range xs {\n\t\t_ = x\n\tA:\n\t}\n\treturn\n}\n"
+	if out != want {
+		t.Errorf("want %q\ngot  %q", want, out)
+	}
+}


### PR DESCRIPTION
## Motivation

- #8524 brought the Go formatter to 99.4% agreement with gofmt on well-formatted input — 31 of 5333 gofmt-clean standard library files still came back changed. This closes all but three of them, so **99.94% of well-formatted files now pass through the formatter unchanged**.

- Every fix here came from reading a real diff rather than from a rule I expected to be missing, and two of them corrected mistakes in #8524 rather than filling gaps.

## Examples

A list takes its level from the line it opens on, and siblings share the level the first broken line sets — so a literal opening mid-line indents its own elements from there:

```go
"T", []Type{
	NewInterfaceType([]*Func{NewFunc(nopos, nil, "M", emptySignature)}, nil),
},
```

A comment written against the brace of a declaration list keeps its blank line, while a bare field still sits flush:

```go
type DiagnosticRelatedInformation struct {

	/*Location defined:
	 * The location of this related diagnostic information.
	 */
	Location Location
}
```

gofmt prints the operand of `*x` as an expression in its own right, so the depth resets and the blanks stay:

```go
return *(*byte)(unsafe.Pointer(uintptr(ctxt.rip() - 1))) == 0xcc
```

And an empty labelled statement closes its block rather than opening a line:

```go
	for _, x := range xs {
		_ = x
	A:
	}
```

## Summary

- **`eachElement` tracks the level of the current line** rather than asking per element whether it breaks the line. Elements alongside the opening delimiter stay on that line's level; from the first element to start a line of its own, the rest share the level it set. `reindentClosingAt` places the closing delimiter at the list's own depth whatever level the elements ahead of it reached.
- **`BlankLinesVisitor` keeps the blank line separating a comment from a brace**, in either position of a declaration list, since that separation reads as the comment's own rather than as padding inside the braces. A bare field or method still sits flush.
- **`BinarySpacingVisitor` resets the depth for a dereferenced operand**, matching `go/printer`, which prints a `StarExpr`'s operand via `expr` rather than `expr1` and so starts it at depth 1. Every other unary operator carries the surrounding depth into its operand.
- **An empty labelled statement no longer takes the block's closing whitespace** as its own prefix.

## Test plan

- [x] `./gradlew :rewrite-go:goTest :rewrite-go:licenseGo` — green
- [x] `go test ./...` in `rewrite-go` — green
- [x] `TestCanonicalInputUnchanged` — 3 of 5333 gofmt-clean files change, down from 31; ceiling lowered to match
- [x] `TestParityGap` — 4405 of 5333 files with every indent stripped come back byte-identical to gofmt, floor raised to match
- [x] `FuzzFormat` — a further 2M executions, clean
- [x] `go vet` and `gofmt -l` clean over the touched packages

## Known gaps

The three remaining files share two causes, both in how gofmt stacks indentation:

- A wrapped expression list contributes an indent level *before* the wrapped binary inside it contributes its own, so a continuation line in `return a |` … or in a broken selector chain lands two levels in rather than one. Reproducing that means modelling `exprList`'s indent alongside `binaryExpr`'s.
- An array length inside a generic type argument (`testFreegc[[1<<15 - 8]byte]`) keeps its blanks, which the current depth model tightens.

Column alignment — struct field types and tags lining up across neighbouring lines — remains unimplemented; it needs rendered widths and is the largest piece still outstanding.
