### PR TITLE
Go: type attribution for non-primitive literals

### DIFF
--- a/rewrite-go/pkg/parser/basic_lit_test.go
+++ b/rewrite-go/pkg/parser/basic_lit_test.go
@@ -93,6 +93,34 @@ func TestIntLiteralExceedingInt32FallsBackToLong(t *testing.T) {
 	assert.Equal(t, int64(5243700879), lit.Value, "value")
 }
 
+// An untyped constant compared against a value of a named type (here `i Code`,
+// `type Code int`) is converted to that named type by go/types. Because a
+// J.Literal on the Java side can only carry a JavaType.Primitive, the literal
+// must be attributed the named type's underlying basic (int) rather than the
+// named type itself, which the Java receiver would drop to null.
+func TestUntypedConstantAgainstNamedTypeKeepsPrimitive(t *testing.T) {
+	// given
+	src := "package main\n\ntype Code int\n\nfunc (i Code) String() string {\n\tif 2052 <= i {\n\t\treturn \"x\"\n\t}\n\treturn \"\"\n}\n"
+
+	// when
+	cu, err := parser.NewGoParser().Parse("g.go", src)
+	require.NoError(t, err, "parse")
+	var found *java.Literal
+	visitor.Walk(cu, func(n java.Tree) bool {
+		if lit, ok := n.(*java.Literal); ok && lit.Value == int64(2052) {
+			found = lit
+			return false
+		}
+		return true
+	})
+	require.NotNil(t, found, "literal 2052 not found")
+
+	// then
+	prim, ok := found.Type.(*java.JavaTypePrimitive)
+	require.Truef(t, ok, "expected *java.JavaTypePrimitive, got %T (a named type would be dropped to null on the Java side)", found.Type)
+	assert.Equal(t, "int", prim.Keyword, "keyword")
+}
+
 // firstLiteralOfType parses src and returns the first *java.Literal whose
 // attributed Type is the primitive `keyword` (e.g. "byte", "char").
 func firstLiteralOfType(t *testing.T, src, keyword string) *java.Literal {

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -2141,6 +2141,20 @@ func (ctx *parseContext) mapBasicLit(lit *ast.BasicLit) *java.Literal {
 
 	l.Type = ctx.valueTypeOf(lit)
 
+	// An untyped constant compared against a value of a named type (e.g.
+	// `type Code int`; `2052 <= i` where `i Code`) is converted to that named
+	// type, so go/types reports the literal's type as the named type. A
+	// J.Literal on the Java side can only carry a JavaType.Primitive, so a named
+	// type is dropped to null there. Map the literal through the named type's
+	// underlying basic to preserve the primitive (e.g. int).
+	if tv, ok := ctx.typeInfo.Types[lit]; ok {
+		if named, ok := tv.Type.(*types.Named); ok {
+			if basic, ok := named.Underlying().(*types.Basic); ok {
+				l.Type = ctx.mapper.mapType(basic)
+			}
+		}
+	}
+
 	// A Go int constant is 64-bit, but Java's int is 32-bit. When the value
 	// overflows Integer, fall back to long so the JVM LST deserializer does not
 	// reconstruct it via Integer.valueOf, which throws and drops the file.


### PR DESCRIPTION
## What's your motivation?

In Go you can have literals whose type is something else than a primitive.
Our LST model for `J.Literal` doesn't support that.

## What's changed?

Therefore adding some logic to "unwrap" the types in some cases, so that the actual underlying primitive type is carried over instead of `nil`.