### PR TITLE
Python: fix type attribution for complex literals

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -849,6 +849,8 @@ class PythonTypeMapping:
             return JavaType.Primitive.Int
         elif isinstance(node.value, float):
             return JavaType.Primitive.Double
+        elif isinstance(node.value, complex):
+            return self._create_class_type('complex')
         elif node.value is None:
             return JavaType.Primitive.None_
         return None

--- a/rewrite-python/rewrite/tests/python/all/tree/literal_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/literal_test.py
@@ -148,12 +148,12 @@ def test_double_quoted_string():
 
 def test_complex_number_lowercase():
     # language=python
-    RecipeSpec().rewrite_run(python("assert 1j"))
+    RecipeSpec().rewrite_run(python("assert 1j", after_recipe=check_first_literal_is_complex()))
 
 
 def test_complex_number_uppercase():
     # language=python
-    RecipeSpec().rewrite_run(python("assert 1J"))
+    RecipeSpec().rewrite_run(python("assert 1J", after_recipe=check_first_literal_is_complex()))
 
 
 def test_complex_number_uppercase_in_subscript():
@@ -277,5 +277,13 @@ def find_first(tree: Tree, clazz: Type[T]) -> T:
 def check_first_literal_type(expected_type):
     def after_recipe(cu):
         assert find_first(cu, Literal).type == expected_type
+    return after_recipe
+
+
+def check_first_literal_is_complex():
+    def after_recipe(cu):
+        literal_type = find_first(cu, Literal).type
+        assert isinstance(literal_type, JavaType.Class)
+        assert literal_type.fully_qualified_name == 'complex'
     return after_recipe
 

--- a/rewrite-python/rewrite/tests/rpc/test_send_queue.py
+++ b/rewrite-python/rewrite/tests/rpc/test_send_queue.py
@@ -17,6 +17,19 @@ def test_changed_ref_slot_is_re_added_instead_of_changed():
     assert q.q[2] == {'state': 'ADD', 'ref': 2}
 
 
+def test_complex_value_serializes_as_paren_free_string():
+    # given
+    q = RpcSendQueue()
+
+    # when
+    value = q._get_primitive_value(1j)
+    value_type = q._get_value_type(1j)
+
+    # then
+    assert value == "1j"
+    assert value_type is None
+
+
 def test_changed_ref_list_item_is_re_added_instead_of_changed():
     q = RpcSendQueue()
     ident = lambda s: s[:1]


### PR DESCRIPTION
## What's changed?

Fix Python type attribution for complex (imaginary numbers) literals, e.g. `0j`.

## What's your motivation?

They currently have no type information and some recipes might struggle.
