### PR TITLE
Maven: an execution context's mirrors no longer discard those recorded at parse time

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/ChangeParentPom.java
@@ -267,7 +267,8 @@ public class ChangeParentPom extends ScanningRecipe<ChangeParentPom.Accumulator>
                             ResolvedPom updatedResolvedPom = mrr.getPom()
                                     .withRequested(updatedPom)
                                     .resolve(ctx, new MavenPomDownloader(
-                                            mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles()));
+                                            mrr.getProjectPoms(), ctx, MavenExecutionContextView.view(ctx).effectiveSettings(mrr),
+                                            mrr.getActiveProfiles()));
                             acc.updatedByPom.put(mrr.getPom().getGav(), mrr.withPom(updatedResolvedPom));
                         }
                     } catch (MavenDownloadingException e) {
@@ -368,7 +369,7 @@ public class ChangeParentPom extends ScanningRecipe<ChangeParentPom.Accumulator>
                             }
 
                             // Retain managed versions from the old parent that are not managed in the new parent
-                            MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                            MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, MavenExecutionContextView.view(ctx).effectiveSettings(mrr), mrr.getActiveProfiles());
                             ResolvedPom oldParent = mpd.download(new GroupArtifactVersion(currentGroupId, currentArtifactId, oldVersion), null, resolvedPom, resolvedPom.getRepositories())
                                     .resolve(emptyList(), mpd, ctx);
                             ResolvedPom newParent = mpd.download(new GroupArtifactVersion(targetGroupId, targetArtifactId, targetVersion.get()), null, resolvedPom, resolvedPom.getRepositories())

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/MavenExecutionContextView.java
@@ -132,7 +132,7 @@ public class MavenExecutionContextView extends DelegatingExecutionContext {
      * @return The mirrors to use for dependency resolution.
      */
     public Collection<MavenRepositoryMirror> getMirrors(@Nullable MavenSettings mavenSettings) {
-        if (mavenSettings != null && !Objects.equals(mavenSettings, getSettings())) {
+        if (mavenSettings != null) {
             return mapMirrors(mavenSettings);
         }
         return getMirrors();

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantDependencyVersions.java
@@ -258,7 +258,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                 }
                 try {
                     GroupArtifactVersion parentGav = mrr.getPom().getRequested().getParent().getGav();
-                    MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                    MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, MavenExecutionContextView.view(ctx).effectiveSettings(mrr), mrr.getActiveProfiles());
                     ResolvedPom parentPom = mpd.download(parentGav, null, mrr.getPom(), mrr.getPom().getRepositories())
                             .resolve(emptyList(), mpd, ctx);
                     ResolvedManagedDependency parentManagedVersion = parentPom.getDependencyManagement().stream()
@@ -308,7 +308,7 @@ public class RemoveRedundantDependencyVersions extends Recipe {
                 }
                 try {
                     GroupArtifactVersion parentGav = mrr.getPom().getRequested().getParent().getGav();
-                    MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                    MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, MavenExecutionContextView.view(ctx).effectiveSettings(mrr), mrr.getActiveProfiles());
                     ResolvedPom parentPom = mpd.download(parentGav, null, mrr.getPom(), mrr.getPom().getRepositories())
                             .resolve(emptyList(), mpd, ctx);
                     return parentPom.getPluginManagement().stream()

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveRedundantProperties.java
@@ -83,7 +83,7 @@ public class RemoveRedundantProperties extends Recipe {
                     MavenPomDownloader downloader = new MavenPomDownloader(
                             mrr.getProjectPoms(),
                             ctx,
-                            mrr.getMavenSettings(),
+                            MavenExecutionContextView.view(ctx).effectiveSettings(mrr),
                             mrr.getActiveProfiles());
                     try {
                         // Resolve the external parent POM properties

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveUnusedProperties.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/RemoveUnusedProperties.java
@@ -180,7 +180,8 @@ public class RemoveUnusedProperties extends ScanningRecipe<RemoveUnusedPropertie
             private boolean parentHasProperty(MavenResolutionResult resolutionResult, String propertyName,
                                               ExecutionContext ctx) {
                 MavenPomDownloader downloader = new MavenPomDownloader(resolutionResult.getProjectPoms(), ctx,
-                        resolutionResult.getMavenSettings(), resolutionResult.getActiveProfiles());
+                        MavenExecutionContextView.view(ctx).effectiveSettings(resolutionResult),
+                        resolutionResult.getActiveProfiles());
                 try {
                     ResolvedPom resolvedBarePom = resolutionResult.getPom().getRequested()
                             .withProperties(emptyMap())

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpdateMavenModel.java
@@ -195,7 +195,8 @@ public class UpdateMavenModel<P> extends MavenVisitor<P> {
     }
 
     private MavenResolutionResult updateResult(ExecutionContext ctx, MavenResolutionResult resolutionResult, Map<Path, Pom> projectPoms) throws MavenDownloadingExceptions {
-        MavenPomDownloader downloader = new MavenPomDownloader(projectPoms, ctx, getResolutionResult().getMavenSettings(),
+        MavenPomDownloader downloader = new MavenPomDownloader(projectPoms, ctx,
+                MavenExecutionContextView.view(ctx).effectiveSettings(getResolutionResult()),
                 getResolutionResult().getActiveProfiles());
 
         try {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindMavenSettings.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindMavenSettings.java
@@ -63,7 +63,7 @@ public class FindMavenSettings extends Recipe {
                                 document.getSourcePath().toString(),
                                 Boolean.TRUE.equals(existenceCheckOnly) ?
                                         "exists" :
-                                        mapper.writerWithDefaultPrettyPrinter().writeValueAsString(mrr.getMavenSettings())
+                                        mapper.writerWithDefaultPrettyPrinter().writeValueAsString(effectiveSettings)
                         ));
                     } catch (JsonProcessingException e) {
                         throw new UncheckedIOException(e);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindRepositoryOrder.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/FindRepositoryOrder.java
@@ -56,7 +56,7 @@ public class FindRepositoryOrder extends Recipe {
                 }
                 for (MavenRepository repository : MavenExecutionContextView.view(ctx)
                         .getRepositories(
-                                mrr.getMavenSettings(),
+                                MavenExecutionContextView.view(ctx).effectiveSettings(mrr),
                                 StreamSupport.stream(mrr.getPom().getActiveProfiles().spliterator(), false)
                                         .collect(toList())
                         )) {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/search/ParentPomInsight.java
@@ -21,6 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.maven.MavenExecutionContextView;
 import org.openrewrite.maven.MavenIsoVisitor;
 import org.openrewrite.maven.internal.MavenPomDownloader;
 import org.openrewrite.maven.table.ParentPomsInUse;
@@ -96,7 +97,7 @@ public class ParentPomInsight extends Recipe {
                 }
 
                 MavenResolutionResult mrr = getResolutionResult();
-                MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, mrr.getMavenSettings(), mrr.getActiveProfiles());
+                MavenPomDownloader mpd = new MavenPomDownloader(mrr.getProjectPoms(), ctx, MavenExecutionContextView.view(ctx).effectiveSettings(mrr), mrr.getActiveProfiles());
 
                 Parent ancestor = mrr.getPom().getRequested().getParent();
                 String relativePath = tag.getChildValue("relativePath").orElse(null);

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/trait/MavenDependency.java
@@ -116,7 +116,7 @@ public class MavenDependency implements Trait<Xml.Tag> {
                         // fact that it's not in the metadata. Usually it won't be, only in situations like the
                         // MapR repository mentioned in the comment above will it be.
                         Pom pom = new MavenPomDownloader(emptyMap(), ctx,
-                                mrr.getMavenSettings(), mrr.getActiveProfiles()).download(new GroupArtifactVersion(groupId, artifactId, ((ExactVersion) versionComparator).getVersion()),
+                                settings, mrr.getActiveProfiles()).download(new GroupArtifactVersion(groupId, artifactId, ((ExactVersion) versionComparator).getVersion()),
                                 null, null, mrr.getPom().getRepositories());
                         if (pom.getGav().getVersion().equals(exactVersion) &&
                             !exactVersion.equals(finalVersion) &&

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenExecutionContextViewTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenExecutionContextViewTest.java
@@ -17,13 +17,23 @@ package org.openrewrite.maven;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
 import org.openrewrite.maven.cache.LocalMavenArtifactCache;
 import org.openrewrite.maven.cache.MavenArtifactCache;
+import org.openrewrite.maven.tree.MavenRepository;
+import org.openrewrite.maven.tree.MavenRepositoryMirror;
+import org.openrewrite.maven.tree.MavenResolutionResult;
+import org.openrewrite.maven.tree.ResolvedPom;
 
 import java.nio.file.Path;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.Tree.randomId;
 
 class MavenExecutionContextViewTest {
 
@@ -55,5 +65,76 @@ class MavenExecutionContextViewTest {
         MavenArtifactCache fromSecondView = MavenExecutionContextView.view(delegate).getArtifactCache();
 
         assertThat(fromFirstView).isSameAs(fromSecondView);
+    }
+
+    /**
+     * Recipes hand the downloader {@link MavenExecutionContextView#effectiveSettings}, so a mirror
+     * configured by whoever is running the recipe has to beat the one recorded when the source was
+     * parsed. {@link MavenRepositoryMirror#apply} takes the first match and {@code MavenSettings.merge}
+     * puts the receiver's mirrors first.
+     */
+    @Test
+    void contextMirrorsWinOverThoseRecordedWhenTheSourceWasParsed() {
+        MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+        ctx.setMavenSettings(mirroring("configured", "external:*", "https://configured.example.com", ctx));
+
+        MavenRepository mirrored = MavenRepositoryMirror.apply(
+          ctx.getMirrors(ctx.effectiveSettings(
+            parsedWith(mirroring("from-build", "central", "https://from-build.example.com", ctx)))),
+          MavenRepository.MAVEN_CENTRAL);
+
+        assertThat(mirrored.getUri()).isEqualTo("https://configured.example.com");
+    }
+
+    @Test
+    void mirrorsRecordedWhenTheSourceWasParsedStillApplyWithoutContextSettings() {
+        MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+
+        MavenRepository mirrored = MavenRepositoryMirror.apply(
+          ctx.getMirrors(ctx.effectiveSettings(
+            parsedWith(mirroring("from-build", "central", "https://from-build.example.com", ctx)))),
+          MavenRepository.MAVEN_CENTRAL);
+
+        assertThat(mirrored.getUri()).isEqualTo("https://from-build.example.com");
+    }
+
+    /** Merged, not replaced: each source still mirrors the repositories the other says nothing about. */
+    @Test
+    void mirrorsFromBothSourcesApply() {
+        MavenExecutionContextView ctx = MavenExecutionContextView.view(new InMemoryExecutionContext());
+        ctx.setMavenSettings(mirroring("configured", "central", "https://configured.example.com", ctx));
+
+        MavenSettings effective = ctx.effectiveSettings(
+          parsedWith(mirroring("from-build", "jboss", "https://from-build.example.com", ctx)));
+        MavenRepository jboss = MavenRepository.builder()
+          .id("jboss")
+          .uri("https://repository.jboss.org/nexus/content/groups/public-jboss/")
+          .build();
+
+        assertThat(MavenRepositoryMirror.apply(ctx.getMirrors(effective), MavenRepository.MAVEN_CENTRAL).getUri())
+          .isEqualTo("https://configured.example.com");
+        assertThat(MavenRepositoryMirror.apply(ctx.getMirrors(effective), jboss).getUri())
+          .isEqualTo("https://from-build.example.com");
+    }
+
+    private static MavenResolutionResult parsedWith(MavenSettings settings) {
+        return new MavenResolutionResult(randomId(), null, ResolvedPom.builder().build(),
+          emptyList(), null, emptyMap(), settings, emptyList(), emptyMap());
+    }
+
+    private static MavenSettings mirroring(String id, String mirrorOf, String url, ExecutionContext ctx) {
+        return requireNonNull(MavenSettings.parse(Parser.Input.fromString(Path.of("settings.xml"),
+          //language=xml
+          """
+            <settings>
+                <mirrors>
+                    <mirror>
+                        <id>%s</id>
+                        <mirrorOf>%s</mirrorOf>
+                        <url>%s</url>
+                    </mirror>
+                </mirrors>
+            </settings>
+            """.formatted(id, mirrorOf, url)), ctx));
     }
 }


### PR DESCRIPTION
## What's wrong

`MavenExecutionContextView.getMirrors(MavenSettings)` is meant to let a supplied settings document override the mirrors configured on the execution context:

```java
if (mavenSettings != null && !Objects.equals(mavenSettings, getSettings())) {
    return mapMirrors(mavenSettings);
}
return getMirrors();
```

`MavenSettings` is annotated `@EqualsAndHashCode(onlyExplicitlyIncluded = true)` and no field is `@Include`d, so **every instance is equal to every other**. The condition is therefore always false once the context has settings of its own, and the supplied settings are discarded entirely — mirrors recorded in `MavenResolutionResult` at parse time stop applying the moment anything calls `setMavenSettings`.

`getRepositories(MavenSettings, List<String>)`, one method down, has no such guard, and `getCredentials(MavenSettings)` concatenates both sources. `getMirrors` is the odd one out.

## Why it matters

Recipes that resolve dynamic versions fan out across every repository a pom declares, so which mirrors are in effect decides both where those requests go and how many there are — a mirror that collapses N declared repositories onto one id also collapses N metadata requests into one, since `distinctNormalizedRepositories` dedupes on the post-mirror id.

We hit this running `UpgradeToJava25` across an open-source corpus: a build-time `settings.xml` mirrors Maven Central to an internal repository, and it silently stopped applying for anyone who also configured settings on the context.

## The change

`effectiveSettings(MavenResolutionResult)` already merges the two, preferring the context's — `MavenSettings.merge` is receiver-wins and `Mirrors.merge` puts the receiver's entries first, which matters because `MavenRepositoryMirror.apply` returns the first match. `MavenVisitor`, `UpgradeDependencyVersion`, `MavenDependency` and `EffectiveMavenRepositories` already pass it.

- Drop the dead guard in `getMirrors`, matching `getRepositories`.
- Pass `effectiveSettings(mrr)` at the nine downloader call sites that passed the raw marker: `RemoveRedundantDependencyVersions` (x2), `ChangeParentPom` (x2), `UpdateMavenModel`, `RemoveRedundantProperties`, `RemoveUnusedProperties`, `ParentPomInsight`, `MavenDependency`. That last one was already calling `effectiveSettings` thirty lines earlier in the same method.
- `FindMavenSettings` computed `effectiveSettings` for its null check and then serialized `mrr.getMavenSettings()` into the `EffectiveMavenSettings` table; `FindRepositoryOrder` passed the raw marker to `getRepositories`. Both now report the effective settings.

Active profiles are left as `mrr.getActiveProfiles()` at the converted sites. That is the pom's effectively-active list, not settings' `<activeProfiles>`, so deriving them from the merged settings the way `MavenVisitor` does would drop pom-declared profiles.

## Behavior

No change when the execution context has no settings of its own, which is the default for every existing caller — `getMirrors(null-context)` still returns the supplied settings' mirrors. When both are present they now merge, with the context's winning on a mirror id collision and taking precedence in match order.

`MavenSettings.equals` is left alone; making it field-based is a wider change than this needs.

Three tests in `MavenExecutionContextViewTest` cover context-wins, supplied-settings-still-apply-without-context-settings, and merged-not-replaced. The last is what surfaced the dead guard. `:rewrite-maven:test` and `:rewrite-gradle:test` pass.
