### PR TITLE
Docker: a recipe's display name and description are values, not overrides

### DIFF
--- a/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/AddOrUpdateLabel.java
@@ -58,15 +58,9 @@ public class AddOrUpdateLabel extends Recipe {
     @Nullable
     String stageName;
 
-    @Override
-    public String getDisplayName() {
-        return "Add Docker LABEL instruction";
-    }
+    String displayName = "Add Docker LABEL instruction";
 
-    @Override
-    public String getDescription() {
-        return "Adds or updates a LABEL instruction in a Dockerfile. By default, adds to the final stage only.";
-    }
+    String description = "Adds or updates a LABEL instruction in a Dockerfile. By default, adds to the final stage only.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/AddUserInstruction.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/AddUserInstruction.java
@@ -67,16 +67,10 @@ public class AddUserInstruction extends Recipe {
     @Nullable
     Boolean skipIfUserExists;
 
-    @Override
-    public String getDisplayName() {
-        return "Add `USER` instruction";
-    }
+    String displayName = "Add `USER` instruction";
 
-    @Override
-    public String getDescription() {
-        return "Adds a `USER` instruction to run the container as a non-root user (CIS Docker Benchmark 4.1). " +
-                "By default, adds to the final stage only and skips if a `USER` instruction already exists.";
-    }
+    String description = "Adds a `USER` instruction to run the container as a non-root user (CIS Docker Benchmark 4.1). " +
+            "By default, adds to the final stage only and skips if a `USER` instruction already exists.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/ChangeFrom.java
@@ -95,17 +95,11 @@ public class ChangeFrom extends Recipe {
     @Nullable
     String newPlatform;
 
-    @Override
-    public String getDisplayName() {
-        return "Change Docker FROM";
-    }
+    String displayName = "Change Docker FROM";
 
-    @Override
-    public String getDescription() {
-        return "Change the base image in a Dockerfile FROM instruction. " +
-                "Each `*` in an `old*` glob is a positional capture; `$N` in the paired `new*` substitutes capture N. " +
-                "`$0` substitutes the full original value; `\\$` is a literal dollar.";
-    }
+    String description = "Change the base image in a Dockerfile FROM instruction. " +
+            "Each `*` in an `old*` glob is a positional capture; `$N` in the paired `new*` substitutes capture N. " +
+            "`$0` substitutes the full original value; `\\$` is a literal dollar.";
 
     @Override
     public Validated<Object> validate() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/CombineRunInstructions.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/CombineRunInstructions.java
@@ -53,16 +53,10 @@ public class CombineRunInstructions extends Recipe {
     @Nullable
     String separator;
 
-    @Override
-    public String getDisplayName() {
-        return "Combine consecutive `RUN` instructions";
-    }
+    String displayName = "Combine consecutive `RUN` instructions";
 
-    @Override
-    public String getDescription() {
-        return "Combines consecutive `RUN` instructions into a single instruction to reduce image layers. " +
-                "Only shell form `RUN` instructions without flags are combined.";
-    }
+    String description = "Combines consecutive `RUN` instructions into a single instruction to reduce image layers. " +
+            "Only shell form `RUN` instructions without flags are combined.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/ReplaceAddWithCopy.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/ReplaceAddWithCopy.java
@@ -54,17 +54,11 @@ public class ReplaceAddWithCopy extends Recipe {
             ".tar.xz", ".txz", ".tar.lz", ".tlz", ".tar.lzma", ".tar.zst"
     ));
 
-    @Override
-    public String getDisplayName() {
-        return "Replace `ADD` with `COPY`";
-    }
+    String displayName = "Replace `ADD` with `COPY`";
 
-    @Override
-    public String getDescription() {
-        return "Replaces `ADD` instructions with `COPY` where appropriate. " +
-                "`ADD` is only kept when the source is a URL or a tar archive that should be auto-extracted. " +
-                "Using `COPY` is preferred for transparency (CIS Docker Benchmark 4.9).";
-    }
+    String description = "Replaces `ADD` instructions with `COPY` where appropriate. " +
+            "`ADD` is only kept when the source is a URL or a tar archive that should be auto-extracted. " +
+            "Using `COPY` is preferred for transparency (CIS Docker Benchmark 4.9).";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/UseExecFormEntrypoint.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/UseExecFormEntrypoint.java
@@ -69,17 +69,11 @@ public class UseExecFormEntrypoint extends Recipe {
     @Nullable
     Boolean convertCmd;
 
-    @Override
-    public String getDisplayName() {
-        return "Use exec form for `ENTRYPOINT` and `CMD`";
-    }
+    String displayName = "Use exec form for `ENTRYPOINT` and `CMD`";
 
-    @Override
-    public String getDescription() {
-        return "Converts shell form `ENTRYPOINT` and `CMD` instructions to exec form (JSON array). " +
-                "Exec form is preferred because it runs the command as PID 1, allowing it to receive " +
-                "Unix signals properly. Shell form wraps commands in `/bin/sh -c` which can cause signal handling issues.";
-    }
+    String description = "Converts shell form `ENTRYPOINT` and `CMD` instructions to exec form (JSON array). " +
+            "Exec form is preferred because it runs the command as PID 1, allowing it to receive " +
+            "Unix signals properly. Shell form wraps commands in `/bin/sh -c` which can cause signal handling issues.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindBaseImages.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindBaseImages.java
@@ -62,15 +62,9 @@ public class FindBaseImages extends Recipe {
     @Nullable
     String platformPattern;
 
-    @Override
-    public String getDisplayName() {
-        return "Find Docker base images";
-    }
+    String displayName = "Find Docker base images";
 
-    @Override
-    public String getDescription() {
-        return "Find all base images (`FROM` instructions) in Dockerfiles.";
-    }
+    String description = "Find all base images (`FROM` instructions) in Dockerfiles.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindEndOfLifeImages.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindEndOfLifeImages.java
@@ -50,18 +50,12 @@ public class FindEndOfLifeImages extends Recipe {
     @Nullable
     Boolean includeApproaching;
 
-    @Override
-    public String getDisplayName() {
-        return "Find end-of-life Docker images";
-    }
+    String displayName = "Find end-of-life Docker images";
 
-    @Override
-    public String getDescription() {
-        return "Identifies Docker images that have reached end-of-life, both the base image of a build " +
-                "stage and an image a `COPY --from` pulls a file out of. " +
-                "Using EOL images poses security risks as they no longer receive security updates. " +
-                "Detected images include EOL versions of Debian, Ubuntu, Alpine, Python, and Node.js.";
-    }
+    String description = "Identifies Docker images that have reached end-of-life, both the base image of a build " +
+            "stage and an image a `COPY --from` pulls a file out of. " +
+            "Using EOL images poses security risks as they no longer receive security updates. " +
+            "Detected images include EOL versions of Debian, Ubuntu, Alpine, Python, and Node.js.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindExposedPorts.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindExposedPorts.java
@@ -45,15 +45,9 @@ public class FindExposedPorts extends Recipe {
     @Nullable
     String portPattern;
 
-    @Override
-    public String getDisplayName() {
-        return "Find exposed ports";
-    }
+    String displayName = "Find exposed ports";
 
-    @Override
-    public String getDescription() {
-        return "Find all `EXPOSE` instructions in Dockerfiles and report the exposed ports.";
-    }
+    String description = "Find all `EXPOSE` instructions in Dockerfiles and report the exposed ports.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindMissingHealthcheck.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindMissingHealthcheck.java
@@ -32,16 +32,10 @@ import org.openrewrite.marker.SearchResult;
 @EqualsAndHashCode(callSuper = false)
 public class FindMissingHealthcheck extends Recipe {
 
-    @Override
-    public String getDisplayName() {
-        return "Find missing `HEALTHCHECK`";
-    }
+    String displayName = "Find missing `HEALTHCHECK`";
 
-    @Override
-    public String getDescription() {
-        return "Finds Dockerfiles where the final stage is missing a `HEALTHCHECK` instruction (CIS Docker Benchmark 4.6). " +
-                "Health checks help container orchestrators determine if a container is healthy and ready to receive traffic.";
-    }
+    String description = "Finds Dockerfiles where the final stage is missing a `HEALTHCHECK` instruction (CIS Docker Benchmark 4.6). " +
+            "Health checks help container orchestrators determine if a container is healthy and ready to receive traffic.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindRootUser.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindRootUser.java
@@ -42,17 +42,11 @@ public class FindRootUser extends Recipe {
     @Nullable
     Boolean includeMissingUser;
 
-    @Override
-    public String getDisplayName() {
-        return "Find containers running as root";
-    }
+    String displayName = "Find containers running as root";
 
-    @Override
-    public String getDescription() {
-        return "Finds containers that run as root user (CIS Docker Benchmark 4.1). " +
-                "This includes explicit `USER root` or `USER 0` instructions, " +
-                "and optionally containers with no `USER` instruction in the final stage (which default to root).";
-    }
+    String description = "Finds containers that run as root user (CIS Docker Benchmark 4.1). " +
+            "This includes explicit `USER root` or `USER 0` instructions, " +
+            "and optionally containers with no `USER` instruction in the final stage (which default to root).";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {

--- a/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindUnpinnedBaseImages.java
+++ b/rewrite-docker/src/main/java/org/openrewrite/docker/search/FindUnpinnedBaseImages.java
@@ -32,17 +32,11 @@ import org.openrewrite.marker.SearchResult;
 @EqualsAndHashCode(callSuper = false)
 public class FindUnpinnedBaseImages extends Recipe {
 
-    @Override
-    public String getDisplayName() {
-        return "Find unpinned base images";
-    }
+    String displayName = "Find unpinned base images";
 
-    @Override
-    public String getDescription() {
-        return "Finds FROM instructions that use unpinned base images (CIS Docker Benchmark 4.2). " +
-                "Images without an explicit tag default to 'latest', which is not reproducible. " +
-                "Images pinned by digest are considered acceptable.";
-    }
+    String description = "Finds FROM instructions that use unpinned base images (CIS Docker Benchmark 4.2). " +
+            "Images without an explicit tag default to 'latest', which is not reproducible. " +
+            "Images pinned by digest are considered acceptable.";
 
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {


### PR DESCRIPTION
Every recipe in `rewrite-docker` is a Lombok `@Value`, so its display name and description can be fields the class carries rather than methods it overrides. `rewrite.yml`'s best practices say so, and the twelve recipes here that still wrote them as `getDisplayName()`/`getDescription()` overrides now do not.

```diff
-    @Override
-    public String getDisplayName() {
-        return "Find containers running as root";
-    }
+    String displayName = "Find containers running as root";
```

No recipe's metadata changes: `:rewrite-docker:recipeCsvGenerate` reproduces `recipes.csv` byte for byte, and `recipeCsvValidate` passes against the unchanged file.

- Split out of #8618, where it arrived as a side effect of temporarily scoping `rewrite.yml`'s best practices to this module. It has nothing to do with that PR's BuildKit lint work, and reviewing it there meant reading twelve files of mechanical churn alongside six new recipes.