### PR TITLE
Yaml: only treat `%` at the start of a line as a directive

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -1162,7 +1162,7 @@ public class YamlParser implements org.openrewrite.Parser {
             char c = input.charAt(i);
 
             if (!inDirective) {
-                if (c == '%') {
+                if (c == '%' && (i == 0 || input.charAt(i - 1) == '\n' || input.charAt(i - 1) == '\r')) {
                     inDirective = true;
                     i++;
                 } else {
@@ -1247,6 +1247,12 @@ public class YamlParser implements org.openrewrite.Parser {
                     inDirective = false;
                 } else {
                     value.append(c);
+                    i++;
+                }
+            } else if (c == '#') {
+                // A comment line may precede directives, so treat it as prefix rather than as content
+                while (i < source.length() && source.charAt(i) != '\n' && source.charAt(i) != '\r') {
+                    prefix.append(source.charAt(i));
                     i++;
                 }
             } else if (c == '-' && i + 2 < source.length() &&

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/DirectiveTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/DirectiveTest.java
@@ -137,6 +137,68 @@ class DirectiveTest implements RewriteTest {
     }
 
     @Test
+    void percentInLeadingCommentIsNotADirective() {
+        rewriteRun(
+          yaml(
+            """
+              # 100%
+
+              key: value
+              """,
+            spec -> spec.afterRecipe(y -> assertThat(y.getDocuments().getFirst().getDirectives()).isEmpty())
+          )
+        );
+    }
+
+    @Test
+    void percentInLeadingCommentBeforeSequence() {
+        rewriteRun(
+          yaml(
+            """
+              # 100%
+
+              - a
+              """,
+            spec -> spec.afterRecipe(y -> assertThat(y.getDocuments().getFirst().getDirectives()).isEmpty())
+          )
+        );
+    }
+
+    @Test
+    void percentAtStartOfLeadingComment() {
+        rewriteRun(
+          yaml(
+            """
+              #%
+              # other
+
+              key: value
+              """,
+            spec -> spec.afterRecipe(y -> assertThat(y.getDocuments().getFirst().getDirectives()).isEmpty())
+          )
+        );
+    }
+
+    @Test
+    void directiveAfterLeadingComment() {
+        rewriteRun(
+          yaml(
+            """
+              # comment
+              %YAML 1.2
+              ---
+              key: value
+              """,
+            spec -> spec.afterRecipe(y -> {
+                Yaml.Document doc = y.getDocuments().getFirst();
+                assertThat(doc.getDirectives()).hasSize(1);
+                assertThat(doc.getDirectives().getFirst().getValue()).isEqualTo("YAML 1.2");
+            })
+          )
+        );
+    }
+
+    @Test
     void directiveCopyPaste() {
         // given
         var original = new Yaml.Directive(


### PR DESCRIPTION
- Fixes #8560

### Problem

A comment before the first (implicit) document containing a `%` was parsed as a directive:

```yaml
# 100%

key: value
```

printed back as

```yaml

# 100%
key: value
```

- `Parser.requirePrintEqualsInput` then rejects the file and it becomes a `ParseError` — so any YAML whose header comment block contains a percent-encoded URL or prose like `# 100% coverage` drops out of the LST entirely. Introduced by #6529 (v8.72.0).

### Fix

`YamlParser.parseDirectivesFromPrefix` scanned for `%` anywhere in the document prefix. It now applies the same "must be at the start of a line" guard that its sibling `preScanDirectives` already had.

While testing this I found a second, related bug: `preScanDirectives` treated a leading comment line as document content and skipped past everything up to the next `---`, so a directive following a comment was never pre-scanned. It then fell back to reconstructing the directive from SnakeYAML's `DocumentStartEvent`, whose `DumperOptions.Version` enum has no `1.2` — so

```yaml
# comment
%YAML 1.2
---
key: value
```

round-tripped as `%YAML 1.1`. `preScanDirectives` now accumulates a comment line into the pending directive prefix instead, keeping the directive's exact source text.

### Tests

Four cases added to `DirectiveTest`, covering the variants from the issue (comment before a mapping, before a sequence, a comment starting with `%`) plus the directive-after-comment case above. All four fail on `main`.