### PR TITLE
Reap a wedged RPC peer's process tree on shutdown

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -59,7 +59,7 @@ import static org.openrewrite.internal.StringUtils.readFully;
  */
 public class RewriteRpcProcess extends Thread {
 
-    // Java 9+ Process/ProcessHandle reflection so this Java 8 module can reap a wedged peer's descendants.
+    // Reflected: these Java 9+ APIs aren't visible to this Java 8 module.
     private static final @Nullable Method PROCESS_DESCENDANTS;
     private static final @Nullable Method PROCESS_HANDLE_DESTROY_FORCIBLY;
 
@@ -70,7 +70,7 @@ public class RewriteRpcProcess extends Thread {
             descendants = Process.class.getMethod("descendants");
             destroyForcibly = Class.forName("java.lang.ProcessHandle").getMethod("destroyForcibly");
         } catch (Exception ignored) {
-            // Descendant reaping needs the Java 9+ ProcessHandle API; on Java 8 only the direct child is destroyed.
+            // Java 8 has no ProcessHandle; only the direct child is destroyed.
         }
         PROCESS_DESCENDANTS = descendants;
         PROCESS_HANDLE_DESTROY_FORCIBLY = destroyForcibly;
@@ -84,8 +84,7 @@ public class RewriteRpcProcess extends Thread {
     @Setter
     private @Nullable Path workingDirectory;
 
-    // Package-private so same-package tests can drive shutdown() against a spawned tree without reflection.
-    // Volatile so a shutdown() running on the JVM hook thread reliably sees the spawned process.
+    // Package-private for tests; volatile for the JVM-hook shutdown() read.
     @Nullable
     volatile Process process;
 
@@ -156,7 +155,7 @@ public class RewriteRpcProcess extends Thread {
             // of the log file.  Instead we drain stderr in a daemon thread.
             Process p = pb.start();
             stderrDrainThread = drainStderr(p, stderrRedirect);
-            // Publish process last so its volatile store also releases the stderrDrainThread write.
+            // Publish process last so its volatile write also releases stderrDrainThread.
             process = p;
         } catch (IOException e) {
             // Record the failure so start() can surface it instead of busy-waiting forever
@@ -192,7 +191,7 @@ public class RewriteRpcProcess extends Thread {
     }
 
     public @Nullable RuntimeException getLivenessCheck() {
-        // A deliberate shutdown SIGKILLs the peer, so don't misreport that as a crash.
+        // Don't report our own shutdown SIGKILL as a crash.
         if (shutDown.get() || process == null) {
             return null;
         }
@@ -253,7 +252,7 @@ public class RewriteRpcProcess extends Thread {
         try {
             Runtime.getRuntime().addShutdownHook(shutdownHook);
         } catch (IllegalStateException e) {
-            // JVM shutdown began before the hook could register; reap now so the peer can't linger.
+            // JVM already shutting down; reap now so the peer can't linger.
             shutdownHook = null;
             shutdown();
             throw new IllegalStateException(
@@ -275,12 +274,11 @@ public class RewriteRpcProcess extends Thread {
     }
 
     public void shutdown() {
-        // Run the teardown once even if the explicit caller and the JVM shutdown hook race.
+        // Run once, even if an explicit caller and the JVM hook race.
         if (!shutDown.compareAndSet(false, true)) {
             return;
         }
-        // Capture the descendants while still connected so a wedged peer that reparents to init
-        // once the direct child is killed can still be force-killed by pid.
+        // Snapshot descendants while connected; they reparent to init once the child is killed.
         List<Object> descendants = captureDescendants(process);
         if (rssSamplerThread != null) {
             rssSamplerThread.interrupt();
@@ -294,14 +292,13 @@ public class RewriteRpcProcess extends Thread {
             }
             shutdownHook = null;
         }
-        // Force-kill the direct child; a wedged peer may never honor a graceful signal.
+        // Force-kill the direct child; a wedged peer may not exit gracefully.
         if (process != null) {
             process.destroyForcibly();
         }
-        // Force-kill any descendant the direct child would otherwise orphan, using handles captured
-        // before the kill severed the tree; empty on Java 8 or for a single-process peer.
+        // Force-kill the descendants captured above; empty on Java 8 or a single-process peer.
         destroyDescendantsForcibly(descendants);
-        // Wait for the drain thread to close its stderrRedirect handle so Windows can delete or reopen the file (see run()).
+        // Join the drain so Windows can delete/reopen the stderrRedirect file (see run()).
         if (stderrDrainThread != null) {
             try {
                 stderrDrainThread.join(TimeUnit.SECONDS.toMillis(2));
@@ -312,10 +309,7 @@ public class RewriteRpcProcess extends Thread {
         }
     }
 
-    /**
-     * The direct child's descendants as Java 9+ {@code ProcessHandle}s captured before shutdown
-     * severs the tree, empty on Java 8 or when the handles cannot be obtained.
-     */
+    /** The peer's descendants as {@code ProcessHandle}s, empty on Java 8 or if unobtainable. */
     private static List<Object> captureDescendants(@Nullable Process p) {
         if (p == null || PROCESS_DESCENDANTS == null) {
             return Collections.emptyList();
@@ -329,7 +323,7 @@ public class RewriteRpcProcess extends Thread {
         }
     }
 
-    /** Force-kill each captured handle, ignoring any that can no longer be reached; a no-op on Java 8 or an empty list. */
+    /** Force-kill each captured handle, skipping any already gone. */
     private static void destroyDescendantsForcibly(List<Object> descendants) {
         if (PROCESS_HANDLE_DESTROY_FORCIBLY == null) {
             return;
@@ -338,7 +332,7 @@ public class RewriteRpcProcess extends Thread {
             try {
                 PROCESS_HANDLE_DESTROY_FORCIBLY.invoke(handle);
             } catch (Exception ignored) {
-                // Best-effort force-kill; a handle we can't reach is no worse than before.
+                // Best-effort; skip a handle we can't reach.
             }
         }
     }

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -35,16 +35,22 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Stream;
 
 import static org.openrewrite.internal.StringUtils.readFully;
 
@@ -52,6 +58,24 @@ import static org.openrewrite.internal.StringUtils.readFully;
  * A client for spawning and communicating with a subprocess that implements Rewrite RPC.
  */
 public class RewriteRpcProcess extends Thread {
+
+    // Java 9+ Process/ProcessHandle reflection so this Java 8 module can reap a wedged peer's descendants.
+    private static final @Nullable Method PROCESS_DESCENDANTS;
+    private static final @Nullable Method PROCESS_HANDLE_DESTROY_FORCIBLY;
+
+    static {
+        Method descendants = null;
+        Method destroyForcibly = null;
+        try {
+            descendants = Process.class.getMethod("descendants");
+            destroyForcibly = Class.forName("java.lang.ProcessHandle").getMethod("destroyForcibly");
+        } catch (Exception ignored) {
+            // Descendant reaping needs the Java 9+ ProcessHandle API; on Java 8 only the direct child is destroyed.
+        }
+        PROCESS_DESCENDANTS = descendants;
+        PROCESS_HANDLE_DESTROY_FORCIBLY = destroyForcibly;
+    }
+
     private final String[] command;
 
     @Setter
@@ -60,8 +84,10 @@ public class RewriteRpcProcess extends Thread {
     @Setter
     private @Nullable Path workingDirectory;
 
+    // Package-private so same-package tests can drive shutdown() against a spawned tree without reflection.
+    // Volatile so a shutdown() running on the JVM hook thread reliably sees the spawned process.
     @Nullable
-    private Process process;
+    volatile Process process;
 
     @SuppressWarnings("NotNullFieldNotInitialized")
     @Getter
@@ -85,6 +111,8 @@ public class RewriteRpcProcess extends Thread {
 
     @Nullable
     private IOException startupFailure;
+
+    private final AtomicBoolean shutDown = new AtomicBoolean();
 
     public RewriteRpcProcess(String... command) {
         this.command = command;
@@ -126,8 +154,10 @@ public class RewriteRpcProcess extends Thread {
             // Don't use ProcessBuilder.redirectError() — on Windows it leaks the
             // parent-side file handle after process termination, preventing deletion
             // of the log file.  Instead we drain stderr in a daemon thread.
-            process = pb.start();
-            stderrDrainThread = drainStderr(process, stderrRedirect);
+            Process p = pb.start();
+            stderrDrainThread = drainStderr(p, stderrRedirect);
+            // Publish process last so its volatile store also releases the stderrDrainThread write.
+            process = p;
         } catch (IOException e) {
             // Record the failure so start() can surface it instead of busy-waiting forever
             // on `process == null`. Throwing here would just kill this thread silently.
@@ -162,7 +192,8 @@ public class RewriteRpcProcess extends Thread {
     }
 
     public @Nullable RuntimeException getLivenessCheck() {
-        if (process == null) {
+        // A deliberate shutdown SIGKILLs the peer, so don't misreport that as a crash.
+        if (shutDown.get() || process == null) {
             return null;
         }
 
@@ -219,7 +250,15 @@ public class RewriteRpcProcess extends Thread {
             } catch (Throwable ignored) {
             }
         }, "rpc-shutdown");
-        Runtime.getRuntime().addShutdownHook(shutdownHook);
+        try {
+            Runtime.getRuntime().addShutdownHook(shutdownHook);
+        } catch (IllegalStateException e) {
+            // JVM shutdown began before the hook could register; reap now so the peer can't linger.
+            shutdownHook = null;
+            shutdown();
+            throw new IllegalStateException(
+                    "JVM shutting down during RPC start; peer reaped: " + String.join(" ", command), e);
+        }
 
         startRssSampler();
 
@@ -236,6 +275,13 @@ public class RewriteRpcProcess extends Thread {
     }
 
     public void shutdown() {
+        // Run the teardown once even if the explicit caller and the JVM shutdown hook race.
+        if (!shutDown.compareAndSet(false, true)) {
+            return;
+        }
+        // Capture the descendants while still connected so a wedged peer that reparents to init
+        // once the direct child is killed can still be force-killed by pid.
+        List<Object> descendants = captureDescendants(process);
         if (rssSamplerThread != null) {
             rssSamplerThread.interrupt();
             rssSamplerThread = null;
@@ -248,30 +294,14 @@ public class RewriteRpcProcess extends Thread {
             }
             shutdownHook = null;
         }
-        if (process != null && process.isAlive()) {
-            process.destroy();
-            try {
-                boolean exited = process.waitFor(5, TimeUnit.SECONDS);
-                if (!exited) {
-                    process.destroyForcibly();
-                    process.waitFor(2, TimeUnit.SECONDS);
-                }
-                int exitCode = process.exitValue();
-                if (exitCode != 0 && exitCode != 1 && exitCode != 143) { // 143 = SIGTERM
-                    throw new RuntimeException("Rewrite RPC process crashed with exit code: " + exitCode);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-            }
+        // Force-kill the direct child; a wedged peer may never honor a graceful signal.
+        if (process != null) {
+            process.destroyForcibly();
         }
-        // Wait for the drain thread to observe EOF and close its handle on
-        // stderrRedirect. Without this, the parent-side file handle outlives
-        // shutdown(); on Windows that breaks `@TempDir` test cleanup and any
-        // reopen-the-same-path flow, because the file can't be deleted or
-        // replaced while a handle is held without FILE_SHARE_DELETE. This is
-        // the same hazard the drain-thread approach exists to avoid (see
-        // run() above). Done outside the isAlive() guard so the join also
-        // runs when the subprocess already exited on its own.
+        // Force-kill any descendant the direct child would otherwise orphan, using handles captured
+        // before the kill severed the tree; empty on Java 8 or for a single-process peer.
+        destroyDescendantsForcibly(descendants);
+        // Wait for the drain thread to close its stderrRedirect handle so Windows can delete or reopen the file (see run()).
         if (stderrDrainThread != null) {
             try {
                 stderrDrainThread.join(TimeUnit.SECONDS.toMillis(2));
@@ -279,6 +309,37 @@ public class RewriteRpcProcess extends Thread {
                 Thread.currentThread().interrupt();
             }
             stderrDrainThread = null;
+        }
+    }
+
+    /**
+     * The direct child's descendants as Java 9+ {@code ProcessHandle}s captured before shutdown
+     * severs the tree, empty on Java 8 or when the handles cannot be obtained.
+     */
+    private static List<Object> captureDescendants(@Nullable Process p) {
+        if (p == null || PROCESS_DESCENDANTS == null) {
+            return Collections.emptyList();
+        }
+        try {
+            List<Object> descendants = new ArrayList<>();
+            ((Stream<?>) PROCESS_DESCENDANTS.invoke(p)).forEach(descendants::add);
+            return descendants;
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
+
+    /** Force-kill each captured handle, ignoring any that can no longer be reached; a no-op on Java 8 or an empty list. */
+    private static void destroyDescendantsForcibly(List<Object> descendants) {
+        if (PROCESS_HANDLE_DESTROY_FORCIBLY == null) {
+            return;
+        }
+        for (Object handle : descendants) {
+            try {
+                PROCESS_HANDLE_DESTROY_FORCIBLY.invoke(handle);
+            } catch (Exception ignored) {
+                // Best-effort force-kill; a handle we can't reach is no worse than before.
+            }
         }
     }
 

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.rpc;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -28,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -164,6 +167,91 @@ class RewriteRpcProcessTest {
                 assertThatThrownBy(process::start)
                         .isInstanceOf(UncheckedIOException.class)
                         .hasMessageContaining(missing));
+    }
+
+    /**
+     * A wedged peer whose grandchild ignores SIGTERM reparents to init when the direct
+     * child is severed. {@link RewriteRpcProcess#shutdown()} must still force-kill it via
+     * the descendant tree captured before the sever, so it can't linger holding a process
+     * slot for the life of a long-running server.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void shutdownForceKillsAWedgedPeerAfterSeveringTheDirectChild() throws Exception {
+        Process peerProcess = new ProcessBuilder("sh", "-c",
+                "sh -c 'trap \"\" TERM; sleep 300' & wait").start();
+        RewriteRpcProcess peer = peerWrapping(peerProcess);
+        await(() -> peerProcess.descendants().count() == 2 ? Boolean.TRUE : null);
+        ProcessHandle wedged = peerProcess.children().findFirst().orElseThrow();
+        try {
+            peer.shutdown();
+
+            // SIGKILL is asynchronous, so poll for the reparented survivor to exit.
+            await(() -> wedged.isAlive() ? null : Boolean.TRUE);
+            assertThat(wedged.isAlive()).isFalse();
+        } finally {
+            wedged.descendants().forEach(ProcessHandle::destroyForcibly);
+            wedged.destroyForcibly();
+            peerProcess.destroyForcibly();
+        }
+    }
+
+    /**
+     * {@link RewriteRpcProcess#shutdown()} runs from both an explicit teardown and the JVM
+     * shutdown hook, so a second call must be a safe no-op rather than tripping over the
+     * fields the first call already cleared.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void shutdownIsIdempotent() throws Exception {
+        Process peerProcess = new ProcessBuilder("sleep", "300").start();
+        RewriteRpcProcess peer = peerWrapping(peerProcess);
+        try {
+            peer.shutdown();
+            peer.shutdown();
+
+            await(() -> peerProcess.isAlive() ? null : Boolean.TRUE);
+            assertThat(peerProcess.isAlive()).isFalse();
+        } finally {
+            peerProcess.destroyForcibly();
+        }
+    }
+
+    /**
+     * A liveness check that runs while {@link RewriteRpcProcess#shutdown()} is force-killing the
+     * peer must not report the deliberate SIGKILL as a crash.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void livenessCheckIsSilentAfterShutdown() throws Exception {
+        Process peerProcess = new ProcessBuilder("sleep", "300").start();
+        RewriteRpcProcess peer = peerWrapping(peerProcess);
+        try {
+            peer.shutdown();
+            await(() -> peerProcess.isAlive() ? null : Boolean.TRUE);
+
+            assertThat(peer.getLivenessCheck()).isNull();
+        } finally {
+            peerProcess.destroyForcibly();
+        }
+    }
+
+    /** An unstarted {@link RewriteRpcProcess} whose {@code process} field is the given spawned tree. */
+    private static RewriteRpcProcess peerWrapping(Process process) {
+        RewriteRpcProcess peer = new RewriteRpcProcess("noop");
+        peer.process = process;
+        return peer;
+    }
+
+    private static <T> T await(Supplier<T> probe) throws InterruptedException {
+        for (int i = 0; i < 100; i++) {
+            T value = probe.get();
+            if (value != null) {
+                return value;
+            }
+            Thread.sleep(50);
+        }
+        throw new AssertionError("Condition never met");
     }
 
     /**


### PR DESCRIPTION
A long-running server that builds LSTs through RPC language peers (for example JavaScript's `java` to `npx` to `node`) starts a subprocess tree per build. When a peer shut down, only its direct child was destroyed. A wedged grandchild that never sees stdin EOF reparented to init and lingered, holding a per-user process slot. Over a session these accumulated until the JVM could no longer spawn any child, so even `git` calls failed with `posix_spawn failed`.

`RewriteRpcProcess.shutdown()` now captures the peer's descendants while still connected, then force-kills the direct child and every descendant. This covers all RPC languages with no caller-side reflection, so the CLI-side workaround collapses to a version bump.

**Known limitations:** a descendant orphaned before shutdown (direct child crashes first) is not reaped. This is rare for stdio peers that do not daemonize. Under a non-reaping PID 1 (bare container), a descendant killed by pid can become a zombie, so run under a reaping init (`docker run --init` or tini).
