### PR TITLE
Groovy: fix ClassCastException in AutoFormat involving implicit-retur…

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MergeSpacesVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MergeSpacesVisitor.java
@@ -215,6 +215,11 @@ public class MergeSpacesVisitor extends GroovyVisitor<Object> {
             //Wrapping can introduce blocks
             return super.visit((J.Block) o, o);
         }
+        if (o instanceof G.ExpressionStatement && !(tree instanceof G.ExpressionStatement)) {
+            // G.ExpressionStatement#acceptGroovy unwraps the visited tree to its inner expression but forwards
+            // the wrapper as context, so unwrap the context too to keep both trees aligned
+            o = ((G.ExpressionStatement) o).getExpression();
+        }
         return super.visit(tree, o);
     }
 
@@ -1277,10 +1282,11 @@ public class MergeSpacesVisitor extends GroovyVisitor<Object> {
 
     @Override
     public <T extends J> J visitParentheses(J.Parentheses<T> parens, @Nullable Object ctx) {
-        J.Parentheses<T> newParens = (J.Parentheses<T>) ctx;
-        if (parens == newParens) {
+        if (parens == ctx || !(ctx instanceof J.Parentheses)) {
             return parens;
         }
+        //noinspection unchecked
+        J.Parentheses<T> newParens = (J.Parentheses<T>) ctx;
         J.Parentheses<T> pa = parens;
         pa = pa.withPrefix(visitSpace(pa.getPrefix(), Space.Location.PARENTHESES_PREFIX, newParens.getPrefix()));
         pa = pa.withMarkers(visitMarkers(pa.getMarkers(), newParens.getMarkers()));

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
@@ -89,4 +89,22 @@ class AutoFormatVisitorTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void parenthesizedClosureReturnValue() {
+        rewriteRun(
+          groovy(
+            """
+              if (convertTemplate == null)
+                  convertTemplate = inTypemap.find({ key, value -> (key instanceof Pattern && key.matcher(apiType).matches()) })?.value
+              """,
+            """
+              if (convertTemplate == null)
+                  convertTemplate = inTypemap.find {key, value ->
+                      (key instanceof Pattern && key.matcher(apiType).matches())
+                  }?.value
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
…n values

## What's changed?

Teaching MergeSpacesVisitor in Groovy to handle `ExpressionStatement` better. I.e. unwrap properly. 
Also adding a cast safety check to `visitParentheses()`.

## What's your motivation?

Fix ClassCastException against some Groovy sources when they are autoformatted:
```
java.lang.ClassCastException: class org.openrewrite.groovy.tree.G$ExpressionStatement cannot be cast to class org.openrewrite.java.tree.J$Parentheses (org.openrewrite.groovy.tree.G$ExpressionStatement and org.openrewrite.java.tree.J$Parentheses are in unnamed module of loader 'app')
  org.openrewrite.groovy.format.MergeSpacesVisitor.visitParentheses(MergeSpacesVisitor.java:1280)
  org.openrewrite.java.tree.J$Parentheses.acceptJava(J.java:5144)
  org.openrewrite.java.tree.J.accept(J.java:55)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:242)
  org.openrewrite.groovy.format.MergeSpacesVisitor.visit(MergeSpacesVisitor.java:218)
```