### PR TITLE
Java: fix two comment-scanning defects that drop modifiers from the LST

### DIFF
--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -2208,7 +2208,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
@@ -2333,7 +2333,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;

--- a/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
+++ b/rewrite-java-11/src/main/java/org/openrewrite/java/isolated/ReloadableJava11ParserVisitor.java
@@ -2186,6 +2186,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         boolean afterFirstModifier = false;
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         final AtomicReference<String> word = new AtomicReference<>("");
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
@@ -2212,12 +2213,14 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
@@ -2321,6 +2324,7 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> annotations = new ArrayList<>();
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         for (int i = cursor; i <= maxAnnotationPosition && i < source.length(); i++) {
             if (annotationPosTable.containsKey(i)) {
                 JCAnnotation jcAnnotation = annotationPosTable.get(i);
@@ -2337,12 +2341,14 @@ public class ReloadableJava11ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && i > 0 && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -2362,7 +2362,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
@@ -2485,7 +2485,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -2341,6 +2341,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         boolean afterFirstModifier = false;
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
 
@@ -2366,12 +2367,14 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
@@ -2473,6 +2476,7 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> annotations = new ArrayList<>();
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         for (int i = cursor; i <= maxAnnotationPosition && i < source.length(); i++) {
             if (annotationPosTable.containsKey(i)) {
                 JCAnnotation jcAnnotation = annotationPosTable.get(i);
@@ -2489,12 +2493,14 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && i > 0 && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -2400,7 +2400,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
@@ -2523,7 +2523,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -2379,6 +2379,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         boolean afterFirstModifier = false;
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
 
@@ -2404,12 +2405,14 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
@@ -2511,6 +2514,7 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> annotations = new ArrayList<>();
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         for (int i = cursor; i <= maxAnnotationPosition && i < source.length(); i++) {
             if (annotationPosTable.containsKey(i)) {
                 JCAnnotation jcAnnotation = annotationPosTable.get(i);
@@ -2527,12 +2531,14 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && i > 0 && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -2411,6 +2411,7 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         boolean afterFirstModifier = false;
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
 
@@ -2436,12 +2437,14 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
@@ -2543,6 +2546,7 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> annotations = new ArrayList<>();
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         for (int i = cursor; i <= maxAnnotationPosition && i < source.length(); i++) {
             if (annotationPosTable.containsKey(i)) {
                 JCAnnotation jcAnnotation = annotationPosTable.get(i);
@@ -2559,12 +2563,14 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && i > 0 && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -2432,7 +2432,7 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
@@ -2555,7 +2555,7 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -2190,7 +2190,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
@@ -2315,7 +2315,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 continue;
             }
             char c = source.charAt(i);
-            if (c == '/' && source.length() > i + 1) {
+            if (c == '/' && source.length() > i + 1 && !inComment && !inMultilineComment) {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;

--- a/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
+++ b/rewrite-java-8/src/main/java/org/openrewrite/java/ReloadableJava8ParserVisitor.java
@@ -2168,6 +2168,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         boolean afterFirstModifier = false;
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         final AtomicReference<String> word = new AtomicReference<>("");
         int afterLastModifierPosition = cursor;
         int lastAnnotationPosition = cursor;
@@ -2194,12 +2195,14 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;
@@ -2303,6 +2306,7 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
         List<J.Annotation> annotations = new ArrayList<>();
         boolean inComment = false;
         boolean inMultilineComment = false;
+        int multilineCommentStart = -1;
         for (int i = cursor; i <= maxAnnotationPosition && i < source.length(); i++) {
             if (annotationPosTable.containsKey(i)) {
                 JCAnnotation jcAnnotation = annotationPosTable.get(i);
@@ -2319,12 +2323,14 @@ public class ReloadableJava8ParserVisitor extends TreePathScanner<J, Space> {
                 char next = source.charAt(i + 1);
                 if (next == '*') {
                     inMultilineComment = true;
+                    multilineCommentStart = i;
                 } else if (next == '/') {
                     inComment = true;
                 }
             }
 
-            if (inMultilineComment && c == '/' && i > 0 && source.charAt(i - 1) == '*') {
+            // The closing `/` cannot be part of the opener, so `/*/` does not terminate a block comment.
+            if (inMultilineComment && c == '/' && i >= multilineCommentStart + 3 && source.charAt(i - 1) == '*') {
                 inMultilineComment = false;
             } else if (inComment && (c == '\n' || c == '\r')) {
                 inComment = false;

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
@@ -52,6 +52,52 @@ class CommentTest implements RewriteTest {
         );
     }
 
+    @Test
+    void multilineOpenerInsideSingleLineCommentBeforeMethodModifier() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  @Deprecated  //*not a block comment
+                  public String value() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multilineOpenerInsideSingleLineCommentBeforeMultipleModifiers() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  @Deprecated  //*not a block comment
+                  public static String value() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void multilineOpenerLaterInSingleLineCommentBeforeFieldModifier() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  @Deprecated  //see /*.java
+                  public int value = 1;
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4995")
     @Test
     void trailingComment() {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/CommentTest.java
@@ -98,6 +98,36 @@ class CommentTest implements RewriteTest {
         );
     }
 
+    @Test
+    void slashImmediatelyAfterMultilineOpenerBeforeModifier() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  @Deprecated /*/ not the end of the comment */ public String value() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void singleLineOpenerInsideMultilineCommentBeforeModifiers() {
+        rewriteRun(
+          java(
+            """
+              class Test {
+                  @Deprecated /* // */ public static String value() {
+                      return null;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4995")
     @Test
     void trailingComment() {


### PR DESCRIPTION
Two Java parser print-idempotency defects, found while triaging `ParseFailures` rows from a large ingest. Both surface as:

```
java.lang.IllegalStateException: <file> is not print idempotent.
	at org.openrewrite.Parser.requirePrintEqualsInput(Parser.java:52)
```

Both are broken comment-state tracking in the same two scanners, reached from opposite directions, so they're one PR with a commit each.

A third, unrelated defect from the same triage is split out to #8565.

---

## 1. `/*` inside a line comment latches the modifier scanner

`sortedModifiersAndAnnotations` and `collectAnnotations` walk the source between an annotation and the declaration that follows, to recover modifiers in source order. Their comment scanner sets `inMultilineComment` on `/*` without checking whether it is already inside a `//` comment:

```java
char c = source.charAt(i);
if (c == '/' && source.length() > i + 1) {
    char next = source.charAt(i + 1);
    if (next == '*') {
        inMultilineComment = true;   // fires on the second '/' of "//*"
    } else if (next == '/') {
        inComment = true;
    }
}
```

Walking `//*x`: the first `/` sets `inComment`, the second sees `next == '*'` and sets `inMultilineComment`. At the newline `inComment` is cleared but `inMultilineComment` is not, and nothing clears it short of a literal `*/`. The scan finds no modifier keywords, so the modifiers never enter the LST and the declaration's type is printed at the modifier's offset.

**Reproducer:**

```java
class Test {
    @Deprecated  //*not a block comment
    public String value() {
        return null;
    }
}
```

prints as:

```java
class Test {
    @Deprecated  //*not a block comment
    String String value() {
        return null;
    }
}
```

`String` and `public` are both 6 characters, so the clobber lands cleanly here. With a shorter type the leftover tail of `public` is emitted as the *name's* prefix — a `Step` return type prints as `Stepic Step`, and a 7-character `Tasklet` swallows the following space and prints as `TaskletTasklet`.

The `/*` can appear anywhere in the comment, not just immediately after the `//`. Fields are affected too (there the modifier is simply lost). A real `/* ... */` later on clears the state and masks the bug.

**Scope:** not a regression — the scanner dates back to `a59e6e970f` (2021) and this reproduces on every release since. Present identically in the Java 8, 11, 17, 21 and 25 parsers; all five are fixed here, and the test is in the TCK so it runs against each.

**Fix:** guard the opener against re-entering comment state.

## 2. `/*/` closes a block comment it shouldn't

Same two scanners, opposite direction from (1). The close condition only checked that the previous character was `*`:

```java
if (inMultilineComment && c == '/' && source.charAt(i - 1) == '*') {
```

The third character of `/*/` satisfies that, so the scanner leaves comment state while still inside the comment, then reads the comment body as modifiers:

```java
class Test {
    @Deprecated /*/ not the end of the comment */ public String value() {
        return null;
    }
}
```

prints as `... String String value()` — the same corruption as (1), reached the other way.

**Fix:** record where the opener started and require the closing `/` to be at least three characters past it, so the opener's own `/` can never close the comment. This also subsumes the `i > 0` bounds check, which was only present in `collectAnnotations` — `sortedModifiersAndAnnotations` could read `source.charAt(-1)`.

**Scope:** pre-existing, same five parser modules.

---

## Testing

Five new TCK tests in `CommentTest`; all five fail on `main` and pass with the fix, and being in the TCK they run against every parser module. Beyond the reproducers above, the `/*/` change was checked against `/**/`, `/***/`, `/*/*/`, `/* /* */`, back-to-back `/*/ a */ /*/ b */`, a multi-line `/*/`-opened comment, and no-whitespace `@Deprecated/*/ x */public`. Full `compatibilityTest` green across `rewrite-java-8/11/17/21/25`, plus the `rewrite-java`, `rewrite-java-test` and `rewrite-java-lombok` test suites.

Aside, not touched here: `StringUtils` (rewrite-core) has a scanner of the same shape that can also latch `inMultilineComment` from inside a `//` comment, e.g. on `// /*`. It consumes two characters per delimiter so `//*` doesn't trip it, and I have no failing case for it, so I've left it alone rather than widen this PR.
