### PR TITLE
Go: fall back to long for int literals exceeding Integer range

### DIFF
--- a/rewrite-go/pkg/parser/basic_lit_test.go
+++ b/rewrite-go/pkg/parser/basic_lit_test.go
@@ -76,6 +76,23 @@ func TestBasicLitDecodedValue(t *testing.T) {
 	}
 }
 
+// A Go int constant whose value exceeds Integer.MAX_VALUE must fall back to the
+// `long` primitive, since the JVM LST deserializer reconstructs an `int`-keyword
+// literal via Integer.valueOf, which throws on an out-of-range value.
+func TestIntLiteralExceedingInt32FallsBackToLong(t *testing.T) {
+	// given: an untyped int constant larger than Integer.MAX_VALUE (2147483647)
+	src := "package main\n\nfunc main() {\n\tv := 5243700879\n\t_ = v\n}\n"
+
+	// when
+	lit := litRHS(t, src)
+
+	// then
+	prim, ok := lit.Type.(*java.JavaTypePrimitive)
+	require.Truef(t, ok, "expected *java.JavaTypePrimitive, got %T", lit.Type)
+	assert.Equal(t, "long", prim.Keyword, "keyword")
+	assert.Equal(t, int64(5243700879), lit.Value, "value")
+}
+
 // firstLiteralOfType parses src and returns the first *java.Literal whose
 // attributed Type is the primitive `keyword` (e.g. "byte", "char").
 func firstLiteralOfType(t *testing.T, src, keyword string) *java.Literal {

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -24,6 +24,7 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"math"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -2139,6 +2140,17 @@ func (ctx *parseContext) mapBasicLit(lit *ast.BasicLit) *java.Literal {
 	l := &java.Literal{ID: uuid.New(), Prefix: prefix, Value: decodeBasicLitValue(lit), Source: lit.Value}
 
 	l.Type = ctx.valueTypeOf(lit)
+
+	// A Go int constant is 64-bit, but Java's int is 32-bit. When the value
+	// overflows Integer, fall back to long so the JVM LST deserializer does not
+	// reconstruct it via Integer.valueOf, which throws and drops the file.
+	if lit.Kind == token.INT {
+		if prim, ok := l.Type.(*java.JavaTypePrimitive); ok && prim.Keyword == "int" {
+			if v, ok := l.Value.(int64); ok && v > math.MaxInt32 {
+				l.Type = &java.JavaTypePrimitive{Keyword: "long"}
+			}
+		}
+	}
 
 	return l
 }


### PR DESCRIPTION
Go source files with an integer literal above `Integer.MAX_VALUE` (2147483647) previously lost their recipe results during Java to Go RPC serialization, and no non-zero exit code signaled the failure.

An untyped Go `int` constant is 64-bit on 64-bit platforms, but it was mapped to a 32-bit Java `int`. When such a literal's value overflowed `Integer`, the JVM LST deserializer reconstructed it via `Integer.valueOf` and threw, dropping the file.

- `mapBasicLit` now falls back to the `long` primitive when an `int`-keyword literal's value exceeds `Integer.MAX_VALUE`. This complements the earlier `int64` to `long` mapping (#8406), which covered explicitly typed 64-bit literals.

- Context: moderneinc/recipes-go#55 (variant 2).