### PR TITLE
Add annotation processor paths to the nearest reactor parent

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddAnnotationProcessor.java
@@ -49,7 +49,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * The behavior differs based on project structure:
  * <ul>
  *   <li><b>Single module:</b> Adds to build/plugins</li>
- *   <li><b>Multi-module with parent in reactor:</b> Adds to parent's build/pluginManagement/plugins</li>
+ *   <li><b>Multi-module with parent in reactor:</b> Adds to the nearest parent's build/pluginManagement/plugins</li>
  *   <li><b>Orphan module (no parent in reactor):</b> Adds to build/plugins</li>
  * </ul>
  */
@@ -113,10 +113,12 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
             for (Map.Entry<Path, Path> e : tentativeChildToParent.entrySet()) {
                 Path child = e.getKey();
                 Path parent = e.getValue();
-                if (reactorLinked.contains(child)) {
-                    parentPomPaths.add(parent);
-                } else {
+                if (!reactorLinked.contains(child)) {
                     orphans.add(child);
+                } else if (!packagingPomPaths.contains(child)) {
+                    // A `pom` module compiles nothing, so it does not claim its own parent.
+                    // Otherwise every ancestor of a module gets configured, not just the nearest.
+                    parentPomPaths.add(parent);
                 }
             }
 
@@ -273,16 +275,13 @@ public class AddAnnotationProcessor extends ScanningRecipe<AddAnnotationProcesso
                     return tree;
                 }
 
-                // GAV-coincident orphan: AddPluginVisitor.isAcceptable would
-                // otherwise short-circuit via its parentPomIsProjectPom()
-                // check and refuse to add the plugin. Targeting the visitor
-                // at this exact source path bypasses that guard.
-                boolean isGavCoincidentOrphan = !isParent && mrr.parentPomIsProjectPom();
-                String pluginFilePattern = isGavCoincidentOrphan ? PathUtils.separatorsToUnix(sourcePath.toString()) : null;
+                // The reactor analysis above already picked this exact POM, so target the
+                // visitor at it rather than let AddPluginVisitor's blanket
+                // parentPomIsProjectPom() guard veto any POM with an in-reactor parent.
                 tree = new AddPluginVisitor(isParent,
                         MAVEN_COMPILER_PLUGIN_GROUP_ID, MAVEN_COMPILER_PLUGIN_ARTIFACT_ID, null,
                         "<configuration><annotationProcessorPaths/></configuration>", null, null,
-                        pluginFilePattern
+                        PathUtils.separatorsToUnix(sourcePath.toString())
                 ).visit(tree, ctx);
 
                 // Then, configure the annotation processor path

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddAnnotationProcessorTest.java
@@ -23,6 +23,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.java.Assertions.mavenProject;
+import static org.openrewrite.java.Assertions.project;
 import static org.openrewrite.maven.Assertions.pomXml;
 
 class AddAnnotationProcessorTest implements RewriteTest {
@@ -2699,6 +2700,414 @@ class AddAnnotationProcessorTest implements RewriteTest {
                                 </plugin>
                             </plugins>
                         </build>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+    }
+
+    @Nested
+    class NestedParents {
+
+        @Test
+        void addToNearestParentNotAggregatorRoot() {
+            // Three-level reactor: the aggregator root is also the parent of an
+            // intermediate parent POM, which in turn parents the module that
+            // compiles sources. Only the intermediate parent should be modified:
+            // it is the nearest parent of the compiling module, and it manages the
+            // processor's version, so no <version> is emitted.
+            rewriteRun(
+              pomXml(
+                // Aggregator and parent of `parent` - should NOT be modified
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>aggregator</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <modules>
+                          <module>parent</module>
+                          <module>core</module>
+                      </modules>
+                      <build>
+                          <pluginManagement>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>org.apache.maven.plugins</groupId>
+                                      <artifactId>maven-compiler-plugin</artifactId>
+                                      <version>3.13.0</version>
+                                  </plugin>
+                              </plugins>
+                          </pluginManagement>
+                      </build>
+                  </project>
+                  """
+              ),
+              mavenProject("parent",
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>aggregator</artifactId>
+                            <version>1</version>
+                        </parent>
+                        <artifactId>parent</artifactId>
+                        <packaging>pom</packaging>
+                        <dependencyManagement>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                    <version>0.2.0</version>
+                                </dependency>
+                            </dependencies>
+                        </dependencyManagement>
+                    </project>
+                    """,
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>aggregator</artifactId>
+                            <version>1</version>
+                        </parent>
+                        <artifactId>parent</artifactId>
+                        <packaging>pom</packaging>
+                        <dependencyManagement>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                    <version>0.2.0</version>
+                                </dependency>
+                            </dependencies>
+                        </dependencyManagement>
+                        <build>
+                            <pluginManagement>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>org.projectlombok</groupId>
+                                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </pluginManagement>
+                        </build>
+                    </project>
+                    """
+                )
+              ),
+              mavenProject("core",
+                pomXml(
+                  // Compiling module - should NOT be modified
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>1</version>
+                            <relativePath>../parent</relativePath>
+                        </parent>
+                        <artifactId>core</artifactId>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void addToRootWhenItDirectlyParentsACompilingModule() {
+            // The aggregator root parents both an intermediate parent and a compiling
+            // module of its own. The root is still the nearest parent of `module-a`,
+            // so both it and the intermediate parent are modified.
+            rewriteRun(
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>aggregator</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <modules>
+                          <module>parent</module>
+                          <module>module-a</module>
+                          <module>core</module>
+                      </modules>
+                  </project>
+                  """,
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>aggregator</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <modules>
+                          <module>parent</module>
+                          <module>module-a</module>
+                          <module>core</module>
+                      </modules>
+                      <build>
+                          <pluginManagement>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>org.apache.maven.plugins</groupId>
+                                      <artifactId>maven-compiler-plugin</artifactId>
+                                      <configuration>
+                                          <annotationProcessorPaths>
+                                              <path>
+                                                  <groupId>org.projectlombok</groupId>
+                                                  <artifactId>lombok-mapstruct-binding</artifactId>
+                                                  <version>0.2.0</version>
+                                              </path>
+                                          </annotationProcessorPaths>
+                                      </configuration>
+                                  </plugin>
+                              </plugins>
+                          </pluginManagement>
+                      </build>
+                  </project>
+                  """
+              ),
+              mavenProject("parent",
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>aggregator</artifactId>
+                            <version>1</version>
+                        </parent>
+                        <artifactId>parent</artifactId>
+                        <packaging>pom</packaging>
+                    </project>
+                    """,
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>aggregator</artifactId>
+                            <version>1</version>
+                        </parent>
+                        <artifactId>parent</artifactId>
+                        <packaging>pom</packaging>
+                        <build>
+                            <pluginManagement>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>org.projectlombok</groupId>
+                                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                                    <version>0.2.0</version>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </pluginManagement>
+                        </build>
+                    </project>
+                    """
+                )
+              ),
+              mavenProject("module-a",
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>aggregator</artifactId>
+                            <version>1</version>
+                        </parent>
+                        <artifactId>module-a</artifactId>
+                    </project>
+                    """
+                )
+              ),
+              mavenProject("core",
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>1</version>
+                            <relativePath>../parent</relativePath>
+                        </parent>
+                        <artifactId>core</artifactId>
+                    </project>
+                    """
+                )
+              )
+            );
+        }
+
+        @Test
+        void addsToParentThatDeclaresTheDependencyWhenGatedByPrecondition() {
+            // Gated by `ModuleHasDependency`, as recipes enabling an annotation processor
+            // typically are. The aggregator root declares no dependencies, so it is never
+            // marked; if the recipe targets it rather than the intermediate parent that
+            // does declare the dependency, nothing is changed at all.
+            rewriteRun(
+              spec -> spec.recipeFromYaml(
+                """
+                  type: specs.openrewrite.org/v1beta/recipe
+                  name: org.openrewrite.maven.AddAnnotationProcessorForDeclaredDependency
+                  displayName: Add an annotation processor for a declared dependency
+                  description: Test.
+                  preconditions:
+                    - org.openrewrite.maven.search.ModuleHasDependency:
+                        groupIdPattern: org.projectlombok
+                        artifactIdPattern: lombok-mapstruct-binding
+                  recipeList:
+                    - org.openrewrite.maven.AddAnnotationProcessor:
+                        groupId: org.projectlombok
+                        artifactId: lombok-mapstruct-binding
+                        version: 0.2.0
+                  """,
+                "org.openrewrite.maven.AddAnnotationProcessorForDeclaredDependency"
+              ),
+              pomXml(
+                """
+                  <project>
+                      <modelVersion>4.0.0</modelVersion>
+                      <groupId>com.mycompany.app</groupId>
+                      <artifactId>aggregator</artifactId>
+                      <version>1</version>
+                      <packaging>pom</packaging>
+                      <modules>
+                          <module>parent</module>
+                          <module>core</module>
+                      </modules>
+                      <build>
+                          <pluginManagement>
+                              <plugins>
+                                  <plugin>
+                                      <groupId>org.apache.maven.plugins</groupId>
+                                      <artifactId>maven-compiler-plugin</artifactId>
+                                      <version>3.13.0</version>
+                                  </plugin>
+                              </plugins>
+                          </pluginManagement>
+                      </build>
+                  </project>
+                  """,
+                spec -> project(spec, "aggregator")
+              ),
+              mavenProject("parent",
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>aggregator</artifactId>
+                            <version>1</version>
+                        </parent>
+                        <artifactId>parent</artifactId>
+                        <packaging>pom</packaging>
+                        <dependencyManagement>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                    <version>0.2.0</version>
+                                    <scope>provided</scope>
+                                </dependency>
+                            </dependencies>
+                        </dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok-mapstruct-binding</artifactId>
+                            </dependency>
+                        </dependencies>
+                    </project>
+                    """,
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>aggregator</artifactId>
+                            <version>1</version>
+                        </parent>
+                        <artifactId>parent</artifactId>
+                        <packaging>pom</packaging>
+                        <dependencyManagement>
+                            <dependencies>
+                                <dependency>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                    <version>0.2.0</version>
+                                    <scope>provided</scope>
+                                </dependency>
+                            </dependencies>
+                        </dependencyManagement>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.projectlombok</groupId>
+                                <artifactId>lombok-mapstruct-binding</artifactId>
+                            </dependency>
+                        </dependencies>
+                        <build>
+                            <pluginManagement>
+                                <plugins>
+                                    <plugin>
+                                        <groupId>org.apache.maven.plugins</groupId>
+                                        <artifactId>maven-compiler-plugin</artifactId>
+                                        <configuration>
+                                            <annotationProcessorPaths>
+                                                <path>
+                                                    <groupId>org.projectlombok</groupId>
+                                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                                </path>
+                                            </annotationProcessorPaths>
+                                        </configuration>
+                                    </plugin>
+                                </plugins>
+                            </pluginManagement>
+                        </build>
+                    </project>
+                    """
+                )
+              ),
+              mavenProject("core",
+                pomXml(
+                  """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <parent>
+                            <groupId>com.mycompany.app</groupId>
+                            <artifactId>parent</artifactId>
+                            <version>1</version>
+                            <relativePath>../parent</relativePath>
+                        </parent>
+                        <artifactId>core</artifactId>
                     </project>
                     """
                 )


### PR DESCRIPTION
In a reactor where an aggregator parents an intermediate parent which in turn parents the compiling modules, `AddAnnotationProcessor` writes nothing at all when it is gated by a dependency precondition.

Three-level shape, which is common — the aggregator exists only to list modules, and the intermediate parent holds the shared dependency and plugin configuration:

```
pom.xml              packaging pom, <modules> lists both, declares no dependencies
  parent/pom.xml     packaging pom, <parent> is the root, declares the processor dependency
    core/pom.xml     jar, <parent> is parent/
```

Two mechanisms interlock:

1. `Scanned.resolve()` puts **both** ancestors into `parentPomPaths`, because the intermediate parent is itself a reactor-linked child of the root. `AddPluginVisitor.isAcceptable` then vetoes the intermediate parent, since its `parentPomIsProjectPom()` is true and no `filePattern` was supplied — `AddAnnotationProcessor` passes one only for GAV-coincident orphans.
2. That leaves the aggregator as the only writable target. The aggregator declares no dependencies, so a dependency-based precondition never marks it and the visitor is gated off.

Net: zero edits, and every module silently loses annotation processing. Every existing multi-module test here has a parent with no `<parent>` element, which is why the shape was never covered.

### Fix

- `Scanned.resolve()` — a reactor-linked child only claims its parent as a target when the child is not `pom` packaging. A `pom` module compiles nothing, so it no longer drags its own ancestor in, leaving the nearest parent of each compiling module as the only target.
- `getVisitor(...)` — the plugin file pattern is now supplied for every pom the recipe decided to modify, not just the GAV-coincident-orphan case. The recipe's own reactor analysis already supersedes the coarser `parentPomIsProjectPom()` veto, and `DeclarativeRecipe` gates only `getVisitor`, not `getScanner`, so the accumulator still sees the whole reactor.

`AddPluginVisitor` is unchanged, so `AddPlugin` and `AddManagedPlugin` keep their guard — those are blanket recipes that genuinely need it.

Writing to the intermediate parent rather than the aggregator also produces a better result: where that parent manages the coordinate and the effective `maven-compiler-plugin` is 3.12.0 or later, the existing `omitVersion` path applies and the `<path>` inherits the managed version instead of pinning the recipe's own.

Two alternatives were considered and rejected: relaxing the veto inside `AddPluginVisitor` would also loosen `AddPlugin`/`AddManagedPlugin`; and "keep only the deepest parent per chain" breaks a reactor where the root directly parents a compiling module of its own.

### Tests

New `NestedParents` nested class:

- `addToNearestParentNotAggregatorRoot` — the shape above; asserts the aggregator and the leaf are untouched, only the intermediate parent is edited, and that no `<version>` is emitted when that parent manages the coordinate.
- `addToRootWhenItDirectlyParentsACompilingModule` — the other direction; an aggregator that directly parents a jar module is still that module's nearest parent and is still configured. Proves the fix is not "never write to aggregators".
- `addsToParentThatDeclaresTheDependencyWhenGatedByPrecondition` — the same reactor under a dependency precondition. This is the one that went from no changes at all to one correct edit.

All three fail without the main-source change. `:rewrite-maven:test` — 1495 tests, 0 failures, 15 pre-existing skips. The existing cases asserting that a module without the dependency is untouched all still pass.

Found by compiling the output of a Java 25 migration across a set of open source repositories, where this cost one project 54 compile errors from lost Lombok-generated members.
