### PR TITLE
Normalize Kotlin type parameter bound colon spacing

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/SpacesVisitor.java
@@ -164,11 +164,14 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
 
     // handle space before colon after declaration name
     private Markers spaceBeforeColonAfterDeclarationName(Markers markers) {
+        return spaceBeforeColon(markers, style.getOther().getBeforeColonAfterDeclarationName());
+    }
+
+    private Markers spaceBeforeColon(Markers markers, boolean spaceBefore) {
         return markers.withMarkers(ListUtils.map(markers.getMarkers(), marker -> {
             if (marker instanceof TypeReferencePrefix) {
                 TypeReferencePrefix mf = (TypeReferencePrefix) marker;
-                return mf.withPrefix(updateSpace(mf.getPrefix(),
-                        style.getOther().getBeforeColonAfterDeclarationName()));
+                return mf.withPrefix(updateSpace(mf.getPrefix(), spaceBefore));
             }
             return marker;
         }));
@@ -352,12 +355,12 @@ public class SpacesVisitor<P> extends KotlinIsoVisitor<P> {
     public J.TypeParameter visitTypeParameter(J.TypeParameter typeParam, P p) {
         J.TypeParameter pa = super.visitTypeParameter(typeParam, p);
 
-        // handle space before colon after declaration name
-        pa = pa.withMarkers(spaceBeforeColonAfterDeclarationName(pa.getMarkers()));
+        // a type parameter bound is a new type definition, e.g. `fun <T : Number> foo()`
+        pa = pa.withMarkers(spaceBeforeColon(pa.getMarkers(), style.getOther().getBeforeColonInNewTypeDefinition()));
         if (pa.getMarkers().findFirst(TypeReferencePrefix.class).isPresent()) {
             pa = pa.withBounds(
                     ListUtils.map(pa.getBounds(), b ->
-                            spaceBefore(b, style.getOther().getAfterColonBeforeDeclarationType()))
+                            spaceBefore(b, style.getOther().getAfterColonInNewTypeDefinition()))
             );
         }
         return pa;

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -1415,11 +1415,11 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         }
 
         if (parameter.getExtendsBound() != null) {
-            bounds = JContainer.build(suffix(parameter.getNameIdentifier()),
+            bounds = JContainer.build(Space.EMPTY,
                     singletonList(padRight((TypeTree) parameter.getExtendsBound().accept(this, data),
                             Space.EMPTY)),
                     Markers.EMPTY);
-            markers = markers.addIfAbsent(new TypeReferencePrefix(randomId(), Space.EMPTY));
+            markers = markers.addIfAbsent(new TypeReferencePrefix(randomId(), suffix(parameter.getNameIdentifier())));
         }
 
         return new J.TypeParameter(

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/format/SpacesTest.java
@@ -1309,6 +1309,51 @@ class SpacesTest implements RewriteTest {
                 );
             }
 
+            @Issue("https://github.com/openrewrite/rewrite/issues/6613")
+            @Test
+            void typeParameterBoundDefaults() {
+                rewriteRun(
+                  kotlin(
+                    """
+                      class Test<T   :   Number>
+
+                      fun <T   :   Number> method(t   :   T) {
+                      }
+                      """,
+                    """
+                      class Test<T : Number>
+
+                      fun <T : Number> method(t: T) {
+                      }
+                      """
+                  )
+                );
+            }
+
+            @Issue("https://github.com/openrewrite/rewrite/issues/6613")
+            @Test
+            void typeParameterBoundWithoutSpaceAroundColon() {
+                rewriteRun(
+                  spaces(style -> style.withOther(style.getOther()
+                    .withBeforeColonInNewTypeDefinition(false)
+                    .withAfterColonInNewTypeDefinition(false))),
+                  kotlin(
+                    """
+                      class Test<T   :   Number>
+
+                      fun <T   :   Number> method(t: T) {
+                      }
+                      """,
+                    """
+                      class Test<T:Number>
+
+                      fun <T:Number> method(t: T) {
+                      }
+                      """
+                  )
+                );
+            }
+
             @Test
             void otherBeforeColonAfterDeclarationNameFalseMethodDeclaration() {
                 rewriteRun(


### PR DESCRIPTION
- Fixes #6613

The whitespace before the colon of a type parameter bound was stored in the bounds `JContainer.before` with an empty `TypeReferencePrefix` marker, while `where` constraints on the same `J.TypeParameter` store it in the marker; since `SpacesVisitor` only ever looked at the marker, `fun <T   :   Number>` was never normalized. The parser now stores that space in the marker in both cases, which prints identically but gives formatters a single place to look.

`SpacesVisitor` formats type parameter bounds with `beforeColonInNewTypeDefinition`/`afterColonInNewTypeDefinition` rather than the declaration-name options, matching Kotlin conventions (`val x: Int` but `fun <T : Number>`) and putting those two previously unused style options to work.

- Still open for a follow-up: `class A   :   B()` and `object   :   Runnable` supertype colons are not normalized either, and variable declarations keep their pre-colon space in `JRightPadded.after` rather than the marker (unifying that is the larger LST change tracked in openrewrite/rewrite-kotlin#477).