### PR TITLE
Docker: one definition of an environment variable reference

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
@@ -327,7 +327,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
     }
 
     private static boolean isVarStart(char c) {
-        return (c >= 'A' && c <= 'Z') || c == '_';
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
     }
 
     private static boolean isVarPart(char c) {
@@ -1228,12 +1228,10 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         return new Docker.Flag(randomId(), flagPrefix, Markers.EMPTY, flagName, flagValue);
     }
 
-    /**
-     * Parse a flag value text into its component parts.
-     * Recognizes environment variables ($VAR, ${VAR}), and splits on = signs.
-     */
     /// Splits the value of a command's flag into its quoted literals, environment variable references
-    /// and the `=` separating a key from a value, as in `--mount=type=bind`.
+    /// and the `=` separating a key from a value, as in `--mount=type=bind`. Everything that is not a
+    /// quote or a separator is handed to [#splitVariables(String, Space)], so a variable reference means
+    /// the same thing here as it does in an argument's value.
     private List<Docker.ArgumentContent> parseFlagValue(String text) {
         List<Docker.ArgumentContent> contents = new ArrayList<>();
         StringBuilder current = new StringBuilder();
@@ -1242,67 +1240,19 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         while (i < text.length()) {
             char c = text.charAt(i);
 
-            if (c == '$') {
-                // Flush any accumulated text
-                if (current.length() > 0) {
-                    contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, current.toString(), null));
-                    current.setLength(0);
-                }
-
-                // Parse environment variable
-                if (i + 1 < text.length() && text.charAt(i + 1) == '{') {
-                    // Braced form: ${VAR}
-                    int endBrace = text.indexOf('}', i + 2);
-                    if (endBrace > i + 2) {
-                        String varContent = text.substring(i + 2, endBrace);
-                        // Handle ${VAR:-default} and similar forms
-                        String varName = varContent;
-                        int colonIdx = varContent.indexOf(':');
-                        if (colonIdx >= 0) {
-                            varName = varContent.substring(0, colonIdx);
-                        }
-                        contents.add(new Docker.EnvironmentVariable(randomId(), Space.EMPTY, Markers.EMPTY, varName, true));
-                        i = endBrace + 1;
-                        continue;
-                    }
-                } else if (i + 1 < text.length()) {
-                    // Unbraced form: $VAR
-                    int varStart = i + 1;
-                    int varEnd = varStart;
-                    while (varEnd < text.length() && isVarChar(text.charAt(varEnd), varEnd == varStart)) {
-                        varEnd++;
-                    }
-                    if (varEnd > varStart) {
-                        String varName = text.substring(varStart, varEnd);
-                        contents.add(new Docker.EnvironmentVariable(randomId(), Space.EMPTY, Markers.EMPTY, varName, false));
-                        i = varEnd;
-                        continue;
-                    }
-                }
-                // Not a valid env var, treat $ as literal
-                current.append(c);
-                i++;
-            } else if (c == '"' || c == '\'') {
+            if (c == '"' || c == '\'') {
                 int close = findClosingQuote(text, i);
                 if (close < 0) {
                     current.append(c);
                     i++;
                     continue;
                 }
-                if (current.length() > 0) {
-                    contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, current.toString(), null));
-                    current.setLength(0);
-                }
+                flushFlagText(current, contents);
                 contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, text.substring(i + 1, close),
                         c == '"' ? Docker.Literal.QuoteStyle.DOUBLE : Docker.Literal.QuoteStyle.SINGLE));
                 i = close + 1;
             } else if (c == '=') {
-                // Flush any accumulated text
-                if (current.length() > 0) {
-                    contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, current.toString(), null));
-                    current.setLength(0);
-                }
-                // Add the equals sign as its own element
+                flushFlagText(current, contents);
                 contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, "=", null));
                 i++;
             } else {
@@ -1310,13 +1260,16 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
                 i++;
             }
         }
-
-        // Flush remaining text
-        if (current.length() > 0) {
-            contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, current.toString(), null));
-        }
+        flushFlagText(current, contents);
 
         return contents.isEmpty() ? singletonList(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, "", null)) : contents;
+    }
+
+    private void flushFlagText(StringBuilder current, List<Docker.ArgumentContent> contents) {
+        if (current.length() > 0) {
+            contents.addAll(splitVariables(current.toString(), Space.EMPTY));
+            current.setLength(0);
+        }
     }
 
     private static int findClosingQuote(String text, int openIndex) {
@@ -1330,13 +1283,6 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
             }
         }
         return -1;
-    }
-
-    private boolean isVarChar(char c, boolean isFirst) {
-        if (isFirst) {
-            return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
-        }
-        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_';
     }
 
     private Docker.ShellForm visitShellFormContext(DockerParser.ShellFormContext ctx) {

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/ArgTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/ArgTest.java
@@ -360,6 +360,49 @@ class ArgTest implements RewriteTest {
         );
     }
 
+    @Test
+    void lowercaseEnvironmentVariableValue() {
+        rewriteRun(
+          docker(
+            """
+              FROM ubuntu:20.04
+              ARG version=$base
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument value = argValue(doc);
+                Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) value.getContents().getFirst();
+                assertThat(var.getName()).isEqualTo("base");
+                assertThat(var.isBraced()).isFalse();
+                assertThat(value.hasEnvironmentVariables()).isTrue();
+                assertThat(value.getText()).isNull();
+                assertThat(value.getTextWithVariables()).isEqualTo("$base");
+            })
+          )
+        );
+    }
+
+    @Test
+    void mixedCaseEnvironmentVariableValue() {
+        rewriteRun(
+          docker(
+            """
+              FROM ubuntu:20.04
+              ARG version=$Java_Version
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument value = argValue(doc);
+                assertThat(value.getContents()).hasSize(1);
+                Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) value.getContents().getFirst();
+                assertThat(var.getName()).isEqualTo("Java_Version");
+                assertThat(var.isBraced()).isFalse();
+                assertThat(value.hasEnvironmentVariables()).isTrue();
+                assertThat(value.getText()).isNull();
+                assertThat(value.getTextWithVariables()).isEqualTo("$Java_Version");
+            })
+          )
+        );
+    }
+
     private static Docker.Argument argValue(Docker.File doc) {
         Docker.Arg arg = (Docker.Arg) doc.getStages().getFirst().getInstructions().getLast();
         return assertThat(arg.getValue()).isNotNull().actual();

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/EnvTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/EnvTest.java
@@ -176,6 +176,29 @@ class EnvTest implements RewriteTest {
         );
     }
 
+    @Test
+    void lowercaseVariableInQuotedPathAppend() {
+        rewriteRun(
+          docker(
+            """
+              FROM alpine:latest
+              ENV path_prefix=/opt
+              ENV PATH="$path_prefix/bin:$PATH"
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument value = envValue(doc);
+                assertThat(value.getContents())
+                  .filteredOn(Docker.EnvironmentVariable.class::isInstance)
+                  .extracting(content -> ((Docker.EnvironmentVariable) content).getName())
+                  .containsExactly("path_prefix", "PATH");
+                assertThat(value.hasEnvironmentVariables()).isTrue();
+                assertThat(value.getText()).isNull();
+                assertThat(value.getTextWithVariables()).isEqualTo("\"$path_prefix/bin:$PATH\"");
+            })
+          )
+        );
+    }
+
     private static Docker.Argument envValue(Docker.File doc) {
         var env = (Docker.Env) doc.getStages().getFirst().getInstructions().getLast();
         return assertThat(env.getPairs()).singleElement().actual().getValue();

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/FromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/FromTest.java
@@ -395,4 +395,104 @@ class FromTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void lowercaseArgReferenceInTag() {
+        rewriteRun(
+          docker(
+            """
+              ARG java_version=17
+              FROM eclipse-temurin:${java_version}
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument tag = doc.getStages().getLast().getFrom().getTag();
+                assertThat(tag).isNotNull();
+                Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) tag.getContents().getFirst();
+                assertThat(var.getName()).isEqualTo("java_version");
+                assertThat(var.isBraced()).isTrue();
+                assertThat(tag.hasEnvironmentVariables()).isTrue();
+                assertThat(tag.getText()).isNull();
+                assertThat(tag.getTextWithVariables()).isEqualTo("${java_version}");
+            })
+          )
+        );
+    }
+
+    @Test
+    void unbracedLowercaseArgReferenceInTag() {
+        rewriteRun(
+          docker(
+            """
+              ARG java_version=17
+              FROM eclipse-temurin:$java_version
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument tag = doc.getStages().getLast().getFrom().getTag();
+                assertThat(tag).isNotNull();
+                Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) tag.getContents().getFirst();
+                assertThat(var.getName()).isEqualTo("java_version");
+                assertThat(var.isBraced()).isFalse();
+                assertThat(tag.getText()).isNull();
+                assertThat(tag.getTextWithVariables()).isEqualTo("$java_version");
+            })
+          )
+        );
+    }
+
+    @Test
+    void mixedCaseArgReferenceInTag() {
+        rewriteRun(
+          docker(
+            """
+              ARG Java_Version=17
+              FROM eclipse-temurin:${Java_Version}
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument tag = doc.getStages().getLast().getFrom().getTag();
+                assertThat(tag).isNotNull();
+                assertThat(((Docker.EnvironmentVariable) tag.getContents().getFirst()).getName()).isEqualTo("Java_Version");
+                assertThat(tag.getText()).isNull();
+                assertThat(tag.getTextWithVariables()).isEqualTo("${Java_Version}");
+            })
+          )
+        );
+    }
+
+    @Test
+    void lowercaseVariableInPlatformFlag() {
+        rewriteRun(
+          docker(
+            """
+              FROM --platform=$target_platform alpine:latest
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument flagValue = doc.getStages().getFirst().getFrom().getFlags().getFirst().getValue();
+                assertThat(flagValue).isNotNull();
+                Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) flagValue.getContents().getFirst();
+                assertThat(var.getName()).isEqualTo("target_platform");
+                assertThat(flagValue.getText()).isNull();
+                assertThat(flagValue.getTextWithVariables()).isEqualTo("$target_platform");
+            })
+          )
+        );
+    }
+
+    @Test
+    void platformFlagKeepsVariableDefault() {
+        rewriteRun(
+          docker(
+            """
+              FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:latest
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.Argument flagValue = doc.getStages().getFirst().getFrom().getFlags().getFirst().getValue();
+                assertThat(flagValue).isNotNull();
+                Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) flagValue.getContents().getFirst();
+                assertThat(var.getName()).isEqualTo("TARGETPLATFORM:-linux/amd64");
+                assertThat(var.isBraced()).isTrue();
+                assertThat(flagValue.getTextWithVariables()).isEqualTo("${TARGETPLATFORM:-linux/amd64}");
+            })
+          )
+        );
+    }
 }


### PR DESCRIPTION
`parseFlagValue` carried its own scanner for `$VAR` / `${VAR}` that disagreed with `splitVariables` — the one an argument's value goes through — in two ways: it truncated a braced name at the first colon, so `FROM --platform=${TARGETPLATFORM:-linux/amd64}` printed back as `${TARGETPLATFORM}`, a Dockerfile losing its default value on a round trip with no recipe involved; and it accepted a lowercase name where `splitVariables` did not, so `$user` modelled a reference in `COPY --chown=$user` and in `COPY $user /dest` (through the lexer's `ENV_VAR` token, which is case-insensitive because the grammar sets `caseInsensitive = true`) but stayed plain text in `ARG u=$user`.

This hands every non-quote, non-separator run of a flag's value to `splitVariables` and widens `isVarStart` to lowercase, leaving one definition; quoting and the `=` in `--mount=type=bind` are unchanged. The tests cover lowercase and mixed-case references in `ARG`, `ENV`, a `FROM` tag and flag values, plus the now-preserved `${VAR:-default}`.

`:rewrite-docker:check` is green (454 tests), and the LST is byte-identical across a 357-file `docker-library` corpus — same round trips, same 438 references, same parse errors — which rules out a regression but does not exercise the fix, since no flag value in that corpus holds a reference.