### PR TITLE
JavaScript: resolve transitive deps from npm v1 lock files

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
+++ b/rewrite-javascript/rewrite/src/javascript/node-resolution-result.ts
@@ -60,13 +60,65 @@ export interface PackageLockEntry {
 }
 
 /**
- * Parsed package-lock.json content structure (npm lockfile v3 format).
+ * Entry in a legacy npm lockfileVersion 1 `dependencies` tree (npm 5/6), with its
+ * requirements under `requires` and nested conflicting versions under `dependencies`.
+ */
+export interface LockfileV1Entry {
+    readonly version?: string;
+    readonly resolved?: string;
+    readonly integrity?: string;
+    readonly license?: string | string[] | { type?: string; url?: string };
+    readonly engines?: Record<string, string> | string[];
+    readonly requires?: Record<string, string>;
+    readonly dependencies?: Record<string, LockfileV1Entry>;
+}
+
+/**
+ * Parsed package-lock.json content structure. The `packages` map is the modern
+ * (lockfileVersion 2/3) shape; `dependencies` is the legacy lockfileVersion 1 tree.
  */
 export interface PackageLockContent {
     readonly name?: string;
     readonly version?: string;
     readonly lockfileVersion?: number;
     readonly packages?: Record<string, PackageLockEntry>;
+    readonly dependencies?: Record<string, LockfileV1Entry>;
+}
+
+/**
+ * Converts a legacy npm lockfileVersion 1 `dependencies` tree into the modern
+ * `packages` map keyed by node_modules path, so the resolver can walk transitive
+ * dependencies the same way it does for lockfileVersion 2/3 files. Returns
+ * undefined when the tree is absent or empty.
+ */
+function convertV1DependencyTree(
+    tree: Record<string, LockfileV1Entry> | undefined
+): Record<string, PackageLockEntry> | undefined {
+    if (!tree || Object.keys(tree).length === 0) {
+        return undefined;
+    }
+    const packages: Record<string, PackageLockEntry> = {};
+
+    function walk(deps: Record<string, LockfileV1Entry>, pathPrefix: string): void {
+        for (const [name, entry] of Object.entries(deps)) {
+            const pkgPath = `${pathPrefix}node_modules/${name}`;
+            packages[pkgPath] = {
+                version: entry.version,
+                resolved: entry.resolved,
+                integrity: entry.integrity,
+                license: entry.license,
+                engines: entry.engines,
+                // v1 folds all declared deps into `requires`; the resolver reads `dependencies`.
+                dependencies: entry.requires,
+            };
+            if (entry.dependencies) {
+                walk(entry.dependencies, `${pkgPath}/`);
+            }
+        }
+    }
+
+    walk(tree, "");
+    return packages;
 }
 
 /**
@@ -524,9 +576,12 @@ export function createNodeResolutionResultMarker(
     function parseResolutions(
         lockContent: PackageLockContent
     ): ResolvedDependency[] {
-        if (!lockContent.packages) return [];
-
-        const packages = lockContent.packages;
+        // Prefer the modern `packages` map; fall back to converting a legacy
+        // lockfileVersion 1 `dependencies` tree when no `packages` map is present.
+        const packages = lockContent.packages && Object.keys(lockContent.packages).length > 0
+            ? lockContent.packages
+            : convertV1DependencyTree(lockContent.dependencies);
+        if (!packages) return [];
 
         // First pass: Create all ResolvedDependency placeholders and build path map
         const packageInfos: Array<{ path: string; name: string; version: string; entry: PackageLockEntry }> = [];

--- a/rewrite-javascript/rewrite/test/javascript/fixtures/lockfiles/npm-v1/package-lock.json
+++ b/rewrite-javascript/rewrite/test/javascript/fixtures/lockfiles/npm-v1/package-lock.json
@@ -1,0 +1,68 @@
+{
+  "name": "json-server-trimmed",
+  "version": "0.14.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "chalk": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        }
+      }
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+      "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "requires": {
+        "color-name": "^1.1.1"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+    },
+    "supports-color": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    }
+  }
+}

--- a/rewrite-javascript/rewrite/test/javascript/fixtures/lockfiles/npm-v1/package.json
+++ b/rewrite-javascript/rewrite/test/javascript/fixtures/lockfiles/npm-v1/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "json-server-trimmed",
+  "version": "0.14.0",
+  "dependencies": {
+    "chalk": "^2.4.1"
+  }
+}

--- a/rewrite-javascript/rewrite/test/javascript/lockfile-parsing.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/lockfile-parsing.test.ts
@@ -249,6 +249,52 @@ describe("Lock file parsing", () => {
         });
     });
 
+    // Legacy npm lockfileVersion 1 fixture: real entries lifted verbatim from
+    // typicode/json-server@v0.14.0 (the `chalk` dependency and its transitive closure),
+    // exercising a deep chain, a `dev` entry, and nested conflicting versions on real bytes.
+    describe("npm v1 (legacy package-lock.json)", () => {
+        test("should resolve the full graph from a lockfileVersion 1 file", async () => {
+            const marker = await parseAndGetMarker("npm-v1");
+            expect(marker).not.toBeNull();
+            expect(marker!.packageManager).toBe(PackageManager.Npm);
+            expect(marker!.resolvedDependencies.length).toBeGreaterThan(0);
+
+            // Direct dependency resolves to its locked version.
+            const chalk = marker!.dependencies.find(d => d.name === "chalk")?.resolved;
+            expect(chalk).toBeDefined();
+            expect(chalk!.version).toBe("2.4.1");
+        });
+
+        test("should resolve a deep transitive dependency", async () => {
+            const marker = await parseAndGetMarker("npm-v1");
+            expect(marker).not.toBeNull();
+
+            // chalk -> ansi-styles -> color-convert -> color-name
+            const chalk = marker!.dependencies.find(d => d.name === "chalk")!.resolved!;
+            const ansiStyles = chalk.dependencies!.find(d => d.name === "ansi-styles")!.resolved!;
+            const colorConvert = ansiStyles.dependencies!.find(d => d.name === "color-convert")!.resolved!;
+            const colorName = colorConvert.dependencies!.find(d => d.name === "color-name")!.resolved!;
+            expect(colorName.version).toBe("1.1.3");
+        });
+
+        test("should resolve nested conflicting versions by node_modules path", async () => {
+            const marker = await parseAndGetMarker("npm-v1");
+            expect(marker).not.toBeNull();
+
+            // The lock file has ansi-styles@3.2.0 at the top level (a `dev` entry) and
+            // ansi-styles@3.2.1 nested under chalk. chalk must resolve to the nested 3.2.1.
+            const chalk = marker!.dependencies.find(d => d.name === "chalk")!.resolved!;
+            const ansiStyles = chalk.dependencies!.find(d => d.name === "ansi-styles")!.resolved!;
+            expect(ansiStyles.version).toBe("3.2.1");
+
+            const ansiStylesVersions = NodeResolutionResultQueries
+                .getAllResolvedVersions(marker!, "ansi-styles")
+                .map(d => d.version)
+                .sort();
+            expect(ansiStylesVersions).toEqual(["3.2.0", "3.2.1"]);
+        });
+    });
+
     describe("bun (bun.lock)", () => {
         test("should parse all dependencies from bun.lock", async () => {
             const marker = await parseAndGetMarker("bun");

--- a/rewrite-javascript/rewrite/test/javascript/lockfile-transitive.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/lockfile-transitive.test.ts
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {describe, expect, test} from "vitest";
+import {
+    createNodeResolutionResultMarker,
+    PackageLockContent,
+    ResolvedDependency
+} from "../../src/javascript/node-resolution-result";
+
+/**
+ * Transitive dependency resolution works for both the modern `packages` map
+ * (npm lockfileVersion 2/3) and the legacy `dependencies` tree (lockfileVersion 1,
+ * npm 5/6). Both lock file shapes describe the same install, so DependencyInsight and
+ * its TypeScript twin FindDependency can walk transitive dependencies from either one.
+ */
+describe("npm lock file transitive resolution", () => {
+
+    const packageJsonContent = {
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+            express: "^4.18.2"
+        }
+    };
+
+    // The same `express` -> `accepts` -> `mime-types` graph, expressed once as a legacy v1
+    // lock file and once as a modern (v2/v3) lock file.
+    const legacyV1Lock = {
+        name: "my-app",
+        version: "1.0.0",
+        lockfileVersion: 1,
+        requires: true,
+        dependencies: {
+            express: {
+                version: "4.18.2",
+                resolved: "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+                integrity: "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
+                requires: {accepts: "~1.3.8"}
+            },
+            accepts: {
+                version: "1.3.8",
+                resolved: "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+                integrity: "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+                requires: {"mime-types": "~2.1.34"}
+            },
+            "mime-types": {
+                version: "2.1.35",
+                resolved: "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+                integrity: "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="
+            }
+        }
+    } as unknown as PackageLockContent;
+
+    const modernLock: PackageLockContent = {
+        name: "my-app",
+        version: "1.0.0",
+        lockfileVersion: 3,
+        packages: {
+            "": {
+                version: "1.0.0",
+                dependencies: {express: "^4.18.2"}
+            },
+            "node_modules/express": {
+                version: "4.18.2",
+                dependencies: {accepts: "~1.3.8"}
+            },
+            "node_modules/accepts": {
+                version: "1.3.8",
+                dependencies: {"mime-types": "~2.1.34"}
+            },
+            "node_modules/mime-types": {
+                version: "2.1.35"
+            }
+        }
+    };
+
+    function resolveTransitive(resolved: ResolvedDependency | undefined, target: string,
+                               visited: Set<string> = new Set()): ResolvedDependency | undefined {
+        if (!resolved) return undefined;
+        const key = `${resolved.name}@${resolved.version}`;
+        if (visited.has(key)) return undefined;
+        visited.add(key);
+        for (const dep of resolved.dependencies || []) {
+            if (dep.name === target) return dep.resolved;
+            const found = resolveTransitive(dep.resolved, target, visited);
+            if (found) return found;
+        }
+        return undefined;
+    }
+
+    // The same express -> accepts -> mime-types graph resolves identically from the legacy
+    // v1 `dependencies` tree and the modern v2/v3 `packages` map.
+    test.each([
+        {label: "legacy lock file (lockfileVersion 1)", lock: legacyV1Lock},
+        {label: "modern lock file (lockfileVersion 2/3)", lock: modernLock},
+    ])("resolves the express -> accepts -> mime-types chain from the $label", ({lock}) => {
+        const marker = createNodeResolutionResultMarker("package.json", packageJsonContent, lock);
+
+        expect(marker.resolvedDependencies.length).toBeGreaterThan(0);
+        const express = marker.dependencies.find(d => d.name === "express");
+        expect(express?.resolved?.version).toBe("4.18.2");
+        expect(resolveTransitive(express?.resolved, "mime-types")?.version).toBe("2.1.35");
+    });
+
+    test("legacy v1 lock file resolves nested conflicting versions by node_modules path", () => {
+        // `a` and `b` both require `shared`, but at incompatible versions. npm 5/6 keeps
+        // `shared@1.0.0` at the top level (for `a`) and nests `shared@2.0.0` under `b`.
+        const nestedV1Lock = {
+            lockfileVersion: 1,
+            requires: true,
+            dependencies: {
+                a: {version: "1.0.0", requires: {shared: "^1.0.0"}},
+                b: {
+                    version: "1.0.0",
+                    requires: {shared: "^2.0.0"},
+                    dependencies: {
+                        shared: {version: "2.0.0"}
+                    }
+                },
+                shared: {version: "1.0.0"}
+            }
+        } as unknown as PackageLockContent;
+
+        const marker = createNodeResolutionResultMarker(
+            "package.json",
+            {name: "my-app", version: "1.0.0", dependencies: {a: "^1.0.0", b: "^1.0.0"}},
+            nestedV1Lock
+        );
+
+        const a = marker.dependencies.find(d => d.name === "a");
+        const b = marker.dependencies.find(d => d.name === "b");
+        expect(a?.resolved?.dependencies?.find(d => d.name === "shared")?.resolved?.version).toBe("1.0.0");
+        expect(b?.resolved?.dependencies?.find(d => d.name === "shared")?.resolved?.version).toBe("2.0.0");
+    });
+
+    test("legacy v1 lock file resolves scoped packages, including a nested scoped version", () => {
+        // A scoped key like `@scope/util` must keep its full name (the leading `@` is not a
+        // version separator), at both the top level and nested under another package.
+        const scopedV1Lock = {
+            lockfileVersion: 1,
+            requires: true,
+            dependencies: {
+                "@scope/app": {
+                    version: "1.0.0",
+                    requires: {"@scope/util": "^2.0.0"},
+                    dependencies: {
+                        "@scope/util": {version: "2.9.9"}
+                    }
+                },
+                "@scope/util": {version: "2.0.0"}
+            }
+        } as unknown as PackageLockContent;
+
+        const marker = createNodeResolutionResultMarker(
+            "package.json",
+            {name: "my-app", version: "1.0.0", dependencies: {"@scope/app": "^1.0.0", "@scope/util": "^2.0.0"}},
+            scopedV1Lock
+        );
+
+        const app = marker.dependencies.find(d => d.name === "@scope/app");
+        expect(app?.resolved?.version).toBe("1.0.0");
+        // The direct scoped dep resolves top-level (2.0.0); the one required by @scope/app
+        // resolves to the version nested under it (2.9.9).
+        expect(marker.dependencies.find(d => d.name === "@scope/util")?.resolved?.version).toBe("2.0.0");
+        expect(app?.resolved?.dependencies?.find(d => d.name === "@scope/util")?.resolved?.version).toBe("2.9.9");
+        const utilVersions = marker.resolvedDependencies
+            .filter(d => d.name === "@scope/util")
+            .map(d => d.version)
+            .sort();
+        expect(utilVersions).toEqual(["2.0.0", "2.9.9"]);
+    });
+
+    test("modern v2 lock file prefers the `packages` map over a legacy `dependencies` tree", () => {
+        // A v2 lock file carries both maps. The `packages` map wins; the stale versions in
+        // the legacy tree must be ignored.
+        const v2Lock = {
+            ...modernLock,
+            lockfileVersion: 2,
+            dependencies: {
+                express: {version: "4.0.0", requires: {accepts: "~1.0.0"}},
+                accepts: {version: "1.0.0"}
+            }
+        } as unknown as PackageLockContent;
+
+        const marker = createNodeResolutionResultMarker("package.json", packageJsonContent, v2Lock);
+
+        const express = marker.dependencies.find(d => d.name === "express");
+        expect(express?.resolved?.version).toBe("4.18.2");
+        expect(resolveTransitive(express?.resolved, "mime-types")?.version).toBe("2.1.35");
+    });
+
+    test("an empty dependency tree yields no resolved dependencies", () => {
+        const emptyV1Lock = {lockfileVersion: 1, requires: true, dependencies: {}} as unknown as PackageLockContent;
+        const marker = createNodeResolutionResultMarker("package.json", packageJsonContent, emptyV1Lock);
+        expect(marker.resolvedDependencies).toHaveLength(0);
+    });
+
+    test("falls back to the legacy `dependencies` tree when the `packages` map is empty", () => {
+        const emptyPackagesLock = {
+            lockfileVersion: 2,
+            packages: {},
+            dependencies: {
+                express: {version: "4.18.2"}
+            }
+        } as unknown as PackageLockContent;
+        const marker = createNodeResolutionResultMarker("package.json", packageJsonContent, emptyPackagesLock);
+        expect(marker.dependencies.find(d => d.name === "express")?.resolved?.version).toBe("4.18.2");
+    });
+});


### PR DESCRIPTION
`org.openrewrite.javascript.search.DependencyInsight` did not report transitive dependencies from a committed `package-lock.json` when "Include transitive dependencies" was selected.

The npm lock file parser only understood the modern `packages` map (lockfileVersion 2/3). A lockfileVersion 1 file (npm 5/6) has no `packages` map, only a nested `dependencies` tree, so the parser produced an empty resolved-dependency graph. Direct dependencies were still matched by name, but every transitive match was silently lost.

The parser now converts a legacy v1 `dependencies` tree into the same internal shape, so transitive dependencies resolve from v1 lock files just as they do from v2/v3.