### PR TITLE
Docker: a `<<-` heredoc is closed by a tab-indented terminator

### DIFF
--- a/rewrite-docker/src/main/antlr/DockerLexer.g4
+++ b/rewrite-docker/src/main/antlr/DockerLexer.g4
@@ -6,7 +6,8 @@ lexer grammar DockerLexer;
 
 @lexer::header
 {import java.util.LinkedList;
-import java.util.Queue;}
+import java.util.Queue;
+import org.openrewrite.docker.internal.Heredocs;}
 
 @lexer::members
 {
@@ -72,6 +73,13 @@ import java.util.Queue;}
         }
     }
 
+    // Both rules that open a heredoc queue its marker exactly as written after the '<<', dash and all,
+    // because the dash is the only thing that tells the rule matching the terminator whether a line
+    // indented with tabs closes this body.
+    private void pushHeredocMarker() {
+        heredocIdentifiers.add(getText().substring(2));
+    }
+
     private boolean atLineContinuation() {
         for (int i = 1; ; i++) {
             int c = _input.LA(i);
@@ -134,13 +142,7 @@ SHELL      : 'SHELL'      { if (!atLineStart) setType(UNQUOTED_TEXT); };
 MAINTAINER : 'MAINTAINER' { if (!atLineStart) setType(UNQUOTED_TEXT); };
 
 // Heredoc start - captures <<EOF or <<-EOF including the identifier and switches to HEREDOC_PREAMBLE mode
-HEREDOC_START : '<<' '-'? [A-Z_][A-Z0-9_]* {
-    // Extract and store the heredoc marker identifier in FIFO order
-    String text = getText();
-    int prefixLen = text.charAt(2) == '-' ? 3 : 2;
-    String marker = text.substring(prefixLen);
-    heredocIdentifiers.add(marker);
-} -> pushMode(HEREDOC_PREAMBLE);
+HEREDOC_START : '<<' '-'? [A-Z_][A-Z0-9_]* { pushHeredocMarker(); } -> pushMode(HEREDOC_PREAMBLE);
 
 // Line continuation - HIDDEN in main mode
 // Supports both backslash (Linux) and backtick (Windows with # escape=`)
@@ -369,13 +371,7 @@ HP_COMMENT : '/*' .*? '*/'  -> channel(HIDDEN);
 HP_LINE_COMMENT : ('//' | '#') ~[\r\n]* '\r'? -> channel(HIDDEN);
 
 // Additional heredoc marker in preamble (for multi-heredoc support)
-HP_HEREDOC_START : '<<' '-'? [A-Z_][A-Z0-9_]* {
-    // Extract and store the heredoc marker identifier in FIFO order
-    String text = getText();
-    int prefixLen = text.charAt(2) == '-' ? 3 : 2;
-    String marker = text.substring(prefixLen);
-    heredocIdentifiers.add(marker);
-} -> type(HEREDOC_START);
+HP_HEREDOC_START : '<<' '-'? [A-Z_][A-Z0-9_]* { pushHeredocMarker(); } -> type(HEREDOC_START);
 
 // Any text on the heredoc line after the marker (destination paths, interpreter names, shell commands, etc.)
 // Exclude < to allow HP_HEREDOC_START to match <<
@@ -397,7 +393,7 @@ H_NEWLINE : '\n' -> type(NEWLINE);
 // For multi-heredoc, we only popMode when the queue is empty (all markers matched in FIFO order)
 HEREDOC_CONTENT : ~[\n]+
 {
-  if(!heredocIdentifiers.isEmpty() && getText().equals(heredocIdentifiers.peek())) {
+  if(!heredocIdentifiers.isEmpty() && Heredocs.closes(heredocIdentifiers.peek(), getText())) {
       setType(UNQUOTED_TEXT);
       heredocIdentifiers.poll();  // Remove from front of queue (FIFO)
       // Only pop mode when all heredoc markers have been matched

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/Assertions.java
@@ -23,6 +23,7 @@ import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.docker.tree.Comment;
 import org.openrewrite.docker.internal.ArgumentContents;
+import org.openrewrite.docker.internal.Heredocs;
 import org.openrewrite.docker.tree.Docker;
 import org.openrewrite.docker.tree.Space;
 import org.openrewrite.internal.StringUtils;
@@ -245,7 +246,7 @@ public class Assertions {
     }
 
     private static class WellFormedVisitor extends DockerIsoVisitor<List<String>> {
-        private static final Pattern HEREDOC_MARKER = Pattern.compile("<<-?([A-Za-z_][A-Za-z0-9_]*)");
+        private static final Pattern HEREDOC_MARKER = Pattern.compile("<<(-?[A-Za-z_][A-Za-z0-9_]*)");
 
         private final Set<UUID> ids = new HashSet<>();
 
@@ -419,8 +420,9 @@ public class Assertions {
             }
             for (int i = 0; i < form.getBodies().size(); i++) {
                 Docker.HeredocBody body = form.getBodies().get(i);
-                if (i < markers.size() && !markers.get(i).equals(body.getClosing())) {
-                    violations.add("expected the heredoc opened by " + quoted(markers.get(i)) + " to close with it," +
+                if (i < markers.size() && !Heredocs.closes(markers.get(i), body.getClosing())) {
+                    String name = markers.get(i).startsWith("-") ? markers.get(i).substring(1) : markers.get(i);
+                    violations.add("expected the heredoc opened by " + quoted(name) + " to close with it," +
                             " but it closes with " + quoted(body.getClosing()));
                 }
                 if (!body.getOpening().startsWith("<<")) {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/DockerParserVisitor.java
@@ -1161,6 +1161,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
             // Track if we've seen the first HEREDOC_START (for destination extraction)
             boolean seenFirstHeredocStart = false;
             int heredocStartCount = 0;
+            List<String> openings = new ArrayList<>();
 
             // Collect all tokens in the preamble (HEREDOC_START and preambleElements)
             for (int i = 0; i < preambleCtx.getChildCount(); i++) {
@@ -1170,6 +1171,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
                     if (tn.getSymbol().getType() == DockerLexer.HEREDOC_START) {
                         heredocStartCount++;
                         seenFirstHeredocStart = true;
+                        openings.add(tn.getText());
                     }
                     // Add whitespace prefix if any
                     Space tokenPrefix = prefix(tn.getSymbol());
@@ -1205,8 +1207,8 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
 
             // Parse each heredoc body
             List<Docker.HeredocBody> bodies = new ArrayList<>();
-            for (DockerParser.HeredocBodyContext bodyCtx : c.heredocBody()) {
-                bodies.add(visitHeredocBodyContext(bodyCtx));
+            for (int i = 0; i < c.heredocBody().size(); i++) {
+                bodies.add(visitHeredocBodyContext(c.heredocBody(i), i < openings.size() ? openings.get(i) : null));
             }
 
             return new Docker.HeredocForm(randomId(), prefix, Markers.EMPTY, preamble, destination, bodies);
@@ -1236,7 +1238,7 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
         return new Docker.Argument(randomId(), argPrefix, Markers.EMPTY, contents);
     }
 
-    private Docker.HeredocBody visitHeredocBodyContext(DockerParser.HeredocBodyContext ctx) {
+    private Docker.HeredocBody visitHeredocBodyContext(DockerParser.HeredocBodyContext ctx, @Nullable String opening) {
         Space prefix = prefix(ctx.getStart());
 
         // Collect content lines from heredocContent
@@ -1245,14 +1247,13 @@ public class DockerParserVisitor extends DockerParserBaseVisitor<Docker> {
             collectHeredocContent(ctx.heredocContent(), contentLines);
         }
 
-        // Get closing marker (UNQUOTED_TEXT) - this is also the opening marker name without <<
+        // The closing marker is the whole line that closed the body, which a "<<-" heredoc allows to be
+        // indented with tabs, so it is not always the text of the marker that opened it
         String closing = ctx.heredocEnd().UNQUOTED_TEXT().getText();
         skip(ctx.heredocEnd().UNQUOTED_TEXT().getSymbol());
 
-        // The opening marker is "<<" + closing (we reconstruct it for the model)
-        String opening = "<<" + closing;
-
-        return new Docker.HeredocBody(randomId(), prefix, Markers.EMPTY, opening, contentLines, closing);
+        return new Docker.HeredocBody(randomId(), prefix, Markers.EMPTY,
+                opening == null ? "<<" + closing : opening, contentLines, closing);
     }
 
     /**

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/Heredocs.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/Heredocs.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.docker.internal;
+
+/**
+ * Where the body of a heredoc ends.
+ * <p>
+ * A heredoc opened with {@code <<-} may be closed by a delimiter line indented with tabs, so that the
+ * body of one written inside an indented block reads as part of it; one opened with plain {@code <<}
+ * is closed only by a line that is the delimiter and nothing else, and an indented copy of it is
+ * content. The lexer decides where to leave heredoc mode by this rule and
+ * {@code org.openrewrite.docker.Assertions} reads that decision back off the parsed tree, so both ask
+ * it here rather than each spelling out its own idea of what closes a body.
+ */
+public final class Heredocs {
+
+    private Heredocs() {
+    }
+
+    /**
+     * Whether a line of a heredoc body closes it.
+     *
+     * @param marker the marker as written after {@code <<}, so {@code "EOF"} or {@code "-EOF"}
+     * @param line   a whole line of the body, without its newline
+     */
+    public static boolean closes(String marker, String line) {
+        if (marker.startsWith("-")) {
+            int indent = 0;
+            while (indent < line.length() && line.charAt(indent) == '\t') {
+                indent++;
+            }
+            return line.substring(indent).equals(marker.substring(1));
+        }
+        return line.equals(marker);
+    }
+}

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/grammar/DockerLexer.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/grammar/DockerLexer.java
@@ -17,6 +17,7 @@
 package org.openrewrite.docker.internal.grammar;
 import java.util.LinkedList;
 import java.util.Queue;
+import org.openrewrite.docker.internal.Heredocs;
 import org.antlr.v4.runtime.Lexer;
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.Token;
@@ -198,6 +199,13 @@ public class DockerLexer extends Lexer {
 	            default:
 	                return false;
 	        }
+	    }
+
+	    // Both rules that open a heredoc queue its marker exactly as written after the '<<', dash and all,
+	    // because the dash is the only thing that tells the rule matching the terminator whether a line
+	    // indented with tabs closes this body.
+	    private void pushHeredocMarker() {
+	        heredocIdentifiers.add(getText().substring(2));
 	    }
 
 	    private boolean atLineContinuation() {
@@ -455,26 +463,14 @@ public class DockerLexer extends Lexer {
 	private void HEREDOC_START_action(RuleContext _localctx, int actionIndex) {
 		switch (actionIndex) {
 		case 19:
-
-			    // Extract and store the heredoc marker identifier in FIFO order
-			    String text = getText();
-			    int prefixLen = text.charAt(2) == '-' ? 3 : 2;
-			    String marker = text.substring(prefixLen);
-			    heredocIdentifiers.add(marker);
-
+			 pushHeredocMarker();
 			break;
 		}
 	}
 	private void HP_HEREDOC_START_action(RuleContext _localctx, int actionIndex) {
 		switch (actionIndex) {
 		case 20:
-
-			    // Extract and store the heredoc marker identifier in FIFO order
-			    String text = getText();
-			    int prefixLen = text.charAt(2) == '-' ? 3 : 2;
-			    String marker = text.substring(prefixLen);
-			    heredocIdentifiers.add(marker);
-
+			 pushHeredocMarker();
 			break;
 		}
 	}
@@ -482,7 +478,7 @@ public class DockerLexer extends Lexer {
 		switch (actionIndex) {
 		case 21:
 
-			  if(!heredocIdentifiers.isEmpty() && getText().equals(heredocIdentifiers.peek())) {
+			  if(!heredocIdentifiers.isEmpty() && Heredocs.closes(heredocIdentifiers.peek(), getText())) {
 			      setType(UNQUOTED_TEXT);
 			      heredocIdentifiers.poll();  // Remove from front of queue (FIFO)
 			      // Only pop mode when all heredoc markers have been matched

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/HeredocTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/HeredocTest.java
@@ -69,6 +69,35 @@ class HeredocTest implements RewriteTest {
     }
 
     @Test
+    void tabIndentedTerminatorClosesADashHeredoc() {
+        rewriteRun(
+          docker(
+            """
+              FROM ubuntu:20.04
+              RUN <<-FILE_END
+              	echo "Hello World"
+              	FILE_END
+              """
+          )
+        );
+    }
+
+    @Test
+    void indentedTerminatorIsContentOfAPlainHeredoc() {
+        rewriteRun(
+          docker(
+            """
+              FROM ubuntu:20.04
+              RUN <<EOF
+                echo "Hello World"
+                EOF
+              EOF
+              """
+          )
+        );
+    }
+
+    @Test
     void multipleHeredocsInRunCommand() {
         // Multiple heredocs chained together with && - a common pattern for creating multiple files
         // See: https://github.com/Bindernews/minblur/blob/7915e7d8765eb3785da4fabda38e744702ec5985/docker/Dockerfile#L13


### PR DESCRIPTION
`RUN <<-EOF` followed by a tab-indented `EOF` failed to parse: the lexer's terminator rule compared the whole body line to the marker with `equals`, so `"\tEOF"` never matched `"EOF"`. The heredoc mode never popped and everything after it was swallowed as body content.

```dockerfile
FROM ubuntu
RUN <<-EOF
	echo hi
	EOF
```

The `-` was also stripped when the marker was queued, so by the time a line had to be judged the lexer could no longer tell `<<EOF` from `<<-EOF` — and that distinction is the whole rule. Docker allows a tab-indented terminator for the `<<-` form only; under plain `<<`, an indented copy of the delimiter is content.

- The two rules that open a heredoc queue the marker as written after the `<<`, dash and all. Both spelled out the same six-line action; they now share one `pushHeredocMarker()`.
- One place, `Heredocs.closes`, answers whether a line closes a body. `Assertions.visitHeredocForm` re-asserted the same rule against the parsed tree with its own `equals`, and would have rejected the now-correctly-parsed tree, so it asks there too.
- A body's `opening` now carries the marker that opened it, as its own documentation says, rather than being rebuilt as `"<<" + closing` — which for `<<-EOF` gave `<<EOF`, and after this fix would have given `<<\tEOF`.

Tests pin both directions: the tab-indented terminator closes a `<<-` heredoc, and an indented terminator under plain `<<` stays content.

Generated lexer sources are checked in, so `:rewrite-docker:generateAntlrSources` is re-run and its output committed. All 583 `rewrite-docker` tests pass.