### PR TITLE
Xml: reject attributes that only exist because of ANTLR error recovery

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -393,27 +393,23 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
     @Override
     public Xml.Attribute visitAttribute(XMLParser.AttributeContext ctx) {
         return convert(ctx, (c, prefix) -> {
-            requireWellFormedAttribute(isBlank(prefix), c);
+            requireWellFormedAttribute(isBlank(prefix) && isSourceToken(c.Name()) &&
+                                       isSourceToken(c.EQUALS()) && isSourceToken(c.STRING()), c);
 
-            requireWellFormedAttribute(isSourceToken(c.Name()), c);
             Xml.Ident key = convert(c.Name(), (t, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, t.getText()));
 
-            requireWellFormedAttribute(isSourceToken(c.EQUALS()), c);
             String beforeEquals = convert(c.EQUALS(), (e, p) -> p);
-            requireWellFormedAttribute(isBlank(beforeEquals), c);
 
-            requireWellFormedAttribute(isSourceToken(c.STRING()), c);
-            Xml.Attribute.Value value = convert(c.STRING(), (v, p) -> {
-                        requireWellFormedAttribute(isBlank(p), c);
-                        return new Xml.Attribute.Value(
-                                randomId(),
-                                p,
-                                Markers.EMPTY,
-                                v.getText().startsWith("'") ? Xml.Attribute.Value.Quote.Single : Xml.Attribute.Value.Quote.Double,
-                                v.getText().substring(1, c.STRING().getText().length() - 1)
-                        );
-                    }
+            Xml.Attribute.Value value = convert(c.STRING(), (v, p) -> new Xml.Attribute.Value(
+                            randomId(),
+                            p,
+                            Markers.EMPTY,
+                            v.getText().startsWith("'") ? Xml.Attribute.Value.Quote.Single : Xml.Attribute.Value.Quote.Double,
+                            v.getText().substring(1, c.STRING().getText().length() - 1)
+                    )
             );
+
+            requireWellFormedAttribute(isBlank(beforeEquals) && isBlank(value.getPrefix()), c);
 
             return new Xml.Attribute(randomId(), prefix, Markers.EMPTY, key, beforeEquals, value);
         });

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -17,6 +17,7 @@ package org.openrewrite.xml.internal;
 
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.jspecify.annotations.Nullable;
@@ -381,6 +382,8 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                         }
                     }
 
+                    requireWellFormedAttribute(isBlank(beforeTagDelimiterPrefix), c);
+
                     return new Xml.Tag(randomId(), prefix, markers, name, attributes,
                             content, closeTag, beforeTagDelimiterPrefix);
                 }
@@ -390,21 +393,67 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
     @Override
     public Xml.Attribute visitAttribute(XMLParser.AttributeContext ctx) {
         return convert(ctx, (c, prefix) -> {
+            requireWellFormedAttribute(isBlank(prefix), c);
+
+            requireWellFormedAttribute(isSourceToken(c.Name()), c);
             Xml.Ident key = convert(c.Name(), (t, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, t.getText()));
 
+            requireWellFormedAttribute(isSourceToken(c.EQUALS()), c);
             String beforeEquals = convert(c.EQUALS(), (e, p) -> p);
+            requireWellFormedAttribute(isBlank(beforeEquals), c);
 
-            Xml.Attribute.Value value = convert(c.STRING(), (v, p) -> new Xml.Attribute.Value(
-                            randomId(),
-                            p,
-                            Markers.EMPTY,
-                            v.getText().startsWith("'") ? Xml.Attribute.Value.Quote.Single : Xml.Attribute.Value.Quote.Double,
-                            v.getText().substring(1, c.STRING().getText().length() - 1)
-                    )
+            requireWellFormedAttribute(isSourceToken(c.STRING()), c);
+            Xml.Attribute.Value value = convert(c.STRING(), (v, p) -> {
+                        requireWellFormedAttribute(isBlank(p), c);
+                        return new Xml.Attribute.Value(
+                                randomId(),
+                                p,
+                                Markers.EMPTY,
+                                v.getText().startsWith("'") ? Xml.Attribute.Value.Quote.Single : Xml.Attribute.Value.Quote.Double,
+                                v.getText().substring(1, c.STRING().getText().length() - 1)
+                        );
+                    }
             );
 
             return new Xml.Attribute(randomId(), prefix, Markers.EMPTY, key, beforeEquals, value);
         });
+    }
+
+    /**
+     * Whether a node is a token that actually appeared in the source, as opposed to absent or
+     * synthesized by ANTLR error recovery. Recovery may insert a token that was never written
+     * (which the printer would then emit as though it had been) or leave the rule's children
+     * out entirely, so neither is safe to build an LST from.
+     */
+    private boolean isSourceToken(@Nullable TerminalNode node) {
+        return node != null && !(node instanceof ErrorNode);
+    }
+
+    private boolean isBlank(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            if (!Character.isWhitespace(text.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Reject an attribute that ANTLR only produced by recovering from malformed markup. Accepting one
+     * yields an {@link Xml.Attribute} that is not in the source: a key or value invented outright, or a
+     * value silently truncated at the point the markup went wrong. Such a tree can still reprint
+     * byte-for-byte, because the dropped source survives in a neighbouring prefix, so
+     * {@code requirePrintEqualsInput} does not catch it and any recipe editing the tag corrupts the file.
+     */
+    private void requireWellFormedAttribute(boolean wellFormed, ParserRuleContext ctx) {
+        if (!wellFormed) {
+            Token start = ctx.getStart();
+            throw new IllegalStateException(String.format(
+                    "Malformed attribute in %s at line %d, column %d. This is most often caused by a literal '\"' " +
+                    "inside a double-quoted attribute value, which XML 1.0 section 2.3 does not permit; write it as " +
+                    "&quot; or delimit the value with single quotes.",
+                    path, start.getLine(), start.getCharPositionInLine() + 1));
+        }
     }
 
     @Override

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -420,10 +420,8 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
     }
 
     /**
-     * Whether a node is a token that actually appeared in the source, as opposed to absent or
-     * synthesized by ANTLR error recovery. Recovery may insert a token that was never written
-     * (which the printer would then emit as though it had been) or leave the rule's children
-     * out entirely, so neither is safe to build an LST from.
+     * Whether a node is a token that appeared in the source, rather than one ANTLR error recovery
+     * synthesized (marked as an {@link ErrorNode}) or left out altogether.
      */
     private boolean isSourceToken(@Nullable TerminalNode node) {
         return node != null && !(node instanceof ErrorNode);
@@ -439,11 +437,9 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
     }
 
     /**
-     * Reject an attribute that ANTLR only produced by recovering from malformed markup. Accepting one
-     * yields an {@link Xml.Attribute} that is not in the source: a key or value invented outright, or a
-     * value silently truncated at the point the markup went wrong. Such a tree can still reprint
-     * byte-for-byte, because the dropped source survives in a neighbouring prefix, so
-     * {@code requirePrintEqualsInput} does not catch it and any recipe editing the tag corrupts the file.
+     * Reject an attribute ANTLR only produced by recovering from malformed markup, which describes
+     * something other than the source. Such a tree can still reprint byte-for-byte, since the dropped
+     * source survives in a neighbouring prefix, so {@code requirePrintEqualsInput} does not catch it.
      */
     private void requireWellFormedAttribute(boolean wellFormed, ParserRuleContext ctx) {
         if (!wellFormed) {

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -22,6 +22,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.FileAttributes;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.xml.internal.grammar.XMLParser;
 import org.openrewrite.xml.internal.grammar.XMLParserBaseVisitor;
@@ -200,13 +201,16 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                     List<Xml.Attribute> attributes = ctx.attribute().stream()
                             .map(this::visitAttribute)
                             .collect(toList());
+                    String beforeTagDelimiterPrefix = prefix(ctx.getStop());
+                    requireWellFormedAttribute(StringUtils.isBlank(beforeTagDelimiterPrefix), c);
+
                     return new Xml.XmlDecl(
                             randomId(),
                             prefix,
                             Markers.EMPTY,
                             name,
                             attributes,
-                            prefix(ctx.getStop())
+                            beforeTagDelimiterPrefix
                     );
                 }
         );
@@ -250,6 +254,8 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
             String beforeType = prefix(ctx.Name());
             String type = convert(ctx.Name(), (n, p) -> n.getText());
             List<Xml.Attribute> attributes = ctx.attribute().stream().map(this::visitAttribute).collect(toList());
+            String beforeDirectiveClose = prefix(ctx.DIRECTIVE_CLOSE());
+            requireWellFormedAttribute(StringUtils.isBlank(beforeDirectiveClose), c);
 
             return new Xml.JspDirective(
                     randomId(),
@@ -258,7 +264,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                     beforeType,
                     type,
                     attributes,
-                    prefix(ctx.DIRECTIVE_CLOSE())
+                    beforeDirectiveClose
             );
         });
     }
@@ -382,7 +388,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                         }
                     }
 
-                    requireWellFormedAttribute(isBlank(beforeTagDelimiterPrefix), c);
+                    requireWellFormedAttribute(StringUtils.isBlank(beforeTagDelimiterPrefix), c);
 
                     return new Xml.Tag(randomId(), prefix, markers, name, attributes,
                             content, closeTag, beforeTagDelimiterPrefix);
@@ -393,7 +399,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
     @Override
     public Xml.Attribute visitAttribute(XMLParser.AttributeContext ctx) {
         return convert(ctx, (c, prefix) -> {
-            requireWellFormedAttribute(isBlank(prefix) && isSourceToken(c.Name()) &&
+            requireWellFormedAttribute(StringUtils.isBlank(prefix) && isSourceToken(c.Name()) &&
                                        isSourceToken(c.EQUALS()) && isSourceToken(c.STRING()), c);
 
             Xml.Ident key = convert(c.Name(), (t, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, t.getText()));
@@ -409,7 +415,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                     )
             );
 
-            requireWellFormedAttribute(isBlank(beforeEquals) && isBlank(value.getPrefix()), c);
+            requireWellFormedAttribute(StringUtils.isBlank(beforeEquals) && StringUtils.isBlank(value.getPrefix()), c);
 
             return new Xml.Attribute(randomId(), prefix, Markers.EMPTY, key, beforeEquals, value);
         });
@@ -423,15 +429,6 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
         return node != null && !(node instanceof ErrorNode);
     }
 
-    private boolean isBlank(String text) {
-        for (int i = 0; i < text.length(); i++) {
-            if (!Character.isWhitespace(text.charAt(i))) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /**
      * Reject an attribute ANTLR only produced by recovering from malformed markup, which describes
      * something other than the source. Such a tree can still reprint byte-for-byte, since the dropped
@@ -441,9 +438,10 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
         if (!wellFormed) {
             Token start = ctx.getStart();
             throw new IllegalStateException(String.format(
-                    "Malformed attribute in %s at line %d, column %d. This is most often caused by a literal '\"' " +
-                    "inside a double-quoted attribute value, which XML 1.0 section 2.3 does not permit; write it as " +
-                    "&quot; or delimit the value with single quotes.",
+                    "Malformed attribute in %s at line %d, column %d. The markup here is not a well-formed " +
+                    "name=\"value\" attribute; common causes are a literal '\"' inside a double-quoted value, which " +
+                    "XML 1.0 section 2.3 does not permit (write it as &quot; or delimit the value with single " +
+                    "quotes), an unquoted value, or an HTML-style attribute written without a value.",
                     path, start.getLine(), start.getCharPositionInLine() + 1));
         }
     }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -421,19 +421,14 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
         });
     }
 
-    /**
-     * Whether a node is a token that appeared in the source, rather than one ANTLR error recovery
-     * synthesized (marked as an {@link ErrorNode}) or left out altogether.
-     */
+    /// Whether a node is a token from the source, rather than one ANTLR error recovery
+    /// synthesized (an [ErrorNode]) or left out altogether.
     private boolean isSourceToken(@Nullable TerminalNode node) {
         return node != null && !(node instanceof ErrorNode);
     }
 
-    /**
-     * Reject an attribute ANTLR only produced by recovering from malformed markup, which describes
-     * something other than the source. Such a tree can still reprint byte-for-byte, since the dropped
-     * source survives in a neighbouring prefix, so {@code requirePrintEqualsInput} does not catch it.
-     */
+    /// Reject an attribute ANTLR only produced by recovering from malformed markup. Such a tree can still
+    /// reprint byte-for-byte — the dropped source survives in a prefix — so `requirePrintEqualsInput` misses it.
     private void requireWellFormedAttribute(boolean wellFormed, ParserRuleContext ctx) {
         if (!wellFormed) {
             Token start = ctx.getStart();

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/internal/XmlParserVisitor.java
@@ -202,7 +202,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                             .map(this::visitAttribute)
                             .collect(toList());
                     String beforeTagDelimiterPrefix = prefix(ctx.getStop());
-                    requireWellFormedAttribute(StringUtils.isBlank(beforeTagDelimiterPrefix), c);
+                    requireWellFormedAttribute(isXmlWhitespace(beforeTagDelimiterPrefix), c);
 
                     return new Xml.XmlDecl(
                             randomId(),
@@ -255,7 +255,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
             String type = convert(ctx.Name(), (n, p) -> n.getText());
             List<Xml.Attribute> attributes = ctx.attribute().stream().map(this::visitAttribute).collect(toList());
             String beforeDirectiveClose = prefix(ctx.DIRECTIVE_CLOSE());
-            requireWellFormedAttribute(StringUtils.isBlank(beforeDirectiveClose), c);
+            requireWellFormedAttribute(isXmlWhitespace(beforeDirectiveClose), c);
 
             return new Xml.JspDirective(
                     randomId(),
@@ -388,7 +388,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                         }
                     }
 
-                    requireWellFormedAttribute(StringUtils.isBlank(beforeTagDelimiterPrefix), c);
+                    requireWellFormedAttribute(isXmlWhitespace(beforeTagDelimiterPrefix), c);
 
                     return new Xml.Tag(randomId(), prefix, markers, name, attributes,
                             content, closeTag, beforeTagDelimiterPrefix);
@@ -399,7 +399,7 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
     @Override
     public Xml.Attribute visitAttribute(XMLParser.AttributeContext ctx) {
         return convert(ctx, (c, prefix) -> {
-            requireWellFormedAttribute(StringUtils.isBlank(prefix) && isSourceToken(c.Name()) &&
+            requireWellFormedAttribute(isXmlWhitespace(prefix) && isSourceToken(c.Name()) &&
                                        isSourceToken(c.EQUALS()) && isSourceToken(c.STRING()), c);
 
             Xml.Ident key = convert(c.Name(), (t, p) -> new Xml.Ident(randomId(), p, Markers.EMPTY, t.getText()));
@@ -415,10 +415,16 @@ public class XmlParserVisitor extends XMLParserBaseVisitor<Xml> {
                     )
             );
 
-            requireWellFormedAttribute(StringUtils.isBlank(beforeEquals) && StringUtils.isBlank(value.getPrefix()), c);
+            requireWellFormedAttribute(isXmlWhitespace(beforeEquals) && isXmlWhitespace(value.getPrefix()), c);
 
             return new Xml.Attribute(randomId(), prefix, Markers.EMPTY, key, beforeEquals, value);
         });
+    }
+
+    /// Whether text is XML `S`, the only thing that may separate a tag's name, attributes and delimiter.
+    /// Stricter than `StringUtils.isBlank`, which accepts characters the `INSIDE`-mode lexer never skips.
+    private boolean isXmlWhitespace(String text) {
+        return StringUtils.indexOfNonWhitespace(text) == -1;
     }
 
     /// Whether a node is a token from the source, rather than one ANTLR error recovery

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -417,14 +417,9 @@ class XmlParserTest implements RewriteTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
-      // ANTLR inserts a missing '=', which the printer then emits: `abc` becomes `abc=`
       "<t k=\"\" abc \"v\"/>",
-      // ANTLR drops the rule's children, leaving the attribute without an '=' or a value
       "<t k=\"\" a b \"v\"/>",
-      // ANTLR resyncs past the `1`, silently truncating the attribute value; this still reprints
-      // byte-for-byte, so only the checks in XmlParserVisitor catch it
       "<t k=\"\" x = 1 \"v\"/>",
-      // no attribute is recovered at all; the stray tokens are swallowed before the tag delimiter
       "<t k=\"\" 10.0.0.1 \"v\"/>",
     })
     void malformedAttributeIsNotSilentlyAccepted(@Language("xml") String source) {
@@ -438,9 +433,6 @@ class XmlParserTest implements RewriteTest {
 
     @Test
     void attributeValueWithUnescapedQuotes() {
-        // An embedded expression whose string literals are not escaped leaves the attribute value
-        // unrepresentable, so the document has to be rejected rather than parsed into a tree whose
-        // `value` attribute silently stops at the first quote.
         SourceFile parsed = XmlParser.builder().build()
           .parse(new InMemoryExecutionContext(t -> {
           }), """

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.ParseExceptionResult;
 import org.openrewrite.Parser.Input;
 import org.openrewrite.SourceFile;
 import org.openrewrite.test.RecipeSpec;
@@ -412,6 +413,67 @@ class XmlParserTest implements RewriteTest {
           .findFirst().orElseThrow();
         assertThat(parsed).isInstanceOf(ParseError.class);
         assertThat(parsed.printAll()).isEqualTo("<root>\n<br>\n</root>");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      // ANTLR inserts a missing '=', which the printer then emits: `abc` becomes `abc=`
+      "<t k=\"\" abc \"v\"/>",
+      // ANTLR drops the rule's children, leaving the attribute without an '=' or a value
+      "<t k=\"\" a b \"v\"/>",
+      // ANTLR resyncs past the `1`, silently truncating the attribute value; this still reprints
+      // byte-for-byte, so only the checks in XmlParserVisitor catch it
+      "<t k=\"\" x = 1 \"v\"/>",
+      // no attribute is recovered at all; the stray tokens are swallowed before the tag delimiter
+      "<t k=\"\" 10.0.0.1 \"v\"/>",
+    })
+    void malformedAttributeIsNotSilentlyAccepted(@Language("xml") String source) {
+        SourceFile parsed = XmlParser.builder().build()
+          .parse(new InMemoryExecutionContext(t -> {
+          }), source)
+          .findFirst().orElseThrow();
+        assertThat(parsed).isInstanceOf(ParseError.class);
+        assertThat(parsed.printAll()).isEqualTo(source);
+    }
+
+    @Test
+    void attributeValueWithUnescapedQuotes() {
+        // An embedded expression whose string literals are not escaped leaves the attribute value
+        // unrepresentable, so the document has to be rejected rather than parsed into a tree whose
+        // `value` attribute silently stops at the first quote.
+        SourceFile parsed = XmlParser.builder().build()
+          .parse(new InMemoryExecutionContext(t -> {
+          }), """
+            <policies>
+                <inbound>
+                    <set-variable name="allowedIps" value="@{
+                        string ips = "";
+                        ips += "10.0.0.1,";
+                        return ips;
+                    }" />
+                </inbound>
+            </policies>
+            """)
+          .findFirst().orElseThrow();
+        assertThat(parsed).isInstanceOf(ParseError.class);
+        assertThat(parsed.getMarkers().findFirst(ParseExceptionResult.class).orElseThrow().getMessage())
+          .contains("Malformed attribute");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+      "<set-variable value='@{ string ips = \"\"; ips += \"10.0.0.1,\"; return ips; }'/>",
+      "<set-variable value=\"@{ string ips = &quot;10.0.0.1&quot;; return ips; }\"/>",
+    })
+    void wellFormedEmbeddedExpressionsKeepTheirFullValue(@Language("xml") String source) {
+        SourceFile parsed = XmlParser.builder().build()
+          .parse(new InMemoryExecutionContext(t -> {
+          }), source)
+          .findFirst().orElseThrow();
+        assertThat(parsed).isInstanceOf(Xml.Document.class);
+        assertThat(((Xml.Document) parsed).getRoot().getAttributes().get(0).getValueAsString())
+          .contains("10.0.0.1")
+          .endsWith("}");
     }
 
     @Issue("https://github.com/openrewrite/rewrite/issues/2189")

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -423,6 +423,7 @@ class XmlParserTest implements RewriteTest {
       "<t k=\"\" 10.0.0.1 \"v\"/>",
       "<t k=\"\" \"orphan\"/>",
       "<?xml version=\"1.0\" \"orphan\"?><t/>",
+      "<t k=\"\"\fabc=\"v\"/>",
     })
     void malformedAttributeIsNotSilentlyAccepted(@Language("xml") String source) {
         SourceFile parsed = XmlParser.builder().build()

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/XmlParserTest.java
@@ -421,6 +421,8 @@ class XmlParserTest implements RewriteTest {
       "<t k=\"\" a b \"v\"/>",
       "<t k=\"\" x = 1 \"v\"/>",
       "<t k=\"\" 10.0.0.1 \"v\"/>",
+      "<t k=\"\" \"orphan\"/>",
+      "<?xml version=\"1.0\" \"orphan\"?><t/>",
     })
     void malformedAttributeIsNotSilentlyAccepted(@Language("xml") String source) {
         SourceFile parsed = XmlParser.builder().build()
@@ -429,6 +431,8 @@ class XmlParserTest implements RewriteTest {
           .findFirst().orElseThrow();
         assertThat(parsed).isInstanceOf(ParseError.class);
         assertThat(parsed.printAll()).isEqualTo(source);
+        assertThat(parsed.getMarkers().findFirst(ParseExceptionResult.class).orElseThrow().getMessage())
+          .contains("Malformed attribute");
     }
 
     @Test


### PR DESCRIPTION
## What's wrong

`XMLParser.g4` applies `attribute : Name '=' STRING` to whatever the lexer produces. On malformed markup ANTLR error recovery reaches that rule with tokens that were never written, and `XmlParserVisitor.visitAttribute` built an `Xml.Attribute` from the result without checking. That goes wrong three different ways:

| Input | Recovery | Result |
|---|---|---|
| `<t k="" abc "v"/>` | inserts the missing `=` | `XmlPrinter` re-emits it — the document reprints as `<t k="" abc="v"/>` |
| `<t k="" a b "v"/>` | drops the rule's children | `c.EQUALS()` is null → `NullPointerException` in `convert` |
| `<t k="" x = 1 "v"/>` | resyncs past the `1` | **silently accepted** as `k=""` plus an invented `x="v"` |

The third is the one that matters. The dropped source survives in the neighbouring prefix, so the document reprints byte-for-byte and `requirePrintEqualsInput` never fires. The file is parsed, cached, and searched with an attribute value that is not what the source says.

## Why it shows up in practice

The usual trigger is an embedded expression containing unescaped double quotes — common in generated or hand-written config that carries a scripting snippet in an attribute:

```xml
<set-variable name="allowedIps" value="@{
    string ips = "";
    ips += "10.0.0.1,";
    ips += "10.0.0.2";
    return ips;
}" />
```

`STRING` is `'"' ~[<"]* '"'`, so this value is not representable — XML 1.0 §2.3 does not permit a literal `"` inside a `"`-delimited value, and `xmllint` rejects the file too. The lexer therefore re-tokenises the value into alternating `STRING` runs with stray tokens in the gaps, and the table above decides which symptom you get. Which one is essentially arbitrary: it depends only on the token shape of whatever sits inside the expression's string literals.

On `main` today, that document parses **without error**, reprints byte-for-byte, and yields:

```
[set-variable name=<allowedIps>]
[set-variable value=<@{
    string ips = >]
```

The value stops at the first quote — the addresses are not in the LST at all. A search recipe reading `value` finds nothing and reports a clean result. Worse, a recipe that *writes* the attribute writes the truncated value back: `ChangeTagAttribute("set-variable", "value", "REDACTED")` currently emits

```xml
<set-variable name="allowedIps" value="REDACTED"";
    ips += "10.0.0.1,";
    ips += "10.0.0.2";
    return ips;
}" />
```

which is no longer valid XML.

## The fix

Require that an attribute is built only from tokens that actually appeared in the source, and that nothing but whitespace separates them:

- each of `Name`, `EQUALS`, `STRING` must be present and not an ANTLR `ErrorNode` (recovery marks inserted tokens as error nodes, so this catches the invented `=` and the null dereference)
- the attribute's prefix, `beforeEquals`, and the value's prefix must be whitespace only (this catches tokens that recovery dropped, which is what silently truncates the value)
- the same whitespace requirement applies to the trailing prefix of each rule that accepts attributes — an element's `beforeTagDelimiterPrefix`, and the equivalents in `visitXmldecl` and `visitJspdirective` — for the case where recovery produces no attribute at all and the stray tokens are swallowed before the closing delimiter

Otherwise the parse fails with a message naming the actual problem:

```
Malformed attribute in policy.xml at line 3, column 9. The markup here is not a well-formed
name="value" attribute; common causes are a literal '"' inside a double-quoted value, which
XML 1.0 section 2.3 does not permit (write it as &quot; or delimit the value with single
quotes), an unquoted value, or an HTML-style attribute written without a value.
```

The separator check matches XML 1.0's `S` production (`#x20 | #x9 | #xD | #xA`) exactly, via
`StringUtils.indexOfNonWhitespace`, rather than `StringUtils.isBlank` — which also accepts `\f`, vertical tab
and non-ASCII Unicode spaces. Inside a tag the lexer skips only `[ \t\r\n]` (`XMLLexer.g4`, `mode INSIDE`),
so a separator holding any other "whitespace" is not whitespace the lexer consumed; it is a character it
failed to match and dropped. Both halves are needed, and neither alone is sufficient. The whitespace checks catch tokens recovery *dropped* — that is what silently truncates the value. The `ErrorNode` check catches tokens recovery *inserted*; there is nothing wrong with any prefix in `<t k="" abc "v"/>`, so a whitespace check cannot see it. Disabling either half locally lets two of the six regression cases through.

`XmlPrinter.visitAttribute` still appends `'='` unconditionally. With this check in place no `Xml.Attribute` can reach it without a real `=` in the source, so it is no longer reachable as a bug; making the `=` optional in the LST would be a much larger change for no gain today.

## Behaviour change

Documents matching the third row above previously parsed into an `Xml.Document` and now become a `ParseError`. That is the point of the change — they were being parsed into a tree that did not describe the source — but it does mean files that used to ingest "successfully" will start reporting. The first two rows already failed, just less legibly (`is not print idempotent`, or an NPE); they now carry an actionable message.

Well-formed spellings are unaffected and keep their full value, so there is a clear path for anyone hitting this:

```xml
<set-variable value='@{ string ips = ""; ips += "10.0.0.1,"; return ips; }'/>
<set-variable value="@{ string ips = &quot;10.0.0.1&quot;; return ips; }"/>
```

## Notes on provenance

The invented `=` and the `NullPointerException` date to the original XML module and only became visible as parse failures once `requirePrintEqualsInput` landed in 8.1.14 (#3459).

The silent truncation is newer. Bisecting released versions (8.1.14 → 8.91.0-SNAPSHOT) puts it at **8.84.4**: before that the same input failed loudly, after it the file is quietly accepted with a truncated value. The only `rewrite-xml` change in that range is #7906, which left-factored the `element` rule to support HTML void elements. The feature itself is correctly gated behind `htmlMode`, but the grammar restructuring it needed is not, so it changed ANTLR's error recovery for the `attribute*` loop in strict XML too. Worth keeping in mind for future grammar refactors — a change that looks purely structural can move which malformed inputs get rejected.

## Testing

Added to `XmlParserTest`:
- `malformedAttributeIsNotSilentlyAccepted` — six recovery shapes (including an orphan string in a tag and in an xmldecl) become a `ParseError`, still print verbatim, and carry the new message
- `attributeValueWithUnescapedQuotes` — the embedded-expression document above, asserting the message
- `wellFormedEmbeddedExpressionsKeepTheirFullValue` — `&quot;` and single-quoted delimiters keep the whole value

`:rewrite-xml:test` and `:rewrite-maven:test` pass. The pre-existing `malformedBareAmpersandDoesNotThrow` / `malformedUnterminatedEndTagDoesNotThrow` / `malformedMissingRootCloseDoesNotThrow` cases still pass, so lenient handling of other malformed input is unchanged.

On the separator character set specifically: `isBlank` and `indexOfNonWhitespace` differ only on
all-whitespace strings containing at least one of 21 characters (`\f`, vertical tab, and 19 non-ASCII
whitespace characters). No file under `rewrite-xml/src/test` or `rewrite-maven/src/test` contains any of
them, raw or as a Java escape, apart from the case added here — so no existing test input can take a
different path.

Two checks on the blast radius of the added strictness:

- Parsing 12,409 XML and POM files from a local `~/.m2/repository` (1,720) and Gradle module cache (10,689) with the patched parser produces zero parse errors, so the guards do not fire on ordinary well-formed XML.
- Differentially probing the old and new visitor over shapes the guards newly reject — HTML boolean attributes, unquoted values, JSP dynamic attributes, `<root a/>` — shows every one of them was **already** a `ParseError` before this change. For those the PR replaces an NPE or an idempotency failure with a readable message. The only previously-successful shapes that now fail are genuinely malformed: `<t a=="1"/>`, and orphan strings inside a tag.
