### PR TITLE
Go: fix RPC handling of codec-less enums

### DIFF
--- a/rewrite-go/pkg/rpc/left_padded_operator_rpc_test.go
+++ b/rewrite-go/pkg/rpc/left_padded_operator_rpc_test.go
@@ -75,6 +75,36 @@ func TestAssignmentOperationRoundTrip_OperatorPreserved(t *testing.T) {
 	}
 }
 
+func TestBinaryOperatorChange_AppliedOnReceive(t *testing.T) {
+	// A recipe that flips `==` to `!=` mutates only the Binary operator element,
+	// producing a CHANGE (not a fresh ADD) diffed against the Equal baseline. The
+	// receiver must apply the new operator; if it re-uses the before value it drops
+	// the change and prints `==` unchanged (the EmptyBlock/Go corruption).
+	id := uuid.New()
+	before := &java.Binary{
+		ID:       id,
+		Left:     makeIdent("a"),
+		Operator: java.LeftPadded[java.BinaryOperator]{Element: java.Equal, Markers: java.Markers{}},
+		Right:    makeIdent("b"),
+	}
+	after := &java.Binary{
+		ID:       id,
+		Left:     makeIdent("a"),
+		Operator: java.LeftPadded[java.BinaryOperator]{Element: java.NotEqual, Markers: java.Markers{}},
+		Right:    makeIdent("b"),
+	}
+	seed := &java.Binary{
+		ID:       id,
+		Operator: java.LeftPadded[java.BinaryOperator]{Element: java.Equal, Markers: java.Markers{}},
+	}
+
+	got := roundTripNodeWithBefore(t, after, before, seed).(*java.Binary)
+
+	if got.Operator.Element != java.NotEqual {
+		t.Errorf("Operator: want NotEqual (!=) after CHANGE, got %v", got.Operator.Element)
+	}
+}
+
 func TestBinaryRoundTrip_OperatorPreserved(t *testing.T) {
 	// Sibling sanity check: a real BinaryOperator must still resolve to Binary,
 	// not be poached by the assignment parser.

--- a/rewrite-go/pkg/rpc/padding_rpc.go
+++ b/rewrite-go/pkg/rpc/padding_rpc.go
@@ -166,13 +166,30 @@ func receiveLeftPadded(r Receiver, q *ReceiveQueue, before any) any {
 // receiveContainerTyped.
 func receiveLeftPaddedEnum[T any](r Receiver, q *ReceiveQueue, before java.LeftPadded[T], parse func(string) T) java.LeftPadded[T] {
 	result := q.Receive(before, func(v any) any {
-		beforeSpace, elem, markers := receiveLeftPaddedParts(r, q, v)
+		beforeSpace, elem, markers := receiveLeftPaddedEnumParts(q, v)
 		return coerceLeftPaddedEnum(beforeSpace, elem, markers, parse)
 	})
 	if result == nil {
 		return before
 	}
 	return result.(java.LeftPadded[T])
+}
+
+// receiveLeftPaddedEnumParts deserializes the three wire fields of an enum-valued
+// JLeftPadded. Unlike receiveLeftPaddedParts it receives the element with a nil
+// closure: enum elements are codec-less scalars, so a CHANGE inlines the new value
+// on the wire (e.g. "NotEqual"), which Receive returns directly for coerceLeftPaddedEnum
+// to parse. A recursion closure would instead make Receive hand back the pre-change
+// `before` element, silently dropping operator mutations.
+func receiveLeftPaddedEnumParts(q *ReceiveQueue, before any) (java.Space, any, java.Markers) {
+	beforeSpace := q.Receive(leftPaddedBefore(before), func(v any) any {
+		return receiveSpace(v.(java.Space), q)
+	})
+	elem := q.Receive(leftPaddedElement(before), nil)
+	markers := q.Receive(leftPaddedMarkers(before), func(v any) any {
+		return receiveMarkersCodec(q, v.(java.Markers))
+	})
+	return beforeSpace.(java.Space), elem, markers.(java.Markers)
 }
 
 // coerceLeftPaddedEnum builds a LeftPadded[T] for an enum slot. The element is either

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -146,6 +146,9 @@ func (q *ReceiveQueue) Receive(before any, onChange func(any) any) any {
 		} else if !isNilValue(before) && getValueType(before) != nil {
 			if t, ok := before.(java.Tree); ok {
 				after = defaultReceiver.Visit(t, q)
+			} else if msg.Value != nil {
+				// A codec-less value-typed scalar (e.g. an operator enum)
+				after = msg.Value
 			} else if codecExpected {
 				panic(missingCodec(*msg.ValueType))
 			} else {

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GolangRecipeIntegTest.java
@@ -350,6 +350,48 @@ class GolangRecipeIntegTest implements RewriteTest {
         );
     }
 
+    /**
+     * Reproduces the reported EmptyBlock/Go corruption root cause: a Java recipe
+     * that mutates a {@code J.Binary} operator ({@code ==} -> {@code !=}) must
+     * round-trip through the Go RPC print path. If the operator change is dropped,
+     * the source prints unchanged (== stays ==).
+     */
+    @Test
+    void flipBinaryOperatorRoundTrips() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new org.openrewrite.java.JavaIsoVisitor<>() {
+              @Override
+              public J.Binary visitBinary(J.Binary binary, org.openrewrite.ExecutionContext ctx) {
+                  J.Binary b = super.visitBinary(binary, ctx);
+                  if (b.getOperator() == J.Binary.Type.Equal) {
+                      return b.withOperator(J.Binary.Type.NotEqual);
+                  }
+                  return b;
+              }
+          })).expectedCyclesThatMakeChanges(1).cycles(1),
+          go(
+            """
+              package main
+
+              func test() {
+              \tif err == nil {
+              \t\thandle(err)
+              \t}
+              }
+              """,
+            """
+              package main
+
+              func test() {
+              \tif err != nil {
+              \t\thandle(err)
+              \t}
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void renameIdentifier() {
         rewriteRun(


### PR DESCRIPTION
## What's changed?

In Go, fix RPC handling of enums which don't have a codec attached. E.g. Binary operator type.

## What's your motivation?

Otherwise recipes over RPC may present stale LSTs (before changes) despite `CHANGE` being sent.
E.g. `EmptyBlock` recipe against Go code might not flip the boolean condition.