### PR TITLE
Model quote style in flag values

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
@@ -1283,6 +1283,20 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
                 // Not a valid env var, treat $ as literal
                 current.append(c);
                 i++;
+            } else if (c == '"' || c == '\'') {
+                int close = findClosingQuote(text, i);
+                if (close < 0) {
+                    current.append(c);
+                    i++;
+                    continue;
+                }
+                if (current.length() > 0) {
+                    contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, current.toString(), null));
+                    current.setLength(0);
+                }
+                contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, text.substring(i + 1, close),
+                        c == '"' ? Docker.Literal.QuoteStyle.DOUBLE : Docker.Literal.QuoteStyle.SINGLE));
+                i = close + 1;
             } else if (c == '=') {
                 // Flush any accumulated text
                 if (current.length() > 0) {
@@ -1304,6 +1318,19 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         }
 
         return contents.isEmpty() ? singletonList(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, "", null)) : contents;
+    }
+
+    private static int findClosingQuote(String text, int openIndex) {
+        char quote = text.charAt(openIndex);
+        for (int i = openIndex + 1; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (quote == '"' && c == '\\') {
+                i++;
+            } else if (c == quote) {
+                return i;
+            }
+        }
+        return -1;
     }
 
     private boolean isVarChar(char c, boolean isFirst) {

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/CopyTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/CopyTest.java
@@ -342,4 +342,28 @@ class CopyTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void quotedChownFlagValue() {
+        rewriteRun(
+          docker(
+            """
+              FROM ubuntu:20.04
+              COPY --chown="me":"grp" src /dst
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                var copy = (Docker.Copy) doc.getStages().getFirst().getInstructions().getLast();
+                assertThat(copy.getFlags()).isNotNull();
+                Docker.Argument chown = copy.getFlags().getFirst().getValue();
+                assertThat(chown).isNotNull();
+                Docker.Literal first = (Docker.Literal) chown.getContents().getFirst();
+                assertThat(first.getText()).isEqualTo("me");
+                assertThat(first.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
+                Docker.Literal last = (Docker.Literal) chown.getContents().getLast();
+                assertThat(last.getText()).isEqualTo("grp");
+                assertThat(last.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
+            })
+          )
+        );
+    }
 }


### PR DESCRIPTION
`parseFlagValueText` already splits a flag value into literals and `$VAR` references, but it had no notion of quotes. So a quoted segment stayed raw:

```
COPY --chown="me":"grp" src /dst
```

gave one `Literal` holding `"me":"grp"` — quotes and all — with `quoteStyle = null`.

Everywhere else in this model a quoted literal records its style in `Docker.Literal.quoteStyle` and the printer re-emits the quotes from it (`DockerPrinter.visitLiteral`). Flag values were the exception, which left recipes to strip and re-add quotes by hand and made `getQuoteStyle()` lie about them.

## After

| Source | Before | After |
| --- | --- | --- |
| `COPY --chown="me":"grp"` | `L<"me":"grp">` | `LD<me> L<:> LD<grp>` |
| `RUN --mount=type=bind,source="a b",target=/x` | `L<"a b",target>` | `LD<a b> L<,target>` |

(`LD` = literal with `quoteStyle=DOUBLE`.)

Single quotes are handled too, and backslash escapes are honoured inside double quotes but not single ones, matching the lexer's `FLAG_VALUE_PART` rule.

## Scope

Printing is unchanged — the printer reconstructs the quotes from `quoteStyle`, so this is an LST-shape fix only. Verified by round-tripping 142 real Dockerfiles found on disk: byte-identical, same as the `main` baseline.

`:rewrite-docker:check` green: 406 tests.

Unterminated quotes are unaffected: the lexer rejects them before this code runs.
