### PR TITLE
Scala: de-flake `doesNotLeakTempDirectories` under parallel test JVMs

### DIFF
--- a/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserTest.java
+++ b/rewrite-scala/src/test/java/org/openrewrite/scala/ScalaParserTest.java
@@ -22,8 +22,15 @@ import org.openrewrite.java.tree.Statement;
 import org.openrewrite.scala.tree.S;
 import org.openrewrite.tree.ParseError;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -231,8 +238,8 @@ class ScalaParserTest {
     @Test
     void doesNotLeakTempDirectories() throws Exception {
         // given
-        java.nio.file.Path tmpRoot = java.nio.file.Paths.get(System.getProperty("java.io.tmpdir"));
-        java.util.Set<java.nio.file.Path> before = listRewriteScalaTempDirs(tmpRoot);
+        Path tmpRoot = Paths.get(System.getProperty("java.io.tmpdir"));
+        Set<Path> before = listRewriteScalaTempDirs(tmpRoot);
 
         // when
         ScalaParser parser = ScalaParser.builder().build();
@@ -242,28 +249,29 @@ class ScalaParserTest {
         assertThat(parsed).hasSize(1);
         assertThat(parsed.get(0)).isInstanceOf(S.CompilationUnit.class);
 
-        // Concurrently running test classes create their own rewrite-scala temp dirs
-        // and delete them when their compile finishes, so a single snapshot comparison
-        // is racy. Poll until only genuinely leaked dirs (which persist) would remain.
-        java.util.Set<java.nio.file.Path> after = listRewriteScalaTempDirs(tmpRoot);
-        after.removeAll(before);
+        // Other test JVMs on this machine continuously create and delete their own
+        // rewrite-scala temp dirs, so waiting for the directory listing to become
+        // empty never converges. Instead take the candidates once and wait for each
+        // of them to disappear: theirs are removed when their compile finishes,
+        // while a directory genuinely leaked by our parse persists.
+        Set<Path> candidates = listRewriteScalaTempDirs(tmpRoot);
+        candidates.removeAll(before);
         long deadline = System.currentTimeMillis() + 30_000;
-        while (!after.isEmpty() && System.currentTimeMillis() < deadline) {
+        while (!candidates.isEmpty() && System.currentTimeMillis() < deadline) {
             Thread.sleep(250);
-            after = listRewriteScalaTempDirs(tmpRoot);
-            after.removeAll(before);
+            candidates.removeIf(p -> !Files.exists(p));
         }
-        assertThat(after)
-            .as("Parsing should not leak any rewrite-scala temp directories")
-            .isEmpty();
+        assertThat(candidates)
+          .as("Parsing should not leak any rewrite-scala temp directories")
+          .isEmpty();
     }
 
-    private static java.util.Set<java.nio.file.Path> listRewriteScalaTempDirs(java.nio.file.Path tmpRoot) throws java.io.IOException {
-        try (java.util.stream.Stream<java.nio.file.Path> entries = java.nio.file.Files.list(tmpRoot)) {
+    private static Set<Path> listRewriteScalaTempDirs(Path tmpRoot) throws IOException {
+        try (Stream<Path> entries = Files.list(tmpRoot)) {
             return entries
-                .filter(java.nio.file.Files::isDirectory)
-                .filter(p -> p.getFileName().toString().startsWith("rewrite-scala"))
-                .collect(Collectors.toCollection(java.util.HashSet::new));
+              .filter(Files::isDirectory)
+              .filter(p -> p.getFileName().toString().startsWith("rewrite-scala"))
+              .collect(Collectors.toCollection(HashSet::new));
         }
     }
 }


### PR DESCRIPTION
`ScalaParserTest#doesNotLeakTempDirectories` fails intermittently on main reporting leaked `/tmp/rewrite-scala*` directories, but there is no real leak: `ScalaCompilerContext.compileAll` deletes its temp dir in a `finally` before the parse returns, while every rewriteRun-based Scala test creates one of these dirs (`RewriteTest` does not set `WORKING_DIRECTORY_ROOT`) across ~4 sibling Gradle test JVMs that share `/tmp`. The old loop re-listed the temp root each poll and re-subtracted the `before` snapshot, so freshly created sibling dirs kept re-entering the candidate set and the "listing is empty" condition never converged within the 30s deadline — the reported dirs were one per sibling executor, mid-compile.

This snapshots the candidate set once after the parse and then waits for each of those specific paths to disappear: a sibling's dir vanishes when its compile finishes, while a genuinely leaked dir persists.

Verified with a standalone churn harness (background thread creating/deleting `rewrite-scala*` dirs, simulated parse in between): under churn with no leak the old logic fails with 3 dirs — exactly the CI symptom — and the new logic passes; with an injected leak the new logic still fails, pointing at only the leaked dir. `./gradlew :rewrite-scala:test` passes.