### PR TITLE
Python: MinimumViableSpacing to add spaces before `not`

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/format/minimum_viable_spacing.py
+++ b/rewrite-python/rewrite/src/rewrite/python/format/minimum_viable_spacing.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import cast, Optional
 
 from rewrite import Tree, P, Cursor, list_find
-from rewrite.java import Statement, Block, Semicolon
+from rewrite.java import Statement, Block, Semicolon, Unary
 from rewrite.python import PythonVisitor, ExpressionStatement
 from rewrite.visitor import T
 
@@ -29,6 +29,12 @@ class MinimumViableSpacingVisitor(PythonVisitor):
                     tree = tree.replace(prefix=new_prefix)
 
         return tree
+
+    def visit_unary(self, unary: Unary, p: P) -> Optional[T]:
+        u = cast(Unary, super().visit_unary(unary, p))
+        if u.operator == Unary.Type.Not and not u.expression.prefix.comments and not u.expression.prefix.whitespace:
+            u = u.replace(_expression=u.expression.replace(_prefix=u.expression.prefix.replace(whitespace=' ')))
+        return cast(Optional[T], u)
 
     def visit(self, tree: Optional[Tree], p: P, parent: Optional[Cursor] = None) -> Optional[T]:
         return cast(Optional[T], tree if self._stop else super().visit(tree, p, parent))

--- a/rewrite-python/rewrite/tests/python/all/format/auto_format_corrections_test.py
+++ b/rewrite-python/rewrite/tests/python/all/format/auto_format_corrections_test.py
@@ -1,5 +1,42 @@
-from rewrite.python import AutoFormat
-from rewrite.test import rewrite_run, python, RecipeSpec
+from rewrite import random_id
+from rewrite.java import Assert, J, P, Unary, JLeftPadded
+from rewrite.java.support_types import Space
+from rewrite.markers import Markers
+from rewrite.python import AutoFormat, PythonVisitor
+from rewrite.test import rewrite_run, python, RecipeSpec, from_visitor
+
+
+class NegateAssertCondition(PythonVisitor):
+    def visit_assert(self, assert_: Assert, p: P) -> J:
+        a = super().visit_assert(assert_, p)
+        if isinstance(a.condition, Unary) and a.condition.operator == Unary.Type.Not:
+            return a
+        negated = Unary(
+            random_id(),
+            a.condition.prefix,
+            Markers.EMPTY,
+            JLeftPadded(Space.EMPTY, Unary.Type.Not, Markers.EMPTY),
+            a.condition.replace(_prefix=Space.EMPTY),
+            None,
+        )
+        return a.replace(_condition=negated)
+
+
+def test_not_added_by_recipe_gets_space_from_autoformat():
+    # given a recipe that wraps the condition in `not` without a space (as InvertCondition does),
+    # when auto-format runs afterwards, then the required space is inserted
+    rewrite_run(
+        # language=python
+        python(
+            "assert x",
+            "assert not x"
+        ),
+        spec=RecipeSpec()
+        .with_recipes(
+            from_visitor(NegateAssertCondition()),
+            AutoFormat()
+        )
+    )
 
 
 def test_fix_missing_space_around_assignment():

--- a/rewrite-python/rewrite/tests/python/all/format/minimum_viable_spacing_test.py
+++ b/rewrite-python/rewrite/tests/python/all/format/minimum_viable_spacing_test.py
@@ -61,6 +61,24 @@ def test_statement_with_semicolon():
     )
 
 
+def test_not_leaves_existing_spacing_untouched():
+    rewrite_run(
+        # language=python
+        python("assert not  x"),
+        spec=RecipeSpec()
+        .with_recipe(from_visitor(MinimumViableSpacingVisitor()))
+    )
+
+
+def test_arithmetic_unary_stays_tight():
+    rewrite_run(
+        # language=python
+        python("assert -x"),
+        spec=RecipeSpec()
+        .with_recipe(from_visitor(MinimumViableSpacingVisitor()))
+    )
+
+
 class DuplicateMethod(PythonVisitor):
     def visit_block(self, block: Block, p: P) -> J:
         if block.statements and isinstance(block.statements[0], MethodInvocation):


### PR DESCRIPTION
## What's changed?

`MinimumViableSpacing` visitor in Python (part of AutoFormat) to add a leading space to Python's not unary expression. Obviously only if missing.

## What's your motivation?

To be used by a few Java recipe against Python code from rewrite-static-analysis.