### PR TITLE
Go: validate print-equals-input at parse time

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -41,6 +42,7 @@ import (
 	"github.com/grafana/pyroscope-go"
 	"golang.org/x/mod/module"
 
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/diff"
 	goparser "github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/preconditions"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
@@ -537,10 +539,11 @@ func (s *server) handleGetLanguages() []string {
 // them, the server falls back to per-file parsing with the stdlib
 // importer (today's behavior).
 type parseRequest struct {
-	Inputs       []parseInput `json:"inputs"`
-	RelativeTo   *string      `json:"relativeTo"`
-	Module       string       `json:"module,omitempty"`
-	GoModContent string       `json:"goModContent,omitempty"`
+	Inputs       []parseInput   `json:"inputs"`
+	RelativeTo   *string        `json:"relativeTo"`
+	Module       string         `json:"module,omitempty"`
+	GoModContent string         `json:"goModContent,omitempty"`
+	Options      map[string]any `json:"options,omitempty"`
 }
 
 // parseInput can be a path-based or text-based input.
@@ -566,6 +569,51 @@ func (p *parseInput) UnmarshalJSON(data []byte) error {
 	}
 	*p = parseInput(a)
 	return nil
+}
+
+// Mirrors org.openrewrite.ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT.
+const requirePrintEqualsInputKey = "org.openrewrite.requirePrintEqualsInput"
+
+// A variable so tests can substitute a printer that produces the mismatch
+// this check exists to catch.
+var printGoCompilationUnit = func(cu *golang.CompilationUnit) string {
+	return printer.Print(cu)
+}
+
+// requirePrintEqualsInput reports whether parse results must print back to
+// their input, which they must unless the client says otherwise. Option maps
+// are loosely typed across peers, so both the string and bool forms count.
+func requirePrintEqualsInput(options map[string]any) bool {
+	switch v := options[requirePrintEqualsInputKey].(type) {
+	case bool:
+		return v
+	case string:
+		enabled, err := strconv.ParseBool(v)
+		return err != nil || enabled
+	}
+	return true
+}
+
+// packageParseError describes, for the file at path, why it has no compilation
+// unit: its own syntax error, or that of the sibling that stopped the package.
+func packageParseError(err error, path string) error {
+	var ppe *goparser.PackageParseError
+	if errors.As(err, &ppe) && ppe.Path != path {
+		return fmt.Errorf("package not parsed: %v", ppe)
+	}
+	return err
+}
+
+// printIdempotencyError reports a compilation unit that does not print back to
+// the source it was parsed from. The message matches the JVM's
+// Parser.requirePrintEqualsInput so both engines word the failure the same way.
+func printIdempotencyError(cu *golang.CompilationUnit, source string) error {
+	printed := printGoCompilationUnit(cu)
+	if printed == source {
+		return nil
+	}
+	return fmt.Errorf("%s is not print idempotent. \n%s", cu.SourcePath,
+		diff.Unified(source, printed, cu.SourcePath))
 }
 
 // When req.Module + req.GoModContent are set, the handler builds a
@@ -678,6 +726,7 @@ func (s *server) handleParse(params json.RawMessage) (any, *rpcError) {
 	// `included` subset of the group.
 	cuByIdx := make(map[int]*golang.CompilationUnit, len(resolvedInputs))
 	parseErrByIdx := make(map[int]error)
+	checkPrint := requirePrintEqualsInput(req.Options)
 	for _, group := range groups {
 		included := make([]fileEntry, 0, len(group))
 		files := make([]goparser.FileInput, 0, len(group))
@@ -703,11 +752,17 @@ func (s *server) handleParse(params json.RawMessage) (any, *rpcError) {
 			// Whole-package parse failure — record per-file ParseErrors
 			// for every file the build context didn't exclude.
 			for _, g := range included {
-				parseErrByIdx[g.idx] = err
+				parseErrByIdx[g.idx] = packageParseError(err, g.input.Path)
 			}
 			continue
 		}
 		for i, cu := range cus {
+			if checkPrint {
+				if perr := printIdempotencyError(cu, included[i].input.Content); perr != nil {
+					parseErrByIdx[included[i].idx] = perr
+					continue
+				}
+			}
 			cuByIdx[included[i].idx] = cu
 		}
 	}
@@ -2252,9 +2307,10 @@ func (s *server) handleTraceGetObject(params json.RawMessage) (any, *rpcError) {
 }
 
 type parseProjectRequest struct {
-	ProjectPath string   `json:"projectPath"`
-	Exclusions  []string `json:"exclusions"`
-	RelativeTo  *string  `json:"relativeTo"`
+	ProjectPath string         `json:"projectPath"`
+	Exclusions  []string       `json:"exclusions"`
+	RelativeTo  *string        `json:"relativeTo"`
+	Options     map[string]any `json:"options,omitempty"`
 }
 
 type parseProjectResponseItem struct {
@@ -2572,6 +2628,7 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 	groups := make(map[groupKey][]fileEntry)
 	type ordered struct {
 		idx        int
+		path       string
 		sourcePath string
 		modCtx     *modCtx
 	}
@@ -2599,7 +2656,7 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 			sourcePath: sourcePath,
 			content:    src,
 		})
-		order = append(order, ordered{idx: i, sourcePath: sourcePath, modCtx: m})
+		order = append(order, ordered{idx: i, path: goFile, sourcePath: sourcePath, modCtx: m})
 	}
 
 	// Parse each group; collect CUs by original input index so the
@@ -2608,6 +2665,8 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 	// don't appear in the response — handled here so the post-parse
 	// `cus` slice aligns with the `included` subset of entries.
 	cuByIdx := make(map[int]*golang.CompilationUnit, len(disc.goFiles))
+	parseErrByIdx := make(map[int]error)
+	checkPrint := requirePrintEqualsInput(req.Options)
 	for key, entries := range groups {
 		p := goparser.NewGoParser()
 		if pi, ok := piByModule[key.moduleDir]; ok {
@@ -2636,10 +2695,18 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		if err != nil {
 			for _, e := range included {
 				s.logger.Printf("ParseProject: parse error in %s: %v", e.path, err)
+				parseErrByIdx[e.idx] = packageParseError(err, e.sourcePath)
 			}
 			continue
 		}
 		for i, cu := range cus {
+			if checkPrint {
+				if perr := printIdempotencyError(cu, included[i].content); perr != nil {
+					s.logger.Printf("ParseProject: %v", perr)
+					parseErrByIdx[included[i].idx] = perr
+					continue
+				}
+			}
 			cuByIdx[included[i].idx] = cu
 		}
 	}
@@ -2650,6 +2717,19 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 	for _, o := range order {
 		cu, ok := cuByIdx[o.idx]
 		if !ok || cu == nil {
+			// Two ways to reach this: the BuildContext excluded the file, which
+			// stays out of the response, or parsing failed, which is reported so
+			// the file still reaches the JVM.
+			if perr := parseErrByIdx[o.idx]; perr != nil {
+				pe := java.NewParseError(o.sourcePath, contents[o.path], perr)
+				id := pe.Ident.String()
+				s.localObjects[id] = pe
+				items = append(items, parseProjectResponseItem{
+					ID:             id,
+					SourceFileType: "org.openrewrite.tree.ParseError",
+					SourcePath:     o.sourcePath,
+				})
+			}
 			continue
 		}
 		if o.modCtx != nil {

--- a/rewrite-go/cmd/rpc/print_idempotency_test.go
+++ b/rewrite-go/cmd/rpc/print_idempotency_test.go
@@ -1,0 +1,277 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/printer"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// The printer reproduces every source these tests use, so a mismatch has to be
+// induced to exercise the reporting path at all.
+func manglePrinterFor(t *testing.T, victim string) {
+	t.Helper()
+	original := printGoCompilationUnit
+	printGoCompilationUnit = func(cu *golang.CompilationUnit) string {
+		out := original(cu)
+		if filepath.Base(cu.SourcePath) == victim {
+			return strings.Replace(out, "\tsecond := 2\n", "", 1)
+		}
+		return out
+	}
+	t.Cleanup(func() { printGoCompilationUnit = original })
+}
+
+const idempotencySource = `package p
+
+func %s() {
+	first := 1
+	second := 2
+	_, _ = first, second
+}
+`
+
+func parseTwoSiblings(t *testing.T, s *server, options map[string]any) map[string]any {
+	t.Helper()
+	dir := t.TempDir()
+	for _, f := range []struct{ name, fn string }{{"a.go", "a"}, {"b.go", "b"}} {
+		writeFile(t, filepath.Join(dir, f.name), strings.Replace(idempotencySource, "%s", f.fn, 1))
+	}
+	relativeTo := dir
+	params, err := json.Marshal(parseRequest{
+		Inputs:     []parseInput{{Path: filepath.Join(dir, "a.go")}, {Path: filepath.Join(dir, "b.go")}},
+		RelativeTo: &relativeTo,
+		Options:    options,
+	})
+	require.NoError(t, err)
+
+	res, rpcErr := s.handleParse(params)
+	require.Nil(t, rpcErr)
+	ids, ok := res.([]string)
+	require.True(t, ok)
+	require.Len(t, ids, 2)
+
+	byName := map[string]any{}
+	for i, name := range []string{"a.go", "b.go"} {
+		byName[name] = s.localObjects[ids[i]]
+	}
+	return byName
+}
+
+func TestHandleParseReportsPrintMismatchPerFile(t *testing.T) {
+	s, _ := newTestServer(t)
+	manglePrinterFor(t, "a.go")
+
+	byName := parseTwoSiblings(t, s, nil)
+
+	pe, ok := byName["a.go"].(*java.ParseError)
+	require.Truef(t, ok, "a.go should be a ParseError, got %T", byName["a.go"])
+	assert.Equal(t, "a.go", pe.SourcePath)
+
+	marker, ok := pe.Markers.Entries[0].(java.ParseExceptionResult)
+	require.True(t, ok)
+	assert.Contains(t, marker.Message, "a.go is not print idempotent.")
+	assert.Contains(t, marker.Message, "--- a/a.go")
+	assert.Contains(t, marker.Message, "-\tsecond := 2")
+
+	// The sibling shares a package and a ParsePackage call; a print
+	// mismatch in one file must not turn the other into an error.
+	_, ok = byName["b.go"].(*golang.CompilationUnit)
+	assert.Truef(t, ok, "b.go should still be a CompilationUnit, got %T", byName["b.go"])
+}
+
+func TestHandleParseChecksPrintByDefault(t *testing.T) {
+	s, _ := newTestServer(t)
+	manglePrinterFor(t, "a.go")
+
+	byName := parseTwoSiblings(t, s, map[string]any{})
+
+	assert.IsType(t, &java.ParseError{}, byName["a.go"])
+}
+
+func TestHandleParseSkipsPrintCheckWhenDisabled(t *testing.T) {
+	s, _ := newTestServer(t)
+	manglePrinterFor(t, "a.go")
+
+	byName := parseTwoSiblings(t, s, map[string]any{requirePrintEqualsInputKey: "false"})
+
+	assert.IsType(t, &golang.CompilationUnit{}, byName["a.go"])
+}
+
+func TestRequirePrintEqualsInputDefaultsOn(t *testing.T) {
+	assert.True(t, requirePrintEqualsInput(nil))
+	assert.True(t, requirePrintEqualsInput(map[string]any{}))
+	assert.True(t, requirePrintEqualsInput(map[string]any{requirePrintEqualsInputKey: "true"}))
+	assert.True(t, requirePrintEqualsInput(map[string]any{requirePrintEqualsInputKey: true}))
+	assert.True(t, requirePrintEqualsInput(map[string]any{requirePrintEqualsInputKey: "nonsense"}))
+	assert.False(t, requirePrintEqualsInput(map[string]any{requirePrintEqualsInputKey: "false"}))
+	assert.False(t, requirePrintEqualsInput(map[string]any{requirePrintEqualsInputKey: false}))
+}
+
+func parseProjectItems(t *testing.T, s *server, dir string, options map[string]any) map[string]parseProjectResponseItem {
+	t.Helper()
+	relativeTo := dir
+	params, err := json.Marshal(parseProjectRequest{ProjectPath: dir, RelativeTo: &relativeTo, Options: options})
+	require.NoError(t, err)
+
+	res, rpcErr := s.handleParseProject(params)
+	require.Nil(t, rpcErr)
+	items, ok := res.([]parseProjectResponseItem)
+	require.True(t, ok)
+
+	byPath := map[string]parseProjectResponseItem{}
+	for _, item := range items {
+		byPath[filepath.ToSlash(item.SourcePath)] = item
+	}
+	return byPath
+}
+
+func TestParseProjectReportsPrintMismatchPerFile(t *testing.T) {
+	s, _ := newTestServer(t)
+	manglePrinterFor(t, "a.go")
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/m\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(dir, "a.go"), strings.Replace(idempotencySource, "%s", "a", 1))
+	writeFile(t, filepath.Join(dir, "b.go"), strings.Replace(idempotencySource, "%s", "b", 1))
+
+	byPath := parseProjectItems(t, s, dir, nil)
+
+	require.Contains(t, byPath, "a.go")
+	assert.Equal(t, "org.openrewrite.tree.ParseError", byPath["a.go"].SourceFileType)
+	pe, ok := s.localObjects[byPath["a.go"].ID].(*java.ParseError)
+	require.Truef(t, ok, "expected a ParseError object, got %T", s.localObjects[byPath["a.go"].ID])
+	assert.Equal(t, idempotencySourceFor("a"), pe.Text)
+
+	require.Contains(t, byPath, "b.go")
+	assert.Equal(t, "org.openrewrite.golang.tree.Go$CompilationUnit", byPath["b.go"].SourceFileType)
+}
+
+func TestParseProjectSkipsPrintCheckWhenDisabled(t *testing.T) {
+	s, _ := newTestServer(t)
+	manglePrinterFor(t, "a.go")
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/m\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(dir, "a.go"), strings.Replace(idempotencySource, "%s", "a", 1))
+
+	byPath := parseProjectItems(t, s, dir, map[string]any{requirePrintEqualsInputKey: "false"})
+
+	assert.Equal(t, "org.openrewrite.golang.tree.Go$CompilationUnit", byPath["a.go"].SourceFileType)
+}
+
+func TestParseProjectEmitsParseErrorForUnparseableFile(t *testing.T) {
+	s, _ := newTestServer(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/m\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(dir, "broken.go"), "package p\n\nfunc f( {\n")
+
+	byPath := parseProjectItems(t, s, dir, nil)
+
+	require.Contains(t, byPath, "broken.go")
+	assert.Equal(t, "org.openrewrite.tree.ParseError", byPath["broken.go"].SourceFileType)
+	pe, ok := s.localObjects[byPath["broken.go"].ID].(*java.ParseError)
+	require.True(t, ok)
+	assert.Equal(t, "package p\n\nfunc f( {\n", pe.Text)
+}
+
+func TestParseProjectAttributesSyntaxErrorToTheOffendingFile(t *testing.T) {
+	s, _ := newTestServer(t)
+
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "go.mod"), "module example.com/m\n\ngo 1.22\n")
+	writeFile(t, filepath.Join(dir, "broken.go"), "package p\n\nfunc Broken( {\n")
+	writeFile(t, filepath.Join(dir, "innocent.go"), "package p\n\nfunc Innocent() {}\n")
+
+	byPath := parseProjectItems(t, s, dir, nil)
+
+	// One file's syntax error stops the whole package, so neither gets a
+	// compilation unit and both have to be accounted for.
+	for _, name := range []string{"broken.go", "innocent.go"} {
+		require.Containsf(t, byPath, name, "every file in the package must be accounted for")
+		assert.Equal(t, "org.openrewrite.tree.ParseError", byPath[name].SourceFileType)
+	}
+
+	assert.Contains(t, messageOf(t, s, byPath["broken.go"].ID), "parse broken.go:")
+
+	innocent := messageOf(t, s, byPath["innocent.go"].ID)
+	assert.Contains(t, innocent, "package not parsed")
+	assert.Contains(t, innocent, "broken.go")
+	assert.NotContains(t, innocent, "parse innocent.go:")
+}
+
+func messageOf(t *testing.T, s *server, id string) string {
+	t.Helper()
+	pe, ok := s.localObjects[id].(*java.ParseError)
+	require.Truef(t, ok, "expected a ParseError, got %T", s.localObjects[id])
+	marker, ok := pe.Markers.Entries[0].(java.ParseExceptionResult)
+	require.True(t, ok)
+	return marker.Message
+}
+
+func idempotencySourceFor(fn string) string {
+	return strings.Replace(idempotencySource, "%s", fn, 1)
+}
+
+func TestPrinterRoundTripsTrickyFiles(t *testing.T) {
+	cases := map[string]string{
+		"crlf":            "package m\r\n\r\nfunc f() {\r\n\tx := 1\r\n\t_ = x\r\n}\r\n",
+		"bom":             "\ufeffpackage m\n",
+		"lineDirective":   "package m\n\n//line foo.go:10\nfunc f() {}\n",
+		"noTrailingNL":    "package m",
+		"commentInParams": "package m\n\nfunc f(a /* x */ int) {}\n",
+		"semicolons":      "package m\n\nfunc f() { a := 1; b := 2; _, _ = a, b }\n",
+		"rawString":       "package m\n\nvar s = `a\\nb\n\tc`\n",
+		"emptyDecls":      "package m\n\nimport ()\n\nvar ()\n\ntype ()\n",
+		"cgoPreamble":     "package m\n\n/*\n#include <stdio.h>\n*/\nimport \"C\"\n",
+		"trailingSpaces":  "package m   \n\nfunc f() {}   \n",
+		"mixedIndent":     "package m\n\nfunc f() {\n  x := 1\n\t_ = x\n}\n",
+		"unicodeIdent":    "package m\n\nvar élève = 1\n",
+		"adjacentComment": "package m\n\n// a\n/* b */\n// c\nfunc f() {}\n",
+	}
+
+	s, _ := newTestServer(t)
+	for name, src := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, name+".go")
+			writeFile(t, path, src)
+			relativeTo := dir
+			params, err := json.Marshal(parseRequest{Inputs: []parseInput{{Path: path}}, RelativeTo: &relativeTo})
+			require.NoError(t, err)
+
+			res, rpcErr := s.handleParse(params)
+			require.Nil(t, rpcErr)
+			ids := res.([]string)
+			require.Len(t, ids, 1)
+
+			cu, ok := s.localObjects[ids[0]].(*golang.CompilationUnit)
+			require.Truef(t, ok, "expected a CompilationUnit, got %T", s.localObjects[ids[0]])
+			assert.Equal(t, src, printer.Print(cu))
+		})
+	}
+}

--- a/rewrite-go/pkg/diff/unified.go
+++ b/rewrite-go/pkg/diff/unified.go
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package diff renders unified diffs for parse-to-print idempotency
+// diagnostics. The output mirrors the C# engine's Core/DiffUtils so the
+// two report the same shape for the same class of failure.
+package diff
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	contextLines = 3
+
+	// Diffs travel to the JVM inside a ParseError marker, so a file the
+	// printer mangles wholesale must not produce a multi-megabyte message.
+	maxDiffLines = 200
+
+	// The LCS table is one cell per line pair. Beyond this the diff
+	// degrades to a plain delete-all/insert-all listing, which truncation
+	// then trims to the leading mismatch.
+	maxLCSCells = 4_000_000
+
+	noNewlineMarker = `\ No newline at end of file`
+)
+
+// Unified renders a git-style unified diff of before against after,
+// or "" when they are identical.
+func Unified(before, after, path string) string {
+	if before == after {
+		return ""
+	}
+
+	a := splitLines(before)
+	b := splitLines(after)
+
+	// Diff only the region around the mismatch: an idempotency failure is
+	// usually a handful of lines in an otherwise identical file.
+	offset := commonPrefix(a, b)
+	if offset > contextLines {
+		offset -= contextLines
+	} else {
+		offset = 0
+	}
+	trimBack := commonSuffix(a[offset:], b[offset:])
+	if trimBack > contextLines {
+		trimBack -= contextLines
+	} else {
+		trimBack = 0
+	}
+	a = a[offset : len(a)-trimBack]
+	b = b[offset : len(b)-trimBack]
+
+	edits := computeEdits(a, b)
+
+	out := []string{"--- a/" + path, "+++ b/" + path}
+	body := make([]string, 0, maxDiffLines)
+	truncated := false
+	for _, hunk := range groupIntoHunks(edits) {
+		if len(body) >= maxDiffLines {
+			truncated = true
+			break
+		}
+		body, truncated = formatHunk(body, maxDiffLines, edits, hunk, a, b, offset)
+		if truncated {
+			break
+		}
+	}
+	out = append(out, body...)
+	if truncated {
+		out = append(out, fmt.Sprintf("... diff truncated after %d lines", maxDiffLines))
+	}
+	return strings.Join(out, "\n") + "\n"
+}
+
+// splitLines drops the empty element a trailing newline leaves behind, and
+// marks its absence the way git does so that a printer which gains or loses
+// the final newline still renders as a visible difference.
+func splitLines(text string) []string {
+	if text == "" {
+		return nil
+	}
+	lines := strings.Split(text, "\n")
+	if lines[len(lines)-1] == "" {
+		return lines[:len(lines)-1]
+	}
+	return append(lines, noNewlineMarker)
+}
+
+func commonPrefix(a, b []string) int {
+	n := 0
+	for n < len(a) && n < len(b) && a[n] == b[n] {
+		n++
+	}
+	return n
+}
+
+func commonSuffix(a, b []string) int {
+	n := 0
+	for n < len(a) && n < len(b) && a[len(a)-1-n] == b[len(b)-1-n] {
+		n++
+	}
+	return n
+}
+
+type editKind int
+
+const (
+	editEqual editKind = iota
+	editDelete
+	editInsert
+)
+
+type edit struct {
+	kind   editKind
+	aIndex int
+	bIndex int
+}
+
+func computeEdits(a, b []string) []edit {
+	if len(a)*len(b) > maxLCSCells {
+		edits := make([]edit, 0, len(a)+len(b))
+		for i := range a {
+			edits = append(edits, edit{editDelete, i, -1})
+		}
+		for j := range b {
+			edits = append(edits, edit{editInsert, -1, j})
+		}
+		return edits
+	}
+
+	lcs := computeLCSTable(a, b)
+	stride := len(b) + 1
+	edits := make([]edit, 0, len(a)+len(b))
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		switch {
+		case a[i] == b[j]:
+			edits = append(edits, edit{editEqual, i, j})
+			i++
+			j++
+		case lcs[(i+1)*stride+j] >= lcs[i*stride+j+1]:
+			edits = append(edits, edit{editDelete, i, -1})
+			i++
+		default:
+			edits = append(edits, edit{editInsert, -1, j})
+			j++
+		}
+	}
+	for ; i < len(a); i++ {
+		edits = append(edits, edit{editDelete, i, -1})
+	}
+	for ; j < len(b); j++ {
+		edits = append(edits, edit{editInsert, -1, j})
+	}
+	return edits
+}
+
+func computeLCSTable(a, b []string) []int {
+	m, n := len(a), len(b)
+	stride := n + 1
+	dp := make([]int, (m+1)*stride)
+	for i := m - 1; i >= 0; i-- {
+		for j := n - 1; j >= 0; j-- {
+			if a[i] == b[j] {
+				dp[i*stride+j] = dp[(i+1)*stride+j+1] + 1
+			} else if dp[(i+1)*stride+j] >= dp[i*stride+j+1] {
+				dp[i*stride+j] = dp[(i+1)*stride+j]
+			} else {
+				dp[i*stride+j] = dp[i*stride+j+1]
+			}
+		}
+	}
+	return dp
+}
+
+type hunkRange struct{ startEdit, endEdit int }
+
+func groupIntoHunks(edits []edit) []hunkRange {
+	type span struct{ start, end int }
+	var changes []span
+	rangeStart := -1
+	for idx, e := range edits {
+		if e.kind != editEqual {
+			if rangeStart < 0 {
+				rangeStart = idx
+			}
+		} else if rangeStart >= 0 {
+			changes = append(changes, span{rangeStart, idx - 1})
+			rangeStart = -1
+		}
+	}
+	if rangeStart >= 0 {
+		changes = append(changes, span{rangeStart, len(edits) - 1})
+	}
+	if len(changes) == 0 {
+		return nil
+	}
+
+	var hunks []hunkRange
+	curStart := max(0, changes[0].start-contextLines)
+	curEnd := min(len(edits)-1, changes[0].end+contextLines)
+	for _, c := range changes[1:] {
+		nextStart := max(0, c.start-contextLines)
+		nextEnd := min(len(edits)-1, c.end+contextLines)
+		if nextStart <= curEnd+1 {
+			curEnd = nextEnd
+			continue
+		}
+		hunks = append(hunks, hunkRange{curStart, curEnd})
+		curStart, curEnd = nextStart, nextEnd
+	}
+	return append(hunks, hunkRange{curStart, curEnd})
+}
+
+// formatHunk appends one hunk to out, stopping and reporting truncation once
+// out reaches limit. offset restores the absolute line numbers of the region
+// Unified trimmed.
+func formatHunk(out []string, limit int, edits []edit, hunk hunkRange, a, b []string, offset int) ([]string, bool) {
+	hunkEdits := edits[hunk.startEdit : hunk.endEdit+1]
+
+	aCount, bCount := 0, 0
+	aStart, bStart := -1, -1
+	for _, e := range hunkEdits {
+		if e.kind != editInsert {
+			if aStart < 0 {
+				aStart = e.aIndex
+			}
+			if a[e.aIndex] != noNewlineMarker {
+				aCount++
+			}
+		}
+		if e.kind != editDelete {
+			if bStart < 0 {
+				bStart = e.bIndex
+			}
+			if b[e.bIndex] != noNewlineMarker {
+				bCount++
+			}
+		}
+	}
+
+	out = append(out, fmt.Sprintf("@@ -%d,%d +%d,%d @@",
+		rangeStart(aStart, aCount, offset), aCount,
+		rangeStart(bStart, bCount, offset), bCount))
+
+	for _, e := range hunkEdits {
+		if len(out) >= limit {
+			return out, true
+		}
+		switch {
+		case e.kind == editEqual && a[e.aIndex] == noNewlineMarker:
+			out = append(out, noNewlineMarker)
+		case e.kind == editEqual:
+			out = append(out, " "+a[e.aIndex])
+		case e.kind == editDelete && a[e.aIndex] == noNewlineMarker,
+			e.kind == editInsert && b[e.bIndex] == noNewlineMarker:
+			out = append(out, noNewlineMarker)
+		case e.kind == editDelete:
+			out = append(out, "-"+a[e.aIndex])
+		default:
+			out = append(out, "+"+b[e.bIndex])
+		}
+	}
+	return out, false
+}
+
+// rangeStart renders a hunk header's line number, using git's 0 for a side the
+// hunk contributes no lines to.
+func rangeStart(start, count, offset int) int {
+	if count == 0 {
+		return max(start, 0) + offset
+	}
+	return start + offset + 1
+}

--- a/rewrite-go/pkg/diff/unified_test.go
+++ b/rewrite-go/pkg/diff/unified_test.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package diff
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func lines(from, to int) string {
+	var sb strings.Builder
+	for i := from; i <= to; i++ {
+		fmt.Fprintf(&sb, "l%d\n", i)
+	}
+	return sb.String()
+}
+
+func TestUnifiedIdentical(t *testing.T) {
+	assert.Equal(t, "", Unified(lines(1, 10), lines(1, 10), "foo.go"))
+	assert.Equal(t, "", Unified("", "", "foo.go"))
+}
+
+func TestUnifiedSingleChangedLine(t *testing.T) {
+	before := lines(1, 10)
+	after := strings.Replace(before, "l5\n", "L5\n", 1)
+
+	assert.Equal(t, `--- a/foo.go
++++ b/foo.go
+@@ -2,7 +2,7 @@
+ l2
+ l3
+ l4
+-l5
++L5
+ l6
+ l7
+ l8
+`, Unified(before, after, "foo.go"))
+}
+
+func TestUnifiedDistantChangesProduceTwoHunks(t *testing.T) {
+	before := lines(1, 30)
+	after := strings.Replace(before, "l2\n", "L2\n", 1)
+	after = strings.Replace(after, "l25\n", "L25\n", 1)
+
+	out := Unified(before, after, "foo.go")
+	assert.Equal(t, 2, strings.Count(out, "@@ -"), "expected two hunks in:\n"+out)
+	assert.Contains(t, out, "@@ -1,5 +1,5 @@")
+	assert.Contains(t, out, "@@ -22,7 +22,7 @@")
+}
+
+func TestUnifiedNearbyChangesMergeIntoOneHunk(t *testing.T) {
+	before := lines(1, 30)
+	after := strings.Replace(before, "l10\n", "L10\n", 1)
+	after = strings.Replace(after, "l13\n", "L13\n", 1)
+
+	out := Unified(before, after, "foo.go")
+	assert.Equal(t, 1, strings.Count(out, "@@ -"), "expected one merged hunk in:\n"+out)
+}
+
+func TestUnifiedPureInsertion(t *testing.T) {
+	assert.Equal(t, `--- a/foo.go
++++ b/foo.go
+@@ -1,2 +1,3 @@
+ l1
++inserted
+ l2
+`, Unified("l1\nl2\n", "l1\ninserted\nl2\n", "foo.go"))
+}
+
+func TestUnifiedTrailingNewlineOnlyDifference(t *testing.T) {
+	out := Unified("package main\n", "package main", "foo.go")
+	// Splitting on "\n" alone would render this as an empty diff.
+	assert.NotEmpty(t, out)
+	assert.Contains(t, out, noNewlineMarker)
+}
+
+func TestUnifiedNoNewlineMarkerIsAnnotationNotLine(t *testing.T) {
+	// git emits the marker unprefixed and outside the @@ line counts.
+	assert.Equal(t, `--- a/foo.go
++++ b/foo.go
+@@ -1,1 +1,1 @@
+ package main
+`+noNewlineMarker+`
+`, Unified("package main\n", "package main", "foo.go"))
+}
+
+func TestUnifiedAgainstEmptyBeforeUsesGitsZeroRange(t *testing.T) {
+	assert.Contains(t, Unified("", "l1\nl2\n", "foo.go"), "@@ -0,0 +1,2 @@")
+}
+
+func TestUnifiedTruncatesRunawayDiff(t *testing.T) {
+	var before, after strings.Builder
+	for i := 0; i < maxDiffLines*2; i++ {
+		fmt.Fprintf(&before, "a%d\n", i)
+		fmt.Fprintf(&after, "b%d\n", i)
+	}
+
+	out := Unified(before.String(), after.String(), "foo.go")
+	assert.Contains(t, out, "diff truncated")
+	assert.LessOrEqual(t, strings.Count(out, "\n"), maxDiffLines+5)
+}
+
+func TestUnifiedGiantInputsDoNotBuildFullTable(t *testing.T) {
+	var before, after strings.Builder
+	for i := 0; i < 40_000; i++ {
+		fmt.Fprintf(&before, "a%d\n", i)
+		fmt.Fprintf(&after, "b%d\n", i)
+	}
+
+	out := Unified(before.String(), after.String(), "foo.go")
+	assert.Contains(t, out, "--- a/foo.go")
+}
+
+func TestUnifiedLineNumbersAreAbsoluteInLongFiles(t *testing.T) {
+	before := lines(1, 5000)
+	after := strings.Replace(before, "l4000\n", "L4000\n", 1)
+
+	out := Unified(before, after, "foo.go")
+	// Common context is trimmed before the LCS runs; the numbers stay absolute.
+	assert.Contains(t, out, "@@ -3997,7 +3997,7 @@")
+	assert.Contains(t, out, "-l4000")
+	assert.Contains(t, out, "+L4000")
+}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -94,6 +94,17 @@ func (gp *GoParser) Parse(sourcePath string, source string) (*golang.Compilation
 	return cus[0], nil
 }
 
+// PackageParseError names the file whose syntax error stopped a package from
+// parsing, so callers reporting per-file can tell the offender from its siblings.
+type PackageParseError struct {
+	Path string
+	Err  error
+}
+
+func (e *PackageParseError) Error() string { return fmt.Sprintf("parse %s: %v", e.Path, e.Err) }
+
+func (e *PackageParseError) Unwrap() error { return e.Err }
+
 // ParsePackage parses every file in a single Go package together so
 // type-checking sees them as one unit. File A's reference to file B's
 // symbol resolves; the resulting CompilationUnits share a single
@@ -126,7 +137,7 @@ func (gp *GoParser) ParsePackage(files []FileInput) ([]*golang.CompilationUnit, 
 	for _, f := range files {
 		a, err := parser.ParseFile(fset, f.Path, f.Content, parser.ParseComments)
 		if err != nil {
-			return nil, fmt.Errorf("parse %s: %w", f.Path, err)
+			return nil, &PackageParseError{Path: f.Path, Err: err}
 		}
 		asts = append(asts, a)
 	}

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/PrintIdempotencyIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/PrintIdempotencyIntegTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.ParseExceptionResult;
+import org.openrewrite.Parser;
+import org.openrewrite.SourceFile;
+import org.openrewrite.golang.GolangParser;
+import org.openrewrite.golang.tree.Go;
+import org.openrewrite.tree.ParseError;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Go server prints every parsed compilation unit and compares it against the
+ * file on disk, reporting a mismatch as a {@link ParseError}. These cover the wire
+ * from the {@link ExecutionContext} option through to that comparison.
+ */
+@Timeout(value = 180, unit = TimeUnit.SECONDS)
+class PrintIdempotencyIntegTest {
+
+    /**
+     * Constructs whose whitespace, line endings or comment placement are the most
+     * likely to be dropped between the Go AST and the LST.
+     */
+    private static final Map<String, String> TRICKY_SOURCES = new LinkedHashMap<>();
+
+    static {
+        TRICKY_SOURCES.put("crlf.go", "package p\r\n\r\nfunc Crlf() int {\r\n\tx := 1\r\n\treturn x\r\n}\r\n");
+        TRICKY_SOURCES.put("bom.go", "\uFEFFpackage p\n\nfunc Bom() {}\n");
+        TRICKY_SOURCES.put("nofinalnewline.go", "package p\n\nfunc NoFinalNewline() {}");
+        TRICKY_SOURCES.put("comments.go", "package p\n\n// a\n/* b */\n// c\nfunc Comments(a /* inline */ int) {}\n");
+        TRICKY_SOURCES.put("mixedindent.go", "package p\n\nfunc MixedIndent() {\n  x := 1\n\t_ = x\n}\n");
+        TRICKY_SOURCES.put("trailingspace.go", "package p   \n\nfunc TrailingSpace() {}   \n");
+        TRICKY_SOURCES.put("rawstring.go", "package p\n\nvar Raw = `a\\nb\n\tc`\n");
+        TRICKY_SOURCES.put("emptydecls.go", "package p\n\nimport ()\n\nvar ()\n\ntype ()\n");
+        TRICKY_SOURCES.put("semicolons.go", "package p\n\nfunc Semis() { a := 1; b := 2; _, _ = a, b }\n");
+        TRICKY_SOURCES.put("linedirective.go", "package p\n\n//line gen.go:10\nfunc LineDirective() {}\n");
+    }
+
+    @TempDir
+    Path tempDir;
+
+    @TempDir
+    Path projectDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(binaryPath)
+                .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Test
+    void trickySourcesSurviveTheCheckWhenParsedAsAProject() throws IOException {
+        write(projectDir.resolve("go.mod"), "module example.com/p\n\ngo 1.22\n");
+        for (Map.Entry<String, String> source : TRICKY_SOURCES.entrySet()) {
+            write(projectDir.resolve(source.getKey()), source.getValue());
+        }
+
+        List<SourceFile> sources = GoRewriteRpc.getOrStart()
+                .parseProject(projectDir, new InMemoryExecutionContext())
+                .collect(toList());
+
+        assertNoParseErrors(sources);
+        assertThat(sources).filteredOn(s -> s instanceof Go.CompilationUnit).hasSize(TRICKY_SOURCES.size());
+    }
+
+    @Test
+    void trickySourcesSurviveTheCheckWhenParsedAsFiles() throws IOException {
+        List<Parser.Input> inputs = TRICKY_SOURCES.entrySet().stream()
+                .map(source -> {
+                    Path path = projectDir.resolve(source.getKey());
+                    try {
+                        write(path, source.getValue());
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                    return Parser.Input.fromFile(path);
+                })
+                .collect(toList());
+
+        List<SourceFile> sources = GolangParser.builder().build()
+                .parseInputs(inputs, projectDir, new InMemoryExecutionContext())
+                .collect(toList());
+
+        assertNoParseErrors(sources);
+    }
+
+    @Test
+    void unparseableFileIsReportedRatherThanDropped() throws IOException {
+        write(projectDir.resolve("go.mod"), "module example.com/p\n\ngo 1.22\n");
+        write(projectDir.resolve("broken.go"), "package p\n\nfunc Broken( {\n");
+
+        List<SourceFile> sources = GoRewriteRpc.getOrStart()
+                .parseProject(projectDir, new InMemoryExecutionContext())
+                .collect(toList());
+
+        assertThat(sources)
+                .filteredOn(s -> s instanceof ParseError)
+                .extracting(s -> s.getSourcePath().toString())
+                .containsExactly("broken.go");
+    }
+
+    private static void assertNoParseErrors(List<SourceFile> sources) {
+        List<ParseError> parseErrors = sources.stream()
+                .filter(s -> s instanceof ParseError)
+                .map(s -> (ParseError) s)
+                .collect(toList());
+        assertThat(parseErrors)
+                .as("expected zero parse errors; got:\n%s", parseErrors.stream()
+                        .map(pe -> pe.getSourcePath() + ": " + pe.getMarkers()
+                                .findFirst(ParseExceptionResult.class)
+                                .map(ParseExceptionResult::getMessage)
+                                .orElse("(no message)"))
+                        .collect(joining("\n")))
+                .isEmpty();
+    }
+
+    private static void write(Path path, String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GolangParser.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GolangParser.java
@@ -61,7 +61,7 @@ public class GolangParser implements Parser {
                     Go.CompilationUnit.class.getName(), ctx, module, goModContent);
         }
         return rpc.parse(sources, relativeTo, this,
-                Go.CompilationUnit.class.getName(), ctx);
+                Go.CompilationUnit.class.getName(), ctx, GoRewriteRpc.parseOptions(ctx));
     }
 
     @Override

--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoParseRequest.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoParseRequest.java
@@ -21,6 +21,7 @@ import org.openrewrite.rpc.request.Parse;
 import org.openrewrite.rpc.request.RpcRequest;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Go-specific Parse RPC payload. Mirrors the rewrite-core {@code Parse}
@@ -52,4 +53,12 @@ public class GoParseRequest implements RpcRequest {
      */
     @Nullable
     String goModContent;
+
+    /**
+     * Parser options the Go server interprets, keyed as in {@link org.openrewrite.ExecutionContext}.
+     * The only key today is {@code REQUIRE_PRINT_EQUALS_INPUT}, which the server treats
+     * as enabled when absent.
+     */
+    @Nullable
+    Map<String, String> options;
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
@@ -56,6 +56,7 @@ import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -118,6 +119,15 @@ public class GoRewriteRpc extends RewriteRpc {
     }
 
     /**
+     * Parser options forwarded to the Go server with every parse request, carrying
+     * this context's {@link ExecutionContext#REQUIRE_PRINT_EQUALS_INPUT} setting.
+     */
+    public static Map<String, String> parseOptions(ExecutionContext ctx) {
+        return Collections.singletonMap(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT,
+                String.valueOf(ctx.getMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, true)));
+    }
+
+    /**
      * Parse a batch of Go source inputs with project (module) context.
      * The Go server constructs a {@code ProjectImporter} from the module
      * path + go.mod content, registers every input as a sibling, and uses
@@ -157,7 +167,8 @@ public class GoRewriteRpc extends RewriteRpc {
                 mappedInputs,
                 relativeTo != null ? relativeTo.toString() : null,
                 module,
-                goModContent
+                goModContent,
+                parseOptions(ctx)
         ), ParseResponse.class);
         if (ids.size() != inputList.size()) {
             throw new IllegalStateException("Parse response size " + ids.size() + " != input size " + inputList.size());
@@ -266,7 +277,7 @@ public class GoRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, base), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, base, parseOptions(ctx)), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 

--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/ParseProject.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/ParseProject.java
@@ -21,6 +21,7 @@ import org.openrewrite.rpc.request.RpcRequest;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 /**
  * RPC request to parse an entire Go project.
@@ -36,17 +37,17 @@ class ParseProject implements RpcRequest {
     @Nullable
     Path relativeTo;
 
-    ParseProject(Path projectPath) {
-        this(projectPath, null, null);
-    }
+    /**
+     * Parser options, as on {@link GoParseRequest#getOptions()}.
+     */
+    @Nullable
+    Map<String, String> options;
 
-    ParseProject(Path projectPath, @Nullable List<String> exclusions) {
-        this(projectPath, exclusions, null);
-    }
-
-    ParseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo) {
+    ParseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo,
+                 @Nullable Map<String, String> options) {
         this.projectPath = projectPath;
         this.exclusions = exclusions;
         this.relativeTo = relativeTo;
+        this.options = options;
     }
 }

--- a/rewrite-go/src/test/java/org/openrewrite/golang/rpc/GoParseOptionsTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/rpc/GoParseOptionsTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GoParseOptionsTest {
+
+    @Test
+    void printIdempotencyIsRequestedByDefault() {
+        assertThat(GoRewriteRpc.parseOptions(new InMemoryExecutionContext()))
+                .containsEntry(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "true");
+    }
+
+    @Test
+    void printIdempotencyFollowsTheExecutionContext() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
+
+        assertThat(GoRewriteRpc.parseOptions(ctx))
+                .containsEntry(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false");
+    }
+
+    @Test
+    void optionsSerializeUnderTheKeyTheGoServerReads() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+
+        // A rename on either side falls back to the default rather than failing.
+
+        assertThat(mapper.writeValueAsString(new GoParseRequest(Collections.emptyList(), null, null, null,
+                Collections.singletonMap(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false"))))
+                .contains("\"options\":{\"org.openrewrite.requirePrintEqualsInput\":\"false\"}");
+
+        assertThat(mapper.writeValueAsString(new ParseProject(java.nio.file.Paths.get("."), null, null,
+                Collections.singletonMap(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false"))))
+                .contains("\"options\":{\"org.openrewrite.requirePrintEqualsInput\":\"false\"}");
+    }
+}


### PR DESCRIPTION
- The Go parse path has no round-trip validation. A `.go` file that parses but prints back differently produces no error, no warning and no `ParseError` — it silently yields a lossy LST, and the loss surfaces later as unexplained hunks in a recipe's `fix.patch`. This was found while verifying moderneinc/recipes-go#84 through the Moderne CLI, where two print-fidelity defects had to be discovered by forcing a full reprint and reading the resulting patch, because nothing in the pipeline reports this class of problem.

Every JVM parser guards against this via `Parser.requirePrintEqualsInput` (`rewrite-core/src/main/java/org/openrewrite/Parser.java:43`) — twenty modules call it. rewrite-go did not.

## Why it has to run in Go

`Go.CompilationUnit.printer()` (`tree/Go.java:252`) round-trips through `GoRewriteRpc.print`, so a JVM-side check would cost an RPC call per file and has nothing local to compare against. The Go server already holds both halves: the source in `handleParse`/`handleParseProject`, and `pkg/printer`.

This is also the TODO already sitting in rewrite-core:

```java
// TODO this should be handled on the remote side.
//    sourceFile = parser.requirePrintEqualsInput(sourceFile, input, relativeTo, ctx);
```
`rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java:641`

## What this does

Both parse handlers print every `*golang.CompilationUnit` and compare it byte-for-byte with the source it was parsed from. A mismatch becomes a per-file `java.ParseError` carrying the original text and the JVM's exact wording, `"<path> is not print idempotent. \n<diff>"`. Per-file matters: the existing failure handling is per-*package*, and a print mismatch in one file must not poison its siblings.

No rewrite-core change was needed. `Parse.options` (a `Map<String, String>`) and the `RewriteRpc.parse(..., options)` overload already existed and Go simply never populated them, so the gate is the existing `ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT` key, on when absent. C# established this exact pattern — `SolutionParser.cs:407` does the same check, gated the same way, in its ParseProject equivalent.

`pkg/diff` is ported from C#'s `Core/DiffUtils` so both engines report this failure identically, with three bounds that file lacks: the diff region is trimmed to the mismatch before the quadratic LCS runs, oversized inputs skip the LCS table, and rendering stops at 200 lines. Without these a wholesale-mangled file would push a multi-megabyte string through RPC into a marker.

## Two repairs in the same handlers

`handleParseProject` dropped a file whose package failed to parse from the response entirely — logged and `continue`d — so the JVM never learned the file existed. It now emits a `ParseError` item; the Java side needed no change, since `parseProject` already resolves `getObject(id, sourceFileType)` generically.

Making those errors visible exposed a second problem: `ParsePackage` bails on the *first* syntax error (`pkg/parser/go_parser.go:129`), so one bad file suppresses every sibling's compilation unit and they all inherited the offender's message — `innocent.go` would report `parse broken.go: broken.go:3:14: expected ')', found '{'`. A typed `PackageParseError` now keeps the syntax error on its own file and tells the siblings which file stopped the package. This also fixes the same long-standing misattribution in `handleParse`.

## Cost

Measured on a real repository, not a fixture — helm/helm, 539 files, 106k LOC, warm, mean of 6 alternating runs of `handleParseProject`:

| check | mean |
|---|---|
| off | 7.101s |
| on | 7.131s |

+30ms, 0.4%. The default stays on comfortably. Zero mismatches across all 532 parsed files; an independent sweep over `rewrite-go` itself (280 files) and 495 Go-stdlib files also found zero, so enabling by default looks safe.

## Tests

`TestUnifiedDiff*` covers the diff renderer including hunk merging, the no-newline annotation, and truncation. `print_idempotency_test.go` covers per-file isolation (a mismatch in one file leaves its package sibling a `CompilationUnit`), the gate in both handlers, syntax-error attribution, and a 13-case round-trip corpus of constructs most likely to be lost — CRLF, BOM, no final newline, `//line` directives, raw strings, mixed indentation, empty declaration groups, a cgo preamble. `PrintIdempotencyIntegTest` runs the same corpus over the real RPC through both the file and project paths; `GoParseOptionsTest` pins the JSON key the Go server reads. The gate and silent-drop tests were mutation-checked — each fails when its behavior is reverted.

Because the Go printer reproduces every source these tests use, the mismatch itself has to be induced; `printGoCompilationUnit` is a variable for that reason.

## Scope

`.go` only. `GoMod`/`GoSum` have their own printers and are equally capable of losing text, and since the JVM-side fallback above is commented out, nothing validates them either — worth a follow-up.

`withErroneous` is not carried. `ParseError.rpcSend`/`rpcReceive` serialize eight fields and `erroneous` is not among them, so retaining the parsed LST on the error would need a rewrite-core codec change affecting all five peers. C# omits it too.

This guards the *parser*. Neither of the two defects that prompted it would have been caught here — both are in code that builds new nodes, where an unmodified round-trip is byte-identical. The argument is that the parser class of loss is undetectable by construction today, and those defects are evidence of how far a fidelity bug travels before anyone notices.

Python has a `require_print_equals_input` helper with zero call sites and JS/TS has nothing, so the same gap exists there; out of scope here.