### PR TITLE
Go: make the import qualifier fallback yield to type attribution

### DIFF
--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -224,11 +224,33 @@ func ReferencedPackages(cu *golang.CompilationUnit) map[string]bool {
 	return refs
 }
 
-// IsReferenced reports whether imp is used by the file whose refs/quals
-// sets are passed in. Both sets come from one ReferencedImports walk per
-// file.
-func IsReferenced(imp *java.Import, refs, quals map[string]bool) bool {
-	return refs[ImportPath(imp)] || quals[PackageName(imp)]
+// ResolvedQualifiers names the qualifiers attribution has already accounted
+// for: those bound by an import refs names. Valid Go cannot bind one
+// qualifier twice, so a non-empty result means either a tree mid-rewrite —
+// how a major-version move reads — or input that arrived invalid, where the
+// qualifier binds arbitrarily and no answer is better than another.
+func ResolvedQualifiers(imports []*java.Import, refs map[string]bool) map[string]bool {
+	resolved := map[string]bool{}
+	for _, imp := range imports {
+		if refs[ImportPath(imp)] {
+			if name := PackageName(imp); name != "" {
+				resolved[name] = true
+			}
+		}
+	}
+	return resolved
+}
+
+// IsReferenced reports whether imp is used by the file whose refs/quals sets
+// are passed in. quals stands in for references attribution could not resolve,
+// so it rescues an import refs does not name — unless resolvedQuals holds the
+// qualifier, which makes refs's silence about this one an answer, not a gap.
+func IsReferenced(imp *java.Import, refs, quals, resolvedQuals map[string]bool) bool {
+	if refs[ImportPath(imp)] {
+		return true
+	}
+	name := PackageName(imp)
+	return quals[name] && !resolvedQuals[name]
 }
 
 func referencedImports(cu *golang.CompilationUnit) (refs, quals map[string]bool) {

--- a/rewrite-go/pkg/recipe/golang/internal/imports_test.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 )
 
 func TestPackageNameForPath(t *testing.T) {
@@ -40,4 +42,18 @@ func TestPackageNameForPath(t *testing.T) {
 	} {
 		assert.Equal(t, want, packageNameForPath(path), "path %q", path)
 	}
+}
+
+func TestResolvedQualifiers(t *testing.T) {
+	blank := "_"
+	imports := []*java.Import{
+		NewImport("math/rand", nil),
+		NewImport("math/rand/v2", nil),
+		NewImport("fmt", nil),
+		NewImport("net/http/pprof", &blank),
+	}
+
+	assert.Equal(t, map[string]bool{"rand": true},
+		ResolvedQualifiers(imports, map[string]bool{"math/rand/v2": true, "net/http/pprof": true}))
+	assert.Empty(t, ResolvedQualifiers(imports, map[string]bool{}))
 }

--- a/rewrite-go/pkg/recipe/golang/remove_import.go
+++ b/rewrite-go/pkg/recipe/golang/remove_import.go
@@ -69,9 +69,10 @@ func (v *removeImportVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p
 	if v.cfg.PackagePath == "" || cu.Imports == nil {
 		return cu
 	}
-	var refs, quals map[string]bool
+	var refs, quals, resolved map[string]bool
 	if !v.cfg.Force {
 		refs, quals = internal.ReferencedImports(cu)
+		resolved = internal.ResolvedQualifiers(importsOf(cu), refs)
 	}
 	for _, rp := range cu.Imports.Elements {
 		imp := rp.Element
@@ -82,7 +83,7 @@ func (v *removeImportVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p
 			if alias := internal.AliasName(imp); alias == "_" || alias == "." {
 				continue
 			}
-			if internal.IsReferenced(imp, refs, quals) {
+			if internal.IsReferenced(imp, refs, quals, resolved) {
 				continue
 			}
 		}

--- a/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
+++ b/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
@@ -59,6 +59,7 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 		return cu
 	}
 	refs, quals := internal.ReferencedImports(cu)
+	resolved := internal.ResolvedQualifiers(importsOf(cu), refs)
 	for _, rp := range cu.Imports.Elements {
 		imp := rp.Element
 		if imp == nil {
@@ -73,10 +74,23 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 		if internal.AliasName(imp) == "." {
 			continue
 		}
-		if internal.IsReferenced(imp, refs, quals) {
+		if internal.IsReferenced(imp, refs, quals, resolved) {
 			continue
 		}
 		cu = internal.RemoveFromBlock(cu, imp)
 	}
 	return cu
+}
+
+func importsOf(cu *golang.CompilationUnit) []*java.Import {
+	if cu == nil || cu.Imports == nil {
+		return nil
+	}
+	imps := make([]*java.Import, 0, len(cu.Imports.Elements))
+	for _, rp := range cu.Imports.Elements {
+		if rp.Element != nil {
+			imps = append(imps, rp.Element)
+		}
+	}
+	return imps
 }

--- a/rewrite-go/test/import_recipes_test.go
+++ b/rewrite-go/test/import_recipes_test.go
@@ -17,12 +17,14 @@
 package test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
 
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
 	recipes "github.com/openrewrite/rewrite/rewrite-go/pkg/recipe/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/template"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
@@ -771,6 +773,67 @@ func TestRemoveUnusedImports_KeepsVersionedPathImportUsedByQualifier(t *testing.
 
 			func f(b []byte, out any) error {
 				y.Hello()
+				return yaml.Unmarshal(b, out)
+			}
+		`),
+	)
+}
+
+func TestRemoveUnusedImports_DropsImportSupersededOnSharedQualifier(t *testing.T) {
+	// The rewrite binds `rand` twice mid-tree, which is what makes the
+	// superseded import contend for the new one's qualifier. Driving the
+	// recipe from compilable source is what puts it in that state — a
+	// hand-written post-rewrite file is invalid Go and binds `rand`
+	// arbitrarily.
+	n := template.Expr("n")
+	r := template.NewRecipe(
+		template.RecipeName("test.RandIntnToIntN"),
+		template.WithDisplayName("Use math/rand/v2"),
+		template.WithBefore(fmt.Sprintf(`rand.Intn(%s)`, n), template.Imports("math/rand")),
+		template.WithAfter(fmt.Sprintf(`rand.IntN(%s)`, n), template.Imports("math/rand/v2"), template.SourceImports("math/rand/v2")),
+		template.WithCaptures(n),
+	)
+
+	spec := NewRecipeSpec().WithRecipe(r)
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import "math/rand"
+
+			func pick() int {
+				return rand.Intn(10)
+			}
+		`, `
+			package main
+
+			import (
+				"math/rand/v2"
+			)
+
+			func pick() int {
+				return rand.IntN(10)
+			}
+		`),
+	)
+}
+
+func TestRemoveUnusedImports_KeepsEveryImportWhenNothingIsAttributed(t *testing.T) {
+	// Attribution names none of these paths, so refs is empty, no qualifier
+	// is resolved, and the lexical fallback keeps every import.
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveUnusedImports{})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				"github.com/x/y/v2"
+				"gopkg.in/check.v1"
+				"gopkg.in/yaml.v3"
+			)
+
+			func f(b []byte, out any) error {
+				check.Assert(y.Hello())
 				return yaml.Unmarshal(b, out)
 			}
 		`),


### PR DESCRIPTION
## Motivation

`RemoveUnusedImports` decides an import is used if type attribution names its path (`refs`) or if its qualifier appears lexically (`quals`). The `quals` fallback exists to cover references attribution could not resolve, but it also overrode a definite `refs` answer: when two imports bind the same qualifier and attribution names only one of them, the other was kept alive on the shared qualifier. That is the shape every major-version package move takes, and it emitted code that does not compile.

A template recipe rewriting `rand.Intn(n)` to `rand.IntN(n)` with `SourceImports("math/rand/v2")`, run over a file importing `math/rand`, produced:

```go
import (
	"math/rand"
	"math/rand/v2"
)

func pick() int {
	return rand.IntN(10)
}
```

which fails with `rand redeclared in this block`, `"math/rand/v2" imported as rand and not used`, and `undefined: rand.IntN (but have Intn)`.

- This is the missing half of #8548. Before it, `PackageName("math/rand/v2")` returned `"v2"`, so the two imports never contended for one name; making versioned paths resolve to the right qualifier is exactly what makes them collide.

## Summary

- A qualifier is **resolved** when some import in the file bearing that name is in `refs`. A resolved qualifier no longer rescues an import absent from `refs`.
- New `internal.ResolvedQualifiers(imports, refs)`; `internal.IsReferenced` takes it as a fourth parameter.
- `RemoveUnusedImports` and `RemoveImport` (under the existing `!Force` guard) compute the resolved set once per compilation unit and pass it through.

This degrades in the right direction: where nothing is attributed, `refs` is empty, no qualifier resolves, and the fallback keeps everything — the case it was written for is untouched. It fires only where attribution has positively accounted for that name.

### Bound on the rule

Running `RemoveUnusedImports` over a *hand-written* post-rewrite file that already imports both paths evicts `math/rand/v2` — the wrong one. That file does not compile, so `go/types` binds the duplicated `rand` to the first import and the rule faithfully evicts the other. This is bounded rather than alarming: valid Go cannot bind one qualifier twice (duplicate names in the file block are a redeclaration error, and aliasing removes the contention because `PackageName` returns the alias; blank and dot imports yield `""` and are skipped). So the resolved set is non-empty only for a tree mid-rewrite — the target case, where `refs` carries the template's attribution on the emitted node — or for input that was already invalid on arrival, where the qualifier binds arbitrarily and no answer is better than another. The rule is inert on well-formed input and merely unhelpful, not newly harmful, on input that was broken before the recipe touched it. This is stated in the `ResolvedQualifiers` doc comment so the next person who reproduces the inversion sees it as characterised.

The corollary drives the test shape: tests must start from compilable source and run the recipe, never assert against a file written in the already-rewritten state, since such a file is by construction the invalid-input case.

### On the API shape

`ResolvedQualifiers` takes a `[]*java.Import` while its neighbours in `internal` (`FindImport`, `HasImport`, `ReferencedImports`) take a `*golang.CompilationUnit`, which costs the small `importsOf` adapter in the recipe package. The slice keeps the function pure and directly unit-testable; a `cu`-taking signature would drop the adapter but push fixture construction into the unit test. Happy to flip it if the convention matters more.

## Test plan

- [x] `TestRemoveUnusedImports_DropsImportSupersededOnSharedQualifier` — the `math/rand` → `math/rand/v2` case end to end through a template recipe with `SourceImports`, asserting the superseded import is gone. Stdlib only; no fixtures, no network, no shipped export data — it needs only that the project's dependencies resolve.
- [x] `TestRemoveUnusedImports_KeepsEveryImportWhenNothingIsAttributed` — a file whose imports attribution names none of, asserting every import survives. This is the case the `quals` fallback exists for and the one most at risk from this change.
- [x] `TestResolvedQualifiers` — two imports binding one qualifier with one in `refs`, plus the empty-`refs` case where no qualifier resolves.
- [x] `go build ./... && go vet ./... && go test ./...` green from `rewrite-go/`.
