### PR TITLE
Docker: a literal holds its value, not the whitespace around it

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
@@ -37,6 +37,7 @@ import java.util.function.Consumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
 public class Assertions {
@@ -447,6 +448,9 @@ public class Assertions {
         public Docker.Argument visitArgument(Docker.Argument argument, List<String> violations) {
             List<Docker.ArgumentContent> contents = argument.getContents();
             for (int i = 1; i < contents.size(); i++) {
+                if (i + 1 == contents.size() && isEmptyLiteral(contents.get(i))) {
+                    continue;
+                }
                 Space prefix = contents.get(i).getPrefix();
                 if (!prefix.getWhitespace().isEmpty() || !prefix.getComments().isEmpty()) {
                     violations.add("expected the contents of the argument " + quoted(ArgumentContents.textWithVariables(argument)) +
@@ -459,11 +463,46 @@ public class Assertions {
         @Override
         public Docker.Literal visitLiteral(Docker.Literal literal, List<String> violations) {
             Docker.Literal.QuoteStyle style = literal.getQuoteStyle();
+            if (style == null) {
+                outerWhitespace(literal, violations);
+            }
             if (style != null && hasUnescapedQuote(literal.getText(), style)) {
                 violations.add("expected the quoted literal " + quoted(literal.getText()) + " to hold no unescaped " +
                         quoteOf(style) + ", which ends the string when it is read back");
             }
             return super.visitLiteral(literal, violations);
+        }
+
+        /// An empty content closing an argument is the one place whitespace between contents is not that
+        /// argument's text: it is what a part reaching a separator has to write back, and the separator
+        /// has no prefix of its own to hold it.
+        private static boolean isEmptyLiteral(Docker.ArgumentContent content) {
+            return content instanceof Docker.Literal && ((Docker.Literal) content).getText().isEmpty();
+        }
+
+        /// A literal whose text runs into the whitespace around it hands every recipe reading its value
+        /// the formatting too. Only where the value itself begins and ends is formatting: whitespace
+        /// where two contents meet is the value's own text, as the space in `"pre $V post"` is.
+        private void outerWhitespace(Docker.Literal literal, List<String> violations) {
+            String text = literal.getText();
+            if (text.isEmpty()) {
+                return;
+            }
+            List<Docker.ArgumentContent> value = valueItIsPartOf(literal);
+            if ((value.get(0) == literal && Character.isWhitespace(text.charAt(0))) ||
+                    (value.get(value.size() - 1) == literal &&
+                            Character.isWhitespace(text.charAt(text.length() - 1)))) {
+                violations.add("expected the literal " + quoted(text) + " to hold only its value, but it starts or" +
+                        " ends with whitespace that belongs in the space around it");
+            }
+        }
+
+        /// The contents the literal shares its value with, which is the literal alone where it is a whole
+        /// value of its own, as an `ARG`'s name and an `ENV`'s key are.
+        private List<Docker.ArgumentContent> valueItIsPartOf(Docker.Literal literal) {
+            Object parent = getCursor().getParentTreeCursor().getValue();
+            return parent instanceof Docker.Argument ? ((Docker.Argument) parent).getContents() :
+                    singletonList(literal);
         }
 
         /// Recipes that copy a subtree, as combining or adding instructions do, hand the same element

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
@@ -27,6 +27,7 @@ import org.openrewrite.docker.internal.grammar.DockerParserBaseVisitor;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
 import org.openrewrite.internal.EncodingDetectingInputStream;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.marker.Markers;
 
 import java.nio.charset.Charset;
@@ -189,20 +190,27 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         );
     }
 
-    /// One part of a value the grammar split on a separator, an image reference or a `USER` specification,
-    /// reaching up to the separator that follows it so that a line continuation written before that
-    /// separator stays with the part. A part can be absent while its separator is present, as in
-    /// `FROM alpine:` or `USER root:`, and is then empty rather than missing, which keeps the separator
-    /// in the printed source.
+    /// One part of a value the grammar split on a separator, an image reference or a `USER` specification.
+    /// A part can be absent while its separator is present, as in `FROM alpine:` or `USER root:`, and is
+    /// then empty rather than missing, which keeps the separator in the printed source. Whitespace
+    /// written before the separator is formatting the printer has to write back, and the separator has
+    /// no prefix of its own to hold it, so it becomes the prefix of an empty content closing the part
+    /// rather than text the part does not mean.
     private Docker.Argument separatedPart(@Nullable ParserRuleContext ctx, @Nullable TerminalNode separator) {
         if (ctx == null) {
             Space prefix = separator == null ? Space.EMPTY : prefix(separator.getSymbol());
             return new Docker.Argument(randomId(), prefix, Markers.EMPTY, emptyList());
         }
         Space prefix = prefix(ctx);
-        int stopIndex = separator == null ? ctx.getStop().getStopIndex() : separator.getSymbol().getStartIndex() - 1;
-        List<Docker.ArgumentContent> contents = parseText(ctx, stopIndex);
-        advanceCursor(stopIndex + 1);
+        List<Docker.ArgumentContent> contents = parseText(ctx);
+        advanceCursor(ctx.getStop().getStopIndex() + 1);
+        if (separator != null) {
+            Space beforeSeparator = prefix(separator.getSymbol());
+            if (!beforeSeparator.isEmpty()) {
+                contents = ListUtils.concat(contents,
+                        new Docker.Literal(randomId(), beforeSeparator, Markers.EMPTY, "", null));
+            }
+        }
         return new Docker.Argument(randomId(), prefix, Markers.EMPTY, contents);
     }
 
@@ -211,19 +219,13 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
     /// anywhere else the quotes are part of the text. Environment variable references are always split
     /// out, since their value cannot be resolved from the source.
     private List<Docker.ArgumentContent> parseText(@Nullable ParserRuleContext textCtx) {
-        return parseText(textCtx, -1);
-    }
-
-    /// As {@link #parseText(ParserRuleContext)}, reading up to {@code stopIndex} when the value
-    /// continues past its last token, as it does when whitespace precedes an image reference separator.
-    private List<Docker.ArgumentContent> parseText(@Nullable ParserRuleContext textCtx, int stopIndex) {
         List<Docker.ArgumentContent> contents = new ArrayList<>();
         if (textCtx == null || textCtx.getChildCount() == 0) {
             return contents;
         }
 
         Token quoted = quotedValue(textCtx);
-        if (quoted != null && stopIndex <= quoted.getStopIndex()) {
+        if (quoted != null) {
             Docker.Literal.QuoteStyle quoteStyle = quoted.getType() == DockerLexer.DOUBLE_QUOTED_STRING ?
                     Docker.Literal.QuoteStyle.DOUBLE : Docker.Literal.QuoteStyle.SINGLE;
             String text = quoted.getText();
@@ -240,7 +242,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
 
         Space prefix = prefix(textCtx.getStart());
         int startIndex = textCtx.getStart().getStartIndex();
-        int endIndex = Math.max(stopIndex, textCtx.getStop().getStopIndex());
+        int endIndex = textCtx.getStop().getStopIndex();
         skip(textCtx.getStop());
         contents.addAll(ArgumentContents.splitVariables(sourceText(startIndex, endIndex), prefix));
         return contents;

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/AssertionsTest.java
@@ -578,6 +578,63 @@ class AssertionsTest implements RewriteTest {
           "to hold no unescaped '");
     }
 
+    @Test
+    void catchesALiteralHoldingTheWhitespaceAroundIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            WORKDIR /app
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Literal visitLiteral(Docker.Literal literal, ExecutionContext ctx) {
+                  return literal.withText(literal.getText() + " ");
+              }
+          },
+          "to hold only its value, but it starts or ends with whitespace");
+    }
+
+    /// An ARG's name, like an ENV's key, is a whole value of its own rather than one content of an
+    /// argument, and the check reaches it just the same.
+    @Test
+    void catchesAValueOfItsOwnHoldingTheWhitespaceAroundIt() {
+        assertMalformed(
+          """
+            FROM alpine
+            ARG VERSION=1
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.Arg visitArg(Docker.Arg arg, ExecutionContext ctx) {
+                  return arg.withName(arg.getName().withText(arg.getName().getText() + " "));
+              }
+          },
+          "to hold only its value, but it starts or ends with whitespace");
+    }
+
+    @Test
+    void catchesWhitespaceAroundAValueThatASeparatorSplitIntoParts() {
+        assertMalformed(
+          """
+            FROM ubuntu:22.04
+            """,
+          new DockerIsoVisitor<>() {
+              @Override
+              public Docker.From visitFrom(Docker.From from, ExecutionContext ctx) {
+                  return from.withImageName(from.getImageName().withContents(ListUtils.mapFirst(
+                    from.getImageName().getContents(),
+                    content -> ((Docker.Literal) content).withText(" ubuntu"))));
+              }
+          },
+          "to hold only its value, but it starts or ends with whitespace");
+    }
+
+    /// A quoted literal's quotes delimit it, so whitespace inside them is what the value means.
+    @Test
+    void acceptsAQuotedLiteralHoldingWhitespaceOfItsOwn() {
+        Assertions.assertWellFormed(parse("FROM alpine\nENV KEY=\" value \"\n"));
+    }
+
     /// An ONBUILD's instruction, and a HEALTHCHECK's CMD, correctly sit on the same line as the
     /// instruction that introduces them.
     @Test

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/FromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/FromTest.java
@@ -381,32 +381,59 @@ class FromTest implements RewriteTest {
         );
     }
 
+    /// A continuation joins the lines it spans, and Docker keeps the indent of the line that follows
+    /// it, so only an unindented continuation leaves an image reference Docker still reads as one:
+    /// `FROM ubuntu\<newline>  :22.04` reaches it as `FROM ubuntu  :22.04`, two arguments where FROM
+    /// takes one or three.
     @Test
     void continuationBeforeTagSeparator() {
         rewriteRun(
           docker(
             """
               FROM ubuntu\\
-                :22.04
+              :22.04
               """,
             spec -> spec.afterRecipe(doc -> {
                 Docker.From from = doc.getStages().getFirst().getFrom();
+                assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("ubuntu");
                 assertThat(((Docker.Literal) from.getTag().getContents().getFirst()).getText()).isEqualTo("22.04");
             })
           )
         );
     }
 
+    /// Whitespace may sit between the escape character and the newline it ends the line with.
     @Test
     void continuationPaddedWithSpacesBeforeTagSeparator() {
         rewriteRun(
           docker(
             """
               FROM ubuntu\\  \s
-                :22.04
+              :22.04
               """,
             spec -> spec.afterRecipe(doc -> {
                 Docker.From from = doc.getStages().getFirst().getFrom();
+                assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("ubuntu");
+                assertThat(((Docker.Literal) from.getTag().getContents().getFirst()).getText()).isEqualTo("22.04");
+            })
+          )
+        );
+    }
+
+    /// A backtick ends a line only under an `# escape=` directive, which is how a Windows Dockerfile
+    /// writes a path without escaping every separator.
+    @Test
+    void backtickContinuationBeforeTagSeparator() {
+        rewriteRun(
+          docker(
+            """
+              # escape=`
+              FROM ubuntu`
+              :22.04
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Docker.From from = doc.getStages().getFirst().getFrom();
+                assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("ubuntu");
                 assertThat(((Docker.Literal) from.getTag().getContents().getFirst()).getText()).isEqualTo("22.04");
             })
           )
@@ -414,16 +441,18 @@ class FromTest implements RewriteTest {
     }
 
     @Test
-    void backtickContinuationBeforeTagSeparator() {
+    void continuationBeforeTheDigestSeparator() {
         rewriteRun(
           docker(
             """
-              FROM ubuntu`
-                :22.04
+              FROM ubuntu\\
+              @sha256:0000000000000000000000000000000000000000000000000000000000000000
               """,
             spec -> spec.afterRecipe(doc -> {
                 Docker.From from = doc.getStages().getFirst().getFrom();
-                assertThat(((Docker.Literal) from.getTag().getContents().getFirst()).getText()).isEqualTo("22.04");
+                assertThat(ArgumentContents.text(from.getImageName())).isEqualTo("ubuntu");
+                assertThat(ArgumentContents.text(from.getDigest()))
+                  .isEqualTo("sha256:0000000000000000000000000000000000000000000000000000000000000000");
             })
           )
         );

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/UserTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/UserTest.java
@@ -299,6 +299,12 @@ class UserTest implements RewriteTest {
         );
     }
 
+    /// Unlike the same shape in a `FROM`, Docker accepts this: `USER` reads everything after the
+    /// keyword as one specification, so the whitespace the continuation leaves behind is part of the
+    /// value, which is why the user holds it rather than the space around it.
+    /// As in a `FROM`, only an unindented continuation leaves a specification Docker still reads the
+    /// same way: it keeps the indent of the line that follows, and `USER app\<newline>  :group` reaches
+    /// it as the user `app  :group`.
     @Test
     void continuationBeforeTheSeparator() {
         rewriteRun(
@@ -306,11 +312,11 @@ class UserTest implements RewriteTest {
             """
               FROM ubuntu:20.04
               USER app\\
-                :group
+              :group
               """,
             spec -> spec.afterRecipe(doc -> {
                 var user = (Docker.User) doc.getStages().getFirst().getInstructions().getLast();
-                assertThat(ArgumentContents.text(user.getUser())).isEqualTo("app\\\n  ");
+                assertThat(ArgumentContents.text(user.getUser())).isEqualTo("app");
                 assertThat(ArgumentContents.text(user.getGroup())).isEqualTo("group");
             })
           )


### PR DESCRIPTION
Formatting belongs in a `Space`, so an unquoted literal whose text runs into the whitespace around it holds source that is not part of its value, and every recipe reading that value reads the formatting too. This adds that as a well-formedness check in `Assertions`, and fixes the one thing it found.

Whitespace *between* an argument's contents stays that argument's own text — `ARG G="pre $V post"` splits into `["pre `, `$V`, ` post"]` — so the check reads only the outer edges. Quoted literals are exempt: `ENV A=" x "` means its spaces.

## What it found

`separatedPart()` reached a part's text up to the separator that follows it, so `FROM ubuntu\⏎:22.04` — which **Docker reads as `ubuntu:22.04`** — modelled its image name as `"ubuntu\⏎"`. A recipe asking which image this is read the formatting too, and one rewriting the value dropped the continuation. Both forms round-trip, so every print-based test stayed green.

The whitespace cannot move to the part that follows: `DockerPrinter.visitFrom` writes `":"` and *then* the tag, so the tag's prefix already holds the whitespace for `FROM ubuntu:\⏎22.04`. One slot, two positions. It becomes the prefix of an **empty content closing the part** instead, which prints identically, stays inside today's tree types, and leaves `ArgumentContents.text()` answering `ubuntu`. The contiguity check in `visitArgument` is relaxed for a trailing empty content.

## Every test here is a Dockerfile Docker accepts

Checked against BuildKit's own `frontend/dockerfile` parser, the code `docker build` uses. A continuation drops the escape character and the newline but **keeps the indent of the line that follows**: `RUN ec\⏎ho hi` is `echo hi`, and `RUN echo \⏎    hi` is `echo     hi`.

So an indented continuation inside an image reference is not valid Docker — `FROM ubuntu\⏎  :22.04` reaches it as `FROM ubuntu  :22.04`, two arguments where FROM takes one or three. The tests that spanned lines that way have been rewritten not to indent, which is the form Docker reads as one reference and the form this fix is about. The backtick test now carries the `# escape=` directive that makes a backtick end a line at all; without it Docker reports an unknown instruction.

Also dropped as invalid rather than kept: whitespace before a separator without a continuation (`FROM ubuntu :22.04`), and a continuation before an empty tag.

`AssertionsTest` gains three cases: a literal that swallowed the whitespace around it is caught, whitespace around a value a separator split into parts is caught, and a quoted literal keeps whitespace of its own.

## Verification

`:rewrite-docker:test` green. Round-trip and tree parts dumped for the 717 Dockerfiles of the corpus behind #8604 and #8610: byte-identical before and after, no parse errors either side.

## Known divergence, not addressed here

`USER app\⏎  :group` *is* valid Docker, which reads everything after the keyword as one specification and so gives the user `"app  :group"` — there, the indent is part of the value, and the tree now says `app`. Fixing that properly means resolving the continuation while keeping the indent, which the literal's text cannot express while it stays a raw source slice. Separately: the lexer treats a backtick as a continuation unconditionally, ignoring the `# escape=` directive.