### PR TITLE
Fix MergeSpaceVisitor unguarded casts for Kotlin, Java, Scala

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/format/MergeSpacesVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/format/MergeSpacesVisitorTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MergeSpacesVisitorTest {
+
+    @Test
+    void ignoresMismatchedContextForParentheses() {
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build()
+          .parse("class Test { boolean value = (true); }")
+          .map(J.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+        J.Parentheses<?> parens = parentheses(cu);
+
+        J merged = new MergeSpacesVisitor(emptyList()).visit(parens, cu);
+
+        assertThat(merged).isSameAs(parens);
+    }
+
+    private static J.Parentheses<?> parentheses(J.CompilationUnit cu) {
+        AtomicReference<J.Parentheses<?>> parentheses = new AtomicReference<>();
+        new JavaIsoVisitor<AtomicReference<J.Parentheses<?>>>() {
+            @Override
+            public <T extends J> J.Parentheses<T> visitParentheses(J.Parentheses<T> parens,
+                                                                    AtomicReference<J.Parentheses<?>> found) {
+                found.set(parens);
+                return super.visitParentheses(parens, found);
+            }
+        }.visit(cu, parentheses);
+        return parentheses.get();
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/format/MergeSpacesVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/format/MergeSpacesVisitor.java
@@ -1142,10 +1142,11 @@ public class MergeSpacesVisitor extends JavaVisitor<Object> {
 
     @Override
     public <T extends J> J visitParentheses(J.Parentheses<T> parens, @Nullable Object ctx) {
-        J.Parentheses<T> newParens = (J.Parentheses<T>) ctx;
-        if (parens == newParens) {
+        if (parens == ctx || !(ctx instanceof J.Parentheses)) {
             return parens;
         }
+        //noinspection unchecked
+        J.Parentheses<T> newParens = (J.Parentheses<T>) ctx;
         J.Parentheses<T> pa = parens;
         pa = pa.withPrefix(visitSpace(pa.getPrefix(), Space.Location.PARENTHESES_PREFIX, newParens.getPrefix()));
         pa = pa.withMarkers(visitMarkers(pa.getMarkers(), newParens.getMarkers()));

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/MergeSpacesVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/MergeSpacesVisitor.java
@@ -1752,10 +1752,11 @@ public class MergeSpacesVisitor extends KotlinVisitor<Object> {
 
     @Override
     public <T extends J> J visitParentheses(J.Parentheses<T> parens, @Nullable Object ctx) {
-        J.Parentheses<T> newParens = (J.Parentheses<T>) ctx;
-        if (parens == newParens) {
+        if (parens == ctx || !(ctx instanceof J.Parentheses)) {
             return parens;
         }
+        //noinspection unchecked
+        J.Parentheses<T> newParens = (J.Parentheses<T>) ctx;
         J.Parentheses<T> pa = parens;
         pa = pa.withPrefix(visitSpace(pa.getPrefix(), Space.Location.PARENTHESES_PREFIX, newParens.getPrefix()));
         pa = pa.withMarkers(visitMarkers(pa.getMarkers(), newParens.getMarkers()));

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/format/MergeSpacesVisitorTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/format/MergeSpacesVisitorTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.kotlin.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.KotlinIsoVisitor;
+import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.style.IntelliJ;
+import org.openrewrite.kotlin.tree.K;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MergeSpacesVisitorTest {
+
+    @Test
+    void ignoresMismatchedContextForParentheses() {
+        K.CompilationUnit cu = KotlinParser.builder().build()
+          .parse("class Test { val value = (true) }")
+          .map(K.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+        J.Parentheses<?> parens = parentheses(cu);
+
+        J merged = new MergeSpacesVisitor(IntelliJ.wrappingAndBraces()).visit(parens, cu);
+
+        assertThat(merged).isSameAs(parens);
+    }
+
+    private static J.Parentheses<?> parentheses(K.CompilationUnit cu) {
+        AtomicReference<J.Parentheses<?>> parentheses = new AtomicReference<>();
+        new KotlinIsoVisitor<AtomicReference<J.Parentheses<?>>>() {
+            @Override
+            public <T extends J> J.Parentheses<T> visitParentheses(J.Parentheses<T> parens,
+                                                                    AtomicReference<J.Parentheses<?>> found) {
+                found.set(parens);
+                return super.visitParentheses(parens, found);
+            }
+        }.visit(cu, parentheses);
+        return parentheses.get();
+    }
+}

--- a/rewrite-scala/src/main/java/org/openrewrite/scala/format/MergeSpacesVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/format/MergeSpacesVisitor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.format;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.tree.S;
+import org.openrewrite.style.NamedStyles;
+
+import java.util.List;
+
+/**
+ * Merges the spaces from a formatted Scala tree into its original counterpart.
+ */
+public class MergeSpacesVisitor extends org.openrewrite.java.format.MergeSpacesVisitor {
+
+    public MergeSpacesVisitor(List<NamedStyles> styles) {
+        super(styles);
+    }
+
+    @Override
+    public @Nullable J visit(@Nullable Tree tree, Object o) {
+        if (o instanceof S.ExpressionStatement && !(tree instanceof S.ExpressionStatement)) {
+            // S.ExpressionStatement#acceptScala unwraps the visited tree but forwards its wrapper as context.
+            o = ((S.ExpressionStatement) o).getExpression();
+        }
+        return super.visit(tree, o);
+    }
+}

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/format/MergeSpacesVisitorTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/format/MergeSpacesVisitorTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala.format;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.scala.ScalaIsoVisitor;
+import org.openrewrite.scala.ScalaParser;
+import org.openrewrite.scala.tree.S;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MergeSpacesVisitorTest {
+
+    @Test
+    void javaMergeVisitorIgnoresExpressionStatementContext() {
+        J.Parentheses<?> parens = parentheses("(true && false)");
+        S.ExpressionStatement expressionStatement = new S.ExpressionStatement(Tree.randomId(), parens);
+
+        J merged = new org.openrewrite.java.format.MergeSpacesVisitor(emptyList()).visit(parens, expressionStatement);
+
+        assertThat(merged).isSameAs(parens);
+    }
+
+    @Test
+    void mergesSpacesInsideParenthesizedExpressionStatements() {
+        J.Parentheses<?> originalParens = parentheses("(true  &&  false)");
+        J.Parentheses<?> formattedParens = parentheses("(true && false)");
+
+        S.ExpressionStatement original = new S.ExpressionStatement(Tree.randomId(), originalParens);
+        S.ExpressionStatement formatted = new S.ExpressionStatement(Tree.randomId(), formattedParens);
+
+        S.ExpressionStatement merged = (S.ExpressionStatement) new MergeSpacesVisitor(emptyList()).visit(original, formatted);
+
+        assertThat(merged.printTrimmed()).isEqualTo("(true && false)");
+    }
+
+    private static J.Parentheses<?> parentheses(String expression) {
+        S.CompilationUnit cu = ScalaParser.builder().build()
+          .parse("""
+            object Test {
+              def method() = {
+                %s
+              }
+            }
+            """.formatted(expression))
+          .map(S.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        AtomicReference<J.Parentheses<?>> parentheses = new AtomicReference<>();
+        new ScalaIsoVisitor<AtomicReference<J.Parentheses<?>>>() {
+            @Override
+            public <T extends J> J.Parentheses<T> visitParentheses(J.Parentheses<T> parens,
+                                                                    AtomicReference<J.Parentheses<?>> found) {
+                found.set(parens);
+                return super.visitParentheses(parens, found);
+            }
+        }.visit(cu, parentheses);
+
+        return parentheses.get();
+    }
+}


### PR DESCRIPTION
## What's changed?

Porting #8550 to other languages: Kotlin, Java, Scala.

## What's your motivation?

I haven't observed the same problem for K, J, S, but when analyzing the issue for Groovy, it turned out it could be possible for these languages too. Thus fixing proactively.