### PR TITLE
Go: keep `.vN` suffixes intact when deriving an import path from an FQN

### DIFF
--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -315,24 +315,25 @@ func (v *referencedPackagesVisitor) VisitFieldAccess(fa *java.FieldAccess, p any
 //     `y.Hello()` after `import "github.com/x/y"`).
 //   - "<importPath>.<TypeName>"    — for named types in that package.
 //
-// Both shapes share an import-path prefix (the leading segment up to the
-// last `.`); we return that prefix so RemoveUnusedImports can match
-// against the literal import path.
+// Both shapes share an import-path prefix; we return that prefix so
+// RemoveUnusedImports can match against the literal import path.
 func pkgPathOf(fqn string) string {
 	if fqn == "" {
 		return ""
 	}
-	// FQNs that are already an import path (no trailing `.TypeName`)
-	// contain a `/` and no `.` after the last `/`. Detect that shape and
-	// return the FQN as-is.
 	if strings.Contains(fqn, "/") {
+		// A `.` in the last path element separates `pkg` from `TypeName`,
+		// except for a gopkg.in-style `.vN`, which is part of the path.
 		lastSlash := strings.LastIndex(fqn, "/")
-		tail := fqn[lastSlash+1:]
-		if !strings.Contains(tail, ".") {
-			return fqn
+		elements := strings.Split(fqn[lastSlash+1:], ".")
+		end := lastSlash + 1 + len(elements[0])
+		for _, element := range elements[1:] {
+			if !isVersionElement(element) {
+				break
+			}
+			end += 1 + len(element)
 		}
-		// `.../pkg.TypeName` shape — strip the trailing `.TypeName`.
-		return fqn[:lastSlash+1+strings.Index(tail, ".")]
+		return fqn[:end]
 	}
 	// Stdlib paths (e.g. "fmt") and "fmt.Println"-style FQNs.
 	if dot := strings.Index(fqn, "."); dot >= 0 {

--- a/rewrite-go/pkg/recipe/golang/internal/imports_test.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports_test.go
@@ -44,6 +44,23 @@ func TestPackageNameForPath(t *testing.T) {
 	}
 }
 
+func TestPkgPathOf(t *testing.T) {
+	for fqn, want := range map[string]string{
+		"gopkg.in/yaml.v3":         "gopkg.in/yaml.v3",
+		"gopkg.in/check.v1":        "gopkg.in/check.v1",
+		"gopkg.in/yaml.v3.Node":    "gopkg.in/yaml.v3",
+		"example.com/pkg.TypeName": "example.com/pkg",
+		"example.com/pkg.V2":       "example.com/pkg",
+		"github.com/x/y/v2":        "github.com/x/y/v2",
+		"encoding/json/v2":         "encoding/json/v2",
+		"fmt.Println":              "fmt",
+		"fmt":                      "fmt",
+		"":                         "",
+	} {
+		assert.Equal(t, want, pkgPathOf(fqn), "fqn %q", fqn)
+	}
+}
+
 func TestResolvedQualifiers(t *testing.T) {
 	blank := "_"
 	imports := []*java.Import{


### PR DESCRIPTION
## Motivation

`pkgPathOf` in `rewrite-go/pkg/recipe/golang/internal/imports.go` turns a type's fully-qualified name into the import path that owns it. When the FQN contained a `/`, it split the last path element at its first `.` and assumed the remainder was a type name. That assumption breaks for gopkg.in-style paths, where the dot is part of the path itself: `gopkg.in/yaml.v3` came back as `gopkg.in/yaml`, and `gopkg.in/check.v1` as `gopkg.in/check`.

Because `pkgPathOf` feeds the `refs` set that `IsReferenced` matches against the literal import path, a mis-split path never matches, and `RemoveUnusedImports` / `RemoveImport` conclude the import is unused.

- This is latent on `main`: with no type attribution present, `refs` comes back empty and the qualifier fallback added by #8555 keeps the import, so `TestRemoveUnusedImports_KeepsVersionedPathImportUsedByQualifier` and `TestNewRecipeWithSourceImportsKeepsVersionedPathImport` pass either way. It stops being masked once attribution populates `refs` — #8555's rule makes the qualifier fallback *yield* to attribution, so `refs` holds the wrong path, `quals` steps aside, and a used import gets deleted. That was observed concretely when merging `main` into the branch that attributes Go calls and types into packages the build cannot load: both tests above failed, with `refs` containing `gopkg.in/yaml` while the import path was `gopkg.in/yaml.v3`.

## Summary

- `pkgPathOf` now walks the dotted segments of the last path element and keeps `.vN` segments as part of the import path, reusing the existing `isVersionElement` predicate (added in #8548). Only a non-version segment starts the type name, so `gopkg.in/yaml.v3.Node` resolves to `gopkg.in/yaml.v3` while `example.com/pkg.TypeName` still strips to `example.com/pkg`. Exported Go type names are capitalized and `isVersionElement` requires a lowercase `v`, so `example.com/pkg.V2` is unaffected.
- Added `TestPkgPathOf`, a table test pinning the helper directly. The end-to-end behavior is masked by the qualifier fallback today, so an integration test would pass with or without the fix.

## Test plan

- [x] `TestPkgPathOf` written first; confirmed it failed only on the `.vN` rows (`gopkg.in/yaml.v3`, `gopkg.in/check.v1`, `gopkg.in/yaml.v3.Node`) while the `example.com/pkg.TypeName`, `github.com/x/y/v2`, `encoding/json/v2`, `fmt.Println` and bare `fmt` rows already passed, then green after the fix.
- [x] `go test ./...` from `rewrite-go/` passes. (`TestParityGap`, behind `-tags gofmtaudit`, already fails on `main` at 4404 vs a floor of 4405 from Go 1.26.6 stdlib drift — pre-existing and untouched here.)
- [x] `gofmt` clean.