### PR TITLE
Send Go marker Spaces over RPC with their comments

### DIFF
--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -190,3 +190,34 @@ func TestChangedCodecLessMarkerRoundTrip(t *testing.T) {
 		t.Errorf("version: want %q, got %v", "8.0", gm.Data["version"])
 	}
 }
+
+func TestTrailingCommaMarkerRoundTripKeepsComments(t *testing.T) {
+	id := uuid.MustParse("cccccccc-dddd-eeee-ffff-000000000000")
+	tc := golang.TrailingComma{
+		Ident:  id,
+		Before: java.Space{Whitespace: " "},
+		After: java.Space{
+			Whitespace: " ",
+			Comments:   []java.Comment{{Text: " third", Suffix: "\n\t\t"}},
+		},
+	}
+	before := java.Markers{ID: uuid.New(), Entries: []java.Marker{tc}}
+
+	after := roundTripMarkers(t, before)
+	got, ok := after.Entries[0].(golang.TrailingComma)
+	if !ok {
+		t.Fatalf("entry is %T, want golang.TrailingComma", after.Entries[0])
+	}
+	if got.Before.Whitespace != tc.Before.Whitespace {
+		t.Errorf("Before.Whitespace: want %q, got %q", tc.Before.Whitespace, got.Before.Whitespace)
+	}
+	if got.After.Whitespace != tc.After.Whitespace {
+		t.Errorf("After.Whitespace: want %q, got %q", tc.After.Whitespace, got.After.Whitespace)
+	}
+	if len(got.After.Comments) != 1 {
+		t.Fatalf("After.Comments: want 1, got %d", len(got.After.Comments))
+	}
+	if got.After.Comments[0].Text != " third" || got.After.Comments[0].Suffix != "\n\t\t" {
+		t.Errorf("After.Comments[0]: want %#v, got %#v", tc.After.Comments[0], got.After.Comments[0])
+	}
+}

--- a/rewrite-go/pkg/rpc/space_rpc.go
+++ b/rewrite-go/pkg/rpc/space_rpc.go
@@ -196,16 +196,19 @@ func sendMarkerCodecFields(v any, q *SendQueue) {
 	case java.RecipesThatMadeChanges:
 		sendRecipesThatMadeChanges(m, q)
 	case golang.GroupedImport:
-		// GroupedImport.rpcSend sends: id (UUID string), before whitespace (string)
+		// GroupedImport.rpcSend sends: id (UUID string), before Space
 		q.GetAndSend(m, func(x any) any { return x.(golang.GroupedImport).Ident.String() }, nil)
-		q.GetAndSend(m, func(x any) any { return x.(golang.GroupedImport).Before.Whitespace }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(golang.GroupedImport).Before },
+			func(v any) { sendSpace(v.(java.Space), q) })
 	case golang.ImportBlock:
-		// ImportBlock.rpcSend sends: id, closePrevious, before, grouped, groupedBefore
+		// ImportBlock.rpcSend sends: id, closePrevious, before Space, grouped, groupedBefore Space
 		q.GetAndSend(m, func(x any) any { return x.(golang.ImportBlock).Ident.String() }, nil)
 		q.GetAndSend(m, func(x any) any { return x.(golang.ImportBlock).ClosePrevious }, nil)
-		q.GetAndSend(m, func(x any) any { return x.(golang.ImportBlock).Before.Whitespace }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(golang.ImportBlock).Before },
+			func(v any) { sendSpace(v.(java.Space), q) })
 		q.GetAndSend(m, func(x any) any { return x.(golang.ImportBlock).Grouped }, nil)
-		q.GetAndSend(m, func(x any) any { return x.(golang.ImportBlock).GroupedBefore.Whitespace }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(golang.ImportBlock).GroupedBefore },
+			func(v any) { sendSpace(v.(java.Space), q) })
 	case golang.ShortVarDecl:
 		q.GetAndSend(m, func(x any) any { return x.(golang.ShortVarDecl).Ident.String() }, nil)
 	case golang.VarKeyword:
@@ -229,10 +232,12 @@ func sendMarkerCodecFields(v any, q *SendQueue) {
 		q.GetAndSend(m, func(x any) any { return x.(golang.StructTag).Ident.String() }, nil)
 		q.GetAndSend(m, func(x any) any { return x.(golang.StructTag).Tag.Source }, nil)
 	case golang.TrailingComma:
-		// TrailingComma.rpcSend sends: id (UUID string), before whitespace, after whitespace
+		// TrailingComma.rpcSend sends: id (UUID string), before Space, after Space
 		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).Ident.String() }, nil)
-		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).Before.Whitespace }, nil)
-		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).After.Whitespace }, nil)
+		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).Before },
+			func(v any) { sendSpace(v.(java.Space), q) })
+		q.GetAndSend(m, func(x any) any { return x.(golang.TrailingComma).After },
+			func(v any) { sendSpace(v.(java.Space), q) })
 	case golang.StructTagQuote:
 		// StructTagQuote.rpcSend sends: id (UUID string), quote (string)
 		q.GetAndSend(m, func(x any) any { return x.(golang.StructTagQuote).Ident.String() }, nil)
@@ -380,15 +385,14 @@ func receiveMarkersCodec(q *ReceiveQueue, before java.Markers) java.Markers {
 		case java.RecipesThatMadeChanges:
 			return receiveRecipesThatMadeChanges(m, q)
 		case golang.GroupedImport:
-			// GroupedImport.rpcSend sends: id (UUID string), before whitespace (string)
+			// GroupedImport.rpcSend sends: id (UUID string), before Space
 			idStr := receiveScalar[string](q, m.Ident.String())
 			if idStr != "" {
 				if parsed, err := uuid.Parse(idStr); err == nil {
 					m.Ident = parsed
 				}
 			}
-			ws := receiveScalar[string](q, m.Before.Whitespace)
-			m.Before = java.Space{Whitespace: ws}
+			m.Before = receiveValue(q, m.Before, func(s java.Space) any { return receiveSpace(s, q) })
 			return m
 		case golang.ImportBlock:
 			// ImportBlock.rpcReceive: id, closePrevious, before, grouped, groupedBefore
@@ -399,11 +403,9 @@ func receiveMarkersCodec(q *ReceiveQueue, before java.Markers) java.Markers {
 				}
 			}
 			m.ClosePrevious = receiveScalar[bool](q, m.ClosePrevious)
-			ws := receiveScalar[string](q, m.Before.Whitespace)
-			m.Before = java.Space{Whitespace: ws}
+			m.Before = receiveValue(q, m.Before, func(s java.Space) any { return receiveSpace(s, q) })
 			m.Grouped = receiveScalar[bool](q, m.Grouped)
-			gbWs := receiveScalar[string](q, m.GroupedBefore.Whitespace)
-			m.GroupedBefore = java.Space{Whitespace: gbWs}
+			m.GroupedBefore = receiveValue(q, m.GroupedBefore, func(s java.Space) any { return receiveSpace(s, q) })
 			return m
 		case golang.ShortVarDecl:
 			idStr := receiveScalar[string](q, m.Ident.String())
@@ -518,10 +520,8 @@ func receiveMarkersCodec(q *ReceiveQueue, before java.Markers) java.Markers {
 					m.Ident = parsed
 				}
 			}
-			beforeWs := receiveScalar[string](q, m.Before.Whitespace)
-			m.Before = java.Space{Whitespace: beforeWs}
-			afterWs := receiveScalar[string](q, m.After.Whitespace)
-			m.After = java.Space{Whitespace: afterWs}
+			m.Before = receiveValue(q, m.Before, func(s java.Space) any { return receiveSpace(s, q) })
+			m.After = receiveValue(q, m.After, func(s java.Space) any { return receiveSpace(s, q) })
 			return m
 		case golang.Semicolon:
 			idStr := receiveScalar[string](q, m.Ident.String())

--- a/rewrite-go/pkg/rpc/value_types.go
+++ b/rewrite-go/pkg/rpc/value_types.go
@@ -245,7 +245,7 @@ func init() {
 	RegisterFactory("org.openrewrite.marker.DeserializationError", func() any { return java.GenericMarker{JavaType: "org.openrewrite.marker.DeserializationError"} })
 	// SearchResult: IS an RpcCodec, sends 2 sub-fields (id, description)
 	RegisterFactory("org.openrewrite.marker.SearchResult", func() any { return java.SearchResult{} })
-	// GroupedImport: IS an RpcCodec, sends 2 sub-fields (id, before whitespace)
+	// GroupedImport: IS an RpcCodec, sends 2 sub-fields (id, before Space)
 	RegisterFactory("org.openrewrite.golang.marker.GroupedImport", func() any { return golang.GroupedImport{} })
 	// ImportBlock: IS an RpcCodec, sends 5 sub-fields (id, closePrevious, before, grouped, groupedBefore)
 	RegisterFactory("org.openrewrite.golang.marker.ImportBlock", func() any { return golang.ImportBlock{} })

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcPrintRoundTripIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcPrintRoundTripIntegTest.java
@@ -443,4 +443,84 @@ class GoRpcPrintRoundTripIntegTest {
                 }
                 """);
     }
+
+    @Test
+    void trailingCommentOnLastCompositeLiteralElementSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                var cases = []tc{
+                \t{
+                \t\tname: "with trailing comment on last entry",
+                \t\tdata: map[string][]string{
+                \t\t\t"a": {"hi"},    // first
+                \t\t\t"b": {"3.14"},  // second
+                \t\t\t"c": {"value"}, // third
+                \t\t},
+                \t},
+                }
+                """);
+    }
+
+    @Test
+    void commentBeforeSecondImportBlockSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                import "fmt"
+
+                // about os
+                import "os"
+
+                func f() {
+                \t_ = fmt.Sprintf
+                \t_ = os.Getenv
+                }
+                """);
+    }
+
+    @Test
+    void commentBeforeGroupedImportParenSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                import /* which */ (
+                \t"fmt"
+                )
+
+                func f() {
+                \t_ = fmt.Sprintf
+                }
+                """);
+    }
+
+    @Test
+    void trailingCommentOnLastCallArgumentSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                func f() {
+                \tg(
+                \t\t1, // one
+                \t)
+                }
+                """);
+    }
+
+    @Test
+    void trailingCommentOnLastParameterSurvivesReset() {
+        assertPrintsUnchangedAfterReset(
+                """
+                package main
+
+                func f(
+                \ta int, // first
+                ) {
+                }
+                """);
+    }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/GroupedImport.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/GroupedImport.java
@@ -17,6 +17,8 @@ package org.openrewrite.golang.marker;
 
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.java.internal.rpc.JavaReceiver;
+import org.openrewrite.java.internal.rpc.JavaSender;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -34,13 +36,13 @@ public class GroupedImport implements Marker, RpcCodec<GroupedImport> {
     @Override
     public void rpcSend(GroupedImport after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, g -> g.getBefore().getWhitespace());
+        q.getAndSend(after, GroupedImport::getBefore, space -> new JavaSender().visitSpace(space, q));
     }
 
     @Override
     public GroupedImport rpcReceive(GroupedImport before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withBefore(Space.format(q.receive(before.getBefore() == null ? "" : before.getBefore().getWhitespace())));
+                .withBefore(q.receive(before.getBefore(), space -> new JavaReceiver().visitSpace(space, q)));
     }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/ImportBlock.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/ImportBlock.java
@@ -17,6 +17,8 @@ package org.openrewrite.golang.marker;
 
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.java.internal.rpc.JavaReceiver;
+import org.openrewrite.java.internal.rpc.JavaSender;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -38,9 +40,9 @@ public class ImportBlock implements Marker, RpcCodec<ImportBlock> {
     public void rpcSend(ImportBlock after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
         q.getAndSend(after, ImportBlock::isClosePrevious);
-        q.getAndSend(after, b -> b.getBefore().getWhitespace());
+        q.getAndSend(after, ImportBlock::getBefore, space -> new JavaSender().visitSpace(space, q));
         q.getAndSend(after, ImportBlock::isGrouped);
-        q.getAndSend(after, b -> b.getGroupedBefore().getWhitespace());
+        q.getAndSend(after, ImportBlock::getGroupedBefore, space -> new JavaSender().visitSpace(space, q));
     }
 
     @Override
@@ -48,8 +50,8 @@ public class ImportBlock implements Marker, RpcCodec<ImportBlock> {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
                 .withClosePrevious(q.receive(before.isClosePrevious()))
-                .withBefore(Space.format(q.receive(before.getBefore() == null ? "" : before.getBefore().getWhitespace())))
+                .withBefore(q.receive(before.getBefore(), space -> new JavaReceiver().visitSpace(space, q)))
                 .withGrouped(q.receive(before.isGrouped()))
-                .withGroupedBefore(Space.format(q.receive(before.getGroupedBefore() == null ? "" : before.getGroupedBefore().getWhitespace())));
+                .withGroupedBefore(q.receive(before.getGroupedBefore(), space -> new JavaReceiver().visitSpace(space, q)));
     }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/marker/TrailingComma.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/marker/TrailingComma.java
@@ -17,6 +17,8 @@ package org.openrewrite.golang.marker;
 
 import lombok.Value;
 import lombok.With;
+import org.openrewrite.java.internal.rpc.JavaReceiver;
+import org.openrewrite.java.internal.rpc.JavaSender;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.marker.Marker;
 import org.openrewrite.rpc.RpcCodec;
@@ -35,15 +37,15 @@ public class TrailingComma implements Marker, RpcCodec<TrailingComma> {
     @Override
     public void rpcSend(TrailingComma after, RpcSendQueue q) {
         q.getAndSend(after, Marker::getId);
-        q.getAndSend(after, t -> t.getBefore().getWhitespace());
-        q.getAndSend(after, t -> t.getAfter().getWhitespace());
+        q.getAndSend(after, TrailingComma::getBefore, space -> new JavaSender().visitSpace(space, q));
+        q.getAndSend(after, TrailingComma::getAfter, space -> new JavaSender().visitSpace(space, q));
     }
 
     @Override
     public TrailingComma rpcReceive(TrailingComma before, RpcReceiveQueue q) {
         return before
                 .withId(q.receiveAndGet(before.getId(), UUID::fromString))
-                .withBefore(Space.format(q.receive(before.getBefore() == null ? "" : before.getBefore().getWhitespace())))
-                .withAfter(Space.format(q.receive(before.getAfter() == null ? "" : before.getAfter().getWhitespace())));
+                .withBefore(q.receive(before.getBefore(), space -> new JavaReceiver().visitSpace(space, q)))
+                .withAfter(q.receive(before.getAfter(), space -> new JavaReceiver().visitSpace(space, q)));
     }
 }


### PR DESCRIPTION
`mod git apply` aborts for all of `gin-gonic/gin@dcaa429` after a Go recipe run, because the "before" text the CLI renders is not byte-identical to the file on disk:

```
org.openrewrite.jgit.api.errors.PatchApplyException: Error applying patch in context_test.go,
hunk HunkHeader[3817,7->4014,7]: hunk does not apply to file content
```

It leaves 14 files partially applied. Plain `git apply` fails identically, so the patch itself is wrong.

## What happens

The `RpcCodec` for the Go-specific `TrailingComma`, `ImportBlock` and `GroupedImport` markers serialized each `Space` field as a bare whitespace string on both sides of the wire:

```java
q.getAndSend(after, t -> t.getAfter().getWhitespace());   // Space.comments never sent
```

Go's `space_rpc.go` mirrored the same truncation, so the two peers stayed in sync while both silently lost `Space.comments`.

For a composite literal whose last element carries a trailing line comment, that comment *and* the newline before the closing brace both live in `TrailingComma`'s `after` space — parsed as `Space(whitespace=" ", comments=[LineComment(" third", suffix="\n\t\t")])`. Only `" "` survived the round trip:

```go
// source                          // after a round trip
"c": {"value"}, // third           "c": {"value"}, },
},
```

The bad line shows up as a *context* line in `fix.patch`, which is why the recipe looks implicated but isn't — `PreferMakeForEmptyMap` never visits composite-literal elements. The recipe is only a trigger: the Go RPC server caches the parsed tree by source-file id, so an unmodified `Print` returns `NO_CHANGE` and Go answers from its own correct cached node. Any tree mutation forces real deserialization, so *any* Go recipe editing such a file produces an unappliable patch. This is also why a pure parse/print round trip in `pkg/parser` + `pkg/printer` is faithful.

`ImportBlock.before` is the space preceding the `import` keyword, so the same defect drops an ordinary comment introducing a second import declaration:

```go
import "fmt"

// about os        <- dropped
import "os"
```

## Fix

Both sides now send the full `Space` through `JavaSender.visitSpace` / `sendSpace`, matching how the Java-side `org.openrewrite.java.marker.TrailingComma` has always sent its suffix. Sending only the comment list would have been narrower but leaves two Space encodings in one file; the shared helpers already exist and are what every other Space-valued field in these codecs uses.

## Tests

Five cases added to `GoRpcPrintRoundTripIntegTest`, which parses, calls `rpc.reset()` to drop both caches, then prints — forcing full deserialization without needing a recipe: a nested composite literal (the reported reproducer), a call argument list, a parameter list, a second import block, and `import /* which */ (` for `GroupedImport.before`. All five fail on `main` and pass here; the composite-literal one reproduces `"c": {"value"}, },` exactly. `TestTrailingCommaMarkerRoundTripKeepsComments` adds a codec-level guard on the Go side.

Note that a `// group` comment *after* the open paren lands in the first import's prefix rather than in `GroupedImport.before`, so `import /* which */ (` is the construct that actually exercises that field.

Verified separately, not committed as a fixture: gin's real 118 KB `context_test.go` at `dcaa429` fails the reset-and-print round trip on `main` and is byte-identical with this change.
