### PR TITLE
Kotlin: map `suspend { }` to a method invocation at every language level

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/Assertions.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/Assertions.java
@@ -57,6 +57,9 @@ public final class Assertions {
     public static SourceFile validateTypes(SourceFile source, TypeValidation typeValidation) {
         if (source instanceof JavaSourceFile) {
             assertValidTypes(typeValidation, (JavaSourceFile) source);
+            if (typeValidation.unknown()) {
+                assertNoUnknownElements(source);
+            }
         }
         return source;
     }
@@ -214,6 +217,24 @@ public final class Assertions {
                 kotlinSourceSpec.afterRecipe(spaceConscious(kotlinSourceSpec));
             }
         };
+    }
+
+    private static void assertNoUnknownElements(SourceFile source) {
+        List<J.Unknown> unknowns = new KotlinIsoVisitor<List<J.Unknown>>() {
+            @Override
+            public J visitUnknown(J.Unknown unknown, List<J.Unknown> unknowns) {
+                unknowns.add(unknown);
+                return super.visitUnknown(unknown, unknowns);
+            }
+        }.reduce(source, new ArrayList<>());
+        if (!unknowns.isEmpty()) {
+            throw new IllegalStateException("LST contains unknown elements\n" + unknowns.stream()
+                    .map(unknown -> unknown.getSource().getMarkers()
+                            .findFirst(ParseExceptionResult.class)
+                            .map(ParseExceptionResult::getMessage)
+                            .orElse("") + unknown.getSource().getText())
+                    .collect(joining("\n\n")));
+        }
     }
 
     private static void assertValidTypes(TypeValidation typeValidation, J sf) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/KotlinParser.java
@@ -568,7 +568,8 @@ public class KotlinParser implements Parser {
         KOTLIN_1_9,
         KOTLIN_2_0,
         KOTLIN_2_1,
-        KOTLIN_2_2
+        KOTLIN_2_2,
+        KOTLIN_2_3
     }
 
     private CompilerConfiguration compilerConfiguration() {
@@ -627,6 +628,8 @@ public class KotlinParser implements Parser {
                 return LanguageVersion.KOTLIN_2_1;
             case KOTLIN_2_2:
                 return LanguageVersion.KOTLIN_2_2;
+            case KOTLIN_2_3:
+                return LanguageVersion.KOTLIN_2_3;
             default:
                 throw new IllegalArgumentException("Unknown language level: " + languageLevel);
         }
@@ -660,6 +663,8 @@ public class KotlinParser implements Parser {
                 return ApiVersion.KOTLIN_2_1;
             case KOTLIN_2_2:
                 return ApiVersion.KOTLIN_2_2;
+            case KOTLIN_2_3:
+                return ApiVersion.KOTLIN_2_3;
             default:
                 throw new IllegalArgumentException("Unknown language level: " + languageLevel);
         }

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1736,17 +1736,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                     spaceAfterShebang = null;
                 }
             } catch (Exception e) {
-                statement = new J.Unknown(
-                        randomId(),
-                        deepPrefix(declaration),
-                        Markers.EMPTY,
-                        new J.Unknown.Source(
-                                randomId(),
-                                Space.EMPTY,
-                                Markers.build(singletonList(ParseExceptionResult.build(KotlinParser.builder().build(), e)
-                                        .withTreeType(declaration.getClass().getName()))),
-                                file.getText().substring(PsiUtilsKt.getStartOffsetSkippingComments(declaration),
-                                        declaration.getTextRange().getEndOffset())));
+                statement = unknown(declaration, e);
             }
 
             statements.add(maybeTrailingSemicolon(statement, declaration));
@@ -1997,8 +1987,12 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
     public J visitBlockExpression(KtBlockExpression expression, ExecutionContext data) {
         List<JRightPadded<Statement>> statements = new ArrayList<>();
         for (KtExpression stmt : expression.getStatements()) {
-            J exp = stmt.accept(this, data);
-            Statement statement = convertToStatement(exp).withPrefix(endFixPrefixAndInfix(stmt));
+            Statement statement;
+            try {
+                statement = convertToStatement(stmt.accept(this, data)).withPrefix(endFixPrefixAndInfix(stmt));
+            } catch (Exception e) {
+                statement = unknown(stmt, e);
+            }
             JRightPadded<Statement> build = maybeTrailingSemicolon(statement, stmt);
             statements.add(build);
         }
@@ -2378,7 +2372,12 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             if (d instanceof KtEnumEntry) {
                 continue;
             }
-            Statement statement = convertToStatement(d.accept(this, data));
+            Statement statement;
+            try {
+                statement = convertToStatement(d.accept(this, data));
+            } catch (Exception e) {
+                statement = unknown(d, e);
+            }
             list.add(maybeTrailingSemicolon(statement, d));
         }
 
@@ -3858,6 +3857,20 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             id = id.withPrefix(merge(prefix, id.getPrefix()));
         }
         return id;
+    }
+
+    private J.Unknown unknown(KtElement element, Exception e) {
+        return new J.Unknown(
+                randomId(),
+                deepPrefix(element),
+                Markers.EMPTY,
+                new J.Unknown.Source(
+                        randomId(),
+                        Space.EMPTY,
+                        Markers.build(singletonList(ParseExceptionResult.build(KotlinParser.builder().build(), e)
+                                .withTreeType(element.getClass().getName()))),
+                        element.getContainingFile().getText().substring(PsiUtilsKt.getStartOffsetSkippingComments(element),
+                                element.getTextRange().getEndOffset())));
     }
 
     private @Nullable FirElement owner(PsiElement element) {

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -3867,7 +3867,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
                 new J.Unknown.Source(
                         randomId(),
                         Space.EMPTY,
-                        Markers.build(singletonList(ParseExceptionResult.build(KotlinParser.builder().build(), e)
+                        Markers.build(singletonList(ParseExceptionResult.build(KotlinParser.class, e, null)
                                 .withTreeType(element.getClass().getName()))),
                         element.getContainingFile().getText().substring(PsiUtilsKt.getStartOffsetSkippingComments(element),
                                 element.getTextRange().getEndOffset())));

--- a/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
+++ b/rewrite-kotlin/src/main/kotlin/org/openrewrite/kotlin/internal/PsiElementAssociations.kt
@@ -16,6 +16,7 @@
 package org.openrewrite.kotlin.internal
 
 import org.jetbrains.kotlin.KtRealPsiSourceElement
+import org.jetbrains.kotlin.builtins.StandardNames
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.util.PsiTreeUtil
 import org.jetbrains.kotlin.fir.FirElement
@@ -32,12 +33,14 @@ import org.jetbrains.kotlin.fir.references.FirErrorNamedReference
 import org.jetbrains.kotlin.fir.references.FirResolvedNamedReference
 import org.jetbrains.kotlin.fir.references.resolved
 import org.jetbrains.kotlin.fir.resolve.calls.FirSyntheticFunctionSymbol
+import org.jetbrains.kotlin.fir.resolve.providers.symbolProvider
 import org.jetbrains.kotlin.fir.resolve.toSymbol
 import org.jetbrains.kotlin.fir.symbols.SymbolInternals
 import org.jetbrains.kotlin.fir.symbols.impl.*
 import org.jetbrains.kotlin.fir.types.*
 import org.jetbrains.kotlin.fir.visitors.FirDefaultVisitor
 import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi
 import org.jetbrains.kotlin.psi.*
 import org.openrewrite.java.tree.JavaType
@@ -147,6 +150,11 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
             return typeMapping.type(typeMap[parent], owner)
         }
         val fir = primary(psiElement)
+        if (fir is FirVariable && psiElement is KtSimpleNameExpression &&
+            fir.name.asString() != psiElement.getReferencedName()) {
+            // `primary` walked up to an enclosing declaration, whose type describes a different name
+            return null
+        }
         if (psiElement != null && fir is FirResolvedQualifier && fir.source != null && (fir.source.psi is KtDotQualifiedExpression || fir.source.psi is KtNameReferenceExpression)) {
             if (fir.symbol is FirRegularClassSymbol) {
                 val classId = (fir.symbol as FirRegularClassSymbol).classId
@@ -259,11 +267,25 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
                     }
 
                     else -> {
-                        null
+                        if (psi is KtCallExpression) resolvedAwayCallType(psi) else null
                     }
                 }
             }
         }
+    }
+
+    @OptIn(SymbolInternals::class)
+    private fun resolvedAwayCallType(psi: KtCallExpression): JavaType.Method? {
+        // Since Kotlin 2.3 `suspend { }` resolves to a suspending lambda, leaving no FIR for the call itself
+        val name = (psi.calleeExpression as? KtNameReferenceExpression)?.getReferencedName()
+        if (elementMap.containsKey(psi) || name != "suspend" ||
+            psi.valueArgumentList != null || psi.lambdaArguments.size != 1) {
+            return null
+        }
+        val symbol = typeMapping.firSession.symbolProvider
+            .getTopLevelFunctionSymbols(StandardNames.BUILT_INS_PACKAGE_FQ_NAME, Name.identifier(name))
+            .firstOrNull() ?: return null
+        return typeMapping.methodDeclarationType(symbol.fir, null)
     }
 
     fun primitiveType(psi: PsiElement): JavaType.Primitive {
@@ -399,7 +421,11 @@ class PsiElementAssociations(val typeMapping: KotlinTypeMapping, val file: FirFi
                     else -> null
                 }
             }
-            else -> throw UnsupportedOperationException("Unsupported call type: ${fir.javaClass}")
+            else -> {
+                // `primary` walked up to an enclosing element, so the compiler resolved this call away
+                if (fir.source?.psi !== psi) null
+                else throw UnsupportedOperationException("Unsupported call type: ${fir.javaClass}")
+            }
         }
     }
 

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/LambdaTest.java
@@ -16,9 +16,16 @@
 package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.openrewrite.Issue;
+import org.openrewrite.java.tree.Expression;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings("RemoveRedundantQualifierName")
@@ -93,6 +100,30 @@ class LambdaTest implements RewriteTest {
                   val lambda : suspend ( ) -> Int = suspend { 1 }
               }
               """
+          )
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = KotlinParser.KotlinLanguageLevel.class, names = "KOTLIN_2_\\d+", mode = EnumSource.Mode.MATCH_ALL)
+    void suspendLambdaAtEveryLanguageLevel(KotlinParser.KotlinLanguageLevel languageLevel) {
+        rewriteRun(
+          spec -> spec.parser(KotlinParser.builder().languageLevel(languageLevel)),
+          kotlin(
+            """
+              fun method ( ) {
+                  val lambda : suspend ( ) -> Int = suspend { 1 }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> {
+                J.MethodDeclaration method = (J.MethodDeclaration) cu.getStatements().getFirst();
+                J.VariableDeclarations lambda = (J.VariableDeclarations) requireNonNull(method.getBody()).getStatements().getFirst();
+                Expression initializer = lambda.getVariables().getFirst().getInitializer();
+                assertThat(initializer).isInstanceOfSatisfying(J.MethodInvocation.class, m -> {
+                    assertThat(m.getSimpleName()).isEqualTo("suspend");
+                    assertThat(m.getMethodType()).isNotNull();
+                });
+            })
           )
         );
     }


### PR DESCRIPTION
## What's changed?

Relates to https://github.com/openrewrite/rewrite/pull/8542, which raises the Kotlin compiler to 2.4.10 and adds the `KOTLIN_2_3` and `KOTLIN_2_4` language levels. This PR adds `KOTLIN_2_3` on its own, because the pinned compiler is already 2.3.20 and without that level the regression test cannot reach the resolution change it guards; the builder default stays `KOTLIN_2_2`. Expect a trivial textual conflict in `KotlinParser`'s enum and switch statements with #8542, whichever lands second.

Since Kotlin 2.3 the compiler resolves `suspend { }` to a suspending lambda **without** emitting a call to `kotlin.suspend`, so the `KtCallExpression` has no FIR of its own. `PsiElementAssociations.fir()` walks up the PSI tree when a node is absent from its element map, so it returns the enclosing `FirProperty`, `getCallType` throws `UnsupportedOperationException: Unsupported call type: …FirPropertyImpl`, and `visitKtFile` replaces the **entire** enclosing top-level declaration with a `J.Unknown`.

```kotlin
fun method ( ) {
    val lambda : suspend ( ) -> Int = suspend { 1 }
}
```

At language level 2.3/2.4 the whole `fun method()` became a `J.Unknown` carrying a `ParseExceptionResult` marker. Nothing surfaced it: zero `ParseError`s, and no output even with `logCompilationWarningsAndErrors(true)`.

Three narrow guards in `PsiElementAssociations`, all keyed on "the FIR found is not about this PSI":

* `getCallType` returns `null` — which `visitCallExpression` already maps to a `J.MethodInvocation`, the same shape 2.2 produces — when the FIR's source PSI is not the expression asked about. It still throws when the FIR really does belong to the expression. This also covers argument position (`take(suspend { 1 })`), where the walk-up lands on `FirResolvedArgumentList`.
* `type()` no longer attributes a `FirVariable` to a `KtSimpleNameExpression` of a different name; without this the callee `suspend` picked up the enclosing `lambda` variable as its `fieldType`.
* `methodInvocationType()` resolves `kotlin.suspend` from the session's symbol provider as a last resort, so the invocation keeps a non-null `JavaType.Method` at 2.3+ instead of trading a `J.Unknown` for an untyped invocation.

Two related improvements:

* **Blast radius.** The `J.Unknown` fallback now also wraps each class-body member and each block statement, so a mapping failure costs one statement instead of an entire top-level declaration. Prefix handling is unchanged (`deepPrefix` *is* `endFixPrefixAndInfix`, purely PSI-derived), so the fallback uses the prefix a successful statement would have.
* **Visibility.** `rewrite-kotlin`'s `Assertions.validateTypes` never implemented the `TypeValidation.unknown()` check that `rewrite-java`'s has, which is why the degradation was invisible in green tests. It now fails with the `ParseExceptionResult` message and the offending source.

## Anything in particular you'd like reviewers to focus on?

* Whether `resolvedAwayCallType` matching `kotlin.suspend` by name is acceptable. It only runs for a call the compiler left no FIR for, with a single lambda argument and no value-argument list; a user-declared `suspend` function resolves normally and never reaches it. The alternative is a `J.MethodInvocation` with a null method type, which is a type-attribution regression at 2.3+.
* Honoring `TypeValidation.unknown()` in `rewrite-kotlin` may surface latent `J.Unknown`s in downstream Kotlin test suites. Tests can opt out with `typeValidationOptions`.

## Checklist

* [x] I've added unit tests to cover both positive and negative cases
* [x] I've read and applied the [recipe conventions](https://docs.openrewrite.org/reference/recipe-conventions-and-best-practices)
* [x] I've used the [IntelliJ IDEA auto-formatter](https://github.com/openrewrite/styles) on affected files

## Testing notes

- `LambdaTest.suspendLambdaAtEveryLanguageLevel` is parameterized with `@EnumSource(names = "KOTLIN_2_\d+", mode = MATCH_ALL)`, so it covers 2.0–2.3 here and picks up 2.4 automatically once https://github.com/openrewrite/rewrite/pull/8542 lands — no dependency on that branch. On `main` it fails at `[4] languageLevel = KOTLIN_2_3` without the parser change and passes with it.

- Also verified against the branch of https://github.com/openrewrite/rewrite/pull/8542 (`barbulescu/kotlin-2.4.10`): the new test fails at 2.3 and 2.4 without this change and passes with it, and the full `:rewrite-kotlin:test` suite is green there. On `main`, `:rewrite-kotlin:test`, `:rewrite-gradle:test` and `:rewrite-android:test` are green.

The narrowed blast radius has no committable regression test — instrumenting the `visitKtFile` catch across the whole rewrite-kotlin corpus at 2.2 shows zero failing declarations today. It was validated on the 2.4 branch with the `getCallType` fix reverted: only the `val lambda …` statement becomes `J.Unknown`, the sibling statements and the other members keep their types, and the file still prints byte-identically.


