### PR TITLE
TypeUtils.findOverriddenMethod accepts cross-package protected overrides

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -116,6 +116,30 @@ class TypeUtilsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void isOverrideProtectedInDifferentPackage() {
+        rewriteRun(
+          java(
+            """
+              package foo;
+              public class Superclass {
+                  protected void foo() { }
+              }
+              """
+          ),
+          java(
+            """
+              package bar;
+              import foo.Superclass;
+              class Clazz extends Superclass {
+                  @Override protected void foo() { }
+              }
+              """,
+            typeIsPresent()
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1759")
     @Test
     void isOverrideParameterizedInterface() {

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -140,6 +140,23 @@ class TypeUtilsTest implements RewriteTest {
         );
     }
 
+    @Test
+    void isNotOverrideOfProtectedObjectMethodFromInterface() {
+        rewriteRun(
+          java(
+            """
+              interface Reproducer extends Cloneable {
+                  Reproducer clone();
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                var cloneMethodType = ((J.MethodDeclaration) cu.getClasses().get(0).getBody().getStatements().get(0)).getMethodType();
+                assertThat(TypeUtils.findOverriddenMethod(cloneMethodType)).isEmpty();
+            })
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1759")
     @Test
     void isOverrideParameterizedInterface() {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -1048,9 +1048,16 @@ public class TypeUtils {
                 .filter(m -> !m.getFlags().contains(Flag.Private))
                 .filter(m -> !m.getFlags().contains(Flag.Static))
                 // If access level is default then check if subclass package is the same from parent class
+                // A protected method is overridable from any package, but only by a class; an interface
+                // does not inherit the protected members of java.lang.Object (JLS 9.2).
                 .filter(m -> m.getFlags().contains(Flag.Public) ||
-                             m.getFlags().contains(Flag.Protected) ||
+                             (m.getFlags().contains(Flag.Protected) && !isInterface(dt)) ||
                              m.getDeclaringType().getPackageName().equals(dt.getPackageName()));
+    }
+
+    private static boolean isInterface(JavaType.FullyQualified type) {
+        return type.getKind() == JavaType.FullyQualified.Kind.Interface ||
+               type.getKind() == JavaType.FullyQualified.Kind.Annotation;
     }
 
     public static Optional<JavaType.Method> findDeclaredMethod(JavaType.@Nullable FullyQualified clazz, String name, List<JavaType> argumentTypes) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -1048,7 +1048,9 @@ public class TypeUtils {
                 .filter(m -> !m.getFlags().contains(Flag.Private))
                 .filter(m -> !m.getFlags().contains(Flag.Static))
                 // If access level is default then check if subclass package is the same from parent class
-                .filter(m -> m.getFlags().contains(Flag.Public) || m.getDeclaringType().getPackageName().equals(dt.getPackageName()));
+                .filter(m -> m.getFlags().contains(Flag.Public) ||
+                             m.getFlags().contains(Flag.Protected) ||
+                             m.getDeclaringType().getPackageName().equals(dt.getPackageName()));
     }
 
     public static Optional<JavaType.Method> findDeclaredMethod(JavaType.@Nullable FullyQualified clazz, String name, List<JavaType> argumentTypes) {


### PR DESCRIPTION
`findOverriddenMethod`'s accessibility filter checked `Flag.Public` but never `Flag.Protected`, so a `protected` method fell through to the package-equality test and was rejected as an override for any subclass outside the superclass's package — contrary to JLS 8.4.8.1, which admits an override when the parent method is public, protected, or package-access in the same package. `TypeUtils.isOverride` delegates here and was wrong in the same way.

The protected clause is scoped to classes: an interface does not inherit the protected members of `java.lang.Object` (JLS 9.2), so an interface method like `Reproducer clone();` still must not count as overriding `Object.clone()` — admitting it made rewrite-static-analysis's `MissingOverrideAnnotation` emit an `@Override` that javac rejects. Both directions are covered by new tests in `TypeUtilsTest`, and the existing `isOverrideOnlyVisible` still passes (package-private across packages remains correctly not an override).

Verified green locally: `:rewrite-java-21:compatibilityTest`, `:rewrite-java-test:test`, `:rewrite-java:test`, plus the full rewrite-static-analysis and rewrite-testing-frameworks suites and the affected rewrite-migrate-java / rewrite-spring recipes built against this branch (the one rewrite-testing-frameworks failure, `UpdateMockWebServerMockResponseTest`, reproduces without this change).

Note that `JavaType.Method.getOverride()` applies no visibility filtering at all, so it and `findOverriddenMethod` still disagree; this change does not close that gap.