### PR TITLE
Docker: the `,` between two options of a flag separates them

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/internal/ArgumentContents.java
@@ -51,8 +51,9 @@ public class ArgumentContents {
     }
 
     /// Splits the value of a command's flag into its quoted literals, environment variable references
-    /// and the `=` separating a key from a value, as in `--mount=type=bind`. Everything that is not a
-    /// quote or a separator is handed to [#splitVariables(String, Space)], so a variable reference means
+    /// and the separators of an option list: the `=` between a key and its value and the `,` between
+    /// one option and the next, as in `--mount=type=bind,from=alpine`. Everything that is not a quote
+    /// or a separator is handed to [#splitVariables(String, Space)], so a variable reference means
     /// the same thing here as it does in an argument's value.
     public static List<Docker.ArgumentContent> flagValue(String text) {
         List<Docker.ArgumentContent> contents = new ArrayList<>();
@@ -73,9 +74,9 @@ public class ArgumentContents {
                 contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, text.substring(i + 1, close),
                         c == '"' ? Docker.Literal.QuoteStyle.DOUBLE : Docker.Literal.QuoteStyle.SINGLE));
                 i = close + 1;
-            } else if (c == '=') {
+            } else if (c == '=' || c == ',') {
                 flushFlagText(current, contents);
-                contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, "=", null));
+                contents.add(new Docker.Literal(randomId(), Space.EMPTY, Markers.EMPTY, String.valueOf(c), null));
                 i++;
             } else {
                 current.append(c);

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/trait/DockerCopyFrom.java
@@ -31,6 +31,7 @@ import org.openrewrite.trait.VisitFunction2;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 
@@ -114,7 +115,7 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Copy> {
         if (isNonNegativeInteger(value)) {
             return true;
         }
-        return stageNames().contains(value);
+        return stageNames().contains(value.toLowerCase(Locale.ROOT));
     }
 
     private static boolean isNonNegativeInteger(String value) {
@@ -129,6 +130,8 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Copy> {
         return true;
     }
 
+    /// The `AS` alias of every stage of the file, lowercased as Docker records and looks them up,
+    /// so `COPY --from=Builder` finds `AS builder`.
     private Set<String> stageNames() {
         Docker.File file = cursor.firstEnclosing(Docker.File.class);
         Set<String> names = new HashSet<>();
@@ -136,7 +139,7 @@ public class DockerCopyFrom implements DockerImageReference<Docker.Copy> {
             for (Docker.Stage stage : file.getStages()) {
                 Docker.From.As as = stage.getFrom().getAs();
                 if (as != null) {
-                    names.add(as.getName().getText());
+                    names.add(as.getName().getText().toLowerCase(Locale.ROOT));
                 }
             }
         }

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/trait/DockerCopyFromTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/trait/DockerCopyFromTest.java
@@ -145,6 +145,31 @@ class DockerCopyFromTest implements RewriteTest {
     }
 
     @Test
+    void stageNameIsMatchedWithoutRegardToCase() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() ->
+            new DockerCopyFrom.Matcher().asVisitor((image, ctx) -> {
+                assertThat(image.isStageReference()).isTrue();
+                assertThat(image.getImageName()).isEmpty();
+                return SearchResult.found(image.getTree());
+            })
+          )),
+          docker(
+            """
+              FROM alpine AS Builder
+              FROM alpine
+              COPY --from=builder /out /app
+              """,
+            """
+              FROM alpine AS Builder
+              FROM alpine
+              ~~>COPY --from=builder /out /app
+              """
+          )
+        );
+    }
+
+    @Test
     void identifiesStageReferenceByNumericIndex() {
         rewriteRun(
           spec -> spec.recipe(RewriteTest.toRecipe(() ->

--- a/rewrite-docker/src/test/java/org/openrewrite/docker/tree/RunTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/tree/RunTest.java
@@ -178,10 +178,10 @@ class RunTest implements RewriteTest {
                 assertThat(run.getFlags().get(0).getName()).isEqualTo("network");
                 assertThat(((Docker.Literal) run.getFlags().get(0).getValue().getContents().getFirst()).getText()).isEqualTo("none");
                 assertThat(run.getFlags().get(1).getName()).isEqualTo("mount");
-                // Flag value is parsed as multiple elements: type, =, cache,target, =, /cache
                 Docker.Argument mountValue = run.getFlags().get(1).getValue();
-                assertThat(mountValue.getContents()).hasSize(5);
-                assertThat(((Docker.Literal) mountValue.getContents().get(0)).getText()).isEqualTo("type");
+                assertThat(mountValue.getContents())
+                  .extracting(content -> ((Docker.Literal) content).getText())
+                  .containsExactly("type", "=", "cache", ",", "target", "=", "/cache");
             })
           )
         );


### PR DESCRIPTION
A flag whose value is an option list, as a `RUN --mount` is, held every option in one run of text: `--mount=type=bind,from=alpine,target=/opt` modelled as `L[type] L[=] L[bind,from] L[=] L[alpine,target] L[=] L[/opt]`, each key glued to the value before it. The `,` is now a content of its own, as the `=` between a key and its value already was, so an option's value is a slice of contents rather than a substring of one — which is what a reader of a mount's `from`, `type` or `target` needs, and what keeps a value holding a quote or a `${VAR}` readable as the contents it was parsed into.

Also matches a stage name without regard to case, as Docker records and looks it up lowercased, so `COPY --from=Builder` finds `AS builder` rather than reading as an external image that happens to share its name.

This started out as support for `RUN --mount=...,from=<image>` as a third site of an image reference; that half was too much surface for how niche the case is. All 2,536 files of a real-world Dockerfile corpus still round-trip byte for byte.