### PR TITLE
Python: fix RPC ser/deser of complex literals

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/send_queue.py
@@ -347,6 +347,11 @@ class RpcSendQueue:
             if math.isinf(obj) or math.isnan(obj):
                 return None
             return obj
+        if isinstance(obj, complex):
+            # Java has no complex primitive, so carry the value as a string. Python's
+            # repr parenthesizes a complex with a non-zero real part ("(3+4j)"); strip
+            # those so the value matches the source, which is also kept in valueSource.
+            return str(obj).strip('()')
         if isinstance(obj, UUID):
             return str(obj)
         if isinstance(obj, Path):

--- a/rewrite-python/src/integTest/java/org/openrewrite/python/ParseProjectIntegTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/ParseProjectIntegTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.json.tree.Json;
 import org.openrewrite.python.marker.PythonResolutionResult;
 import org.openrewrite.python.rpc.PythonRewriteRpc;
@@ -338,6 +340,38 @@ class ParseProjectIntegTest {
         // Each file should have its own distinct marker pointing to its own path
         assertThat(baseMarker.getPath()).isEqualTo("requirements.txt");
         assertThat(devMarker.getPath()).isEqualTo("requirements-dev.txt");
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void complexLiteralValueSurvivesRpcBridge() throws Exception {
+        Path projectDir = tempDir.resolve("complex_literal");
+        Files.createDirectories(projectDir);
+        Files.writeString(projectDir.resolve("main.py"), "x = 0j\n");
+
+        List<SourceFile> sources = client()
+                .parseProject(projectDir, new InMemoryExecutionContext())
+                .collect(toList());
+
+        SourceFile main = sources.stream()
+                .filter(sf -> sf.getSourcePath().getFileName().toString().equals("main.py"))
+                .findFirst()
+                .orElseThrow();
+
+        List<J.Literal> literals = new java.util.ArrayList<>();
+        new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.Literal visitLiteral(J.Literal literal, Integer p) {
+                literals.add(literal);
+                return literal;
+            }
+        }.visit(main, 0);
+
+        assertThat(literals).hasSize(1);
+        assertThat(literals.get(0).getValueSource()).isEqualTo("0j");
+        assertThat(literals.get(0).getValue())
+                .as("complex literal value must survive the RPC bridge, not be dropped to null")
+                .isEqualTo("0j");
     }
 
     private PythonRewriteRpc client() {


### PR DESCRIPTION
## What's changed?

Fixing RPC handling of Python's complex (imaginary) literals.

## What's your motivation?

Otherwise their `.getValue()` is dropped over RPC.