### PR TITLE
Python: SimplifyBooleanExpression not to mangle Python chained compar…

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -204,6 +204,9 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
             J parenthesized = ((J.Parentheses<?>) expr).getTree();
             if (parenthesized instanceof J.Binary) {
                 J.Binary binary = (J.Binary) parenthesized;
+                if (isComparison(binary.getLeft()) || isComparison(binary.getRight())) {
+                    return j;
+                }
                 J.Binary.Type negated = maybeNegate(binary.getOperator());
                 if (negated != binary.getOperator()) {
                     j = binary.withOperator(negated).withPrefix(j.getPrefix());
@@ -229,9 +232,12 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
 
     private Expression maybeNegate(Expression expr) {
         if (expr instanceof J.Binary) {
-            J.Binary.Type negated = maybeNegate(((J.Binary) expr).getOperator());
-            if (negated != ((J.Binary) expr).getOperator()) {
-                return ((J.Binary) expr).withOperator(negated).withPrefix(expr.getPrefix());
+            J.Binary binary = (J.Binary) expr;
+            if (!isComparison(binary.getLeft()) && !isComparison(binary.getRight())) {
+                J.Binary.Type negated = maybeNegate(binary.getOperator());
+                if (negated != binary.getOperator()) {
+                    return binary.withOperator(negated).withPrefix(expr.getPrefix());
+                }
             }
         } else if (expr instanceof J.Unary && ((J.Unary) expr).getOperator() == J.Unary.Type.Not) {
             return ((J.Unary) expr).getExpression().withPrefix(expr.getPrefix());
@@ -268,6 +274,21 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
             default:
                 return operator;
         }
+    }
+
+    private boolean isComparison(Expression expr) {
+        if (expr instanceof J.Binary) {
+            switch (((J.Binary) expr).getOperator()) {
+                case LessThan:
+                case GreaterThan:
+                case LessThanOrEqual:
+                case GreaterThanOrEqual:
+                case Equal:
+                case NotEqual:
+                    return true;
+            }
+        }
+        return false;
     }
 
     private final MethodMatcher isEmpty = new MethodMatcher("java.lang.String isEmpty()");

--- a/rewrite-python/src/integTest/java/org/openrewrite/python/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.cleanup;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.nio.file.Path;
+
+import static org.openrewrite.python.Assertions.python;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+@Timeout(60)
+class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder()
+                .log(tempDir.resolve("python-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        PythonRewriteRpc.shutdownCurrent();
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder());
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(toRecipe(SimplifyBooleanExpressionVisitor::new))
+                .validateRecipeSerialization(false);
+    }
+
+    @Test
+    void doNotInvertChainedComparison() {
+        rewriteRun(
+                python(
+                        """
+                        def test(value):
+                            if not (0 <= value < 6):
+                                return value
+                        """
+                )
+        );
+    }
+
+    @Test
+    void invertSingleComparison() {
+        rewriteRun(
+                python(
+                        """
+                        def test(a, b):
+                            if not (a < b):
+                                return a
+                        """,
+                        """
+                        def test(a, b):
+                            if a >= b:
+                                return a
+                        """
+                )
+        );
+    }
+}


### PR DESCRIPTION
…isons

## What's changed?

Similar to https://github.com/openrewrite/rewrite-static-analysis/pull/1010, applied to `SimplifyBooleanExpression` recipe.
Adding a guard against Python chained comparisons.

## What's your motivation?

Otherwise it makes unwarranted changes to Python code, resulting in semantics change, e.g.
```python
def in_range(x):
    if not (0 <= x < 10):
        return "out of range"
    return "ok"
```
would become:
```python
def in_range(x):
    if 0 <= x >= 10:
        return "out of range"
    return "ok"
```

