### PR TITLE
Update Java compatibility behind `options.release.set()` and local variables

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
@@ -30,10 +30,13 @@ import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static java.lang.Boolean.TRUE;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.Tree.randomId;
 
@@ -92,6 +95,7 @@ public class UpdateJavaCompatibility extends Recipe {
         return Preconditions.check(new IsBuildGradle<>(), new JavaIsoVisitor<ExecutionContext>() {
             boolean sourceCompatibilityFound;
             boolean targetCompatibilityFound;
+            Set<String> compatibilityVariables = emptySet();
 
             @Override
             public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
@@ -100,6 +104,7 @@ public class UpdateJavaCompatibility extends Recipe {
                 }
                 sourceCompatibilityFound = false;
                 targetCompatibilityFound = false;
+                compatibilityVariables = findCompatibilityVariables(tree);
                 J visited = super.visit(tree, ctx);
                 if (visited instanceof G.CompilationUnit) {
                     G.CompilationUnit c = (G.CompilationUnit) visited;
@@ -139,6 +144,23 @@ public class UpdateJavaCompatibility extends Recipe {
             }
 
             @Override
+            public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, ExecutionContext ctx) {
+                J.VariableDeclarations.NamedVariable v = super.visitVariable(variable, ctx);
+                Expression initializer = v.getInitializer();
+                if (initializer == null || !compatibilityVariables.contains(v.getSimpleName())) {
+                    return v;
+                }
+
+                DeclarationStyle currentStyle = getCurrentStyle(initializer);
+                Integer currentMajor = getMajorVersion(initializer);
+                if (shouldUpdateVersion(currentMajor) || shouldUpdateStyle(currentStyle)) {
+                    DeclarationStyle actualStyle = declarationStyle == null ? currentStyle : declarationStyle;
+                    return v.withInitializer(changeJavaVersion(initializer, actualStyle));
+                }
+                return v;
+            }
+
+            @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = super.visitMethodInvocation(method, ctx);
                 if (SOURCE_COMPATIBILITY_METHOD.matches(m) || SOURCE_COMPATIBILITY_DSL.matches(m)) {
@@ -150,6 +172,21 @@ public class UpdateJavaCompatibility extends Recipe {
                 return handleMethodInvocation(m);
             }
         });
+    }
+
+    // Variables a compatibility assignment reads from; the version lives in their initializer, not the assignment.
+    private Set<String> findCompatibilityVariables(Tree tree) {
+        Set<String> names = new HashSet<>();
+        new JavaIsoVisitor<Set<String>>() {
+            @Override
+            public J.Assignment visitAssignment(J.Assignment assignment, Set<String> names) {
+                if (assignment.getAssignment() instanceof J.Identifier && isCompatibilityAssignment(assignment)) {
+                    names.add(((J.Identifier) assignment.getAssignment()).getSimpleName());
+                }
+                return super.visitAssignment(assignment, names);
+            }
+        }.visit(tree, names);
+        return names;
     }
 
     private G.CompilationUnit addGroovyCompatibilityType(G.CompilationUnit c, String targetCompatibilityType, ExecutionContext ctx) {
@@ -204,30 +241,33 @@ public class UpdateJavaCompatibility extends Recipe {
         }.visitNonNull(c, ctx);
     }
 
-    private J.Assignment handleAssignment(J.Assignment a) {
+    private boolean isCompatibilityAssignment(J.Assignment a) {
         if (a.getVariable() instanceof J.Identifier) {
             J.Identifier variable = (J.Identifier) a.getVariable();
 
             if (compatibilityType == null) {
-                if (!("sourceCompatibility".equals(variable.getSimpleName()) || "targetCompatibility".equals(variable.getSimpleName()))) {
-                    return a;
-                }
-            } else if (!(compatibilityType.toString().toLowerCase() + "Compatibility").equals(variable.getSimpleName())) {
-                return a;
+                return "sourceCompatibility".equals(variable.getSimpleName()) || "targetCompatibility".equals(variable.getSimpleName());
             }
+            return (compatibilityType.toString().toLowerCase() + "Compatibility").equals(variable.getSimpleName());
         } else if (a.getVariable() instanceof J.FieldAccess) {
             J.FieldAccess fieldAccess = (J.FieldAccess) a.getVariable();
             if (compatibilityType == null) {
-                if (!("sourceCompatibility".equals(fieldAccess.getSimpleName()) || "targetCompatibility".equals(fieldAccess.getSimpleName()) ||
-                        ("release".equals(fieldAccess.getSimpleName()) &&
-                                ((fieldAccess.getTarget() instanceof J.Identifier && "options".equals(((J.Identifier) fieldAccess.getTarget()).getSimpleName())) ||
-                                        (fieldAccess.getTarget() instanceof J.FieldAccess && "options".equals(((J.FieldAccess) fieldAccess.getTarget()).getSimpleName())))))) {
-                    return a;
-                }
-            } else if (!(compatibilityType.toString().toLowerCase() + "Compatibility").equals(fieldAccess.getSimpleName())) {
-                return a;
+                return "sourceCompatibility".equals(fieldAccess.getSimpleName()) || "targetCompatibility".equals(fieldAccess.getSimpleName()) ||
+                        isCompilerRelease(fieldAccess);
             }
-        } else {
+            return (compatibilityType.toString().toLowerCase() + "Compatibility").equals(fieldAccess.getSimpleName());
+        }
+        return false;
+    }
+
+    private static boolean isCompilerRelease(J.FieldAccess fieldAccess) {
+        return "release".equals(fieldAccess.getSimpleName()) &&
+                ((fieldAccess.getTarget() instanceof J.Identifier && "options".equals(((J.Identifier) fieldAccess.getTarget()).getSimpleName())) ||
+                        (fieldAccess.getTarget() instanceof J.FieldAccess && "options".equals(((J.FieldAccess) fieldAccess.getTarget()).getSimpleName())));
+    }
+
+    private J.Assignment handleAssignment(J.Assignment a) {
+        if (!isCompatibilityAssignment(a)) {
             return a;
         }
 
@@ -268,6 +308,18 @@ public class UpdateJavaCompatibility extends Recipe {
 
             return SearchResult.found(m, "Attempted to update to Java version to " + version +
                     "  but was unsuccessful, please update manually");
+        }
+
+        // The property API spelling of `options.release = 8`
+        if (compatibilityType == null && "set".equals(m.getSimpleName()) && m.getArguments().size() == 1 &&
+                m.getSelect() instanceof J.FieldAccess && isCompilerRelease((J.FieldAccess) m.getSelect())) {
+            DeclarationStyle currentStyle = getCurrentStyle(m.getArguments().get(0));
+            Integer currentMajor = getMajorVersion(m.getArguments().get(0));
+            if (shouldUpdateVersion(currentMajor) || shouldUpdateStyle(currentStyle)) {
+                DeclarationStyle actualStyle = declarationStyle == null ? currentStyle : declarationStyle;
+                return m.withArguments(ListUtils.mapFirst(m.getArguments(), arg -> changeJavaVersion(arg, actualStyle)));
+            }
+            return m;
         }
 
         if (SOURCE_COMPATIBILITY_DSL.matches(m) || TARGET_COMPATIBILITY_DSL.matches(m)) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpdateJavaCompatibilityTest.java
@@ -481,6 +481,156 @@ class UpdateJavaCompatibilityTest implements RewriteTest {
         );
     }
 
+    @Issue("https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release")
+    @Test
+    void releasePropertyGetsUpdated() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+
+              tasks.withType(JavaCompile) {
+                  options.release.set(8)
+              }
+
+              compileJava {
+                  options.release.set(8)
+              }
+
+              compileJava.options.release.set(8)
+              """,
+            """
+              plugins {
+                  id "java"
+              }
+
+              tasks.withType(JavaCompile) {
+                  options.release.set(11)
+              }
+
+              compileJava {
+                  options.release.set(11)
+              }
+
+              compileJava.options.release.set(11)
+              """
+          )
+        );
+    }
+
+    @Issue("https://docs.gradle.org/current/userguide/building_java_projects.html#sec:compiling_with_release")
+    @Test
+    void releasePropertyGetsUpdatedInKotlinDSL() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
+          buildGradleKts(
+            """
+              plugins {
+                  java
+              }
+
+              tasks.withType(JavaCompile::class) {
+                  if (JavaVersion.current().isJava9Compatible) {
+                      options.release.set(8)
+                  } else {
+                      sourceCompatibility = "1.8"
+                      targetCompatibility = "1.8"
+                  }
+              }
+
+              tasks.named<JavaCompile>("compileJava") {
+                  options.release.set(8)
+              }
+              """,
+            """
+              plugins {
+                  java
+              }
+
+              tasks.withType(JavaCompile::class) {
+                  if (JavaVersion.current().isJava9Compatible) {
+                      options.release.set(11)
+                  } else {
+                      sourceCompatibility = "11"
+                      targetCompatibility = "11"
+                  }
+              }
+
+              tasks.named<JavaCompile>("compileJava") {
+                  options.release.set(11)
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void compatibilityFromLocalVariable() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+
+              java {
+                  def javaVersion = JavaVersion.VERSION_1_8
+                  sourceCompatibility = javaVersion
+                  targetCompatibility = javaVersion
+              }
+              """,
+            """
+              plugins {
+                  id "java"
+              }
+
+              java {
+                  def javaVersion = JavaVersion.VERSION_11
+                  sourceCompatibility = javaVersion
+                  targetCompatibility = javaVersion
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void onlyUpdateVariablesFeedingCompatibility() {
+        rewriteRun(
+          spec -> spec.recipe(new UpdateJavaCompatibility(11, null, null, null, null)),
+          buildGradle(
+            """
+              plugins {
+                  id "java"
+              }
+
+              def someOtherVersion = JavaVersion.VERSION_1_8
+
+              java {
+                  sourceCompatibility = JavaVersion.VERSION_1_8
+                  targetCompatibility = JavaVersion.VERSION_1_8
+              }
+              """,
+            """
+              plugins {
+                  id "java"
+              }
+
+              def someOtherVersion = JavaVersion.VERSION_1_8
+
+              java {
+                  sourceCompatibility = JavaVersion.VERSION_11
+                  targetCompatibility = JavaVersion.VERSION_11
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void updateExisitingSourceCompatibilityInKotlinDSL() {
         rewriteRun(


### PR DESCRIPTION
Two spellings of a Java version that `UpdateJavaCompatibility` does not follow, each leaving a build declaring an older level than the source it now contains.

### `options.release.set(N)`

The assignment spelling is already updated:

```groovy
tasks.withType(JavaCompile) {
    options.release = 8      // updated today
}
```

The Gradle property-API spelling is a `J.MethodInvocation` rather than a `J.Assignment`, and `handleMethodInvocation` only recognised `jvmToolchain(..)` and `JavaLanguageVersion.of(..)`:

```kotlin
tasks.withType(JavaCompile::class) {
    options.release.set(8)   // left at 8
}
```

Since the recipe already updates `options.release = N`, this is completing existing intent rather than new policy — the two spellings now share one definition of what the release option is, in `isCompilerRelease`, so they cannot drift.

`javaLauncher.set(..)` and `languageVersion.set(..)` are unaffected: their select is a `J.Identifier`, not a `J.FieldAccess` named `release`.

### A version held in a local variable

```groovy
java {
    def javaVersion = JavaVersion.VERSION_17
    sourceCompatibility = javaVersion
    targetCompatibility = javaVersion
}
```

`handleAssignment` matches the assignment, but the right-hand side is an identifier, so `getMajorVersion` returns null and nothing is updated. The version literal lives in the variable declaration, which was never visited for this purpose.

A scan pass now collects the names of variables that appear on the right-hand side of an assignment passing the *same* `isCompatibilityAssignment` predicate the rewrite uses, so the two cannot drift, and `visitVariable` rewrites only those initializers. A pre-pass is required because the declaration precedes the assignment in source order.

Matching is by simple name within one compilation unit, with no scope tracking — two same-named variables in different closures would both be rewritten. That is consistent with the string-name matching this recipe already uses throughout, and `onlyUpdateVariablesFeedingCompatibility` locks in that an unrelated `JavaVersion.VERSION_*` local is left alone.

### Tests

Four added: `options.release.set(8)` in Groovy across three shapes including the flat `compileJava.options.release.set(8)`; the same in Kotlin DSL, modelled on a real convention plugin's `if (JavaVersion.current().isJava9Compatible) { options.release.set(8) } else { sourceCompatibility = "1.8" }` so both spellings are asserted to move together; the local variable case; and the negative case.

`:rewrite-gradle:test` — 55 tests in `UpdateJavaCompatibilityTest`, 0 failures. Whole module: 1317 tests, 0 failures.

### Noticed while working here, left alone

The `jvmToolchain`/`JavaLanguageVersion.of` block and the `sourceCompatibility(..)`/`targetCompatibility(..)` DSL-method block both call `shouldUpdateStyle(declarationStyle)`, which reduces to `declarationStyle != null && declarationStyle != declarationStyle` — always false. So `declarationStyle` never applies to those forms unless the version also changes. The new branch uses the correct `shouldUpdateStyle(currentStyle)` that `handleAssignment` uses, rather than propagating it, but fixing the two existing sites would change current behaviour and seemed out of scope here.

Found by compiling the output of a Java 25 migration across a set of open source repositories.
