### PR TITLE
JSON: a member's leading whitespace belongs to the member, not its key

### DIFF
--- a/rewrite-javascript/rewrite/src/json/parser.ts
+++ b/rewrite-javascript/rewrite/src/json/parser.ts
@@ -255,8 +255,7 @@ class JsoncParserReader {
                 markers: emptyMarkers
             } satisfies Json.RightPadded<Json.Member> as Json.RightPadded<Json.Member>);
         } else {
-            // Parse members
-            // Put back the trivia by prepending it to the key's prefix
+            // Trivia consumed while probing for '}' belongs to the first member's prefix
             let pendingTrivia = afterOpen;
 
             while (true) {
@@ -467,10 +466,10 @@ class JsoncParserReader {
     }
 
     private parseMember(pendingTrivia: string): Json.Member {
-        const keyPrefix = pendingTrivia + this.consumeTrivia();
+        const memberPrefix = pendingTrivia + this.consumeTrivia();
         const key = this.parseKey({
             id: randomId(),
-            prefix: space(keyPrefix),
+            prefix: emptySpace,
             markers: emptyMarkers
         });
 
@@ -485,7 +484,7 @@ class JsoncParserReader {
         return {
             kind: Json.Kind.Member,
             id: randomId(),
-            prefix: emptySpace,
+            prefix: space(memberPrefix),
             markers: emptyMarkers,
             key: {
                 kind: Json.Kind.RightPadded,

--- a/rewrite-javascript/rewrite/src/json/tree.ts
+++ b/rewrite-javascript/rewrite/src/json/tree.ts
@@ -324,10 +324,10 @@ export function detectIndent(doc: Json.Document): string {
 
     if (isObject(doc.value)) {
         if (doc.value.members && doc.value.members.length > 0) {
-            // Look at the prefix of the first member's key to detect indentation
+            // Look at the prefix of the first member to detect indentation
             const firstMemberRightPadded = doc.value.members[0];
             const firstMember = firstMemberRightPadded.element as Json.Member;
-            const prefix = firstMember.key.element.prefix.whitespace;
+            const prefix = firstMember.prefix.whitespace;
             // Extract just the spaces/tabs after the newline
             const match = prefix.match(/\n([ \t]+)/);
             if (match) {

--- a/rewrite-javascript/rewrite/test/json/member-prefix.test.ts
+++ b/rewrite-javascript/rewrite/test/json/member-prefix.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {json, JsonParser, JsonVisitor} from "../../src/json";
+import {detectIndent, Json} from "../../src/json/tree";
+import {ExecutionContext, foundSearchResult, Recipe, SourceFile, TreeVisitor} from "../../src";
+import {RecipeSpec} from "../../src/test";
+
+// Mirrored by rewrite-json/src/test/java/org/openrewrite/json/JsonMemberPrefixTest.java
+
+async function parse(text: string): Promise<Json.Document> {
+    for await (const sf of new JsonParser().parse({text, sourcePath: "a.json"})) {
+        return sf as SourceFile as Json.Document;
+    }
+    throw new Error("no source file produced");
+}
+
+function members(doc: Json.Document): Json.Member[] {
+    return (doc.value as Json.Object).members.map(m => m.element as Json.Member);
+}
+
+describe("member prefix placement", () => {
+    test("leading whitespace belongs to the member, not its key", async () => {
+        const [member] = members(await parse('{\n  "_version": "1.65.0"\n}\n'));
+
+        expect(member.prefix.whitespace).toBe("\n  ");
+        expect(member.key.element.prefix.whitespace).toBe("");
+    });
+
+    test("every member in a multi-member object", async () => {
+        const [first, second] = members(await parse('{\n  "a": 1,\n  "b": 2\n}'));
+
+        expect(first.prefix.whitespace).toBe("\n  ");
+        expect(first.key.element.prefix.whitespace).toBe("");
+        expect(second.prefix.whitespace).toBe("\n  ");
+        expect(second.key.element.prefix.whitespace).toBe("");
+    });
+
+    test("nested object members", async () => {
+        const [outer] = members(await parse('{\n  "libs": {\n    "sap.makit": {}\n  }\n}'));
+        const [inner] = (outer.value as Json.Object).members.map(m => m.element as Json.Member);
+
+        expect(outer.prefix.whitespace).toBe("\n  ");
+        expect(inner.prefix.whitespace).toBe("\n    ");
+        expect(inner.key.element.prefix.whitespace).toBe("");
+    });
+
+    test("comments preceding a member belong to the member", async () => {
+        const [member] = members(await parse('{\n  // a comment\n  "a": 1\n}'));
+
+        expect(member.prefix.whitespace).toBe("\n  ");
+        expect(member.prefix.comments.map(c => c.text)).toEqual([" a comment"]);
+        expect(member.key.element.prefix.comments).toEqual([]);
+    });
+
+    test("detectIndent reads the member prefix", async () => {
+        expect(detectIndent(await parse('{\n  "a": 1\n}'))).toBe("  ");
+        expect(detectIndent(await parse('{\n\t"a": 1\n}'))).toBe("\t");
+        expect(detectIndent(await parse('{"a": 1}'))).toBe("    ");
+        expect(detectIndent(await parse('[\n  1\n]'))).toBe("  ");
+    });
+});
+
+class MarkMembers extends Recipe {
+    name = "org.openrewrite.json.test.mark-members";
+    displayName = "Mark members";
+    description = "Attaches a search result marker to every JSON object member.";
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        return new class extends JsonVisitor<ExecutionContext> {
+            protected override async visitMember(member: Json.Member, ctx: ExecutionContext): Promise<Json | undefined> {
+                return foundSearchResult(await super.visitMember(member, ctx) as Json.Member);
+            }
+        };
+    }
+}
+
+describe("marking a member", () => {
+    const spec = new RecipeSpec();
+    spec.recipe = new MarkMembers();
+
+    test("renders the marker against the key, not the end of the previous line", () => spec.rewriteRun(
+        json(
+            `{
+  "libs": {
+    "sap.makit": {}
+  }
+}`,
+            `{
+  /*~~>*/"libs": {
+    /*~~>*/"sap.makit": {}
+  }
+}`
+        )
+    ));
+});

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonMemberPrefixTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonMemberPrefixTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.json;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.json.tree.Comment;
+import org.openrewrite.json.tree.Json;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.json.Assertions.json;
+import static org.openrewrite.test.RewriteTest.toRecipe;
+
+/**
+ * Pins where a member's leading whitespace lives; mirrored by
+ * {@code rewrite-javascript/rewrite/test/json/member-prefix.test.ts} so both parsers build the same LST.
+ */
+class JsonMemberPrefixTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(JsonParser.builder());
+    }
+
+    private static List<Json.Member> members(Json.Document doc) {
+        return ((Json.JsonObject) doc.getValue()).getMembers().stream()
+          .map(Json.Member.class::cast)
+          .toList();
+    }
+
+    @Test
+    void leadingWhitespaceBelongsToTheMemberNotItsKey() {
+        rewriteRun(
+          json(
+            """
+              {
+                "_version": "1.65.0"
+              }
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Json.Member member = members(doc).get(0);
+                assertThat(member.getPrefix().getWhitespace()).isEqualTo("\n  ");
+                assertThat(member.getKey().getPrefix().getWhitespace()).isEmpty();
+            })
+          )
+        );
+    }
+
+    @Test
+    void everyMemberInAMultiMemberObject() {
+        rewriteRun(
+          json(
+            """
+              {
+                "a": 1,
+                "b": 2
+              }
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                for (Json.Member member : members(doc)) {
+                    assertThat(member.getPrefix().getWhitespace()).isEqualTo("\n  ");
+                    assertThat(member.getKey().getPrefix().getWhitespace()).isEmpty();
+                }
+            })
+          )
+        );
+    }
+
+    @Test
+    void nestedObjectMembers() {
+        rewriteRun(
+          json(
+            """
+              {
+                "libs": {
+                  "sap.makit": {}
+                }
+              }
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Json.Member outer = members(doc).get(0);
+                Json.Member inner = (Json.Member) ((Json.JsonObject) outer.getValue()).getMembers().get(0);
+                assertThat(outer.getPrefix().getWhitespace()).isEqualTo("\n  ");
+                assertThat(inner.getPrefix().getWhitespace()).isEqualTo("\n    ");
+                assertThat(inner.getKey().getPrefix().getWhitespace()).isEmpty();
+            })
+          )
+        );
+    }
+
+    @Test
+    void commentsPrecedingAMemberBelongToTheMember() {
+        rewriteRun(
+          json(
+            """
+              {
+                // a comment
+                "a": 1
+              }
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                Json.Member member = members(doc).get(0);
+                assertThat(member.getPrefix().getWhitespace()).isEqualTo("\n  ");
+                assertThat(member.getPrefix().getComments()).extracting(Comment::getText).containsExactly(" a comment");
+                assertThat(member.getKey().getPrefix().getComments()).isEmpty();
+            })
+          )
+        );
+    }
+
+    @Test
+    void markingAMemberRendersTheMarkerAgainstTheKey() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JsonIsoVisitor<ExecutionContext>() {
+              @Override
+              public Json.Member visitMember(Json.Member member, ExecutionContext ctx) {
+                  return SearchResult.found(super.visitMember(member, ctx));
+              }
+          })),
+          json(
+            """
+              {
+                "libs": {
+                  "sap.makit": {}
+                }
+              }
+              """,
+            """
+              {
+                /*~~>*/"libs": {
+                  /*~~>*/"sap.makit": {}
+                }
+              }
+              """
+          )
+        );
+    }
+}


### PR DESCRIPTION
The Java and TypeScript JSON parsers build different LSTs for the same document. For `{\n  "_version": "1.65.0"\n}`, Java puts the member's leading whitespace on `Json.Member.prefix` and leaves the key literal's prefix empty; TypeScript does the opposite. Both print identical text, so the divergence stays invisible until a recipe reaches for a prefix.

`beforeSyntax` emits the prefix and *then* the markers, so `foundSearchResult(member)` on the TypeScript model renders the marker before the newline, attaching it to the end of the previous line:

```
{
  "libs": {/*~~(deprecated library)~~>*/
    "sap.makit": {}
  }
}
```

On the Java model the same marker lands after the indentation, immediately before the key — where a reader expects it. A JSON detect-only recipe marking deprecated library entries in a `manifest.json` is what surfaced this.

### Which side is wrong

TypeScript. `Json.Member` is the outermost node whose first syntax element is the key, so the leading trivia belongs on the member — the rule the Java parsers follow for a construct's prefix. `JsonParserVisitor.visitMember` gets there because `convert` consumes `prefix(ctx)` off the member context before `visitKey` runs. `JsoncParserReader.parseMember` was pushing the trivia down onto the inner key literal.

### The fix

`parseMember` puts the accumulated trivia on `Json.Member.prefix` and builds the key with an empty prefix. `detectIndent` in `src/json/tree.ts` was the only in-repo consumer of the old placement and now reads `firstMember.prefix`. `Json.Kind.Member` appears nowhere else in `src/` outside the parser, visitor and tree helpers, and `find-dependency.ts` marks the *key* rather than the member, so its output is unchanged.

Teaching `detectIndent` to tolerate both shapes was rejected: it would leave the two parsers disagreeing and push the problem onto every future recipe.

### Tests

`JsonMemberPrefixTest` and `test/json/member-prefix.test.ts` are mirrored pairs pinning the member prefix, the empty key prefix, nested members, a comment preceding a member, and the printed placement of a search-result marker attached to a member. The TypeScript file also covers `detectIndent`. All six TypeScript cases fail against the pre-fix parser and pass after, verified by reverting the parser change with the tests in place.

`:rewrite-json:test` is green, and so is the TypeScript suite excluding `test/rpc/**` (160 files, 1779 passed / 21 skipped); the excluded RPC tests need `generateTestClasspath` and touch no JSON member prefixes.

### Scope

Code outside this repository that reads `member.key.element.prefix` to recover indentation needs the same one-line move to `member.prefix`.
