### PR TITLE
Java 25: strip javac's EOI sentinel from `///` markdown doc comment text

### DIFF
--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
@@ -58,6 +58,11 @@ import static org.openrewrite.java.tree.Space.EMPTY;
 import static org.openrewrite.java.tree.Space.format;
 
 public class ReloadableJava25JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
+    /**
+     * javac's {@code LayoutCharacters.EOI}, the sentinel it appends to its scanner buffers.
+     */
+    private static final char EOI = 0x1A;
+
     private final Attr attr;
 
     private final Symbol.@Nullable TypeSymbol symbol;
@@ -1062,6 +1067,13 @@ public class ReloadableJava25JavadocVisitor extends DocTreeScanner<Tree, List<Ja
 
     public List<Javadoc> visitText(String node) {
         List<Javadoc> texts = new ArrayList<>();
+
+        // `DCRawText#getContent()` can return the content of a markdown (`///`) doc comment with javac's
+        // end-of-input sentinel appended, e.g. when the content ends in a backslash. The sentinel is not
+        // present in `source`, so leaving it in place both corrupts the text and desynchronizes the cursor.
+        if (!node.isEmpty() && node.charAt(node.length() - 1) == EOI) {
+            node = node.substring(0, node.length() - 1);
+        }
 
         if (!node.isEmpty() && Character.isWhitespace(node.charAt(0)) && !Character.isWhitespace(source.charAt(cursor))) {
             node = node.stripLeading();

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
@@ -1066,9 +1066,8 @@ public class ReloadableJava25JavadocVisitor extends DocTreeScanner<Tree, List<Ja
     public List<Javadoc> visitText(String node) {
         List<Javadoc> texts = new ArrayList<>();
 
-        // `DCRawText#getContent()` can return the content of a markdown (`///`) doc comment with javac's
-        // end-of-input sentinel appended, e.g. when the content ends in a backslash. The sentinel is not
-        // present in `source`, so leaving it in place both corrupts the text and desynchronizes the cursor.
+        // javac can append its end-of-input sentinel to `DCRawText#getContent()` for `///` doc comments,
+        // e.g. when the content ends in a backslash. It is absent from `source`, so it also skews the cursor.
         if (!node.isEmpty() && node.charAt(node.length() - 1) == EOI) {
             node = node.substring(0, node.length() - 1);
         }

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25JavadocVisitor.java
@@ -58,9 +58,7 @@ import static org.openrewrite.java.tree.Space.EMPTY;
 import static org.openrewrite.java.tree.Space.format;
 
 public class ReloadableJava25JavadocVisitor extends DocTreeScanner<Tree, List<Javadoc>> {
-    /**
-     * javac's {@code LayoutCharacters.EOI}, the sentinel it appends to its scanner buffers.
-     */
+    /// javac's {@code LayoutCharacters.EOI}, the sentinel it appends to its scanner buffers.
     private static final char EOI = 0x1A;
 
     private final Attr attr;

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/JavadocTest.java
@@ -3172,5 +3172,46 @@ class JavadocTest implements RewriteTest {
               )
             );
         }
+
+        @Test
+        void tripleSlashEndingInBackslash() {
+            rewriteRun(
+              java(
+                """
+                  /// Trailing backslash \\
+                  class Test {}
+                  """
+              )
+            );
+        }
+
+        @Test
+        void bannerCommentEndingInBackslashes() {
+            rewriteRun(
+              java(
+                """
+                  class Test {
+                  \t////Section\\\\\\\\
+                  \tvoid first() {}
+
+                  \t///////////Section\\\\\\\\\\\\\\
+                  \tvoid second() {}
+                  }
+                  """
+              )
+            );
+        }
+
+        @Test
+        void tripleSlashWithNonEscapingBackslash() {
+            rewriteRun(
+              java(
+                """
+                  ///a\\b
+                  class Test {}
+                  """
+              )
+            );
+        }
     }
 }


### PR DESCRIPTION
A `///` markdown doc comment whose content ends in a backslash round-trips with a stray `0x1A` appended, so the file fails the print idempotency check:

```
java.lang.IllegalStateException: <file> is not print idempotent.
	at org.openrewrite.Parser.requirePrintEqualsInput(Parser.java:52)
```

- Found while triaging `ParseFailures` rows from a large ingest. Split out of #8564, which fixes two unrelated comment-scanning defects in the same area.

## Root cause

This one is upstream in javac, not in our code — we copy the string it hands us. `com.sun.tools.javac.tree.DCTree.DCRawText#getContent()` can return the content of a JEP 467 markdown doc comment with javac's `LayoutCharacters.EOI` (`0x1A`) sentinel appended; its escape lookahead runs past the end of the comment buffer. Visible with a plain `DocTrees` probe, no OpenRewrite involved:

```
///x\   ->  DCRawText.getContent() = [x\<0x1A>]
///x    ->  DCRawText.getContent() = [x]
```

Confirmed on both JDK 25.0.3 and JDK 26.0.1, so it isn't something we can wait out upstream. I'll report it to OpenJDK separately.

## Reproducer

```java
class Test {
    ///x\
    void m() {}
}
```

prints back as `    ///x\<0x1A>`.

The practical trigger is a doc comment ending in backslashes. Banner comments hit this, because four-or-more leading slashes still start with `///` and javac therefore classifies them as markdown doc comments rather than ordinary line comments:

```java
class Test {
	////Section\\\\
	void first() {}
}
```

The exact javac predicate is erratic — trailing runs of 1, 2, 4, 5, 7 and 8 backslashes leak but 3 and 6 do not; `///a\b` leaks while `///a\bc` and `///a\*b` do not — so this strips defensively rather than trying to model the condition.

## Fix

Strip a trailing sentinel in `visitText(String)`, the single point every raw content string passes through. Leaving it in place corrupts the text and also desynchronizes the cursor, since the sentinel isn't present in `source`.

## Scope

- Regression in 8.76.0, introduced by #7087, which routed `///` comments through `ReloadableJava25JavadocVisitor`. Last good release is 8.75.11 — before that these lines stayed plain `TextComment`s and round-tripped fine.

Java 25 parser only, since `///` doc comments are JDK 23+.

## Testing

Three new tests in `JavadocTest.MarkdownDocComment`; all three fail on `main` and pass with the fix. `rewrite-java-25:compatibilityTest` green.
