### PR TITLE
Docker: assert a tree models what it prints

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
 import org.openrewrite.internal.ListUtils;
@@ -162,7 +163,6 @@ public class AddOrUpdateLabel extends Recipe {
             Docker.Literal.QuoteStyle originalStyle = original == null ? null : original.getQuoteStyle();
             quoteStyle = originalStyle == null ? Docker.Literal.QuoteStyle.DOUBLE : originalStyle;
         }
-        return new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY, singletonList(
-                new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, text, quoteStyle)));
+        return new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY, ArgumentContents.of(text, quoteStyle));
     }
 }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/AddUserInstruction.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/AddUserInstruction.java
@@ -22,6 +22,7 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
 import org.openrewrite.internal.ListUtils;
@@ -29,7 +30,6 @@ import org.openrewrite.marker.Markers;
 
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 /**
@@ -176,18 +176,11 @@ public class AddUserInstruction extends Recipe {
             }
 
             private Docker.Argument createArgument(String text, Space prefix) {
-                Docker.ArgumentContent content = new Docker.Literal(
-                        randomId(),
-                        Space.EMPTY,
-                        Markers.EMPTY,
-                        text,
-                        null
-                );
                 return new Docker.Argument(
                         randomId(),
                         prefix,
                         Markers.EMPTY,
-                        singletonList(content)
+                        ArgumentContents.of(text, null)
                 );
             }
         };

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
@@ -17,16 +17,22 @@ package org.openrewrite.docker;
 
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.SourceFile;
+import org.openrewrite.Tree;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
 import org.openrewrite.test.TypeValidation;
+import org.openrewrite.tree.ParseError;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
+
+import static java.util.stream.Collectors.toList;
 
 public class Assertions {
     private Assertions() {
@@ -92,6 +98,126 @@ public class Assertions {
                 throw new AssertionError("Expected no non-whitespace in whitespace, but found: " + elementsWithNonBlankWhitespace);
             }
         }
+        if (tv.parseAndPrintEquality()) {
+            assertReparsesToTheSameTree(sf);
+        }
         return sf;
+    }
+
+    /// A tree prints losslessly by construction, so printing alone cannot tell whether its elements
+    /// mean what they say. Reading the printed source back and comparing what the two trees model
+    /// catches a tree that prints correctly but holds the wrong thing: an image reference whose tag
+    /// sits in its name, a value whose variable reference is only text, an exec form whose arguments
+    /// have lost their quotes.
+    private static void assertReparsesToTheSameTree(SourceFile sf) {
+        String printed = sf.printAll(new PrintOutputCapture<>(0, PrintOutputCapture.MarkerPrinter.SANITIZED));
+        List<SourceFile> reparsed = DockerParser.builder().build()
+                .parse(new InMemoryExecutionContext(), printed)
+                .collect(toList());
+        if (reparsed.size() != 1 || reparsed.get(0) instanceof ParseError) {
+            throw new AssertionError("Expected printing the tree to yield a parseable Dockerfile, but got " +
+                    (reparsed.size() == 1 ? "a parse error" : reparsed.size() + " source files") + ":\n" + printed);
+        }
+        String printedSemantics = semantics(reparsed.get(0));
+        String treeSemantics = semantics(sf);
+        if (!printedSemantics.equals(treeSemantics)) {
+            throw new AssertionError("Expected the tree to model what it prints, but\n" + printed +
+                    "\nmodels " + printedSemantics + "\nwhile the tree models " + treeSemantics);
+        }
+    }
+
+    /// Everything a tree models apart from its formatting, so that comparing two trees compares what
+    /// they mean rather than what they print.
+    private static String semantics(Tree tree) {
+        return new DockerIsoVisitor<StringBuilder>() {
+            @Override
+            public @Nullable Docker visit(@Nullable Tree t, StringBuilder out) {
+                if (!(t instanceof Docker)) {
+                    return super.visit(t, out);
+                }
+                Docker d = (Docker) t;
+                out.append('(').append(d.getClass().getSimpleName());
+                if (d instanceof Docker.Literal) {
+                    Docker.Literal l = (Docker.Literal) d;
+                    out.append(' ').append(l.getQuoteStyle()).append(' ').append(l.getText());
+                } else if (d instanceof Docker.EnvironmentVariable) {
+                    Docker.EnvironmentVariable e = (Docker.EnvironmentVariable) d;
+                    out.append(' ').append(e.getName()).append(' ').append(e.isBraced());
+                } else if (d instanceof Docker.Flag) {
+                    out.append(' ').append(((Docker.Flag) d).getName());
+                } else if (d instanceof Docker.Port) {
+                    Docker.Port p = (Docker.Port) d;
+                    out.append(' ').append(p.getText()).append(' ').append(p.getStart())
+                            .append('-').append(p.getEnd()).append(' ').append(p.getProtocol());
+                } else if (d instanceof Docker.Volume) {
+                    out.append(' ').append(((Docker.Volume) d).isJsonForm());
+                } else if (d instanceof Docker.Healthcheck) {
+                    out.append(' ').append(((Docker.Healthcheck) d).isNone());
+                } else if (d instanceof Docker.HeredocForm) {
+                    out.append(' ').append(((Docker.HeredocForm) d).getPreamble());
+                } else if (d instanceof Docker.HeredocBody) {
+                    Docker.HeredocBody b = (Docker.HeredocBody) d;
+                    out.append(' ').append(b.getOpening()).append(' ').append(b.getClosing())
+                            .append(' ').append(b.getContentLines());
+                }
+                Docker visited = super.visit(t, out);
+                out.append(')');
+                return visited;
+            }
+
+            @Override
+            public Docker.From visitFrom(Docker.From from, StringBuilder out) {
+                if (from.getFlags() != null) {
+                    from.getFlags().forEach(flag -> visit(flag, out));
+                }
+                out.append(" name");
+                visit(from.getImageName(), out);
+                if (from.getTag() != null) {
+                    out.append(" tag");
+                    visit(from.getTag(), out);
+                }
+                if (from.getDigest() != null) {
+                    out.append(" digest");
+                    visit(from.getDigest(), out);
+                }
+                if (from.getAs() != null) {
+                    visitFromAs(from.getAs(), out);
+                }
+                return from;
+            }
+
+            @Override
+            public Docker.From.As visitFromAs(Docker.From.As as, StringBuilder out) {
+                out.append("(As ").append(as.getKeyword());
+                visit(as.getName(), out);
+                out.append(')');
+                return as;
+            }
+
+            @Override
+            public Docker.Env.EnvPair visitEnvPair(Docker.Env.EnvPair pair, StringBuilder out) {
+                out.append("(EnvPair ").append(pair.isHasEquals());
+                Docker.Env.EnvPair p = super.visitEnvPair(pair, out);
+                out.append(')');
+                return p;
+            }
+
+            @Override
+            public Docker.Label.LabelPair visitLabelPair(Docker.Label.LabelPair pair, StringBuilder out) {
+                out.append("(LabelPair ").append(pair.isHasEquals());
+                Docker.Label.LabelPair p = super.visitLabelPair(pair, out);
+                out.append(')');
+                return p;
+            }
+
+            @Override
+            public Docker.CopyShellForm visitCopyShellForm(Docker.CopyShellForm form, StringBuilder out) {
+                out.append(" sources");
+                form.getSources().forEach(source -> visit(source, out));
+                out.append(" destination");
+                visit(form.getDestination(), out);
+                return form;
+            }
+        }.reduce(tree, new StringBuilder()).toString();
     }
 }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
@@ -19,6 +19,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.trait.DockerFrom;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
@@ -30,7 +31,6 @@ import java.util.List;
 import java.util.Objects;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 @Value
@@ -194,15 +194,15 @@ public class ChangeFrom extends Recipe {
                 }
             }
 
-            // Get quote style from original
             Docker.Literal.QuoteStyle quoteStyle = image.getQuoteStyle();
 
-            // Check if the original was a single content item (e.g., a single quoted string)
-            boolean wasSingleContent = f.getImageName().getContents().size() == 1 &&
+            // A quoted reference is one literal holding image, tag and digest together, and splitting it
+            // would quote each part on its own. Everything else keeps image, tag and digest in the fields
+            // the parser would put them in, so that reading the result back finds the same tree.
+            boolean wasSingleQuotedReference = quoteStyle != null && f.getImageName().getContents().size() == 1 &&
                     f.getTag() == null && f.getDigest() == null;
 
-            if (wasSingleContent) {
-                // Keep as a single content item (don't split)
+            if (wasSingleQuotedReference) {
                 String imagePart = resolvedNewImageName != null ? resolvedNewImageName : currentImageName;
                 StringBuilder sb = new StringBuilder(imagePart);
                 // For tag: null=keep existing, ""=remove, value=set
@@ -221,15 +221,13 @@ public class ChangeFrom extends Recipe {
                 } else if (currentDigest != null) {
                     sb.append("@").append(currentDigest);
                 }
-                Docker.ArgumentContent newContent = createContent(sb.toString(), quoteStyle);
-                Docker.Argument newImageArg = f.getImageName().withContents(singletonList(newContent));
+                Docker.Argument newImageArg = f.getImageName().withContents(ArgumentContents.of(sb.toString(), quoteStyle));
                 return result.withImageName(newImageArg);
             }
 
             // Update image name: null=keep, value=set
             if (resolvedNewImageName != null) {
-                Docker.ArgumentContent newImageContent = createContent(resolvedNewImageName, quoteStyle);
-                Docker.Argument newImageArg = f.getImageName().withContents(singletonList(newImageContent));
+                Docker.Argument newImageArg = f.getImageName().withContents(ArgumentContents.of(resolvedNewImageName, quoteStyle));
                 result = result.withImageName(newImageArg);
             }
 
@@ -238,8 +236,8 @@ public class ChangeFrom extends Recipe {
                 if (resolvedNewTag.isEmpty()) {
                     result = result.withTag(null);
                 } else {
-                    Docker.ArgumentContent newTagContent = createContent(resolvedNewTag, quoteStyle);
-                    Docker.Argument newTagArg = new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY, singletonList(newTagContent));
+                    Docker.Argument newTagArg = new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY,
+                            ArgumentContents.of(resolvedNewTag, quoteStyle));
                     result = result.withTag(newTagArg);
                 }
             }
@@ -249,8 +247,8 @@ public class ChangeFrom extends Recipe {
                 if (resolvedNewDigest.isEmpty()) {
                     result = result.withDigest(null);
                 } else {
-                    Docker.ArgumentContent newDigestContent = createContent(resolvedNewDigest, quoteStyle);
-                    Docker.Argument newDigestArg = new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY, singletonList(newDigestContent));
+                    Docker.Argument newDigestArg = new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY,
+                            ArgumentContents.of(resolvedNewDigest, quoteStyle));
                     result = result.withDigest(newDigestArg);
                 }
             }
@@ -363,10 +361,6 @@ public class ChangeFrom extends Recipe {
         return highest;
     }
 
-    private Docker.ArgumentContent createContent(String text, Docker.Literal.@Nullable QuoteStyle quoteStyle) {
-        return new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, text, quoteStyle);
-    }
-
     private Docker.From updatePlatformFlag(Docker.From from, @Nullable String platform) {
         List<Docker.Flag> oldFlags = from.getFlags();
 
@@ -399,12 +393,7 @@ public class ChangeFrom extends Recipe {
 
     private Docker.Argument updatePlatformValue(Docker.@Nullable Argument existingValue, String platform) {
         if (existingValue != null && !existingValue.getContents().isEmpty()) {
-            // Update existing value using withers
-            Docker.ArgumentContent firstContent = existingValue.getContents().get(0);
-            if (firstContent instanceof Docker.Literal) {
-                Docker.Literal updated = ((Docker.Literal) firstContent).withText(platform);
-                return existingValue.withContents(singletonList(updated));
-            }
+            return existingValue.withContents(ArgumentContents.of(platform, existingValue.getQuoteStyle()));
         }
         // Fallback: create new value
         return createPlatformValue(platform, existingValue != null ? existingValue.getPrefix() : Space.EMPTY);
@@ -415,13 +404,7 @@ public class ChangeFrom extends Recipe {
                 randomId(),
                 prefix,
                 Markers.EMPTY,
-                singletonList(new Docker.Literal(
-                        randomId(),
-                        Space.EMPTY,
-                        Markers.EMPTY,
-                        platform,
-                        null
-                ))
+                ArgumentContents.of(platform, null)
         );
     }
 }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
@@ -20,6 +20,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.docker.internal.ArgumentContents;
+import org.openrewrite.docker.internal.ImageReferences;
 import org.openrewrite.docker.trait.DockerFrom;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
@@ -172,6 +173,22 @@ public class ChangeFrom extends Recipe {
             String resolvedNewDigest = resolve(newDigest, currentDigest, oldDigest);
             String resolvedNewPlatform = resolve(newPlatform, currentPlatform, oldPlatform);
 
+            Docker.Literal.QuoteStyle quoteStyle = image.getQuoteStyle();
+
+            // A new name carrying a tag or digest belongs in the fields the parser would put them in, so
+            // that reading the result back finds the same tree. A quoted reference is one literal holding
+            // all three together, and splitting it would quote each part on its own, so it stays whole.
+            if (resolvedNewImageName != null && quoteStyle == null) {
+                Docker.@Nullable Argument[] parts = ImageReferences.split(resolvedNewImageName, Space.EMPTY);
+                resolvedNewImageName = parts[0].getTextWithVariables();
+                if (resolvedNewTag == null && parts[1] != null) {
+                    resolvedNewTag = parts[1].getTextWithVariables();
+                }
+                if (resolvedNewDigest == null && parts[2] != null) {
+                    resolvedNewDigest = parts[2].getTextWithVariables();
+                }
+            }
+
             boolean imageNameChanged = resolvedNewImageName != null && !currentImageName.equals(resolvedNewImageName);
             boolean tagChanged = resolvedNewTag != null && !resolvedNewTag.equals(currentTag == null ? "" : currentTag);
             boolean digestChanged = resolvedNewDigest != null && !resolvedNewDigest.equals(currentDigest == null ? "" : currentDigest);
@@ -194,11 +211,6 @@ public class ChangeFrom extends Recipe {
                 }
             }
 
-            Docker.Literal.QuoteStyle quoteStyle = image.getQuoteStyle();
-
-            // A quoted reference is one literal holding image, tag and digest together, and splitting it
-            // would quote each part on its own. Everything else keeps image, tag and digest in the fields
-            // the parser would put them in, so that reading the result back finds the same tree.
             boolean wasSingleQuotedReference = quoteStyle != null && f.getImageName().getContents().size() == 1 &&
                     f.getTag() == null && f.getDigest() == null;
 

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.marker.Markers;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.Collections.singletonList;
+import static org.openrewrite.Tree.randomId;
+
+/**
+ * Builds the contents of a {@link Docker.Argument} from text. Both the parser and recipes that
+ * synthesize values go through here, so a value a recipe writes is modelled the same way as one
+ * read back from the printed Dockerfile.
+ */
+public class ArgumentContents {
+    private ArgumentContents() {
+    }
+
+    /// The contents of a value whose text is {@code text} and whose quote style, if the value is a
+    /// single quoted string, is {@code quoteStyle}. Single quotes never expand, so such a value is
+    /// always one literal. Double quotes do, and a value holding a reference is no longer one
+    /// literal, which puts its quotes into the text.
+    public static List<Docker.ArgumentContent> of(String text, Docker.Literal.@Nullable QuoteStyle quoteStyle) {
+        if (quoteStyle == Docker.Literal.QuoteStyle.SINGLE ||
+                (quoteStyle == Docker.Literal.QuoteStyle.DOUBLE && !containsVariable(text))) {
+            return singletonList(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, text, quoteStyle));
+        }
+        if (quoteStyle == Docker.Literal.QuoteStyle.DOUBLE) {
+            return splitVariables('"' + text + '"', Space.EMPTY);
+        }
+        return splitVariables(text, Space.EMPTY);
+    }
+
+    /// Splits environment variable references out of a value's text. Token boundaries are no guide here:
+    /// the lexer emits `--name=value` as a single token, so a reference can sit inside one. What counts
+    /// as a reference mirrors the lexer's `ENV_VAR` and `SPECIAL_VAR` rules, so `$$` and `$1` stay text.
+    public static List<Docker.ArgumentContent> splitVariables(String text, Space prefix) {
+        List<Docker.ArgumentContent> contents = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+        boolean singleQuoted = false;
+        int i = 0;
+        while (i < text.length()) {
+            char c = text.charAt(i);
+            char next = i + 1 < text.length() ? text.charAt(i + 1) : 0;
+            if (c == '\'') {
+                singleQuoted = !singleQuoted;
+                current.append(c);
+                i++;
+                continue;
+            }
+            if (c == '\\' && next != 0 && !singleQuoted) {
+                current.append(c).append(next);
+                i += 2;
+                continue;
+            }
+            if (singleQuoted) {
+                current.append(c);
+                i++;
+                continue;
+            }
+            String name = null;
+            boolean braced = false;
+            if (c == '$' && next == '{') {
+                int close = text.indexOf('}', i + 2);
+                if (close > i + 2 && isVarStart(text.charAt(i + 2))) {
+                    name = text.substring(i + 2, close);
+                    braced = true;
+                    i = close + 1;
+                }
+            } else if (c == '$' && isVarStart(next)) {
+                int end = i + 1;
+                while (end < text.length() && isVarPart(text.charAt(end))) {
+                    end++;
+                }
+                name = text.substring(i + 1, end);
+                i = end;
+            } else if (c == '$' && isSpecialVar(next)) {
+                current.append(c).append(next);
+                i += 2;
+                continue;
+            }
+            if (name == null) {
+                current.append(c);
+                i++;
+                continue;
+            }
+            if (current.length() > 0) {
+                contents.add(new Docker.Literal(randomId(), contents.isEmpty() ? prefix : Space.EMPTY,
+                        Markers.EMPTY, current.toString(), null));
+                current.setLength(0);
+            }
+            contents.add(new Docker.EnvironmentVariable(randomId(), contents.isEmpty() ? prefix : Space.EMPTY,
+                    Markers.EMPTY, name, braced));
+        }
+        if (current.length() > 0 || contents.isEmpty()) {
+            contents.add(new Docker.Literal(randomId(), contents.isEmpty() ? prefix : Space.EMPTY,
+                    Markers.EMPTY, current.toString(), null));
+        }
+        return contents;
+    }
+
+    public static boolean containsVariable(String text) {
+        for (Docker.ArgumentContent content : splitVariables(text, Space.EMPTY)) {
+            if (content instanceof Docker.EnvironmentVariable) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isVarStart(char c) {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
+    }
+
+    private static boolean isVarPart(char c) {
+        return isVarStart(c) || (c >= '0' && c <= '9');
+    }
+
+    private static boolean isSpecialVar(char c) {
+        return c == '!' || c == '$' || c == '?' || c == '#' || c == '@' || c == '*' || (c >= '0' && c <= '9');
+    }
+}

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
@@ -219,7 +219,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
             String unquoted = text.substring(1, text.length() - 1);
             // Single quotes never expand, so such a value is always whole. Double quotes do, and a value
             // holding a reference is no longer one literal, which puts its quotes into the text.
-            if (quoteStyle == Docker.Literal.QuoteStyle.SINGLE || !containsVariable(unquoted)) {
+            if (quoteStyle == Docker.Literal.QuoteStyle.SINGLE || !ArgumentContents.containsVariable(unquoted)) {
                 Space prefix = prefix(quoted);
                 skip(quoted);
                 contents.add(new Docker.Literal(randomId(), prefix, Markers.EMPTY, unquoted, quoteStyle));
@@ -231,7 +231,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         int startIndex = textCtx.getStart().getStartIndex();
         int endIndex = Math.max(stopIndex, textCtx.getStop().getStopIndex());
         skip(textCtx.getStop());
-        contents.addAll(splitVariables(sourceText(startIndex, endIndex), prefix));
+        contents.addAll(ArgumentContents.splitVariables(sourceText(startIndex, endIndex), prefix));
         return contents;
     }
 
@@ -242,94 +242,6 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         return first instanceof DockerParser.QuotedContext ? ((DockerParser.QuotedContext) first).getStart() : null;
     }
 
-    /// Splits environment variable references out of a value's text. Token boundaries are no guide here:
-    /// the lexer emits `--name=value` as a single token, so a reference can sit inside one. What counts
-    /// as a reference mirrors the lexer's `ENV_VAR` and `SPECIAL_VAR` rules, so `$$` and `$1` stay text.
-    private List<Docker.ArgumentContent> splitVariables(String text, Space prefix) {
-        List<Docker.ArgumentContent> contents = new ArrayList<>();
-        StringBuilder current = new StringBuilder();
-        boolean singleQuoted = false;
-        int i = 0;
-        while (i < text.length()) {
-            char c = text.charAt(i);
-            char next = i + 1 < text.length() ? text.charAt(i + 1) : 0;
-            if (c == '\'') {
-                singleQuoted = !singleQuoted;
-                current.append(c);
-                i++;
-                continue;
-            }
-            if (c == '\\' && next != 0 && !singleQuoted) {
-                current.append(c).append(next);
-                i += 2;
-                continue;
-            }
-            if (singleQuoted) {
-                current.append(c);
-                i++;
-                continue;
-            }
-            String name = null;
-            boolean braced = false;
-            if (c == '$' && next == '{') {
-                int close = text.indexOf('}', i + 2);
-                if (close > i + 2 && isVarStart(text.charAt(i + 2))) {
-                    name = text.substring(i + 2, close);
-                    braced = true;
-                    i = close + 1;
-                }
-            } else if (c == '$' && isVarStart(next)) {
-                int end = i + 1;
-                while (end < text.length() && isVarPart(text.charAt(end))) {
-                    end++;
-                }
-                name = text.substring(i + 1, end);
-                i = end;
-            } else if (c == '$' && isSpecialVar(next)) {
-                current.append(c).append(next);
-                i += 2;
-                continue;
-            }
-            if (name == null) {
-                current.append(c);
-                i++;
-                continue;
-            }
-            if (current.length() > 0) {
-                contents.add(new Docker.Literal(randomId(), contents.isEmpty() ? prefix : Space.EMPTY,
-                        Markers.EMPTY, current.toString(), null));
-                current.setLength(0);
-            }
-            contents.add(new Docker.EnvironmentVariable(randomId(), contents.isEmpty() ? prefix : Space.EMPTY,
-                    Markers.EMPTY, name, braced));
-        }
-        if (current.length() > 0 || contents.isEmpty()) {
-            contents.add(new Docker.Literal(randomId(), contents.isEmpty() ? prefix : Space.EMPTY,
-                    Markers.EMPTY, current.toString(), null));
-        }
-        return contents;
-    }
-
-    private boolean containsVariable(String text) {
-        for (Docker.ArgumentContent content : splitVariables(text, Space.EMPTY)) {
-            if (content instanceof Docker.EnvironmentVariable) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    private static boolean isVarStart(char c) {
-        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || c == '_';
-    }
-
-    private static boolean isVarPart(char c) {
-        return isVarStart(c) || (c >= '0' && c <= '9');
-    }
-
-    private static boolean isSpecialVar(char c) {
-        return c == '!' || c == '$' || c == '?' || c == '#' || c == '@' || c == '*' || (c >= '0' && c <= '9');
-    }
 
     private String sourceText(int startIndex, int stopIndex) {
         return source.substring(source.offsetByCodePoints(0, startIndex),
@@ -1113,7 +1025,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
 
     /// Splits the value of a command's flag into its quoted literals, environment variable references
     /// and the `=` separating a key from a value, as in `--mount=type=bind`. Everything that is not a
-    /// quote or a separator is handed to [#splitVariables(String, Space)], so a variable reference means
+    /// quote or a separator is handed to [ArgumentContents#splitVariables(String, Space)], so a variable reference means
     /// the same thing here as it does in an argument's value.
     private List<Docker.ArgumentContent> parseFlagValue(String text) {
         List<Docker.ArgumentContent> contents = new ArrayList<>();
@@ -1150,7 +1062,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
 
     private void flushFlagText(StringBuilder current, List<Docker.ArgumentContent> contents) {
         if (current.length() > 0) {
-            contents.addAll(splitVariables(current.toString(), Space.EMPTY));
+            contents.addAll(ArgumentContents.splitVariables(current.toString(), Space.EMPTY));
             current.setLength(0);
         }
     }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
@@ -242,7 +242,6 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         return first instanceof DockerParser.QuotedContext ? ((DockerParser.QuotedContext) first).getStart() : null;
     }
 
-
     private String sourceText(int startIndex, int stopIndex) {
         return source.substring(source.offsetByCodePoints(0, startIndex),
                 source.offsetByCodePoints(0, stopIndex + 1));

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ImageReferences.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ImageReferences.java
@@ -23,7 +23,6 @@ import org.openrewrite.marker.Markers;
 import java.util.ArrayList;
 import java.util.List;
 
-import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 /**
@@ -44,7 +43,7 @@ public final class ImageReferences {
      * text separates the tag rather than being kept as part of a quoted name.
      */
     public static Docker.@Nullable Argument[] split(String reference, Space prefix) {
-        return split(singletonList(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, reference, null)), prefix);
+        return split(ArgumentContents.of(reference, null), prefix);
     }
 
     /**

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
@@ -23,20 +23,16 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.docker.DockerVisitor;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.internal.ImageReferences;
 import org.openrewrite.docker.tree.Docker;
-import org.openrewrite.docker.tree.Space;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.marker.Markers;
 import org.openrewrite.trait.VisitFunction2;
 
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-
-import static java.util.Collections.singletonList;
-import static org.openrewrite.Tree.randomId;
 
 /**
  * A trait representing the image reference carried by the {@code --from} flag of a
@@ -193,8 +189,7 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Instruction> 
         if (arg == null) {
             return getTree();
         }
-        Docker.Argument newValue = arg.withContents(singletonList(
-          new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, reference, null)));
+        Docker.Argument newValue = arg.withContents(ArgumentContents.of(reference, null));
         List<Docker.Flag> newFlags = ListUtils.map(flags(), f ->
           "from".equals(f.getName()) ? f.withValue(newValue) : f);
         Docker.Instruction instruction = getTree();

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerFrom.java
@@ -23,6 +23,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.docker.DockerVisitor;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.internal.ImageReferences;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
@@ -32,7 +33,6 @@ import org.openrewrite.trait.VisitFunction2;
 
 import java.util.Optional;
 
-import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 /**
@@ -126,7 +126,7 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
     @Override
     public Docker.From withTag(String tag) {
         return getTree().withTag(new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY,
-                singletonList(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, tag, getQuoteStyle()))));
+                ArgumentContents.of(tag, getQuoteStyle())));
     }
 
     /**

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/AddOrUpdateLabelTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/AddOrUpdateLabelTest.java
@@ -297,6 +297,22 @@ class AddOrUpdateLabelTest implements RewriteTest {
     }
 
     @Test
+    void modelsAVariableReferenceInAValue() {
+        rewriteRun(
+          spec -> spec.recipe(new AddOrUpdateLabel("version", "$APP_VERSION", null, null)),
+          docker(
+            """
+              FROM ubuntu:22.04
+              """,
+            """
+              FROM ubuntu:22.04
+              LABEL version=$APP_VERSION
+              """
+          )
+        );
+    }
+
+    @Test
     void noChangeWhenMultiTokenValueAlreadyMatches() {
         rewriteRun(
           spec -> spec.recipe(new AddOrUpdateLabel("desc", "\"a b\" c", true, null)),

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/AddUserInstructionTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/AddUserInstructionTest.java
@@ -175,4 +175,21 @@ class AddUserInstructionTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void modelsAVariableReferenceInAUserName() {
+        rewriteRun(
+          spec -> spec.recipe(new AddUserInstruction("$APP_USER", null, null, null)),
+          docker(
+            """
+              FROM alpine:3.18
+              """,
+            """
+              FROM alpine:3.18
+              USER $APP_USER
+              """
+          )
+        );
+    }
+
 }

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.test.RewriteTest;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.openrewrite.docker.Assertions.docker;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+class AssertionsTest implements RewriteTest {
+
+    @Test
+    void catchesATreeThatPrintsCorrectlyButModelsTheWrongThing() {
+        assertThatThrownBy(() -> rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new DockerIsoVisitor<ExecutionContext>() {
+              @Override
+              public Docker.From visitFrom(Docker.From from, ExecutionContext ctx) {
+                  // Appending the tag to the image name prints as "alpine:3.14", but leaves the tag
+                  // unmodelled, so From#getTag stays null.
+                  Docker.Literal name = (Docker.Literal) from.getImageName().getContents().getFirst();
+                  if (name.getText().contains(":")) {
+                      return from;
+                  }
+                  return from.withImageName(from.getImageName().withContents(
+                    singletonList(name.withText(name.getText() + ":3.14"))));
+              }
+          })),
+          docker(
+            """
+              FROM alpine
+              """,
+            """
+              FROM alpine:3.14
+              """
+          )
+        )).isInstanceOf(AssertionError.class)
+          .hasMessageContaining("Expected the tree to model what it prints");
+    }
+
+}

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/ChangeFromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/ChangeFromTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.docker;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
@@ -768,7 +769,13 @@ class ChangeFromTest implements RewriteTest {
                 """
                   FROM ubuntu:22.04
                   RUN apt-get update
-                  """
+                  """,
+                spec -> spec.afterRecipe(doc -> {
+                    Docker.From from = doc.getStages().getFirst().getFrom();
+                    assertThat(from.getImageName().getText()).isEqualTo("ubuntu");
+                    assertThat(from.getTag()).isNotNull();
+                    assertThat(from.getTag().getText()).isEqualTo("22.04");
+                })
               )
             );
         }
@@ -785,7 +792,13 @@ class ChangeFromTest implements RewriteTest {
                 """
                   FROM ubuntu@sha256:abc123
                   RUN apt-get update
-                  """
+                  """,
+                spec -> spec.afterRecipe(doc -> {
+                    Docker.From from = doc.getStages().getFirst().getFrom();
+                    assertThat(from.getImageName().getText()).isEqualTo("ubuntu");
+                    assertThat(from.getDigest()).isNotNull();
+                    assertThat(from.getDigest().getText()).isEqualTo("sha256:abc123");
+                })
               )
             );
         }
@@ -1053,7 +1066,15 @@ class ChangeFromTest implements RewriteTest {
                   """,
                 """
                   FROM ubuntu:22.04-$VAR
-                  """
+                  """,
+                spec -> spec.afterRecipe(doc -> {
+                    // "\$" only stops $VAR being read as a capture reference; what it writes is a
+                    // variable reference like any other, and is modelled as one.
+                    Docker.Argument tag = doc.getStages().getFirst().getFrom().getTag();
+                    assertThat(tag).isNotNull();
+                    assertThat(tag.getText()).isNull();
+                    assertThat(tag.getTextWithVariables()).isEqualTo("22.04-$VAR");
+                })
               )
             );
         }

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/ChangeFromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/ChangeFromTest.java
@@ -781,6 +781,68 @@ class ChangeFromTest implements RewriteTest {
         }
 
         @Test
+        void newImageNameCarryingATagFillsTheTagField() {
+            rewriteRun(
+              spec -> spec.recipe(new ChangeFrom("ubuntu", null, null, null, "eclipse-temurin:17", null, null, null)),
+              docker(
+                """
+                  FROM ubuntu
+                  """,
+                """
+                  FROM eclipse-temurin:17
+                  """,
+                spec -> spec.afterRecipe(doc -> {
+                    Docker.From from = doc.getStages().getFirst().getFrom();
+                    assertThat(from.getImageName().getText()).isEqualTo("eclipse-temurin");
+                    assertThat(from.getTag()).isNotNull();
+                    assertThat(from.getTag().getText()).isEqualTo("17");
+                })
+              )
+            );
+        }
+
+        @Test
+        void newImageNameCarryingADigestFillsTheDigestField() {
+            rewriteRun(
+              spec -> spec.recipe(new ChangeFrom("ubuntu", null, null, null, "ubuntu@sha256:abc123", null, null, null)),
+              docker(
+                """
+                  FROM ubuntu
+                  """,
+                """
+                  FROM ubuntu@sha256:abc123
+                  """,
+                spec -> spec.afterRecipe(doc -> {
+                    Docker.From from = doc.getStages().getFirst().getFrom();
+                    assertThat(from.getImageName().getText()).isEqualTo("ubuntu");
+                    assertThat(from.getDigest()).isNotNull();
+                    assertThat(from.getDigest().getText()).isEqualTo("sha256:abc123");
+                })
+              )
+            );
+        }
+
+        @Test
+        void newImageNameKeepsARegistryPortInTheName() {
+            rewriteRun(
+              spec -> spec.recipe(new ChangeFrom("ubuntu", null, null, null, "localhost:5000/ubuntu", null, null, null)),
+              docker(
+                """
+                  FROM ubuntu
+                  """,
+                """
+                  FROM localhost:5000/ubuntu
+                  """,
+                spec -> spec.afterRecipe(doc -> {
+                    Docker.From from = doc.getStages().getFirst().getFrom();
+                    assertThat(from.getImageName().getText()).isEqualTo("localhost:5000/ubuntu");
+                    assertThat(from.getTag()).isNull();
+                })
+              )
+            );
+        }
+
+        @Test
         void addDigestToUntaggedImage() {
             rewriteRun(
               spec -> spec.recipe(new ChangeFrom("ubuntu", null, null, null, null, null, "sha256:abc123", null)),

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/trait/DockerImageReferenceTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/trait/DockerImageReferenceTest.java
@@ -118,4 +118,24 @@ class DockerImageReferenceTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void modelsAVariableReferenceARecipeWrites() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new DockerImageReference.Matcher().imageName("nginx").asVisitor((ref, ctx) ->
+              "$VERSION".equals(ref.getTag().orElse(null)) ? ref.getTree() : ref.withTag("$VERSION"))
+          )),
+          docker(
+            """
+              FROM nginx:1.20
+              COPY --from=nginx:1.25 /web /app
+              """,
+            """
+              FROM nginx:$VERSION
+              COPY --from=nginx:$VERSION /web /app
+              """
+          )
+        );
+    }
 }


### PR DESCRIPTION
`Assertions.docker` validates whitespace today, and `RewriteTest` separately checks that a tree prints back to the expected text. Neither can see a tree that prints correctly but holds the wrong thing, because printing is lossless by construction — whatever an element stores comes back out.

So this reads the printed source back and compares what the two trees model. Running it over the existing suite found two real defects in `ChangeFrom`, both fixed here.

### `ChangeFrom` put the tag in the image name

`wasSingleContent` kept image, tag and digest in one literal whenever the original `FROM` had neither a tag nor a digest. That is right for a quoted reference, which cannot be split without quoting each part on its own, but it also caught the ordinary unquoted case:

```
FROM ubuntu   ->   FROM ubuntu:22.04
```

prints correctly, while `From#getImageName` returns `ubuntu:22.04` and `From#getTag` returns null. Anything reading the structured fields afterwards — `DockerImageReference`, `FindUnpinnedBaseImages`, `NormalizeDockerHubImageName`, or a second `ChangeFrom` — gets the wrong answer. Same for a digest added to an untagged image. Only a quoted reference stays whole now.

### A written `$VAR` was only text

`ChangeFrom` built every value as a single plain literal, so a tag it wrote as `22.04-$VAR` held the reference as text, where the same Dockerfile read from disk models an `EnvironmentVariable`. The parser's splitting moved to `ArgumentContents`, which recipes now share, so a value a recipe writes is modelled the way one that is read back is. (`\$` in a `ChangeFrom` option still only stops `$VAR` being read as a capture reference; what it writes is a variable reference like any other.)

### Notes

- The check is gated on `TypeValidation#parseAndPrintEquality`, so `TypeValidation.none()` turns it off along with the existing print check.
- It runs on the parsed source and on every recipe result, and costs nothing measurable — the module's suite takes the same time as before.
- `AssertionsTest` covers the check itself: a recipe that appends `:3.14` to an image name now fails the assertion rather than passing on printed output.