### PR TITLE
Go: stop `RemoveUnusedImports` deleting imports a repository name spells

### DIFF
--- a/rewrite-go/cmd/rpc/after_visits_test.go
+++ b/rewrite-go/cmd/rpc/after_visits_test.go
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	goparser "github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/template"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+const sourceImportsChildName = "org.openrewrite.go.test.PreferSlicesSort$Strings"
+
+// sourceImportsChild mirrors the shape every `template.SourceImports` recipe in
+// recipes-go has: the after template's import edit is composed onto the source
+// file through GoVisitor.DoAfterVisit rather than returned from Visit.
+var sourceImportsChild = func() recipe.Recipe {
+	s := template.Expr("s")
+	return template.NewRecipe(
+		template.RecipeName(sourceImportsChildName),
+		template.WithDisplayName("sort.Strings -> slices.Sort"),
+		template.WithDescription("Replaces `sort.Strings` with `slices.Sort`."),
+		template.WithBefore(fmt.Sprintf(`sort.Strings(%s)`, s), template.Imports("sort")),
+		template.WithAfter(fmt.Sprintf(`slices.Sort(%s)`, s), template.Imports("slices"), template.SourceImports("slices")),
+		template.WithCaptures(s),
+	)
+}()
+
+// sourceImportsComposite is the declaring recipe, the only form under which a
+// configured template recipe reaches the registry: Register derives a
+// constructor by reflection, which yields a zero-valued instance, so only a
+// composite's children are registered as the instances they were built as.
+type sourceImportsComposite struct{ recipe.Base }
+
+func (*sourceImportsComposite) Name() string { return "org.openrewrite.go.test.PreferSlicesSort" }
+func (*sourceImportsComposite) DisplayName() string {
+	return "Prefer slices.Sort over sort type helpers"
+}
+func (*sourceImportsComposite) Description() string {
+	return "Replaces `sort.Strings` with `slices.Sort`."
+}
+func (*sourceImportsComposite) RecipeList() []recipe.Recipe {
+	return []recipe.Recipe{sourceImportsChild}
+}
+
+const afterVisitsBefore = `package slicesort
+
+import (
+	"sort"
+)
+
+// SortKeys sorts the given keys.
+func SortKeys(keys []string) []string {
+	sort.Strings(keys)
+	return keys
+}
+`
+
+const afterVisitsAfter = `package slicesort
+
+import (
+	"slices"
+)
+
+// SortKeys sorts the given keys.
+func SortKeys(keys []string) []string {
+	slices.Sort(keys)
+	return keys
+}
+`
+
+// seedTreeForVisit stages `src` as the tree the host is about to dispatch a
+// visit against: the parsed LST becomes Go's reverse-direction baseline and the
+// host's scripted reply is a NO_CHANGE, so getObjectFromJava hands it back.
+func seedTreeForVisit(t *testing.T, s *server, treeID, src string) {
+	t.Helper()
+	cu, err := goparser.NewGoParser().Parse("sort.go", src)
+	if err != nil {
+		t.Fatalf("parse source: %v", err)
+	}
+	s.reverseRemoteObjects[treeID] = cu
+	s.reader = bufio.NewReader(bytes.NewReader(frameReverseGetObjectReply(t, []map[string]any{
+		{"state": "NO_CHANGE"},
+		{"state": "END_OF_OBJECT"},
+	})))
+	s.writer = &bytes.Buffer{}
+}
+
+func printVisited(t *testing.T, s *server, treeID string) string {
+	t.Helper()
+	tree, ok := s.localObjects[treeID].(java.Tree)
+	if !ok {
+		t.Fatalf("localObjects[%q] = %#v, want a tree", treeID, s.localObjects[treeID])
+	}
+	return printer.Print(tree)
+}
+
+// The host dispatches through Visit for a lone recipe and BatchVisit for a
+// composite, so a drain in only one of them would make a recipe's import edits
+// depend on the shape of the run.
+func TestVisitPathsDrainAfterVisits(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		dispatch func(t *testing.T, s *server, visitorName, treeID string)
+	}{
+		{
+			name: "Visit",
+			dispatch: func(t *testing.T, s *server, visitorName, treeID string) {
+				params, err := json.Marshal(visitRequest{Visitor: visitorName, TreeID: treeID, SourceFileType: "Go"})
+				if err != nil {
+					t.Fatalf("marshal visit request: %v", err)
+				}
+				if _, rpcErr := s.handleVisit(params); rpcErr != nil {
+					t.Fatalf("handleVisit returned error: %+v", rpcErr)
+				}
+			},
+		},
+		{
+			name: "BatchVisit",
+			dispatch: func(t *testing.T, s *server, visitorName, treeID string) {
+				params, err := json.Marshal(batchVisitRequest{
+					TreeID:         treeID,
+					SourceFileType: "Go",
+					Visitors:       []batchVisitItem{{Visitor: visitorName}},
+				})
+				if err != nil {
+					t.Fatalf("marshal batch visit request: %v", err)
+				}
+				if _, rpcErr := s.handleBatchVisit(params); rpcErr != nil {
+					t.Fatalf("handleBatchVisit returned error: %+v", rpcErr)
+				}
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _ := newTestServer(t)
+			s.registry.Register(&sourceImportsComposite{})
+			recipeID := prepareRecipe(t, s, sourceImportsChildName)
+
+			const treeID = "tree-1"
+			seedTreeForVisit(t, s, treeID, afterVisitsBefore)
+
+			tc.dispatch(t, s, "edit:"+recipeID, treeID)
+
+			if got := printVisited(t, s, treeID); got != afterVisitsAfter {
+				t.Errorf("visited source:\ngot:\n%s\nwant:\n%s", got, afterVisitsAfter)
+			}
+		})
+	}
+}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2116,6 +2116,15 @@ func (s *server) handleBatchVisit(params json.RawMessage) (any, *rpcError) {
 		// visitor added any new ones (`hasNewMessages`).
 		preKeys := stringSet(ctx.MessageKeys())
 		after := v.Visit(current, ctx)
+		if t, ok := after.(java.Tree); ok {
+			// Part of this visitor's edit, on the same terms as in handleVisit.
+			after = visitor.DrainAfterVisits(v, t, ctx)
+		} else if q, ok := v.(visitor.AfterVisitsProvider); ok {
+			// A deleted tree leaves nothing to apply them to, and an editor
+			// instance can be shared across files: emptying the queue is what
+			// keeps them off the next one.
+			q.AfterVisits()
+		}
 
 		deleted := after == nil
 		modified := !deleted && !treeIdentical(before, after)

--- a/rewrite-go/pkg/recipe/golang/activate.go
+++ b/rewrite-go/pkg/recipe/golang/activate.go
@@ -27,6 +27,7 @@ func Activate(r *recipe.Registry) {
 	r.Register(&FindTypes{}, golangCategory, searchCategory)
 	r.Register(&FindMethods{}, golangCategory, searchCategory)
 	r.Register(&RenameXToFlag{}, golangCategory)
+	r.Register(&WrapErrorWithContext{}, golangCategory)
 	r.Register(&AddImport{}, golangCategory)
 	r.Register(&RemoveImport{}, golangCategory)
 	r.Register(&RemoveUnusedImports{}, golangCategory)

--- a/rewrite-go/pkg/recipe/golang/internal/imports.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports.go
@@ -23,6 +23,7 @@ package internal
 import (
 	"sort"
 	"strings"
+	"unicode"
 
 	"github.com/google/uuid"
 
@@ -101,7 +102,40 @@ func packageNameForPath(path string) string {
 	if i := strings.LastIndex(last, "."); i > 0 && isVersionElement(last[i+1:]) {
 		last = last[:i]
 	}
-	return last
+	return trimRepoAffix(last)
+}
+
+// trimRepoAffix drops the `go` a repository name carries to say what language
+// it holds — `go-toml` hosting `package toml`. A hyphen or a dot cannot appear
+// in a Go identifier, so an element spelling one is a repository name and never
+// the package name it declares.
+func trimRepoAffix(element string) string {
+	for _, affix := range []string{"go-", "go."} {
+		if len(element) > len(affix) && strings.HasPrefix(element, affix) {
+			return element[len(affix):]
+		}
+	}
+	for _, affix := range []string{"-go", ".go"} {
+		if len(element) > len(affix) && strings.HasSuffix(element, affix) {
+			return element[:len(element)-len(affix)]
+		}
+	}
+	return element
+}
+
+// isIdentifier reports whether s can be a Go identifier, and so whether it can
+// be the name a package declares.
+func isIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if r == '_' || unicode.IsLetter(r) || (i > 0 && unicode.IsDigit(r)) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 // isVersionElement reports whether a path element is a major-version marker.
@@ -209,48 +243,73 @@ func IsLocal(importPath, modulePath string) bool {
 	return importPath == modulePath || strings.HasPrefix(importPath, modulePath+"/")
 }
 
-// ReferencedImports walks the body of cu once and returns the two signals
-// that decide whether an import is used: refs, the import paths carried by
-// the parser's Type attribution, and quals, the identifiers used lexically
-// as package qualifiers — the attribution-free signal goimports relies on.
-// Aliases and dot imports land in refs under the package's import path.
-func ReferencedImports(cu *golang.CompilationUnit) (refs, quals map[string]bool) {
-	return referencedImports(cu)
+// ImportUses answers, for each import of a file, whether the file still uses
+// it. Build one per compilation unit with UsesOf and ask it about as many
+// imports as needed; the file is walked once.
+type ImportUses struct {
+	// refs holds the import paths the parser's Type attribution names.
+	refs map[string]bool
+	// quals holds the identifiers used lexically as package qualifiers — the
+	// attribution-free signal goimports relies on.
+	quals map[string]bool
+	// resolvedQuals holds the qualifiers an import refs names already binds.
+	// Valid Go cannot bind one qualifier twice, so a non-empty entry means
+	// either a tree mid-rewrite — how a major-version move reads — or input
+	// that arrived invalid, where the qualifier binds arbitrarily and no
+	// answer is better than another.
+	resolvedQuals map[string]bool
 }
 
-// ReferencedPackages returns just the import-path set of ReferencedImports.
+// UsesOf walks cu once and gathers the signals its imports are judged by.
+func UsesOf(cu *golang.CompilationUnit) ImportUses {
+	refs, quals := referencedImports(cu)
+	u := ImportUses{refs: refs, quals: quals, resolvedQuals: map[string]bool{}}
+	for _, imp := range ImportsOf(cu) {
+		if name := PackageName(imp); name != "" && refs[ImportPath(imp)] {
+			u.resolvedQuals[name] = true
+		}
+	}
+	return u
+}
+
+// Referenced reports whether the file still uses imp.
+func (u ImportUses) Referenced(imp *java.Import) bool {
+	if u.refs[ImportPath(imp)] {
+		return true
+	}
+	// Blank and dot imports bind no qualifier; whether they survive is a
+	// policy their callers hold.
+	name := PackageName(imp)
+	if name == "" {
+		return false
+	}
+	if u.quals[name] && !u.resolvedQuals[name] {
+		return true
+	}
+	// A name no package can declare matches no qualifier, so reading its
+	// absence as disuse would condemn the import on the one signal left.
+	return !isIdentifier(name)
+}
+
+// ImportsOf returns the imports cu declares, in source order.
+func ImportsOf(cu *golang.CompilationUnit) []*java.Import {
+	if cu == nil || cu.Imports == nil {
+		return nil
+	}
+	imps := make([]*java.Import, 0, len(cu.Imports.Elements))
+	for _, rp := range cu.Imports.Elements {
+		if rp.Element != nil {
+			imps = append(imps, rp.Element)
+		}
+	}
+	return imps
+}
+
+// ReferencedPackages returns the import paths the parser's Type attribution
+// names in the body of cu.
 func ReferencedPackages(cu *golang.CompilationUnit) map[string]bool {
 	refs, _ := referencedImports(cu)
 	return refs
-}
-
-// ResolvedQualifiers names the qualifiers attribution has already accounted
-// for: those bound by an import refs names. Valid Go cannot bind one
-// qualifier twice, so a non-empty result means either a tree mid-rewrite —
-// how a major-version move reads — or input that arrived invalid, where the
-// qualifier binds arbitrarily and no answer is better than another.
-func ResolvedQualifiers(imports []*java.Import, refs map[string]bool) map[string]bool {
-	resolved := map[string]bool{}
-	for _, imp := range imports {
-		if refs[ImportPath(imp)] {
-			if name := PackageName(imp); name != "" {
-				resolved[name] = true
-			}
-		}
-	}
-	return resolved
-}
-
-// IsReferenced reports whether imp is used by the file whose refs/quals sets
-// are passed in. quals stands in for references attribution could not resolve,
-// so it rescues an import refs does not name — unless resolvedQuals holds the
-// qualifier, which makes refs's silence about this one an answer, not a gap.
-func IsReferenced(imp *java.Import, refs, quals, resolvedQuals map[string]bool) bool {
-	if refs[ImportPath(imp)] {
-		return true
-	}
-	name := PackageName(imp)
-	return quals[name] && !resolvedQuals[name]
 }
 
 func referencedImports(cu *golang.CompilationUnit) (refs, quals map[string]bool) {

--- a/rewrite-go/pkg/recipe/golang/internal/imports_test.go
+++ b/rewrite-go/pkg/recipe/golang/internal/imports_test.go
@@ -20,25 +20,35 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
-	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 )
 
 func TestPackageNameForPath(t *testing.T) {
 	for path, want := range map[string]string{
-		"strings":                   "strings",
-		"encoding/json":             "json",
-		"github.com/pkg/errors":     "errors",
-		"encoding/json/v2":          "json",
-		"encoding/json/jsontext":    "jsontext",
-		"github.com/x/y/v2":         "y",
-		"github.com/x/y/v10":        "y",
-		"gopkg.in/yaml.v3":          "yaml",
-		"gopkg.in/check.v1":         "check",
-		"example.com/shipped/mathx": "mathx",
-		"v2":                        "v2",
-		"github.com/x/version":      "version",
-		"github.com/x/v2x":          "v2x",
+		"strings":                             "strings",
+		"encoding/json":                       "json",
+		"github.com/pkg/errors":               "errors",
+		"encoding/json/v2":                    "json",
+		"encoding/json/jsontext":              "jsontext",
+		"github.com/x/y/v2":                   "y",
+		"github.com/x/y/v10":                  "y",
+		"gopkg.in/yaml.v3":                    "yaml",
+		"gopkg.in/check.v1":                   "check",
+		"example.com/shipped/mathx":           "mathx",
+		"v2":                                  "v2",
+		"github.com/x/version":                "version",
+		"github.com/x/v2x":                    "v2x",
+		"github.com/pelletier/go-toml/v2":     "toml",
+		"github.com/goccy/go-yaml":            "yaml",
+		"github.com/dustin/go-humanize":       "humanize",
+		"github.com/mattn/go-isatty":          "isatty",
+		"github.com/nats-io/nats.go":          "nats",
+		"k8s.io/client-go":                    "client",
+		"github.com/go-viper/mapstructure/v2": "mapstructure",
+		"go.uber.org/zap":                     "zap",
+		"github.com/x/go":                     "go",
 	} {
 		assert.Equal(t, want, packageNameForPath(path), "path %q", path)
 	}
@@ -61,16 +71,68 @@ func TestPkgPathOf(t *testing.T) {
 	}
 }
 
-func TestResolvedQualifiers(t *testing.T) {
-	blank := "_"
-	imports := []*java.Import{
-		NewImport("math/rand", nil),
-		NewImport("math/rand/v2", nil),
-		NewImport("fmt", nil),
-		NewImport("net/http/pprof", &blank),
+func TestIsIdentifier(t *testing.T) {
+	for s, want := range map[string]bool{
+		"toml": true, "x9": true, "_x": true, "": false,
+		"go-toml": false, "nats.go": false, "9x": false,
+	} {
+		assert.Equal(t, want, isIdentifier(s), "%q", s)
 	}
+}
 
-	assert.Equal(t, map[string]bool{"rand": true},
-		ResolvedQualifiers(imports, map[string]bool{"math/rand/v2": true, "net/http/pprof": true}))
-	assert.Empty(t, ResolvedQualifiers(imports, map[string]bool{}))
+func TestImportUsesReferenced(t *testing.T) {
+	blank := "_"
+	rand1 := NewImport("math/rand", nil)
+	rand2 := NewImport("math/rand/v2", nil)
+	fmtImp := NewImport("fmt", nil)
+	pprof := NewImport("net/http/pprof", &blank)
+
+	attributed := ImportUses{
+		refs:          map[string]bool{"math/rand/v2": true},
+		quals:         map[string]bool{"rand": true},
+		resolvedQuals: map[string]bool{"rand": true},
+	}
+	assert.True(t, attributed.Referenced(rand2), "attribution names the path")
+	assert.False(t, attributed.Referenced(rand1),
+		"the qualifier is spoken for, so refs passing over this import is an answer")
+
+	lexical := ImportUses{
+		refs:          map[string]bool{},
+		quals:         map[string]bool{"rand": true},
+		resolvedQuals: map[string]bool{},
+	}
+	assert.True(t, lexical.Referenced(rand1), "the qualifier stands in for attribution")
+	assert.False(t, lexical.Referenced(fmtImp))
+	assert.False(t, lexical.Referenced(pprof), "a blank import binds no qualifier")
+	assert.True(t, lexical.Referenced(NewImport("github.com/x/foo-bar", nil)),
+		"no qualifier can spell this name, so its absence says nothing")
+}
+
+func TestUsesOfReadsAttributionAndQualifiers(t *testing.T) {
+	cu, err := parser.NewGoParser().Parse("f.go", `package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/x/y"
+)
+
+func f() {
+	fmt.Println(y.Hello())
+}
+`)
+	require.NoError(t, err)
+
+	uses := UsesOf(cu)
+	assert.Equal(t, map[string]bool{"fmt": true, "y": true}, uses.quals)
+	assert.Equal(t, map[string]bool{"fmt": true, "y": true}, uses.resolvedQuals,
+		"a qualifier binding under the name its path spells resolves to that path")
+	assert.False(t, uses.refs["strings"], "an import the body never names")
+
+	imports := ImportsOf(cu)
+	require.Len(t, imports, 3)
+	assert.True(t, uses.Referenced(imports[0]), "fmt")
+	assert.False(t, uses.Referenced(imports[1]), "strings")
+	assert.True(t, uses.Referenced(imports[2]), "github.com/x/y")
 }

--- a/rewrite-go/pkg/recipe/golang/remove_import.go
+++ b/rewrite-go/pkg/recipe/golang/remove_import.go
@@ -69,10 +69,9 @@ func (v *removeImportVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p
 	if v.cfg.PackagePath == "" || cu.Imports == nil {
 		return cu
 	}
-	var refs, quals, resolved map[string]bool
+	var uses internal.ImportUses
 	if !v.cfg.Force {
-		refs, quals = internal.ReferencedImports(cu)
-		resolved = internal.ResolvedQualifiers(importsOf(cu), refs)
+		uses = internal.UsesOf(cu)
 	}
 	for _, rp := range cu.Imports.Elements {
 		imp := rp.Element
@@ -83,7 +82,7 @@ func (v *removeImportVisitor) VisitCompilationUnit(cu *golang.CompilationUnit, p
 			if alias := internal.AliasName(imp); alias == "_" || alias == "." {
 				continue
 			}
-			if internal.IsReferenced(imp, refs, quals, resolved) {
+			if uses.Referenced(imp) {
 				continue
 			}
 		}

--- a/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
+++ b/rewrite-go/pkg/recipe/golang/remove_unused_imports.go
@@ -58,13 +58,8 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 	if cu.Imports == nil || len(cu.Imports.Elements) == 0 {
 		return cu
 	}
-	refs, quals := internal.ReferencedImports(cu)
-	resolved := internal.ResolvedQualifiers(importsOf(cu), refs)
-	for _, rp := range cu.Imports.Elements {
-		imp := rp.Element
-		if imp == nil {
-			continue
-		}
+	uses := internal.UsesOf(cu)
+	for _, imp := range internal.ImportsOf(cu) {
 		// Blank imports stay — they exist for init() side-effects.
 		if internal.AliasName(imp) == "_" {
 			continue
@@ -74,23 +69,10 @@ func (v *removeUnusedImportsVisitor) VisitCompilationUnit(cu *golang.Compilation
 		if internal.AliasName(imp) == "." {
 			continue
 		}
-		if internal.IsReferenced(imp, refs, quals, resolved) {
+		if uses.Referenced(imp) {
 			continue
 		}
 		cu = internal.RemoveFromBlock(cu, imp)
 	}
 	return cu
-}
-
-func importsOf(cu *golang.CompilationUnit) []*java.Import {
-	if cu == nil || cu.Imports == nil {
-		return nil
-	}
-	imps := make([]*java.Import, 0, len(cu.Imports.Elements))
-	for _, rp := range cu.Imports.Elements {
-		if rp.Element != nil {
-			imps = append(imps, rp.Element)
-		}
-	}
-	return imps
 }

--- a/rewrite-go/pkg/recipe/golang/wrap_error_with_context.go
+++ b/rewrite-go/pkg/recipe/golang/wrap_error_with_context.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package golang
+
+import (
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/recipe"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// WrapErrorWithContext rewrites `return err` into
+// `return fmt.Errorf("<func>: %w", err)` and adds the `fmt` import. It stands
+// in for the codequality recipe of the same name, so tests can compose a
+// recipe that builds an un-attributed reference with one that reads imports.
+type WrapErrorWithContext struct {
+	recipe.Base
+}
+
+func (r *WrapErrorWithContext) Name() string {
+	return "org.openrewrite.golang.test.WrapErrorWithContext"
+}
+func (r *WrapErrorWithContext) DisplayName() string { return "Wrap error with context (test)" }
+func (r *WrapErrorWithContext) Description() string {
+	return "Test recipe that replaces `return err` with `return fmt.Errorf(\"funcName: %w\", err)`."
+}
+
+func (r *WrapErrorWithContext) Editor() recipe.TreeVisitor {
+	return visitor.Init(&wrapErrorWithContextVisitor{})
+}
+
+type wrapErrorWithContextVisitor struct {
+	visitor.GoVisitor
+	funcName string
+}
+
+func (v *wrapErrorWithContextVisitor) VisitMethodDeclaration(md *java.MethodDeclaration, p any) java.J {
+	outer := v.funcName
+	if md.Name != nil {
+		v.funcName = md.Name.Name
+	}
+	result := v.GoVisitor.VisitMethodDeclaration(md, p)
+	v.funcName = outer
+	return result
+}
+
+func (v *wrapErrorWithContextVisitor) VisitReturn(ret *java.Return, p any) java.J {
+	ret = v.GoVisitor.VisitReturn(ret, p).(*java.Return)
+	ident, ok := ret.Expression.(*java.Identifier)
+	if !ok || ident.Name != "err" || v.funcName == "" {
+		return ret
+	}
+	MaybeAddImport(v, "fmt", nil, false)
+	c := *ret
+	c.Expression = &java.MethodInvocation{
+		Prefix: java.SingleSpace,
+		Select: &java.RightPadded[java.Expression]{Element: &java.Identifier{Name: "fmt"}},
+		Name:   &java.Identifier{Name: "Errorf"},
+		Arguments: java.Container[java.Expression]{
+			Elements: []java.RightPadded[java.Expression]{
+				{Element: &java.Literal{Source: `"` + v.funcName + `: %w"`}},
+				{Element: &java.Identifier{Prefix: java.SingleSpace, Name: "err"}},
+			},
+		},
+	}
+	return &c
+}

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/RemoveUnusedImportsCompositionIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/RemoveUnusedImportsCompositionIntegTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
+import org.openrewrite.golang.GolangParser;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.golang.Assertions.go;
+
+/**
+ * A reference an earlier recipe introduced has to still read as a use of its import
+ * when a later recipe runs, and both recipes reach the tree over RPC.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class RemoveUnusedImportsCompositionIntegTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+          .goBinaryPath(binaryPath)
+          .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Override
+    public void defaults(org.openrewrite.test.RecipeSpec spec) {
+        spec.typeValidationOptions(TypeValidation.builder()
+          .allowNonWhitespaceInWhitespace(true)
+          .identifiers(false)
+          .methodInvocations(false)
+          .build());
+    }
+
+    /** One scheduler cycle, which is what batches both recipes into a single RPC. */
+    @Test
+    void importAddedByAnEarlierRecipeSurvivesTheComposite() {
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        rewriteRun(
+          spec -> spec.recipes(
+            rpc.prepareRecipe("org.openrewrite.golang.test.WrapErrorWithContext"),
+            rpc.prepareRecipe("org.openrewrite.golang.RemoveUnusedImports")),
+          go(
+            """
+              package main
+
+              import (
+              \t"errors"
+              )
+
+              func doWork() error {
+              \tif err := errors.New("boom"); err != nil {
+              \t\treturn err
+              \t}
+              \treturn nil
+              }
+              """,
+            """
+              package main
+
+              import (
+              \t"errors"
+              \t"fmt"
+              )
+
+              func doWork() error {
+              \tif err := errors.New("boom"); err != nil {
+              \t\treturn fmt.Errorf("doWork: %w", err)
+              \t}
+              \treturn nil
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void importAddedByAnEarlierRecipeSurvives() {
+        GoRewriteRpc rpc = GoRewriteRpc.getOrStart();
+        String source = """
+          package main
+
+          import (
+          \t"errors"
+          )
+
+          func doWork() error {
+          \tif err := errors.New("boom"); err != nil {
+          \t\treturn err
+          \t}
+          \treturn nil
+          }
+          """;
+        SourceFile cu = GolangParser.builder().build().parse(source).findFirst().orElseThrow();
+        rpc.reset();
+
+        var ctx = new InMemoryExecutionContext();
+        Tree wrapped = rpc.prepareRecipe("org.openrewrite.golang.test.WrapErrorWithContext")
+          .getVisitor().visit(cu, ctx);
+        assertThat(rpc.print((SourceFile) wrapped))
+          .contains("fmt.Errorf(\"doWork: %w\", err)")
+          .contains("\"fmt\"");
+
+        Tree pruned = rpc.prepareRecipe("org.openrewrite.golang.RemoveUnusedImports")
+          .getVisitor().visit(wrapped, ctx);
+        assertThat(rpc.print((SourceFile) pruned))
+          .contains("fmt.Errorf(\"doWork: %w\", err)")
+          .contains("\"fmt\"");
+    }
+}

--- a/rewrite-go/test/import_recipes_test.go
+++ b/rewrite-go/test/import_recipes_test.go
@@ -839,3 +839,99 @@ func TestRemoveUnusedImports_KeepsEveryImportWhenNothingIsAttributed(t *testing.
 		`),
 	)
 }
+
+func TestRemoveUnusedImports_DropsUnreferencedRepoPrefixedPath(t *testing.T) {
+	// `go-yaml` binds `yaml`, which nothing here uses.
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveUnusedImports{})
+	before := `
+		package main
+
+		import (
+			"github.com/goccy/go-yaml"
+			"github.com/x/y"
+		)
+
+		func f() {
+			y.Hello()
+		}
+	`
+	after := `
+		package main
+
+		import (
+			"github.com/x/y"
+		)
+
+		func f() {
+			y.Hello()
+		}
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}
+
+func TestRemoveUnusedImports_KeepsImportUnderRepoPrefixedPath(t *testing.T) {
+	// `github.com/pelletier/go-toml/v2` declares `package toml`.
+	spec := NewRecipeSpec().WithRecipe(&recipes.RemoveUnusedImports{})
+	spec.RewriteRun(t,
+		Golang(`
+			package main
+
+			import (
+				"github.com/pelletier/go-toml/v2"
+			)
+
+			func Encode(v map[string]any) ([]byte, error) {
+				return toml.Marshal(v)
+			}
+		`),
+	)
+}
+
+type wrapThenRemoveUnused struct {
+	recipe.Base
+}
+
+func (r *wrapThenRemoveUnused) Name() string {
+	return "org.openrewrite.golang.test.WrapThenRemoveUnused"
+}
+func (r *wrapThenRemoveUnused) DisplayName() string { return "Wrap then remove unused" }
+func (r *wrapThenRemoveUnused) Description() string {
+	return "Wraps errors with context, then removes unused imports."
+}
+func (r *wrapThenRemoveUnused) RecipeList() []recipe.Recipe {
+	return []recipe.Recipe{&recipes.WrapErrorWithContext{}, &recipes.RemoveUnusedImports{}}
+}
+
+func TestRemoveUnusedImports_KeepsImportAddedByEarlierRecipe(t *testing.T) {
+	spec := NewRecipeSpec().WithRecipe(&wrapThenRemoveUnused{})
+	before := `
+		package main
+
+		import (
+			"errors"
+		)
+
+		func doWork() error {
+			if err := errors.New("boom"); err != nil {
+				return err
+			}
+			return nil
+		}
+	`
+	after := `
+		package main
+
+		import (
+			"errors"
+			"fmt"
+		)
+
+		func doWork() error {
+			if err := errors.New("boom"); err != nil {
+				return fmt.Errorf("doWork: %w", err)
+			}
+			return nil
+		}
+	`
+	spec.RewriteRun(t, Golang(before, after))
+}


### PR DESCRIPTION
`org.openrewrite.golang.RemoveUnusedImports` deletes imports that are still referenced. Run on its own over `spf13/viper@528f741` it rewrites exactly one file, and the result does not compile:

```
internal/encoding/toml/codec.go:8:9: undefined: toml
internal/encoding/toml/codec.go:13:9: undefined: toml
```

```diff
 package toml

-import (
-	"github.com/pelletier/go-toml/v2"
-)
-
 func (Codec) Encode(v map[string]any) ([]byte, error) {
 	return toml.Marshal(v)
```

The same import is reachable from any recipe, not just this one: a template recipe declaring `SourceImports(...)` queues `ImportService.RemoveUnusedImportsVisitor()` (`pkg/template/template_recipe.go:277`), so a composite of recipes that never mention imports still breaks these files.

## Why the import read as unused

`github.com/pelletier/go-toml/v2` declares `package toml`. When the build cannot load a module, `ProjectImporter` stub-resolves it and the qualifier identifier gets no type, so the decision falls to the lexical fallback, which derives the qualifier from the path. `packageNameForPath` stripped `/vN` and `.vN` only, yielding `go-toml`, which matches nothing the file writes, so the import was condemned.

A hyphen or a dot cannot appear in a Go identifier. An element spelling one is therefore a repository name and never the package name it declares — `go-toml` hosts `package toml`, `nats.go` hosts `package nats`. `packageNameForPath` now trims that affix, which is a correct derivation rather than a safer guess, and leaves imports whose name the path does spell (`mapstructure/v2`, `go.yaml.in/yaml/v3`, `math/rand/v2`) exactly as they were.

For the residue — a derived name that still is not a valid identifier, like `foo-bar` — no qualifier could ever match it, so reading its absence from the qualifier set as disuse condemns the import on the one signal left. Those are now kept unless attribution says otherwise.

I first fixed this by keeping any import when the file used a qualifier no import spelled. Review found that trades one broken build for another: a composite that deletes a file's last `strings.TrimSpace(...)` while leaving an untyped qualifier behind keeps `"strings"`, and in Go an unused import is a hard error. The derivation fix has no such direction.

## The second bug: after-visits dropped when the host batches

`handleBatchVisit` never drained the after-visits an editor queued; `handleVisit` did. `RecipeRunCycle` takes the batch path whenever adjacent recipes share an RPC peer, and a composite `RpcRecipe` plus its children already clears that bar, so `MaybeAddImport`, `MaybeRemoveImport` and every `template.SourceImports` edit were silently discarded there.

This is what the reported "`RemoveUnusedImports` removes an import an earlier recipe added" case actually is. Running `WrapErrorWithContext` and `RemoveUnusedImports` as a composite leaves `fmt.Errorf(...)` with no `"fmt"` import — but the import was never added, not added and then removed. `WrapErrorWithContext` alone works because a lone leaf recipe is never batched.

A visitor that deletes its tree leaves nothing to drain onto, and an editor instance can be shared across files, so that path now empties the queue instead of leaving it for the next file.

## Verification

Run over full checkouts with the parse setup `ParseProject` uses (module path, requires, replaces and every source on the `ProjectImporter`):

| repository | before | after |
| --- | --- | --- |
| `gin-gonic/gin@dcaa429` | 5 files rewritten (`render/toml.go`, `render/yaml.go`, `logger.go`, `binding/toml.go`, `binding/yaml.go`) | 0 changed |
| `spf13/viper@528f741` | 1 file (`internal/encoding/toml/codec.go`) | 0 changed |
| `minio/minio-go` | 2 files (`pkg/cors/cors.go`, `api.go`) | 0 changed |

`go build ./...` fails on each of those before and passes on all three after. Every one of the seven pre-change rewrites is the same miss — `go-toml`, `go-yaml`, `go-humanize`, `go-isatty` — so no legitimate removal was given up to fix them.

## Tests

`TestRemoveUnusedImports_KeepsImportUnderRepoPrefixedPath` is the viper file, and `TestRemoveUnusedImports_DropsUnreferencedRepoPrefixedPath` is its pair: an unused `github.com/goccy/go-yaml` still goes, so the affix trimming does not make such imports unremovable. `TestPackageNameForPath` gains the four repository-prefixed paths plus `nats.go` and `client-go`, and `TestUsesOfReadsAttributionAndQualifiers` covers the derivation against a parsed unit.

For the batch path, `TestVisitPathsDrainAfterVisits` runs one `template.SourceImports` recipe through both `handleVisit` and `handleBatchVisit` and requires the same result, pinning the invariant rather than the handler that happened to be broken; it fakes the host with a scripted `NO_CHANGE` reply, so it needs no built binary. `RemoveUnusedImportsCompositionIntegTest` covers the imperative half end to end, driving the real scheduler and RPC server, which is the only place the batch dispatch is chosen for real.

## Notes for review

`WrapErrorWithContext` is a test fixture registered in the Go registry so the integTest can `prepareRecipe` it, which makes it marketplace-visible under `org.openrewrite.golang.test.*`. `RenameXToFlag` already ships that way; this is the second, and it is a judgment call rather than a settled convention.

Left alone deliberately: `AddImport{OnlyIfReferenced: true}` consults attribution only, so a reference an earlier recipe inserted is invisible to it — the mirror of the bug fixed here on the removal side. Switching it to `ImportUses` cuts both ways, since a local named `fmt` would then count as a reference and add an import nothing needs.

Porting the drain into `GoVisitor.Visit` itself, the way Java, JS and Python all do it, is a separate change: Go has no `PostVisit` hook, and `AutoFormatVisitor` never calls `GoVisitor.Visit` at all, so a drain placed there would turn it into a no-op.
