### PR TITLE
SimplifyBooleanExpression to handle missing type attribution

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitorTest.java
@@ -19,10 +19,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Recipe;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
+
+import java.util.List;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -1058,5 +1064,50 @@ class SimplifyBooleanExpressionVisitorTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void doNotFailOnNumericComparisonWhenLiteralTypeMissing() {
+        rewriteRun(
+          spec -> spec.recipe(new StripLiteralTypesThenSimplify())
+            .expectedCyclesThatMakeChanges(1)
+            .typeValidationOptions(TypeValidation.none()),
+          java(
+            """
+              class A {
+                  boolean a = 1906 >= 8521;
+              }
+              """
+          )
+        );
+    }
+
+    private static class StripLiteralTypesThenSimplify extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Strip numeric literal types, then simplify boolean expressions";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Mimics a non-Java LST (e.g. an untyped Go constant) where a numeric literal carries no type.";
+        }
+
+        @Override
+        public List<Recipe> getRecipeList() {
+            return List.of(
+              toRecipe(() -> new JavaIsoVisitor<ExecutionContext>() {
+                  @Override
+                  public J.Literal visitLiteral(J.Literal literal, ExecutionContext ctx) {
+                      if (literal.getValue() instanceof Integer && literal.getType() != null) {
+                          return new J.Literal(literal.getId(), literal.getPrefix(), literal.getMarkers(),
+                            literal.getValue(), literal.getValueSource(), null, null);
+                      }
+                      return literal;
+                  }
+              }),
+              toRecipe(SimplifyBooleanExpressionVisitor::new)
+            );
+        }
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/cleanup/SimplifyBooleanExpressionVisitor.java
@@ -332,6 +332,7 @@ public class SimplifyBooleanExpressionVisitor extends JavaVisitor<ExecutionConte
 
     private static boolean isNumericLiteral(Expression expression) {
         return expression instanceof J.Literal &&
+                expression.getType() instanceof JavaType.Primitive &&
                 ((JavaType.Primitive) expression.getType()).isNumeric();
     }
 


### PR DESCRIPTION
## What's changed?

Improving the `SimplifyBooleanExpression` to handle the cases with missing type attribution better.

## What's your motivation?

Fix this happening to some pieces of Go code:
```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.JavaType$Primitive.isNumeric()" because the return value of "org.openrewrite.java.tree.Expression.getType()" is null
  org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor.isNumericLiteral(SimplifyBooleanExpressionVisitor.java:335)
  org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor.compareNumericLiterals(SimplifyBooleanExpressionVisitor.java:350)
  org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor.visitBinary(SimplifyBooleanExpressionVisitor.java:122)
  org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor.visitBinary(SimplifyBooleanExpressionVisitor.java:31)
  org.openrewrite.java.tree.J$Binary.acceptJava(J.java:705)
  org.openrewrite.java.tree.J.accept(J.java:55)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:242)
  org.openrewrite.staticanalysis.SimplifyBooleanExpression$1.visit(SimplifyBooleanExpression.java:53)
  org.openrewrite.staticanalysis.SimplifyBooleanExpression$1.visit(SimplifyBooleanExpression.java:48)
  org.openrewrite.TreeVisitor.visitAndCast(TreeVisitor.java:328)
  org.openrewrite.java.JavaVisitor.visitBinary(JavaVisitor.java:408)
  org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor.visitBinary(SimplifyBooleanExpressionVisitor.java:34)
  org.openrewrite.java.cleanup.SimplifyBooleanExpressionVisitor.visitBinary(SimplifyBooleanExpressionVisitor.java:31)
  org.openrewrite.java.tree.J$Binary.acceptJava(J.java:705)
  org.openrewrite.java.tree.J.accept(J.java:55)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:242)
  ...
```