### PR TITLE
Go: instantiate a `GoTemplate` into a detached node

### DIFF
--- a/rewrite-go/pkg/template/go_template.go
+++ b/rewrite-go/pkg/template/go_template.go
@@ -19,6 +19,8 @@ package template
 import (
 	"sync"
 
+	"github.com/google/uuid"
+
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
@@ -62,6 +64,46 @@ func (t *GoTemplate) Apply(cursor *visitor.Cursor, values *MatchResult) java.J {
 		return fresh
 	}
 	return placeAt(fresh, cursor)
+}
+
+// Instantiate produces the template as a detached node for a recipe that
+// inserts the result somewhere new, where Apply replaces a matched node. Bound
+// values are copied, so a spliced subtree may also stay where it came from.
+// The result carries no leading whitespace. It is nil unless every capture is
+// bound to a single subtree, the only form substitution handles.
+func (t *GoTemplate) Instantiate(values *MatchResult) java.J {
+	for name, capture := range t.captures {
+		if capture.IsVariadic() || values == nil || values.Get(name) == nil {
+			return nil
+		}
+	}
+	instantiated := t.Apply(nil, values)
+	if instantiated == nil {
+		return nil
+	}
+	// The prefix is the gap the scaffold leaves before the template code,
+	// not whitespace the template itself declares.
+	return setLeadingPrefix(withFreshIDs(instantiated), java.EmptySpace)
+}
+
+// withFreshIDs returns a copy of j in which every node has a new ID, keeping
+// IDs unique within whatever tree the result is inserted into.
+func withFreshIDs(j java.J) java.J {
+	v := &idRefreshVisitor{}
+	v.Self = v
+	return v.Visit(j, nil).(java.J)
+}
+
+type idRefreshVisitor struct {
+	visitor.GoVisitor
+}
+
+func (v *idRefreshVisitor) Visit(t java.Tree, p any) java.Tree {
+	visited := v.GoVisitor.Visit(t, p)
+	if j, ok := visited.(java.J); ok && j != nil {
+		return j.WithID(uuid.New())
+	}
+	return visited
 }
 
 // getTree lazily parses the template and caches the result.

--- a/rewrite-go/pkg/template/instantiate_test.go
+++ b/rewrite-go/pkg/template/instantiate_test.go
@@ -1,0 +1,270 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package template
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// findLiteral returns the first literal in src whose Source matches want.
+func findLiteral(t *testing.T, src, want string) *java.Literal {
+	t.Helper()
+	p := parser.NewGoParser()
+	cu, err := p.Parse("test.go", src)
+	require.NoError(t, err)
+
+	var found java.J
+	visitor.Init(&literalFinder{target: want, found: &found}).Visit(cu, nil)
+	require.NotNilf(t, found, "could not find literal %s in:\n%s", want, src)
+	return found.(*java.Literal)
+}
+
+// findIdentifier returns the last identifier in src named want, which in these
+// test sources is the use site rather than the declaration.
+func findIdentifier(t *testing.T, src, want string) *java.Identifier {
+	t.Helper()
+	p := parser.NewGoParser()
+	cu, err := p.Parse("test.go", src)
+	require.NoError(t, err)
+
+	var found java.J
+	visitor.Init(&lastIdentFinder{target: want, found: &found}).Visit(cu, nil)
+	require.NotNilf(t, found, "could not find identifier %q in:\n%s", want, src)
+	return found.(*java.Identifier)
+}
+
+func TestInstantiateTopLevelWithSplicedSubtree(t *testing.T) {
+	msgLit := findLiteral(t, `package main
+
+import "errors"
+
+func f() error {
+	return errors.New("not found")
+}
+`, `"not found"`)
+	require.NotNil(t, msgLit.Type, "precondition: parsed literal should carry a type")
+
+	name := Ident("name")
+	msg := Expr("msg").WithType("string")
+	tmpl := TopLevelTemplate(fmt.Sprintf("var %s = errors.New(%s)", name, msg)).
+		Captures(name, msg).
+		Imports("errors").
+		Build()
+
+	decl := tmpl.Instantiate(NewMatchResult().
+		Bind(name, &java.Identifier{Name: "ErrNotFound"}).
+		Bind(msg, msgLit))
+
+	require.NotNil(t, decl, "Instantiate should produce a detached node")
+	assert.Equal(t, `var ErrNotFound = errors.New("not found")`, printer.Print(decl))
+
+	vd, ok := decl.(*java.VariableDeclarations)
+	require.Truef(t, ok, "expected *java.VariableDeclarations, got %T", decl)
+
+	mi, ok := vd.Variables[0].Element.Initializer.Element.(*java.MethodInvocation)
+	require.Truef(t, ok, "expected *java.MethodInvocation initializer, got %T", vd.Variables[0].Element.Initializer.Element)
+
+	// The template's own call is attributed by go/types, not by hand.
+	require.NotNil(t, mi.MethodType, "errors.New should be attributed")
+	assert.Equal(t, "New", mi.MethodType.Name)
+	require.NotNil(t, mi.MethodType.DeclaringType)
+	assert.Equal(t, "errors", mi.MethodType.DeclaringType.GetFullyQualifiedName())
+
+	spliced, ok := mi.Arguments.Elements[0].Element.(*java.Literal)
+	require.Truef(t, ok, "expected spliced *java.Literal, got %T", mi.Arguments.Elements[0].Element)
+	assert.Equal(t, msgLit.Source, spliced.Source)
+	assert.Same(t, msgLit.Type, spliced.Type, "spliced node should keep its type attribution")
+	assert.NotEqual(t, msgLit.ID, spliced.ID, "the bound node stays usable where it came from")
+}
+
+func TestInstantiateSplicedIdentifierKeepsType(t *testing.T) {
+	errIdent := findIdentifier(t, `package main
+
+import "errors"
+
+func f() error {
+	err := errors.New("boom")
+	return err
+}
+`, "err")
+	require.NotNil(t, errIdent.Type, "precondition: parsed identifier should carry a type")
+
+	errCap := Expr("err").WithType("error")
+	tmpl := ExpressionTemplate(fmt.Sprintf(`fmt.Errorf("ctx: %%w", %s)`, errCap)).
+		Captures(errCap).
+		Imports("fmt").
+		Build()
+
+	expr := tmpl.Instantiate(NewMatchResult().Bind(errCap, errIdent))
+	require.NotNil(t, expr)
+	assert.Equal(t, `fmt.Errorf("ctx: %w", err)`, printer.Print(expr))
+
+	mi, ok := expr.(*java.MethodInvocation)
+	require.Truef(t, ok, "expected *java.MethodInvocation, got %T", expr)
+	require.NotNil(t, mi.MethodType, "fmt.Errorf should be attributed")
+
+	spliced, ok := mi.Arguments.Elements[1].Element.(*java.Identifier)
+	require.Truef(t, ok, "expected spliced *java.Identifier, got %T", mi.Arguments.Elements[1].Element)
+	assert.Same(t, errIdent.Type, spliced.Type, "spliced identifier should keep its type attribution")
+	assert.NotEqual(t, errIdent.ID, spliced.ID, "the bound node stays usable where it came from")
+}
+
+func TestInstantiateReusesTemplateWithFreshIDs(t *testing.T) {
+	name := Ident("name")
+	tmpl := TopLevelTemplate(fmt.Sprintf(`var %s = errors.New("x")`, name)).
+		Captures(name).
+		Imports("errors").
+		Build()
+
+	first := tmpl.Instantiate(NewMatchResult().Bind(name, &java.Identifier{Name: "ErrOne"}))
+	second := tmpl.Instantiate(NewMatchResult().Bind(name, &java.Identifier{Name: "ErrTwo"}))
+
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+	assert.Equal(t, `var ErrOne = errors.New("x")`, printer.Print(first))
+	assert.Equal(t, `var ErrTwo = errors.New("x")`, printer.Print(second))
+	assert.NotEqual(t, first.(*java.VariableDeclarations).ID, second.(*java.VariableDeclarations).ID,
+		"instantiations of one template must not share node IDs")
+}
+
+func TestInstantiateWithoutCaptures(t *testing.T) {
+	tmpl := TopLevelTemplate(`var ErrNotFound = errors.New("not found")`).Imports("errors").Build()
+
+	decl := tmpl.Instantiate(nil)
+	require.NotNil(t, decl)
+	assert.Equal(t, `var ErrNotFound = errors.New("not found")`, printer.Print(decl))
+}
+
+func TestInstantiateRejectsUnboundCapture(t *testing.T) {
+	name := Ident("name")
+	msg := Expr("msg").WithType("string")
+	tmpl := TopLevelTemplate(fmt.Sprintf("var %s = errors.New(%s)", name, msg)).
+		Captures(name, msg).
+		Imports("errors").
+		Build()
+
+	assert.Nil(t, tmpl.Instantiate(NewMatchResult().Bind(name, &java.Identifier{Name: "ErrNotFound"})))
+	assert.Nil(t, tmpl.Instantiate(nil))
+	// A nil binding satisfies Has, so the guard has to read the value itself.
+	assert.Nil(t, tmpl.Instantiate(NewMatchResult().
+		Bind(name, &java.Identifier{Name: "ErrNotFound"}).
+		Bind(msg, nil)))
+}
+
+func TestInstantiateStripsScaffoldPrefixAcrossNodeKinds(t *testing.T) {
+	for _, code := range []string{
+		"&Foo{}", "*p", "<-ch", "a &^ b", "func() {}", "[]int{1}",
+		"x + 1", "f(1)", "m[k]", "x.(T)", "map[string]int{}", "-n", "!ok",
+	} {
+		t.Run(code, func(t *testing.T) {
+			out := ExpressionTemplate(code).Build().Instantiate(nil)
+			require.NotNil(t, out)
+			assert.Equalf(t, java.EmptySpace, out.GetPrefix(),
+				"%T carries a scaffold prefix; setPrefix needs a case for it", out)
+		})
+	}
+}
+
+func TestInstantiateLeavesBoundSubtreeUsable(t *testing.T) {
+	msgLit := findLiteral(t, "package main\n\nvar m = \"reused\"\n", `"reused"`)
+
+	msg := Expr("msg").WithType("string")
+	tmpl := TopLevelTemplate(fmt.Sprintf("var E = errors.New(%s)", msg)).
+		Captures(msg).
+		Imports("errors").
+		Build()
+
+	first := tmpl.Instantiate(NewMatchResult().Bind(msg, msgLit))
+	second := tmpl.Instantiate(NewMatchResult().Bind(msg, msgLit))
+	require.NotNil(t, first)
+	require.NotNil(t, second)
+
+	firstArg := literalArgOf(t, first)
+	secondArg := literalArgOf(t, second)
+	assert.NotEqual(t, msgLit.ID, firstArg.ID)
+	assert.NotEqual(t, firstArg.ID, secondArg.ID,
+		"two instantiations sharing a binding must not share node IDs")
+}
+
+func literalArgOf(t *testing.T, decl java.J) *java.Literal {
+	t.Helper()
+	vd, ok := decl.(*java.VariableDeclarations)
+	require.Truef(t, ok, "expected *java.VariableDeclarations, got %T", decl)
+	mi, ok := vd.Variables[0].Element.Initializer.Element.(*java.MethodInvocation)
+	require.Truef(t, ok, "expected *java.MethodInvocation, got %T", vd.Variables[0].Element.Initializer.Element)
+	lit, ok := mi.Arguments.Elements[0].Element.(*java.Literal)
+	require.Truef(t, ok, "expected *java.Literal argument, got %T", mi.Arguments.Elements[0].Element)
+	return lit
+}
+
+func TestInstantiateRejectsVariadicCapture(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("errors.New(%s)", args)).
+		Captures(args).
+		Imports("errors").
+		Build()
+
+	assert.Nil(t, tmpl.Instantiate(NewMatchResult().Bind(args, &java.Literal{Source: `"x"`})))
+}
+
+func TestBindIsChainableAndReadable(t *testing.T) {
+	a, b := Expr("a"), Expr("b")
+	lit := &java.Literal{Source: "1"}
+	ident := &java.Identifier{Name: "x"}
+
+	m := NewMatchResult().Bind(a, lit).Bind(b, ident)
+
+	assert.Same(t, lit, m.GetCapture(a))
+	assert.Same(t, ident, m.GetCapture(b))
+	assert.True(t, m.Has("a"))
+	assert.False(t, m.Has("c"))
+}
+
+type literalFinder struct {
+	visitor.GoVisitor
+	target string
+	found  *java.J
+}
+
+func (v *literalFinder) VisitLiteral(lit *java.Literal, p any) java.J {
+	if *v.found == nil && lit.Source == v.target {
+		*v.found = lit
+	}
+	return v.GoVisitor.VisitLiteral(lit, p)
+}
+
+type lastIdentFinder struct {
+	visitor.GoVisitor
+	target string
+	found  *java.J
+}
+
+func (v *lastIdentFinder) VisitIdentifier(ident *java.Identifier, p any) java.J {
+	if ident.Name == v.target {
+		*v.found = ident
+	}
+	return v.GoVisitor.VisitIdentifier(ident, p)
+}

--- a/rewrite-go/pkg/template/match_result.go
+++ b/rewrite-go/pkg/template/match_result.go
@@ -31,6 +31,14 @@ func (m *MatchResult) bind(name string, value java.J) {
 	m.bindings[name] = value
 }
 
+// Bind associates a capture with the subtree to substitute for it, so a
+// template can be instantiated without a pattern match. Returns the receiver,
+// for chaining.
+func (m *MatchResult) Bind(c *Capture, value java.J) *MatchResult {
+	m.bind(c.Name(), value)
+	return m
+}
+
 // bindList stores a variadic captured list.
 func (m *MatchResult) bindList(name string, values []java.J) {
 	m.bindings[name] = values

--- a/rewrite-go/pkg/template/substitution.go
+++ b/rewrite-go/pkg/template/substitution.go
@@ -75,6 +75,24 @@ func setPrefix(j java.J, prefix java.Space) java.J {
 		return n.WithPrefix(prefix)
 	case *java.Unary:
 		return n.WithPrefix(prefix)
+	case *golang.Binary:
+		return n.WithPrefix(prefix)
+	case *golang.Unary:
+		return n.WithPrefix(prefix)
+	case *golang.AssignmentOperation:
+		return n.WithPrefix(prefix)
+	case *golang.PointerType:
+		return n.WithPrefix(prefix)
+	case *golang.Variadic:
+		return n.WithPrefix(prefix)
+	case *golang.StatementExpression:
+		return n.WithPrefix(prefix)
+	case *golang.ExpressionStatement:
+		return n.WithPrefix(prefix)
+	case *golang.DeclarationBlock:
+		return n.WithPrefix(prefix)
+	case *java.ParameterizedType:
+		return n.WithPrefix(prefix)
 	case *java.FieldAccess:
 		return n.WithPrefix(prefix)
 	case *java.MethodInvocation:


### PR DESCRIPTION
- A recipe that wants to build a node for *insertion* rather than replacement cannot use a template's captures. `MatchResult`'s `bind`/`bindList` are unexported, so only a match can populate one, and `Apply(nil, values)` is therefore usable only with `values == nil`. The concrete caller is `sentinelDecl` in [moderneinc/recipes-go#79](https://github.com/moderneinc/recipes-go/pull/79), building `var ErrFoo = errors.New("msg")` for the top of a file it is editing — 39 lines of hand-constructed `java.VariableDeclarations` / `MethodInvocation` / `Identifier` with the type attribution stated by hand via `lstutil.NamedType` / `lstutil.FuncType`. Across that repo the same pattern appears at 24 sites in 12 files.

The workaround is interpolating into the template's code string, which only works when every substituted value has textual source. The normal case is splicing in an existing subtree so it keeps its own attribution, and there is no way to express that without bindings.

```go
var (
    sentinelName = template.Ident("name")
    sentinelMsg  = template.Expr("msg").WithType("string")
    sentinelTmpl = template.TopLevelTemplate(
        fmt.Sprintf("var %s = errors.New(%s)", sentinelName, sentinelMsg)).
        Captures(sentinelName, sentinelMsg).Imports("errors").Build()
)

decl := sentinelTmpl.Instantiate(template.NewMatchResult().
    Bind(sentinelName, &java.Identifier{Name: e.varName}).
    Bind(sentinelMsg, e.lit))
```

`errors.New` comes back attributed by go/types — `DeclaringType` `errors`, the `error` interface as `ReturnType`, real `ParameterNames` — and the bound literal keeps the attribution it was parsed with. `Apply` is untouched; `Instantiate` delegates to it.

## Two defects found making the contract hold

`setPrefix` is a type switch covering 55 of the 77 node kinds that have `WithPrefix`, and it silently falls through for the rest. Nine of the missing ones can be a template root or a bound value, so the scaffold's own leading whitespace survived into the result:

```
&Foo{}     -> " &Foo{}"     (golang.Unary)
a &^ b     -> " a &^ b"     (golang.Binary)
func() {}  -> " func() {}"  (golang.StatementExpression)
```

This also affected `Apply`, since `placeAt` calls the same helper — replacing a node with a `&Foo{}` template kept the scaffold's prefix instead of the replaced node's.

Splicing a bound subtree by reference is safe for `Apply`, where the matched node disappears. It is not safe for `Instantiate`, whose whole purpose is inserting the result somewhere new while the bound subtree normally stays where it came from, which puts two nodes with one UUID in a single tree. `J.WithID` is on the interface, so refreshing IDs rides the generic `Visit` seam without a type switch; bound values are now copied.

`Bind(c, nil)` also needed handling — a nil binding satisfies `Has` but not `Get`, so the guard passed and substitution emitted `var E = errors.New(__plh_msg__)`, uncompilable output where the doc promises `nil`.

## Tests

`pkg/template/instantiate_test.go`. The main case parses real Go source, binds the extracted `"not found"` literal into the sentinel template, and asserts on the detached result that `errors.New` carries a go/types `MethodType` *and* that the spliced argument keeps its `Type` while getting a fresh ID. `TestInstantiateStripsScaffoldPrefixAcrossNodeKinds` is a 13-case table pinning the whitespace contract so the `setPrefix` switch cannot rot silently again; it fails on all five kinds above without the `substitution.go` change.

## Deliberately not fixed

`Apply` re-parses the scaffold on every call (`getTree()` is only a validity probe whose result is discarded), so a shared `*GoTemplate` saves one of two parses rather than keeping a cache. Making the cache real needs a clone pass, since re-parsing is currently what guarantees unique IDs; that is a separate change.

Variadic captures still do not substitute — `substitute` swaps one node for one node, so a bound list reaches the output as its raw placeholder. `bindList` therefore stays unexported and `Instantiate` refuses variadic captures rather than emitting a placeholder.