### PR TITLE
Apply OpenRewrite recipe best practices to rewrite-docker

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
@@ -119,8 +119,7 @@ public class ChangeFrom extends Recipe {
         validated = validateBackrefs(validated, "newImageName", newImageName, oldImageName);
         validated = validateBackrefs(validated, "newTag", newTag, oldTag);
         validated = validateBackrefs(validated, "newDigest", newDigest, oldDigest);
-        validated = validateBackrefs(validated, "newPlatform", newPlatform, oldPlatform);
-        return validated;
+        return validateBackrefs(validated, "newPlatform", newPlatform, oldPlatform);
     }
 
     private static Validated<Object> validateBackrefs(Validated<Object> validated, String field,

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/internal/EolImageDataGenerator.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/internal/EolImageDataGenerator.java
@@ -29,7 +29,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.*;
-import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Fetches end-of-life data from <a href="https://endoflife.date">endoflife.date</a>
@@ -234,7 +237,7 @@ public class EolImageDataGenerator {
             List<VersionInfo> eolVersions = filterEolVersions(parsed);
             List<VersionInfo> activeVersions = parsed.stream()
                     .filter(v -> !v.isEol)
-                    .collect(Collectors.toList());
+                    .collect(toList());
 
             if (eolVersions.isEmpty()) {
                 continue;
@@ -277,7 +280,7 @@ public class EolImageDataGenerator {
         HttpResponse<String> response = HTTP.send(request, HttpResponse.BodyHandlers.ofString());
         if (response.statusCode() != 200) {
             System.err.println("HTTP " + response.statusCode() + " for " + url);
-            return Collections.emptyList();
+            return emptyList();
         }
         return JSON.readValue(response.body(), new TypeReference<>() {});
     }
@@ -346,7 +349,7 @@ public class EolImageDataGenerator {
                         return false;
                     }
                 })
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     private static String computeReplacement(TrackedProduct product,
@@ -359,7 +362,7 @@ public class EolImageDataGenerator {
                 yield sorted.stream()
                         .limit(2)
                         .map(v -> v.cycle)
-                        .collect(Collectors.joining(" or "));
+                        .collect(joining(" or "));
             }
             case TWO_NEWEST_LTS -> {
                 // For Ubuntu, LTS versions end in .04


### PR DESCRIPTION
Ran `org.openrewrite.recipes.rewrite.OpenRewriteRecipeBestPracticesSubset` from `rewrite.yml` against the `rewrite-docker` module and committed the results. `InlineVariable` collapses the final `validated = ...; return validated;` pair in `ChangeFrom.validate()` into a direct return, and `UseStaticImport` converts `Collectors.toList`/`Collectors.joining` and `Collections.emptyList` to static imports in `EolImageDataGenerator`. No behavior changes; `./gradlew :rewrite-docker:build` passes.

One thing worth noting separately: the run reports `org.openrewrite.java.recipes.migrate.RemoveTraitsUsageRecipes` (referenced from `JavaRecipeBestPracticesSubset`) as *"refers to a recipe that doesn't exist"* — that package is genuinely absent from the latest released `org.openrewrite.recipe:rewrite-rewrite:0.30.0`, so that entry is currently a silent no-op unless it is expected to resolve from a snapshot.