### PR TITLE
Fix `TypeValidation` unknown reporting and `none()` whitespace polarity

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/Assertions.java
@@ -18,6 +18,7 @@ package org.openrewrite.java;
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.ParseExceptionResult;
 import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
@@ -85,14 +86,17 @@ public class Assertions {
                 List<J.Unknown> allUnknown = new JavaIsoVisitor<List<J.Unknown>>() {
                     @Override
                     public J.Unknown visitUnknown(J.Unknown unknown, List<J.Unknown> list) {
-                        J.Unknown err = super.visitUnknown(unknown, list);
-                        list.add(err);
-                        return err;
+                        J.Unknown u = super.visitUnknown(unknown, list);
+                        list.add(u);
+                        return u;
                     }
                 }.reduce(source, new ArrayList<>());
                 if (!allUnknown.isEmpty()) {
-                    throw new IllegalStateException("LST contains erroneous nodes\n" + allUnknown.stream()
-                            .map(unknown -> unknown.getSource().getText())
+                    throw new IllegalStateException("LST contains unknown elements\n" + allUnknown.stream()
+                            .map(unknown -> unknown.getSource().getMarkers()
+                                    .findFirst(ParseExceptionResult.class)
+                                    .map(per -> per.getMessage() + "\n")
+                                    .orElse("") + unknown.getSource().getText())
                             .collect(joining("\n\n")));
                 }
             }

--- a/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
+++ b/rewrite-test/src/main/java/org/openrewrite/test/TypeValidation.java
@@ -150,7 +150,22 @@ public class TypeValidation {
      * Skip all invariant validation checks.
      */
     public static TypeValidation none() {
-        return new TypeValidation(false, false, false, false, false, false, false, false, o -> false, false, false, false, false, false, false);
+        return builder()
+                .classDeclarations(false)
+                .identifiers(false)
+                .methodDeclarations(false)
+                .variableDeclarations(false)
+                .methodInvocations(false)
+                .constructorInvocations(false)
+                .dependencyModel(false)
+                .cursorAcyclic(false)
+                .erroneous(false)
+                .unknown(false)
+                .immutableExecutionContext(false)
+                .immutableScanning(false)
+                .allowNonWhitespaceInWhitespace(true)
+                .parseAndPrintEquality(false)
+                .build();
     }
 
     static TypeValidation before(RecipeSpec testMethodSpec, RecipeSpec testClassSpec) {

--- a/rewrite-test/src/test/java/org/openrewrite/test/TypeValidationTest.java
+++ b/rewrite-test/src/test/java/org/openrewrite/test/TypeValidationTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TypeValidationTest {
+
+    @Test
+    void noneInvertsEveryFlagFromAll() throws IllegalAccessException {
+        TypeValidation all = TypeValidation.all();
+        TypeValidation none = TypeValidation.none();
+        for (Field field : TypeValidation.class.getDeclaredFields()) {
+            if (field.getType() == boolean.class && !Modifier.isStatic(field.getModifiers()) && !field.isSynthetic()) {
+                field.setAccessible(true);
+                assertThat(field.getBoolean(none))
+                  .as("%s is not skipped by none()", field.getName())
+                  .isNotEqualTo(field.getBoolean(all));
+            }
+        }
+    }
+
+    @Test
+    void noneSkipsWhitespaceValidation() {
+        assertThat(TypeValidation.none().allowNonWhitespaceInWhitespace()).isTrue();
+        assertThat(TypeValidation.all().allowNonWhitespaceInWhitespace()).isFalse();
+    }
+}


### PR DESCRIPTION
- Addresses **B2** and **B4** of #8568.

**B2** — `java.Assertions#validateTypes` reported `J.Unknown` elements with the message `"LST contains erroneous nodes"`, copy-pasted from the `J.Erroneous` branch directly above it, and dropped the `ParseExceptionResult` message entirely. It now says `"LST contains unknown elements"` and prefixes each offending source snippet with the parse exception message, matching `kotlin.Assertions#assertNoUnknownElements`.

**B4** — `TypeValidation.none()` is documented as skipping all invariant validation, but passed `allowNonWhitespaceInWhitespace = false`, which *enables* whitespace validation; that flag's polarity is inverted relative to its siblings. Rather than rename the field (a breaking change for the 100+ call sites of the builder), `none()` now passes `true`, and is constructed through the builder instead of the positional all-args constructor that made the mistake invisible in the first place.

Added `TypeValidationTest` to guard the invariant that `none()` flips every boolean flag relative to `all()`, so a future field added without updating `none()` fails loudly.