### PR TITLE
`AddOrUpdateLabel`: stop corrupting old-format labels

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
@@ -89,7 +89,8 @@ public class AddOrUpdateLabel extends Recipe {
             if (key.equals(extractText(pair.getKey()))) {
                 boolean shouldOverwrite = overwriteExisting == null || overwriteExisting;
                 return shouldOverwrite && !value.equals(extractText(pair.getValue())) ?
-                        pair.withValue(createArgument(value, pair.getValue())) : pair;
+                        pair.withValue(createArgument(value, pair.getValue())
+                                .withPrefix(pair.getValue().getPrefix())) : pair;
             }
             return super.visitLabelPair(pair, ctx);
         }
@@ -160,7 +161,12 @@ public class AddOrUpdateLabel extends Recipe {
             return null;
         }
         StringBuilder builder = new StringBuilder();
-        for (Docker.ArgumentContent content : arg.getContents()) {
+        List<Docker.ArgumentContent> contents = arg.getContents();
+        for (int i = 0; i < contents.size(); i++) {
+            Docker.ArgumentContent content = contents.get(i);
+            if (i > 0) {
+                builder.append(content.getPrefix().getWhitespace());
+            }
             if (content instanceof Docker.Literal) {
                 builder.append(((Docker.Literal) content).getText());
             } else if (content instanceof Docker.EnvironmentVariable) {

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/AddOrUpdateLabelTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/AddOrUpdateLabelTest.java
@@ -214,4 +214,34 @@ class AddOrUpdateLabelTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void noChangeWhenOldFormatMultiWordValueAlreadyMatches() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateLabel("author", "John Doe", true, null)),
+          docker(
+            """
+              FROM ubuntu:22.04
+              LABEL author John Doe
+              """
+          )
+        );
+    }
+
+    @Test
+    void updateOldFormatValueKeepsSeparatingSpace() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateLabel("author", "Jane Roe", true, null)),
+          docker(
+            """
+              FROM ubuntu:22.04
+              LABEL author John Doe
+              """,
+            """
+              FROM ubuntu:22.04
+              LABEL author "Jane Roe"
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
`AddOrUpdateLabel` emits invalid Dockerfiles when it touches an old-format label (`LABEL key value`, no `=`).

| `AddOrUpdateLabel("author", …)` on `LABEL author John Doe` | `main` | This PR |
| --- | --- | --- |
| value `"John Doe"` (already correct) | `LABEL author"John Doe"` | *no change* |
| value `"Jane Roe"` | `LABEL author"Jane Roe"` | `LABEL author "Jane Roe"` |

The first row is the worse one: the recipe corrupts the file while making **no semantic change at all**.

## Cause

Two independent defects that compound.

**Reading the value back drops separators.** An argument's contents carry the whitespace between them in each content's `prefix`, so `LABEL author John Doe` is `[Literal("John"), Literal("Doe", prefix=" ")]`. The private `extractText` concatenates only `getText()`, yielding `"JohnDoe"`. That never equals the requested `"John Doe"`, so the overwrite branch always fires.

**Writing it back drops the separator.** `createArgument` builds the replacement with `Space.EMPTY`, and in old format there is no `=` to stand between key and value, so the printer emits them flush against each other.

## Fix

Append each non-first content's prefix whitespace when reading, and carry the original value's prefix onto the replacement when writing. Both are confined to `AddOrUpdateLabel`.

The read guard is on `index > 0` rather than "is the buffer empty", so a leading empty literal (`LABEL k="" v`) can't swallow the separator.

`:rewrite-docker:check` green: 407 tests, including two regression tests for the rows above.
