### PR TITLE
Do not remove bare returns in RemoveRedundantDependencyVersions

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/RemoveRedundantDependencyVersions.java
@@ -278,7 +278,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                                 @Override
                                 public J.Return visitReturn(J.Return _return, ExecutionContext ctx) {
                                     J.Return r = super.visitReturn(_return, ctx);
-                                    if (r.getExpression() == null) {
+                                    if (_return.getExpression() != null && r.getExpression() == null) {
                                         //noinspection DataFlowIssue
                                         return null;
                                     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/RemoveRedundantDependencyVersionsTest.java
@@ -1078,4 +1078,33 @@ class RemoveRedundantDependencyVersionsTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void doesNotRemoveEarlyReturnFromClosure() {
+        rewriteRun(
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              subprojects { subproject ->
+                  if (subproject.name == 'bom') {
+                      return
+                  }
+
+                  apply plugin: 'java-library'
+              }
+
+              dependencies {
+                  implementation("org.apache.commons:commons-lang3:3.14.0")
+              }
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
`RemoveRedundantDependencyVersions` deleted *any* `J.Return` with a null expression, anywhere in the build script:

```java
public J.Return visitReturn(J.Return _return, ExecutionContext ctx) {
    J.Return r = super.visitReturn(_return, ctx);
    if (r.getExpression() == null) {
        return null;
    }
    return r;
}
```

- The intent (from #5409) is to clean up the wrapper left behind when the recipe removes the expression inside an implicit `J.Return` — Groovy models a closure's last statement as an implicit return, so removing a redundant constraint leaves a `J.Return` with no expression. But the guard only inspects the post-visit state, so it also deletes returns that were bare in the source.

On `spring-projects/spring-integration` this silently dropped the guard clause from the root build script, changing the semantics of the build:

```diff
 subprojects { subproject ->
     if (subproject.name == 'spring-integration-bom') {
-        return
     }

     apply plugin: 'java-library'
 }
```

Now the return is only removed when this visit is what emptied it.