### PR TITLE
Fix the gofmt group separator on imports inserted by AddImport

### DIFF
--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -405,14 +405,37 @@ func RemoveFromBlock(cu *golang.CompilationUnit, imp *java.Import) *golang.Compi
 	return &c
 }
 
+// groupIndent reports the per-line indent shared by the elements of an
+// `import (...)` block, taken from the first element that carries one and
+// stripped of any leading blank-line newlines.
+func groupIndent(elements []java.RightPadded[*java.Import]) java.Space {
+	for _, rp := range elements {
+		if rp.Element == nil {
+			continue
+		}
+		canonical := rp.Element.Prefix.Whitespace
+		for strings.HasPrefix(canonical, "\n\n") {
+			canonical = canonical[1:]
+		}
+		if strings.HasPrefix(canonical, "\n") {
+			return java.Space{Whitespace: canonical}
+		}
+	}
+	return java.Space{Whitespace: "\n\t"}
+}
+
+// groupSeparator is the prefix of an element that opens a gofmt group
+// after another: the indent preceded by a blank line.
+func groupSeparator(indent java.Space) java.Space {
+	return java.Space{Whitespace: "\n" + indent.Whitespace}
+}
+
 // insertGrouped places imp at the end of its own group while preserving
 // the relative order of pre-existing imports. New groups appear in
 // stdlib / third-party / local order.
 //
-// Whitespace handling: the new import inherits a sibling's Prefix (the
-// `\n\t` indent inside an `import (...)` block) so the printer renders
-// it on its own line. When inserting into an empty block (no siblings),
-// a sensible default is used.
+// Whitespace handling: imp's Prefix is the group separator when it opens a
+// group after another, else the plain indent.
 func insertGrouped(elements []java.RightPadded[*java.Import], imp *java.Import, modulePath string) []java.RightPadded[*java.Import] {
 	target := GroupOf(ImportPath(imp), modulePath)
 	insertAt := len(elements)
@@ -423,18 +446,12 @@ func insertGrouped(elements []java.RightPadded[*java.Import], imp *java.Import, 
 			break
 		}
 	}
+	indent := groupIndent(elements)
 	if imp.Prefix.Whitespace == "" && len(elements) > 0 {
-		// Borrow the surrounding indent. If we're inserting in front,
-		// take the first sibling's prefix; otherwise the previous
-		// sibling's. Both reliably end with `\n\t` in a grouped block.
-		var donor *java.Import
-		if insertAt < len(elements) {
-			donor = elements[insertAt].Element
+		if insertAt > 0 && GroupOf(ImportPath(elements[insertAt-1].Element), modulePath) != target {
+			imp.Prefix = groupSeparator(indent)
 		} else {
-			donor = elements[len(elements)-1].Element
-		}
-		if donor != nil {
-			imp.Prefix = donor.Prefix
+			imp.Prefix = indent
 		}
 	}
 	wrapped := java.RightPadded[*java.Import]{Element: imp}
@@ -442,6 +459,15 @@ func insertGrouped(elements []java.RightPadded[*java.Import], imp *java.Import, 
 	out = append(out, elements[:insertAt]...)
 	out = append(out, wrapped)
 	out = append(out, elements[insertAt:]...)
+
+	if insertAt < len(elements) && out[insertAt+1].Element != nil {
+		// imp was spliced in front of a strictly later group, so the
+		// element it displaced opens that group and takes the separator.
+		// Only the whitespace moves; the Prefix may carry comments.
+		displaced := *out[insertAt+1].Element
+		displaced.Prefix.Whitespace = groupSeparator(indent).Whitespace
+		out[insertAt+1].Element = &displaced
+	}
 
 	// Re-balance trailing whitespace: in a grouped block the last
 	// element's After holds the space before `)`. When we appended at
@@ -503,26 +529,7 @@ func SortByGroup(elements []java.RightPadded[*java.Import], modulePath string) [
 	betweenAfter := elements[0].After
 	closingAfter := elements[len(elements)-1].After
 
-	// Re-derive the per-line indent prefix from the first non-blank-line
-	// element so the blank-line separator below can prepend a single \n
-	// to it. The smallest existing prefix that ends in \n + indent wins.
-	indentPrefix := java.Space{Whitespace: "\n\t"}
-	for _, rp := range elements {
-		if rp.Element == nil {
-			continue
-		}
-		ws := rp.Element.Prefix.Whitespace
-		// Strip a leading blank-line newline so we get the canonical
-		// "\n\t" indent rather than "\n\n\t".
-		canonical := ws
-		for strings.HasPrefix(canonical, "\n\n") {
-			canonical = canonical[1:]
-		}
-		if strings.HasPrefix(canonical, "\n") {
-			indentPrefix = java.Space{Whitespace: canonical}
-			break
-		}
-	}
+	indentPrefix := groupIndent(elements)
 
 	type bucket struct {
 		group ImportGroup
@@ -545,7 +552,7 @@ func SortByGroup(elements []java.RightPadded[*java.Import], modulePath string) [
 	}
 
 	out := make([]java.RightPadded[*java.Import], 0, len(elements))
-	groupSeparatorPrefix := java.Space{Whitespace: "\n" + indentPrefix.Whitespace}
+	groupSeparatorPrefix := groupSeparator(indentPrefix)
 	for _, b := range buckets {
 		if len(b.items) == 0 {
 			continue

--- a/rewrite-go/test/import_recipes_test.go
+++ b/rewrite-go/test/import_recipes_test.go
@@ -418,3 +418,226 @@ func TestOrderImports_AlphabeticalWithinGroupAndBlankLineBetween(t *testing.T) {
 	`
 	spec.RewriteRun(t, Golang(before, after))
 }
+
+func TestAddImport_GroupSeparatorWhitespace(t *testing.T) {
+	tests := []struct {
+		name   string
+		module string
+		add    string
+		before string
+		after  string
+	}{
+		{
+			name: "joins the stdlib group when a third-party group follows",
+			add:  "strings",
+			before: `
+				package main
+
+				import (
+					"fmt"
+
+					"github.com/x/y"
+				)
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import (
+					"fmt"
+					"strings"
+
+					"github.com/x/y"
+				)
+
+				func main() {}
+			`,
+		},
+		{
+			name: "opens a new leading group in front of an existing one",
+			add:  "fmt",
+			before: `
+				package main
+
+				import (
+					"github.com/x/y"
+				)
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import (
+					"fmt"
+
+					"github.com/x/y"
+				)
+
+				func main() {}
+			`,
+		},
+		{
+			name: "opens a new trailing group after an existing one",
+			add:  "github.com/x/y",
+			before: `
+				package main
+
+				import (
+					"fmt"
+				)
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import (
+					"fmt"
+
+					"github.com/x/y"
+				)
+
+				func main() {}
+			`,
+		},
+		{
+			name:   "opens a new middle group between stdlib and local",
+			module: "example.com/app",
+			add:    "github.com/x/y",
+			before: `
+				package main
+
+				import (
+					"fmt"
+
+					"example.com/app/pkg"
+				)
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import (
+					"fmt"
+
+					"github.com/x/y"
+
+					"example.com/app/pkg"
+				)
+
+				func main() {}
+			`,
+		},
+		{
+			name: "carries the displaced import's comment into the second group",
+			add:  "fmt",
+			before: `
+				package main
+
+				import (
+					// networking
+					"github.com/x/y"
+				)
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import (
+					"fmt"
+
+					// networking
+					"github.com/x/y"
+				)
+
+				func main() {}
+			`,
+		},
+		{
+			name:   "separates a new middle group from an unseparated following group",
+			module: "example.com/app",
+			add:    "github.com/x/y",
+			before: `
+				package main
+
+				import (
+					"fmt"
+					"example.com/app/pkg"
+				)
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import (
+					"fmt"
+
+					"github.com/x/y"
+
+					"example.com/app/pkg"
+				)
+
+				func main() {}
+			`,
+		},
+		{
+			name: "appends to the only group",
+			add:  "strings",
+			before: `
+				package main
+
+				import (
+					"fmt"
+				)
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import (
+					"fmt"
+					"strings"
+				)
+
+				func main() {}
+			`,
+		},
+		{
+			name: "creates the block when the file has no imports",
+			add:  "fmt",
+			before: `
+				package main
+
+				func main() {}
+			`,
+			after: `
+				package main
+
+				import "fmt"
+
+				func main() {}
+			`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := NewRecipeSpec().WithRecipe(&recipes.AddImport{PackagePath: tt.add})
+			if tt.module == "" {
+				spec.RewriteRun(t, Golang(tt.before, tt.after))
+				return
+			}
+			spec.RewriteRun(t,
+				GoProject("app",
+					GoMod("module "+tt.module+"\n\ngo 1.22\n"),
+					Golang(tt.before, tt.after),
+				),
+			)
+		})
+	}
+}


### PR DESCRIPTION
`MaybeAddImport(v, "strings", nil, false)` on a file whose import block already has a third-party group gives the new import a blank line above it, so gofmt reads it as a group of its own:

```go
import (
	"fmt"

	"strings"   // gofmt puts this directly under "fmt", with no blank line

	"github.com/x/y"
)
```

`insertGrouped` picked the whitespace donor by position — `elements[insertAt]` whenever `insertAt < len(elements)`. When the new import lands at the end of its own group but before a later group, that donor is the *first element of the next group*, whose `Prefix` is the group separator `"\n\n\t"` rather than the plain indent `"\n\t"`.

Position is the wrong key; group membership is. `elements[insertAt-1]` is not a reliable same-group sibling either: `insertAt` is the first index whose group is strictly *greater* than the target, so the preceding element's group is only `<=`. Adding `"github.com/x/y"` to a block holding just `"fmt"` has to *open* a group, and copying `"fmt"`'s indent glues the two together. The new import now takes the separator exactly when the element before it belongs to an earlier group, and the plain indent otherwise.

The trailing edge needs the same treatment, and gets it from the same invariant: `elements[insertAt]` is by construction in a strictly greater group, so it always opens the group after the new import and always takes the separator. That subsumes the leading-edge case (`insertAt == 0`) as one instance instead of a special branch. Without it a block that wasn't blank-line separated to begin with stays wrong:

```go
// module example.com/app; adding "github.com/x/y"
import (
	"fmt"

	"github.com/x/y"
	"example.com/app/pkg"   // goimports reads these two as one group
)
```

Only `Prefix.Whitespace` is rewritten on that element, not the whole `java.Space`. `Prefix.Comments` carries a group's leading comments, and assigning a fresh `Space` drops them — inserting `"fmt"` in front of a commented `"github.com/x/y"` deleted the comment outright.

`groupIndent` is extracted from the byte-identical inline logic in `SortByGroup` and shared.

`TestAddImport_GroupSeparatorWhitespace` in `rewrite-go/test/import_recipes_test.go` is table-driven over eight cases: the reported end-of-stdlib insert, a new leading / trailing / middle group, a displaced import carrying its `//` comment into the second group, an unseparated following group, plus append-within-group and empty-block regression guards. Five of the eight were confirmed failing before the fix. The middle-group case passed on `main` only by coincidence — borrowing the next group's separator happened to be right there — which is why it is pinned now.

Not fixed here: `UseStringsBuilderInLoop` in `moderneinc/recipes-go` pins the extra blank line in its expected output today, with a comment pointing at `insertGrouped`. Once this lands and ships, that expectation and the comment should be tightened.
