### PR TITLE
Implement variadic captures in GoTemplate

### DIFF
--- a/rewrite-go/doc/recipe-authoring.md
+++ b/rewrite-go/doc/recipe-authoring.md
@@ -384,6 +384,47 @@ name, and assert on its attributed type. Throw `AssertionError` with a
 descriptive message on mismatch — drop them straight into an
 `afterRecipe(cu -> ...)` lambda.
 
+## Variadic captures
+
+A capture marked `Variadic(min, max)` stands for a run of list elements
+rather than one subtree, so one pattern covers a call of any arity
+(`-1` for `max` means unlimited):
+
+```go
+args := template.Expr("args").Variadic(0, -1)
+before := template.Expression(fmt.Sprintf("assert.Equal(%s)", args)).Captures(args).Build()
+after := template.ExpressionTemplate(fmt.Sprintf("require.Equal(%s)", args)).Captures(args).Build()
+```
+
+`MatchResult.GetList(name)` reads the run back, and `BindList` supplies
+one by hand for `Instantiate`:
+
+```go
+tmpl.Instantiate(template.NewMatchResult().
+    Bind(recv, tIdent).
+    BindList(args, template.Elems(coreArgs, msgArgs)))
+```
+
+`Elems` is there because Go converts neither `[]java.Expression` nor
+`[]java.Statement` to the `[]java.J` `BindList` takes, and a recipe
+holds one of those. It concatenates any number of element slices, so
+a leading single node goes in as `Elems([]java.Expression{recv}, ...)`.
+
+A run of any length is a binding, zero included, so an empty one
+leaves the call reading as `require.Equal(t)`. A run outside the
+capture's bounds is not, and `Instantiate` returns nil — the same
+bounds the match path enforces.
+
+Two rules bound what this covers. **A list splits at one variadic
+capture**: with one, every other pattern element takes one candidate
+element, so the run's length is arithmetic and the captures after it
+match positionally. A list holding two variadic captures leaves the
+split undetermined, and the match fails.
+**A run needs a list to expand into**: a call's arguments or a block's
+statements. A variadic placeholder anywhere else has nowhere to go, and
+`Apply` returns nil rather than emit the placeholder — as it does for
+any capture left unbound.
+
 ## Surface boundaries
 
 When in doubt about what pattern to use:

--- a/rewrite-go/pkg/template/PARITY-AUDIT.md
+++ b/rewrite-go/pkg/template/PARITY-AUDIT.md
@@ -20,6 +20,7 @@ present, what was added in this PR, and what is intentionally deferred.
 | Named placeholders | `#{name}` substitution by name + type constraint | positional `#{X}` capture-by-name through `*Capture` | ✓ named via `*Capture` already; type constraints are deferred (see below) |
 | Type-checked named placeholders | `#{name:any(java.util.List)}` | not yet | deferred — out-of-scope per the eng review's v1 scope cut |
 | Cursor-aware insertion | parameter to `.apply(cursor, ...)` | parameter to `.Apply(cursor, ...)` | ✓ shipped — the cursor names the node being replaced, from which `Apply` takes the leading whitespace, whether the result needs parenthesizing against the expression around it, and the level to indent to |
+| Variadic placeholders | n/a | `Capture.Variadic(min, max)` matched by `GoPattern`, expanded by `GoTemplate` | ✓ shipped — Go-side delta over Java. `JavaTemplate` has no variadic placeholder; `Substitutions.maybeExpandVarargsNewArray` flattens a captured varargs `J.NewArray` back into an argument list, which is a Java-language repair rather than a capture kind |
 
 ## Already present before this PR (no delta required)
 

--- a/rewrite-go/pkg/template/capture.go
+++ b/rewrite-go/pkg/template/capture.go
@@ -78,13 +78,27 @@ func (c *Capture) WithType(typeName string) *Capture {
 	return &cp
 }
 
-// min and max set bounds (-1 for max means unlimited).
+// min and max set bounds (-1 for max means unlimited). A capture matches a
+// run of list elements, so it is only usable where the pattern puts it in a
+// list: a call's arguments or a block's statements.
 func (c *Capture) Variadic(min, max int) *Capture {
+	if min < 0 {
+		panic(fmt.Sprintf("capture %q: negative minCount %d", c.name, min))
+	}
+	if max >= 0 && max < min {
+		panic(fmt.Sprintf("capture %q: maxCount %d below minCount %d", c.name, max, min))
+	}
 	cp := *c
 	cp.variadic = true
 	cp.minCount = min
 	cp.maxCount = max
 	return &cp
+}
+
+// allowsCount reports whether a run of n elements is within the capture's
+// bounds. A capture that is not variadic bounds nothing, admitting any run.
+func (c *Capture) allowsCount(n int) bool {
+	return n >= c.minCount && (c.maxCount < 0 || n <= c.maxCount)
 }
 
 func captureMap(captures []*Capture) map[string]*Capture {

--- a/rewrite-go/pkg/template/comparator.go
+++ b/rewrite-go/pkg/template/comparator.go
@@ -58,10 +58,8 @@ func (c *patternComparator) matchNode(pattern, candidate java.J) bool {
 	}
 
 	// Check if the pattern node is a placeholder identifier.
-	if ident, ok := pattern.(*java.Identifier); ok {
-		if name, isPlaceholder := FromPlaceholder(ident.Name); isPlaceholder {
-			return c.bindCapture(name, candidate)
-		}
+	if name, isPlaceholder := placeholderName(pattern); isPlaceholder {
+		return c.bindCapture(name, candidate)
 	}
 
 	// Both nodes must be the same concrete type.
@@ -453,11 +451,104 @@ func (c *patternComparator) matchOptionalRightPaddedExpr(pattern, candidate *jav
 }
 
 func (c *patternComparator) matchExpressionList(pattern, candidate []java.RightPadded[java.Expression]) bool {
-	if len(pattern) != len(candidate) {
+	return matchList(c, pattern, candidate)
+}
+
+// matchList compares two element lists, letting a variadic capture in the
+// pattern absorb a run of candidate elements. One variadic makes the run's
+// length arithmetic — every other pattern element takes one — so the captures
+// after it match positionally. Two leave the split undetermined, and fail.
+func matchList[T java.J](c *patternComparator, pattern, candidate []java.RightPadded[T]) bool {
+	at, ok := variadicIndex(c, pattern)
+	if !ok {
 		return false
 	}
+	if at < 0 {
+		return len(pattern) == len(candidate) && matchElements(c, pattern, candidate)
+	}
+
+	run := len(candidate) - (len(pattern) - 1)
+	name, _ := placeholderName(java.J(pattern[at].Element))
+	if !c.captures[name].allowsCount(run) {
+		return false
+	}
+	if !matchElements(c, pattern[:at], candidate[:at]) {
+		return false
+	}
+	if !matchElements(c, pattern[at+1:], candidate[at+run:]) {
+		return false
+	}
+	return c.bindRun(name, unwrap(candidate[at:at+run]))
+}
+
+func matchElements[T java.J](c *patternComparator, pattern, candidate []java.RightPadded[T]) bool {
 	for i := range pattern {
 		if !c.matchNode(pattern[i].Element, candidate[i].Element) {
+			return false
+		}
+	}
+	return true
+}
+
+// variadicIndex returns the position of the pattern's variadic capture, -1 when
+// it has none, and ok=false when it has more than one.
+func variadicIndex[T java.J](c *patternComparator, pattern []java.RightPadded[T]) (int, bool) {
+	at := -1
+	for i := range pattern {
+		name, ok := placeholderName(java.J(pattern[i].Element))
+		if !ok || !c.isVariadic(name) {
+			continue
+		}
+		if at >= 0 {
+			return 0, false
+		}
+		at = i
+	}
+	return at, true
+}
+
+func unwrap[T java.J](padded []java.RightPadded[T]) []java.J {
+	values := make([]java.J, len(padded))
+	for i, rp := range padded {
+		values[i] = rp.Element
+	}
+	return values
+}
+
+// placeholderName returns the capture name j stands for, if j is a placeholder
+// identifier. An identifier is an expression, so one written in statement
+// position reaches here inside the wrapper the parser puts it in.
+func placeholderName(j java.J) (string, bool) {
+	if stmt, ok := j.(*golang.ExpressionStatement); ok {
+		j = stmt.Expression
+	}
+	ident, ok := j.(*java.Identifier)
+	if !ok {
+		return "", false
+	}
+	return FromPlaceholder(ident.Name)
+}
+
+// A comparator built for structural equality carries no captures, so every
+// placeholder it meets is an ordinary identifier.
+func (c *patternComparator) isVariadic(name string) bool {
+	capture, ok := c.captures[name]
+	return ok && capture.IsVariadic()
+}
+
+// bindRun binds the run a variadic capture absorbed, enforcing structural
+// equality with a prior binding the way bindCapture does for a single node.
+func (c *patternComparator) bindRun(name string, values []java.J) bool {
+	prev, bound := c.result.listBinding(name)
+	if !bound {
+		c.result.bindList(name, values)
+		return true
+	}
+	if len(prev) != len(values) {
+		return false
+	}
+	for i := range prev {
+		if !structurallyEqual(prev[i], values[i]) {
 			return false
 		}
 	}
@@ -469,15 +560,7 @@ func (c *patternComparator) matchExpressionRightPaddedList(pattern, candidate []
 }
 
 func (c *patternComparator) matchStatementList(pattern, candidate []java.RightPadded[java.Statement]) bool {
-	if len(pattern) != len(candidate) {
-		return false
-	}
-	for i := range pattern {
-		if !c.matchNode(pattern[i].Element, candidate[i].Element) {
-			return false
-		}
-	}
-	return true
+	return matchList(c, pattern, candidate)
 }
 
 func (c *patternComparator) matchStatementContainer(pattern, candidate java.Container[java.Statement]) bool {

--- a/rewrite-go/pkg/template/go_template.go
+++ b/rewrite-go/pkg/template/go_template.go
@@ -72,10 +72,11 @@ func (t *GoTemplate) Apply(cursor *visitor.Cursor, values *MatchResult) java.J {
 // inserts the result somewhere new, where Apply replaces a matched node. Bound
 // values are copied, so a spliced subtree may also stay where it came from.
 // The result carries no leading whitespace. It is nil unless every capture is
-// bound to a single subtree, the only form substitution handles.
+// bound, through Bind for a single subtree or BindList for a run of them
+// within the capture's declared bounds.
 func (t *GoTemplate) Instantiate(values *MatchResult) java.J {
-	for name, capture := range t.captures {
-		if capture.IsVariadic() || values == nil || values.Get(name) == nil {
+	for _, capture := range t.captures {
+		if values == nil || !values.satisfies(capture) {
 			return nil
 		}
 	}

--- a/rewrite-go/pkg/template/instantiate_test.go
+++ b/rewrite-go/pkg/template/instantiate_test.go
@@ -220,16 +220,6 @@ func literalArgOf(t *testing.T, decl java.J) *java.Literal {
 	return lit
 }
 
-func TestInstantiateRejectsVariadicCapture(t *testing.T) {
-	args := Expr("args").Variadic(0, -1)
-	tmpl := ExpressionTemplate(fmt.Sprintf("errors.New(%s)", args)).
-		Captures(args).
-		Imports("errors").
-		Build()
-
-	assert.Nil(t, tmpl.Instantiate(NewMatchResult().Bind(args, &java.Literal{Source: `"x"`})))
-}
-
 func TestBindIsChainableAndReadable(t *testing.T) {
 	a, b := Expr("a"), Expr("b")
 	lit := &java.Literal{Source: "1"}

--- a/rewrite-go/pkg/template/match_result.go
+++ b/rewrite-go/pkg/template/match_result.go
@@ -48,6 +48,49 @@ func (m *MatchResult) bindList(name string, values []java.J) {
 	m.bindings[name] = values
 }
 
+// BindList associates a capture with the subtrees to substitute for it, which
+// the placeholder's enclosing list expands to. A run of any length is a
+// binding, zero included. Elems builds the argument from the element slices a
+// recipe holds. Returns the receiver, for chaining.
+func (m *MatchResult) BindList(c *Capture, values []java.J) *MatchResult {
+	m.bindList(c.Name(), values)
+	return m
+}
+
+// Elems concatenates element slices into the []java.J BindList takes. Go
+// converts neither []java.Expression nor []java.Statement to that on its own,
+// and a recipe holds one of those rather than a []java.J.
+func Elems[T java.J](groups ...[]T) []java.J {
+	n := 0
+	for _, group := range groups {
+		n += len(group)
+	}
+	values := make([]java.J, 0, n)
+	for _, group := range groups {
+		for _, value := range group {
+			values = append(values, value)
+		}
+	}
+	return values
+}
+
+// listBinding returns the list bound to name, and whether the binding is a list
+// at all. It is the binding's shape, not the capture's declaration, that
+// decides how substitution treats a placeholder.
+func (m *MatchResult) listBinding(name string) ([]java.J, bool) {
+	list, ok := m.bindings[name].([]java.J)
+	return list, ok
+}
+
+// satisfies reports whether c has a value substitution can use: a run within
+// the capture's bounds, or a single subtree that holds a node.
+func (m *MatchResult) satisfies(c *Capture) bool {
+	if run, ok := m.listBinding(c.Name()); ok {
+		return c.allowsCount(len(run))
+	}
+	return m.Get(c.Name()) != nil
+}
+
 func (m *MatchResult) Has(name string) bool {
 	_, ok := m.bindings[name]
 	return ok

--- a/rewrite-go/pkg/template/substitution.go
+++ b/rewrite-go/pkg/template/substitution.go
@@ -54,15 +54,145 @@ func (v *substitutionVisitor) VisitIdentifier(ident *java.Identifier, p any) jav
 	return parenthesized(setLeadingPrefix(val, ident.Prefix), v.Cursor())
 }
 
-// substitute applies the substitution visitor to the template tree,
-// replacing all placeholder identifiers with captured values.
+// A list binding expands within the list its placeholder sits in, so the
+// placeholder's own visit leaves it in place for the enclosing call or block to
+// replace. Get holds only single bindings, and returns nil for a list.
+func (v *substitutionVisitor) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
+	visited := v.GoVisitor.VisitMethodInvocation(mi, p)
+	call, ok := visited.(*java.MethodInvocation)
+	if !ok {
+		return visited
+	}
+	expanded, changed := expandList(v, call.Arguments.Elements, expressionSeparator)
+	if !changed {
+		return call
+	}
+	c := *call
+	c.Arguments.Elements = expanded
+	return &c
+}
+
+func (v *substitutionVisitor) VisitBlock(block *java.Block, p any) java.J {
+	visited := v.GoVisitor.VisitBlock(block, p)
+	b, ok := visited.(*java.Block)
+	if !ok {
+		return visited
+	}
+	expanded, changed := expandList(v, b.Statements, statementSeparator)
+	if !changed {
+		return b
+	}
+	return b.WithStatements(expanded)
+}
+
+// separator supplies the leading whitespace of the nth element a placeholder
+// expands to, given the whitespace the placeholder itself carried.
+type separator func(n int, placeholder java.Space) java.Space
+
+// Arguments are separated by the comma the printer emits plus a space, which is
+// what the parser leaves on every argument after the first.
+func expressionSeparator(n int, placeholder java.Space) java.Space {
+	if n == 0 {
+		return placeholder
+	}
+	return java.SingleSpace
+}
+
+// Statements are separated by the line break and indent the placeholder already
+// stands at, so every one of them starts where it did.
+func statementSeparator(_ int, placeholder java.Space) java.Space {
+	return placeholder
+}
+
+// expandList replaces each list-bound placeholder with the subtrees bound to
+// it. The run takes over the placeholder's padding: the whitespace before it
+// goes to the run's first element, the whitespace after it to the last. An
+// empty run hands the whitespace before it to the element taking its place.
+func expandList[T java.J](v *substitutionVisitor, elements []java.RightPadded[T], sep separator) ([]java.RightPadded[T], bool) {
+	changed := false
+	expanded := make([]java.RightPadded[T], 0, len(elements))
+	var vacated *java.Space
+
+	for _, rp := range elements {
+		prefix := rp.Element.GetPrefix()
+		if vacated != nil {
+			prefix, vacated = *vacated, nil
+		}
+
+		var values []java.J
+		isList := false
+		if name, isPlaceholder := placeholderName(java.J(rp.Element)); isPlaceholder {
+			values, isList = v.values.listBinding(name)
+		}
+
+		if !isList {
+			if !java.SpaceEqual(prefix, rp.Element.GetPrefix()) {
+				element, ok := setPrefix(rp.Element, prefix).(T)
+				if !ok {
+					return elements, false
+				}
+				rp.Element = element
+			}
+			expanded = append(expanded, rp)
+			continue
+		}
+
+		changed = true
+		if len(values) == 0 {
+			vacated = &prefix
+			continue
+		}
+		for i, value := range values {
+			// Returning the list untouched leaves the placeholder
+			// standing, which substitute reads as the failure it is.
+			element, ok := setPrefix(value, sep(i, prefix)).(T)
+			if !ok {
+				return elements, false
+			}
+			padded := java.RightPadded[T]{Element: element}
+			if i == len(values)-1 {
+				padded.After, padded.Markers = rp.After, rp.Markers
+			}
+			expanded = append(expanded, padded)
+		}
+	}
+	return expanded, changed
+}
+
+// substitute applies the substitution visitor to the template tree, replacing
+// all placeholder identifiers with captured values. It is nil unless every
+// placeholder was replaced, a placeholder in the output being no valid Go.
 func substitute(templateTree java.J, values *MatchResult) java.J {
 	v := newSubstitutionVisitor(values)
 	result := v.Visit(templateTree, nil)
 	if result == nil {
 		return nil
 	}
-	return result.(java.J)
+	substituted, ok := result.(java.J)
+	if !ok || holdsPlaceholder(substituted) {
+		return nil
+	}
+	return substituted
+}
+
+func holdsPlaceholder(j java.J) bool {
+	found := false
+	f := &placeholderFinder{found: &found}
+	f.Self = f
+	f.Visit(j, nil)
+	return found
+}
+
+type placeholderFinder struct {
+	visitor.GoVisitor
+	found *bool
+}
+
+func (v *placeholderFinder) VisitIdentifier(ident *java.Identifier, p any) java.J {
+	if IsPlaceholder(ident.Name) {
+		*v.found = true
+	}
+	return v.GoVisitor.VisitIdentifier(ident, p)
 }
 
 func setPrefix(j java.J, prefix java.Space) java.J {

--- a/rewrite-go/pkg/template/variadic_test.go
+++ b/rewrite-go/pkg/template/variadic_test.go
@@ -1,0 +1,368 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package template
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+)
+
+// findCall returns the first call of the named function in src.
+func findCall(t *testing.T, src, name string) *java.MethodInvocation {
+	t.Helper()
+	p := parser.NewGoParser()
+	cu, err := p.Parse("test.go", src)
+	require.NoError(t, err)
+
+	var found java.J
+	visitor.Init(&callFinder{target: name, found: &found}).Visit(cu, nil)
+	require.NotNilf(t, found, "could not find call to %q in:\n%s", name, src)
+	return found.(*java.MethodInvocation)
+}
+
+// callSource wraps calls in a compilable file so the arity varies but nothing else does.
+func callSource(calls ...string) string {
+	src := "package main\n\nfunc f(xs ...int) int { return 0 }\n"
+	for i, call := range calls {
+		src += fmt.Sprintf("\nvar v%d = %s\n", i, call)
+	}
+	return src
+}
+
+func TestMatchVariadicArgumentsOfAnyArity(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	pat := Expression(fmt.Sprintf("f(%s)", args)).Captures(args).Build()
+
+	for _, tc := range []struct {
+		call string
+		want int
+	}{
+		{"f()", 0},
+		{"f(1)", 1},
+		{"f(1, 2, 3)", 3},
+	} {
+		t.Run(tc.call, func(t *testing.T) {
+			call := findCall(t, callSource(tc.call), "f")
+			result := pat.Match(call, nil)
+			require.NotNilf(t, result, "one pattern should match %s", tc.call)
+			assert.Len(t, result.GetList("args"), tc.want)
+		})
+	}
+}
+
+func TestMatchVariadicHonoursMinAndMaxCount(t *testing.T) {
+	args := Expr("args").Variadic(1, 2)
+	pat := Expression(fmt.Sprintf("f(%s)", args)).Captures(args).Build()
+
+	assert.Nil(t, pat.Match(findCall(t, callSource("f()"), "f"), nil), "0 args is below minCount 1")
+	assert.NotNil(t, pat.Match(findCall(t, callSource("f(1)"), "f"), nil))
+	assert.NotNil(t, pat.Match(findCall(t, callSource("f(1, 2)"), "f"), nil))
+	assert.Nil(t, pat.Match(findCall(t, callSource("f(1, 2, 3)"), "f"), nil), "3 args is above maxCount 2")
+}
+
+func TestMatchVariadicBetweenFixedCaptures(t *testing.T) {
+	first, rest, last := Expr("first"), Expr("rest").Variadic(0, -1), Expr("last")
+	pat := Expression(fmt.Sprintf("f(%s, %s, %s)", first, rest, last)).
+		Captures(first, rest, last).
+		Build()
+
+	// The one variadic makes the split arithmetic, so the trailing fixed
+	// capture binds the last argument rather than being starved by a greedy run.
+	result := pat.Match(findCall(t, callSource("f(1, 2, 3, 4)"), "f"), nil)
+	require.NotNil(t, result)
+	assert.Equal(t, "1", result.Get("first").(*java.Literal).Source)
+	assert.Equal(t, "4", result.Get("last").(*java.Literal).Source)
+	middle := result.GetList("rest")
+	require.Len(t, middle, 2)
+	assert.Equal(t, "2", middle[0].(*java.Literal).Source)
+	assert.Equal(t, "3", middle[1].(*java.Literal).Source)
+
+	// Two fixed captures need two arguments of their own.
+	assert.NotNil(t, pat.Match(findCall(t, callSource("f(1, 2)"), "f"), nil))
+	assert.Nil(t, pat.Match(findCall(t, callSource("f(1)"), "f"), nil))
+}
+
+func TestMatchRejectsTwoVariadicsInOneList(t *testing.T) {
+	a, b := Expr("a").Variadic(0, -1), Expr("b").Variadic(0, -1)
+	pat := Expression(fmt.Sprintf("f(%s, %s)", a, b)).Captures(a, b).Build()
+
+	assert.Nil(t, pat.Match(findCall(t, callSource("f(1, 2)"), "f"), nil),
+		"a list splits at one variadic; two leave the split undetermined")
+}
+
+func TestMatchRepeatedVariadicCaptureNeedsEqualRuns(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	pat := Expression(fmt.Sprintf("f(%s) + f(%s)", args, args)).Captures(args).Build()
+
+	src := func(expr string) string {
+		return "package main\n\nfunc f(xs ...int) int { return 0 }\n\nvar v = " + expr + "\n"
+	}
+	p := parser.NewGoParser()
+	match := func(expr string) *MatchResult {
+		cu, err := p.Parse("test.go", src(expr))
+		require.NoError(t, err)
+		var found java.J
+		visitor.Init(&binaryFinder{found: &found}).Visit(cu, nil)
+		require.NotNil(t, found)
+		return pat.Match(found, nil)
+	}
+
+	assert.NotNil(t, match("f(1, 2) + f(1, 2)"))
+	assert.Nil(t, match("f(1, 2) + f(1)"), "a repeated capture binds one run, not two")
+	assert.Nil(t, match("f(1, 2) + f(1, 3)"))
+}
+
+func TestApplyFailsWhenABoundNodeCannotSitInTheList(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("f(%s)", args)).Captures(args).Build()
+
+	// A return statement is no expression, so it cannot become an argument.
+	values := NewMatchResult().BindList(args, []java.J{&java.Return{}})
+	assert.Nil(t, tmpl.Apply(nil, values))
+}
+
+func TestRewriteExpandsVariadicArguments(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	before := Expression(fmt.Sprintf("before(%s)", args)).Captures(args).Build()
+	after := ExpressionTemplate(fmt.Sprintf("after(%s)", args)).Captures(args).Build()
+
+	r := &rewriteRecipeWithVisitor{visitor: Rewrite(before, after)}
+	test.NewRecipeSpec().WithRecipe(r).RewriteRun(t,
+		test.Golang(`
+			package main
+
+			func before(xs ...int) int { return 0 }
+			func after(xs ...int) int  { return 0 }
+
+			var a = before()
+			var b = before(1)
+			var c = before(1, 2, 3)
+		`, `
+			package main
+
+			func before(xs ...int) int { return 0 }
+			func after(xs ...int) int  { return 0 }
+
+			var a = after()
+			var b = after(1)
+			var c = after(1, 2, 3)
+		`),
+	)
+}
+
+func TestRewriteMixesVariadicWithFixedCaptures(t *testing.T) {
+	recv, args := Expr("recv"), Expr("args").Variadic(0, -1)
+	before := Expression(fmt.Sprintf("before(%s, %s)", recv, args)).Captures(recv, args).Build()
+	after := ExpressionTemplate(fmt.Sprintf("after(%s, %s)", args, recv)).Captures(recv, args).Build()
+
+	r := &rewriteRecipeWithVisitor{visitor: Rewrite(before, after)}
+	test.NewRecipeSpec().WithRecipe(r).RewriteRun(t,
+		test.Golang(`
+			package main
+
+			func before(xs ...int) int { return 0 }
+			func after(xs ...int) int  { return 0 }
+
+			var a = before(1)
+			var b = before(1, 2, 3)
+		`, `
+			package main
+
+			func before(xs ...int) int { return 0 }
+			func after(xs ...int) int  { return 0 }
+
+			var a = after(1)
+			var b = after(2, 3, 1)
+		`),
+	)
+}
+
+func TestRewriteExpandsVariadicStatements(t *testing.T) {
+	body := Stmt("body").Variadic(0, -1)
+	before := StatementPattern(fmt.Sprintf("if ok {\n%s\n}", body)).Captures(body).Build()
+	after := StatementTemplate(fmt.Sprintf("if !ok {\n%s\n}", body)).Captures(body).Build()
+
+	r := &rewriteRecipeWithVisitor{visitor: Rewrite(before, after)}
+	test.NewRecipeSpec().WithRecipe(r).RewriteRun(t,
+		test.Golang(`
+			package main
+
+			func f(ok bool) {
+				if ok {
+					g()
+					g()
+				}
+			}
+
+			func g() {}
+		`, `
+			package main
+
+			func f(ok bool) {
+				if !ok {
+					g()
+					g()
+				}
+			}
+
+			func g() {}
+		`),
+	)
+}
+
+func TestInstantiateWithHandBoundList(t *testing.T) {
+	recv, args := Expr("recv"), Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("assert.Equal(%s, %s)", recv, args)).
+		Captures(recv, args).
+		Build()
+
+	call := tmpl.Instantiate(NewMatchResult().
+		Bind(recv, &java.Identifier{Name: "t"}).
+		BindList(args, []java.J{
+			&java.Literal{Source: "want"},
+			&java.Literal{Source: "got"},
+		}))
+
+	require.NotNil(t, call)
+	assert.Equal(t, "assert.Equal(t, want, got)", printer.Print(call))
+}
+
+func TestInstantiateWithEmptyList(t *testing.T) {
+	recv, args := Expr("recv"), Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("assert.True(%s, %s)", recv, args)).
+		Captures(recv, args).
+		Build()
+
+	call := tmpl.Instantiate(NewMatchResult().
+		Bind(recv, &java.Identifier{Name: "t"}).
+		BindList(args, nil))
+
+	require.NotNil(t, call)
+	assert.Equal(t, "assert.True(t)", printer.Print(call))
+}
+
+func TestInstantiateHonoursBoundsOnAHandBoundRun(t *testing.T) {
+	args := Expr("args").Variadic(1, 2)
+	tmpl := ExpressionTemplate(fmt.Sprintf("f(%s)", args)).Captures(args).Build()
+
+	run := func(n int) []java.J {
+		values := make([]java.J, n)
+		for i := range values {
+			values[i] = &java.Literal{Source: "1"}
+		}
+		return values
+	}
+
+	assert.Nil(t, tmpl.Instantiate(NewMatchResult().BindList(args, run(0))), "below minCount 1")
+	assert.NotNil(t, tmpl.Instantiate(NewMatchResult().BindList(args, run(1))))
+	assert.NotNil(t, tmpl.Instantiate(NewMatchResult().BindList(args, run(2))))
+	assert.Nil(t, tmpl.Instantiate(NewMatchResult().BindList(args, run(3))), "above maxCount 2")
+}
+
+func TestElemsConcatenatesElementSlices(t *testing.T) {
+	recv := &java.Identifier{Name: "t"}
+	coreArgs := []java.Expression{&java.Identifier{Name: "want"}, &java.Identifier{Name: "got"}}
+	msgArgs := []java.Expression{&java.Literal{Source: `"boom"`}}
+
+	args := Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("assert.Equal(%s)", args)).Captures(args).Build()
+
+	call := tmpl.Instantiate(NewMatchResult().
+		BindList(args, Elems([]java.Expression{recv}, coreArgs, msgArgs)))
+
+	require.NotNil(t, call)
+	assert.Equal(t, `assert.Equal(t, want, got, "boom")`, printer.Print(call))
+}
+
+func TestElemsWidensStatements(t *testing.T) {
+	stmts := []java.Statement{&java.Return{}, &java.Return{}}
+	assert.Len(t, Elems(stmts), 2)
+	assert.Empty(t, Elems[java.Expression]())
+}
+
+func TestInstantiateRefusesUnboundVariadicCapture(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("errors.New(%s)", args)).
+		Captures(args).
+		Imports("errors").
+		Build()
+
+	assert.Nil(t, tmpl.Instantiate(NewMatchResult()))
+}
+
+func TestInstantiateSplicedListNodesGetFreshIDs(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("f(%s)", args)).Captures(args).Build()
+
+	lit := &java.Literal{Source: "1"}
+	call := tmpl.Instantiate(NewMatchResult().BindList(args, []java.J{lit, lit}))
+
+	require.NotNil(t, call)
+	mi, ok := call.(*java.MethodInvocation)
+	require.Truef(t, ok, "expected *java.MethodInvocation, got %T", call)
+	require.Len(t, mi.Arguments.Elements, 2)
+	first, second := mi.Arguments.Elements[0].Element.GetID(), mi.Arguments.Elements[1].Element.GetID()
+	assert.NotEqual(t, lit.ID, first, "the bound node stays usable where it came from")
+	assert.NotEqual(t, first, second, "one node bound twice must not yield two of the same ID")
+}
+
+func TestApplyFailsForVariadicOutsideListPosition(t *testing.T) {
+	args := Expr("args").Variadic(0, -1)
+	tmpl := ExpressionTemplate(fmt.Sprintf("%s + 1", args)).Captures(args).Build()
+
+	values := NewMatchResult().BindList(args, []java.J{&java.Literal{Source: "2"}})
+	assert.Nil(t, tmpl.Apply(nil, values),
+		"a list has nowhere to expand outside a list position")
+}
+
+func TestApplyFailsRatherThanEmitAPlaceholder(t *testing.T) {
+	bound, unbound := Expr("bound"), Expr("unbound")
+	tmpl := ExpressionTemplate(fmt.Sprintf("f(%s, %s)", bound, unbound)).
+		Captures(bound, unbound).
+		Build()
+
+	values := NewMatchResult().Bind(bound, &java.Literal{Source: "1"})
+	assert.Nil(t, tmpl.Apply(nil, values), "an unbound capture has no substitute to emit")
+}
+
+func TestVariadicRejectsInvalidBounds(t *testing.T) {
+	assert.Panics(t, func() { Expr("x").Variadic(-1, 3) })
+	assert.Panics(t, func() { Expr("x").Variadic(3, 2) })
+	assert.NotPanics(t, func() { Expr("x").Variadic(3, -1) })
+}
+
+type callFinder struct {
+	visitor.GoVisitor
+	target string
+	found  *java.J
+}
+
+func (v *callFinder) VisitMethodInvocation(mi *java.MethodInvocation, p any) java.J {
+	if *v.found == nil && mi.Name != nil && mi.Name.Name == v.target {
+		*v.found = mi
+	}
+	return v.GoVisitor.VisitMethodInvocation(mi, p)
+}


### PR DESCRIPTION
`Capture.Variadic(min, max)` has been on the `pkg/template` surface setting `variadic`/`minCount`/`maxCount`, with `MatchResult.bindings` documented as `single: java.J, variadic: []java.J`, and nothing read any of it. `bindList` had no callers in the module, `MinCount()`/`MaxCount()` no consumers, `comparator.go` no variadic handling, and the only `.Variadic(...)` call anywhere was `instantiate_test.go:224` asserting that `Instantiate` *rejects* one. So a template could not say "these N arguments", and a recipe emitting a call whose arity varies at runtime had to carry one template per arity.

## Matching

A list splits at **one** variadic capture. That makes the run's length arithmetic — `len(candidate) - (len(pattern) - 1)`, since every other pattern element takes exactly one candidate element — so the captures *after* the variadic match positionally instead of by backtracking, and a trailing fixed capture is never starved by a greedy run:

```go
first, rest, last := Expr("first"), Expr("rest").Variadic(0, -1), Expr("last")
// f(1, 2, 3, 4) binds first=1, rest=[2 3], last=4
```

Two variadic captures in one list leave the split undetermined, and the match fails. `matchExpressionList` and `matchStatementList` both route through the same generic `matchList`, so a run in a block's statements works the same way.

A negative run can't reach the slicing: `Variadic` rejects a negative `min`, so `allowsCount` fails first.

## Substitution

`Get` returns nil for a list binding, so `VisitIdentifier` leaves a list-bound placeholder standing and the enclosing `VisitMethodInvocation`/`VisitBlock` expands it. Separators follow what the parser produces — verified against it, since `g(1, 2, 3)` yields prefixes `""`, `" "`, `" "` and `g()` is zero elements rather than a `J.Empty`:

- **arguments** — placeholder's prefix on the first element, `SingleSpace` on the rest
- **statements** — the placeholder's prefix on every element, their separator being the line break and indent it already stands at

**An empty run can't just drop its element.** `after(%s, %s)` with an empty run left the following fixed capture carrying its `" "` separator in leading position, printing `after( 1)`. An empty run now hands its whitespace to whichever element takes its place.

**Statement placeholders arrive wrapped.** An identifier is an expression, so `__plh_body__` in statement position comes back as `golang.ExpressionStatement{Identifier}` — the statement test failed to match until `placeholderName` learned to see through the wrapper. That also fixes single, non-variadic `Stmt` captures in a statement list, which had the same blind spot.

## Why the no-placeholder rule is structural

`substitute` scans its result and returns nil if any `__plh_` identifier survives. One gate covers a variadic outside a list position, a capture left unbound, and a bound node the list has no slot for (a statement among arguments: the cast fails, the list returns untouched, the gate catches it). An explicit failure flag was redundant against it — every one of those paths leaves the placeholder in the tree — so there is one failure mechanism rather than two.

## A latent leak this also closes

The gate above is not variadic-specific, and it fixes a bug that predates this work: **an unbound single capture leaked `__plh_x__` into rewritten source.** `VisitIdentifier` fell through when a capture had no binding, leaving the placeholder identifier in the output tree, and nothing downstream objected — the result was emitted as source. `Apply` now returns nil instead, so the recipe makes no change rather than a corrupting one.

This is a behaviour change beyond the stated scope, and the one thing here most likely to surprise an existing recipe: anything relying on partial substitution stops producing output. Nothing in this repo did, and recipes-go's suite is green, but it is worth a reviewer's attention rather than being buried in the variadic mechanics.

## API

`Instantiate` drops its variadic rejection and checks the run against the capture's declared bounds, matching what the match path already did. The predicate moved to `Capture.allowsCount`, called by both the comparator and `MatchResult.satisfies` — the comparator's private copy is how the two paths drifted apart to begin with, and sharing it is worth more than the behaviour change.

`BindList` supplies a run by hand. `Elems` widens, because Go converts neither `[]java.Expression` nor `[]java.Statement` to `[]java.J` (interface satisfaction doesn't lift through slices) and a recipe holds one of those:

```go
tmpl.Instantiate(template.NewMatchResult().
    BindList(args, template.Elems([]java.Expression{recv}, coreArgs, msgArgs)))
```

`Elems` is a free generic function so `BindList` stays a chainable method; a generic `BindElems(m, c, values)` would have worked too but reads as `BindElems(BindElems(m, ...), ...)`. `Bind` needs no counterpart — `Expression` and `Statement` each embed `J`, so a *single* value converts implicitly; only the slice doesn't.

## Tests

`variadic_test.go` — 16 tests: one pattern matching 0/1/N arguments, min/max on both the match and instantiate paths, a variadic mixed with fixed captures on both sides, a repeated variadic capture requiring equal runs, two variadics in one list failing, statement-list expansion, a hand-bound run through `Instantiate`, one node bound twice getting distinct fresh IDs, and both not-a-list-position cases returning nil. The round-trip tests assert printed output, so a surviving `__plh_` would fail them.

`TestInstantiateRejectsVariadicCapture` is deleted — it asserted exactly the behaviour this relaxes.

## Downstream check

`moderneinc/recipes-go` was migrated onto this branch — `go.mod` pointed at a worktree — as an independent check. Three results, proving different things — and the sweep is the weakest of them, contrary to how a reader might rank them. That migration is uncommitted in the migrating checkout, so the line counts below are a reported local result and not yet reachable from any ref; the sweep harness they came from is on recipes-go `main` and is reproducible today.

- **Shape coverage** — recipes-go's 38 testify unit tests pass. These are what actually exercise this change against real code: nested calls in argument position, preserved format messages, and parenthesis balancing (`TestPreserveMessageBalancesParens`, `TestPreserveMessageKeepsComplexFormat`, `TestAdoptRequireEqualPreservesContextMessage`, in `tests/migration/testify/`). They compare printed source, so a shifted padding convention fails them directly.
- **Whole-catalog regression** — a 5-repo sweep produces findings byte-identical to the pre-change run. Worth running, but weak evidence for *this* change: across all five repos it yields four testify rewrites total, so it would match either way. Its value is catching a padding shift in template-based recipes nobody is thinking about. Reproducible rather than reported: `tests/validation_test.go` pins gorilla/mux, spf13/cobra, sirupsen/logrus, go-chi/chi and labstack/echo at fixed revisions, and `REALWORLD_REPOS=1 go test ./tests/ -run TestParseRealRepos -count=1` re-runs it.
- **Attribution** — `TestRewrittenTreesStayAttributed` passes with no new gaps, so `assert.Equal` still carries its real signature from the shipped export data.

`adopt_common.go`'s arity-keyed template cache goes from 57 lines to 35: variadic captures alone get it to 43, and `Elems` gets the rest by removing both the widening loops and the hand-rolled concatenation. The `assertionTemplate` struct disappears and the cache key loses its arity component.

## Not in this PR

- Repointing recipes-go's `go.mod` off the worktree, which needs a `rewrite-go` tag — neither #8586 (`Bind` + `Instantiate`) nor #8545 (shipped export data), which this builds on, is in a released tag yet. A direct read of recipes-go's eight other `[]java.RightPadded[java.Expression]` sites found none that wants variadic captures — each edits a list in place at fixed arity (`make(..., len(args))`, then swap one index) rather than constructing one. The behavioural sweep above cannot establish this; it only compares findings before and after.





