### PR TITLE
Parse modifiers terminated by a type parameter list

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -2222,7 +2222,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // Check: char is whitespace, the `<` of a type parameter list, OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
+                // Modifiers end at whitespace, at a type parameter list's `<`, or at an adjacent annotation's `@`
                 if (Character.isWhitespace(c) || c == '<' || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
                     if (noSpace) {
                         word.getAndUpdate(w -> w + c);

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -2222,8 +2222,8 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
-                if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
+                // Check: char is whitespace, the `<` of a type parameter list, OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
+                if (Character.isWhitespace(c) || c == '<' || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
                     if (noSpace) {
                         word.getAndUpdate(w -> w + c);
                         noSpace = false;

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -2343,7 +2343,6 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         boolean inMultilineComment = false;
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
-        boolean noSpace = false;
 
         int keywordStartIdx = -1;
         for (int i = cursor; i < source.length(); i++) {
@@ -2377,10 +2376,13 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
-                if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
+                // A modifier is terminated by whitespace, by the `<` of a type parameter list, or by the `@` of a
+                // directly adjacent annotation; only in the last case does the terminated word include `c` itself.
+                boolean beforeAnnotation = !Character.isWhitespace(c) && c != '<' &&
+                        i + 1 < source.length() && source.charAt(i + 1) == '@';
+                if (Character.isWhitespace(c) || c == '<' || beforeAnnotation) {
                     if (keywordStartIdx != -1) {
-                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, noSpace ? i + 1 : i));
+                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, beforeAnnotation ? i + 1 : i));
                         keywordStartIdx = -1;
 
                         if (matching == null) {

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -2376,8 +2376,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // A modifier is terminated by whitespace, by the `<` of a type parameter list, or by the `@` of a
-                // directly adjacent annotation; only in the last case does the terminated word include `c` itself.
+                // Modifiers end at whitespace, at a type parameter list's `<`, or at an adjacent annotation's `@`
                 boolean beforeAnnotation = !Character.isWhitespace(c) && c != '<' &&
                         i + 1 < source.length() && source.charAt(i + 1) == '@';
                 if (Character.isWhitespace(c) || c == '<' || beforeAnnotation) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -2414,8 +2414,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // A modifier is terminated by whitespace, by the `<` of a type parameter list, or by the `@` of a
-                // directly adjacent annotation; only in the last case does the terminated word include `c` itself.
+                // Modifiers end at whitespace, at a type parameter list's `<`, or at an adjacent annotation's `@`
                 boolean beforeAnnotation = !Character.isWhitespace(c) && c != '<' &&
                         i + 1 < source.length() && source.charAt(i + 1) == '@';
                 if (Character.isWhitespace(c) || c == '<' || beforeAnnotation) {

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -2381,7 +2381,6 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         boolean inMultilineComment = false;
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
-        boolean noSpace = false;
 
         int keywordStartIdx = -1;
         for (int i = cursor; i < source.length(); i++) {
@@ -2415,10 +2414,13 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
-                if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
+                // A modifier is terminated by whitespace, by the `<` of a type parameter list, or by the `@` of a
+                // directly adjacent annotation; only in the last case does the terminated word include `c` itself.
+                boolean beforeAnnotation = !Character.isWhitespace(c) && c != '<' &&
+                        i + 1 < source.length() && source.charAt(i + 1) == '@';
+                if (Character.isWhitespace(c) || c == '<' || beforeAnnotation) {
                     if (keywordStartIdx != -1) {
-                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, noSpace ? i + 1 : i));
+                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, beforeAnnotation ? i + 1 : i));
                         keywordStartIdx = -1;
 
                         if (matching == null) {

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -2446,8 +2446,7 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // A modifier is terminated by whitespace, by the `<` of a type parameter list, or by the `@` of a
-                // directly adjacent annotation; only in the last case does the terminated word include `c` itself.
+                // Modifiers end at whitespace, at a type parameter list's `<`, or at an adjacent annotation's `@`
                 boolean beforeAnnotation = !Character.isWhitespace(c) && c != '<' &&
                         i + 1 < source.length() && source.charAt(i + 1) == '@';
                 if (Character.isWhitespace(c) || c == '<' || beforeAnnotation) {

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -2413,7 +2413,6 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         boolean inMultilineComment = false;
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
-        boolean noSpace = false;
 
         int keywordStartIdx = -1;
         for (int i = cursor; i < source.length(); i++) {
@@ -2447,10 +2446,13 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
-                if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
+                // A modifier is terminated by whitespace, by the `<` of a type parameter list, or by the `@` of a
+                // directly adjacent annotation; only in the last case does the terminated word include `c` itself.
+                boolean beforeAnnotation = !Character.isWhitespace(c) && c != '<' &&
+                        i + 1 < source.length() && source.charAt(i + 1) == '@';
+                if (Character.isWhitespace(c) || c == '<' || beforeAnnotation) {
                     if (keywordStartIdx != -1) {
-                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, noSpace ? i + 1 : i));
+                        Modifier matching = MODIFIER_BY_KEYWORD.get(source.substring(keywordStartIdx, beforeAnnotation ? i + 1 : i));
                         keywordStartIdx = -1;
 
                         if (matching == null) {

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -2204,8 +2204,8 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // Check: char is whitespace OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
-                if (Character.isWhitespace(c) || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
+                // Check: char is whitespace, the `<` of a type parameter list, OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
+                if (Character.isWhitespace(c) || c == '<' || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
                     if (noSpace) {
                         word.getAndUpdate(w -> w + c);
                         noSpace = false;

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -2204,7 +2204,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
             } else if (!inMultilineComment && !inComment) {
-                // Check: char is whitespace, the `<` of a type parameter list, OR next char is an `@` (which is an annotation preceded by modifier/annotation without space)
+                // Modifiers end at whitespace, at a type parameter list's `<`, or at an adjacent annotation's `@`
                 if (Character.isWhitespace(c) || c == '<' || (noSpace = (i + 1 < source.length() && source.charAt(i + 1) == '@'))) {
                     if (noSpace) {
                         word.getAndUpdate(w -> w + c);

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodDeclarationTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/MethodDeclarationTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.Issue;
 import org.openrewrite.java.MinimumJava25;
 import org.openrewrite.test.RewriteTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.java;
 
 class MethodDeclarationTest implements RewriteTest {
@@ -64,6 +65,44 @@ class MethodDeclarationTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/8531")
+    @Test
+    void typeParametersDirectlyAfterModifier() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  public static<P, R> R foo(P p) {
+                      return null;
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> assertModifiers(cu, J.Modifier.Type.Public, J.Modifier.Type.Static))
+          )
+        );
+    }
+
+    @Test
+    void annotationDirectlyAfterModifier() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  public@Deprecated static <P> P foo(P p) {
+                      return p;
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> assertModifiers(cu, J.Modifier.Type.Public, J.Modifier.Type.Static))
+          )
+        );
+    }
+
+    private static void assertModifiers(J.CompilationUnit cu, J.Modifier.Type... expected) {
+        J.MethodDeclaration method = (J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(0);
+        assertThat(method.getModifiers()).map(J.Modifier::getType).containsExactly(expected);
     }
 
     @Test

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/MethodParamPadTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/MethodParamPadTest.java
@@ -346,6 +346,32 @@ class MethodParamPadTest implements RewriteTest {
     }
 
     @Test
+    void staticGenericMethodWithoutSpaceBeforeTypeParameters() {
+        rewriteRun(
+          java(
+            """
+              import java.util.Map;
+
+              class A<K, V> {
+                  public static<K, V> A<K, V> of(Map.Entry<K, V> entry) {
+                      return new A<>();
+                  }
+              }
+              """,
+            """
+              import java.util.Map;
+
+              class A<K, V> {
+                  public static <K, V> A<K, V> of(Map.Entry<K, V> entry) {
+                      return new A<>();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void recordWithCompactConstructor() {
         rewriteRun(
           version(java(


### PR DESCRIPTION
- Fixes #8531

### Root cause

Not a `MethodParamPad` bug — a parser bug that `MethodParamPad` exposes.

`sortedModifiersAndAnnotations` scans the source for modifier keywords and only ended a keyword at whitespace or at an adjacent `@`. For

```java
public static<K extends Serializable, V extends Serializable> SerializableMapEntry<K, V> of(Map.Entry<K, V> entry)
```

the scan of the second keyword ran past `<` and stopped at the first space, yielding the word `static<K` (well, `static<K,` after the type bound), which is not a modifier. The loop then reset the cursor to just after `public` and bailed out, so:

- `static` never became a `J.Modifier`, and
- the text `static<` ended up inside the type parameters' prefix `Space`.

Printing was still lossless, which is why this went unnoticed. But any recipe that rewrites that prefix deletes the modifier. `MethodParamPad` delegates to `SpacesVisitor`, which normalizes `TYPE_PARAMETERS_PREFIX` to `" "` — turning the method into a non-static one and breaking compilation at every `Type::of` reference.

`RewriteTest`'s "non-whitespace characters in its whitespace" check catches it directly:

```
public~~(non-whitespace)~~> static<~~<K, V> A<K, V> of(Map.Entry<K, V> entry) {
```

### Fix

Treat `<` as a modifier terminator alongside whitespace and `@`, in all five `Reloadable*ParserVisitor`s. In 17/21/25 the `noSpace` flag was also never reset once set, so it is replaced by a `beforeAnnotation` local computed per character with the same short-circuit semantics.

### Tests

- `MethodDeclarationTest#typeParametersDirectlyAfterModifier` (TCK, runs against all five parsers) asserts the modifiers are `[public, static]`. Verified to fail on both parser variants before the fix.
- `MethodDeclarationTest#annotationDirectlyAfterModifier` covers `public@Deprecated static <P> P foo(P p)`, which was untested.
- `MethodParamPadTest#staticGenericMethodWithoutSpaceBeforeTypeParameters` is the reporter's reproducer; the recipe now correctly inserts the space and keeps `static`.

Full TCK compatibility suites on Java 8/11/17/21/25, plus `:rewrite-java:test` and `:rewrite-java-test:test`, are green.