### PR TITLE
Remove unreachable COMMENT handling from `parseText`

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
@@ -224,21 +224,6 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         }
 
         // Complex case: parse token by token
-        boolean foundComment = false;
-        for (int i = textCtx.getChildCount() - 1; i >= 0; i--) {
-            ParseTree child = textCtx.getChild(i);
-            if (child instanceof DockerParser.TextElementContext) {
-                DockerParser.TextElementContext textElement = (DockerParser.TextElementContext) child;
-                if (textElement.getChildCount() > 0 && textElement.getChild(0) instanceof TerminalNode) {
-                    TerminalNode terminal = (TerminalNode) textElement.getChild(0);
-                    if (terminal.getSymbol().getType() == DockerLexer.COMMENT) {
-                        foundComment = true;
-                        break;
-                    }
-                }
-            }
-        }
-
         for (int i = 0; i < textCtx.getChildCount(); i++) {
             ParseTree child = textCtx.getChild(i);
 
@@ -249,10 +234,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
                     Token token = terminal.getSymbol();
                     String tokenText = token.getText();
 
-                    if (token.getType() == DockerLexer.COMMENT) {
-                        // COMMENT tokens are ignored - they will be part of next element's prefix
-                        break; // Stop processing tokens once we hit a comment
-                    } else if (token.getType() == DockerLexer.DOUBLE_QUOTED_STRING) {
+                    if (token.getType() == DockerLexer.DOUBLE_QUOTED_STRING) {
                         Space elementPrefix = prefix(token);
                         skip(token);
                         String value = tokenText.substring(1, tokenText.length() - 1);


### PR DESCRIPTION
`DockerParserVisitor.parseText` contains two pieces of COMMENT handling that cannot run:

- a branch testing `token.getType() == DockerLexer.COMMENT` inside the token loop
- a pre-scan loop that sets `foundComment`, which nothing ever reads

The lexer declares `COMMENT : '#' ~[\r\n]* -> channel(HIDDEN);` and no parser rule references the token, so a `COMMENT` can never appear as a child of a text element.

## Verification

Beyond reading the grammar, I replaced the branch body with a throw and parsed 152 sources — 142 real Dockerfiles found on disk plus 10 shaped specifically to place comments where they might reach it (leading, trailing on each instruction type, and inside a line continuation). Zero hits, all 152 still round-tripping, and the full `rewrite-docker` suite passed with the throw in place.

`:rewrite-docker:check` is green: 405 tests.

## What is deliberately kept

The `fullText.contains("#")` check that routes text through the token-by-token path stays. That one is load-bearing: the fast path takes a raw `source.substring` over the whole rule, which would pull a comment's text *into* the literal when a line continuation puts one mid-argument. The slow path puts it in a prefix instead, which is where comments already live.

Comment placement in the LST is unchanged by this PR — it removes only code that cannot execute.
