### PR TITLE
Go: a capture's declared type constrains what a pattern matches

### DIFF
--- a/rewrite-go/doc/recipe-authoring.md
+++ b/rewrite-go/doc/recipe-authoring.md
@@ -417,6 +417,57 @@ name, and assert on its attributed type. Throw `AssertionError` with a
 descriptive message on mismatch — drop them straight into an
 `afterRecipe(cu -> ...)` lambda.
 
+## Typed captures
+
+`Capture.WithType` declares the Go type a capture stands for. The
+scaffold declares the placeholder with it, so the pattern type-checks,
+and the match binds only a subtree whose attributed type is assignable
+to it:
+
+```go
+e := template.Expr("e").WithType("error")
+pat := template.Expression(fmt.Sprintf("%s == nil", e)).Captures(e).Build()
+```
+
+That matches `err == nil` and refuses `s == nil` where `s` is a
+`*string`. Assignability follows Go's rule as far as the attributed model
+records it, so an interface is satisfied by a type carrying its methods:
+a concrete `*MyErr` answers to `error` the way `io.EOF` does. `errors.Is`
+takes two `error` arguments, so this is the guard that makes
+`err == io.EOF` → `errors.Is(err, io.EOF)` a rewrite a pattern can state
+safely.
+
+Three rules bound it:
+
+- **A declared type is read whatever `TypeMatching` says.** The mode
+  governs the type slots a pattern did not ask about; this is one it did.
+- **A candidate the parser could not attribute is the mode's decision.**
+  `TypeMatchingLenient` binds it; the other two refuse. A template parsed
+  alone attributes only the stdlib (see "Module context for type
+  attribution"), so a typed capture against an unattributed tree no-ops
+  by default — `GoPattern.Explain` counts what it refused for want of
+  attribution, which tells that apart from source that differs.
+- **Only an expression carries a type.** `WithType` on a `Stmt`, `Ident`
+  or `TypeExpr` capture panics, and a type name the pattern uses but
+  cannot resolve fails the parse rather than constraining nothing. Name
+  it through `Imports`, `Context` or `ExportData`.
+
+Four limits come from what the model carries, all of them worth knowing
+before a recipe leans on a typed capture as a safety guard:
+
+- **A method promoted from an embedded field is not in the embedding
+  type's method set** (`named.NumMethods` is what a type declares). So
+  `struct{ Inner }` does not answer to an interface `Inner` satisfies,
+  and the capture under-matches.
+- **`*T` and `T` are one attributed type.** A capture declared `error`
+  binds a `MyErr{}` whose `Error()` has a pointer receiver, which Go
+  would reject — the one direction in which the guard over-matches.
+- **A variadic `...T` parameter is recorded as `[]T`** with no flag to
+  tell the two apart, so an interface method that is variadic is
+  satisfied by one taking a slice.
+- **A type that export data names but does not describe carries no
+  method set**, so it satisfies an interface only by being it.
+
 ## Variadic captures
 
 A capture marked `Variadic(min, max)` stands for a run of list elements

--- a/rewrite-go/doc/recipe-authoring.md
+++ b/rewrite-go/doc/recipe-authoring.md
@@ -437,7 +437,7 @@ takes two `error` arguments, so this is the guard that makes
 `err == io.EOF` → `errors.Is(err, io.EOF)` a rewrite a pattern can state
 safely.
 
-Three rules bound it:
+Four rules bound it:
 
 - **A declared type is read whatever `TypeMatching` says.** The mode
   governs the type slots a pattern did not ask about; this is one it did.
@@ -447,6 +447,9 @@ Three rules bound it:
   attribution"), so a typed capture against an unattributed tree no-ops
   by default — `GoPattern.Explain` counts what it refused for want of
   attribution, which tells that apart from source that differs.
+- **The type filters a match, not a bind.** `MatchResult.Bind` splices
+  the node you name, so `Instantiate` will emit `errors.New(42)` for a
+  capture declared `string`. Hand-built nodes are yours to get right.
 - **Only an expression carries a type.** `WithType` on a `Stmt`, `Ident`
   or `TypeExpr` capture panics, and a type name the pattern uses but
   cannot resolve fails the parse rather than constraining nothing. Name

--- a/rewrite-go/pkg/matcher/assignability_test.go
+++ b/rewrite-go/pkg/matcher/assignability_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+func method(name string, returns java.JavaType, params ...java.JavaType) *java.JavaTypeMethod {
+	return &java.JavaTypeMethod{Name: name, ReturnType: returns, ParameterTypes: params}
+}
+
+func goInterface(fqn string, methods ...*java.JavaTypeMethod) *java.JavaTypeClass {
+	return &java.JavaTypeClass{FullyQualifiedName: fqn, Kind: "Interface", Methods: methods}
+}
+
+func goClass(fqn string, methods ...*java.JavaTypeMethod) *java.JavaTypeClass {
+	return &java.JavaTypeClass{FullyQualifiedName: fqn, Kind: "Class", Methods: methods}
+}
+
+// errorType is how the type mapper attributes Go's predeclared `error`.
+func errorType() *java.JavaTypeClass {
+	return goInterface("error", method("Error", goType("string")))
+}
+
+func TestIsAssignableToTypeAcceptsTheSameType(t *testing.T) {
+	assert.True(t, IsAssignableToType(errorType(), errorType()))
+}
+
+func TestIsAssignableToTypeFoldsSpellingsOfOneType(t *testing.T) {
+	assert.True(t, IsAssignableToType(goType("byte"), goType("uint8")))
+	assert.True(t, IsAssignableToType(goType("uint8"), goType("byte")))
+}
+
+func TestIsAssignableToTypeAcceptsALiteralKeyword(t *testing.T) {
+	assert.True(t, IsAssignableToType(litType("int"), goType("int")))
+	assert.False(t, IsAssignableToType(litType("int"), goType("string")))
+}
+
+func TestIsAssignableToTypeAcceptsAStructuralImplementation(t *testing.T) {
+	myErr := goClass("a.MyErr", method("Error", goType("string")))
+	assert.True(t, IsAssignableToType(myErr, errorType()))
+}
+
+func TestIsAssignableToTypeRefusesAMissingMethod(t *testing.T) {
+	assert.False(t, IsAssignableToType(goClass("a.Plain"), errorType()))
+}
+
+func TestIsAssignableToTypeRefusesAMismatchedSignature(t *testing.T) {
+	assert.False(t, IsAssignableToType(goClass("a.WrongErr", method("Error", goType("int"))), errorType()))
+	assert.False(t, IsAssignableToType(
+		goClass("a.ArgErr", method("Error", goType("string"), goType("string"))), errorType()))
+}
+
+func TestIsAssignableToTypeAcceptsAnythingAsAny(t *testing.T) {
+	assert.True(t, IsAssignableToType(goType("string"), goInterface("any")))
+}
+
+func TestIsAssignableToTypeRefusesAnUnrelatedClass(t *testing.T) {
+	assert.False(t, IsAssignableToType(goType("string"), goType("time.Duration")))
+}
+
+func TestIsAssignableToTypeRefusesAnAbsentType(t *testing.T) {
+	assert.False(t, IsAssignableToType(nil, errorType()))
+	assert.False(t, IsAssignableToType(goType("string"), nil))
+	assert.False(t, IsAssignableToType(&java.JavaTypeUnknown{}, errorType()))
+	assert.False(t, IsAssignableToType(goType("string"), &java.JavaTypeUnknown{}))
+}
+
+func TestIsAssignableToTypeRefusesAShallowClassWithNoMethods(t *testing.T) {
+	shallow := &java.JavaTypeShallowClass{JavaTypeClass: *goClass("x.Err")}
+	assert.False(t, IsAssignableToType(shallow, errorType()))
+}
+
+// An embedded interface arrives flattened into the embedding one's methods.
+func TestIsAssignableToTypeAcceptsAnInterfaceSatisfyingAnother(t *testing.T) {
+	stringer := goInterface("fmt.Stringer", method("String", goType("string")))
+	both := goInterface("a.Both", method("Error", goType("string")), method("String", goType("string")))
+	assert.True(t, IsAssignableToType(both, stringer))
+	assert.False(t, IsAssignableToType(stringer, errorType()))
+}
+
+// Go declares no interface relation, but a peer model over RPC records one.
+func TestIsAssignableToTypeFollowsARecordedInterface(t *testing.T) {
+	recorded := goClass("a.Recorded")
+	recorded.Interfaces = []java.FullyQualified{errorType()}
+	assert.True(t, IsAssignableToType(recorded, errorType()))
+}
+
+func TestIsAssignableToTypeComparesTypeArguments(t *testing.T) {
+	mapOf := func(k, v java.JavaType) java.JavaType {
+		return &java.JavaTypeParameterized{
+			Type:           goClass("map"),
+			TypeParameters: []java.JavaType{k, v},
+		}
+	}
+	assert.True(t, IsAssignableToType(mapOf(goType("string"), goType("int")), mapOf(goType("string"), goType("int"))))
+	assert.False(t, IsAssignableToType(mapOf(goType("int"), goType("string")), mapOf(goType("string"), goType("int"))))
+}
+
+func TestIsAssignableToTypeAcceptsALiteralAsAny(t *testing.T) {
+	assert.True(t, IsAssignableToType(litType("int"), goInterface("any")))
+	assert.False(t, IsAssignableToType(litType("int"), errorType()))
+}

--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -90,6 +90,71 @@ func isAssignableToFQN(t java.JavaType, fqn string, visited map[java.JavaType]bo
 	return false
 }
 
+// IsAssignableToType reports whether a value of type from may be used where to
+// is wanted. Go satisfies an interface by carrying its methods and declares it
+// nowhere, so an interface target is answered from the two method sets.
+func IsAssignableToType(from, to java.JavaType) bool {
+	if from == nil || to == nil || java.IsUnknown(from) || java.IsUnknown(to) {
+		return false
+	}
+	if IsSameGoType(from, to) {
+		return true
+	}
+	// A literal's keyword names a class of Go types, so it answers to any of
+	// them by name — and, carrying no method set, to no interface but the
+	// empty one.
+	if (isLiteralKeyword(from) || isLiteralKeyword(to)) && SharesGoTypeName(from, to) {
+		return true
+	}
+	// An interface is the only target a Go value reaches without being it,
+	// whether by carrying its methods or by a relation a peer model recorded.
+	if iface := AsClass(to); iface != nil && iface.Kind == "Interface" {
+		fqn := GetFullyQualifiedName(to)
+		return hasMethodSet(from, iface.Methods) || (fqn != "" && IsAssignableTo(from, fqn))
+	}
+	return false
+}
+
+// hasMethodSet reports whether from carries every method of an interface. The
+// empty one asks for nothing, which is what makes `any` a target every
+// attributed type reaches.
+func hasMethodSet(from java.JavaType, methods []*java.JavaTypeMethod) bool {
+	if len(methods) == 0 {
+		return true
+	}
+	cls := AsClass(from)
+	if cls == nil {
+		return false
+	}
+	for _, want := range methods {
+		if !hasMethod(cls, want) {
+			return false
+		}
+	}
+	return true
+}
+
+func hasMethod(cls *java.JavaTypeClass, want *java.JavaTypeMethod) bool {
+	for _, have := range cls.Methods {
+		if have.Name == want.Name && sameSignature(have, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func sameSignature(a, b *java.JavaTypeMethod) bool {
+	if len(a.ParameterTypes) != len(b.ParameterTypes) {
+		return false
+	}
+	for i := range a.ParameterTypes {
+		if !IsSameGoType(a.ParameterTypes[i], b.ParameterTypes[i]) {
+			return false
+		}
+	}
+	return IsSameGoType(a.ReturnType, b.ReturnType)
+}
+
 // Implements checks if the type implements the given interface FQN.
 // Unlike IsAssignableTo, this returns false if the type IS the interface.
 func Implements(t java.JavaType, interfaceFQN string) bool {
@@ -149,6 +214,20 @@ func GoTypeNames(t java.JavaType) []string {
 		}
 	}
 	return []string{GetFullyQualifiedName(t)}
+}
+
+// SharesGoTypeName reports whether two attributed types name a Go type in
+// common, a literal `1` sharing one with an `int` and with an `int32`.
+func SharesGoTypeName(a, b java.JavaType) bool {
+	others := GoTypeNames(b)
+	for _, name := range GoTypeNames(a) {
+		for _, other := range others {
+			if name != "" && name == other {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func anyGoTypeName(t java.JavaType, in map[string]bool) bool {

--- a/rewrite-go/pkg/template/PARITY-AUDIT.md
+++ b/rewrite-go/pkg/template/PARITY-AUDIT.md
@@ -361,6 +361,15 @@ folded, and the method set last. A name the scaffold cannot resolve fails the pa
 than silently constraining nothing, and a declared type on anything but an
 expression capture panics, an expression being the only thing that carries one.
 
+The type filters what a match binds, and not what `MatchResult.Bind` does:
+`Instantiate` splices the node an author names, so `WithType("string")` bound
+to an `int` literal emits `errors.New(42)` and says nothing. This is
+`JavaTemplate`'s split too — `Substitutions.substituteTypedPattern` reads the
+declared type to generate the substitution stub and never compares the
+parameter against it — and it is what keeps a hand-built node with no
+attribution bindable, which a recipe supplying a runtime-computed literal
+needs.
+
 A run absorbed by a variadic capture is held to the type element by element,
 and a pattern that is a placeholder alone reaches the comparator to be held
 there too — its kind rejects nothing, so the type is all that is left.
@@ -428,7 +437,7 @@ configuration and could not carry a closure regardless. Enforcing
 | Variadic capture | a bounded run anywhere in a list, via `Capture.Variadic(min, max)` | marker-based, whole list | whole argument list only |
 | Match-free template instantiation | `MatchResult.Bind` / `BindList` | — | — |
 | Type-attribution comparison | opt-in, three modes | — | on by default, lenient only |
-| Type-constrained capture | `WithType`, assignable, interfaces satisfied structurally | parsed and never read | — |
+| Type-constrained capture | `WithType` filtering a match, assignable, interfaces satisfied structurally | parsed and never read | — |
 
 ### Enforcement
 

--- a/rewrite-go/pkg/template/PARITY-AUDIT.md
+++ b/rewrite-go/pkg/template/PARITY-AUDIT.md
@@ -25,7 +25,7 @@ present, what was added in this PR, and what is intentionally deferred.
 | Pattern → template rewrite | `JavaIsoVisitor` + `JavaTemplate.apply` per visit | `template.Rewrite(before, after)` returns a `RewriteVisitor` | ✓ shipped (single-call ergonomic that matches and replaces in one step — Go-side delta over Java) |
 | Context-sensitive parsing | `.contextSensitive()` | not yet | deferred (recipes in the wild rarely flip this on for refactoring; revisit if a real recipe asks) |
 | Named placeholders | `#{name}` substitution by name + type constraint | positional `#{X}` capture-by-name through `*Capture` | ✓ named via `*Capture` already; type constraints are deferred (see below) |
-| Type-checked named placeholders | `#{name:any(java.util.List)}` | not yet | deferred — out-of-scope per the eng review's v1 scope cut |
+| Type-checked named placeholders | `#{name:any(java.util.List)}` | `Capture.WithType("time.Duration")` | ✓ shipped — assignability, with interface satisfaction computed from the two method sets since Go declares none |
 | Cursor-aware insertion | parameter to `.apply(cursor, ...)` | parameter to `.Apply(cursor, ...)` | ✓ shipped — the cursor names the node being replaced, from which `Apply` takes the leading whitespace, whether the result needs parenthesizing against the expression around it, and the level to indent to |
 | Variadic placeholders | n/a | `Capture.Variadic(min, max)` matched by `GoPattern`, expanded by `GoTemplate` | ✓ shipped — Go-side delta over Java. `JavaTemplate` has no variadic placeholder; `Substitutions.maybeExpandVarargsNewArray` flattens a captured varargs `J.NewArray` back into an argument list, which is a Java-language repair rather than a capture kind |
 
@@ -54,20 +54,16 @@ Surface that was already at parity:
 
 These are explicitly out-of-scope per the eng review:
 
-1. **Type-checked named placeholders** (`#{name:any(...)}`). v1 keeps
-   capture-typed placeholders. Rationale: Go's lighter type system makes
-   the constraint syntax less load-bearing for refactor recipes; revisit
-   when a real recipe asks for it.
-2. **`contextSensitive()` parse mode.** JavaTemplate flips this on when
+1. **`contextSensitive()` parse mode.** JavaTemplate flips this on when
    the template references symbols only resolvable from the surrounding
    cursor (e.g. inner-class names). The Go scaffold parser is already
    "context-light" by default (it doesn't attempt to resolve the
    template's own references against the call site's environment), so
    the explicit toggle adds little until Go-specific use cases surface.
-3. **Static imports.** Java's `staticImports` adds `import static …`
+2. **Static imports.** Java's `staticImports` adds `import static …`
    declarations. Go has no static-import concept; the Go template
    compiler ignores the surface entirely.
-4. **Coordinate API surface (`JavaCoordinates`).** Java's
+3. **Coordinate API surface (`JavaCoordinates`).** Java's
    `apply(coordinates, params)` lets recipes splice templates *before* /
    *after* / *replace* a target node. The Go equivalent is the
    pattern-match approach: write a `GoPattern` for the target, write a
@@ -112,7 +108,7 @@ The Java →  Go porting cheat-sheet:
 | `.imports("foo")`                      | `.Imports("foo")`                                        |
 | `.apply(getCursor(), JavaCoordinates.replace(target), arg1, arg2)` | match `target` with a `GoPattern`, then `template.Rewrite(before, after)` — the `RewriteVisitor` does the splice |
 | `#{any()}` as a wildcard placeholder    | a `*Capture` interpolated into the pattern string, which prints as its placeholder |
-| `#{name:any(java.util.List)}`           | not yet — file an issue if you hit this                  |
+| `#{name:any(java.util.List)}`           | `template.Expr("x").WithType("time.Duration")`            |
 
 ### Conclusion
 
@@ -346,9 +342,43 @@ unbound while still reporting a match — the placeholder then prints into the
 source. Attribution tells the two apart: a value's identifier carries the
 variable it reads, and a package name carries none, being no value.
 
-`Capture.WithType` declares a type for a capture and feeds it to the scaffold
-preamble. Under either type-matching mode it also holds what the capture
-matched to that type, a run absorbed by a variadic capture included.
+### The type a capture declares
+
+`Capture.WithType` is the one type comparison an author writes by hand, so it
+is read whatever the mode says about the slots around it — including
+`TypeMatchingOff`, where nothing else is. The mode keeps the question it
+answers everywhere else: a candidate carrying no attribution binds under
+`TypeMatchingLenient` and is refused under the other two.
+
+The constraint is the type the scaffold preamble resolved the placeholder to,
+not the name it was written with. That is what lets an interface be satisfied
+structurally: Go declares no `implements`, and `mapNamed` accordingly leaves
+`Interfaces` empty, so `error` is answered from the candidate's method set and
+a `*MyErr` carrying `Error() string` matches where `io.EOF` does.
+`matcher.IsAssignableToType` is that relation — identity first, then a
+literal's keyword answering for the class of Go types it names, `byte`/`uint8`
+folded, and the method set last. A name the scaffold cannot resolve fails the parse rather
+than silently constraining nothing, and a declared type on anything but an
+expression capture panics, an expression being the only thing that carries one.
+
+A run absorbed by a variadic capture is held to the type element by element,
+and a pattern that is a placeholder alone reaches the comparator to be held
+there too — its kind rejects nothing, so the type is all that is left.
+
+Satisfaction is as exact as the attributed model, which falls short of Go in
+four ways doc/recipe-authoring.md lists under "Typed captures" — each a
+property of the type mapper rather than of this comparison, and the first two
+pinned by `capture_type_test.go` so a model that grows past them fails there.
+
+Java is the only peer with the same surface, and Go follows it:
+`JavaTemplateSemanticallyEqual` resolves `#{name:any(FQN)}` to a `JavaType`
+when the template is parsed and matches with
+`TypeUtils.isAssignableTo(…, INFER)`, with no mode to switch it off and
+`isPseudoType` refusing an unattributed candidate. It also refuses to bind a
+type rather than an expression, which is the rule the panic states earlier.
+JavaScript parses a `typeConstraint` out of its placeholder identifiers in
+`utils.ts` and its comparator never reads it; Python has no typed capture at
+all. Both offer a predicate instead — see "Capture constraints" below.
 
 **Degraded attribution.** A type-comparing match against a package whose
 attribution is incomplete returns false, which reads exactly like source that
@@ -398,6 +428,7 @@ configuration and could not carry a closure regardless. Enforcing
 | Variadic capture | a bounded run anywhere in a list, via `Capture.Variadic(min, max)` | marker-based, whole list | whole argument list only |
 | Match-free template instantiation | `MatchResult.Bind` / `BindList` | — | — |
 | Type-attribution comparison | opt-in, three modes | — | on by default, lenient only |
+| Type-constrained capture | `WithType`, assignable, interfaces satisfied structurally | parsed and never read | — |
 
 ### Enforcement
 

--- a/rewrite-go/pkg/template/PARITY-AUDIT.md
+++ b/rewrite-go/pkg/template/PARITY-AUDIT.md
@@ -379,6 +379,14 @@ four ways doc/recipe-authoring.md lists under "Typed captures" — each a
 property of the type mapper rather than of this comparison, and the first two
 pinned by `capture_type_test.go` so a model that grows past them fails there.
 
+The first of them bounds what a pattern can take over from a hand-written
+visitor. `error` is satisfied by embedding as often as by declaring, so
+`struct{ error }` and a wrapper over a base error type are refused, and a
+recipe converting `err == target` shape checks to a typed capture matches less
+than the code it replaces. `types.NewMethodSet` is where a mapper reads the
+promoted methods; `mapNamed` reads `named.NumMethods`, which is the declared
+ones.
+
 Java is the only peer with the same surface, and Go follows it:
 `JavaTemplateSemanticallyEqual` resolves `#{name:any(FQN)}` to a `JavaType`
 when the template is parsed and matches with

--- a/rewrite-go/pkg/template/capture.go
+++ b/rewrite-go/pkg/template/capture.go
@@ -71,8 +71,13 @@ func Ident(name string) *Capture {
 	return &Capture{name: name, kind: CaptureName, maxCount: -1}
 }
 
-// The type name is used in the scaffold preamble for type-attributed matching.
+// WithType declares the Go type a capture stands for. The scaffold preamble
+// declares the placeholder with it, so the pattern type-checks, and a match
+// holds what the capture bound to it. Only an expression carries a type.
 func (c *Capture) WithType(typeName string) *Capture {
+	if c.kind != CaptureExpression {
+		panic(fmt.Sprintf("capture %q: a declared type constrains an expression capture only", c.name))
+	}
 	cp := *c
 	cp.typeName = typeName
 	return &cp

--- a/rewrite-go/pkg/template/capture.go
+++ b/rewrite-go/pkg/template/capture.go
@@ -73,7 +73,8 @@ func Ident(name string) *Capture {
 
 // WithType declares the Go type a capture stands for. The scaffold preamble
 // declares the placeholder with it, so the pattern type-checks, and a match
-// holds what the capture bound to it. Only an expression carries a type.
+// binds only a candidate assignable to it. Only an expression carries a type.
+// See doc/recipe-authoring.md: Typed captures, for what the model cannot see.
 func (c *Capture) WithType(typeName string) *Capture {
 	if c.kind != CaptureExpression {
 		panic(fmt.Sprintf("capture %q: a declared type constrains an expression capture only", c.name))

--- a/rewrite-go/pkg/template/capture_type_test.go
+++ b/rewrite-go/pkg/template/capture_type_test.go
@@ -42,6 +42,7 @@ var errorArgs = []struct{ name, expr string }{
 	{"Plain", "Plain{}"},
 	{"MyErrValue", "MyErr{}"},
 	{"Outer", "Outer{}"},
+	{"Wrapped", "Wrapped{}"},
 }
 
 const errorFixture = `package a
@@ -59,6 +60,8 @@ type Inner struct{}
 func (i Inner) Error() string { return "y" }
 
 type Outer struct{ Inner }
+
+type Wrapped struct{ error }
 
 var ErrFoo = &MyErr{}
 
@@ -200,7 +203,8 @@ func TestCaptureTypeConstrainsABarePlaceholderPattern(t *testing.T) {
 	pat := template.Expression(c.String()).Captures(c).Build()
 	for name, want := range map[string]bool{
 		"err": true, "io.EOF": true, "ErrFoo": true, "MyErrValue": true,
-		"string": false, "int": false, "literal": false, "Plain": false, "Outer": false,
+		"string": false, "int": false, "literal": false, "Plain": false,
+		"Outer": false, "Wrapped": false,
 	} {
 		arg := takeArg(t, name).(*java.MethodInvocation).Arguments.Elements[0].Element
 		require.Equal(t, want, pat.Matches(arg, nil), name)
@@ -241,7 +245,9 @@ func TestCaptureTypeAcceptsEveryAttributedValueAsAny(t *testing.T) {
 // Two limits the attributed model imposes, pinned so a model that grows past
 // them fails here. See doc/recipe-authoring.md: Typed captures.
 func TestCaptureTypeMissesAMethodPromotedFromAnEmbeddedField(t *testing.T) {
-	require.False(t, takePattern("error").Matches(takeArg(t, "Outer"), nil), "Outer embeds Inner")
+	pat := takePattern("error")
+	require.False(t, pat.Matches(takeArg(t, "Outer"), nil), "Outer embeds Inner")
+	require.False(t, pat.Matches(takeArg(t, "Wrapped"), nil), "Wrapped embeds error itself")
 }
 
 func TestCaptureTypeReadsAPointerAsItsPointee(t *testing.T) {

--- a/rewrite-go/pkg/template/capture_type_test.go
+++ b/rewrite-go/pkg/template/capture_type_test.go
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package template_test
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/template"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+)
+
+// errorArgs names one operand of each kind a capture declared `error` has to
+// tell apart — the interface itself, concrete types carrying its method, and
+// types carrying neither — beside the source that produces it.
+var errorArgs = []struct{ name, expr string }{
+	{"err", "err"},
+	{"io.EOF", "io.EOF"},
+	{"ErrFoo", "ErrFoo"},
+	{"string", "s"},
+	{"int", "n"},
+	{"literal", "1"},
+	{"Plain", "Plain{}"},
+	{"MyErrValue", "MyErr{}"},
+	{"Outer", "Outer{}"},
+}
+
+const errorFixture = `package a
+
+import "io"
+
+type MyErr struct{}
+
+func (e *MyErr) Error() string { return "x" }
+
+type Plain struct{}
+
+type Inner struct{}
+
+func (i Inner) Error() string { return "y" }
+
+type Outer struct{ Inner }
+
+var ErrFoo = &MyErr{}
+
+func f(err error, s *string, n int) {
+%s}
+
+func take(v any) {}
+`
+
+// errorFixtureCalls parses the fixture once for the tests below to read from.
+var errorFixtureCalls = sync.OnceValues(func() ([]*java.MethodInvocation, error) {
+	var calls strings.Builder
+	for _, arg := range errorArgs {
+		fmt.Fprintf(&calls, "\ttake(%s)\n", arg.expr)
+	}
+	cu, err := parser.NewGoParser().Parse("a.go", fmt.Sprintf(errorFixture, calls.String()))
+	if err != nil {
+		return nil, err
+	}
+	return nodesOf[*java.MethodInvocation](cu), nil
+})
+
+// takeArg returns the call whose argument errorArgs named, so an assertion
+// states the operand it means and adding one renumbers nothing.
+func takeArg(t testing.TB, name string) java.J {
+	t.Helper()
+	calls, err := errorFixtureCalls()
+	require.NoError(t, err)
+	for i, arg := range errorArgs {
+		if arg.name == name {
+			return calls[i]
+		}
+	}
+	t.Fatalf("errorFixture has no argument named %q", name)
+	return nil
+}
+
+func takePattern(typeName string) *template.GoPattern {
+	return takePatternMode(typeName, template.TypeMatchingOff)
+}
+
+func takePatternMode(typeName string, mode template.TypeMatchingMode) *template.GoPattern {
+	arg := template.Expr("v").WithType(typeName)
+	return template.Expression(fmt.Sprintf("take(%s)", arg)).
+		Captures(arg).TypeMatching(mode).Build()
+}
+
+// unattributedArg is one candidate under two questions: whether it matches,
+// and whether Explain calls the refusal inconclusive.
+const unattributedArg = `package a
+
+import "example.invalid/nowhere"
+
+func f() { take(nowhere.Thing) }
+
+func take(v any) {}
+`
+
+func TestCaptureTypeIsEnforcedWithoutTypeMatching(t *testing.T) {
+	pat := takePattern("error")
+	require.True(t, pat.Matches(takeArg(t, "err"), nil))
+	require.False(t, pat.Matches(takeArg(t, "string"), nil))
+}
+
+// The shape the `prefer_errors_is` recipe family matches.
+func TestCaptureTypeConstrainsANilComparison(t *testing.T) {
+	e := template.Expr("e").WithType("error")
+	pat := template.Expression(fmt.Sprintf("%s == nil", e)).Captures(e).Build()
+	binaries := nodesOf[*java.Binary](parseSource(t, `package a
+
+func f(err error, s *string) {
+	_ = err == nil
+	_ = s == nil
+}
+`))
+	require.Len(t, binaries, 2)
+	require.True(t, pat.Matches(binaries[0], nil), "err == nil")
+	require.False(t, pat.Matches(binaries[1], nil), "s == nil")
+}
+
+func TestCaptureTypeAcceptsAConcreteImplementation(t *testing.T) {
+	pat := takePattern("error")
+	require.True(t, pat.Matches(takeArg(t, "io.EOF"), nil))
+	require.True(t, pat.Matches(takeArg(t, "ErrFoo"), nil), "*MyErr carries Error() string")
+	require.False(t, pat.Matches(takeArg(t, "Plain"), nil), "Plain carries no Error()")
+}
+
+func TestCaptureTypeAcceptsABasicTypeEitherWayItIsCarried(t *testing.T) {
+	pat := takePattern("int")
+	require.True(t, pat.Matches(takeArg(t, "int"), nil))
+	require.True(t, pat.Matches(takeArg(t, "literal"), nil))
+	require.False(t, pat.Matches(takeArg(t, "err"), nil))
+}
+
+func TestCaptureTypeFollowsTheModeOnAnUnattributedCandidate(t *testing.T) {
+	for _, mode := range allModes {
+		require.Equal(t, mode == template.TypeMatchingLenient,
+			takePatternMode("error", mode).Matches(firstCall(t, unattributedArg), nil), "mode %v", mode)
+	}
+}
+
+func TestCaptureTypeReportsAnUnattributedCandidateAsInconclusive(t *testing.T) {
+	why := takePattern("error").Explain(firstCall(t, unattributedArg), nil)
+	require.False(t, why.Matched)
+	require.Equal(t, 1, why.InconclusiveTypes)
+}
+
+func TestCaptureTypeOnANonExpressionCapturePanics(t *testing.T) {
+	require.Panics(t, func() { template.Stmt("s").WithType("int") })
+	require.Panics(t, func() { template.Ident("i").WithType("int") })
+	require.Panics(t, func() { template.TypeExpr("t").WithType("int") })
+}
+
+func TestCaptureTypeThatDoesNotResolveIsAParseError(t *testing.T) {
+	_, err := takePattern("nowhere.Missing").TreeOrError()
+	require.ErrorContains(t, err, "nowhere.Missing")
+	require.ErrorContains(t, err, "v")
+}
+
+func TestCaptureTypeConstrainsEveryElementOfAVariadicRun(t *testing.T) {
+	args := template.Expr("args").WithType("error").Variadic(1, -1)
+	pat := template.Expression(fmt.Sprintf("join(%s)", args)).Captures(args).Build()
+	calls := allCalls(t, `package a
+
+func f(a error, b error, n int) {
+	join(a, b)
+	join(a, n)
+}
+
+func join(v ...any) {}
+`)
+	require.Len(t, calls, 2)
+	require.True(t, pat.Matches(calls[0], nil))
+	require.False(t, pat.Matches(calls[1], nil))
+}
+
+func TestCaptureTypeConstrainsABarePlaceholderPattern(t *testing.T) {
+	c := template.Expr("v").WithType("error")
+	pat := template.Expression(c.String()).Captures(c).Build()
+	for name, want := range map[string]bool{
+		"err": true, "io.EOF": true, "ErrFoo": true, "MyErrValue": true,
+		"string": false, "int": false, "literal": false, "Plain": false, "Outer": false,
+	} {
+		arg := takeArg(t, name).(*java.MethodInvocation).Arguments.Elements[0].Element
+		require.Equal(t, want, pat.Matches(arg, nil), name)
+		require.Equal(t, want, pat.MatchViaWalk(arg, nil) != nil, "%s via walk", name)
+	}
+}
+
+func TestCaptureTypeComparesTypeArguments(t *testing.T) {
+	src := `package a
+
+func f(good map[string]int, bad map[int][]byte, ci chan int, cs chan string) {
+	take(good)
+	take(bad)
+	take(ci)
+	take(cs)
+}
+
+func take(v any) {}
+`
+	for declared, want := range map[string][]bool{
+		"map[string]int": {true, false, false, false},
+		"chan int":       {false, false, true, false},
+	} {
+		pat := takePattern(declared)
+		for i, call := range allCalls(t, src) {
+			require.Equal(t, want[i], pat.Matches(call, nil), "%s against call %d", declared, i)
+		}
+	}
+}
+
+func TestCaptureTypeAcceptsEveryAttributedValueAsAny(t *testing.T) {
+	pat := takePattern("any")
+	for _, arg := range errorArgs {
+		require.True(t, pat.Matches(takeArg(t, arg.name), nil), arg.name)
+	}
+}
+
+// Two limits the attributed model imposes, pinned so a model that grows past
+// them fails here. See doc/recipe-authoring.md: Typed captures.
+func TestCaptureTypeMissesAMethodPromotedFromAnEmbeddedField(t *testing.T) {
+	require.False(t, takePattern("error").Matches(takeArg(t, "Outer"), nil), "Outer embeds Inner")
+}
+
+func TestCaptureTypeReadsAPointerAsItsPointee(t *testing.T) {
+	require.True(t, takePattern("error").Matches(takeArg(t, "MyErrValue"), nil), "Error() is on *MyErr")
+}

--- a/rewrite-go/pkg/template/comparator.go
+++ b/rewrite-go/pkg/template/comparator.go
@@ -29,6 +29,7 @@ import (
 // and a candidate tree, binding placeholder identifiers to captured nodes.
 type patternComparator struct {
 	captures map[string]*Capture
+	declared map[string]java.JavaType
 	result   *MatchResult
 	cursor   *visitor.Cursor
 	mode     TypeMatchingMode
@@ -46,24 +47,25 @@ type patternComparator struct {
 }
 
 // allowsDeclaredType holds a capture to the type it was declared with. The
-// declaration reaches the scaffold preamble either way; reading it here is
-// what makes it a constraint rather than only parse context.
+// declaration is the one type comparison an author writes by hand, so the mode
+// does not switch it off; it decides only the candidate carrying no
+// attribution.
 func (c *patternComparator) allowsDeclaredType(name string, candidate java.J) bool {
-	capture, ok := c.captures[name]
-	if !ok || c.mode == TypeMatchingOff || capture.TypeName() == "" {
+	want, ok := c.declared[name]
+	if !ok {
 		return true
 	}
 	var actual java.JavaType
 	if expr, ok := candidate.(java.Expression); ok {
 		actual = matcher.TypeOfExpression(expr)
 	}
-	if actual == nil {
+	if actual == nil || java.IsUnknown(actual) {
 		if c.tracking {
 			c.noteInconclusive()
 		}
 		return c.mode == TypeMatchingLenient
 	}
-	return matcher.IsAssignableTo(actual, capture.TypeName())
+	return matcher.IsAssignableToType(actual, want)
 }
 
 func (c *patternComparator) matchTypeSlot(pattern, candidate java.JavaType) bool {
@@ -75,15 +77,6 @@ func (c *patternComparator) matchTypeSlot(pattern, candidate java.JavaType) bool
 		c.noteInconclusive()
 	}
 	return result
-}
-
-func newPatternComparator(captures map[string]*Capture, cursor *visitor.Cursor, mode TypeMatchingMode, variadic bool) *patternComparator {
-	return &patternComparator{
-		captures: captures,
-		cursor:   cursor,
-		mode:     mode,
-		variadic: variadic,
-	}
 }
 
 // bindings is the result the comparator fills, built at the first binding:
@@ -217,7 +210,7 @@ func (c *patternComparator) bindRun(name string, values []java.J) bool {
 func structurallyEqual(a, b java.J) bool {
 	// A comparator with no captures meets no placeholder, so a match is
 	// equality.
-	return newPatternComparator(nil, nil, TypeMatchingOff, false).matchNode(a, b)
+	return (&patternComparator{mode: TypeMatchingOff}).matchNode(a, b)
 }
 
 // unparenthesize reads through the parentheses around a node.

--- a/rewrite-go/pkg/template/explain.go
+++ b/rewrite-go/pkg/template/explain.go
@@ -55,7 +55,7 @@ func (p *GoPattern) Explain(candidate java.J, cursor *visitor.Cursor) *MatchExpl
 	}
 	// Matched is what Match answers, so the explanation is of the behaviour
 	// the caller sees rather than of another path to the same question.
-	cmp := newPatternComparator(p.captures, cursor, p.mode, p.variadic)
+	cmp := p.comparator(cursor)
 	cmp.tracking = true
 	why := &MatchExplanation{
 		Matched:               cmp.match(tree, candidate) != nil,
@@ -66,7 +66,7 @@ func (p *GoPattern) Explain(candidate java.J, cursor *visitor.Cursor) *MatchExpl
 	// Only the walk names the field it is at, so it supplies the path where
 	// the hand-written comparisons decided.
 	if why.InconclusiveTypes > 0 && why.FirstInconclusivePath == "" {
-		walk := newPatternComparator(p.captures, cursor, p.mode, p.variadic)
+		walk := p.comparator(cursor)
 		walk.tracking, walk.skipFastPath = true, true
 		walk.match(tree, candidate)
 		why.FirstInconclusivePath = strings.Join(walk.firstInconclusive, ".")

--- a/rewrite-go/pkg/template/export_test.go
+++ b/rewrite-go/pkg/template/export_test.go
@@ -31,7 +31,7 @@ func (p *GoPattern) MatchesViaWalk(candidate java.J, cursor *visitor.Cursor) boo
 	if err != nil || tree == nil {
 		return false
 	}
-	cmp := newPatternComparator(p.captures, cursor, p.mode, p.variadic)
+	cmp := p.comparator(cursor)
 	cmp.skipFastPath = true
 	return cmp.match(tree, candidate) != nil
 }
@@ -51,7 +51,7 @@ func (p *GoPattern) MatchViaWalk(candidate java.J, cursor *visitor.Cursor) *Matc
 	if err != nil || tree == nil {
 		return nil
 	}
-	cmp := newPatternComparator(p.captures, cursor, p.mode, p.variadic)
+	cmp := p.comparator(cursor)
 	cmp.skipFastPath = true
 	return cmp.match(tree, candidate)
 }

--- a/rewrite-go/pkg/template/go_pattern.go
+++ b/rewrite-go/pkg/template/go_pattern.go
@@ -17,6 +17,7 @@
 package template
 
 import (
+	"fmt"
 	"io/fs"
 	"reflect"
 	"sync"
@@ -40,7 +41,11 @@ type GoPattern struct {
 
 	once     sync.Once
 	cached   java.J
-	parseErr error
+	declared map[string]java.JavaType
+	// rootIsPlaceholder marks a pattern that is a placeholder alone: it has
+	// no kind to reject a candidate on.
+	rootIsPlaceholder bool
+	parseErr          error
 }
 
 // Match attempts to match this pattern against the given candidate node.
@@ -51,26 +56,16 @@ func (p *GoPattern) Match(candidate java.J, cursor *visitor.Cursor) *MatchResult
 		return nil
 	}
 
-	// Fast reject: if the pattern root (when not a placeholder) has a different
-	// concrete type than the candidate, the match cannot succeed.
-	if ident, ok := patternTree.(*java.Identifier); ok {
-		if _, isPlaceholder := FromPlaceholder(ident.Name); isPlaceholder {
-			// Pattern is a bare placeholder — it matches anything.
-			result := NewMatchResult()
-			result.bind(ident.Name[len(placeholderPrefix):len(ident.Name)-len(placeholderSuffix)], candidate)
-			return result
-		}
-	}
 	// The same rule matchNode applies to every node, narrowed by the pattern
 	// root already being unwrapped, and worth its own place: rejecting here
-	// costs no comparator.
-	if reflect.TypeOf(patternTree) != reflect.TypeOf(candidate) &&
+	// costs no comparator. A placeholder root reaches the comparator instead,
+	// to be bound and held to the type it declared.
+	if !p.rootIsPlaceholder &&
+		reflect.TypeOf(patternTree) != reflect.TypeOf(candidate) &&
 		reflect.TypeOf(patternTree) != reflect.TypeOf(unparenthesize(candidate)) {
 		return nil
 	}
-
-	cmp := newPatternComparator(p.captures, cursor, p.mode, p.variadic)
-	return cmp.match(patternTree, candidate)
+	return p.comparator(cursor).match(patternTree, candidate)
 }
 
 func (p *GoPattern) Matches(candidate java.J, cursor *visitor.Cursor) bool {
@@ -84,9 +79,57 @@ func (p *GoPattern) getTree() (java.J, error) {
 		if p.cached != nil {
 			// A pattern is never printed, so it keeps only what it matches by.
 			p.cached = unparenthesize(p.cached)
+			_, p.rootIsPlaceholder = placeholderName(p.cached)
+			p.declared, p.parseErr = declaredTypes(p.cached, p.captures)
 		}
 	})
 	return p.cached, p.parseErr
+}
+
+// comparator reads the types getTree resolved, so a match runs through it only
+// after the parse.
+func (p *GoPattern) comparator(cursor *visitor.Cursor) *patternComparator {
+	return &patternComparator{
+		captures: p.captures,
+		declared: p.declared,
+		cursor:   cursor,
+		mode:     p.mode,
+		variadic: p.variadic,
+	}
+}
+
+// declaredTypes resolves each typed capture against the placeholder the
+// scaffold preamble declared for it. A name that did not resolve would
+// constrain nothing, which reads as a pattern matching everything, so it fails
+// the parse.
+func declaredTypes(tree java.J, captures map[string]*Capture) (map[string]java.JavaType, error) {
+	var declared map[string]java.JavaType
+	var err error
+	visitor.Walk(tree, func(t java.Tree) bool {
+		ident, ok := t.(*java.Identifier)
+		if !ok {
+			return true
+		}
+		name, isPlaceholder := FromPlaceholder(ident.Name)
+		if !isPlaceholder {
+			return true
+		}
+		capture, ok := captures[name]
+		if !ok || capture.TypeName() == "" {
+			return true
+		}
+		if ident.Type == nil || java.IsUnknown(ident.Type) {
+			err = fmt.Errorf("capture %q declares type %q, which the pattern could not resolve; "+
+				"name it through Imports, Context or ExportData", name, capture.TypeName())
+			return false
+		}
+		if declared == nil {
+			declared = make(map[string]java.JavaType)
+		}
+		declared[name] = ident.Type
+		return true
+	})
+	return declared, err
 }
 
 type PatternBuilder struct {

--- a/rewrite-go/pkg/template/match_bench_test.go
+++ b/rewrite-go/pkg/template/match_bench_test.go
@@ -116,3 +116,36 @@ func benchWalk(b *testing.B, pattern string, candidate fixture) {
 		pat.MatchesViaWalk(node, nil)
 	}
 }
+
+// benchCaptureMatch times a call pattern with one capture against an argument
+// of errorFixture, which a typed capture needs attributed on both sides.
+func benchCaptureMatch(b *testing.B, capture *template.Capture, arg string) {
+	pat := template.Expression(fmt.Sprintf("take(%s)", capture)).Captures(capture).Build()
+	node := takeArg(b, arg)
+	pat.Matches(node, nil) // parse the pattern outside the timed loop
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		pat.Matches(node, nil)
+	}
+}
+
+// A capture that declares no type reads no attribution.
+func BenchmarkMatchCapture(b *testing.B) {
+	benchCaptureMatch(b, template.Expr("v"), "err")
+}
+
+// The declared type and the candidate's are one type, the comparison a typed
+// capture usually makes.
+func BenchmarkMatchTypedCapture(b *testing.B) {
+	benchCaptureMatch(b, template.Expr("v").WithType("error"), "err")
+}
+
+// A concrete type reaches the interface through its method set.
+func BenchmarkMatchTypedCaptureStructural(b *testing.B) {
+	benchCaptureMatch(b, template.Expr("v").WithType("error"), "ErrFoo")
+}
+
+func BenchmarkMatchTypedCaptureMiss(b *testing.B) {
+	benchCaptureMatch(b, template.Expr("v").WithType("error"), "string")
+}

--- a/rewrite-go/pkg/template/matcher_audit_test.go
+++ b/rewrite-go/pkg/template/matcher_audit_test.go
@@ -290,7 +290,7 @@ func fastPathAgrees(t *testing.T, mode template.TypeMatchingMode) {
 // assert what the pattern was attributed with.
 func patternCall(t *testing.T, pat *template.GoPattern) *java.MethodInvocation {
 	t.Helper()
-	calls := callsIn(t, pat.Tree(t))
+	calls := nodesOf[*java.MethodInvocation](pat.Tree(t))
 	require.NotEmpty(t, calls, "no call in the pattern")
 	return calls[0]
 }
@@ -304,34 +304,21 @@ func patternParamFQNs(mi *java.MethodInvocation) []string {
 }
 
 // allCalls returns every call expression in a source file, in source order.
-func allCalls(t *testing.T, src string) []*java.MethodInvocation {
+func allCalls(t testing.TB, src string) []*java.MethodInvocation {
 	t.Helper()
-	return callsIn(t, parseSource(t, src))
+	return nodesOf[*java.MethodInvocation](parseSource(t, src))
 }
 
-func callsIn(t testing.TB, tree java.J) []*java.MethodInvocation {
-	t.Helper()
-	var calls []*java.MethodInvocation
+// nodesOf returns every node of one kind in a tree, in source order.
+func nodesOf[T java.J](tree java.J) []T {
+	var nodes []T
 	visitor.Walk(tree, func(n java.Tree) bool {
-		if mi, ok := n.(*java.MethodInvocation); ok {
-			calls = append(calls, mi)
+		if node, ok := n.(T); ok {
+			nodes = append(nodes, node)
 		}
 		return true
 	})
-	return calls
-}
-
-func firstStmt(t *testing.T, src string) java.J {
-	t.Helper()
-	cu, err := parser.NewGoParser().Parse("a.go", src)
-	require.NoError(t, err)
-	for _, s := range cu.Statements {
-		if md, ok := s.Element.(*java.MethodDeclaration); ok && md.Body != nil {
-			return md.Body.Statements[0].Element
-		}
-	}
-	t.Fatal("no body")
-	return nil
+	return nodes
 }
 
 func parseSource(t testing.TB, src string) java.J {

--- a/rewrite-go/pkg/template/type_matching.go
+++ b/rewrite-go/pkg/template/type_matching.go
@@ -27,8 +27,9 @@ import (
 type TypeMatchingMode int
 
 const (
-	// TypeMatchingOff leaves type slots unread, which is what a pattern
-	// written without attribution in mind expects.
+	// TypeMatchingOff leaves unread every type slot but the one a capture
+	// declared, which is what a pattern written without attribution in mind
+	// expects.
 	TypeMatchingOff TypeMatchingMode = iota
 
 	// TypeMatchingLenient compares two attributions and accepts one that is
@@ -56,7 +57,7 @@ func compareTypes(a, b java.JavaType, mode TypeMatchingMode) (bool, bool) {
 	// of them agree when the classes overlap. matcher.IsSameGoType answers
 	// false for a keyword by design and cannot serve here.
 	if isPrimitive(a) && isPrimitive(b) {
-		return sharesGoTypeName(a, b), true
+		return matcher.SharesGoTypeName(a, b), true
 	}
 	if ma, mb := matcher.AsMethod(a), matcher.AsMethod(b); ma != nil && mb != nil {
 		return compareMethodTypes(ma, mb, mode)
@@ -77,17 +78,6 @@ func compareTypes(a, b java.JavaType, mode TypeMatchingMode) (bool, bool) {
 func isPrimitive(t java.JavaType) bool {
 	_, ok := t.(*java.JavaTypePrimitive)
 	return ok
-}
-
-func sharesGoTypeName(a, b java.JavaType) bool {
-	for _, name := range matcher.GoTypeNames(a) {
-		for _, other := range matcher.GoTypeNames(b) {
-			if name != "" && name == other {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // A variable is the name it was declared with and the type it holds. Its

--- a/rewrite-go/pkg/template/type_matching_test.go
+++ b/rewrite-go/pkg/template/type_matching_test.go
@@ -29,7 +29,7 @@ import (
 
 // firstCall returns the leading call expression in a source file, so a test
 // can state the source it means rather than the tree it produces.
-func firstCall(t *testing.T, src string) *java.MethodInvocation {
+func firstCall(t testing.TB, src string) *java.MethodInvocation {
 	t.Helper()
 	calls := allCalls(t, src)
 	require.NotEmpty(t, calls, "no call in %q", src)
@@ -150,26 +150,10 @@ func TestCaptureTypeRefusesAnArgumentOfAnotherType(t *testing.T) {
 	require.Nil(t, capturePattern(template.TypeMatchingLenient).Match(intCall(t), nil))
 }
 
-// Without type matching the declared type is scaffold context only.
-func TestCaptureTypeIsUnenforcedWhenTypeMatchingIsOff(t *testing.T) {
-	require.NotNil(t, capturePattern(template.TypeMatchingOff).Match(intCall(t), nil))
-}
-
-// A statement carries no type slot, so the attribution is a missing one.
-func TestStatementCaptureWithTypeFollowsTheMode(t *testing.T) {
-	cand := firstStmt(t, `package a
-
-func f(c bool) {
-	if c {
-		return
-	}
-}
-`)
+// See capture_type_test.go for what a declared type constrains.
+func TestCaptureTypeIsEnforcedInEveryMode(t *testing.T) {
 	for _, mode := range allModes {
-		body := template.Stmt("body").WithType("int")
-		pat := template.StatementPattern(fmt.Sprintf("if c {\n%s\n}", body)).
-			Captures(body).Context("var c bool").TypeMatching(mode).Build()
-		require.Equal(t, mode != template.TypeMatchingStrict, pat.Matches(cand, nil), "mode %v", mode)
+		require.Nil(t, capturePattern(mode).Match(intCall(t), nil), "mode %v", mode)
 	}
 }
 


### PR DESCRIPTION
`Capture.WithType` was read when the template scaffold was parsed, so a pattern would type-check, and not when that pattern was compared against a candidate. A capture declared `error` matched an operand of any type:

```go
e := template.Expr("e").WithType("error")
pat := template.Expression(fmt.Sprintf("%s == nil", e)).Captures(e).Build()
```

against `func f(err error, s *string) { _ = err == nil; _ = s == nil }`:

```
err == nil   (err is error)    matches: true
s == nil     (s is *string)    matches: true     <- should not
```

`PARITY-AUDIT.md` recorded this as deferred under the eng review's v1 scope cut. #8631 has since added `patternComparator.allowsDeclaredType`, but gated it on `mode != TypeMatchingOff` — the default — so the constraint stayed inert unless a recipe opted into type matching, and both the audit row and the deferred item were stale against the code.

## What a declared type now means

It is read in every mode. The mode governs the type slots a pattern did not ask about; a declared type is one it did. The mode keeps only the question it answers everywhere else: a candidate the parser could not attribute binds under `TypeMatchingLenient` and is refused under the other two. That matters because a Go template parsed alone attributes only the stdlib, so this is the case a recipe meets on an unattributed tree.

"Satisfies" is assignability, not identity, and the constraint is the `JavaType` the scaffold resolved the placeholder to rather than the name it was written with. That is what lets an interface be satisfied structurally: Go declares no `implements`, and `mapNamed` accordingly leaves `Interfaces` empty, so `error` is answered from the candidate's method set — a concrete `*MyErr` carrying `Error() string` matches where `io.EOF` does. `matcher.IsAssignableToType` is that relation: identity first, then a literal's keyword answering for the class of Go types it names (a `J.Literal` still carries a `JavaType.Primitive` while a basic type is a `JavaTypeClass` since #8606), `byte`/`uint8` folded, and the method set last.

The type filters what a match binds and not what `MatchResult.Bind` does — `Instantiate` splices the node an author names, so a capture declared `string` bound to an `int` literal emits `errors.New(42)` and says nothing. `JavaTemplate` splits the same way (`Substitutions.substituteTypedPattern` reads the declared type to generate the substitution stub and never compares the parameter against it), and it is what keeps a hand-built node carrying no attribution bindable, which a recipe supplying a runtime-computed literal needs.

Two constructions that could only ever produce a silently-wrong recipe now fail loudly: a type name the scaffold cannot resolve fails the parse rather than constraining nothing, and `WithType` on a `Stmt`, `Ident` or `TypeExpr` capture panics, an expression being the only thing that carries a type.

## Where the model falls short of Go

`doc/recipe-authoring.md` lists four gaps under "Typed captures"; two are load-bearing. `named.NumMethods` is what a type declares, so a method promoted from an embedded field is absent — `struct{ error }` and a wrapper over a base error type do not satisfy `error`, and the capture **under**-matches. `mapType` unwraps `*T` to `T`, so a capture declared `error` binds a `MyErr{}` whose `Error()` has a pointer receiver — the one direction in which the guard **over**-matches, though the comparison that would expose it does not compile in Go either. Both are pinned by tests asserting the wrong-in-Go answer, so a type mapper that grows past them fails there rather than drifting. `types.NewMethodSet` is where a mapper would read promoted methods; changing `mapNamed` to use it widens every `JavaTypeClass` in the model and wants its own PR.

## Why Java's semantics and not the other two matchers

Java is the only peer with this surface. `JavaTemplateSemanticallyEqual` resolves `#{name:any(FQN)}` to a `JavaType` when the template is parsed and matches with `TypeUtils.isAssignableTo(…, INFER)` — no mode to switch it off, and `isPseudoType` refusing an unattributed candidate. It also declines to bind a type rather than an expression, which is the rule the panic states. JavaScript parses a `typeConstraint` out of its placeholder identifiers in `utils.ts` and its comparator never reads it; Python has no typed capture at all. Both offer an arbitrary predicate instead, which a Go recipe does not need — it is compiled Go, and the audit's "Capture constraints" section covers why.

## Tests and cost

`capture_type_test.go` covers the reproduction above, a concrete implementer accepted where a method-less struct is refused, type arguments compared (`map[string]int` against `map[int][]byte`), a bare-placeholder pattern root, and the unattributed case across all three modes with its `Explain` count; the panics, the parse error and a typed variadic run are there too. `matcher/assignability_test.go` covers the relation itself, including the peer-model `Interfaces` path that Go's own mapper never fills. The distinctness audit from #8631 still passes.

`moderneinc/recipes-go` at the head of its PR #84, thirteen of whose captures carry `WithType`, builds and tests green against this branch.

An untyped capture pays one map lookup — slightly less than before, which did a captures lookup on every bind. Measured on an M2 Max, the untyped fast paths are unchanged (`MatchHit` 101ns, `MatchMiss` 7.2ns, `MatchSameKindMiss` 49ns) and a typed capture costs +21ns on a hit and +44ns when the answer comes from the method set, with no extra allocations.

## Not in this PR

`moderneinc/recipes-go` can collapse the eight `prefer_errors_is_*` recipes onto patterns: `rewriteToErrorsIs` hand-checks that both operands are assignable to `error` after matching, which is exactly what a typed capture now expresses, and that check is what kept the shape half hand-rolled too. Whoever does it should read the embedding gap above first — `err == target` where `target` embeds its error would stop matching, and the symptom is a recipe quietly doing less rather than anything failing.

`compareTypes` compares a parameterized *type slot* by its raw name, so `map[string]int` and `map[int]byte` read as one type under `TypeMatchingStrict`. The declared-type path no longer has that hole; tightening the slot path is a behaviour change and wants its own PR.

