### PR TITLE
Go: fix the whitespace fuzzer and the formatter bugs it found

### DIFF
--- a/rewrite-go/pkg/format/binary_spacing.go
+++ b/rewrite-go/pkg/format/binary_spacing.go
@@ -346,27 +346,37 @@ func walkBinary(e binaryOperands) (has4, has5 bool, maxProblem int) {
 }
 
 // unaryOperator reports the token a unary expression writes ahead of its
-// operand, which can join the binary operator to its left.
+// operand, which can join the binary operator to its left. Go parses `&`, `*`
+// and `<-` into a golang.Unary; the java.Unary spellings reach here from a
+// synthesized tree, which the printer accepts just the same.
 func unaryOperator(e java.Expression) (string, bool) {
-	u, ok := e.(*java.Unary)
-	if !ok {
-		return "", false
-	}
-	switch u.Operator.Element {
-	case java.Positive:
-		return "+", true
-	case java.Negate:
-		return "-", true
-	case java.Not:
-		return "!", true
-	case java.BitwiseNot:
-		return "^", true
-	case java.Deref:
-		return "*", true
-	case java.AddressOf:
-		return "&", true
-	case java.Receive:
-		return "<-", true
+	switch u := e.(type) {
+	case *java.Unary:
+		switch u.Operator.Element {
+		case java.Positive:
+			return "+", true
+		case java.Negate:
+			return "-", true
+		case java.Not:
+			return "!", true
+		case java.BitwiseNot:
+			return "^", true
+		case java.Deref:
+			return "*", true
+		case java.AddressOf:
+			return "&", true
+		case java.Receive:
+			return "<-", true
+		}
+	case *golang.Unary:
+		switch u.Operator.Element {
+		case golang.AddressOf:
+			return "&", true
+		case golang.Indirection:
+			return "*", true
+		case golang.Receive:
+			return "<-", true
+		}
 	}
 	return "", false
 }

--- a/rewrite-go/pkg/format/binary_spacing_test.go
+++ b/rewrite-go/pkg/format/binary_spacing_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+)
+
+func TestBinaryOperandMeetsUnaryOperator(t *testing.T) {
+	// Each operand sits deep enough to be written tight, which puts the binary
+	// operator against the unary operator to its right.
+	sources := []string{
+		"package A\n\nvar A = 0%0&&0& &0\n",
+		"package A\n\nfunc F(p *int) { _ = 0%0&&0/ *p }\n",
+		"package A\n\nfunc F(p *int) { _ = 0%0&&0* *p }\n",
+		"package A\n\nfunc F(c chan int) { _ = 0%0&&0- <-c }\n",
+		"package A\n\nvar A = 0%0&&0+ +0\n",
+		"package A\n\nvar A = 0%0&&0& ^0\n",
+	}
+	for _, src := range sources {
+		t.Run(src, func(t *testing.T) {
+			p := parser.NewGoParser()
+			p.ParseOnly = true
+			cu, err := p.Parse("t.go", src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			want, err := gofmtSource("t.go", src)
+			if err != nil {
+				t.Fatalf("gofmt: %v", err)
+			}
+			if got := runAutoFormat(cu); got != want {
+				t.Errorf("got  %q\nwant %q", got, want)
+			}
+		})
+	}
+}

--- a/rewrite-go/pkg/format/doc_comments.go
+++ b/rewrite-go/pkg/format/doc_comments.go
@@ -100,12 +100,14 @@ func canonicalDoc(s java.Space, atFileStart bool) java.Space {
 // whatever preceded them.
 func docCommentRun(s java.Space, atFileStart bool) (int, bool) {
 	last := len(s.Comments) - 1
+	// Only the line break itself may stand between the run and the token it
+	// documents: go/printer leaves an indented token undocumented.
 	if last < 0 || s.Comments[last].Suffix != "\n" {
 		return 0, false
 	}
 	for start := last; ; start-- {
 		// A run reaching the start of s, or preceded by anything other than a
-		// bare line break, is as far back as this doc comment goes.
+		// single line break, is as far back as this doc comment goes.
 		if start == 0 {
 			if s.Whitespace == "" && !atFileStart {
 				return 0, false
@@ -115,11 +117,16 @@ func docCommentRun(s java.Space, atFileStart bool) (int, bool) {
 			}
 			return 0, true
 		}
-		if s.Comments[start-1].Suffix != "\n" {
-			return start, true
+		if !joinsLines(s.Comments[start-1].Suffix) {
+			return start, strings.Contains(s.Comments[start-1].Suffix, "\n")
 		}
 	}
 }
+
+// joinsLines reports whether ws puts what follows it on the next line with no
+// blank line between, which is the separation go/ast holds a comment group
+// together across.
+func joinsLines(ws string) bool { return strings.Count(ws, "\n") == 1 }
 
 // canonicalDocComment reformats one doc comment run, mirroring
 // go/printer.formatDocComment. Directives keep their own text and follow the

--- a/rewrite-go/pkg/format/doc_comments_test.go
+++ b/rewrite-go/pkg/format/doc_comments_test.go
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+)
+
+func TestDocCommentRun(t *testing.T) {
+	tests := map[string]struct{ src, want string }{
+		"indented line stays in the run": {
+			src:  "package p\n\n//a\n\t\t//b\nfunc A() {}\n",
+			want: "package p\n\n// a\n// b\nfunc A() {}\n",
+		},
+		"indented token documents nothing": {
+			src:  "package p\n\n//a\n\t\tfunc A() {}\n",
+			want: "package p\n\n//a\n\t\tfunc A() {}\n",
+		},
+		"blank line ends the run": {
+			src:  "package p\n\n//a\n\n//b\nfunc A() {}\n",
+			want: "package p\n\n//a\n\n// b\nfunc A() {}\n",
+		},
+		"trailing comment documents nothing": {
+			src:  "package p\n\nvar x = 1 //a\n",
+			want: "package p\n\nvar x = 1 //a\n",
+		},
+		"comment after a comment on the same line documents nothing": {
+			src:  "package p /**/ //\nfunc A() {}\n",
+			want: "package p /**/ //\nfunc A() {}\n",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			p := parser.NewGoParser()
+			p.ParseOnly = true
+			cu, err := p.Parse("t.go", tc.src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := printer.Print(NewDocCommentVisitor(nil).Visit(cu, nil)); got != tc.want {
+				t.Errorf("got  %q\nwant %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDocCommentFormattingIsIdempotent(t *testing.T) {
+	// go/doc/comment rewrites this text again on a second pass when it is read
+	// alone; grouped with the line above it, as go/ast groups it, the first
+	// pass settles it.
+	src := "package A\n\n//\n\n//0\n\t\t\t//`0``0``````0`0`0\nfunc  A()"
+	p := parser.NewGoParser()
+	p.ParseOnly = true
+	cu, err := p.Parse("t.go", src)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	once := runAutoFormat(cu)
+	again, err := p.Parse("t.go", once)
+	if err != nil {
+		t.Fatalf("re-parse: %v", err)
+	}
+	if twice := runAutoFormat(again); twice != once {
+		t.Errorf("once  %q\ntwice %q", once, twice)
+	}
+}

--- a/rewrite-go/pkg/format/fuzz_test.go
+++ b/rewrite-go/pkg/format/fuzz_test.go
@@ -155,11 +155,12 @@ func reWhitespace(src string, rnd *rand.Rand) (string, bool) {
 		if offset < prevEnd || offset > len(src) {
 			return "", false
 		}
+		// go/scanner reports a semicolon inserted for a line break as "\n": it
+		// occupies no source text, and the gap that follows carries the break.
+		implicit := tok == gotoken.SEMICOLON && lit == "\n"
 		width := len(lit)
 		switch {
-		case tok == gotoken.SEMICOLON && lit == "\n":
-			// Inserted for a line break rather than written, so it occupies no
-			// source text and the gap that follows carries the break.
+		case implicit:
 			width = 0
 		case lit == "":
 			width = len(tok.String())
@@ -171,7 +172,7 @@ func reWhitespace(src string, rnd *rand.Rand) (string, bool) {
 		// text can be shorter than the source it came from. Mutating around a
 		// token whose text does not match the source would move the token
 		// boundaries, so leave those sources alone.
-		if lit != "" && src[offset:offset+width] != lit {
+		if lit != "" && !implicit && src[offset:offset+width] != lit {
 			return "", false
 		}
 

--- a/rewrite-go/pkg/format/minimum_spacing.go
+++ b/rewrite-go/pkg/format/minimum_spacing.go
@@ -235,13 +235,25 @@ func withLeadingSpace(t java.Tree) java.Tree {
 
 // fusesWith reports whether the first token of after would join the last token
 // of before, which happens when the characters either side of the join can both
-// appear inside one identifier or number.
+// appear inside one identifier or number, or together spell one operator.
 func fusesWith(before, after string) bool {
 	before = strings.TrimRight(before, " \t\n")
 	if before == "" || after == "" {
 		return false
 	}
-	return tokenChar(before[len(before)-1]) && tokenChar(after[0])
+	return tokenChar(before[len(before)-1]) && tokenChar(after[0]) ||
+		spellsOperator(before, after[0])
+}
+
+// spellsOperator reports whether writing a straight after before lexes as one
+// operator rather than two, keeping `+ +x` from reading as `++x`. before is the
+// whole operator, so a `<-` followed by `-` stays two tokens.
+func spellsOperator(before string, a byte) bool {
+	switch before + string(a) {
+	case "++", "--", "&&", "&^":
+		return true
+	}
+	return false
 }
 
 func tokenChar(b byte) bool {

--- a/rewrite-go/pkg/format/minimum_spacing_test.go
+++ b/rewrite-go/pkg/format/minimum_spacing_test.go
@@ -104,3 +104,31 @@ func stripAllSpaces(v reflect.Value) reflect.Value {
 		return v
 	}
 }
+
+func TestFusesWith(t *testing.T) {
+	tests := map[string]struct {
+		before, after string
+		want          bool
+	}{
+		"keyword and name":        {"var", "x", true},
+		"keyword and literal":     {"return", "0", true},
+		"keyword and punctuation": {"return", "(x)", false},
+		"already separated":       {"var", " x", false},
+		"plus and plus":           {"+", "+x", true},
+		"minus and minus":         {"-", "-x", true},
+		"and and and":             {"&", "&x", true},
+		"and and complement":      {"&", "^x", true},
+		"complement and self":     {"^", "^x", false},
+		"not and self":            {"!", "!x", false},
+		"star and self":           {"*", "*x", false},
+		"receive and minus":       {"<-", "-x", false},
+		"plus and name":           {"+", "x", false},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := fusesWith(tc.before, tc.after); got != tc.want {
+				t.Errorf("fusesWith(%q, %q) = %v, want %v", tc.before, tc.after, got, tc.want)
+			}
+		})
+	}
+}

--- a/rewrite-go/pkg/format/spaces.go
+++ b/rewrite-go/pkg/format/spaces.go
@@ -19,6 +19,7 @@ package format
 import (
 	"strings"
 
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
@@ -69,10 +70,27 @@ func (v *SpacesVisitor) VisitAssignmentOperation(ao *java.AssignmentOperation, p
 	return ao
 }
 
+// VisitUnary writes the operand straight after the operator, except where the
+// two would then lex as one token.
 func (v *SpacesVisitor) VisitUnary(u *java.Unary, p any) java.J {
 	u = v.GoVisitor.VisitUnary(u, p).(*java.Unary)
-	u.Operand = clearExpressionLeadingSpace(u.Operand)
+	tightened := clearExpressionLeadingSpace(u.Operand)
+	op, ahead := prefixOperator(u.Operator.Element)
+	if !ahead || !fusesWith(op, printer.Print(tightened)) {
+		u.Operand = tightened
+	}
 	return u
+}
+
+// prefixOperator returns the operator text for the forms that write it ahead of
+// the operand. The postfix forms report false: their operator lands on the far
+// side of the operand and never meets its leading space.
+func prefixOperator(op java.UnaryOperator) (string, bool) {
+	switch op {
+	case java.PostIncrement, java.PostDecrement, java.SpreadPostfix:
+		return "", false
+	}
+	return printer.UnaryOperatorString(op), true
 }
 
 // ensureSingleSpace returns the space unchanged if it contains a

--- a/rewrite-go/pkg/format/spaces_test.go
+++ b/rewrite-go/pkg/format/spaces_test.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package format
+
+import (
+	"testing"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+)
+
+func TestUnaryOperandSpacing(t *testing.T) {
+	sources := []string{
+		"package p\n\nvar A = + +0\n",
+		"package p\n\nvar A = - -0\n",
+		"package p\n\nvar A = ^ ^0\n",
+		"package p\n\nvar A = !  !true\n",
+		"package p\n\nvar A = -  0\n",
+		"package p\n\nvar A = 1 - -0\n",
+	}
+	for _, src := range sources {
+		t.Run(src, func(t *testing.T) {
+			p := parser.NewGoParser()
+			p.ParseOnly = true
+			cu, err := p.Parse("t.go", src)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			want, err := gofmtSource("t.go", src)
+			if err != nil {
+				t.Fatalf("gofmt: %v", err)
+			}
+			if got := runAutoFormat(cu); got != want {
+				t.Errorf("got  %q\nwant %q", got, want)
+			}
+		})
+	}
+}

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/7230feedf3cb0c52
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/7230feedf3cb0c52
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A\nvar A=0%0&&0& &00000")
+int64(344)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/8628b52a7a2a058a
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/8628b52a7a2a058a
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A\nvar A=+ +0")
+int64(217)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/9bd16c05ad9414cc
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/9bd16c05ad9414cc
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A/**/ //\nfunc A()")
+int64(-179)

--- a/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/c0259baa5439270c
+++ b/rewrite-go/pkg/format/testdata/fuzz/FuzzFormat/c0259baa5439270c
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("package A\n//\n//0\n//`0``0``````0`0`0\nfunc A()")
+int64(-36)

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -822,9 +822,9 @@ func (p *GoPrinter) VisitUnary(unary *java.Unary, param any) java.J {
 	if unary.Operator.Element == java.PostIncrement || unary.Operator.Element == java.PostDecrement || unary.Operator.Element == java.SpreadPostfix {
 		p.Visit(unary.Operand, out)
 		p.visitSpace(unary.Operator.Before, out)
-		out.Append(unaryOperatorString(unary.Operator.Element))
+		out.Append(UnaryOperatorString(unary.Operator.Element))
 	} else {
-		out.Append(unaryOperatorString(unary.Operator.Element))
+		out.Append(UnaryOperatorString(unary.Operator.Element))
 		p.Visit(unary.Operand, out)
 	}
 	p.afterSyntax(unary.Markers, out)
@@ -1501,7 +1501,8 @@ func assignmentOperatorString(op java.AssignmentOperator) string {
 	}
 }
 
-func unaryOperatorString(op java.UnaryOperator) string {
+// UnaryOperatorString returns the source text of a unary operator.
+func UnaryOperatorString(op java.UnaryOperator) string {
 	switch op {
 	case java.Negate:
 		return "-"


### PR DESCRIPTION
## Motivation

`FuzzFormat` is meant to protect the Go formatter's whitespace handling — the one thing the corpus tests cannot cover, since gofmt normalizes odd spacing away before it ever reaches a fixture. It was testing nothing. `reWhitespace`, the mutator that re-whitespaces a valid source before handing it to the formatter, always returned `("", false)`, so every input was discarded before the formatter ran.

Go inserts an implicit semicolon at the end of essentially every line. The scanner reports it as `lit == "\n"` occupying no source text, so the mutator correctly sets `width = 0` — but the guard below then compared `src[offset:offset+0]`, the empty string, against `lit`, `"\n"`, and bailed. Every non-trivial input failed on its first statement, and the target had never executed against mutated input since it was written.

With the mutator fixed, the fuzzer immediately found four pre-existing formatter bugs, two of which emit Go that does not parse and one of which silently comments out the rest of a file.

## Summary

**The fuzzer**

- Exempt the implicit semicolon from the source-text guard: it has no source text to compare against.

**The bugs it found** — each with a regression test and its corpus seed

- **Doc comment runs split by indentation.** `docCommentRun` required exactly `"\n"` between comment lines, but go/ast groups comments by line, not column, so an indented continuation line started a new run. Formatting only the tail handed `go/doc/comment` a text that package itself rewrites on a second pass, making the formatter non-idempotent on input where gofmt is stable. Interior lines now stay in the run; the run must still abut its token across a single line break, matching go/printer's `posFor(comment.End()+1) == next`.
- **A comment trailing another comment on the same line taken as a doc comment.** `package A/**/ //\nfunc A()` dropped the `//` and the line break it carried, emitting `package A/**/ func A()`, which does not parse. A run that does not begin a line documents nothing.
- **Unary operator fused with its operand.** `SpacesVisitor` cleared the operand's leading space unconditionally, turning `+ +0` into `++0` and `- -0` into `--0`. Both fail to parse. The space is now kept where operator and operand would lex as one token, which is what gofmt does.
- **Binary operator fused with a following unary operator.** `walkBinary` mirrors go/printer's `"/*"`, `"&&"`, `"&^"` problem table, but `unaryOperator` only inspected `java.Unary` while Go parses `&`, `*` and `<-` into `golang.Unary`, so those pairs never matched. `0%0&&0& &0` lost a token, and `0%0&&0/ *p` became `0/*p` — a comment swallowing the remainder of the file.

**Supporting**

- `unaryOperatorString` is exported as `UnaryOperatorString` so the formatter can spell the operator it is about to write.

## Test plan

- [x] `reWhitespace` confirmed broken before the fix by direct instrumentation, and confirmed to reach the formatter after: 1200 of 1200 mutations survive the parser/printer round-trip gate and every one is changed by the formatter.
- [x] Each of the four bugs reproduced with a failing test written before its fix.
- [x] `go test ./...` green.
- [x] 30-minute fuzz run, 104M executions, no failures. The four corpus seeds run under plain `go test`.
- [x] `go test -tags gofmtaudit ./pkg/format/`: `TestCanonicalInputUnchanged` passes — the doc comment and minimum spacing passes rewrite 0 of 5333 gofmt-clean stdlib files, and the full pipeline stays at its damage ceiling of 3. `TestShapeshiftAudit` passes.
- [x] `go test -tags parityaudit ./pkg/printer/...` passes.
- [x] Unary and binary spacing expectations pinned against real `gofmt` output rather than hand-written.
- [x] Benchmarked: no measurable change in formatting time, +0.5% allocations.

`TestParityGap` fails at 4404 against a floor of 4405. This is pre-existing Go 1.26.6 stdlib drift, confirmed identical on the unmodified base with these changes stashed, and untouched here.
