### PR TITLE
JavaScript: mint fresh LST ids on every template application

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -17,7 +17,7 @@ import {Cursor, isTree, produceAsync, Tree, updateIfChanged} from '../..';
 import {emptySpace, J, Statement, Type} from '../../java';
 import {Any, Capture, JavaScriptParser, JavaScriptVisitor, JS} from '..';
 import {create as produce} from 'mutative';
-import {CaptureMarker, PlaceholderUtils, WRAPPER_FUNCTION_NAME} from './utils';
+import {CaptureMarker, dedupeIds, PlaceholderUtils, randomizeIds, WRAPPER_FUNCTION_NAME} from './utils';
 import {CAPTURE_NAME_SYMBOL, CAPTURE_TYPE_SYMBOL, CaptureImpl, CaptureValue, RAW_CODE_SYMBOL, RawCode} from './capture';
 import {PlaceholderReplacementVisitor} from './placeholder-replacement';
 import {JavaCoordinates} from './template';
@@ -260,12 +260,18 @@ export class TemplateEngine {
             substitutions.set(placeholder, parameters[i]);
         }
 
+        // Before substitution, so that substituted captures keep the ids they had in the source tree
+        const freshAst = await randomizeIds(ast);
+
         // Unsubstitute placeholders with actual parameter values and match results
         const visitor = new PlaceholderReplacementVisitor(substitutions, values, wrappersMap);
-        const unsubstitutedAst = (await visitor.visit(ast, null))!;
+        const unsubstitutedAst = (await visitor.visit(freshAst, null))!;
+
+        // Catches the capture that was spliced in more than once, which `randomizeIds` cannot see
+        const dedupedAst = await dedupeIds(unsubstitutedAst);
 
         // Apply the template to the current AST
-        return new TemplateApplier(cursor, coordinates, unsubstitutedAst).apply();
+        return new TemplateApplier(cursor, coordinates, dedupedAst).apply();
     }
 
     /**

--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -17,7 +17,7 @@ import {Cursor, isTree, produceAsync, Tree, updateIfChanged} from '../..';
 import {emptySpace, J, Statement, Type} from '../../java';
 import {Any, Capture, JavaScriptParser, JavaScriptVisitor, JS} from '..';
 import {create as produce} from 'mutative';
-import {CaptureMarker, dedupeIds, PlaceholderUtils, randomizeIds, WRAPPER_FUNCTION_NAME} from './utils';
+import {CaptureMarker, PlaceholderUtils, randomizeIds, retainIds, treeIds, WRAPPER_FUNCTION_NAME} from './utils';
 import {CAPTURE_NAME_SYMBOL, CAPTURE_TYPE_SYMBOL, CaptureImpl, CaptureValue, RAW_CODE_SYMBOL, RawCode} from './capture';
 import {PlaceholderReplacementVisitor} from './placeholder-replacement';
 import {JavaCoordinates} from './template';
@@ -260,18 +260,26 @@ export class TemplateEngine {
             substitutions.set(placeholder, parameters[i]);
         }
 
-        // Before substitution, so that substituted captures keep the ids they had in the source tree
-        const freshAst = await randomizeIds(ast);
+        // Before substitution, so that ids carried over from the source tree survive this pass
+        const fresh = await randomizeIds(ast);
 
         // Unsubstitute placeholders with actual parameter values and match results
         const visitor = new PlaceholderReplacementVisitor(substitutions, values, wrappersMap);
-        const unsubstitutedAst = (await visitor.visit(freshAst, null))!;
+        const unsubstitutedAst = (await visitor.visit(fresh.tree, null))!;
 
-        // Catches the capture that was spliced in more than once, which `randomizeIds` cannot see
-        const dedupedAst = await dedupeIds(unsubstitutedAst);
+        // An id may only be kept where the node answering to it is leaving the tree, which is the
+        // subtree this application replaces. A parameter named twice, or spliced in from somewhere
+        // that stays, would otherwise put one id in two places.
+        const retainable = new Set(fresh.ids);
+        if (coordinates.tree) {
+            for (const id of await treeIds(coordinates.tree as J)) {
+                retainable.add(id);
+            }
+        }
+        const uniqueAst = await retainIds(unsubstitutedAst, retainable);
 
         // Apply the template to the current AST
-        return new TemplateApplier(cursor, coordinates, dedupedAst).apply();
+        return new TemplateApplier(cursor, coordinates, uniqueAst).apply();
     }
 
     /**

--- a/rewrite-javascript/rewrite/src/javascript/templating/pattern.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/pattern.ts
@@ -579,7 +579,7 @@ export class Pattern {
  * @example
  * const x = capture('x');
  * const pat = pattern`foo(${x})`;
- * const match = await pat.match(someNode);
+ * const match = await pat.match(someNode, cursor);
  * if (match) {
  *     const captured = match.get('x');  // Get by name
  *     // or
@@ -590,7 +590,7 @@ export class Pattern {
  * // Variadic captures return arrays
  * const args = capture({ variadic: true });
  * const pat = pattern`foo(${args})`;
- * const match = await pat.match(methodInvocation);
+ * const match = await pat.match(methodInvocation, cursor);
  * if (match) {
  *     const capturedArgs = match.get(args);  // Returns J[] for variadic captures
  * }

--- a/rewrite-javascript/rewrite/src/javascript/templating/template.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/template.ts
@@ -142,11 +142,11 @@ export class TemplateBuilder {
  *
  * @example
  * // Generate a literal AST node
- * const result = template`2`.apply(cursor, coordinates);
+ * const result = await template`2`.apply(node, cursor);
  *
  * @example
  * // Generate an AST node with a parameter
- * const result = template`${capture()}`.apply(cursor, coordinates);
+ * const result = await template`${capture()}`.apply(node, cursor);
  *
  * @example
  * // Access properties of captured nodes in templates
@@ -154,10 +154,10 @@ export class TemplateBuilder {
  * const pat = pattern`foo(${method})`;
  * const tmpl = template`bar(${method.name})`; // Access the 'name' property
  *
- * const match = await pat.match(someNode);
+ * const match = await pat.match(someNode, cursor);
  * if (match) {
  *     // The template will insert just the 'name' subtree from the captured method
- *     const result = await tmpl.apply(cursor, someNode, match);
+ *     const result = await tmpl.apply(someNode, cursor, { values: match });
  * }
  *
  * @example
@@ -383,7 +383,7 @@ export class Template {
  * @example
  * // Simple template with literal
  * const tmpl = template`console.log("hello")`;
- * const result = await tmpl.apply(cursor, node);
+ * const result = await tmpl.apply(node, cursor);
  *
  * @example
  * // Template with capture - matches captured value from pattern
@@ -391,9 +391,9 @@ export class Template {
  * const pat = pattern`foo(${expr})`;
  * const tmpl = template`bar(${expr})`;
  *
- * const match = await pat.match(node);
+ * const match = await pat.match(node, cursor);
  * if (match) {
- *     const result = await tmpl.apply(cursor, node, match);
+ *     const result = await tmpl.apply(node, cursor, { values: match });
  * }
  *
  * @example

--- a/rewrite-javascript/rewrite/src/javascript/templating/template.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/template.ts
@@ -92,7 +92,8 @@ export class TemplateBuilder {
     /**
      * Adds a parameter to the template.
      *
-     * @param value The parameter value (Capture, Tree, or primitive)
+     * @param value The parameter value (Capture, Tree, or primitive); may be added more than once
+     *              (see {@link template})
      * @returns This builder for chaining
      */
     param(value: TemplateParameter): this {
@@ -377,7 +378,10 @@ export class Template {
  * - J.Container<T>: Elements will be expanded in place
  *
  * @param strings The string parts of the template
- * @param parameters The parameters between the string parts (Capture, CaptureValue, TemplateParam, Tree, Tree[], J.RightPadded, J.RightPadded[], or J.Container)
+ * @param parameters The parameters between the string parts (Capture, CaptureValue, TemplateParam, Tree, Tree[], J.RightPadded, J.RightPadded[], or J.Container).
+ *                   A parameter may appear more than once — `(${arr} ? f(${arr}) : -1)`. A node
+ *                   keeps its id only at its first occurrence, and only if it belongs to the
+ *                   subtree being replaced; anything else is spliced under fresh ids.
  * @returns A Template object that can be applied to generate AST nodes
  *
  * @example

--- a/rewrite-javascript/rewrite/src/javascript/templating/utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/utils.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 import {Cursor} from '../..';
-import {J} from '../../java';
+import {J, NameTree} from '../../java';
 import {JS} from '../index';
+import {JavaScriptVisitor} from '../visitor';
 import {Marker, Markers} from '../../markers';
 import {randomId} from '../../uuid';
 import {ConstraintFunction, VariadicOptions} from './types';
@@ -114,6 +115,43 @@ export function generateCacheKey(
         contextStatements.join(';'),
         JSON.stringify(dependencies)
     ].join('::');
+}
+
+abstract class IdVisitor extends JavaScriptVisitor<any> {
+    // `JavaVisitor.visitTypeName` is a no-op stub, which leaves annotation names unreachable
+    protected override async visitTypeName<N extends NameTree>(nameTree: N, p: any): Promise<N> {
+        return (await this.visit(nameTree, p)) as N;
+    }
+}
+
+class RandomizeIdVisitor extends IdVisitor {
+    protected override async postVisit(tree: J, p: any): Promise<J | undefined> {
+        return {...tree, id: randomId()};
+    }
+}
+
+class DedupeIdVisitor extends IdVisitor {
+    private readonly seen = new Set<string>();
+
+    protected override async postVisit(tree: J, p: any): Promise<J | undefined> {
+        if (this.seen.has(tree.id)) {
+            const id = randomId();
+            this.seen.add(id);
+            return {...tree, id};
+        }
+        this.seen.add(tree.id);
+        return tree;
+    }
+}
+
+/** Structural copy of `tree` with a fresh `id` on every `Tree` node; counterpart of Java's `RandomizeIdVisitor`. */
+export function randomizeIds<T extends J>(tree: T): Promise<T> {
+    return new RandomizeIdVisitor().visit(tree, null) as Promise<T>;
+}
+
+/** Copy of `tree` with duplicate `Tree` ids resolved within it, keeping the first occurrence on its original id. */
+export function dedupeIds<T extends J>(tree: T): Promise<T> {
+    return new DedupeIdVisitor().visit(tree, null) as Promise<T>;
 }
 
 /**

--- a/rewrite-javascript/rewrite/src/javascript/templating/utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/utils.ts
@@ -125,33 +125,61 @@ abstract class IdVisitor extends JavaScriptVisitor<any> {
 }
 
 class RandomizeIdVisitor extends IdVisitor {
+    readonly minted = new Set<string>();
+
     protected override async postVisit(tree: J, p: any): Promise<J | undefined> {
-        return {...tree, id: randomId()};
+        const id = randomId();
+        this.minted.add(id);
+        return {...tree, id};
     }
 }
 
-class DedupeIdVisitor extends IdVisitor {
-    private readonly seen = new Set<string>();
+class CollectIdVisitor extends IdVisitor {
+    readonly ids = new Set<string>();
 
     protected override async postVisit(tree: J, p: any): Promise<J | undefined> {
-        if (this.seen.has(tree.id)) {
-            const id = randomId();
-            this.seen.add(id);
-            return {...tree, id};
-        }
-        this.seen.add(tree.id);
+        this.ids.add(tree.id);
         return tree;
     }
 }
 
-/** Structural copy of `tree` with a fresh `id` on every `Tree` node; counterpart of Java's `RandomizeIdVisitor`. */
-export function randomizeIds<T extends J>(tree: T): Promise<T> {
-    return new RandomizeIdVisitor().visit(tree, null) as Promise<T>;
+class RetainIdVisitor extends IdVisitor {
+    private readonly seen = new Set<string>();
+
+    constructor(private readonly retainable: ReadonlySet<string>) {
+        super();
+    }
+
+    protected override async postVisit(tree: J, p: any): Promise<J | undefined> {
+        if (this.retainable.has(tree.id) && !this.seen.has(tree.id)) {
+            this.seen.add(tree.id);
+            return tree;
+        }
+        const id = randomId();
+        this.seen.add(id);
+        return {...tree, id};
+    }
 }
 
-/** Copy of `tree` with duplicate `Tree` ids resolved within it, keeping the first occurrence on its original id. */
-export function dedupeIds<T extends J>(tree: T): Promise<T> {
-    return new DedupeIdVisitor().visit(tree, null) as Promise<T>;
+/**
+ * Structural copy of `tree` with a fresh `id` on every `Tree` node, and the ids that were minted;
+ * counterpart of Java's `RandomizeIdVisitor`.
+ */
+export async function randomizeIds<T extends J>(tree: T): Promise<{ tree: T, ids: ReadonlySet<string> }> {
+    const visitor = new RandomizeIdVisitor();
+    return {tree: (await visitor.visit(tree, null)) as T, ids: visitor.minted};
+}
+
+/** The `id` of every `Tree` node in `tree`. */
+export async function treeIds(tree: J): Promise<ReadonlySet<string>> {
+    const visitor = new CollectIdVisitor();
+    await visitor.visit(tree, null);
+    return visitor.ids;
+}
+
+/** Copy of `tree` in which an `id` survives only where it is `retainable` and unused so far. */
+export function retainIds<T extends J>(tree: T, retainable: ReadonlySet<string>): Promise<T> {
+    return new RetainIdVisitor(retainable).visit(tree, null) as Promise<T>;
 }
 
 /**

--- a/rewrite-javascript/rewrite/test/javascript/templating/template-id-uniqueness.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/template-id-uniqueness.test.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Cursor, rootCursor} from "../../../src";
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {J} from "../../../src/java";
+import {
+    capture,
+    JavaScriptParser,
+    JavaScriptVisitor,
+    JS,
+    Pattern,
+    pattern,
+    Template,
+    template,
+    typescript
+} from "../../../src/javascript";
+
+// Template ASTs are cached, so without fresh ids per application two applications share ids (customer-requests#3057)
+
+const PADDING_KINDS: ReadonlySet<string> = new Set<string>([
+    J.Kind.RightPadded,
+    J.Kind.LeftPadded,
+    J.Kind.Container
+]);
+
+/** Every `Tree` position in `tree`, counting repeated object references separately so duplicates are not hidden. */
+function treeNodes(value: any, out: { id: string, kind: string, node: any }[] = []): { id: string, kind: string, node: any }[] {
+    if (value === null || typeof value !== 'object') {
+        return out;
+    }
+    if (Array.isArray(value)) {
+        for (const element of value) {
+            treeNodes(element, out);
+        }
+        return out;
+    }
+    const isPadding = typeof value.kind === 'string' && PADDING_KINDS.has(value.kind);
+    const isTreeNode = typeof value.id === 'string' && typeof value.kind === 'string' &&
+        typeof value.markers === 'object';
+    if (!isPadding && !isTreeNode) {
+        return out;
+    }
+    if (isTreeNode) {
+        out.push({id: value.id, kind: value.kind, node: value});
+    }
+    for (const key of Object.keys(value)) {
+        if (key !== 'markers') {
+            treeNodes(value[key], out);
+        }
+    }
+    return out;
+}
+
+function duplicateIds(tree: any): string[] {
+    const counts = new Map<string, number>();
+    for (const node of treeNodes(tree)) {
+        counts.set(node.id, (counts.get(node.id) ?? 0) + 1);
+    }
+    return [...counts].filter(([, count]) => count > 1).map(([id]) => id);
+}
+
+function expectUniqueIds(cu: JS.CompilationUnit): void {
+    expect(duplicateIds(cu)).toEqual([]);
+}
+
+/** Applies `tmpl` wherever `pat` matches, the way a recipe would. */
+function matchAndReplace(pat: Pattern, tmpl: Template) {
+    return new class extends JavaScriptVisitor<any> {
+        override async visitUnary(unary: J.Unary, p: any): Promise<J | undefined> {
+            const u = (await super.visitUnary(unary, p)) as J.Unary;
+            const match = await pat.match(u, this.cursor);
+            return match ? tmpl.apply(u, this.cursor, {values: match}) : u;
+        }
+
+        override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+            const m = (await super.visitMethodInvocation(method, p)) as J.MethodInvocation;
+            const match = await pat.match(m, this.cursor);
+            return match ? tmpl.apply(m, this.cursor, {values: match}) : m;
+        }
+    };
+}
+
+async function parse(src: string, sourcePath = 'a.ts'): Promise<JS.CompilationUnit> {
+    const parser = new JavaScriptParser({});
+    return (await parser.parse({text: src, sourcePath}).next()).value as JS.CompilationUnit;
+}
+
+async function firstOfKind<T extends J>(cu: JS.CompilationUnit, kind: string): Promise<{ node: T, cursor: Cursor }> {
+    let found: { node: T, cursor: Cursor } | undefined;
+    await new class extends JavaScriptVisitor<any> {
+        protected override async preVisit(tree: J, p: any): Promise<J | undefined> {
+            if (!found && tree.kind === kind) {
+                found = {node: tree as T, cursor: this.cursor};
+            }
+            return tree;
+        }
+    }().visit(cu, null, rootCursor());
+    return found!;
+}
+
+// The recipe from the issue, with the pattern/template pair at module scope as a real recipe's would be
+const x = capture('x');
+const doubleNegation = pattern`!!${x}`;
+const booleanCall = template`Boolean(${x})`;
+
+describe('template id uniqueness', () => {
+    const spec = new RecipeSpec();
+
+    test('two applications of one template within a tree share no ids', () => {
+        spec.recipe = fromVisitor(matchAndReplace(doubleNegation, booleanCall));
+
+        return spec.rewriteRun({
+            ...typescript(
+                'const b = !!!!foo;',
+                'const b = Boolean(Boolean(foo));'
+            ),
+            afterRecipe: expectUniqueIds
+        });
+    });
+
+    test('three applications of one template within a tree share no ids', () => {
+        spec.recipe = fromVisitor(matchAndReplace(doubleNegation, booleanCall));
+
+        return spec.rewriteRun({
+            ...typescript(
+                'const b = !!!!!!foo;',
+                'const b = Boolean(Boolean(Boolean(foo)));'
+            ),
+            afterRecipe: expectUniqueIds
+        });
+    });
+
+    test('two applications at sibling positions share no ids', () => {
+        // Unlike the nested case, neither application can clean up after the other
+        spec.recipe = fromVisitor(matchAndReplace(doubleNegation, booleanCall));
+
+        return spec.rewriteRun({
+            ...typescript(
+                'const a = !!foo;\nconst b = !!bar;',
+                'const a = Boolean(foo);\nconst b = Boolean(bar);'
+            ),
+            afterRecipe: expectUniqueIds
+        });
+    });
+
+    test('a variadic capture expanded in two applications shares no ids', () => {
+        // Variadic expansion bypasses `visit()` in `PlaceholderReplacementVisitor`
+        const args = capture({variadic: true});
+        spec.recipe = fromVisitor(matchAndReplace(pattern`foo(${args})`, template`bar(${args})`));
+
+        return spec.rewriteRun({
+            ...typescript(
+                'foo(1, 2);\nfoo(3, 4);',
+                'bar(1, 2);\nbar(3, 4);'
+            ),
+            afterRecipe: expectUniqueIds
+        });
+    });
+
+    test('a capture spliced into a template twice yields no duplicate ids', () => {
+        const y = capture('y');
+        spec.recipe = fromVisitor(matchAndReplace(pattern`foo(${y})`, template`bar(${y}, ${y})`));
+
+        return spec.rewriteRun({
+            ...typescript(
+                'foo(1);',
+                'bar(1, 1);'
+            ),
+            afterRecipe: expectUniqueIds
+        });
+    });
+
+    test('source files rewritten in one process share no ids and no node instances', async () => {
+        spec.recipe = fromVisitor(matchAndReplace(doubleNegation, booleanCall));
+
+        const rewritten: JS.CompilationUnit[] = [];
+        await spec.rewriteRun(
+            {
+                ...typescript('const b = !!foo;', 'const b = Boolean(foo);'),
+                afterRecipe: (cu: JS.CompilationUnit) => {
+                    rewritten.push(cu);
+                }
+            },
+            {
+                ...typescript('const d = !!bar;', 'const d = Boolean(bar);'),
+                afterRecipe: (cu: JS.CompilationUnit) => {
+                    rewritten.push(cu);
+                }
+            }
+        );
+        expect(rewritten).toHaveLength(2);
+
+        const [a, c] = rewritten;
+        const cNodes = treeNodes(c);
+        const cIds = new Set(cNodes.map(n => n.id));
+        const cInstances = new Set(cNodes.map(n => n.node));
+
+        expect(treeNodes(a).filter(n => cIds.has(n.id))).toEqual([]);
+        expect(treeNodes(a).filter(n => cInstances.has(n.node))).toEqual([]);
+    });
+
+    test('two Template instances with identical code share no ids', async () => {
+        // The AST caches are keyed on template text, so a per-visit template does not sidestep the sharing
+        const first = await firstOfKind<J.Literal>(await parse('const a = 1;\n'), J.Kind.Literal);
+        const second = await firstOfKind<J.Literal>(await parse('const b = 1;\n'), J.Kind.Literal);
+
+        const firstResult = (await template`Boolean(someIdentifier)`.apply(first.node, first.cursor))!;
+        const secondResult = (await template`Boolean(someIdentifier)`.apply(second.node, second.cursor))!;
+
+        // Guards against the assertions below passing vacuously on an unapplied template
+        expect((firstResult as J.MethodInvocation).name.simpleName).toBe('Boolean');
+        expect((secondResult as J.MethodInvocation).name.simpleName).toBe('Boolean');
+
+        const secondIds = new Set(treeNodes(secondResult).map(n => n.id));
+        const firstIds = treeNodes(firstResult).map(n => n.id);
+        expect(firstIds.length).toBeGreaterThan(1);
+        expect(firstIds.filter(id => secondIds.has(id))).toEqual([]);
+    });
+
+    test('a substituted capture keeps the id it had in the source tree', async () => {
+        // Ids are refreshed before substitution, so nodes carried over from the source tree keep their identity
+        const cu = await parse('foo(1);\n');
+        const {node, cursor} = await firstOfKind<J.MethodInvocation>(cu, J.Kind.MethodInvocation);
+
+        const y = capture('y');
+        const match = await pattern`foo(${y})`.match(node, cursor);
+        const captured = match!.get('y') as J;
+
+        const result = (await template`bar(${y})`.apply(node, cursor, {values: match}))!;
+
+        expect((result as J.MethodInvocation).name.simpleName).toBe('bar');
+        expect(treeNodes(result).map(n => n.id)).toContain(captured.id);
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/template-id-uniqueness.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/template-id-uniqueness.test.ts
@@ -230,6 +230,28 @@ describe('template id uniqueness', () => {
         expect(firstIds.filter(id => secondIds.has(id))).toEqual([]);
     });
 
+    test('a node spliced into two applications shares no ids', () => {
+        // Hoisted out of the visitor, so every application splices the very same node
+        let hoisted: J | undefined;
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                if (method.name.simpleName !== 'wrap') {
+                    return method;
+                }
+                hoisted ??= method.arguments.elements[0].element;
+                return template`f(${hoisted!})`.apply(method, this.cursor);
+            }
+        });
+
+        return spec.rewriteRun({
+            ...typescript(
+                'wrap(1);\nwrap(2);',
+                'f(1);\nf(1);'
+            ),
+            afterRecipe: expectUniqueIds
+        });
+    });
+
     test('a substituted capture keeps the id it had in the source tree', async () => {
         // Ids are refreshed before substitution, so nodes carried over from the source tree keep their identity
         const cu = await parse('foo(1);\n');


### PR DESCRIPTION
`Template.apply()` handed out the cached template AST as-is. Template ASTs are parsed once and kept in three caches — `Template._cachedTemplate`, `globalAstCache`, and the engine's `TemplateCache` — and `PlaceholderReplacementVisitor` only rewrites the placeholder nodes, so everything else came back carrying the ids it was parsed with. Apply one template twice and you get two nodes with one id.

It reproduces inside a single tree (`!!!!foo` → `Boolean(Boolean(foo))` gives two `J.MethodInvocation` under one id) and, more damagingly, across every file rewritten in the same process. There the cached nodes aren't merely id-equal — they're the same objects, so two independent `SourceFile`s end up sharing live node instances.

Printing is unaffected, which is why nothing caught it: the existing templating tests all compare source text.

### The fix

Java has never had this problem. `JavaTemplateParser.cache()` ends with `ListUtils.map(js, j -> new RandomizeIdVisitor<Integer>().visit(j, 0))`, placed outside the hit/miss branches so it runs on every retrieval, and it applies to the parsed stub *before* `Substitutions` grafts in the caller's parameter trees — which keep their original ids. `RandomizeIdVisitor` here is the same idea, called from `applyTemplateFromAst()` ahead of `PlaceholderReplacementVisitor`, so substituted captures still keep the ids they had in the source tree.

`DedupeIdVisitor` covers a second case that re-iding the template cannot reach: a capture spliced into a template more than once, as in ``template`bar(${x}, ${x})` ``, emits the captured subtree twice under its source id. That one deliberately goes beyond Java, which has the same gap in `Substitutions.maybeParameter` and doesn't close it.

### `visitTypeName`

Both visitors override `visitTypeName`. That's worth calling out, because it's a gap in the visitor rather than in this change:

```ts
// src/java/visitor.ts:74
protected async visitTypeName<N extends NameTree>(nameTree: N, p: P): Promise<N> {
    return nameTree;
}
```

`visitAnnotation` routes `annotationType` through that stub, so no `JavaVisitor` or `JavaScriptVisitor` currently traverses an annotation's name. Without the override, a template containing a decorator leaves `@dec`'s identifier carrying its cached id. On a corpus covering generics, decorators, destructuring, enums, namespaces, and mapped and conditional types, 5 of 262 nodes survived re-iding for this reason; with the override, 0 of 322.

I've kept the override local to these two visitors rather than changing `JavaVisitor`, since making every JS recipe start traversing annotation names is a much wider change than this fix warrants. Happy to raise it separately if that's worth doing.

### Cost

Warm `Template.apply()` measures 0.0681 ms/op with these visitors, against 0.0782 ms/op for an equivalent hand-rolled structural walk. The traversal is not a meaningful cost next to the cold parse the caches exist to avoid.

### Also

Corrects stale argument order in the `@example` blocks of `template` and `pattern`, which showed `apply(cursor, node)` and `match(node)` against the actual `apply(tree, cursor, options)` and `match(tree, cursor, options)`.

### Testing

`template-id-uniqueness.test.ts`, eight cases: nested applications, sibling applications, two files rewritten in one run, a variadic capture, a capture spliced twice, two separately constructed templates with identical text, and the invariant that a substituted capture keeps its source id. Seven fail without the change; six fail if the recipe is made inert, so they can't pass vacuously.

Full JS suite green at 143 files / 1609 tests.

- Reported as moderneinc/customer-requests#3057.
