### PR TITLE
JavaScript: Don't remove `|| false` and other boolean coercions in `SimplifyBooleanExpression`

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -464,7 +464,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         if (getCursor().firstEnclosing(SourceFile.class) instanceof J.CompilationUnit) {
             return true;
         }
-        return innerExpression.getType() == JavaType.Primitive.Boolean;
+        return isBooleanValued(innerExpression);
     }
 
     /**
@@ -510,15 +510,6 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
     }
 
     private boolean isBooleanValued(Expression expression) {
-        if (expression.getType() == JavaType.Primitive.Boolean) {
-            return true;
-        }
-        if (expression instanceof J.Literal) {
-            return ((J.Literal) expression).getValue() instanceof Boolean;
-        }
-        if (expression instanceof J.Unary) {
-            return ((J.Unary) expression).getOperator() == J.Unary.Type.Not;
-        }
         if (expression instanceof J.Binary) {
             J.Binary binary = (J.Binary) expression;
             switch (binary.getOperator()) {
@@ -540,6 +531,12 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
             J tree = ((J.Parentheses<?>) expression).getTree();
             return tree instanceof Expression && isBooleanValued((Expression) tree);
         }
-        return false;
+        if (expression instanceof J.Unary) {
+            return ((J.Unary) expression).getOperator() == J.Unary.Type.Not;
+        }
+        if (expression instanceof J.Literal) {
+            return ((J.Literal) expression).getValue() instanceof Boolean;
+        }
+        return expression.getType() == JavaType.Primitive.Boolean;
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -37,11 +37,11 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         if (asBinary.getOperator() == J.Binary.Type.And) {
             if (isLiteralFalse(asBinary.getLeft())) {
                 j = asBinary.getLeft();
-            } else if (isLiteralFalse(asBinary.getRight())) {
+            } else if (isLiteralFalse(asBinary.getRight()) && shouldSimplifyShortCircuitOn(asBinary.getLeft())) {
                 j = asBinary.getRight().withPrefix(asBinary.getRight().getPrefix().withWhitespace(""));
             } else if (isLiteralTrue(asBinary.getLeft())) {
                 j = asBinary.getRight();
-            } else if (isLiteralTrue(asBinary.getRight())) {
+            } else if (isLiteralTrue(asBinary.getRight()) && shouldSimplifyShortCircuitOn(asBinary.getLeft())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
             } else if (!(asBinary.getLeft() instanceof MethodCall) &&
                        SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
@@ -50,11 +50,11 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
         } else if (asBinary.getOperator() == J.Binary.Type.Or) {
             if (isLiteralTrue(asBinary.getLeft())) {
                 j = asBinary.getLeft();
-            } else if (isLiteralTrue(asBinary.getRight())) {
+            } else if (isLiteralTrue(asBinary.getRight()) && shouldSimplifyShortCircuitOn(asBinary.getLeft())) {
                 j = asBinary.getRight().withPrefix(asBinary.getRight().getPrefix().withWhitespace(""));
             } else if (isLiteralFalse(asBinary.getLeft())) {
                 j = asBinary.getRight();
-            } else if (isLiteralFalse(asBinary.getRight())) {
+            } else if (isLiteralFalse(asBinary.getRight()) && shouldSimplifyShortCircuitOn(asBinary.getLeft())) {
                 j = asBinary.getLeft().withPrefix(asBinary.getLeft().getPrefix().withWhitespace(""));
             } else if (!(asBinary.getLeft() instanceof MethodCall) &&
                        SemanticallyEqual.areEqual(asBinary.getLeft(), asBinary.getRight())) {
@@ -487,5 +487,59 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
             return true;
         }
         return j instanceof Expression && ((Expression) j).getType() == JavaType.Primitive.Boolean;
+    }
+
+    /**
+     * Determines whether a short-circuit expression with a boolean literal operand can be simplified,
+     * e.g. {@code x && true}, {@code x && false}, {@code x || true}, or {@code x || false}.
+     * <p>
+     * In Java, {@code &&} and {@code ||} are boolean-only, so these always simplify to {@code x} or the
+     * literal. In languages like JavaScript/TypeScript and Groovy, {@code &&}/{@code ||} return one of
+     * their operands unchanged based on truthiness, so {@code x || false} yields {@code false} when
+     * {@code x} is falsy (e.g. {@code undefined}) rather than the original value. Simplifying then
+     * changes semantics unless {@code x} is boolean-typed.
+     *
+     * @param nonLiteralOperand the operand that is not the boolean literal
+     * @return true if the short-circuit expression can be safely simplified
+     */
+    protected boolean shouldSimplifyShortCircuitOn(J nonLiteralOperand) {
+        if (getCursor().firstEnclosing(SourceFile.class) instanceof J.CompilationUnit) {
+            return true;
+        }
+        return nonLiteralOperand instanceof Expression && isBooleanValued((Expression) nonLiteralOperand);
+    }
+
+    private boolean isBooleanValued(Expression expression) {
+        if (expression.getType() == JavaType.Primitive.Boolean) {
+            return true;
+        }
+        if (expression instanceof J.Literal) {
+            return ((J.Literal) expression).getValue() instanceof Boolean;
+        }
+        if (expression instanceof J.Unary) {
+            return ((J.Unary) expression).getOperator() == J.Unary.Type.Not;
+        }
+        if (expression instanceof J.Binary) {
+            J.Binary binary = (J.Binary) expression;
+            switch (binary.getOperator()) {
+                case LessThan:
+                case GreaterThan:
+                case LessThanOrEqual:
+                case GreaterThanOrEqual:
+                case Equal:
+                case NotEqual:
+                    return true;
+                case And:
+                case Or:
+                    return isBooleanValued(binary.getLeft()) && isBooleanValued(binary.getRight());
+                default:
+                    return false;
+            }
+        }
+        if (expression instanceof J.Parentheses) {
+            J tree = ((J.Parentheses<?>) expression).getTree();
+            return tree instanceof Expression && isBooleanValued((Expression) tree);
+        }
+        return false;
     }
 }

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -136,6 +136,19 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
     }
 
     @Test
+    void doubleNegationOfShortCircuitChainPreserved() {
+        rewriteRun(
+          javascript(
+            """
+              function isElement(sources) {
+                  return !!(sources && sources.nodeName && sources.nodeType === 1);
+              }
+              """
+          )
+        );
+    }
+
+    @Test
     void simplifyBooleanLiterals() {
         rewriteRun(
           javascript(

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -24,6 +24,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.javascript.Assertions.javascript;
+import static org.openrewrite.javascript.Assertions.typescript;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 @SuppressWarnings("JSUnusedLocalSymbols")
@@ -59,6 +60,76 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
             """
               const x = "hello";
               const y = !(!x);
+              """
+          )
+        );
+    }
+
+    @Test
+    void orFalsePreservedForNonBooleanOperand() {
+        rewriteRun(
+          javascript(
+            """
+              function f(o) {
+                  o.withCredentials = o.value || false;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void andTruePreservedForNonBooleanOperand() {
+        rewriteRun(
+          javascript(
+            """
+              function f(o) {
+                  o.value = o.value && true;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void orTruePreservedForNonBooleanOperand() {
+        rewriteRun(
+          javascript(
+            """
+              function f(o) {
+                  o.value = o.value || true;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void andFalsePreservedForNonBooleanOperand() {
+        rewriteRun(
+          javascript(
+            """
+              function f(o) {
+                  o.value = o.value && false;
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void orFalseSimplifiedForBooleanTypedOperand() {
+        rewriteRun(
+          typescript(
+            """
+              function f(b: boolean) {
+                  const c = b || false;
+              }
+              """,
+            """
+              function f(b: boolean) {
+                  const c = b;
+              }
               """
           )
         );


### PR DESCRIPTION
## What's changed?

Amending `SimplifyBooleanExpression` not to remove `|| false` and other Boolean coercions from JavaScript code.

## What's your motivation?

In JavaScript it's a common pattern to have:
```
a = someLogic() || false
```

Removing the `|| false` alters the program semantics.