### PR TITLE
Docker: read an argument's text where the recipes run

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
@@ -87,9 +87,9 @@ public class AddOrUpdateLabel extends Recipe {
 
         @Override
         public Docker.Label.LabelPair visitLabelPair(Docker.Label.LabelPair pair, ExecutionContext ctx) {
-            if (key.equals(pair.getKey().getTextWithVariables())) {
+            if (key.equals(ArgumentContents.textWithVariables(pair.getKey()))) {
                 boolean shouldOverwrite = overwriteExisting == null || overwriteExisting;
-                return shouldOverwrite && !value.equals(pair.getValue().getTextWithVariables()) ?
+                return shouldOverwrite && !value.equals(ArgumentContents.textWithVariables(pair.getValue())) ?
                         pair.withValue(createArgument(value, pair.getValue())
                                 .withPrefix(pair.getValue().getPrefix())) : pair;
             }
@@ -125,7 +125,7 @@ public class AddOrUpdateLabel extends Recipe {
             return new DockerIsoVisitor<AtomicBoolean>() {
                 @Override
                 public Docker.Label.LabelPair visitLabelPair(Docker.Label.LabelPair pair, AtomicBoolean matchFound) {
-                    if (!matchFound.get() && key.equals(pair.getKey().getTextWithVariables())) {
+                    if (!matchFound.get() && key.equals(ArgumentContents.textWithVariables(pair.getKey()))) {
                         matchFound.set(true);
                     }
                     return pair;
@@ -160,7 +160,7 @@ public class AddOrUpdateLabel extends Recipe {
     private static Docker.Argument createArgument(String text, Docker.@Nullable Argument original) {
         Docker.Literal.@Nullable QuoteStyle quoteStyle = null;
         if (text.contains(" ") || text.contains("=")) {
-            Docker.Literal.QuoteStyle originalStyle = original == null ? null : original.getQuoteStyle();
+            Docker.Literal.QuoteStyle originalStyle = original == null ? null : ArgumentContents.quoteStyle(original);
             quoteStyle = originalStyle == null ? Docker.Literal.QuoteStyle.DOUBLE : originalStyle;
         }
         return new Docker.Argument(randomId(), Space.EMPTY, Markers.EMPTY, ArgumentContents.of(text, quoteStyle));

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
@@ -22,6 +22,7 @@ import org.openrewrite.PrintOutputCapture;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.docker.tree.Comment;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
 import org.openrewrite.internal.StringUtils;
@@ -441,7 +442,7 @@ public class Assertions {
             for (int i = 1; i < contents.size(); i++) {
                 Space prefix = contents.get(i).getPrefix();
                 if (!prefix.getWhitespace().isEmpty() || !prefix.getComments().isEmpty()) {
-                    violations.add("expected the contents of the argument " + quoted(argument.getTextWithVariables()) +
+                    violations.add("expected the contents of the argument " + quoted(ArgumentContents.textWithVariables(argument)) +
                             " to be contiguous, but one is preceded by " + quoted(prefix.toString()));
                 }
             }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
@@ -181,12 +181,12 @@ public class ChangeFrom extends Recipe {
             // all three together, and splitting it would quote each part on its own, so it stays whole.
             if (resolvedNewImageName != null && quoteStyle == null) {
                 Docker.@Nullable Argument[] parts = ImageReferences.split(resolvedNewImageName, Space.EMPTY);
-                resolvedNewImageName = parts[0].getTextWithVariables();
+                resolvedNewImageName = ArgumentContents.textWithVariables(parts[0]);
                 if (resolvedNewTag == null && parts[1] != null) {
-                    resolvedNewTag = parts[1].getTextWithVariables();
+                    resolvedNewTag = ArgumentContents.textWithVariables(parts[1]);
                 }
                 if (resolvedNewDigest == null && parts[2] != null) {
-                    resolvedNewDigest = parts[2].getTextWithVariables();
+                    resolvedNewDigest = ArgumentContents.textWithVariables(parts[2]);
                 }
             }
 
@@ -422,7 +422,7 @@ public class ChangeFrom extends Recipe {
 
     private Docker.Argument updatePlatformValue(Docker.@Nullable Argument existingValue, String platform) {
         if (existingValue != null && !existingValue.getContents().isEmpty()) {
-            return existingValue.withContents(ArgumentContents.of(platform, existingValue.getQuoteStyle()));
+            return existingValue.withContents(ArgumentContents.of(platform, ArgumentContents.quoteStyle(existingValue)));
         }
         // Fallback: create new value
         return createPlatformValue(platform, existingValue != null ? existingValue.getPrefix() : Space.EMPTY);

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
@@ -27,9 +27,16 @@ import static java.util.Collections.singletonList;
 import static org.openrewrite.Tree.randomId;
 
 /**
- * Builds the contents of a {@link Docker.Argument} from text. Both the parser and recipes that
- * synthesize values go through here, so a value a recipe writes is modelled the same way as one
- * read back from the printed Dockerfile.
+ * Builds the contents of a {@link Docker.Argument} from text, and reads them back out. Both the
+ * parser and recipes that synthesize values go through here, so a value a recipe writes is modelled
+ * the same way as one read back from the printed Dockerfile.
+ * <p>
+ * {@link Docker.Argument} exposes the readers below as instance methods for recipe authors, but
+ * everything in this module that the Moderne CLI loads from a recipe jar calls them here instead.
+ * The CLI's {@code RecipeClassLoader} delegates {@code org.openrewrite.docker.tree} to its own
+ * bundled rewrite-docker while loading recipes, traits and this package from the recipe jar, so a
+ * method added to an LST class is missing at runtime whenever the CLI predates it. These statics
+ * ship alongside their callers, and read only LST members that long predate them.
  */
 public class ArgumentContents {
     private ArgumentContents() {
@@ -116,6 +123,58 @@ public class ArgumentContents {
                     Markers.EMPTY, current.toString(), null));
         }
         return contents;
+    }
+
+    /// @return The text of every content of `argument`, or `null` if an environment variable
+    /// reference makes it impossible to resolve statically.
+    public static @Nullable String text(Docker.Argument argument) {
+        StringBuilder text = new StringBuilder();
+        for (Docker.ArgumentContent content : argument.getContents()) {
+            if (content instanceof Docker.EnvironmentVariable) {
+                return null;
+            }
+            if (content instanceof Docker.Literal) {
+                text.append(((Docker.Literal) content).getText());
+            }
+        }
+        return text.toString();
+    }
+
+    /// @return As [#text], but rendering environment variable references in their original
+    /// `$VAR` or `${VAR}` form rather than giving up.
+    public static String textWithVariables(Docker.Argument argument) {
+        StringBuilder text = new StringBuilder();
+        for (Docker.ArgumentContent content : argument.getContents()) {
+            if (content instanceof Docker.Literal) {
+                text.append(((Docker.Literal) content).getText());
+            } else if (content instanceof Docker.EnvironmentVariable) {
+                Docker.EnvironmentVariable env = (Docker.EnvironmentVariable) content;
+                text.append(env.isBraced() ? "${" + env.getName() + "}" : "$" + env.getName());
+            }
+        }
+        return text.toString();
+    }
+
+    /// @return The quote style of the first quoted literal in `argument`, or `null` if none is quoted.
+    public static Docker.Literal.@Nullable QuoteStyle quoteStyle(Docker.Argument argument) {
+        for (Docker.ArgumentContent content : argument.getContents()) {
+            if (content instanceof Docker.Literal) {
+                Docker.Literal.QuoteStyle style = ((Docker.Literal) content).getQuoteStyle();
+                if (style != null) {
+                    return style;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static boolean containsVariable(Docker.Argument argument) {
+        for (Docker.ArgumentContent content : argument.getContents()) {
+            if (content instanceof Docker.EnvironmentVariable) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public static boolean containsVariable(String text) {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
@@ -30,13 +30,6 @@ import static org.openrewrite.Tree.randomId;
  * Builds the contents of a {@link Docker.Argument} from text, and reads them back out. Both the
  * parser and recipes that synthesize values go through here, so a value a recipe writes is modelled
  * the same way as one read back from the printed Dockerfile.
- * <p>
- * The readers live here rather than on {@link Docker.Argument} because the Moderne CLI's
- * {@code RecipeClassLoader} delegates {@code org.openrewrite.docker.tree} to the rewrite-docker the
- * CLI itself bundles, while loading recipes, traits and this package from the recipe jar. A method
- * added to an LST class is therefore missing at runtime for anyone whose CLI predates it, and
- * calling one raises {@link NoSuchMethodError} mid-recipe. These statics ship alongside their
- * callers, and read only LST members that long predate them.
  */
 public class ArgumentContents {
     private ArgumentContents() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
@@ -31,12 +31,12 @@ import static org.openrewrite.Tree.randomId;
  * parser and recipes that synthesize values go through here, so a value a recipe writes is modelled
  * the same way as one read back from the printed Dockerfile.
  * <p>
- * {@link Docker.Argument} exposes the readers below as instance methods for recipe authors, but
- * everything in this module that the Moderne CLI loads from a recipe jar calls them here instead.
- * The CLI's {@code RecipeClassLoader} delegates {@code org.openrewrite.docker.tree} to its own
- * bundled rewrite-docker while loading recipes, traits and this package from the recipe jar, so a
- * method added to an LST class is missing at runtime whenever the CLI predates it. These statics
- * ship alongside their callers, and read only LST members that long predate them.
+ * The readers live here rather than on {@link Docker.Argument} because the Moderne CLI's
+ * {@code RecipeClassLoader} delegates {@code org.openrewrite.docker.tree} to the rewrite-docker the
+ * CLI itself bundles, while loading recipes, traits and this package from the recipe jar. A method
+ * added to an LST class is therefore missing at runtime for anyone whose CLI predates it, and
+ * calling one raises {@link NoSuchMethodError} mid-recipe. These statics ship alongside their
+ * callers, and read only LST members that long predate them.
  */
 public class ArgumentContents {
     private ArgumentContents() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
@@ -23,6 +23,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.docker.DockerVisitor;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.internal.ImageReferences;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.internal.ListUtils;
@@ -98,7 +99,7 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Instruction> 
      */
     public Optional<String> getFromValue() {
         Docker.Argument arg = fromArgument();
-        return arg == null ? Optional.empty() : Optional.of(arg.getTextWithVariables());
+        return arg == null ? Optional.empty() : Optional.of(ArgumentContents.textWithVariables(arg));
     }
 
     /**
@@ -117,7 +118,7 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Instruction> 
         if (arg == null) {
             return false;
         }
-        String value = arg.getText();
+        String value = ArgumentContents.text(arg);
         if (value == null) {
             return false;
         }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerFrom.java
@@ -73,7 +73,7 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
         }
         for (Docker.Flag flag : from.getFlags()) {
             if ("platform".equals(flag.getName()) && flag.getValue() != null) {
-                return flag.getValue().getTextWithVariables();
+                return ArgumentContents.textWithVariables(flag.getValue());
             }
         }
         return null;
@@ -95,7 +95,7 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
      * @return true if the image is "scratch"
      */
     public boolean isScratch() {
-        return "scratch".equals(getTree().getImageName().getText());
+        return "scratch".equals(ArgumentContents.text(getTree().getImageName()));
     }
 
     /**
@@ -104,7 +104,7 @@ public class DockerFrom implements DockerImageReference<Docker.From> {
      * @return The quote style, or null if unquoted
      */
     public Docker.Literal.@Nullable QuoteStyle getQuoteStyle() {
-        return getTree().getImageName().getQuoteStyle();
+        return ArgumentContents.quoteStyle(getTree().getImageName());
     }
 
     /**

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerImageReference.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerImageReference.java
@@ -21,6 +21,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.docker.DockerVisitor;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.trait.Trait;
 import org.openrewrite.trait.VisitFunction2;
@@ -71,7 +72,7 @@ public interface DockerImageReference<T extends Docker.Instruction> extends Trai
      */
     default Optional<String> getImageName() {
         Docker.Argument imageName = getImageNameArgument();
-        return imageName == null ? Optional.empty() : Optional.of(imageName.getTextWithVariables());
+        return imageName == null ? Optional.empty() : Optional.of(ArgumentContents.textWithVariables(imageName));
     }
 
     /// As [#getImageName()], but decomposed into the registry the image is pulled from and the path
@@ -102,7 +103,7 @@ public interface DockerImageReference<T extends Docker.Instruction> extends Trai
      */
     default Optional<String> getTag() {
         Docker.Argument tag = getTagArgument();
-        return tag == null ? Optional.empty() : Optional.of(tag.getTextWithVariables());
+        return tag == null ? Optional.empty() : Optional.of(ArgumentContents.textWithVariables(tag));
     }
 
     /**
@@ -110,7 +111,7 @@ public interface DockerImageReference<T extends Docker.Instruction> extends Trai
      */
     default Optional<String> getDigest() {
         Docker.Argument digest = getDigestArgument();
-        return digest == null ? Optional.empty() : Optional.of(digest.getTextWithVariables());
+        return digest == null ? Optional.empty() : Optional.of(ArgumentContents.textWithVariables(digest));
     }
 
     /**
@@ -139,12 +140,12 @@ public interface DockerImageReference<T extends Docker.Instruction> extends Trai
         }
         Docker.Argument tag = getTagArgument();
         if (tag == null) {
-            if (imageName.hasEnvironmentVariables()) {
+            if (ArgumentContents.containsVariable(imageName)) {
                 return Optional.empty();
             }
             return Optional.of(UnpinnedReason.IMPLICIT_LATEST);
         }
-        if ("latest".equals(tag.getText())) {
+        if ("latest".equals(ArgumentContents.text(tag))) {
             return Optional.of(UnpinnedReason.EXPLICIT_LATEST);
         }
         return Optional.empty();

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerTraitMatcher.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerTraitMatcher.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.docker.trait;
 
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.trait.SimpleTraitMatcher;
@@ -74,7 +75,7 @@ abstract class DockerTraitMatcher<U extends Trait<?>> extends SimpleTraitMatcher
      * @return true if the part matches
      */
     static boolean partMatches(Docker.Argument part, String pattern) {
-        return matchesBidirectional(extractTextForMatching(part), pattern, part.hasEnvironmentVariables());
+        return matchesBidirectional(extractTextForMatching(part), pattern, ArgumentContents.containsVariable(part));
     }
 
     /// As [#partMatches], but for an image name, where a pattern also matches a name that spells
@@ -89,6 +90,6 @@ abstract class DockerTraitMatcher<U extends Trait<?>> extends SimpleTraitMatcher
         String text = extractTextForMatching(imageName);
         ImageName name = ImageName.parse(text);
         ImageName patternName = ImageName.parse(pattern);
-        return matchesBidirectional(name.getCanonical(), patternName.getCanonical(), imageName.hasEnvironmentVariables());
+        return matchesBidirectional(name.getCanonical(), patternName.getCanonical(), ArgumentContents.containsVariable(imageName));
     }
 }

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/tree/Docker.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/tree/Docker.java
@@ -22,7 +22,6 @@ import lombok.With;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.docker.DockerVisitor;
-import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.internal.DockerPrinter;
 import org.openrewrite.marker.Markers;
 
@@ -979,27 +978,6 @@ public interface Docker extends Tree {
         Markers markers;
 
         List<ArgumentContent> contents;
-
-        /// @return The text of every content, or `null` if an environment variable reference makes it
-        /// impossible to resolve statically.
-        public @Nullable String getText() {
-            return ArgumentContents.text(this);
-        }
-
-        /// @return As [#getText()], but rendering environment variable references in their original
-        /// `$VAR` or `${VAR}` form rather than giving up.
-        public String getTextWithVariables() {
-            return ArgumentContents.textWithVariables(this);
-        }
-
-        /// @return The quote style of the first quoted literal, or `null` if none is quoted.
-        public Literal.@Nullable QuoteStyle getQuoteStyle() {
-            return ArgumentContents.quoteStyle(this);
-        }
-
-        public boolean hasEnvironmentVariables() {
-            return ArgumentContents.containsVariable(this);
-        }
 
         @Override
         public <P> Docker acceptDocker(DockerVisitor<P> v, P p) {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/tree/Docker.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/tree/Docker.java
@@ -22,6 +22,7 @@ import lombok.With;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.docker.DockerVisitor;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.internal.DockerPrinter;
 import org.openrewrite.marker.Markers;
 
@@ -982,53 +983,22 @@ public interface Docker extends Tree {
         /// @return The text of every content, or `null` if an environment variable reference makes it
         /// impossible to resolve statically.
         public @Nullable String getText() {
-            StringBuilder text = new StringBuilder();
-            for (ArgumentContent content : contents) {
-                if (content instanceof EnvironmentVariable) {
-                    return null;
-                }
-                if (content instanceof Literal) {
-                    text.append(((Literal) content).getText());
-                }
-            }
-            return text.toString();
+            return ArgumentContents.text(this);
         }
 
         /// @return As [#getText()], but rendering environment variable references in their original
         /// `$VAR` or `${VAR}` form rather than giving up.
         public String getTextWithVariables() {
-            StringBuilder text = new StringBuilder();
-            for (ArgumentContent content : contents) {
-                if (content instanceof Literal) {
-                    text.append(((Literal) content).getText());
-                } else if (content instanceof EnvironmentVariable) {
-                    EnvironmentVariable env = (EnvironmentVariable) content;
-                    text.append(env.isBraced() ? "${" + env.getName() + "}" : "$" + env.getName());
-                }
-            }
-            return text.toString();
+            return ArgumentContents.textWithVariables(this);
         }
 
         /// @return The quote style of the first quoted literal, or `null` if none is quoted.
         public Literal.@Nullable QuoteStyle getQuoteStyle() {
-            for (ArgumentContent content : contents) {
-                if (content instanceof Literal) {
-                    Literal.QuoteStyle style = ((Literal) content).getQuoteStyle();
-                    if (style != null) {
-                        return style;
-                    }
-                }
-            }
-            return null;
+            return ArgumentContents.quoteStyle(this);
         }
 
         public boolean hasEnvironmentVariables() {
-            for (ArgumentContent content : contents) {
-                if (content instanceof EnvironmentVariable) {
-                    return true;
-                }
-            }
-            return false;
+            return ArgumentContents.containsVariable(this);
         }
 
         @Override

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/ChangeFromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/ChangeFromTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.docker;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -772,9 +773,9 @@ class ChangeFromTest implements RewriteTest {
                   """,
                 spec -> spec.afterRecipe(doc -> {
                     Docker.From from = doc.getStages().getFirst().getFrom();
-                    assertThat(from.getImageName().getText()).isEqualTo("ubuntu");
+                    assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("ubuntu");
                     assertThat(from.getTag()).isNotNull();
-                    assertThat(from.getTag().getText()).isEqualTo("22.04");
+                    assertThat(ArgumentContents.text(from.getTag())).isEqualTo("22.04");
                 })
               )
             );
@@ -793,9 +794,9 @@ class ChangeFromTest implements RewriteTest {
                   """,
                 spec -> spec.afterRecipe(doc -> {
                     Docker.From from = doc.getStages().getFirst().getFrom();
-                    assertThat(from.getImageName().getText()).isEqualTo("eclipse-temurin");
+                    assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("eclipse-temurin");
                     assertThat(from.getTag()).isNotNull();
-                    assertThat(from.getTag().getText()).isEqualTo("17");
+                    assertThat(ArgumentContents.text(from.getTag())).isEqualTo("17");
                 })
               )
             );
@@ -814,9 +815,9 @@ class ChangeFromTest implements RewriteTest {
                   """,
                 spec -> spec.afterRecipe(doc -> {
                     Docker.From from = doc.getStages().getFirst().getFrom();
-                    assertThat(from.getImageName().getText()).isEqualTo("ubuntu");
+                    assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("ubuntu");
                     assertThat(from.getDigest()).isNotNull();
-                    assertThat(from.getDigest().getText()).isEqualTo("sha256:abc123");
+                    assertThat(ArgumentContents.text(from.getDigest())).isEqualTo("sha256:abc123");
                 })
               )
             );
@@ -835,7 +836,7 @@ class ChangeFromTest implements RewriteTest {
                   """,
                 spec -> spec.afterRecipe(doc -> {
                     Docker.From from = doc.getStages().getFirst().getFrom();
-                    assertThat(from.getImageName().getText()).isEqualTo("localhost:5000/ubuntu");
+                    assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("localhost:5000/ubuntu");
                     assertThat(from.getTag()).isNull();
                 })
               )
@@ -857,9 +858,9 @@ class ChangeFromTest implements RewriteTest {
                   """,
                 spec -> spec.afterRecipe(doc -> {
                     Docker.From from = doc.getStages().getFirst().getFrom();
-                    assertThat(from.getImageName().getText()).isEqualTo("ubuntu");
+                    assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("ubuntu");
                     assertThat(from.getDigest()).isNotNull();
-                    assertThat(from.getDigest().getText()).isEqualTo("sha256:abc123");
+                    assertThat(ArgumentContents.text(from.getDigest())).isEqualTo("sha256:abc123");
                 })
               )
             );
@@ -1195,8 +1196,8 @@ class ChangeFromTest implements RewriteTest {
                     // variable reference like any other, and is modelled as one.
                     Docker.Argument tag = doc.getStages().getFirst().getFrom().getTag();
                     assertThat(tag).isNotNull();
-                    assertThat(tag.getText()).isNull();
-                    assertThat(tag.getTextWithVariables()).isEqualTo("22.04-$VAR");
+                    assertThat(ArgumentContents.text(tag)).isNull();
+                    assertThat(ArgumentContents.textWithVariables(tag)).isEqualTo("22.04-$VAR");
                 })
               )
             );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/ArgTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/ArgTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.docker.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -101,7 +102,7 @@ class ArgTest implements RewriteTest {
                 Docker.Literal literal = (Docker.Literal) value.getContents().getFirst();
                 assertThat(literal.getText()).isEqualTo("1.0.0");
                 assertThat(literal.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
-                assertThat(value.getText()).isEqualTo("1.0.0");
+                assertThat(ArgumentContents.text(value)).isEqualTo("1.0.0");
             })
           )
         );
@@ -120,7 +121,7 @@ class ArgTest implements RewriteTest {
                 Docker.Literal literal = (Docker.Literal) value.getContents().getFirst();
                 assertThat(literal.getText()).isEqualTo("1.0.0");
                 assertThat(literal.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.SINGLE);
-                assertThat(value.getText()).isEqualTo("1.0.0");
+                assertThat(ArgumentContents.text(value)).isEqualTo("1.0.0");
             })
           )
         );
@@ -137,8 +138,8 @@ class ArgTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
                 assertThat(((Docker.Literal) value.getContents().getFirst()).getQuoteStyle()).isNull();
-                assertThat(value.getQuoteStyle()).isNull();
-                assertThat(value.getText()).isEqualTo("1.0.0");
+                assertThat(ArgumentContents.quoteStyle(value)).isNull();
+                assertThat(ArgumentContents.text(value)).isEqualTo("1.0.0");
             })
           )
         );
@@ -152,7 +153,7 @@ class ArgTest implements RewriteTest {
               FROM ubuntu:20.04
               ARG DESCRIPTION="some value"
               """,
-            spec -> spec.afterRecipe(doc -> assertThat(argValue(doc).getText()).isEqualTo("some value"))
+            spec -> spec.afterRecipe(doc -> assertThat(ArgumentContents.text(argValue(doc))).isEqualTo("some value"))
           )
         );
     }
@@ -167,8 +168,8 @@ class ArgTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
-                assertThat(value.getText()).isEmpty();
-                assertThat(value.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
+                assertThat(ArgumentContents.text(value)).isEmpty();
+                assertThat(ArgumentContents.quoteStyle(value)).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
             })
           )
         );
@@ -187,9 +188,9 @@ class ArgTest implements RewriteTest {
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) value.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("BASE");
                 assertThat(var.isBraced()).isFalse();
-                assertThat(value.hasEnvironmentVariables()).isTrue();
-                assertThat(value.getText()).isNull();
-                assertThat(value.getTextWithVariables()).isEqualTo("$BASE");
+                assertThat(ArgumentContents.containsVariable(value)).isTrue();
+                assertThat(ArgumentContents.text(value)).isNull();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("$BASE");
             })
           )
         );
@@ -210,8 +211,8 @@ class ArgTest implements RewriteTest {
                 assertThat(var.getName()).isEqualTo("BASE");
                 assertThat(var.isBraced()).isTrue();
                 assertThat(((Docker.Literal) value.getContents().getLast()).getText()).isEqualTo("-suffix");
-                assertThat(value.getText()).isNull();
-                assertThat(value.getTextWithVariables()).isEqualTo("${BASE}-suffix");
+                assertThat(ArgumentContents.text(value)).isNull();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("${BASE}-suffix");
             })
           )
         );
@@ -228,8 +229,8 @@ class ArgTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
                 assertThat(value.getContents()).hasSize(1);
-                assertThat(value.getQuoteStyle()).isNull();
-                assertThat(value.getText()).isEqualTo("a\"b\"c");
+                assertThat(ArgumentContents.quoteStyle(value)).isNull();
+                assertThat(ArgumentContents.text(value)).isEqualTo("a\"b\"c");
             })
           )
         );
@@ -243,7 +244,7 @@ class ArgTest implements RewriteTest {
               FROM ubuntu:20.04
               ARG URL=http://example.com/x#fragment
               """,
-            spec -> spec.afterRecipe(doc -> assertThat(argValue(doc).getText()).isEqualTo("http://example.com/x#fragment"))
+            spec -> spec.afterRecipe(doc -> assertThat(ArgumentContents.text(argValue(doc))).isEqualTo("http://example.com/x#fragment"))
           )
         );
     }
@@ -259,8 +260,8 @@ class ArgTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
                 assertThat(value.getContents()).hasSize(1);
-                assertThat(value.getQuoteStyle()).isNull();
-                assertThat(value.getText()).isEqualTo("--flag=\"a b\"");
+                assertThat(ArgumentContents.quoteStyle(value)).isNull();
+                assertThat(ArgumentContents.text(value)).isEqualTo("--flag=\"a b\"");
             })
           )
         );
@@ -277,7 +278,7 @@ class ArgTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
                 assertThat(value.getContents()).hasSize(1);
-                assertThat(value.getText()).isEqualTo("\"a b\",more");
+                assertThat(ArgumentContents.text(value)).isEqualTo("\"a b\",more");
             })
           )
         );
@@ -297,9 +298,9 @@ class ArgTest implements RewriteTest {
                 assertThat(((Docker.Literal) value.getContents().get(0)).getText()).isEqualTo("\"pre ");
                 assertThat(((Docker.EnvironmentVariable) value.getContents().get(1)).getName()).isEqualTo("V");
                 assertThat(((Docker.Literal) value.getContents().get(2)).getText()).isEqualTo(" post\"");
-                assertThat(value.getQuoteStyle()).isNull();
-                assertThat(value.hasEnvironmentVariables()).isTrue();
-                assertThat(value.getTextWithVariables()).isEqualTo("\"pre $V post\"");
+                assertThat(ArgumentContents.quoteStyle(value)).isNull();
+                assertThat(ArgumentContents.containsVariable(value)).isTrue();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("\"pre $V post\"");
             })
           )
         );
@@ -316,9 +317,9 @@ class ArgTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
                 assertThat(value.getContents()).hasSize(1);
-                assertThat(value.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.SINGLE);
-                assertThat(value.hasEnvironmentVariables()).isFalse();
-                assertThat(value.getText()).isEqualTo("pre $V post");
+                assertThat(ArgumentContents.quoteStyle(value)).isEqualTo(Docker.Literal.QuoteStyle.SINGLE);
+                assertThat(ArgumentContents.containsVariable(value)).isFalse();
+                assertThat(ArgumentContents.text(value)).isEqualTo("pre $V post");
             })
           )
         );
@@ -335,8 +336,8 @@ class ArgTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
                 assertThat(value.getContents()).hasSize(1);
-                assertThat(value.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
-                assertThat(value.hasEnvironmentVariables()).isFalse();
+                assertThat(ArgumentContents.quoteStyle(value)).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
+                assertThat(ArgumentContents.containsVariable(value)).isFalse();
             })
           )
         );
@@ -353,8 +354,8 @@ class ArgTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = argValue(doc);
                 assertThat(value.getContents()).hasSize(1);
-                assertThat(value.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
-                assertThat(value.getText()).isEqualTo("no vars here");
+                assertThat(ArgumentContents.quoteStyle(value)).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
+                assertThat(ArgumentContents.text(value)).isEqualTo("no vars here");
             })
           )
         );
@@ -373,9 +374,9 @@ class ArgTest implements RewriteTest {
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) value.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("base");
                 assertThat(var.isBraced()).isFalse();
-                assertThat(value.hasEnvironmentVariables()).isTrue();
-                assertThat(value.getText()).isNull();
-                assertThat(value.getTextWithVariables()).isEqualTo("$base");
+                assertThat(ArgumentContents.containsVariable(value)).isTrue();
+                assertThat(ArgumentContents.text(value)).isNull();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("$base");
             })
           )
         );
@@ -395,9 +396,9 @@ class ArgTest implements RewriteTest {
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) value.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("Java_Version");
                 assertThat(var.isBraced()).isFalse();
-                assertThat(value.hasEnvironmentVariables()).isTrue();
-                assertThat(value.getText()).isNull();
-                assertThat(value.getTextWithVariables()).isEqualTo("$Java_Version");
+                assertThat(ArgumentContents.containsVariable(value)).isTrue();
+                assertThat(ArgumentContents.text(value)).isNull();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("$Java_Version");
             })
           )
         );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/EnvTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/EnvTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.docker.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.List;
@@ -111,7 +112,7 @@ class EnvTest implements RewriteTest {
                 Docker.Literal literal = (Docker.Literal) value.getContents().getFirst();
                 assertThat(literal.getText()).isEqualTo("18.0.0");
                 assertThat(literal.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
-                assertThat(value.getText()).isEqualTo("18.0.0");
+                assertThat(ArgumentContents.text(value)).isEqualTo("18.0.0");
             })
           )
         );
@@ -130,7 +131,7 @@ class EnvTest implements RewriteTest {
                 Docker.Literal literal = (Docker.Literal) value.getContents().getFirst();
                 assertThat(literal.getText()).isEqualTo("18.0.0");
                 assertThat(literal.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
-                assertThat(value.getText()).isEqualTo("18.0.0");
+                assertThat(ArgumentContents.text(value)).isEqualTo("18.0.0");
             })
           )
         );
@@ -150,9 +151,9 @@ class EnvTest implements RewriteTest {
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) value.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("BASE");
                 assertThat(var.isBraced()).isTrue();
-                assertThat(value.hasEnvironmentVariables()).isTrue();
-                assertThat(value.getText()).isNull();
-                assertThat(value.getTextWithVariables()).isEqualTo("${BASE}-suffix");
+                assertThat(ArgumentContents.containsVariable(value)).isTrue();
+                assertThat(ArgumentContents.text(value)).isNull();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("${BASE}-suffix");
             })
           )
         );
@@ -168,9 +169,9 @@ class EnvTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 Docker.Argument value = envValue(doc);
-                assertThat(value.hasEnvironmentVariables()).isTrue();
-                assertThat(value.getText()).isNull();
-                assertThat(value.getTextWithVariables()).isEqualTo("\"/opt/venv/bin:$PATH\"");
+                assertThat(ArgumentContents.containsVariable(value)).isTrue();
+                assertThat(ArgumentContents.text(value)).isNull();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("\"/opt/venv/bin:$PATH\"");
             })
           )
         );
@@ -191,9 +192,9 @@ class EnvTest implements RewriteTest {
                   .filteredOn(Docker.EnvironmentVariable.class::isInstance)
                   .extracting(content -> ((Docker.EnvironmentVariable) content).getName())
                   .containsExactly("path_prefix", "PATH");
-                assertThat(value.hasEnvironmentVariables()).isTrue();
-                assertThat(value.getText()).isNull();
-                assertThat(value.getTextWithVariables()).isEqualTo("\"$path_prefix/bin:$PATH\"");
+                assertThat(ArgumentContents.containsVariable(value)).isTrue();
+                assertThat(ArgumentContents.text(value)).isNull();
+                assertThat(ArgumentContents.textWithVariables(value)).isEqualTo("\"$path_prefix/bin:$PATH\"");
             })
           )
         );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/FromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/FromTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.docker.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.test.RewriteTest;
 
 import java.util.List;
@@ -406,9 +407,9 @@ class FromTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 Docker.From from = doc.getStages().getLast().getFrom();
-                assertThat(from.getImageName().getTextWithVariables()).isEqualTo("\"ubuntu:${TAG}\"");
+                assertThat(ArgumentContents.textWithVariables(from.getImageName())).isEqualTo("\"ubuntu:${TAG}\"");
                 assertThat(from.getTag()).isNull();
-                assertThat(from.getImageName().hasEnvironmentVariables()).isTrue();
+                assertThat(ArgumentContents.containsVariable(from.getImageName())).isTrue();
             })
           )
         );
@@ -428,9 +429,9 @@ class FromTest implements RewriteTest {
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) tag.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("java_version");
                 assertThat(var.isBraced()).isTrue();
-                assertThat(tag.hasEnvironmentVariables()).isTrue();
-                assertThat(tag.getText()).isNull();
-                assertThat(tag.getTextWithVariables()).isEqualTo("${java_version}");
+                assertThat(ArgumentContents.containsVariable(tag)).isTrue();
+                assertThat(ArgumentContents.text(tag)).isNull();
+                assertThat(ArgumentContents.textWithVariables(tag)).isEqualTo("${java_version}");
             })
           )
         );
@@ -450,8 +451,8 @@ class FromTest implements RewriteTest {
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) tag.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("java_version");
                 assertThat(var.isBraced()).isFalse();
-                assertThat(tag.getText()).isNull();
-                assertThat(tag.getTextWithVariables()).isEqualTo("$java_version");
+                assertThat(ArgumentContents.text(tag)).isNull();
+                assertThat(ArgumentContents.textWithVariables(tag)).isEqualTo("$java_version");
             })
           )
         );
@@ -469,8 +470,8 @@ class FromTest implements RewriteTest {
                 Docker.Argument tag = doc.getStages().getLast().getFrom().getTag();
                 assertThat(tag).isNotNull();
                 assertThat(((Docker.EnvironmentVariable) tag.getContents().getFirst()).getName()).isEqualTo("Java_Version");
-                assertThat(tag.getText()).isNull();
-                assertThat(tag.getTextWithVariables()).isEqualTo("${Java_Version}");
+                assertThat(ArgumentContents.text(tag)).isNull();
+                assertThat(ArgumentContents.textWithVariables(tag)).isEqualTo("${Java_Version}");
             })
           )
         );
@@ -488,8 +489,8 @@ class FromTest implements RewriteTest {
                 assertThat(flagValue).isNotNull();
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) flagValue.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("target_platform");
-                assertThat(flagValue.getText()).isNull();
-                assertThat(flagValue.getTextWithVariables()).isEqualTo("$target_platform");
+                assertThat(ArgumentContents.text(flagValue)).isNull();
+                assertThat(ArgumentContents.textWithVariables(flagValue)).isEqualTo("$target_platform");
             })
           )
         );
@@ -508,7 +509,7 @@ class FromTest implements RewriteTest {
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) flagValue.getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("TARGETPLATFORM:-linux/amd64");
                 assertThat(var.isBraced()).isTrue();
-                assertThat(flagValue.getTextWithVariables()).isEqualTo("${TARGETPLATFORM:-linux/amd64}");
+                assertThat(ArgumentContents.textWithVariables(flagValue)).isEqualTo("${TARGETPLATFORM:-linux/amd64}");
             })
           )
         );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/LabelTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/LabelTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.docker.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -157,13 +158,13 @@ class LabelTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Label.LabelPair pair = onlyPair(doc);
                 assertThat(pair.isHasEquals()).isTrue();
-                assertThat(pair.getKey().getText()).isEqualTo("version");
+                assertThat(ArgumentContents.text(pair.getKey())).isEqualTo("version");
                 Docker.EnvironmentVariable var = (Docker.EnvironmentVariable) pair.getValue().getContents().getFirst();
                 assertThat(var.getName()).isEqualTo("VAL");
                 assertThat(var.isBraced()).isFalse();
-                assertThat(pair.getValue().hasEnvironmentVariables()).isTrue();
-                assertThat(pair.getValue().getText()).isNull();
-                assertThat(pair.getValue().getTextWithVariables()).isEqualTo("$VAL");
+                assertThat(ArgumentContents.containsVariable(pair.getValue())).isTrue();
+                assertThat(ArgumentContents.text(pair.getValue())).isNull();
+                assertThat(ArgumentContents.textWithVariables(pair.getValue())).isEqualTo("$VAL");
             })
           )
         );
@@ -181,7 +182,7 @@ class LabelTest implements RewriteTest {
                 Docker.Label.LabelPair pair = onlyPair(doc);
                 assertThat(pair.isHasEquals()).isTrue();
                 assertThat(pair.getValue().getContents()).hasSize(2);
-                assertThat(pair.getValue().getTextWithVariables()).isEqualTo("${BASE}-suffix");
+                assertThat(ArgumentContents.textWithVariables(pair.getValue())).isEqualTo("${BASE}-suffix");
             })
           )
         );
@@ -199,9 +200,9 @@ class LabelTest implements RewriteTest {
                 var label = (Docker.Label) doc.getStages().getFirst().getInstructions().getLast();
                 assertThat(label.getPairs()).hasSize(3);
                 assertThat(label.getPairs()).allSatisfy(pair -> assertThat(pair.isHasEquals()).isTrue());
-                assertThat(label.getPairs().get(0).getValue().getTextWithVariables()).isEqualTo("1");
-                assertThat(label.getPairs().get(1).getValue().getTextWithVariables()).isEqualTo("$X");
-                assertThat(label.getPairs().get(2).getValue().getTextWithVariables()).isEqualTo("3");
+                assertThat(ArgumentContents.textWithVariables(label.getPairs().get(0).getValue())).isEqualTo("1");
+                assertThat(ArgumentContents.textWithVariables(label.getPairs().get(1).getValue())).isEqualTo("$X");
+                assertThat(ArgumentContents.textWithVariables(label.getPairs().get(2).getValue())).isEqualTo("3");
             })
           )
         );
@@ -218,7 +219,7 @@ class LabelTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Label.LabelPair pair = onlyPair(doc);
                 assertThat(pair.isHasEquals()).isFalse();
-                assertThat(pair.getValue().getText()).isEqualTo("John Doe");
+                assertThat(ArgumentContents.text(pair.getValue())).isEqualTo("John Doe");
             })
           )
         );
@@ -236,8 +237,8 @@ class LabelTest implements RewriteTest {
                 Docker.Label.LabelPair pair = onlyPair(doc);
                 assertThat(pair.isHasEquals()).isFalse();
                 assertThat(pair.getValue().getContents()).hasSize(1);
-                assertThat(pair.getValue().getQuoteStyle()).isNull();
-                assertThat(pair.getValue().getText()).isEqualTo("\"John Doe\" of ACME");
+                assertThat(ArgumentContents.quoteStyle(pair.getValue())).isNull();
+                assertThat(ArgumentContents.text(pair.getValue())).isEqualTo("\"John Doe\" of ACME");
             })
           )
         );
@@ -254,8 +255,8 @@ class LabelTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 Docker.Label.LabelPair pair = onlyPair(doc);
                 assertThat(pair.getValue().getContents()).hasSize(1);
-                assertThat(pair.getValue().hasEnvironmentVariables()).isFalse();
-                assertThat(pair.getValue().getText()).isEqualTo("'John $D' of ACME");
+                assertThat(ArgumentContents.containsVariable(pair.getValue())).isFalse();
+                assertThat(ArgumentContents.text(pair.getValue())).isEqualTo("'John $D' of ACME");
             })
           )
         );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/MaintainerTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/MaintainerTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.docker.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,7 +53,7 @@ class MaintainerTest implements RewriteTest {
                 Docker.Literal literal = (Docker.Literal) maintainer.getText().getContents().getFirst();
                 assertThat(literal.getText()).isEqualTo("John Doe");
                 assertThat(literal.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
-                assertThat(maintainer.getText().getText()).isEqualTo("John Doe");
+                assertThat(ArgumentContents.text(maintainer.getText())).isEqualTo("John Doe");
             })
           )
         );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/UserTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/UserTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.docker.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,8 +68,8 @@ class UserTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 var user = (Docker.User) doc.getStages().getFirst().getInstructions().getLast();
-                assertThat(user.getUser().getText()).isEqualTo("app");
-                assertThat(user.getGroup().getText()).isEqualTo("group:extra");
+                assertThat(ArgumentContents.text(user.getUser())).isEqualTo("app");
+                assertThat(ArgumentContents.text(user.getGroup())).isEqualTo("group:extra");
             })
           )
         );
@@ -106,7 +107,7 @@ class UserTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 var user = (Docker.User) doc.getStages().getFirst().getInstructions().getLast();
-                assertThat(user.getUser().getText()).isEqualTo("app");
+                assertThat(ArgumentContents.text(user.getUser())).isEqualTo("app");
                 var group = (Docker.Literal) user.getGroup().getContents().getFirst();
                 assertThat(group.getText()).isEqualTo("group");
                 assertThat(group.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.SINGLE);
@@ -125,7 +126,7 @@ class UserTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 var user = (Docker.User) doc.getStages().getFirst().getInstructions().getLast();
-                assertThat(user.getUser().getText()).isEqualTo("app");
+                assertThat(ArgumentContents.text(user.getUser())).isEqualTo("app");
                 assertThat(user.getGroup().getContents()).isEmpty();
             })
           )
@@ -143,7 +144,7 @@ class UserTest implements RewriteTest {
             spec -> spec.afterRecipe(doc -> {
                 var user = (Docker.User) doc.getStages().getFirst().getInstructions().getLast();
                 assertThat(user.getUser().getContents()).isEmpty();
-                assertThat(user.getGroup().getText()).isEqualTo("group");
+                assertThat(ArgumentContents.text(user.getGroup())).isEqualTo("group");
             })
           )
         );
@@ -196,8 +197,8 @@ class UserTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 var user = (Docker.User) doc.getStages().getFirst().getInstructions().getLast();
-                assertThat(user.getUser().getText()).isEqualTo("app\\\n  ");
-                assertThat(user.getGroup().getText()).isEqualTo("group");
+                assertThat(ArgumentContents.text(user.getUser())).isEqualTo("app\\\n  ");
+                assertThat(ArgumentContents.text(user.getGroup())).isEqualTo("group");
             })
           )
         );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/WorkdirTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/WorkdirTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.docker.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.docker.internal.ArgumentContents;
 import org.openrewrite.test.RewriteTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -52,7 +53,7 @@ class WorkdirTest implements RewriteTest {
                 Docker.Literal literal = (Docker.Literal) workdir.getPath().getContents().getFirst();
                 assertThat(literal.getText()).isEqualTo("/app dir");
                 assertThat(literal.getQuoteStyle()).isEqualTo(Docker.Literal.QuoteStyle.DOUBLE);
-                assertThat(workdir.getPath().getText()).isEqualTo("/app dir");
+                assertThat(ArgumentContents.text(workdir.getPath())).isEqualTo("/app dir");
             })
           )
         );
@@ -68,9 +69,9 @@ class WorkdirTest implements RewriteTest {
               """,
             spec -> spec.afterRecipe(doc -> {
                 var workdir = (Docker.Workdir) doc.getStages().getFirst().getInstructions().getLast();
-                assertThat(workdir.getPath().hasEnvironmentVariables()).isTrue();
-                assertThat(workdir.getPath().getText()).isNull();
-                assertThat(workdir.getPath().getTextWithVariables()).isEqualTo("/app/$SUB");
+                assertThat(ArgumentContents.containsVariable(workdir.getPath())).isTrue();
+                assertThat(ArgumentContents.text(workdir.getPath())).isNull();
+                assertThat(ArgumentContents.textWithVariables(workdir.getPath())).isEqualTo("/app/$SUB");
             })
           )
         );


### PR DESCRIPTION
The Moderne CLI splits one rewrite-docker jar across two classloaders: `RecipeClassLoader` delegates `org.openrewrite.docker.tree` to the rewrite-docker the CLI itself bundles, while recipes, traits and `internal` are loaded child-first from the recipe artifact, so the four methods #8576 added to `Docker.Argument` are missing at runtime for anyone whose CLI predates them and any recipe calling them raises `NoSuchMethodError` mid-run — reproduced against CLI 4.6.3, which bundles rewrite-docker 8.90.3.

The first commit moves those four implementations into `ArgumentContents`, which ships in the same half of the split as its callers and reads only LST members that long predate the CLIs in the field. The second drops them from `Docker.Argument` altogether, since keeping them fixed nothing for callers outside this module — the `Docker$Argument` they link against is the CLI's — and v8.90.3 is still the latest release, so nothing has ever shipped them and no published recipe can be compiled against them.

The LST API is now identical to v8.90.3's but for `Instruction.getKeyword()`, pulled up to the interface in #8603; a recipe iterating `Stage.getInstructions()` and calling it would hit the same problem on an older CLI, so it may be worth the same treatment.

Verified with CLI 4.6.3's own jars that the case which threw now runs clean, and that the newer parser still builds and round-trips 8.90.3 trees; `:rewrite-docker:test` is green at 572 tests.