### PR TITLE
Docker: assert a tree is well formed, not just that it prints

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
@@ -24,6 +24,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.docker.tree.Comment;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
+import org.openrewrite.internal.StringUtils;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
 import org.openrewrite.test.TypeValidation;
@@ -37,6 +38,8 @@ import java.util.regex.Pattern;
 import static java.util.stream.Collectors.toList;
 
 public class Assertions {
+    private static final Pattern LINE_CONTINUATION = Pattern.compile("[\\\\`][ \\t]*(?=\\r?\\n)");
+
     private Assertions() {
     }
 
@@ -107,7 +110,7 @@ public class Assertions {
     /// Line continuations are whitespace to a Dockerfile, so the `\` or `` ` `` that introduces one is
     /// not text sitting where only formatting belongs.
     private static boolean isWhitespace(String text) {
-        return text.replaceAll("[\\\\`][ \\t]*(?=\\r?\\n)", "").trim().isEmpty();
+        return LINE_CONTINUATION.matcher(text).replaceAll("").trim().isEmpty();
     }
 
     /// A tree prints losslessly by construction, so printing alone cannot tell whether its elements
@@ -246,7 +249,7 @@ public class Assertions {
         private final Set<UUID> ids = new HashSet<>();
 
         /// The one [Space] that nothing follows, and so the one whose trailing comment needs no newline
-        /// after it.
+        /// after it. A [Space] holding comments is never a flyweight, so reference identity is enough.
         private @Nullable Space eof;
 
         @Override
@@ -254,7 +257,9 @@ public class Assertions {
             if (tree instanceof Docker) {
                 Docker d = (Docker) tree;
                 uniqueId(d.getId(), d.getClass(), violations);
-                keyword(d, violations);
+                if (d instanceof Docker.Instruction) {
+                    keyword(((Docker.Instruction) d).getKeyword(), d.getClass(), violations);
+                }
             }
             return super.visit(tree, violations);
         }
@@ -266,10 +271,10 @@ public class Assertions {
             for (int i = 1; i < globalArgs.size(); i++) {
                 startsItsOwnLine(globalArgs.get(i), violations);
             }
-            for (int i = 0; i < file.getStages().size(); i++) {
-                Docker.Stage stage = file.getStages().get(i);
-                if ((i > 0 || !globalArgs.isEmpty()) &&
-                        !containsNewline(stage.getPrefix()) && !containsNewline(stage.getFrom().getPrefix())) {
+            List<Docker.Stage> stages = file.getStages();
+            for (int i = globalArgs.isEmpty() ? 1 : 0; i < stages.size(); i++) {
+                Docker.Stage stage = stages.get(i);
+                if (!containsNewline(stage.getPrefix()) && !containsNewline(stage.getFrom().getPrefix())) {
                     violations.add("expected the Stage to start its own line, but neither it nor its From has a" +
                             " newline in its prefix");
                 }
@@ -319,7 +324,7 @@ public class Assertions {
         @Override
         public Docker.From.@Nullable As visitFromAs(Docker.From.As as, List<String> violations) {
             uniqueId(as.getId(), as.getClass(), violations);
-            keyword(as.getKeyword(), "AS", "As", violations);
+            keyword(as.getKeyword(), as.getClass(), violations);
             return super.visitFromAs(as, violations);
         }
 
@@ -350,7 +355,7 @@ public class Assertions {
         @Override
         public Docker.Flag visitFlag(Docker.Flag flag, List<String> violations) {
             String name = flag.getName();
-            if (name.startsWith("-") || name.indexOf('=') >= 0 || containsWhitespace(name)) {
+            if (name.startsWith("-") || name.indexOf('=') >= 0 || StringUtils.containsWhitespace(name)) {
                 violations.add("expected the flag name " + quoted(name) + " to be bare, as the printer writes the" +
                         " leading \"--\" and any \"=\" itself");
             }
@@ -377,7 +382,7 @@ public class Assertions {
         @Override
         public Docker.Shell visitShell(Docker.Shell shell, List<String> violations) {
             for (Docker.Argument argument : shell.getArguments()) {
-                doubleQuoted(argument, violations);
+                doubleQuotedContents(argument, violations);
             }
             return super.visitShell(shell, violations);
         }
@@ -386,7 +391,7 @@ public class Assertions {
         public Docker.Volume visitVolume(Docker.Volume volume, List<String> violations) {
             if (volume.isJsonForm()) {
                 for (Docker.Argument value : volume.getValues()) {
-                    doubleQuoted(value, violations);
+                    doubleQuotedContents(value, violations);
                 }
             }
             return super.visitVolume(volume, violations);
@@ -446,13 +451,9 @@ public class Assertions {
         @Override
         public Docker.Literal visitLiteral(Docker.Literal literal, List<String> violations) {
             Docker.Literal.QuoteStyle style = literal.getQuoteStyle();
-            if (style != null) {
-                boolean escapable = style == Docker.Literal.QuoteStyle.DOUBLE;
-                char quote = escapable ? '"' : '\'';
-                if (hasUnescapedQuote(literal.getText(), quote, escapable)) {
-                    violations.add("expected the quoted literal " + quoted(literal.getText()) + " to hold no" +
-                            " unescaped " + quote + ", which ends the string when it is read back");
-                }
+            if (style != null && hasUnescapedQuote(literal.getText(), style)) {
+                violations.add("expected the quoted literal " + quoted(literal.getText()) + " to hold no unescaped " +
+                        quoteOf(style) + ", which ends the string when it is read back");
             }
             return super.visitLiteral(literal, violations);
         }
@@ -467,53 +468,16 @@ public class Assertions {
             }
         }
 
-        private void keyword(Docker d, List<String> violations) {
-            if (d instanceof Docker.From) {
-                keyword(((Docker.From) d).getKeyword(), "FROM", "From", violations);
-            } else if (d instanceof Docker.Run) {
-                keyword(((Docker.Run) d).getKeyword(), "RUN", "Run", violations);
-            } else if (d instanceof Docker.Add) {
-                keyword(((Docker.Add) d).getKeyword(), "ADD", "Add", violations);
-            } else if (d instanceof Docker.Copy) {
-                keyword(((Docker.Copy) d).getKeyword(), "COPY", "Copy", violations);
-            } else if (d instanceof Docker.Arg) {
-                keyword(((Docker.Arg) d).getKeyword(), "ARG", "Arg", violations);
-            } else if (d instanceof Docker.Env) {
-                keyword(((Docker.Env) d).getKeyword(), "ENV", "Env", violations);
-            } else if (d instanceof Docker.Label) {
-                keyword(((Docker.Label) d).getKeyword(), "LABEL", "Label", violations);
-            } else if (d instanceof Docker.Cmd) {
-                keyword(((Docker.Cmd) d).getKeyword(), "CMD", "Cmd", violations);
-            } else if (d instanceof Docker.Entrypoint) {
-                keyword(((Docker.Entrypoint) d).getKeyword(), "ENTRYPOINT", "Entrypoint", violations);
-            } else if (d instanceof Docker.Expose) {
-                keyword(((Docker.Expose) d).getKeyword(), "EXPOSE", "Expose", violations);
-            } else if (d instanceof Docker.Volume) {
-                keyword(((Docker.Volume) d).getKeyword(), "VOLUME", "Volume", violations);
-            } else if (d instanceof Docker.Shell) {
-                keyword(((Docker.Shell) d).getKeyword(), "SHELL", "Shell", violations);
-            } else if (d instanceof Docker.Workdir) {
-                keyword(((Docker.Workdir) d).getKeyword(), "WORKDIR", "Workdir", violations);
-            } else if (d instanceof Docker.User) {
-                keyword(((Docker.User) d).getKeyword(), "USER", "User", violations);
-            } else if (d instanceof Docker.Stopsignal) {
-                keyword(((Docker.Stopsignal) d).getKeyword(), "STOPSIGNAL", "Stopsignal", violations);
-            } else if (d instanceof Docker.Onbuild) {
-                keyword(((Docker.Onbuild) d).getKeyword(), "ONBUILD", "Onbuild", violations);
-            } else if (d instanceof Docker.Healthcheck) {
-                keyword(((Docker.Healthcheck) d).getKeyword(), "HEALTHCHECK", "Healthcheck", violations);
-            } else if (d instanceof Docker.Maintainer) {
-                keyword(((Docker.Maintainer) d).getKeyword(), "MAINTAINER", "Maintainer", violations);
-            }
-        }
-
+        /// Every element that has a keyword spells it the same as its own type, so the type is the
+        /// expectation and a new instruction is checked without anyone remembering to add it here.
         /// Dockerfile keywords are case insensitive, so a lower case keyword is the one the source
         /// wrote. Anything else is a keyword that no longer says what its element is, or one holding
         /// whitespace the printer expects to find on whatever follows it.
-        private void keyword(String keyword, String expected, String element, List<String> violations) {
-            if (!expected.equalsIgnoreCase(keyword)) {
-                violations.add("expected the keyword of a " + element + " to be " + expected +
-                        " ignoring case, but it is " + quoted(keyword));
+        private void keyword(String keyword, Class<?> type, List<String> violations) {
+            String element = type.getSimpleName();
+            if (!element.equalsIgnoreCase(keyword)) {
+                violations.add("expected the keyword of a " + element + " to be " +
+                        element.toUpperCase(Locale.ROOT) + " ignoring case, but it is " + quoted(keyword));
             }
         }
 
@@ -532,7 +496,7 @@ public class Assertions {
             }
         }
 
-        private void doubleQuoted(Docker.Argument argument, List<String> violations) {
+        private void doubleQuotedContents(Docker.Argument argument, List<String> violations) {
             for (Docker.ArgumentContent content : argument.getContents()) {
                 if (content instanceof Docker.Literal) {
                     doubleQuoted((Docker.Literal) content, violations);
@@ -553,11 +517,11 @@ public class Assertions {
         /// printed source ever saying so.
         private void portModelsItsText(Docker.Port port, List<String> violations) {
             String text = port.getText();
-            String range = text;
+            String ports = text;
             Docker.Port.Protocol protocol = Docker.Port.Protocol.TCP;
             int slash = text.indexOf('/');
             if (slash >= 0) {
-                range = text.substring(0, slash);
+                ports = text.substring(0, slash);
                 String name = text.substring(slash + 1);
                 if ("udp".equalsIgnoreCase(name)) {
                     protocol = Docker.Port.Protocol.UDP;
@@ -568,17 +532,17 @@ public class Assertions {
             }
             Integer start;
             Integer end = null;
-            int dash = range.indexOf('-');
+            int dash = ports.indexOf('-');
             try {
-                start = Integer.valueOf(dash < 0 ? range : range.substring(0, dash));
+                start = Integer.valueOf(dash < 0 ? ports : ports.substring(0, dash));
                 if (dash >= 0) {
-                    end = Integer.valueOf(range.substring(dash + 1));
+                    end = Integer.valueOf(ports.substring(dash + 1));
                 }
             } catch (NumberFormatException e) {
                 violations.add("expected the port " + quoted(text) + " to hold a port number or a range of them");
                 return;
             }
-            if (!start.equals(port.getStart()) || !Objects.equals(end, port.getEnd()) ||
+            if (!Objects.equals(start, port.getStart()) || !Objects.equals(end, port.getEnd()) ||
                     protocol != port.getProtocol()) {
                 violations.add("expected the port " + quoted(text) + " to model " + range(start, end) + " " +
                         protocol + ", but it models " + range(port.getStart(), port.getEnd()) + " " +
@@ -597,7 +561,11 @@ public class Assertions {
             return port != null && (port < 0 || port > 65535);
         }
 
-        private static boolean hasUnescapedQuote(String text, char quote, boolean escapable) {
+        /// A single quoted string has no escape processing at all, so any quote of its own style ends
+        /// it; a double quoted one can hold an escaped quote.
+        private static boolean hasUnescapedQuote(String text, Docker.Literal.QuoteStyle style) {
+            boolean escapable = style == Docker.Literal.QuoteStyle.DOUBLE;
+            char quote = quoteOf(style);
             for (int i = 0; i < text.length(); i++) {
                 char c = text.charAt(i);
                 if (escapable && c == '\\') {
@@ -609,13 +577,8 @@ public class Assertions {
             return false;
         }
 
-        private static boolean containsWhitespace(String text) {
-            for (int i = 0; i < text.length(); i++) {
-                if (Character.isWhitespace(text.charAt(i))) {
-                    return true;
-                }
-            }
-            return false;
+        private static char quoteOf(Docker.Literal.QuoteStyle style) {
+            return style == Docker.Literal.QuoteStyle.DOUBLE ? '"' : '\'';
         }
 
         /// [Space#getLastWhitespace()] and [Space#getIndent()] answer with the last comment's prefix

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
@@ -21,6 +21,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
+import org.openrewrite.docker.tree.Comment;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
 import org.openrewrite.test.SourceSpec;
@@ -28,9 +29,10 @@ import org.openrewrite.test.SourceSpecs;
 import org.openrewrite.test.TypeValidation;
 import org.openrewrite.tree.ParseError;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.util.stream.Collectors.toList;
 
@@ -85,10 +87,7 @@ public class Assertions {
             List<Docker> elementsWithNonBlankWhitespace = new DockerIsoVisitor<List<Docker>>() {
                 @Override
                 public Space visitSpace(Space space, List<Docker> elements) {
-                    // Strip line continuation characters (\ or ` followed by optional whitespace and newline)
-                    // before checking, since they are valid in Dockerfile whitespace
-                    String ws = space.getWhitespace().replaceAll("[\\\\`][ \\t]*(?=\\r?\\n)", "");
-                    if (!ws.trim().isEmpty()) {
+                    if (!isWhitespace(space.getWhitespace())) {
                         elements.add(getCursor().firstEnclosingOrThrow(Docker.class));
                     }
                     return super.visitSpace(space, elements);
@@ -98,10 +97,17 @@ public class Assertions {
                 throw new AssertionError("Expected no non-whitespace in whitespace, but found: " + elementsWithNonBlankWhitespace);
             }
         }
+        assertWellFormed(sf);
         if (tv.parseAndPrintEquality()) {
             assertReparsesToTheSameTree(sf);
         }
         return sf;
+    }
+
+    /// Line continuations are whitespace to a Dockerfile, so the `\` or `` ` `` that introduces one is
+    /// not text sitting where only formatting belongs.
+    private static boolean isWhitespace(String text) {
+        return text.replaceAll("[\\\\`][ \\t]*(?=\\r?\\n)", "").trim().isEmpty();
     }
 
     /// A tree prints losslessly by construction, so printing alone cannot tell whether its elements
@@ -219,5 +225,408 @@ public class Assertions {
                 return form;
             }
         }.reduce(tree, new StringBuilder()).toString();
+    }
+
+    /// A recipe that assembles a tree by hand can leave it holding what the printer cannot express, or
+    /// can express only by changing what the source means: a subtree copied without fresh ids, an
+    /// instruction that does not start its own line, a flag whose name already carries its dashes.
+    /// Unlike [TypeValidation#allowNonWhitespaceInWhitespace] and [TypeValidation#parseAndPrintEquality]
+    /// there is no flag to turn these off, because a tree that cannot print what it models is never
+    /// what a test meant to assert.
+    static void assertWellFormed(SourceFile sf) {
+        List<String> violations = new WellFormedVisitor().reduce(sf, new ArrayList<>());
+        if (!violations.isEmpty()) {
+            throw new AssertionError("Expected a well formed tree, but found:\n  " + String.join("\n  ", violations));
+        }
+    }
+
+    private static class WellFormedVisitor extends DockerIsoVisitor<List<String>> {
+        private static final Pattern HEREDOC_MARKER = Pattern.compile("<<-?([A-Za-z_][A-Za-z0-9_]*)");
+
+        private final Set<UUID> ids = new HashSet<>();
+
+        /// The one [Space] that nothing follows, and so the one whose trailing comment needs no newline
+        /// after it.
+        private @Nullable Space eof;
+
+        @Override
+        public @Nullable Docker visit(@Nullable Tree tree, List<String> violations) {
+            if (tree instanceof Docker) {
+                Docker d = (Docker) tree;
+                uniqueId(d.getId(), d.getClass(), violations);
+                keyword(d, violations);
+            }
+            return super.visit(tree, violations);
+        }
+
+        @Override
+        public Docker.File visitFile(Docker.File file, List<String> violations) {
+            eof = file.getEof();
+            List<Docker.Arg> globalArgs = file.getGlobalArgs();
+            for (int i = 1; i < globalArgs.size(); i++) {
+                startsItsOwnLine(globalArgs.get(i), violations);
+            }
+            for (int i = 0; i < file.getStages().size(); i++) {
+                Docker.Stage stage = file.getStages().get(i);
+                if ((i > 0 || !globalArgs.isEmpty()) &&
+                        !containsNewline(stage.getPrefix()) && !containsNewline(stage.getFrom().getPrefix())) {
+                    violations.add("expected the Stage to start its own line, but neither it nor its From has a" +
+                            " newline in its prefix");
+                }
+            }
+            return super.visitFile(file, violations);
+        }
+
+        @Override
+        public Docker.Stage visitStage(Docker.Stage stage, List<String> violations) {
+            for (Docker.Instruction instruction : stage.getInstructions()) {
+                startsItsOwnLine(instruction, violations);
+            }
+            return super.visitStage(stage, violations);
+        }
+
+        @Override
+        public Space visitSpace(Space space, List<String> violations) {
+            List<Comment> comments = space.getComments();
+            for (int i = 0; i < comments.size(); i++) {
+                Comment comment = comments.get(i);
+                if (!comment.getText().startsWith("#")) {
+                    violations.add("expected the comment " + quoted(comment.getText()) + " to start with \"#\"");
+                }
+                if (comment.getText().indexOf('\n') >= 0) {
+                    violations.add("expected the comment " + quoted(comment.getText()) + " to hold a single line");
+                }
+                if (!isWhitespace(comment.getPrefix())) {
+                    violations.add("expected the prefix of the comment " + quoted(comment.getText()) +
+                            " to be whitespace, but it is " + quoted(comment.getPrefix()));
+                }
+                boolean last = i + 1 == comments.size();
+                String following = last ? space.getWhitespace() : comments.get(i + 1).getPrefix();
+                if (following.indexOf('\n') < 0 && !(last && space == eof)) {
+                    violations.add("expected a newline after the comment " + quoted(comment.getText()) +
+                            ", or whatever follows it is read back as part of it");
+                }
+            }
+            return super.visitSpace(space, violations);
+        }
+
+        @Override
+        public Docker.From visitFrom(Docker.From from, List<String> violations) {
+            nonEmpty(from.getImageName(), "the image name of a From", violations);
+            return super.visitFrom(from, violations);
+        }
+
+        @Override
+        public Docker.From.@Nullable As visitFromAs(Docker.From.As as, List<String> violations) {
+            uniqueId(as.getId(), as.getClass(), violations);
+            keyword(as.getKeyword(), "AS", "As", violations);
+            return super.visitFromAs(as, violations);
+        }
+
+        @Override
+        public Docker.Env.EnvPair visitEnvPair(Docker.Env.EnvPair pair, List<String> violations) {
+            uniqueId(pair.getId(), pair.getClass(), violations);
+            return super.visitEnvPair(pair, violations);
+        }
+
+        @Override
+        public Docker.Label.LabelPair visitLabelPair(Docker.Label.LabelPair pair, List<String> violations) {
+            uniqueId(pair.getId(), pair.getClass(), violations);
+            return super.visitLabelPair(pair, violations);
+        }
+
+        @Override
+        public Docker.Workdir visitWorkdir(Docker.Workdir workdir, List<String> violations) {
+            nonEmpty(workdir.getPath(), "the path of a Workdir", violations);
+            return super.visitWorkdir(workdir, violations);
+        }
+
+        @Override
+        public Docker visitCopyShellForm(Docker.CopyShellForm form, List<String> violations) {
+            nonEmpty(form.getDestination(), "the destination of a CopyShellForm", violations);
+            return super.visitCopyShellForm(form, violations);
+        }
+
+        @Override
+        public Docker.Flag visitFlag(Docker.Flag flag, List<String> violations) {
+            String name = flag.getName();
+            if (name.startsWith("-") || name.indexOf('=') >= 0 || containsWhitespace(name)) {
+                violations.add("expected the flag name " + quoted(name) + " to be bare, as the printer writes the" +
+                        " leading \"--\" and any \"=\" itself");
+            }
+            return super.visitFlag(flag, violations);
+        }
+
+        @Override
+        public Docker.Healthcheck visitHealthcheck(Docker.Healthcheck healthcheck, List<String> violations) {
+            if (healthcheck.isNone() && healthcheck.getFlags() != null && !healthcheck.getFlags().isEmpty()) {
+                violations.add("expected HEALTHCHECK NONE to carry no flags, but it carries " +
+                        healthcheck.getFlags().size() + ", which the printer drops");
+            }
+            return super.visitHealthcheck(healthcheck, violations);
+        }
+
+        @Override
+        public Docker.ExecForm visitExecForm(Docker.ExecForm execForm, List<String> violations) {
+            for (Docker.Literal argument : execForm.getArguments()) {
+                doubleQuoted(argument, violations);
+            }
+            return super.visitExecForm(execForm, violations);
+        }
+
+        @Override
+        public Docker.Shell visitShell(Docker.Shell shell, List<String> violations) {
+            for (Docker.Argument argument : shell.getArguments()) {
+                doubleQuoted(argument, violations);
+            }
+            return super.visitShell(shell, violations);
+        }
+
+        @Override
+        public Docker.Volume visitVolume(Docker.Volume volume, List<String> violations) {
+            if (volume.isJsonForm()) {
+                for (Docker.Argument value : volume.getValues()) {
+                    doubleQuoted(value, violations);
+                }
+            }
+            return super.visitVolume(volume, violations);
+        }
+
+        @Override
+        public Docker.Port visitPort(Docker.Port port, List<String> violations) {
+            if (!port.isVariable()) {
+                portModelsItsText(port, violations);
+            }
+            return super.visitPort(port, violations);
+        }
+
+        @Override
+        public Docker.HeredocForm visitHeredocForm(Docker.HeredocForm form, List<String> violations) {
+            List<String> markers = new ArrayList<>();
+            Matcher matcher = HEREDOC_MARKER.matcher(form.getPreamble());
+            while (matcher.find()) {
+                markers.add(matcher.group(1));
+            }
+            if (markers.size() != form.getBodies().size()) {
+                violations.add("expected the preamble " + quoted(form.getPreamble()) + " to open one heredoc per" +
+                        " body, but it opens " + markers.size() + " for " + form.getBodies().size() + " bodies");
+            }
+            for (int i = 0; i < form.getBodies().size(); i++) {
+                Docker.HeredocBody body = form.getBodies().get(i);
+                if (i < markers.size() && !markers.get(i).equals(body.getClosing())) {
+                    violations.add("expected the heredoc opened by " + quoted(markers.get(i)) + " to close with it," +
+                            " but it closes with " + quoted(body.getClosing()));
+                }
+                if (!body.getOpening().startsWith("<<")) {
+                    violations.add("expected the heredoc opening " + quoted(body.getOpening()) +
+                            " to start with \"<<\"");
+                }
+                for (String line : body.getContentLines()) {
+                    if (!line.endsWith("\n")) {
+                        violations.add("expected the heredoc line " + quoted(line) + " to end with a newline");
+                    }
+                }
+            }
+            return super.visitHeredocForm(form, violations);
+        }
+
+        @Override
+        public Docker.Argument visitArgument(Docker.Argument argument, List<String> violations) {
+            List<Docker.ArgumentContent> contents = argument.getContents();
+            for (int i = 1; i < contents.size(); i++) {
+                Space prefix = contents.get(i).getPrefix();
+                if (!prefix.getWhitespace().isEmpty() || !prefix.getComments().isEmpty()) {
+                    violations.add("expected the contents of the argument " + quoted(argument.getTextWithVariables()) +
+                            " to be contiguous, but one is preceded by " + quoted(prefix.toString()));
+                }
+            }
+            return super.visitArgument(argument, violations);
+        }
+
+        @Override
+        public Docker.Literal visitLiteral(Docker.Literal literal, List<String> violations) {
+            Docker.Literal.QuoteStyle style = literal.getQuoteStyle();
+            if (style != null) {
+                boolean escapable = style == Docker.Literal.QuoteStyle.DOUBLE;
+                char quote = escapable ? '"' : '\'';
+                if (hasUnescapedQuote(literal.getText(), quote, escapable)) {
+                    violations.add("expected the quoted literal " + quoted(literal.getText()) + " to hold no" +
+                            " unescaped " + quote + ", which ends the string when it is read back");
+                }
+            }
+            return super.visitLiteral(literal, violations);
+        }
+
+        /// Recipes that copy a subtree, as combining or adding instructions do, hand the same element
+        /// to two parents. The tree still prints, but any visitor that navigates by id, and any recipe
+        /// that edits one of the two, sees both.
+        private void uniqueId(UUID id, Class<?> type, List<String> violations) {
+            if (!ids.add(id)) {
+                violations.add("expected every element to have its own id, but a " + type.getSimpleName() +
+                        " repeats " + id);
+            }
+        }
+
+        private void keyword(Docker d, List<String> violations) {
+            if (d instanceof Docker.From) {
+                keyword(((Docker.From) d).getKeyword(), "FROM", "From", violations);
+            } else if (d instanceof Docker.Run) {
+                keyword(((Docker.Run) d).getKeyword(), "RUN", "Run", violations);
+            } else if (d instanceof Docker.Add) {
+                keyword(((Docker.Add) d).getKeyword(), "ADD", "Add", violations);
+            } else if (d instanceof Docker.Copy) {
+                keyword(((Docker.Copy) d).getKeyword(), "COPY", "Copy", violations);
+            } else if (d instanceof Docker.Arg) {
+                keyword(((Docker.Arg) d).getKeyword(), "ARG", "Arg", violations);
+            } else if (d instanceof Docker.Env) {
+                keyword(((Docker.Env) d).getKeyword(), "ENV", "Env", violations);
+            } else if (d instanceof Docker.Label) {
+                keyword(((Docker.Label) d).getKeyword(), "LABEL", "Label", violations);
+            } else if (d instanceof Docker.Cmd) {
+                keyword(((Docker.Cmd) d).getKeyword(), "CMD", "Cmd", violations);
+            } else if (d instanceof Docker.Entrypoint) {
+                keyword(((Docker.Entrypoint) d).getKeyword(), "ENTRYPOINT", "Entrypoint", violations);
+            } else if (d instanceof Docker.Expose) {
+                keyword(((Docker.Expose) d).getKeyword(), "EXPOSE", "Expose", violations);
+            } else if (d instanceof Docker.Volume) {
+                keyword(((Docker.Volume) d).getKeyword(), "VOLUME", "Volume", violations);
+            } else if (d instanceof Docker.Shell) {
+                keyword(((Docker.Shell) d).getKeyword(), "SHELL", "Shell", violations);
+            } else if (d instanceof Docker.Workdir) {
+                keyword(((Docker.Workdir) d).getKeyword(), "WORKDIR", "Workdir", violations);
+            } else if (d instanceof Docker.User) {
+                keyword(((Docker.User) d).getKeyword(), "USER", "User", violations);
+            } else if (d instanceof Docker.Stopsignal) {
+                keyword(((Docker.Stopsignal) d).getKeyword(), "STOPSIGNAL", "Stopsignal", violations);
+            } else if (d instanceof Docker.Onbuild) {
+                keyword(((Docker.Onbuild) d).getKeyword(), "ONBUILD", "Onbuild", violations);
+            } else if (d instanceof Docker.Healthcheck) {
+                keyword(((Docker.Healthcheck) d).getKeyword(), "HEALTHCHECK", "Healthcheck", violations);
+            } else if (d instanceof Docker.Maintainer) {
+                keyword(((Docker.Maintainer) d).getKeyword(), "MAINTAINER", "Maintainer", violations);
+            }
+        }
+
+        /// Dockerfile keywords are case insensitive, so a lower case keyword is the one the source
+        /// wrote. Anything else is a keyword that no longer says what its element is, or one holding
+        /// whitespace the printer expects to find on whatever follows it.
+        private void keyword(String keyword, String expected, String element, List<String> violations) {
+            if (!expected.equalsIgnoreCase(keyword)) {
+                violations.add("expected the keyword of a " + element + " to be " + expected +
+                        " ignoring case, but it is " + quoted(keyword));
+            }
+        }
+
+        /// An instruction the printer writes straight after the one before it, as a recipe that
+        /// inserts an instruction without a prefix does, prints as `FROM alpineRUN x`.
+        private void startsItsOwnLine(Docker d, List<String> violations) {
+            if (!containsNewline(d.getPrefix())) {
+                violations.add("expected the " + d.getClass().getSimpleName() + " to start its own line, but its" +
+                        " prefix is " + quoted(d.getPrefix().getWhitespace()));
+            }
+        }
+
+        private void nonEmpty(Docker.Argument argument, String what, List<String> violations) {
+            if (argument.getContents().isEmpty()) {
+                violations.add("expected " + what + " to hold at least one content");
+            }
+        }
+
+        private void doubleQuoted(Docker.Argument argument, List<String> violations) {
+            for (Docker.ArgumentContent content : argument.getContents()) {
+                if (content instanceof Docker.Literal) {
+                    doubleQuoted((Docker.Literal) content, violations);
+                }
+            }
+        }
+
+        /// JSON array elements are the one place a Dockerfile is not shell, and an element that loses
+        /// its quotes prints a JSON array that Docker refuses to read.
+        private void doubleQuoted(Docker.Literal literal, List<String> violations) {
+            if (literal.getQuoteStyle() != Docker.Literal.QuoteStyle.DOUBLE) {
+                violations.add("expected the JSON array element " + quoted(literal.getText()) +
+                        " to be double quoted, but it is " + (literal.isQuoted() ? "single quoted" : "unquoted"));
+            }
+        }
+
+        /// A [Docker.Port] prints its text and models its fields, so the two can disagree without the
+        /// printed source ever saying so.
+        private void portModelsItsText(Docker.Port port, List<String> violations) {
+            String text = port.getText();
+            String range = text;
+            Docker.Port.Protocol protocol = Docker.Port.Protocol.TCP;
+            int slash = text.indexOf('/');
+            if (slash >= 0) {
+                range = text.substring(0, slash);
+                String name = text.substring(slash + 1);
+                if ("udp".equalsIgnoreCase(name)) {
+                    protocol = Docker.Port.Protocol.UDP;
+                } else if (!"tcp".equalsIgnoreCase(name)) {
+                    violations.add("expected the port " + quoted(text) + " to name a protocol Docker knows");
+                    return;
+                }
+            }
+            Integer start;
+            Integer end = null;
+            int dash = range.indexOf('-');
+            try {
+                start = Integer.valueOf(dash < 0 ? range : range.substring(0, dash));
+                if (dash >= 0) {
+                    end = Integer.valueOf(range.substring(dash + 1));
+                }
+            } catch (NumberFormatException e) {
+                violations.add("expected the port " + quoted(text) + " to hold a port number or a range of them");
+                return;
+            }
+            if (!start.equals(port.getStart()) || !Objects.equals(end, port.getEnd()) ||
+                    protocol != port.getProtocol()) {
+                violations.add("expected the port " + quoted(text) + " to model " + range(start, end) + " " +
+                        protocol + ", but it models " + range(port.getStart(), port.getEnd()) + " " +
+                        port.getProtocol());
+            }
+            if (outOfRange(start) || outOfRange(end)) {
+                violations.add("expected the port " + quoted(text) + " to be between 0 and 65535");
+            }
+        }
+
+        private static String range(@Nullable Integer start, @Nullable Integer end) {
+            return end == null ? String.valueOf(start) : start + "-" + end;
+        }
+
+        private static boolean outOfRange(@Nullable Integer port) {
+            return port != null && (port < 0 || port > 65535);
+        }
+
+        private static boolean hasUnescapedQuote(String text, char quote, boolean escapable) {
+            for (int i = 0; i < text.length(); i++) {
+                char c = text.charAt(i);
+                if (escapable && c == '\\') {
+                    i++;
+                } else if (c == quote) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private static boolean containsWhitespace(String text) {
+            for (int i = 0; i < text.length(); i++) {
+                if (Character.isWhitespace(text.charAt(i))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// [Space#getLastWhitespace()] and [Space#getIndent()] answer with the last comment's prefix
+        /// when a [Space] holds comments, but [org.openrewrite.docker.internal.DockerPrinter] writes
+        /// comments before the whitespace, so the text abutting the next token is always the whitespace.
+        private static boolean containsNewline(Space space) {
+            return space.getWhitespace().indexOf('\n') >= 0;
+        }
+
+        private static String quoted(String text) {
+            return '"' + text.replace("\n", "\\n").replace("\t", "\\t") + '"';
+        }
     }
 }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/DockerVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/DockerVisitor.java
@@ -32,7 +32,8 @@ public class DockerVisitor<P> extends TreeVisitor<Docker, P> {
         d = d.withPrefix(visitSpace(d.getPrefix(), p));
         d = d.withMarkers(visitMarkers(d.getMarkers(), p));
         d = d.withGlobalArgs(ListUtils.map(d.getGlobalArgs(), arg -> (Docker.Arg) visit(arg, p)));
-        return d.withStages(ListUtils.map(d.getStages(), stage -> (Docker.Stage) visit(stage, p)));
+        d = d.withStages(ListUtils.map(d.getStages(), stage -> (Docker.Stage) visit(stage, p)));
+        return d.withEof(visitSpace(d.getEof(), p));
     }
 
     public Docker visitStage(Docker.Stage stage, P p) {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/tree/Docker.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/tree/Docker.java
@@ -148,6 +148,10 @@ public interface Docker extends Tree {
      * Base interface for all Dockerfile instructions
      */
     interface Instruction extends Docker {
+        /**
+         * The instruction's keyword as the source wrote it, which Dockerfile matches ignoring case.
+         */
+        String getKeyword();
     }
 
     /**

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
@@ -232,12 +232,7 @@ class AssertionsTest implements RewriteTest {
             FROM alpine
             ENTRYPOINT ["java", "-jar", "app.jar"]
             """,
-          new DockerIsoVisitor<>() {
-              @Override
-              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
-                  return literal.withQuoteStyle(null);
-              }
-          },
+          unquoteLiterals(),
           "expected the JSON array element \"java\" to be double quoted");
     }
 
@@ -248,12 +243,7 @@ class AssertionsTest implements RewriteTest {
             FROM alpine
             SHELL ["/bin/bash", "-c"]
             """,
-          new DockerIsoVisitor<>() {
-              @Override
-              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
-                  return literal.withQuoteStyle(null);
-              }
-          },
+          unquoteLiterals(),
           "expected the JSON array element \"/bin/bash\" to be double quoted");
     }
 
@@ -264,12 +254,7 @@ class AssertionsTest implements RewriteTest {
             FROM alpine
             VOLUME ["/data"]
             """,
-          new DockerIsoVisitor<>() {
-              @Override
-              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
-                  return literal.withQuoteStyle(null);
-              }
-          },
+          unquoteLiterals(),
           "expected the JSON array element \"/data\" to be double quoted");
     }
 
@@ -558,6 +543,23 @@ class AssertionsTest implements RewriteTest {
           "to hold no unescaped \"");
     }
 
+    @Test
+    void catchesASingleQuotedLiteralHoldingTheQuoteThatEndsIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            ENV KEY='value'
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.getQuoteStyle() == Docker.Literal.QuoteStyle.SINGLE ?
+                    literal.withText("va'lue") : literal;
+              }
+          },
+          "to hold no unescaped '");
+    }
+
     /// An ONBUILD's instruction, and a HEALTHCHECK's CMD, correctly sit on the same line as the
     /// instruction that introduces them.
     @Test
@@ -576,21 +578,34 @@ class AssertionsTest implements RewriteTest {
         Assertions.assertWellFormed(parse("FROM alpine\n# no newline after this"));
     }
 
+    /// That exemption is only from needing a newline. A trailing comment lives in the file's `eof`
+    /// [Space], which every other check still reaches.
     @Test
-    void catchesASingleQuotedLiteralHoldingTheQuoteThatEndsIt() {
+    void catchesATrailingCommentThatIsNotOne() {
         assertMalformed(
           """
             FROM alpine
-            ENV KEY='value'
+            # trailing
             """,
           new DockerIsoVisitor<>() {
               @Override
-              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
-                  return literal.getQuoteStyle() == Docker.Literal.QuoteStyle.SINGLE ?
-                    literal.withText("va'lue") : literal;
+              public Space visitSpace(Space space, ExecutionContext ctx) {
+                  return space.withComments(ListUtils.map(space.getComments(),
+                    comment -> comment.withText(comment.getText().substring(1))));
               }
           },
-          "to hold no unescaped '");
+          "to start with \"#\"");
+    }
+
+    /// The same defect in three places the checks reach separately: an exec form, a SHELL and a
+    /// JSON form VOLUME.
+    private static DockerIsoVisitor<ExecutionContext> unquoteLiterals() {
+        return new DockerIsoVisitor<>() {
+            @Override
+            public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                return literal.withQuoteStyle(null);
+            }
+        };
     }
 
     private static void assertMalformed(@Language("dockerfile") String source,

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
@@ -15,16 +15,32 @@
  */
 package org.openrewrite.docker;
 
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.docker.tree.Comment;
 import org.openrewrite.docker.tree.Docker;
+import org.openrewrite.docker.tree.Space;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.UUID;
+
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.docker.Assertions.docker;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
+/// Each test here mutates a parsed tree the way a recipe assembling one by hand would, and asserts
+/// that validation says so. Mutating a real parse rather than driving a recipe is deliberate: the
+/// validation a recipe result goes through only runs when the recipe changed the printed source, and
+/// several of these defects change nothing about what the tree prints.
 class AssertionsTest implements RewriteTest {
 
     @Test
@@ -55,4 +71,543 @@ class AssertionsTest implements RewriteTest {
           .hasMessageContaining("Expected the tree to model what it prints");
     }
 
+    /// The other tests here call the structural checks directly, so this one proves that a recipe
+    /// result reaches them at all.
+    @Test
+    void validatesTheTreeARecipeProduces() {
+        assertThatThrownBy(() -> rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new DockerIsoVisitor<ExecutionContext>() {
+              @Override
+              public Docker.Run visitRun(Docker.Run run, ExecutionContext ctx) {
+                  return "RUN".equals(run.getKeyword()) ? run.withKeyword("EXEC") : run;
+              }
+          })),
+          docker(
+            """
+              FROM alpine
+              RUN echo hi
+              """,
+            """
+              FROM alpine
+              EXEC echo hi
+              """
+          )
+        )).isInstanceOf(AssertionError.class)
+          .hasMessageContaining("expected the keyword of a Run to be RUN");
+    }
+
+    @Test
+    void catchesASubtreeCopiedWithoutFreshIds() {
+        UUID shared = randomId();
+        assertMalformed(
+          """
+            FROM alpine
+            RUN echo hi
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.withId(shared);
+              }
+          },
+          "expected every element to have its own id");
+    }
+
+    @Test
+    void catchesAKeywordThatDisagreesWithItsInstruction() {
+        assertMalformed(
+          """
+            FROM alpine
+            RUN echo hi
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Run visitRun(Docker.Run run, ExecutionContext ctx) {
+                  return run.withKeyword("EXEC");
+              }
+          },
+          "expected the keyword of a Run to be RUN");
+    }
+
+    @Test
+    void catchesAKeywordThatCarriesWhitespace() {
+        assertMalformed(
+          """
+            FROM alpine AS build
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.From.As visitFromAs(Docker.From.As as, ExecutionContext ctx) {
+                  return as.withKeyword(" AS");
+              }
+          },
+          "expected the keyword of a As to be AS");
+    }
+
+    @Test
+    void catchesAnInstructionThatDoesNotStartItsOwnLine() {
+        assertMalformed(
+          """
+            FROM alpine
+            RUN echo hi
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Run visitRun(Docker.Run run, ExecutionContext ctx) {
+                  return run.withPrefix(Space.SINGLE_SPACE);
+              }
+          },
+          "expected the Run to start its own line");
+    }
+
+    @Test
+    void catchesAStageThatDoesNotStartItsOwnLine() {
+        assertMalformed(
+          """
+            ARG VERSION=3.14
+            FROM alpine:${VERSION}
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Stage visitStage(Docker.Stage stage, ExecutionContext ctx) {
+                  return stage.withPrefix(Space.EMPTY).withFrom(stage.getFrom().withPrefix(Space.SINGLE_SPACE));
+              }
+          },
+          "expected the Stage to start its own line");
+    }
+
+    @Test
+    void catchesAGlobalArgThatDoesNotStartItsOwnLine() {
+        assertMalformed(
+          """
+            ARG VERSION=3.14
+            ARG DIGEST=sha256
+            FROM alpine:${VERSION}
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Arg visitArg(Docker.Arg arg, ExecutionContext ctx) {
+                  return "DIGEST".equals(arg.getName().getText()) ? arg.withPrefix(Space.SINGLE_SPACE) : arg;
+              }
+          },
+          "expected the Arg to start its own line");
+    }
+
+    @Test
+    void catchesAFlagNameThatAlreadyCarriesItsDashes() {
+        assertMalformed(
+          """
+            FROM --platform=linux/amd64 alpine
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Flag visitFlag(Docker.Flag flag, ExecutionContext ctx) {
+                  return flag.withName("--" + flag.getName());
+              }
+          },
+          "expected the flag name \"--platform\" to be bare");
+    }
+
+    @Test
+    void catchesFlagsOnAHealthcheckNoneThatThePrinterDrops() {
+        assertMalformed(
+          """
+            FROM alpine
+            HEALTHCHECK NONE
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Healthcheck visitHealthcheck(Docker.Healthcheck healthcheck, ExecutionContext ctx) {
+                  return healthcheck.withFlags(singletonList(new Docker.Flag(
+                    randomId(), Space.SINGLE_SPACE, Markers.EMPTY, "interval", null)));
+              }
+          },
+          "expected HEALTHCHECK NONE to carry no flags");
+    }
+
+    @Test
+    void catchesAnExecFormArgumentThatLostItsQuotes() {
+        assertMalformed(
+          """
+            FROM alpine
+            ENTRYPOINT ["java", "-jar", "app.jar"]
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.withQuoteStyle(null);
+              }
+          },
+          "expected the JSON array element \"java\" to be double quoted");
+    }
+
+    @Test
+    void catchesAShellArgumentThatLostItsQuotes() {
+        assertMalformed(
+          """
+            FROM alpine
+            SHELL ["/bin/bash", "-c"]
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.withQuoteStyle(null);
+              }
+          },
+          "expected the JSON array element \"/bin/bash\" to be double quoted");
+    }
+
+    @Test
+    void catchesAJsonFormVolumeValueThatLostItsQuotes() {
+        assertMalformed(
+          """
+            FROM alpine
+            VOLUME ["/data"]
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.withQuoteStyle(null);
+              }
+          },
+          "expected the JSON array element \"/data\" to be double quoted");
+    }
+
+    @Test
+    void catchesAPortThatDisagreesWithItsText() {
+        assertMalformed(
+          """
+            FROM alpine
+            EXPOSE 8080/udp
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Port visitPort(Docker.Port port, ExecutionContext ctx) {
+                  return port.withStart(9090);
+              }
+          },
+          "expected the port \"8080/udp\" to model 8080 UDP, but it models 9090 UDP");
+    }
+
+    @Test
+    void catchesAPortOutsideTheRangeAPortCanHave() {
+        assertMalformed(
+          """
+            FROM alpine
+            EXPOSE 8080
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Port visitPort(Docker.Port port, ExecutionContext ctx) {
+                  return port.withText("99999").withStart(99999);
+              }
+          },
+          "to be between 0 and 65535");
+    }
+
+    @Test
+    void catchesAPortWhoseProtocolDockerDoesNotKnow() {
+        assertMalformed(
+          """
+            FROM alpine
+            EXPOSE 8080/tcp
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Port visitPort(Docker.Port port, ExecutionContext ctx) {
+                  return port.withText("8080/sctp");
+              }
+          },
+          "expected the port \"8080/sctp\" to name a protocol Docker knows");
+    }
+
+    @Test
+    void catchesAPortWhoseTextIsNotAPortAtAll() {
+        assertMalformed(
+          """
+            FROM alpine
+            EXPOSE 8080
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Port visitPort(Docker.Port port, ExecutionContext ctx) {
+                  return port.withText("http");
+              }
+          },
+          "expected the port \"http\" to hold a port number or a range of them");
+    }
+
+    @Test
+    void catchesAHeredocThatOpensWithoutAMarker() {
+        assertMalformed(
+          """
+            FROM alpine
+            RUN <<EOF
+            echo hi
+            EOF
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.HeredocForm visitHeredocForm(Docker.HeredocForm form, ExecutionContext ctx) {
+                  return form.withBodies(ListUtils.map(form.getBodies(), body -> body.withOpening("EOF")));
+              }
+          },
+          "expected the heredoc opening \"EOF\" to start with \"<<\"");
+    }
+
+    @Test
+    void catchesAHeredocThatClosesWithADifferentMarker() {
+        assertMalformed(
+          """
+            FROM alpine
+            RUN <<EOF
+            echo hi
+            EOF
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.HeredocForm visitHeredocForm(Docker.HeredocForm form, ExecutionContext ctx) {
+                  return form.withBodies(ListUtils.map(form.getBodies(), body -> body.withClosing("DONE")));
+              }
+          },
+          "expected the heredoc opened by \"EOF\" to close with it, but it closes with \"DONE\"");
+    }
+
+    @Test
+    void catchesAHeredocBodyWithNoMarkerToOpenIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            RUN <<EOF
+            echo hi
+            EOF
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.HeredocForm visitHeredocForm(Docker.HeredocForm form, ExecutionContext ctx) {
+                  return form.withPreamble(form.getPreamble().replace("<<EOF", "cat"));
+              }
+          },
+          "to open one heredoc per body, but it opens 0 for 1 bodies");
+    }
+
+    @Test
+    void catchesAHeredocLineThatSwallowsTheNextOne() {
+        assertMalformed(
+          """
+            FROM alpine
+            RUN <<EOF
+            echo hi
+            EOF
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.HeredocForm visitHeredocForm(Docker.HeredocForm form, ExecutionContext ctx) {
+                  return form.withBodies(ListUtils.map(form.getBodies(), body -> body.withContentLines(
+                    ListUtils.map(body.getContentLines(), line -> line.replace("\n", "")))));
+              }
+          },
+          "to end with a newline");
+    }
+
+    @Test
+    void catchesACommentThatSwallowsWhatFollowsIt() {
+        assertMalformed(
+          """
+            # syntax=docker/dockerfile:1
+            FROM alpine
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Space visitSpace(Space space, ExecutionContext ctx) {
+                  return space.getComments().isEmpty() ? space : space.withWhitespace(" ");
+              }
+          },
+          "expected a newline after the comment \"# syntax=docker/dockerfile:1\"");
+    }
+
+    @Test
+    void catchesACommentThatIsNotOne() {
+        assertMalformed(
+          """
+            # syntax=docker/dockerfile:1
+            FROM alpine
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Space visitSpace(Space space, ExecutionContext ctx) {
+                  return space.withComments(ListUtils.map(space.getComments(),
+                    comment -> comment.withText(comment.getText().substring(1))));
+              }
+          },
+          "to start with \"#\"");
+    }
+
+    @Test
+    void catchesACommentSpanningMoreThanItsOwnLine() {
+        assertMalformed(
+          """
+            # first
+            FROM alpine
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Space visitSpace(Space space, ExecutionContext ctx) {
+                  return space.withComments(ListUtils.map(space.getComments(),
+                    comment -> comment.withText(comment.getText() + "\nRUN echo hi")));
+              }
+          },
+          "to hold a single line");
+    }
+
+    @Test
+    void catchesACommentPrecededBySomethingOtherThanWhitespace() {
+        assertMalformed(
+          """
+            # first
+            FROM alpine
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Space visitSpace(Space space, ExecutionContext ctx) {
+                  return space.withComments(ListUtils.map(space.getComments(),
+                    comment -> new Comment(comment.getText(), "RUN echo hi", Markers.EMPTY)));
+              }
+          },
+          "to be whitespace, but it is \"RUN echo hi\"");
+    }
+
+    @Test
+    void catchesAnArgumentWhoseContentsAreSplitApart() {
+        assertMalformed(
+          """
+            FROM alpine
+            ENV KEY=prefix$SUFFIX
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Argument visitArgument(Docker.Argument argument, ExecutionContext ctx) {
+                  return argument.getContents().size() < 2 ? argument :
+                    argument.withContents(ListUtils.map(argument.getContents(),
+                      (i, content) -> i == 0 ? content : content.withPrefix(Space.SINGLE_SPACE)));
+              }
+          },
+          "to be contiguous");
+    }
+
+    @Test
+    void catchesAnImageNameWithNothingInIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.From visitFrom(Docker.From from, ExecutionContext ctx) {
+                  return from.withImageName(from.getImageName().withContents(emptyList()));
+              }
+          },
+          "expected the image name of a From to hold at least one content");
+    }
+
+    @Test
+    void catchesAWorkdirPathWithNothingInIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            WORKDIR /app
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Workdir visitWorkdir(Docker.Workdir workdir, ExecutionContext ctx) {
+                  return workdir.withPath(workdir.getPath().withContents(emptyList()));
+              }
+          },
+          "expected the path of a Workdir to hold at least one content");
+    }
+
+    @Test
+    void catchesACopyDestinationWithNothingInIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            COPY app.jar /app/
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker visitCopyShellForm(Docker.CopyShellForm form, ExecutionContext ctx) {
+                  return form.withDestination(form.getDestination().withContents(emptyList()));
+              }
+          },
+          "expected the destination of a CopyShellForm to hold at least one content");
+    }
+
+    @Test
+    void catchesAQuotedLiteralHoldingTheQuoteThatEndsIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            ENTRYPOINT ["java"]
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.withText("ja\"va");
+              }
+          },
+          "to hold no unescaped \"");
+    }
+
+    /// An ONBUILD's instruction, and a HEALTHCHECK's CMD, correctly sit on the same line as the
+    /// instruction that introduces them.
+    @Test
+    void acceptsAnInstructionSharingALineWithTheOneThatIntroducesIt() {
+        Assertions.assertWellFormed(parse(
+          """
+            FROM alpine
+            ONBUILD RUN echo hi
+            HEALTHCHECK CMD curl -f http://localhost/
+            """));
+    }
+
+    /// Nothing follows the last comment in a file, so nothing can be swallowed into it.
+    @Test
+    void acceptsAFileEndingInACommentWithNoNewlineAfterIt() {
+        Assertions.assertWellFormed(parse("FROM alpine\n# no newline after this"));
+    }
+
+    @Test
+    void catchesASingleQuotedLiteralHoldingTheQuoteThatEndsIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            ENV KEY='value'
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.getQuoteStyle() == Docker.Literal.QuoteStyle.SINGLE ?
+                    literal.withText("va'lue") : literal;
+              }
+          },
+          "to hold no unescaped '");
+    }
+
+    private static void assertMalformed(@Language("dockerfile") String source,
+                                        DockerIsoVisitor<ExecutionContext> mutation,
+                                        String violation) {
+        SourceFile parsed = parse(source);
+        Assertions.assertWellFormed(parsed);
+        SourceFile mutated = (SourceFile) requireNonNull(mutation.visit(parsed, new InMemoryExecutionContext()));
+        assertThatThrownBy(() -> Assertions.assertWellFormed(mutated))
+          .isInstanceOf(AssertionError.class)
+          .hasMessageContaining(violation);
+    }
+
+    private static SourceFile parse(@Language("dockerfile") String source) {
+        return DockerParser.builder().build()
+          .parse(new InMemoryExecutionContext(), source)
+          .findFirst()
+          .orElseThrow();
+    }
 }


### PR DESCRIPTION
- Follows #8601, which asserted that a `Docker` tree *models what it prints*. This asserts that it is *structurally able to print what it models* — the checks deliberately left out of that PR.

A Dockerfile LST prints losslessly by construction, so printing is no evidence a recipe built a sane tree. `Assertions.validate` already ran on both the parsed source and every recipe result; it now also runs twelve structural invariants there.

## The checks, and the recipe bug each one catches

| # | Invariant | What it catches |
|---|---|---|
| 1 | Every element has its own `UUID` | A recipe that copies a subtree without fresh ids hands the same element to two parents. The tree still prints, but a visitor navigating by id, or a later recipe editing one of the two, sees both. `CombineRunInstructions` and `AddOciLabels` are the shape of recipe prone to this. |
| 2 | `keyword` agrees with the instruction type, ignoring case, and carries no surrounding whitespace | A `Run` whose keyword says `EXEC` prints something that is no longer a RUN. Whitespace on a keyword is whitespace the printer expects to find on whatever follows it, so it prints twice or not at all. Includes `From.As.keyword` being `AS`. |
| 3 | Instructions start their own line | A recipe that inserts an instruction without a prefix prints `FROM alpineRUN x`. Applies to each `Stage.instructions` entry, each non-first `File.globalArgs` entry, and each `Stage` (via its own or its `From`'s prefix) after the first thing in the file. An `Onbuild`'s instruction and a `Healthcheck`'s `Cmd` correctly share their parent's line and are excluded — `acceptsAnInstructionSharingALineWithTheOneThatIntroducesIt` holds that carve-out in place. |
| 4 | `Flag.name` is bare | `DockerPrinter#visitFlag` writes the leading `--` and any `=` itself, so a flag named `--platform` prints as `----platform`. |
| 5 | `HEALTHCHECK NONE` carries no flags | `DockerPrinter#visitHealthcheck` silently drops `getFlags()` when `cmd == null`. Pure, previously unguarded data loss. |
| 6 | Exec-form literals are double quoted | Every `Literal` in `ExecForm.arguments`, `Shell.arguments` and a JSON-form `Volume.values`. JSON arrays are the one place a Dockerfile is not shell; an element that loses its quotes prints an array Docker refuses to read. Directly relevant to `UseExecFormEntrypoint`. |
| 7 | `Port.text` agrees with its parsed fields | A `Port` prints its text and models its fields, so the two can disagree without the printed source ever saying so. `start`, `end` and `protocol` are re-derived from the text and compared, and the range is checked against 0–65535. Ports holding a variable are skipped. |
| 8 | Heredoc integrity | `<<` markers in `HeredocForm.preamble` match `bodies.size()`, each body closes with the marker at its position, each `contentLines` entry ends with a newline, and `opening` starts with `<<`. A body whose closing marker no longer matches never terminates on reparse. |
| 9 | Comments are well formed | `Comment.text` starts with `#` and holds one line, its prefix is whitespace, and whatever follows it has a newline — otherwise the next token is read back as part of the comment. The last comment in the file is exempt, since nothing follows it. |
| 10 | `Argument.contents` are contiguous | Whitespace on a content after the first splits the argument in two when the file is read back, so `prefix$SUFFIX` becomes two arguments. |
| 11 | Required arguments are non-empty | `From.imageName`, `Workdir.path` and `CopyShellForm.destination` hold at least one content. An emptied one prints `FROM ` and loses the instruction's subject. |
| 12 | A quoted `Literal` holds no unescaped quote of its own style | The quote ends the string when it is read back. Single-quoted strings have no escape processing at all (`SQ_STRING` in the lexer), so any `'` counts. |

## Gating

Ungated. `allowNonWhitespaceInWhitespace` and `parseAndPrintEquality` are both tolerances for something a test might reasonably want to allow: formatting that is not quite formatting, and the cost of a full reparse. There is no comparable reason to want a tree that cannot print what it models, so these throw unconditionally. They fire zero times across the module's 533 existing tests.

## Mutation tests

Every check has a test that mutates a parsed tree the way a recipe assembling one by hand would, and asserts validation says so. `assertMalformed` first asserts the *unmutated* parse is well formed, so each test proves the mutation alone is what fires the check.

They call the checks directly rather than driving a recipe, deliberately: a recipe result is only validated when the recipe changed the printed source, and several of these defects — a duplicated id, a port disagreeing with its text — change nothing about what the tree prints, so a `rewriteRun` would never reach the assertion. `validatesTheTreeARecipeProduces` covers the wiring end to end with a mutation that *does* change the text.

- Neutering `assertWellFormed` fails 30 of the 33 tests in `AssertionsTest`; the 3 that survive are #8601's test and the two positive tests asserting the carve-outs.

## Left alone, deliberately

- **`Space#getLastWhitespace()` and `getIndent()`** answer with the *last comment's prefix* when a `Space` holds comments, but `DockerPrinter` writes comments *before* the whitespace, so the text abutting the next token is always the whitespace. Both are unused in `rewrite-docker`, so this is latent rather than live. Check 3 is built on `getWhitespace()` and says why at `WellFormedVisitor#containsNewline`; fixing the two methods is a behavioural change to `Space` and belongs in its own PR.
- **An unquoted `Literal` whose text starts with a quote**, and **a `Literal` holding an unmodelled `$VAR`**. Both are the documented current behaviour of the old-format ENV/LABEL parse path — see `EnvTest.quotedValueFollowedByMoreTextIsWhole` and `LabelTest.oldFormatValueIsOneLiteralHoldingSourceText`. Real modelling debt, but it belongs behind a parser fix rather than in front of it; asserting it now would only break tests that assert today's shape.

`./gradlew :rewrite-docker:build --offline` is green.