### PR TITLE
Fix parsing successive @Field declarations

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -197,6 +197,20 @@ public class GroovyParserVisitor {
         }
 
         for (ClassNode aClass : ast.getClasses()) {
+            if (aClass.getName().equals(ast.getMainClassName())) {
+                for (FieldNode field : aClass.getFields()) {
+                    if (isFieldDeclaration(field)) {
+                        // The @Field transform leaves a null ConstantExpression in the script body, but the generated
+                        // script field retains the declaration's type and initializer. Restore the source annotation
+                        // and replace that placeholder statement with the field.
+                        ClassNode fieldAnnotationType = new ClassNode(Field.class);
+                        if (field.getAnnotations(fieldAnnotationType).isEmpty()) {
+                            field.addAnnotation(new AnnotationNode(fieldAnnotationType));
+                        }
+                        sortedByPosition.put(pos(field), field);
+                    }
+                }
+            }
             // skip over the synthetic script class
             if (!aClass.getName().equals(ast.getMainClassName()) || !aClass.getName().endsWith("doesntmatter")) {
                 // synthetic helper classes Groovy generates for traits hold the bodies of trait methods/fields;
@@ -943,7 +957,7 @@ public class GroovyParserVisitor {
                     typeMapping.variableType(field)
             );
 
-            if (field.getInitialExpression() != null) {
+            if (field.getInitialExpression() != null && !(field.getInitialExpression() instanceof EmptyExpression)) {
                 Space beforeAssign = sourceBefore("=");
                 Expression initializer = visitor.doVisit(field.getInitialExpression());
                 namedVariable = namedVariable.getPadding().withInitializer(padLeft(beforeAssign, initializer));
@@ -3507,6 +3521,11 @@ public class GroovyParserVisitor {
             RewriteGroovyClassVisitor classVisitor = new RewriteGroovyClassVisitor(unit);
             classVisitor.visitMethod(methodNode);
             return JRightPadded.build(classVisitor.pollQueue());
+        } else if (node instanceof FieldNode) {
+            FieldNode fieldNode = (FieldNode) node;
+            RewriteGroovyClassVisitor classVisitor = new RewriteGroovyClassVisitor(unit);
+            classVisitor.visitField(fieldNode);
+            return JRightPadded.build(classVisitor.pollQueue());
         } else if (node instanceof ImportNode) {
             ImportNode importNode = (ImportNode) node;
             Space importPrefix = sourceBefore("import");
@@ -3630,6 +3649,15 @@ public class GroovyParserVisitor {
 
     private static LineColumn pos(ASTNode node) {
         return new LineColumn(node.getLineNumber(), node.getColumnNumber());
+    }
+
+    private boolean isFieldDeclaration(FieldNode field) {
+        if (!appearsInSource(field)) {
+            return false;
+        }
+        int offset = sourceLineNumberOffsets[field.getLineNumber() - 1] + field.getColumnNumber() - 1;
+        return source.startsWith("@" + Field.class.getSimpleName(), offset) ||
+                source.startsWith("@" + Field.class.getCanonicalName(), offset);
     }
 
     private static boolean isSynthetic(ASTNode node) {

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/JenkinsFileTest.java
@@ -23,6 +23,36 @@ import static org.openrewrite.groovy.Assertions.groovy;
 
 class JenkinsFileTest implements RewriteTest {
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/6243")
+    @Test
+    void annotatedScriptFieldsWithListInitializer() {
+        rewriteRun(
+          groovy(
+            """
+              import groovy.transform.Field
+
+              @Field def foo
+
+              // list of pull requests created
+              @Field List<String> newPullRequests = []
+
+              pipeline {
+                  stages {
+                      stage('Setup') {
+                          steps {
+                              script {
+                                  // empty
+                              }
+                          }
+                      }
+                  }
+              }
+              """,
+            spec -> spec.path("Jenkinsfile")
+          )
+        );
+    }
+
     @Test
     void jenkinsfile() {
         // the Jenkinsfile from spring-projects/spring-data-release


### PR DESCRIPTION
## What changed

- Recover top-level `@Field` declarations from the generated Groovy script fields, which retain the original type and initializer.
- Replace the null script-body placeholders at the same source positions.
- Treat Groovy's `EmptyExpression` as an absent initializer.
- Add the Jenkinsfile regression from #6243.

## Why

Groovy's `@Field` AST transform moves declarations onto the generated script class and leaves null `ConstantExpression` placeholders in the script body. The existing source-based fallback scans forward for `=`, so an uninitialized `@Field` followed by another initialized field can be combined incorrectly. That drops the second annotation, comment, and generic type when the source is printed.

Using the generated field nodes preserves the declaration boundaries and the typed initializer, so successive annotated fields round-trip idempotently.

## User impact

Jenkinsfiles and other Groovy scripts with successive `@Field` declarations no longer lose annotations, comments, or declared types during parse/print.

## Verification

- `:rewrite-groovy:test --tests org.openrewrite.groovy.JenkinsFileTest.annotatedScriptFieldsWithListInitializer`
- `:rewrite-groovy:test --tests org.openrewrite.groovy.tree.AnnotationTest`
- `:rewrite-groovy:check` (includes the Groovy 2 compatibility suite, license checks, and recipe CSV validation)

- Fixes #6243