### PR TITLE
Scala: fix comment-only files printing their comment twice

### DIFF
--- a/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParserVisitor.java
+++ b/rewrite-scala/src/main/java/org/openrewrite/scala/ScalaParserVisitor.java
@@ -100,29 +100,33 @@ public class ScalaParserVisitor {
             }
         }
 
-        // If we didn't get any statements and have source content, create an Unknown node
-        // But skip if we already have a package declaration (to avoid duplication)
-        if (statements.isEmpty() && !source.trim().isEmpty() && packageDecl == null) {
-            J.Unknown.Source unknownSource = new J.Unknown.Source(
-                randomId(),
-                EMPTY,
-                Markers.EMPTY,
-                source
-            );
-
-            J.Unknown unknown = new J.Unknown(
-                randomId(),
-                EMPTY,
-                Markers.EMPTY,
-                unknownSource
-            );
-
-            statements.add(unknown);
-        }
-
-        // Get remaining source for EOF
         String remainingSource = converter.getRemainingSource(parseResult, source, result.getLastCursorPosition());
-        Space eof = remainingSource.isEmpty() ? EMPTY : Space.build(remainingSource, Collections.emptyList());
+        Space eof = remainingSource.isEmpty() ? EMPTY : ScalaSpace.format(remainingSource);
+
+        if (statements.isEmpty() && packageDecl == null) {
+            Space whole = ScalaSpace.format(source);
+            if (isWhitespaceAndComments(whole)) {
+                // A file of only whitespace and comments has no statements; it is modeled entirely by EOF.
+                eof = whole;
+            } else {
+                J.Unknown.Source unknownSource = new J.Unknown.Source(
+                    randomId(),
+                    EMPTY,
+                    Markers.EMPTY,
+                    source
+                );
+
+                J.Unknown unknown = new J.Unknown(
+                    randomId(),
+                    EMPTY,
+                    Markers.EMPTY,
+                    unknownSource
+                );
+
+                statements.add(unknown);
+                eof = EMPTY;
+            }
+        }
 
         // Build S.CompilationUnit
         return new S.CompilationUnit(
@@ -138,5 +142,17 @@ public class ScalaParserVisitor {
             JRightPadded.withElements(Collections.emptyList(), statements),
             eof                            // Space eof
         );
+    }
+
+    private static boolean isWhitespaceAndComments(Space space) {
+        if (!space.getWhitespace().trim().isEmpty()) {
+            return false;
+        }
+        for (Comment comment : space.getComments()) {
+            if (!comment.getSuffix().trim().isEmpty()) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
+++ b/rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaASTConverter.scala
@@ -353,17 +353,7 @@ class ScalaASTConverter {
    * This should return the source text after the last parsed element.
    */
   def getRemainingSource(parseResult: ScalaParseResult, source: String, lastCursorPosition: Int): String = {
-    // If tree is empty (parse error), don't return any remaining source
-    // The Unknown node will handle the entire source
-    if (parseResult.tree.isEmpty) {
-      return ""
-    }
-
-    // Return any remaining source after the last cursor position
-    if (lastCursorPosition < source.length) {
-      source.substring(lastCursorPosition)
-    } else {
-      ""
-    }
+    val start = Math.max(lastCursorPosition, 0)
+    if (start < source.length) source.substring(start) else ""
   }
 }

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/CommentOnlyFileTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/CommentOnlyFileTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.scala;
+
+import org.intellij.lang.annotations.Language;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.openrewrite.scala.Assertions.scala;
+
+/**
+ * A file holding nothing but whitespace and comments has no statements: the comments belong to the
+ * compilation unit's EOF space, never to a {@link J.Unknown} covering the whole source.
+ */
+class CommentOnlyFileTest implements RewriteTest {
+
+    /**
+     * A null path exercises {@link ScalaParser#sourcePathFromSourceText}, which derives a {@code .sbt}
+     * path for sources that declare neither a package nor a class-like declaration.
+     */
+    static Stream<Arguments> commentOnlySources() {
+        return Stream.of(
+          arguments(null, "// only a comment\n", 1),
+          arguments("Foo.scala", "// only a comment\n", 1),
+          arguments("build.sbt", "// only a comment\n", 1),
+          arguments("Foo.scala", "// only a comment", 1),
+          arguments("build.sbt", "// only a comment", 1),
+          arguments("Foo.scala", "/* only a comment */\n", 1),
+          arguments("Foo.scala", "/* only a comment */\n\n", 1),
+          arguments("Foo.scala", "// first\n\n/* second\n * continued\n */\n// third\n", 3),
+          arguments("Foo.scala", "\n\n", 0),
+          arguments("build.sbt", "   \n", 0),
+          arguments("Foo.scala", "", 0)
+        );
+    }
+
+    @MethodSource("commentOnlySources")
+    @ParameterizedTest
+    void commentOnlyFile(@Nullable String path, @Language("scala") String source, int comments) {
+        rewriteRun(
+          scala(source, spec -> {
+              if (path != null) {
+                  spec.path(path);
+              }
+              spec.noTrim().afterRecipe(cu -> {
+                  assertThat(cu.getStatements()).isEmpty();
+                  assertThat(cu.getPackageDeclaration()).isNull();
+                  assertThat(cu.getEof().getComments()).hasSize(comments);
+              });
+          })
+        );
+    }
+
+    static Stream<Arguments> commentsAroundDeclarations() {
+        return Stream.of(
+          arguments("Foo.scala", "// leading comment\nclass A\n", 0),
+          arguments("build.sbt", "// leading comment\nname := \"demo\"\n", 0),
+          arguments("Foo.scala", "class A\n// trailing comment\n", 1)
+        );
+    }
+
+    @MethodSource("commentsAroundDeclarations")
+    @ParameterizedTest
+    void commentAlongsideDeclaration(String path, @Language("scala") String source, int eofComments) {
+        rewriteRun(
+          scala(source, spec -> spec.path(path).noTrim().afterRecipe(cu -> {
+              assertThat(cu.getStatements()).hasSize(1);
+              assertThat(cu.getEof().getComments()).hasSize(eofComments);
+          }))
+        );
+    }
+}

--- a/rewrite-scala/src/test/java/org/openrewrite/scala/CommentOnlyFileTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/CommentOnlyFileTest.java
@@ -90,4 +90,26 @@ class CommentOnlyFileTest implements RewriteTest {
           }))
         );
     }
+
+    static Stream<Arguments> packageDeclarationsFollowedByComments() {
+        return Stream.of(
+          arguments("foo/Foo.scala", "package foo\n// trailing comment\n", 1),
+          arguments("foo/Foo.scala", "package foo\n\n/* trailing comment */\n", 1),
+          arguments("foo/bar/Foo.scala", "package foo.bar\n// first\n// second\n", 2),
+          arguments("foo/Foo.scala", "package foo\n// no trailing newline", 1),
+          arguments("foo/Foo.scala", "package foo\n\n", 0)
+        );
+    }
+
+    @MethodSource("packageDeclarationsFollowedByComments")
+    @ParameterizedTest
+    void packageDeclarationFollowedByComments(String path, @Language("scala") String source, int eofComments) {
+        rewriteRun(
+          scala(source, spec -> spec.path(path).noTrim().afterRecipe(cu -> {
+              assertThat(cu.getPackageDeclaration()).isNotNull();
+              assertThat(cu.getStatements()).isEmpty();
+              assertThat(cu.getEof().getComments()).hasSize(eofComments);
+          }))
+        );
+    }
 }


### PR DESCRIPTION
A Scala file containing nothing but whitespace and comments produced both a `J.Unknown` holding the entire source and an EOF space holding the same text, so the comment was printed twice and the file failed to parse. `ScalaASTConverter.getRemainingSource` returned `""` whenever dotty produced an empty tree, which masked the duplication for `.scala` sources — `.sbt` sources parse to the `object __SbtScript__` wrapper, so their tree is non-empty and the duplicate was emitted.

Such a file now maps to a compilation unit with an empty statement list and the comments in EOF rather than a whole-file `J.Unknown` (which `rewrite-scala/CLAUDE.md` forbids), and EOF space is built with `ScalaSpace.format` so trailing comments become real `Comment` elements. Whitespace-only and empty files, which previously printed as empty and failed to parse, round-trip too.

Added `CommentOnlyFileTest` covering `//`- and `/* */`-only files on both the derived `.sbt` path and an explicit `.scala` path, with and without a trailing newline, whitespace-only/empty files, and comments leading or trailing a real declaration; 10 of its 14 cases fail without this fix. `./gradlew :rewrite-scala:test` is green (950 tests).

- Note for openrewrite/rewrite#8568 task A3 (enabling `TypeValidation.unknown()` for Scala): comment-only files no longer hit the fallback, but 51 whole-file `J.Unknown`s remain for bare top-level expressions (`42`, `"hello"`, `(a + b) * c`) because `ScalaASTConverter` keeps only conversions that are a `Statement`; wrapping those in the existing `S.ExpressionStatement` looks like the fix, and is left out of scope here.