### PR TITLE
JavaScript: a `catch` clause may bind no variable at all

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format/minimum-viable-spacing-visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/minimum-viable-spacing-visitor.ts
@@ -222,7 +222,8 @@ export class MinimumViableSpacingVisitor<P> extends JavaScriptVisitor<P> {
             first = false;
         }
 
-        if (!first) {
+        // `catch { }` has a parameter with no variables
+        if (!first && ret.variables.length > 0) {
             ret = produce(ret, draft => {
                 this.ensureSpace(draft.variables[0].element.prefix);
             });

--- a/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
@@ -31,8 +31,8 @@ import {fromVisitor, RecipeSpec, SourceSpec} from "../../../src/test";
 import {MinimumViableSpacingVisitor} from "../../../src/javascript/format";
 import {JavaScriptParser, JavaScriptVisitor, JS, typescript} from "../../../src/javascript";
 import {create as produce} from "mutative";
-import {mapAsync, ParserInput, SourceFile} from "../../../src";
-import {J} from "../../../src/java";
+import {emptyMarkers, mapAsync, ParserInput, randomId, SourceFile} from "../../../src";
+import {emptySpace, J} from "../../../src/java";
 
 class RemoveSpacesVisitor<P> extends JavaScriptVisitor<P> {
     override async visitSpace(space: J.Space, p: P): Promise<J.Space> {
@@ -164,5 +164,44 @@ describe('MinimumViableSpacingVisitor', () => {
                 // @formatter:on
             ))
     });
-});
 
+    test('optional catch binding', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `try { doWork() } catch { recover() }`,
+                `try{doWork()}catch{recover()}`,
+                // @formatter:on
+            ))
+    });
+
+    test('catch parameter with a modifier and no variables', async () => {
+        const modifier: J.Modifier = {
+            kind: J.Kind.Modifier,
+            id: randomId(),
+            prefix: emptySpace,
+            markers: emptyMarkers,
+            keyword: "const",
+            type: J.ModifierType.LanguageExtension,
+            annotations: []
+        };
+
+        class AddModifierVisitor<P> extends JavaScriptVisitor<P> {
+            override async visitVariableDeclarations(v: J.VariableDeclarations, p: P): Promise<J | undefined> {
+                const ret = await super.visitVariableDeclarations(v, p) as J.VariableDeclarations;
+                return ret.variables.length === 0 ? produce(ret, draft => {
+                    // a modifier is what makes the visitor go looking for a first variable
+                    draft.modifiers = [modifier];
+                }) : ret;
+            }
+        }
+
+        const parser = new JavaScriptParser({});
+        for await (const cu of parser.parse({text: `try { } catch { }`, sourcePath: "a.ts"})) {
+            const withModifier = (await new AddModifierVisitor().visit<JS.CompilationUnit>(cu, undefined))!;
+            const formatted = await new MinimumViableSpacingVisitor().visit(withModifier, undefined);
+            expect(formatted).toBeDefined();
+        }
+    });
+});


### PR DESCRIPTION
Running the Java recipe `org.openrewrite.staticanalysis.NeedBraces` over `oauth2-vanilla/ui/src/main/resources/static/browser/scripts-T6DMDFTB.js` in `spring-guides/tut-spring-security-and-angular-js` fails the whole source file:

```
io.moderne.jsonrpc.JsonRpcException: Request Visit failed with message: TypeError: Cannot read properties of undefined (reading 'element')
    at <anonymous> (.../@openrewrite/rewrite/src/javascript/format/minimum-viable-spacing-visitor.ts:227:53)
    at MinimumViableSpacingVisitor.visitVariableDeclarations (.../minimum-viable-spacing-visitor.ts:226:26)
    at async MinimumViableSpacingVisitor.visitControlParentheses (.../java/visitor.ts:346:19)
    at async MinimumViableSpacingVisitor.visitTryCatch (.../java/visitor.ts:1034:24)
  org.openrewrite.java.JavaVisitor.maybeAutoFormat(JavaVisitor.java:76)
  org.openrewrite.staticanalysis.NeedBraces$NeedBracesVisitor.visitIf(NeedBraces.java:180)
```

`visitVariableDeclarations` reads `variables[0]` with no length check. The parameter of an ES2019 optional catch binding — `try { } catch { }`, which that bundle contains 13 times — is a `J.VariableDeclarations` whose `variables` list is deliberately empty (`parser.ts:4151`), so the read yields `undefined` and the visitor throws. Nothing about this shape is new: `visitCatchClause` has produced it unchanged since the initial JavaScript support commit.

`SpacesVisitor` already guards this exact list on this exact node, so the empty-catch case was known and only this call site missed it:

```ts
if (catch_.parameter.tree.element.variables.length > 0) {
    catch_.parameter.tree.element.variables[...length - 1].after.whitespace = "";
}
```

The guard here is the same shape. Reaching the throwing line additionally requires `leadingAnnotations` or `modifiers` to be non-empty, which a freshly parsed catch parameter never is — that part of the failing tree is still unexplained and is tracked separately; it does not change what this code should do when handed a parameter with no variables.

## Tests

`optional catch binding` runs `try { } catch { }` through the visitor end to end. `catch parameter with a modifier and no variables` builds the tree that actually reached the failing line — an empty-`variables` catch parameter carrying a modifier — and asserts the visitor returns. Reverting the guard makes the second test fail with the production error verbatim; the first keeps passing, which is why it alone is not enough.

## Audit

Every other `[0]` and `[length - 1]` access in the six formatter visitors is either already guarded or on a list the parser never leaves empty; `variables` on a catch parameter is the only one it does. A sweep of 57 edge-case snippets plus the bundle above through all six visitors and `AutoformatVisitor` reports no other failure. Four unguarded accesses are unreachable from a parsed tree and left alone: `caseLabels.elements[0]` (`default:` yields one Identifier label), `NamedImports` first/last (`import { }` yields one `ImportSpecifier` placeholder, though its `NamedExports` twin is guarded), parameter `variables[0]` (rest, destructured and defaulted parameters all arrive with one variable), and `CompilationUnit.statements[0]` (only reached from a statement already in that list).