### PR TITLE
Docker: one implementation of an image reference for FROM and COPY --from

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ImageReferences.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ImageReferences.java
@@ -23,6 +23,7 @@ import org.openrewrite.marker.Markers;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 /**
@@ -35,6 +36,15 @@ import static org.openrewrite.Tree.randomId;
 public final class ImageReferences {
 
     private ImageReferences() {
+    }
+
+    /**
+     * Splits an image reference a recipe supplied as text, such as {@code "nginx:1.25"}, into
+     * {@code {imageName, tag, digest}}. The parts are unquoted literals, so that a colon in the
+     * text separates the tag rather than being kept as part of a quoted name.
+     */
+    public static Docker.@Nullable Argument[] split(String reference, Space prefix) {
+        return split(singletonList(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, reference, null)), prefix);
     }
 
     /**

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
@@ -105,7 +105,8 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Instruction> 
      * or empty if there is no {@code --from} flag.
      */
     public Optional<String> getFromValue() {
-        return Optional.ofNullable(new Matcher().extractTextWithVariables(fromArgument()));
+        Docker.Argument arg = fromArgument();
+        return arg == null ? Optional.empty() : Optional.of(arg.getTextWithVariables());
     }
 
     /**
@@ -124,7 +125,7 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Instruction> 
         if (arg == null) {
             return false;
         }
-        String value = new Matcher().extractText(arg);
+        String value = arg.getText();
         if (value == null) {
             return false;
         }
@@ -161,77 +162,25 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Instruction> 
     }
 
     /**
-     * Returns the image name (without tag or digest), or empty if this is a stage reference
-     * or there is no {@code --from} flag.
+     * Returns the image name of the referenced external image, or {@code null} if the
+     * {@code --from} names an earlier build stage or is absent.
      */
     @Override
-    public Optional<String> getImageName() {
+    public Docker.@Nullable Argument getImageNameArgument() {
         Docker.@Nullable Argument[] components = components();
-        return components == null ? Optional.empty() : Optional.ofNullable(new Matcher().extractTextWithVariables(components[0]));
+        return components == null ? null : components[0];
     }
 
-    /**
-     * Returns the tag, or empty if no tag is specified or this is a stage reference.
-     */
     @Override
-    public Optional<String> getTag() {
+    public Docker.@Nullable Argument getTagArgument() {
         Docker.@Nullable Argument[] components = components();
-        return components == null ? Optional.empty() : Optional.ofNullable(new Matcher().extractTextWithVariables(components[1]));
+        return components == null ? null : components[1];
     }
 
-    /**
-     * Returns the digest, or empty if no digest is specified or this is a stage reference.
-     */
     @Override
-    public Optional<String> getDigest() {
+    public Docker.@Nullable Argument getDigestArgument() {
         Docker.@Nullable Argument[] components = components();
-        return components == null ? Optional.empty() : Optional.ofNullable(new Matcher().extractTextWithVariables(components[2]));
-    }
-
-    /**
-     * Returns true if the referenced external image is pinned by digest.
-     */
-    @Override
-    public boolean isDigestPinned() {
-        Docker.@Nullable Argument[] components = components();
-        return components != null && components[2] != null;
-    }
-
-    /**
-     * Returns true if the referenced external image is unpinned (no tag or an explicit
-     * "latest" tag). Stage references and digest-pinned images are considered pinned.
-     */
-    @Override
-    public boolean isUnpinned() {
-        return getUnpinnedReason().isPresent();
-    }
-
-    /**
-     * Returns the reason the referenced external image is unpinned, or empty if it's pinned
-     * or this is a stage reference.
-     */
-    @Override
-    public Optional<UnpinnedReason> getUnpinnedReason() {
-        Docker.@Nullable Argument[] components = components();
-        if (components == null) {
-            return Optional.empty();
-        }
-        if (components[2] != null) {
-            return Optional.empty();
-        }
-        if (components[1] == null) {
-            // A reference whose name is an unresolved environment variable can't be classified;
-            // conservatively treat it as pinned rather than assuming an implicit "latest".
-            if (new Matcher().hasEnvironmentVariables(components[0])) {
-                return Optional.empty();
-            }
-            return Optional.of(UnpinnedReason.IMPLICIT_LATEST);
-        }
-        String tag = new Matcher().extractText(components[1]);
-        if ("latest".equals(tag)) {
-            return Optional.of(UnpinnedReason.EXPLICIT_LATEST);
-        }
-        return Optional.empty();
+        return components == null ? null : components[2];
     }
 
     /**
@@ -270,48 +219,6 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Instruction> 
         }
         String suffix = getDigest().map(d -> "@" + d).orElse("");
         return withImageReference(name.get() + ":" + tag + suffix);
-    }
-
-    /**
-     * Checks if the image name matches the given glob pattern; always false for stage references.
-     */
-    @Override
-    public boolean imageNameMatches(String pattern) {
-        Docker.@Nullable Argument[] components = components();
-        if (components == null) {
-            return false;
-        }
-        Matcher m = new Matcher();
-        String text = m.extractTextForMatching(components[0]);
-        return m.matchesBidirectional(text, pattern, m.hasEnvironmentVariables(components[0]));
-    }
-
-    /**
-     * Checks if the tag matches the given glob pattern; false for stage references or when absent.
-     */
-    @Override
-    public boolean tagMatches(String pattern) {
-        Docker.@Nullable Argument[] components = components();
-        if (components == null || components[1] == null) {
-            return false;
-        }
-        Matcher m = new Matcher();
-        String text = m.extractTextForMatching(components[1]);
-        return m.matchesBidirectional(text, pattern, m.hasEnvironmentVariables(components[1]));
-    }
-
-    /**
-     * Checks if the digest matches the given glob pattern; false for stage references or when absent.
-     */
-    @Override
-    public boolean digestMatches(String pattern) {
-        Docker.@Nullable Argument[] components = components();
-        if (components == null || components[2] == null) {
-            return false;
-        }
-        Matcher m = new Matcher();
-        String text = m.extractTextForMatching(components[2]);
-        return m.matchesBidirectional(text, pattern, m.hasEnvironmentVariables(components[2]));
     }
 
     /**

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerFrom.java
@@ -46,37 +46,19 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
     @Getter
     private final Cursor cursor;
 
-    /**
-     * Returns the image name (without tag or digest).
-     * Environment variables are preserved in their original form.
-     *
-     * @return The image name
-     */
     @Override
-    public Optional<String> getImageName() {
-        return Optional.ofNullable(new Matcher().extractTextWithVariables(getTree().getImageName()));
+    public Docker.Argument getImageNameArgument() {
+        return getTree().getImageName();
     }
 
-    /**
-     * Returns the tag, or empty if no tag is specified.
-     * Environment variables are preserved in their original form.
-     *
-     * @return The tag, or empty
-     */
     @Override
-    public Optional<String> getTag() {
-        return Optional.ofNullable(new Matcher().extractTextWithVariables(getTree().getTag()));
+    public Docker.@Nullable Argument getTagArgument() {
+        return getTree().getTag();
     }
 
-    /**
-     * Returns the digest, or empty if no digest is specified.
-     * Environment variables are preserved in their original form.
-     *
-     * @return The digest, or empty
-     */
     @Override
-    public Optional<String> getDigest() {
-        return Optional.ofNullable(new Matcher().extractTextWithVariables(getTree().getDigest()));
+    public Docker.@Nullable Argument getDigestArgument() {
+        return getTree().getDigest();
     }
 
     /**
@@ -89,10 +71,9 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
         if (from.getFlags() == null) {
             return null;
         }
-        Matcher m = new Matcher();
         for (Docker.Flag flag : from.getFlags()) {
             if ("platform".equals(flag.getName()) && flag.getValue() != null) {
-                return m.extractTextWithVariables(flag.getValue());
+                return flag.getValue().getTextWithVariables();
             }
         }
         return null;
@@ -114,62 +95,7 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
      * @return true if the image is "scratch"
      */
     public boolean isScratch() {
-        String name = new Matcher().extractText(getTree().getImageName());
-        return "scratch".equals(name);
-    }
-
-    /**
-     * Returns true if this image is unpinned (no tag, uses "latest" tag, or has no digest).
-     * Images with a digest are considered pinned regardless of tag.
-     *
-     * @return true if the image is unpinned
-     */
-    @Override
-    public boolean isUnpinned() {
-        return getUnpinnedReason().isPresent();
-    }
-
-    /**
-     * Returns the reason this image is unpinned, or empty if it's pinned.
-     * Images with a digest are considered pinned. Images with environment variables
-     * in the tag are conservatively considered pinned (we can't determine the value).
-     *
-     * @return The reason for being unpinned, or empty if pinned
-     */
-    @Override
-    public Optional<UnpinnedReason> getUnpinnedReason() {
-        Docker.From from = getTree();
-        // Images with digest are pinned
-        if (from.getDigest() != null) {
-            return Optional.empty();
-        }
-        // No tag means implicit "latest", unless the name is an unresolved environment
-        // variable, in which case we can't classify it and conservatively treat it as pinned
-        if (from.getTag() == null) {
-            if (new Matcher().hasEnvironmentVariables(from.getImageName())) {
-                return Optional.empty();
-            }
-            return Optional.of(UnpinnedReason.IMPLICIT_LATEST);
-        }
-        // Explicit "latest" tag is unpinned (if it's a literal, not env var)
-        String tag = new Matcher().extractText(from.getTag());
-        if ("latest".equals(tag)) {
-            return Optional.of(UnpinnedReason.EXPLICIT_LATEST);
-        }
-        // Has a specific tag (or env var tag) - considered pinned
-        return Optional.empty();
-    }
-
-    /**
-     * Returns true if this image is pinned by digest (carries an {@code @sha256:...} reference),
-     * regardless of tag. This is distinct from {@link #isUnpinned()}, which is tag-based: an image
-     * with a specific tag but no digest is not "unpinned", yet it is not digest-pinned either.
-     *
-     * @return true if a digest is present
-     */
-    @Override
-    public boolean isDigestPinned() {
-        return getTree().getDigest() != null;
+        return "scratch".equals(getTree().getImageName().getText());
     }
 
     /**
@@ -178,54 +104,7 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
      * @return The quote style, or null if unquoted
      */
     public Docker.Literal.@Nullable QuoteStyle getQuoteStyle() {
-        return new Matcher().getQuoteStyle(getTree().getImageName());
-    }
-
-    /**
-     * Checks if the image name (without tag/digest) matches the given glob pattern.
-     *
-     * @param pattern The glob pattern to match against
-     * @return true if the image name matches
-     */
-    @Override
-    public boolean imageNameMatches(String pattern) {
-        Matcher m = new Matcher();
-        String text = m.extractTextForMatching(getTree().getImageName());
-        return m.matchesBidirectional(text, pattern, m.hasEnvironmentVariables(getTree().getImageName()));
-    }
-
-    /**
-     * Checks if the tag matches the given glob pattern.
-     *
-     * @param pattern The glob pattern to match against
-     * @return true if the tag matches, false if no tag or doesn't match
-     */
-    @Override
-    public boolean tagMatches(String pattern) {
-        Docker.Argument tag = getTree().getTag();
-        if (tag == null) {
-            return false;
-        }
-        Matcher m = new Matcher();
-        String text = m.extractTextForMatching(tag);
-        return m.matchesBidirectional(text, pattern, m.hasEnvironmentVariables(tag));
-    }
-
-    /**
-     * Checks if the digest matches the given glob pattern.
-     *
-     * @param pattern The glob pattern to match against
-     * @return true if the digest matches, false if no digest or doesn't match
-     */
-    @Override
-    public boolean digestMatches(String pattern) {
-        Docker.Argument digest = getTree().getDigest();
-        if (digest == null) {
-            return false;
-        }
-        Matcher m = new Matcher();
-        String text = m.extractTextForMatching(digest);
-        return m.matchesBidirectional(text, pattern, m.hasEnvironmentVariables(digest));
+        return getTree().getImageName().getQuoteStyle();
     }
 
     /**
@@ -236,11 +115,7 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
     @Override
     public Docker.From withImageReference(String reference) {
         Docker.From from = getTree();
-        // Pass an unquoted literal so split() decomposes name/tag/digest; a quote style would
-        // short-circuit that and keep the whole reference as a single image name.
-        Docker.@Nullable Argument[] parts = ImageReferences.split(
-                singletonList(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, reference, null)),
-                from.getImageName().getPrefix());
+        Docker.@Nullable Argument[] parts = ImageReferences.split(reference, from.getImageName().getPrefix());
         return from.withImageName(parts[0]).withTag(parts[1]).withDigest(parts[2]);
     }
 

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerImageReference.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerImageReference.java
@@ -27,6 +27,8 @@ import org.openrewrite.trait.VisitFunction2;
 
 import java.util.Optional;
 
+import static org.openrewrite.docker.trait.DockerTraitMatcher.partMatches;
+
 /**
  * A trait representing an image reference anywhere in a Dockerfile: the base image of a
  * {@code FROM} instruction (see {@link DockerFrom}) or the image carried by the {@code --from}
@@ -45,50 +47,109 @@ import java.util.Optional;
 public interface DockerImageReference<T extends Docker.Instruction> extends Trait<T> {
 
     /**
-     * Returns the image name (without tag or digest), or empty if the reference does not
-     * resolve to an external image (e.g. a build-stage reference).
+     * Returns the image name as it appears in the tree, or {@code null} where the instruction does
+     * not name an image at all: a {@code COPY} without a {@code --from} flag, or one whose
+     * {@code --from} names an earlier build stage. The tag and digest are {@code null} whenever
+     * this is.
      */
-    Optional<String> getImageName();
+    Docker.@Nullable Argument getImageNameArgument();
+
+    /**
+     * Returns the tag as it appears in the tree, or {@code null} if the reference has none.
+     */
+    Docker.@Nullable Argument getTagArgument();
+
+    /**
+     * Returns the digest as it appears in the tree, or {@code null} if the reference has none.
+     */
+    Docker.@Nullable Argument getDigestArgument();
+
+    /**
+     * Returns the image name (without tag or digest), or empty if the reference does not
+     * resolve to an external image (e.g. a build-stage reference). Environment variable
+     * references are preserved in their original form.
+     */
+    default Optional<String> getImageName() {
+        Docker.Argument imageName = getImageNameArgument();
+        return imageName == null ? Optional.empty() : Optional.of(imageName.getTextWithVariables());
+    }
 
     /**
      * Returns the tag, or empty if no tag is specified.
      */
-    Optional<String> getTag();
+    default Optional<String> getTag() {
+        Docker.Argument tag = getTagArgument();
+        return tag == null ? Optional.empty() : Optional.of(tag.getTextWithVariables());
+    }
 
     /**
      * Returns the digest, or empty if no digest is specified.
      */
-    Optional<String> getDigest();
+    default Optional<String> getDigest() {
+        Docker.Argument digest = getDigestArgument();
+        return digest == null ? Optional.empty() : Optional.of(digest.getTextWithVariables());
+    }
 
     /**
-     * Returns true if the referenced image is pinned by digest.
+     * Returns true if the referenced image is pinned by digest, whatever its tag.
      */
-    boolean isDigestPinned();
+    default boolean isDigestPinned() {
+        return getDigestArgument() != null;
+    }
 
     /**
      * Returns true if the referenced image is unpinned (no tag or an explicit "latest" tag).
      */
-    boolean isUnpinned();
+    default boolean isUnpinned() {
+        return getUnpinnedReason().isPresent();
+    }
 
     /**
-     * Returns the reason the referenced image is unpinned, or empty if it is pinned.
+     * Returns the reason the referenced image is unpinned, or empty if it is pinned. An image
+     * carrying a digest is pinned whatever its tag, and one whose name is an unresolved
+     * environment variable cannot be classified, so it is conservatively taken to be pinned.
      */
-    Optional<UnpinnedReason> getUnpinnedReason();
+    default Optional<UnpinnedReason> getUnpinnedReason() {
+        Docker.Argument imageName = getImageNameArgument();
+        if (imageName == null || getDigestArgument() != null) {
+            return Optional.empty();
+        }
+        Docker.Argument tag = getTagArgument();
+        if (tag == null) {
+            if (imageName.hasEnvironmentVariables()) {
+                return Optional.empty();
+            }
+            return Optional.of(UnpinnedReason.IMPLICIT_LATEST);
+        }
+        if ("latest".equals(tag.getText())) {
+            return Optional.of(UnpinnedReason.EXPLICIT_LATEST);
+        }
+        return Optional.empty();
+    }
 
     /**
      * Checks if the image name matches the given glob pattern.
      */
-    boolean imageNameMatches(String pattern);
+    default boolean imageNameMatches(String pattern) {
+        Docker.Argument imageName = getImageNameArgument();
+        return imageName != null && partMatches(imageName, pattern);
+    }
 
     /**
-     * Checks if the tag matches the given glob pattern.
+     * Checks if the tag matches the given glob pattern; false if no tag is specified.
      */
-    boolean tagMatches(String pattern);
+    default boolean tagMatches(String pattern) {
+        Docker.Argument tag = getTagArgument();
+        return tag != null && partMatches(tag, pattern);
+    }
 
     /**
-     * Checks if the digest matches the given glob pattern.
+     * Checks if the digest matches the given glob pattern; false if no digest is specified.
      */
-    boolean digestMatches(String pattern);
+    default boolean digestMatches(String pattern) {
+        Docker.Argument digest = getDigestArgument();
+        return digest != null && partMatches(digest, pattern);
+    }
 
     /**
      * Returns the instruction with its image reference replaced by {@code reference}

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerTraitMatcher.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerTraitMatcher.java
@@ -15,8 +15,6 @@
  */
 package org.openrewrite.docker.trait;
 
-import org.jetbrains.annotations.Contract;
-import org.jspecify.annotations.Nullable;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.trait.SimpleTraitMatcher;
@@ -37,7 +35,7 @@ abstract class DockerTraitMatcher<U extends Trait<?>> extends SimpleTraitMatcher
      * @param arg The argument to extract text from
      * @return Text with environment variables replaced by '*'
      */
-    protected String extractTextForMatching(Docker.Argument arg) {
+    static String extractTextForMatching(Docker.Argument arg) {
         StringBuilder sb = new StringBuilder();
         for (Docker.ArgumentContent content : arg.getContents()) {
             if (content instanceof Docker.Literal) {
@@ -50,41 +48,6 @@ abstract class DockerTraitMatcher<U extends Trait<?>> extends SimpleTraitMatcher
     }
 
     /**
-     * Extracts text from a Docker argument, returning null if the argument contains
-     * any environment variables (since the actual value cannot be determined statically).
-     *
-     * @param arg The argument to extract text from, may be null
-     * @return The literal text content, or null if the argument is null or contains environment variables
-     */
-    @Contract(value = "null -> null", pure = true)
-    protected @Nullable String extractText(Docker.@Nullable Argument arg) {
-        return arg == null ? null : arg.getText();
-    }
-
-    /**
-     * Extracts text from a Docker argument, including environment variable references
-     * in their original form (e.g., ${VAR} or $VAR).
-     *
-     * @param arg The argument to extract text from, may be null
-     * @return The text content with environment variable references preserved, or null if arg is null
-     */
-    @Contract(value = "null -> null; !null -> !null", pure = true)
-    protected @Nullable String extractTextWithVariables(Docker.@Nullable Argument arg) {
-        return arg == null ? null : arg.getTextWithVariables();
-    }
-
-    /**
-     * Checks if a Docker argument contains any environment variables.
-     *
-     * @param arg The argument to check, may be null
-     * @return true if the argument contains environment variables, false otherwise
-     */
-    @Contract(value = "null -> false", pure = true)
-    protected boolean hasEnvironmentVariables(Docker.@Nullable Argument arg) {
-        return arg != null && arg.hasEnvironmentVariables();
-    }
-
-    /**
      * Performs bidirectional glob matching when environment variables are present.
      * When the text contains wildcards (from env vars), we need to check if either
      * the pattern matches the text OR the text (as a pattern) matches the pattern.
@@ -94,7 +57,7 @@ abstract class DockerTraitMatcher<U extends Trait<?>> extends SimpleTraitMatcher
      * @param hasEnvVars Whether the original text contained environment variables
      * @return true if there's a match in either direction
      */
-    protected boolean matchesBidirectional(String text, String pattern, boolean hasEnvVars) {
+    static boolean matchesBidirectional(String text, String pattern, boolean hasEnvVars) {
         if (hasEnvVars) {
             return StringUtils.matchesGlob(text, pattern) ||
                     StringUtils.matchesGlob(pattern, text);
@@ -103,12 +66,14 @@ abstract class DockerTraitMatcher<U extends Trait<?>> extends SimpleTraitMatcher
     }
 
     /**
-     * Gets the quote style from a Docker argument, if any literal content is quoted.
+     * Checks whether one part of an image reference matches a glob pattern, treating any
+     * environment variable it contains as a wildcard.
      *
-     * @param arg The argument to check
-     * @return The quote style, or null if unquoted
+     * @param part    The image name, tag or digest to match
+     * @param pattern The glob pattern to match against
+     * @return true if the part matches
      */
-    protected Docker.Literal.@Nullable QuoteStyle getQuoteStyle(Docker.Argument arg) {
-        return arg.getQuoteStyle();
+    static boolean partMatches(Docker.Argument part, String pattern) {
+        return matchesBidirectional(extractTextForMatching(part), pattern, part.hasEnvironmentVariables());
     }
 }

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/trait/DockerCopyFromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/trait/DockerCopyFromTest.java
@@ -359,4 +359,75 @@ class DockerCopyFromTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void stageReferenceFollowedByAnotherFlag() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new DockerCopyFrom.Matcher().asVisitor((image, ctx) -> {
+                assertThat(image.getFromValue()).contains("build");
+                assertThat(image.isStageReference()).isTrue();
+                assertThat(image.getImageName()).isEmpty();
+                return SearchResult.found(image.getTree());
+            })
+          )),
+          docker(
+            """
+              FROM golang AS build
+              COPY --from=build --link /target/ /
+              """,
+            """
+              FROM golang AS build
+              ~~>COPY --from=build --link /target/ /
+              """
+          )
+        );
+    }
+
+    @Test
+    void quotedValueKeepsItsColon() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new DockerCopyFrom.Matcher().asVisitor((image, ctx) -> {
+                assertThat(image.getImageName()).contains("alpine:3");
+                assertThat(image.getTag()).isEmpty();
+                return SearchResult.found(image.getTree());
+            })
+          )),
+          docker(
+            """
+              FROM ubuntu
+              COPY --from="alpine:3" /out /app
+              """,
+            """
+              FROM ubuntu
+              ~~>COPY --from="alpine:3" /out /app
+              """
+          )
+        );
+    }
+
+    @Test
+    void variableDefaultIsNotATag() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new DockerCopyFrom.Matcher().asVisitor((image, ctx) -> {
+                assertThat(image.getImageName()).contains("${BUILDER:-golang:1.24}");
+                assertThat(image.getTag()).isEmpty();
+                assertThat(image.isStageReference()).isFalse();
+                return SearchResult.found(image.getTree());
+            })
+          )),
+          docker(
+            """
+              FROM ubuntu
+              COPY --from=${BUILDER:-golang:1.24} /out /app
+              """,
+            """
+              FROM ubuntu
+              ~~>COPY --from=${BUILDER:-golang:1.24} /out /app
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
`DockerFrom` and `DockerCopyFrom` each carried their own copy of the same nine accessors — name, tag, digest, pinning classification and glob matching — so the two could drift on rules such as whether a digest outranks a `latest` tag. `DockerImageReference` now holds that logic once, as default methods over three `Docker.Argument` hooks the traits supply from wherever their reference lives (the three fields of a `FROM`, or the split of the `--from` flag's value), leaving each trait only what is specific to it and retiring the `DockerTraitMatcher` helpers that only the duplicated code needed.

`ImageReferences` gained a `split(String, Space)`, so `withImageReference` no longer wraps its argument in a deliberately unquoted literal to stop the contents-based splitter from keeping the whole reference as a quoted name.

The LST is untouched and behaviour is unchanged, verified byte-identical against a 355-file corpus of `docker-library` Dockerfiles: same round trips, same parse errors, same trait values including glob results. Three tests were added for cases that had none: a quoted `--from="alpine:3"`, a `--from=${BUILDER:-golang:1.24}` whose default is not a tag, and `COPY --from=build --link`, where the stage reference is followed by another flag.
