### PR TITLE
Parse MavenConfig so that we don't miss that source of profile activation/deactivation

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenConfig.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenConfig.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
+/**
+ * The command line arguments a plain {@code mvn} invocation in a project directory would pick up from
+ * {@code .mvn/maven.config}. A {@link MavenParser} that ignores this file resolves poms differently than
+ * the project's own build does, most visibly when the build activates a profile that contributes
+ * properties, repositories, or a parent.
+ * <p>
+ * Only the options that change how a pom resolves are modeled: {@code -P}/{@code --activate-profiles} and
+ * {@code -D}/{@code --define}. Everything else in the file is ignored rather than rejected, so an
+ * unrecognized or future option does not cost the caller the options it does understand.
+ *
+ * @see MavenParser.Builder#mavenConfig(MavenConfig)
+ */
+@Value
+public class MavenConfig {
+    public static final MavenConfig EMPTY = new MavenConfig(emptyList(), emptyList(), emptyMap());
+
+    /**
+     * Profiles activated by {@code -P}, in the order they appear. Maven activates these on top of whatever
+     * the poms and settings activate on their own.
+     */
+    List<String> activeProfiles;
+
+    /**
+     * Profiles that {@code -P} explicitly deactivates with a {@code !} or {@code -} prefix. These suppress a
+     * profile that would otherwise activate itself, so they cannot be expressed by simply omitting them from
+     * {@code getActiveProfiles()}.
+     */
+    List<String> inactiveProfiles;
+
+    /**
+     * User properties set by {@code -D}. A flag given without a value is {@code "true"}, matching Maven.
+     */
+    Map<String, String> properties;
+
+    /**
+     * Read {@code <mavenRoot>/.mvn/maven.config}. Maven reads this file from the directory it was invoked in
+     * alone, so it is deliberately not searched for in parent or child directories.
+     *
+     * @param mavenRoot The directory a {@code mvn} invocation would run from, i.e. the one containing {@code .mvn}.
+     * @param ctx       Receives an {@link IOException} through {@link ExecutionContext#getOnError()} if the file
+     *                  exists but cannot be read.
+     * @return The parsed config, or {@link #EMPTY} if there is no {@code .mvn/maven.config} or it cannot be read.
+     */
+    public static MavenConfig read(Path mavenRoot, ExecutionContext ctx) {
+        Path mavenConfig = mavenRoot.resolve(".mvn").resolve("maven.config");
+        if (!Files.isRegularFile(mavenConfig)) {
+            return EMPTY;
+        }
+        try {
+            return parse(new String(Files.readAllBytes(mavenConfig)));
+        } catch (IOException e) {
+            ctx.getOnError().accept(new UncheckedIOException("Failed to read maven.config at " + mavenConfig, e));
+            return EMPTY;
+        }
+    }
+
+    public static MavenConfig parse(String mavenConfig) {
+        List<String> args = tokenize(mavenConfig);
+        List<String> activeProfiles = new ArrayList<>();
+        List<String> inactiveProfiles = new ArrayList<>();
+        Map<String, String> properties = new LinkedHashMap<>();
+
+        for (int i = 0; i < args.size(); i++) {
+            String arg = args.get(i);
+            if (isOption(arg, "-P", "--activate-profiles")) {
+                String value = attachedValue(arg, "-P", "--activate-profiles");
+                if (value == null && i + 1 < args.size()) {
+                    value = args.get(++i);
+                }
+                if (value != null) {
+                    addProfiles(value, activeProfiles, inactiveProfiles);
+                }
+            } else if (isOption(arg, "-D", "--define")) {
+                String value = attachedValue(arg, "-D", "--define");
+                if (value == null && i + 1 < args.size()) {
+                    value = args.get(++i);
+                }
+                if (value != null) {
+                    addProperty(value, properties);
+                }
+            }
+        }
+
+        return activeProfiles.isEmpty() && inactiveProfiles.isEmpty() && properties.isEmpty() ?
+                EMPTY :
+                new MavenConfig(activeProfiles, inactiveProfiles, properties);
+    }
+
+    /**
+     * Maven has read this file one argument per line since 3.9, and as whitespace-separated arguments before
+     * that. Splitting on whitespace within each line accepts both, and quoting recovers the one case the two
+     * forms disagree on: an argument whose value contains a space.
+     */
+    private static List<String> tokenize(String mavenConfig) {
+        List<String> args = new ArrayList<>();
+        for (String line : mavenConfig.split("\r?\n")) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.charAt(0) == '#') {
+                continue;
+            }
+            StringBuilder arg = new StringBuilder();
+            char quote = 0;
+            for (int i = 0; i < trimmed.length(); i++) {
+                char c = trimmed.charAt(i);
+                if (quote != 0) {
+                    if (c == quote) {
+                        quote = 0;
+                    } else {
+                        arg.append(c);
+                    }
+                } else if (c == '"' || c == '\'') {
+                    quote = c;
+                } else if (Character.isWhitespace(c)) {
+                    if (arg.length() > 0) {
+                        args.add(arg.toString());
+                        arg.setLength(0);
+                    }
+                } else {
+                    arg.append(c);
+                }
+            }
+            if (arg.length() > 0) {
+                args.add(arg.toString());
+            }
+        }
+        return args;
+    }
+
+    private static boolean isOption(String arg, String shortOption, String longOption) {
+        return arg.startsWith(shortOption) || arg.equals(longOption) || arg.startsWith(longOption + "=");
+    }
+
+    /**
+     * @return The value attached to the option itself ({@code -Pfoo}, {@code --activate-profiles=foo}), or
+     * {@code null} when the option stands alone and its value is the next argument.
+     */
+    private static @Nullable String attachedValue(String arg, String shortOption, String longOption) {
+        if (arg.startsWith(longOption + "=")) {
+            return arg.substring(longOption.length() + 1);
+        }
+        if (arg.startsWith(shortOption) && arg.length() > shortOption.length()) {
+            return arg.substring(shortOption.length());
+        }
+        return null;
+    }
+
+    private static void addProfiles(String value, List<String> activeProfiles, List<String> inactiveProfiles) {
+        for (String profile : value.split(",")) {
+            profile = profile.trim();
+            if (profile.isEmpty()) {
+                continue;
+            }
+            char first = profile.charAt(0);
+            if (first == '!' || first == '-') {
+                String deactivated = profile.substring(1).trim();
+                if (!deactivated.isEmpty()) {
+                    inactiveProfiles.add(deactivated);
+                }
+            } else {
+                activeProfiles.add(profile);
+            }
+        }
+    }
+
+    private static void addProperty(String value, Map<String, String> properties) {
+        int equals = value.indexOf('=');
+        if (equals < 0) {
+            // `mvn -Dfoo` sets foo to "true"
+            properties.put(value, "true");
+        } else if (equals > 0) {
+            properties.put(value.substring(0, equals), value.substring(equals + 1));
+        }
+    }
+}

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenParser.java
@@ -201,11 +201,28 @@ public class MavenParser implements Parser {
             return this;
         }
 
+        /**
+         * @param profiles Profile ids to activate, using the same notation as {@code mvn -P}: an id prefixed with
+         *                 {@code !} or {@code -} deactivates that profile instead, suppressing it even when it
+         *                 would have activated itself.
+         */
         public Builder activeProfiles(@Nullable String... profiles) {
             //noinspection ConstantConditions
             if (profiles != null) {
                 addAll(this.activeProfiles, profiles);
             }
+            return this;
+        }
+
+        /**
+         * Parse poms the way a {@code mvn} invocation that picks up this {@code .mvn/maven.config} would.
+         */
+        public Builder mavenConfig(MavenConfig mavenConfig) {
+            this.activeProfiles.addAll(mavenConfig.getActiveProfiles());
+            for (String inactiveProfile : mavenConfig.getInactiveProfiles()) {
+                this.activeProfiles.add("!" + inactiveProfile);
+            }
+            this.properties.putAll(mavenConfig.getProperties());
             return this;
         }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/Pom.java
@@ -182,7 +182,8 @@ public class Pom {
             return pomActivatedProfiles;
         }
         return profiles.stream()
-                .filter(p -> p.getActivation() != null && Boolean.TRUE.equals(p.getActivation().getActiveByDefault()))
+                .filter(p -> p.getActivation() != null && Boolean.TRUE.equals(p.getActivation().getActiveByDefault()) &&
+                             !ProfileActivation.isDeactivated(p.getId(), explicitActiveProfiles))
                 .collect(toList());
     }
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ProfileActivation.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/tree/ProfileActivation.java
@@ -38,18 +38,49 @@ public class ProfileActivation {
 
     public static boolean isActive(@Nullable String id, Iterable<String> activeProfiles,
                                    @Nullable ProfileActivation activation) {
-        if (id != null) {
-            for (String activeProfile : activeProfiles) {
-                if (activeProfile.trim().equals(id)) {
-                    return true;
-                }
+        if (isDeactivated(id, activeProfiles)) {
+            return false;
+        }
+        boolean anyExplicitlyActivated = false;
+        for (String activeProfile : activeProfiles) {
+            String profile = activeProfile.trim();
+            if (isDeactivation(profile)) {
+                continue;
+            }
+            anyExplicitlyActivated = true;
+            if (profile.equals(id)) {
+                return true;
             }
         }
         return activation != null &&
                (activation.isActive() ||
                 // Active by default is *only* enabled when no other profile is marked active by any other mechanism
                 // So even this check for any other explicit activation is overly broad
-                (Boolean.TRUE.equals(activation.getActiveByDefault()) && !activeProfiles.iterator().hasNext()));
+                (Boolean.TRUE.equals(activation.getActiveByDefault()) && !anyExplicitlyActivated));
+    }
+
+    /**
+     * Maven's {@code -P !id} (equivalently {@code -P -id}) suppresses a profile regardless of how it would
+     * otherwise have activated, including one activated by {@code -P} in the same invocation.
+     *
+     * @param id             The id of the profile being considered.
+     * @param activeProfiles Profiles named on the command line, deactivations included with their prefix intact.
+     */
+    public static boolean isDeactivated(@Nullable String id, Iterable<String> activeProfiles) {
+        if (id == null) {
+            return false;
+        }
+        for (String activeProfile : activeProfiles) {
+            String profile = activeProfile.trim();
+            if (isDeactivation(profile) && profile.substring(1).trim().equals(id)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isDeactivation(String profile) {
+        return !profile.isEmpty() && (profile.charAt(0) == '!' || profile.charAt(0) == '-');
     }
 
     public boolean isActive() {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenConfigTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenConfigTest.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.maven;
+
+import org.intellij.lang.annotations.Language;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+class MavenConfigTest {
+
+    @TempDir
+    Path mavenRoot;
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "-Pfoo",
+      "-P foo",
+      "-P\tfoo",
+      "--activate-profiles=foo",
+      "--activate-profiles foo",
+      "-P\nfoo"
+    })
+    void everyFormOfActivatingAProfile(String config) {
+        assertThat(MavenConfig.parse(config).getActiveProfiles()).containsExactly("foo");
+    }
+
+    @Test
+    void commaSeparatedProfiles() {
+        assertThat(MavenConfig.parse("-Pfoo,bar,baz").getActiveProfiles())
+          .containsExactly("foo", "bar", "baz");
+    }
+
+    @Test
+    void whitespaceAroundCommaSeparatedProfiles() {
+        assertThat(MavenConfig.parse("--activate-profiles='foo, bar'").getActiveProfiles())
+          .containsExactly("foo", "bar");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-P!foo", "-P-foo"})
+    void deactivatedProfilesAreNotActive(String mavenConfig) {
+        MavenConfig config = MavenConfig.parse(mavenConfig);
+        assertThat(config.getActiveProfiles()).isEmpty();
+        assertThat(config.getInactiveProfiles()).containsExactly("foo");
+    }
+
+    @Test
+    void activatedAndDeactivatedProfilesInOneOption() {
+        MavenConfig config = MavenConfig.parse("-Pfoo,!bar,baz");
+        assertThat(config.getActiveProfiles()).containsExactly("foo", "baz");
+        assertThat(config.getInactiveProfiles()).containsExactly("bar");
+    }
+
+    @Test
+    void repeatedProfileOptionsAccumulate() {
+        assertThat(MavenConfig.parse("-Pfoo\n-Pbar").getActiveProfiles())
+          .containsExactly("foo", "bar");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "-Dfoo=bar",
+      "-D foo=bar",
+      "--define=foo=bar",
+      "--define foo=bar"
+    })
+    void everyFormOfDefiningAProperty(String config) {
+        assertThat(MavenConfig.parse(config).getProperties()).containsExactly(entry("foo", "bar"));
+    }
+
+    @Test
+    void propertyWithoutAValueIsTrue() {
+        assertThat(MavenConfig.parse("-Dskip.tests").getProperties())
+          .containsExactly(entry("skip.tests", "true"));
+    }
+
+    @Test
+    void propertyValueSplitsOnTheFirstEqualsSign() {
+        assertThat(MavenConfig.parse("-Dexclude=**/*Test.java=skip").getProperties())
+          .containsExactly(entry("exclude", "**/*Test.java=skip"));
+    }
+
+    @Test
+    void quotedPropertyValueMayContainSpaces() {
+        assertThat(MavenConfig.parse("-Dmessage=\"hello world\" -Pfoo").getProperties())
+          .containsExactly(entry("message", "hello world"));
+    }
+
+    @Test
+    void commentsAndBlankLinesAreIgnored() {
+        assertThat(MavenConfig.parse("""
+          # activate the corporate profile
+          -Pcorp
+
+          # a comment that mentions -Pnot-a-real-profile
+          -T1C
+          """).getActiveProfiles()).containsExactly("corp");
+    }
+
+    @Test
+    void unrecognizedOptionsDoNotDiscardRecognizedOnes() {
+        MavenConfig config = MavenConfig.parse("-T 1C --no-transfer-progress -Pcorp -e -Dfoo=bar");
+        assertThat(config.getActiveProfiles()).containsExactly("corp");
+        assertThat(config.getProperties()).containsExactly(entry("foo", "bar"));
+    }
+
+    @Test
+    void optionsSpreadOverLinesAndWithinLines() {
+        // Maven 3.9+ reads one argument per line; older versions split the whole file on whitespace
+        MavenConfig config = MavenConfig.parse("""
+          --batch-mode
+          -Pcorp,release
+          -Dmaven.compiler.release=17 -Dfoo=bar
+          """);
+        assertThat(config.getActiveProfiles()).containsExactly("corp", "release");
+        assertThat(config.getProperties())
+          .containsExactly(entry("maven.compiler.release", "17"), entry("foo", "bar"));
+    }
+
+    @Test
+    void carriageReturnsAreNotPartOfTheValue() {
+        assertThat(MavenConfig.parse("-Pcorp\r\n-Dfoo=bar\r\n").getActiveProfiles())
+          .containsExactly("corp");
+    }
+
+    @Test
+    void optionAtEndOfFileWithNoValue() {
+        assertThat(MavenConfig.parse("-Dfoo=bar\n-P").getActiveProfiles()).isEmpty();
+    }
+
+    @Test
+    void nothingToParse() {
+        assertThat(MavenConfig.parse("")).isSameAs(MavenConfig.EMPTY);
+        assertThat(MavenConfig.parse("-T1C")).isSameAs(MavenConfig.EMPTY);
+    }
+
+    @Test
+    void readsFromTheMavenRoot() throws IOException {
+        Files.createDirectories(mavenRoot.resolve(".mvn"));
+        Files.writeString(mavenRoot.resolve(".mvn/maven.config"), "-Pcorp");
+
+        assertThat(MavenConfig.read(mavenRoot, new InMemoryExecutionContext()).getActiveProfiles())
+          .containsExactly("corp");
+    }
+
+    @Test
+    void noMavenConfigOnDisk() {
+        assertThat(MavenConfig.read(mavenRoot, new InMemoryExecutionContext())).isSameAs(MavenConfig.EMPTY);
+    }
+
+    /**
+     * Maven reads maven.config from the directory it was invoked in alone, so a config belonging to a
+     * subproject must not leak into a parse rooted above it.
+     */
+    @Test
+    void mavenConfigInASubdirectoryIsNotRead() throws IOException {
+        Files.createDirectories(mavenRoot.resolve("submodule/.mvn"));
+        Files.writeString(mavenRoot.resolve("submodule/.mvn/maven.config"), "-Pcorp");
+
+        assertThat(MavenConfig.read(mavenRoot, new InMemoryExecutionContext())).isSameAs(MavenConfig.EMPTY);
+    }
+
+    /**
+     * The point of parsing the file at all: a property that only a maven.config-activated profile
+     * contributes has to reach the resolved pom, or the parse sees a project the build never builds.
+     */
+    @Test
+    void profilesAndPropertiesReachTheResolvedPom() {
+        @Language("xml")
+        String pom = """
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.corp</groupId>
+              <artifactId>app</artifactId>
+              <version>1.0</version>
+              <profiles>
+                  <profile>
+                      <id>corp</id>
+                      <properties>
+                          <maven.compiler.release>17</maven.compiler.release>
+                      </properties>
+                  </profile>
+              </profiles>
+          </project>
+          """;
+
+        assertThat(resolveProperties(MavenParser.builder(), pom))
+          .doesNotContainKey("maven.compiler.release");
+
+        assertThat(resolveProperties(
+          MavenParser.builder().mavenConfig(MavenConfig.parse("-Pcorp -Dfoo=bar")), pom))
+          .containsEntry("maven.compiler.release", "17")
+          .containsEntry("foo", "bar");
+    }
+
+    /**
+     * The reason deactivation is modeled at all: a profile the pom activates on its own cannot be turned off
+     * by leaving it out of the active profile list.
+     */
+    @Test
+    void deactivatedProfilesDoNotReachTheResolvedPom() {
+        @Language("xml")
+        String pom = """
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.corp</groupId>
+              <artifactId>app</artifactId>
+              <version>1.0</version>
+              <profiles>
+                  <profile>
+                      <id>corp</id>
+                      <activation>
+                          <activeByDefault>true</activeByDefault>
+                      </activation>
+                      <properties>
+                          <maven.compiler.release>17</maven.compiler.release>
+                      </properties>
+                  </profile>
+              </profiles>
+          </project>
+          """;
+
+        assertThat(resolveProperties(MavenParser.builder(), pom))
+          .containsEntry("maven.compiler.release", "17");
+
+        assertThat(resolveProperties(
+          MavenParser.builder().mavenConfig(MavenConfig.parse("-P!corp")), pom))
+          .doesNotContainKey("maven.compiler.release");
+    }
+
+    @Test
+    void deactivationWinsOverActivationOfTheSameProfile() {
+        @Language("xml")
+        String pom = """
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.corp</groupId>
+              <artifactId>app</artifactId>
+              <version>1.0</version>
+              <profiles>
+                  <profile>
+                      <id>corp</id>
+                      <properties>
+                          <maven.compiler.release>17</maven.compiler.release>
+                      </properties>
+                  </profile>
+              </profiles>
+          </project>
+          """;
+
+        assertThat(resolveProperties(
+          MavenParser.builder().mavenConfig(MavenConfig.parse("-Pcorp,!corp")), pom))
+          .doesNotContainKey("maven.compiler.release");
+    }
+
+    /**
+     * A profile that is active by default stays active when some other profile is deactivated, since
+     * deactivation is not the "another profile was activated" that turns activeByDefault off.
+     */
+    @Test
+    void deactivatingOneProfileDoesNotDeactivateAnotherActiveByDefault() {
+        @Language("xml")
+        String pom = """
+          <project>
+              <modelVersion>4.0.0</modelVersion>
+              <groupId>com.corp</groupId>
+              <artifactId>app</artifactId>
+              <version>1.0</version>
+              <profiles>
+                  <profile>
+                      <id>corp</id>
+                      <activation>
+                          <activeByDefault>true</activeByDefault>
+                      </activation>
+                      <properties>
+                          <maven.compiler.release>17</maven.compiler.release>
+                      </properties>
+                  </profile>
+                  <profile>
+                      <id>release</id>
+                      <properties>
+                          <gpg.skip>false</gpg.skip>
+                      </properties>
+                  </profile>
+              </profiles>
+          </project>
+          """;
+
+        assertThat(resolveProperties(
+          MavenParser.builder().mavenConfig(MavenConfig.parse("-P!release")), pom))
+          .containsEntry("maven.compiler.release", "17")
+          .doesNotContainKey("gpg.skip");
+    }
+
+    private static Map<String, String> resolveProperties(MavenParser.Builder parser, @Language("xml") String pom) {
+        return parser.skipDependencyResolution(true).build()
+          .parse(pom)
+          .findFirst()
+          .orElseThrow()
+          .getMarkers()
+          .findFirst(MavenResolutionResult.class)
+          .orElseThrow()
+          .getPom()
+          .getProperties();
+    }
+}

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenParserTest.java
@@ -1457,6 +1457,39 @@ class MavenParserTest implements RewriteTest {
             );
         }
 
+        @DisplayName("a profile deactivated with `-P !id` is inactive even though it activates itself")
+        @Test
+        void deactivatedProfileIsNotActive() {
+            rewriteRun(
+              recipeSpec -> recipeSpec
+                .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext()))
+                .parser(MavenParser.builder().activeProfiles("!active-profile-2")),
+              mavenProject("c",
+                pomXml(
+                  parent
+                )
+              ),
+              pomXml(
+                child, spec -> spec.afterRecipe(pomXml -> {
+                      Map<String, List<ResolvedDependency>> deps =
+                        pomXml.getMarkers()
+                          .findFirst(MavenResolutionResult.class)
+                          .orElseThrow()
+                          .getDependencies()
+                          .get(Scope.Compile)
+                          .stream()
+                          .collect(groupingBy(ResolvedDependency::getArtifactId));
+
+                      assertThat(deps)
+                        .hasEntrySatisfying("slf4j-api", rds -> assertThat(rds)
+                          .singleElement().extracting(ResolvedDependency::getVersion).isEqualTo("2.0.9"))
+                        .doesNotContainKey("commons-io");
+                  }
+                )
+              )
+            );
+        }
+
         @Test
         void settingsActiveProfiles() {
             var mavenCtx = MavenExecutionContextView.view(new InMemoryExecutionContext(t -> {
@@ -3500,7 +3533,7 @@ class MavenParserTest implements RewriteTest {
                 spec -> spec.afterRecipe(pomXml -> {
                     ResolvedPom pom = pomXml.getMarkers().findFirst(MavenResolutionResult.class).orElseThrow().getPom();
                     assertThat(pom.getVersion()).isEqualTo("1.2.3");
-                    assertThat(pom.getRequestedDependencies().get(0).getVersion()).isEqualTo("${project.version}");
+                    assertThat(pom.getRequestedDependencies().getFirst().getVersion()).isEqualTo("${project.version}");
                     assertThat(pom.getValue("${project.version}")).isEqualTo("1.2.3");
                 })
               )


### PR DESCRIPTION
Maven command line arguments can be recorded in a config file. Add utility for retrieving active/inactive profiles from there