### PR TITLE
Go: fix handling of empty for

### DIFF
--- a/rewrite-go/pkg/parser/for_control_test.go
+++ b/rewrite-go/pkg/parser/for_control_test.go
@@ -57,9 +57,10 @@ func TestConditionOnlyForHasEmptyInitAndUpdate(t *testing.T) {
 	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers), "expected golang.ImplicitForClauses marker on the control")
 }
 
-// An infinite `for {}` has no condition, but its init/update placeholders must
-// still be present and marked implicit.
-func TestInfiniteForHasEmptyInitAndUpdate(t *testing.T) {
+// An infinite `for {}` has no source-level clauses, but Java models `for (;;)`
+// with J.Empty in all three slots so the fields are never null. All three must
+// therefore be present and marked implicit.
+func TestInfiniteForHasEmptyInitConditionAndUpdate(t *testing.T) {
 	// given
 	src := "package main\n\nfunc f() {\n\tfor {\n\t}\n}\n"
 
@@ -72,7 +73,13 @@ func TestInfiniteForHasEmptyInitAndUpdate(t *testing.T) {
 		t.Fatalf("Init element must be *java.Empty, got %T", control.Init.Element)
 	}
 	require.NotNil(t, control.Update, "Update must not be nil for an infinite for")
-	require.Nil(t, control.Condition, "infinite for must have no condition")
+	if _, ok := control.Update.Element.(*java.Empty); !ok {
+		t.Fatalf("Update element must be *java.Empty, got %T", control.Update.Element)
+	}
+	require.NotNil(t, control.Condition, "Condition must not be nil for an infinite for")
+	if _, ok := control.Condition.Element.(*java.Empty); !ok {
+		t.Fatalf("Condition element must be *java.Empty, got %T", control.Condition.Element)
+	}
 	require.NotNil(t, java.FindMarker[golang.ImplicitForClauses](control.Markers), "expected golang.ImplicitForClauses marker on the control")
 }
 

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1868,6 +1868,11 @@ func (ctx *parseContext) mapForStmt(stmt *ast.ForStmt) *java.ForLoop {
 			control.Prefix, cond = hoistLeftPrefix(cond)
 			condRP := java.RightPadded[java.Expression]{Element: cond}
 			control.Condition = &condRP
+		} else {
+			// Infinite `for {}`: Java models `for (;;)` with a J.Empty condition,
+			// so the field is never null. Fill it with a synthetic J.Empty rather
+			// than leaving it nil; GoPrinter omits it via the ImplicitForClauses marker.
+			control.Condition = &java.RightPadded[java.Expression]{Element: &java.Empty{ID: uuid.New()}}
 		}
 		control.Init = &java.RightPadded[java.Statement]{Element: &java.Empty{ID: uuid.New()}}
 		control.Update = &java.RightPadded[java.Statement]{Element: &java.Empty{ID: uuid.New()}}


### PR DESCRIPTION
## What's changed?

- Continuation of #8479.
Fixing handling Go for loops with no conditions at all, i.e. an infinite loop like `for {}`

## What's your motivation?

- Addressing bullet point 2 from https://github.com/openrewrite/rewrite/issues/8461#issuecomment-5354016347