### PR TITLE
C#: use J.Empty in for loop with no init

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/StatementTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/StatementTests.cs
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
 using OpenRewrite.Test;
 
 namespace OpenRewrite.Tests.Tree;
@@ -248,6 +250,45 @@ public class ForLoopTests : RewriteTest
                 """
             )
         );
+    }
+
+    [Fact]
+    public void InfiniteForHasEmptyInitConditionAndUpdate()
+    {
+        // given
+        var cu = new CSharpParser().Parse(
+            """
+            class Foo {
+                void Bar() {
+                    for (;;) { }
+                }
+            }
+            """);
+
+        // when
+        var finder = new ForLoopFinder();
+        finder.Cursor = new OpenRewrite.Core.Cursor(null, OpenRewrite.Core.Cursor.ROOT_VALUE);
+        finder.Visit(cu, 0);
+        var control = finder.Found!.LoopControl;
+
+        // then
+        Assert.NotNull(finder.Found);
+        Assert.Single(control.Init);
+        Assert.IsType<Empty>(control.Init[0].Element);
+        Assert.IsType<Empty>(control.Condition.Element);
+        Assert.Single(control.Update);
+        Assert.IsType<Empty>(control.Update[0].Element);
+    }
+
+    private class ForLoopFinder : CSharpVisitor<int>
+    {
+        public ForLoop? Found { get; private set; }
+
+        public override J VisitForLoop(ForLoop forLoop, int p)
+        {
+            Found ??= forLoop;
+            return base.VisitForLoop(forLoop, p);
+        }
     }
 }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -4021,6 +4021,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var firstSemiPrefix = ExtractSpaceBefore(node.FirstSemicolonToken);
         _cursor = node.FirstSemicolonToken.Span.End;
 
+        if (init.Count == 0)
+        {
+            var empty = new Empty(Guid.NewGuid(), firstSemiPrefix, Markers.Empty);
+            init.Add(new JRightPadded<Statement>(empty, Space.Empty, Markers.Empty));
+        }
+
         // Parse condition
         Expression? condExpr = null;
         if (node.Condition != null)


### PR DESCRIPTION
## What's changed?

Similar to #8577, but for C#.
Making sure empty init section of a `for` loop is parsed as `J.Empty` instead of `nil/null`.

## What's your motivation?

Fixing the following error on some of the rewrite-static-analysis recipes running against C# code:
```
java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
  java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
  java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
  java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
  java.base/java.util.Objects.checkIndex(Objects.java:365)
  java.base/java.util.ArrayList.get(ArrayList.java:428)
  org.openrewrite.staticanalysis.WhileInsteadOfFor$1.visitForLoop(WhileInsteadOfFor.java:53
```