### PR TITLE
JavaScript: a project below the git root is still in a git work tree

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/project-parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/project-parser.ts
@@ -545,6 +545,12 @@ export class ProjectParser {
             }
         }
 
+        // A project inside an ignored directory is invisible to git; the walk is what
+        // discovers it.
+        if (files.length === 0) {
+            return this.discoverFilesWithWalk();
+        }
+
         // Filter by our exclusion patterns and accepted file types
         return files.filter(file => this.isAcceptedFile(file, this.gitExclusions));
     }
@@ -658,10 +664,20 @@ export class ProjectParser {
     }
 
     /**
-     * Checks if the project is a git repository.
+     * Checks whether a git work tree encloses the project, which for a project below the
+     * repository root is an ancestor directory. A linked work tree or submodule has `.git`
+     * as a file, so presence rather than kind is what counts.
      */
     private isGitRepository(): boolean {
-        return fs.existsSync(path.join(this.projectPath, ".git"));
+        let dir = this.projectPath;
+        while (!fs.existsSync(path.join(dir, ".git"))) {
+            const parent = path.dirname(dir);
+            if (parent === dir) {
+                return false;
+            }
+            dir = parent;
+        }
+        return true;
     }
 
     /**

--- a/rewrite-javascript/rewrite/test/rpc/project-parser-exclusions.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/project-parser-exclusions.test.ts
@@ -90,3 +90,85 @@ describe("ProjectParser exclusions", () => {
         }
     });
 });
+
+/** A git repo whose project lives in `ui/`, with the only `.gitignore` at the root. */
+function nestedProject(root: string): string {
+    write(root, ".gitignore", "target/\n");
+    write(root, "pom.xml", "<project/>\n");
+    write(root, "ui/package.json", '{"name": "ui"}\n');
+    write(root, "ui/src/app.ts");
+    write(root, "ui/dist/keep.ts");
+    write(root, "ui/target/classes/static/browser/app.js");
+
+    spawnSync("git", ["init"], {cwd: root});
+    spawnSync("git", ["add", "ui/dist/keep.ts"], {cwd: root});
+    return path.join(root, "ui");
+}
+
+describe("ProjectParser discovery in a project below the git root", () => {
+    it("honours the repository root .gitignore", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            const files = await discovered(nestedProject(tmpDir.path));
+            expect(files).toContain("src/app.ts");
+            expect(files).not.toContain("target/classes/static/browser/app.js");
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+
+    it("keeps a tracked output directory, which is the project's own source", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            expect(await discovered(nestedProject(tmpDir.path))).toContain("dist/keep.ts");
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+
+    it("recognizes a work tree whose .git is a file", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            const root = path.join(tmpDir.path, "repo");
+            nestedProject(root);
+            const git = (...args: string[]) => spawnSync("git", args, {cwd: root, encoding: "utf8"});
+            git("add", "-A");
+            git("-c", "user.email=t@t", "-c", "user.name=t", "commit", "--no-verify", "-m", "initial");
+            const worktree = path.join(tmpDir.path, "linked");
+            git("worktree", "add", "--detach", worktree);
+            expect(fs.statSync(path.join(worktree, ".git")).isFile()).toBe(true);
+            // Ignored output is not checked out, so this work tree needs its own copy.
+            write(worktree, "ui/target/classes/static/browser/app.js");
+
+            const files = await discovered(path.join(worktree, "ui"));
+            expect(files).toContain("dist/keep.ts");
+            expect(files).not.toContain("target/classes/static/browser/app.js");
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+
+    it("falls back to the walk for a project the repository ignores entirely", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            write(tmpDir.path, ".gitignore", "ui/\n");
+            write(tmpDir.path, "ui/src/app.ts");
+            spawnSync("git", ["init"], {cwd: tmpDir.path});
+            expect(await discovered(path.join(tmpDir.path, "ui"))).toEqual(["src/app.ts"]);
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+
+    it("walks with the default exclusions when no work tree encloses the project", async () => {
+        const tmpDir = await dir({unsafeCleanup: true});
+        try {
+            write(tmpDir.path, "src/app.ts");
+            write(tmpDir.path, "dist/keep.ts");
+            write(tmpDir.path, "build/out.ts");
+            expect(await discovered(tmpDir.path)).toEqual(["src/app.ts"]);
+        } finally {
+            await tmpDir.cleanup();
+        }
+    });
+});


### PR DESCRIPTION
A Moderne CLI recipe run over `spring-guides/tut-spring-security-and-angular-js` parsed the same file twice and reported two identical recipe errors, one for the source and one for Maven's copy of it:

```
oauth2-vanilla/ui/src/main/resources/static/browser/scripts-T6DMDFTB.js
oauth2-vanilla/ui/target/classes/static/browser/scripts-T6DMDFTB.js
```

- The repository's root `.gitignore` contains `target/`, so git-based discovery would never have seen the second path. It never ran. `ProjectParser.isGitRepository()` tested for a `.git` entry in `projectPath` — the directory holding `package.json`, here `oauth2-vanilla/ui` — so `useGit` was false and `discoverFiles` fell through to `discoverFilesWithWalk()`, which knows nothing about `.gitignore` and excludes only the seven fixed `DEFAULT_EXCLUSIONS` patterns (`node_modules`, `dist`, `build`, `.git`, `coverage`, `*.min.js`, `*.bundle.js`). `target` is not among them, and `MavenBuildStep` runs before `JavaScriptBuildStep`, so `target/classes` was fully populated by the time the JS parser walked it. This is not a corner case: every JS project that is not at the git root took the walk, which is most of them in a polyglot corpus, so the git path that #8437 was written for almost never executed.

The gate is the only thing that was wrong. `discoverFilesWithGit()` already works from a nested directory: `git ls-files` run with `cwd` set to `oauth2-vanilla/ui` exits 0 and returns paths relative to that directory, already scoped to the subtree and already filtered by the root `.gitignore` four levels up — nothing under `target/` appears. So the fix is to look for the enclosing work tree instead of a `.git` in `projectPath`: walk up from the project directory until `.git` exists or the filesystem root is reached. Still `fs.existsSync`, which treats a `.git` *file* as present — that is what makes linked work trees and submodules work.

One guard comes with it. If git succeeds but both invocations report zero paths, discovery falls back to the walk. That case is a project inside an ignored directory: today the walk finds its files, and with the gate fixed git would return nothing and the project would come back empty. The existing fallback only fires when git fails.

- `DEFAULT_EXCLUSIONS` and `DEFAULT_TRACKED_EXCLUSIONS` are deliberately untouched. Adding `**/target/**` would match at any depth and eat a legitimate `src/app/target/` — the same shape as the `src/dist/` regression #8437 fixed. The point here is to make #8437's behaviour reach the repos it was written for.

- Five cases in `project-parser-exclusions.test.ts` cover the nested layout; the first three fail before the gate change. A `.js` under `<project>/target/classes/` is not discovered while `<project>/src/app.ts` is; a tracked `<project>/dist/keep.ts` still is, extending #8437's invariant that git-tracked output is the project's own source; a linked work tree, whose `.git` is a file, is recognized; a project the repository ignores entirely still comes back from the walk; and a directory with no enclosing work tree still walks with the full `DEFAULT_EXCLUSIONS`.
