### PR TITLE
JS: templates parenthesize substitutions that would otherwise re-associate

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -709,6 +709,8 @@ export class TemplateApplier {
         if (requiredPrecedence(frames[1], originalTree.id) !== undefined) {
             return [frames[1], originalTree.id];
         }
+        // A chained rule rewrites the previous rule's detached result, leaving the cursor on the node
+        // that result stands in for; a wrong guess here only ever adds parentheses, never drops them
         return frames[0].id !== originalTree.id && requiredPrecedence(frames[1], frames[0].id) !== undefined ?
             [frames[1], frames[0].id] : undefined;
     }
@@ -753,7 +755,6 @@ export class TemplateApplier {
 
             // Determine context and wrap if needed
             if (parentExpectsStatement && originalIsStatement) {
-                // A statement may not start with `{`, `function` or `class`
                 const needsGrouping = resultIsExpression && startsWithDeclarationToken(resultToUse);
                 // Statement context: wrap in ExpressionStatement if result is not a statement
                 if (needsGrouping || (!resultIsStatement && resultIsExpression)) {

--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -20,6 +20,7 @@ import {create as produce} from 'mutative';
 import {CaptureMarker, PlaceholderUtils, WRAPPER_FUNCTION_NAME} from './utils';
 import {CAPTURE_NAME_SYMBOL, CAPTURE_TYPE_SYMBOL, CaptureImpl, CaptureValue, RAW_CODE_SYMBOL, RawCode} from './capture';
 import {PlaceholderReplacementVisitor} from './placeholder-replacement';
+import {maybeParenthesize, parenthesize, requiredPrecedence, startsWithDeclarationToken} from './precedence';
 import {JavaCoordinates} from './template';
 import {maybeAutoFormat} from '../format';
 import {isExpression, isStatement} from '../parser-utils';
@@ -677,8 +678,39 @@ export class TemplateApplier {
         }
 
         const originalTree = tree as J;
-        const resultToUse = this.wrapTree(originalTree, this.ast);
+        let resultToUse = this.wrapTree(originalTree, this.ast);
+        const slot = this.replacedSlot(originalTree);
+        if (slot) {
+            // `format` substitutes the target's prefix, so decide against the prefix that will print
+            resultToUse = maybeParenthesize(slot[0], slot[1], {...resultToUse, prefix: originalTree.prefix});
+        }
         return this.format(resultToUse, originalTree);
+    }
+
+    /** The node holding the tree being replaced and the id it holds it under, per the cursor. */
+    private replacedSlot(originalTree: J): [J, string] | undefined {
+        const frames: J[] = [];
+        for (let c: Cursor | undefined = this.cursor; c && frames.length < 2; c = c.parent) {
+            if (isTree(c.value)) {
+                frames.push(c.value as J);
+            }
+        }
+        if (frames.length === 0) {
+            return undefined;
+        }
+
+        // The visitor may sit on the node holding what is being replaced rather than on it
+        if (requiredPrecedence(frames[0], originalTree.id) !== undefined) {
+            return [frames[0], originalTree.id];
+        }
+        if (frames.length < 2) {
+            return undefined;
+        }
+        if (requiredPrecedence(frames[1], originalTree.id) !== undefined) {
+            return [frames[1], originalTree.id];
+        }
+        return frames[0].id !== originalTree.id && requiredPrecedence(frames[1], frames[0].id) !== undefined ?
+            [frames[1], frames[0].id] : undefined;
     }
 
     private async format(resultToUse: J, originalTree: J) {
@@ -721,14 +753,17 @@ export class TemplateApplier {
 
             // Determine context and wrap if needed
             if (parentExpectsStatement && originalIsStatement) {
+                // A statement may not start with `{`, `function` or `class`
+                const needsGrouping = resultIsExpression && startsWithDeclarationToken(resultToUse);
                 // Statement context: wrap in ExpressionStatement if result is not a statement
-                if (!resultIsStatement && resultIsExpression) {
+                if (needsGrouping || (!resultIsStatement && resultIsExpression)) {
+                    const expression = needsGrouping ? parenthesize(resultToUse) : resultToUse;
                     resultToUse = {
                         kind: JS.Kind.ExpressionStatement,
                         id: randomId(),
-                        prefix: resultToUse.prefix,
-                        markers: resultToUse.markers,
-                        expression: { ...resultToUse, prefix: emptySpace }
+                        prefix: expression.prefix,
+                        markers: expression.markers,
+                        expression: { ...expression, prefix: emptySpace }
                     } as JS.ExpressionStatement;
                 }
             } else if (!parentExpectsStatement) {

--- a/rewrite-javascript/rewrite/src/javascript/templating/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/index.ts
@@ -71,14 +71,9 @@ export {
 export {
     Precedence,
     precedenceOf,
-    slotConstraints,
-    requiredPrecedence,
     maybeParenthesize,
-    parenthesize,
-    startsWithObjectLiteral,
-    startsWithDeclarationToken
+    parenthesize
 } from './precedence';
-export type {SlotConstraints} from './precedence';
 
 // Export engine utilities (for testing)
 export {

--- a/rewrite-javascript/rewrite/src/javascript/templating/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/index.ts
@@ -67,6 +67,19 @@ export {
     template
 } from './template';
 
+// Precedence utilities, so hand-written visitors need not carry their own parenthesization
+export {
+    Precedence,
+    precedenceOf,
+    slotConstraints,
+    requiredPrecedence,
+    maybeParenthesize,
+    parenthesize,
+    startsWithObjectLiteral,
+    startsWithDeclarationToken
+} from './precedence';
+export type {SlotConstraints} from './precedence';
+
 // Export engine utilities (for testing)
 export {
     clearTemplateCache

--- a/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
@@ -20,6 +20,7 @@ import {JavaScriptVisitor} from '../visitor';
 import {create as produce} from 'mutative';
 import {PlaceholderUtils} from './utils';
 import {CaptureImpl, TemplateParamImpl, CaptureValue, CAPTURE_NAME_SYMBOL} from './capture';
+import {enclosingTree, maybeParenthesize} from './precedence';
 import {Parameter} from './types';
 
 /**
@@ -40,7 +41,8 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
         if (tree.kind !== JS.Kind.BindingElement && this.isPlaceholder(tree)) {
             const replacement = this.replacePlaceholder(tree);
             if (replacement !== tree) {
-                return replacement as R;
+                // `this.cursor` is still the enclosing template node: `super.visit()` has not pushed this one
+                return maybeParenthesize(enclosingTree(parent ?? this.cursor), tree.id, replacement, true) as R;
             }
         }
 

--- a/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
@@ -62,7 +62,7 @@ export const Precedence = {
 } as const;
 
 /** What a slot demands of what sits in it, including the shape restrictions precedence cannot express. */
-export interface SlotConstraints {
+interface SlotConstraints {
     /** The lowest precedence that can sit here unparenthesized. */
     readonly precedence: number;
     /** The slot is a `MemberExpression`, which excludes a call: `new f()()` means `(new f())()`. */
@@ -131,7 +131,7 @@ export function precedenceOf(expression: J): number {
 }
 
 /** What the slot of `parent` holding `childId` demands, or `undefined` for a slot not modelled here. */
-export function slotConstraints(parent: J, childId: string): SlotConstraints | undefined {
+function slotConstraints(parent: J, childId: string): SlotConstraints | undefined {
     switch (parent.kind) {
         case J.Kind.Parentheses:
         case J.Kind.ControlParentheses: {
@@ -247,7 +247,6 @@ export function slotConstraints(parent: J, childId: string): SlotConstraints | u
         case J.Kind.NewClass: {
             const newClass = parent as J.NewClass;
             if (newClass.class?.id === childId) {
-                // A `new` callee is a MemberExpression: neither a call nor an optional chain
                 return {precedence: Precedence.Call, noCallShape: true, noOptionalChain: true};
             }
             return isContainerElement(newClass.arguments, childId) ? {precedence: Precedence.Assignment} : undefined;
@@ -281,7 +280,6 @@ export function slotConstraints(parent: J, childId: string): SlotConstraints | u
             return (parent as JS.Spread).expression?.id === childId ? {precedence: Precedence.Assignment} : undefined;
 
         case JS.Kind.TaggedTemplateExpression:
-            // A tagged template on an optional chain is a syntax error
             return (parent as JS.TaggedTemplateExpression).tag?.element?.id === childId ?
                 {precedence: Precedence.Call, noOptionalChain: true} : undefined;
 
@@ -299,7 +297,6 @@ export function slotConstraints(parent: J, childId: string): SlotConstraints | u
         }
 
         case J.Kind.Lambda:
-            // The concise body of an arrow function, where an object literal reads as a block
             return (parent as J.Lambda).body?.id === childId ?
                 {precedence: Precedence.Assignment, noLeadingObjectLiteral: true} : undefined;
 
@@ -309,7 +306,6 @@ export function slotConstraints(parent: J, childId: string): SlotConstraints | u
                 {precedence: Precedence.Call} : undefined;
 
         case JS.Kind.ExpressionStatement:
-            // A statement may not start with `{`, `function` or `class`
             return (parent as JS.ExpressionStatement).expression?.id === childId ?
                 {precedence: 0, noLeadingDeclarationToken: true} : undefined;
 
@@ -469,7 +465,7 @@ function isObjectLiteral(expression: J): boolean {
     return expression.kind === J.Kind.NewClass && !(expression as J.NewClass).class;
 }
 
-/** Whether this is a CallExpression, not a MemberExpression; `new f().g()` binds as `(new f()).g()`. */
+/** Whether this is a CallExpression rather than a MemberExpression. */
 function isCallShaped(expression: J): boolean {
     switch (expression.kind) {
         case J.Kind.MethodInvocation:
@@ -489,7 +485,7 @@ function isOptional(expression: J): boolean {
     return expression.markers.markers.some(marker => marker.kind === JS.Markers.Optional);
 }
 
-/** Whether any link of the member chain is optional (`?.`), which is a marker, not a node. */
+/** Whether any link of the member chain is optional (`?.`). */
 function hasOptionalChain(expression: J): boolean {
     if (isOptional(expression)) {
         return true;
@@ -507,12 +503,12 @@ function isDotAdjacentNumber(expression: J): boolean {
     return !!source && /^\d[\d_]*$/.test(source);
 }
 
-/** Whether the printed form begins with `{`, which reads as a block body rather than an object. */
-export function startsWithObjectLiteral(expression: J): boolean {
+/** Whether the printed form begins with `{`. */
+function startsWithObjectLiteral(expression: J): boolean {
     return isObjectLiteral(leftmostExpression(expression));
 }
 
-/** Whether the printed form begins with `{`, `function` or `class`, none of which may open a statement. */
+/** Whether the printed form begins with `{`, `function` or `class`. */
 export function startsWithDeclarationToken(expression: J): boolean {
     const leftmost = leftmostExpression(expression);
     return isObjectLiteral(leftmost) || isFunctionOrClassExpression(leftmost);

--- a/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
@@ -1,0 +1,662 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {isTree} from '../..';
+import {emptySpace, J} from '../../java';
+import {emptyMarkers, Marker, markers} from '../../markers';
+import {randomId} from '../../uuid';
+import {JS} from '..';
+
+// Known gap: a bare `in` in a C-style for-head needs parentheses this cannot see ([In] grammar parameter)
+
+/** JavaScript operator precedence, as ordered by the ECMAScript grammar; a higher number binds tighter. */
+export const Precedence = {
+    /** `a, b` */
+    Comma: 1,
+    /** `=`, `+=`, `? :`, `=>`, `yield`, `...` — everything at `AssignmentExpression` level. */
+    Assignment: 2,
+    /** `||` and `??` */
+    LogicalOr: 3,
+    /** `&&` */
+    LogicalAnd: 4,
+    /** `|` */
+    BitOr: 5,
+    /** `^` */
+    BitXor: 6,
+    /** `&` */
+    BitAnd: 7,
+    /** `==` `!=` `===` `!==` */
+    Equality: 8,
+    /** `<` `>` `<=` `>=` `in` `instanceof` `as` `satisfies` */
+    Relational: 9,
+    /** `<<` `>>` `>>>` */
+    Shift: 10,
+    /** `+` `-` */
+    Additive: 11,
+    /** `*` `/` `%` */
+    Multiplicative: 12,
+    /** `**` (right-associative) */
+    Exponentiation: 13,
+    /** `!` `~` `+` `-` `++x` `--x` `typeof` `void` `delete` `await` */
+    Prefix: 14,
+    /** `x++` `x--` */
+    Postfix: 15,
+    /** `new X` without an argument list */
+    New: 16,
+    /** `a.b` `a[b]` `f()` `new X()` `` tag`...` `` */
+    Call: 17,
+    /** Literals, identifiers, parenthesized expressions, array/object literals, JSX. */
+    Primary: 18
+} as const;
+
+/** What a slot demands of what sits in it, including the shape restrictions precedence cannot express. */
+export interface SlotConstraints {
+    /** The lowest precedence that can sit here unparenthesized. */
+    readonly precedence: number;
+    /** The slot is a `MemberExpression`, which excludes a call: `new f()()` means `(new f())()`. */
+    readonly noCallShape?: boolean;
+    /** The slot forbids an optional chain anywhere in it, as `new` and tagged templates do. */
+    readonly noOptionalChain?: boolean;
+    /** The slot may not start with `{`, which would be read as a block. */
+    readonly noLeadingObjectLiteral?: boolean;
+    /** The slot may not start with `{`, `function` or `class`, as a statement may not. */
+    readonly noLeadingDeclarationToken?: boolean;
+    /** The slot is followed by `.`, so a bare integer literal would lex as a decimal point. */
+    readonly followedByDot?: boolean;
+}
+
+/** The precedence of `expression` as printed; a kind this module does not model counts as Primary. */
+export function precedenceOf(expression: J): number {
+    switch (expression.kind) {
+        case J.Kind.Binary:
+            return binaryPrecedence((expression as J.Binary).operator.element) ?? Precedence.Primary;
+        case JS.Kind.Binary:
+            return jsBinaryPrecedence((expression as JS.Binary).operator.element) ?? Precedence.Primary;
+        case J.Kind.Unary: {
+            const operator = (expression as J.Unary).operator.element;
+            return isPostfixOperator(operator) ? Precedence.Postfix : Precedence.Prefix;
+        }
+        case J.Kind.InstanceOf:
+        case JS.Kind.As:
+        case JS.Kind.SatisfiesExpression:
+            return Precedence.Relational;
+        case JS.Kind.AssignmentOperation:
+            // `**` is the odd one out: every other JS.AssignmentOperation is a compound assignment
+            return (expression as JS.AssignmentOperation).operator.element === JS.AssignmentOperation.Type.Power ?
+                Precedence.Exponentiation : Precedence.Assignment;
+        case J.Kind.Ternary:
+        case J.Kind.Assignment:
+        case J.Kind.AssignmentOperation:
+        case J.Kind.Lambda:
+        case J.Kind.Yield:
+        case JS.Kind.ArrowFunction:
+        case JS.Kind.Spread:
+            return Precedence.Assignment;
+        case J.Kind.TypeCast:
+        case JS.Kind.Await:
+        case JS.Kind.Delete:
+        case JS.Kind.TypeOf:
+        case JS.Kind.Void:
+            return Precedence.Prefix;
+        case J.Kind.FieldAccess:
+        case J.Kind.ArrayAccess:
+        case J.Kind.MethodInvocation:
+        case JS.Kind.FunctionCall:
+        case JS.Kind.ExpressionWithTypeArguments:
+        case JS.Kind.TaggedTemplateExpression:
+            return Precedence.Call;
+        case J.Kind.NewClass:
+            return isObjectLiteral(expression) ? Precedence.Primary :
+                hasOmitParentheses(expression as J.NewClass) ? Precedence.New : Precedence.Call;
+        case JS.Kind.ExpressionStatement:
+            return precedenceOf((expression as JS.ExpressionStatement).expression);
+        case JS.Kind.StatementExpression:
+            // `yield x` is parsed as a J.Yield inside a JS.StatementExpression
+            return precedenceOf((expression as JS.StatementExpression).statement);
+        default:
+            return Precedence.Primary;
+    }
+}
+
+/** What the slot of `parent` holding `childId` demands, or `undefined` for a slot not modelled here. */
+export function slotConstraints(parent: J, childId: string): SlotConstraints | undefined {
+    switch (parent.kind) {
+        case J.Kind.Parentheses:
+        case J.Kind.ControlParentheses: {
+            const parentheses = parent as J.Parentheses<J>;
+            return parentheses.tree?.element?.id === childId ? {precedence: 0} : undefined;
+        }
+
+        case J.Kind.Binary: {
+            const binary = parent as J.Binary;
+            const precedence = binaryPrecedence(binary.operator.element);
+            if (precedence === undefined) {
+                return undefined;
+            }
+            // Left-associative: the right operand of an equally binding operator needs parentheses
+            if (binary.left?.id === childId) {
+                return {precedence};
+            }
+            return binary.right?.id === childId ? {precedence: precedence + 1} : undefined;
+        }
+
+        case JS.Kind.Binary: {
+            const binary = parent as JS.Binary;
+            const precedence = jsBinaryPrecedence(binary.operator.element);
+            if (precedence === undefined) {
+                return undefined;
+            }
+            if (binary.left?.id === childId) {
+                return {precedence};
+            }
+            return binary.right?.id === childId ? {precedence: precedence + 1} : undefined;
+        }
+
+        case J.Kind.Unary: {
+            const unary = parent as J.Unary;
+            if (unary.expression?.id !== childId) {
+                return undefined;
+            }
+            // `++`/`--` need a reference as their operand, not merely a unary expression
+            return {precedence: isUpdateOperator(unary.operator.element) ? Precedence.Call : Precedence.Prefix};
+        }
+
+        case J.Kind.Ternary: {
+            const ternary = parent as J.Ternary;
+            if (ternary.condition?.id === childId) {
+                // The condition is a ShortCircuitExpression, so it binds tighter than `? :` itself
+                return {precedence: Precedence.LogicalOr};
+            }
+            if (ternary.truePart?.element?.id === childId || ternary.falsePart?.element?.id === childId) {
+                return {precedence: Precedence.Assignment};
+            }
+            return undefined;
+        }
+
+        case J.Kind.Assignment: {
+            const assignment = parent as J.Assignment;
+            if (assignment.variable?.id === childId) {
+                return {precedence: Precedence.Call};
+            }
+            return assignment.assignment?.element?.id === childId ? {precedence: Precedence.Assignment} : undefined;
+        }
+
+        case J.Kind.AssignmentOperation: {
+            const assignment = parent as J.AssignmentOperation;
+            if (assignment.variable?.id === childId) {
+                return {precedence: Precedence.Call};
+            }
+            return assignment.assignment?.id === childId ? {precedence: Precedence.Assignment} : undefined;
+        }
+
+        case JS.Kind.AssignmentOperation: {
+            const assignment = parent as JS.AssignmentOperation;
+            const power = assignment.operator.element === JS.AssignmentOperation.Type.Power;
+            if (assignment.variable?.id === childId) {
+                // `-a ** b` is a syntax error, and `**` is right-associative besides
+                return {precedence: power ? Precedence.Postfix : Precedence.Call};
+            }
+            if (assignment.assignment?.id === childId) {
+                return {precedence: power ? Precedence.Exponentiation : Precedence.Assignment};
+            }
+            return undefined;
+        }
+
+        case J.Kind.FieldAccess: {
+            const fieldAccess = parent as J.FieldAccess;
+            return fieldAccess.target?.id === childId ?
+                {precedence: Precedence.Call, followedByDot: !isOptional(fieldAccess.target)} : undefined;
+        }
+
+        case J.Kind.ArrayAccess: {
+            const arrayAccess = parent as J.ArrayAccess;
+            if (arrayAccess.indexed?.id === childId) {
+                return {precedence: Precedence.Call};
+            }
+            return arrayAccess.dimension?.index?.element?.id === childId ? {precedence: 0} : undefined;
+        }
+
+        case J.Kind.MethodInvocation: {
+            const method = parent as J.MethodInvocation;
+            if (method.select?.element?.id === childId) {
+                return {precedence: Precedence.Call, followedByDot: !isOptional(method.select.element)};
+            }
+            return isContainerElement(method.arguments, childId) ? {precedence: Precedence.Assignment} : undefined;
+        }
+
+        case JS.Kind.FunctionCall: {
+            const call = parent as JS.FunctionCall;
+            if (call.function?.element?.id === childId) {
+                return {precedence: Precedence.Call};
+            }
+            return isContainerElement(call.arguments, childId) ? {precedence: Precedence.Assignment} : undefined;
+        }
+
+        case J.Kind.NewClass: {
+            const newClass = parent as J.NewClass;
+            if (newClass.class?.id === childId) {
+                // A `new` callee is a MemberExpression: neither a call nor an optional chain
+                return {precedence: Precedence.Call, noCallShape: true, noOptionalChain: true};
+            }
+            return isContainerElement(newClass.arguments, childId) ? {precedence: Precedence.Assignment} : undefined;
+        }
+
+        case J.Kind.NewArray:
+            return isContainerElement((parent as J.NewArray).initializer, childId) ?
+                {precedence: Precedence.Assignment} : undefined;
+
+        case J.Kind.InstanceOf:
+            return (parent as J.InstanceOf).expression?.element?.id === childId ?
+                {precedence: Precedence.Relational} : undefined;
+
+        case JS.Kind.As:
+            return (parent as JS.As).left?.element?.id === childId ? {precedence: Precedence.Relational} : undefined;
+
+        case JS.Kind.SatisfiesExpression:
+            return ((parent as JS.SatisfiesExpression).expression as J)?.id === childId ?
+                {precedence: Precedence.Relational} : undefined;
+
+        case J.Kind.TypeCast:
+            return (parent as J.TypeCast).expression?.id === childId ? {precedence: Precedence.Prefix} : undefined;
+
+        case JS.Kind.Await:
+        case JS.Kind.Delete:
+        case JS.Kind.TypeOf:
+        case JS.Kind.Void:
+            return (parent as JS.Await).expression?.id === childId ? {precedence: Precedence.Prefix} : undefined;
+
+        case JS.Kind.Spread:
+            return (parent as JS.Spread).expression?.id === childId ? {precedence: Precedence.Assignment} : undefined;
+
+        case JS.Kind.TaggedTemplateExpression:
+            // A tagged template on an optional chain is a syntax error
+            return (parent as JS.TaggedTemplateExpression).tag?.element?.id === childId ?
+                {precedence: Precedence.Call, noOptionalChain: true} : undefined;
+
+        case JS.Kind.ExpressionWithTypeArguments:
+            return ((parent as JS.ExpressionWithTypeArguments).clazz as J)?.id === childId ?
+                {precedence: Precedence.Call} : undefined;
+
+        case JS.Kind.PropertyAssignment:
+            return (parent as JS.PropertyAssignment).initializer?.id === childId ?
+                {precedence: Precedence.Assignment} : undefined;
+
+        case J.Kind.NamedVariable: {
+            const variable = parent as J.VariableDeclarations.NamedVariable;
+            return variable.initializer?.element?.id === childId ? {precedence: Precedence.Assignment} : undefined;
+        }
+
+        case J.Kind.Lambda:
+            // The concise body of an arrow function, where an object literal reads as a block
+            return (parent as J.Lambda).body?.id === childId ?
+                {precedence: Precedence.Assignment, noLeadingObjectLiteral: true} : undefined;
+
+        case J.Kind.ClassDeclaration:
+            // `class A extends B {}` takes a LeftHandSideExpression
+            return (parent as J.ClassDeclaration).extends?.element?.id === childId ?
+                {precedence: Precedence.Call} : undefined;
+
+        case JS.Kind.ExpressionStatement:
+            // A statement may not start with `{`, `function` or `class`
+            return (parent as JS.ExpressionStatement).expression?.id === childId ?
+                {precedence: 0, noLeadingDeclarationToken: true} : undefined;
+
+        default:
+            return undefined;
+    }
+}
+
+/** The precedence of the slot of `parent` holding `childId`; see {@link slotConstraints} for the rest. */
+export function requiredPrecedence(parent: J, childId: string): number | undefined {
+    return slotConstraints(parent, childId)?.precedence;
+}
+
+/** Parenthesizes `expression` if the slot of `parent` holding `childId` would otherwise reparse it. */
+export function maybeParenthesize(parent: J | undefined, childId: string, expression: J,
+                                  slotOwnsTrailingMarkers: boolean = false): J {
+    if (!parent) {
+        return expression;
+    }
+
+    const constraints = slotConstraints(parent, childId);
+    if (!constraints) {
+        return expression;
+    }
+
+    // A statement wrapper is transparent here: the parentheses belong around the expression
+    if (expression.kind === JS.Kind.ExpressionStatement) {
+        const inner = (expression as JS.ExpressionStatement).expression;
+        const wrapped = wrapIfNeeded(parent, childId, constraints, inner, slotOwnsTrailingMarkers);
+        return wrapped === inner ? expression : {...expression, expression: wrapped} as JS.ExpressionStatement;
+    }
+    return wrapIfNeeded(parent, childId, constraints, expression, slotOwnsTrailingMarkers);
+}
+
+/** The nearest enclosing LST node in a cursor path, skipping the padding wrappers visitors push. */
+export function enclosingTree(cursor: { value: any, parent?: any } | undefined): J | undefined {
+    let current = cursor;
+    while (current) {
+        if (isTree(current.value)) {
+            return current.value as J;
+        }
+        current = current.parent;
+    }
+    return undefined;
+}
+
+/** Wraps in `J.Parentheses`, moving the prefix out so the surrounding whitespace survives. */
+export function parenthesize(expression: J, slotOwnsTrailingMarkers: boolean = false): J.Parentheses<J> {
+    const trailing = slotOwnsTrailingMarkers ? expression.markers.markers.filter(isTrailingMarker) : [];
+    const inner = trailing.length === 0 ? expression : {
+        ...expression,
+        markers: markers(...expression.markers.markers.filter(m => !isTrailingMarker(m)))
+    };
+    return {
+        kind: J.Kind.Parentheses,
+        id: randomId(),
+        prefix: expression.prefix,
+        markers: trailing.length === 0 ? emptyMarkers : markers(...trailing),
+        tree: {
+            kind: J.Kind.RightPadded,
+            element: {...inner, prefix: emptySpace},
+            after: emptySpace,
+            markers: emptyMarkers
+        }
+    };
+}
+
+function wrapIfNeeded(parent: J, childId: string, constraints: SlotConstraints, expression: J,
+                      slotOwnsTrailingMarkers: boolean): J {
+    if (precedenceOf(expression) < constraints.precedence ||
+        (constraints.noCallShape && isCallShaped(expression)) ||
+        (constraints.noOptionalChain && hasOptionalChain(expression)) ||
+        (constraints.noLeadingObjectLiteral && startsWithObjectLiteral(expression)) ||
+        (constraints.noLeadingDeclarationToken && startsWithDeclarationToken(expression)) ||
+        (constraints.followedByDot && isDotAdjacentNumber(expression)) ||
+        mixesNullishWithLogical(parent, expression) ||
+        wouldFuseSigns(parent, childId, expression)) {
+        return parenthesize(expression, slotOwnsTrailingMarkers);
+    }
+    return expression;
+}
+
+function binaryPrecedence(operator: J.Binary.Type): number | undefined {
+    switch (operator) {
+        case J.Binary.Type.Multiplication:
+        case J.Binary.Type.Division:
+        case J.Binary.Type.Modulo:
+            return Precedence.Multiplicative;
+        case J.Binary.Type.Addition:
+        case J.Binary.Type.Subtraction:
+            return Precedence.Additive;
+        case J.Binary.Type.LeftShift:
+        case J.Binary.Type.RightShift:
+        case J.Binary.Type.UnsignedRightShift:
+            return Precedence.Shift;
+        case J.Binary.Type.LessThan:
+        case J.Binary.Type.GreaterThan:
+        case J.Binary.Type.LessThanOrEqual:
+        case J.Binary.Type.GreaterThanOrEqual:
+            return Precedence.Relational;
+        case J.Binary.Type.Equal:
+        case J.Binary.Type.NotEqual:
+            return Precedence.Equality;
+        case J.Binary.Type.BitAnd:
+            return Precedence.BitAnd;
+        case J.Binary.Type.BitXor:
+            return Precedence.BitXor;
+        case J.Binary.Type.BitOr:
+            return Precedence.BitOr;
+        case J.Binary.Type.And:
+            return Precedence.LogicalAnd;
+        case J.Binary.Type.Or:
+            return Precedence.LogicalOr;
+        default:
+            // An operator this table does not know; both callers then leave the expression alone
+            return undefined;
+    }
+}
+
+/** @see binaryPrecedence */
+function jsBinaryPrecedence(operator: JS.Binary.Type): number | undefined {
+    switch (operator) {
+        case JS.Binary.Type.IdentityEquals:
+        case JS.Binary.Type.IdentityNotEquals:
+            return Precedence.Equality;
+        case JS.Binary.Type.As:
+        case JS.Binary.Type.In:
+            return Precedence.Relational;
+        case JS.Binary.Type.QuestionQuestion:
+            return Precedence.LogicalOr;
+        case JS.Binary.Type.Comma:
+            return Precedence.Comma;
+        default:
+            return undefined;
+    }
+}
+
+function isUpdateOperator(operator: J.Unary.Type): boolean {
+    return operator === J.Unary.Type.PreIncrement || operator === J.Unary.Type.PreDecrement ||
+        isPostfixOperator(operator);
+}
+
+function isPostfixOperator(operator: J.Unary.Type): boolean {
+    return operator === J.Unary.Type.PostIncrement || operator === J.Unary.Type.PostDecrement;
+}
+
+function isContainerElement(container: J.Container<J> | undefined, childId: string): boolean {
+    return !!container?.elements?.some(element => element?.element?.id === childId);
+}
+
+function hasOmitParentheses(newClass: J.NewClass): boolean {
+    return !!newClass.arguments?.markers?.markers?.some(marker => marker.kind === J.Markers.OmitParentheses);
+}
+
+/** The JS parser reuses `J.NewClass` for object literals, which have no `class`. */
+function isObjectLiteral(expression: J): boolean {
+    return expression.kind === J.Kind.NewClass && !(expression as J.NewClass).class;
+}
+
+/** Whether this is a CallExpression, not a MemberExpression; `new f().g()` binds as `(new f()).g()`. */
+function isCallShaped(expression: J): boolean {
+    switch (expression.kind) {
+        case J.Kind.MethodInvocation:
+        case JS.Kind.FunctionCall:
+            return true;
+        case J.Kind.FieldAccess:
+            return isCallShaped((expression as J.FieldAccess).target);
+        case J.Kind.ArrayAccess:
+            return isCallShaped((expression as J.ArrayAccess).indexed);
+        default:
+            return false;
+    }
+}
+
+/** `?.` is a marker on the node to the left of it rather than a node of its own. */
+function isOptional(expression: J): boolean {
+    return expression.markers.markers.some(marker => marker.kind === JS.Markers.Optional);
+}
+
+/** Whether any link of the member chain is optional (`?.`), which is a marker, not a node. */
+function hasOptionalChain(expression: J): boolean {
+    if (isOptional(expression)) {
+        return true;
+    }
+    const next = leftmostChild(expression);
+    return next !== undefined && hasOptionalChain(next);
+}
+
+/** Whether a following `.` lexes into the number: `1.toString()` fails, `1.5`/`1e3`/`0x10`/`1?.x` do not. */
+function isDotAdjacentNumber(expression: J): boolean {
+    if (expression.kind !== J.Kind.Literal) {
+        return false;
+    }
+    const source = (expression as J.Literal).valueSource;
+    return !!source && /^\d[\d_]*$/.test(source);
+}
+
+/** Whether the printed form begins with `{`, which reads as a block body rather than an object. */
+export function startsWithObjectLiteral(expression: J): boolean {
+    return isObjectLiteral(leftmostExpression(expression));
+}
+
+/** Whether the printed form begins with `{`, `function` or `class`, none of which may open a statement. */
+export function startsWithDeclarationToken(expression: J): boolean {
+    const leftmost = leftmostExpression(expression);
+    return isObjectLiteral(leftmost) || isFunctionOrClassExpression(leftmost);
+}
+
+/** A function or class *expression*, which the JS parser wraps in a `JS.StatementExpression`. */
+function isFunctionOrClassExpression(expression: J): boolean {
+    if (expression.kind !== JS.Kind.StatementExpression) {
+        return false;
+    }
+    const statement = (expression as JS.StatementExpression).statement;
+    return statement?.kind === J.Kind.MethodDeclaration || statement?.kind === J.Kind.ClassDeclaration;
+}
+
+/** Walks down the left spine, to the token the expression starts with. */
+function leftmostExpression(expression: J): J {
+    let current = expression;
+    for (let next = leftmostChild(current); next; next = leftmostChild(current)) {
+        current = next;
+    }
+    return current;
+}
+
+function leftmostChild(expression: J): J | undefined {
+    switch (expression.kind) {
+        case J.Kind.Binary:
+            return (expression as J.Binary).left;
+        case JS.Kind.Binary:
+            return (expression as JS.Binary).left;
+        case J.Kind.Ternary:
+            return (expression as J.Ternary).condition;
+        case J.Kind.Assignment:
+            return (expression as J.Assignment).variable;
+        case J.Kind.AssignmentOperation:
+            return (expression as J.AssignmentOperation).variable;
+        case JS.Kind.AssignmentOperation:
+            return (expression as JS.AssignmentOperation).variable;
+        case J.Kind.FieldAccess:
+            return (expression as J.FieldAccess).target;
+        case J.Kind.ArrayAccess:
+            return (expression as J.ArrayAccess).indexed;
+        case J.Kind.MethodInvocation:
+            return (expression as J.MethodInvocation).select?.element;
+        case JS.Kind.FunctionCall:
+            return (expression as JS.FunctionCall).function?.element;
+        case J.Kind.InstanceOf:
+            return (expression as J.InstanceOf).expression?.element;
+        case JS.Kind.As:
+            return (expression as JS.As).left?.element;
+        case JS.Kind.SatisfiesExpression:
+            return (expression as JS.SatisfiesExpression).expression as J;
+        case JS.Kind.TaggedTemplateExpression:
+            return (expression as JS.TaggedTemplateExpression).tag?.element;
+        case JS.Kind.ExpressionStatement:
+            return (expression as JS.ExpressionStatement).expression;
+        case J.Kind.Unary: {
+            const unary = expression as J.Unary;
+            return isPostfixOperator(unary.operator.element) ? unary.expression : undefined;
+        }
+        default:
+            return undefined;
+    }
+}
+
+/** Markers the printer emits *after* the node they sit on. */
+function isTrailingMarker(marker: Marker): boolean {
+    return marker.kind === JS.Markers.NonNullAssertion || marker.kind === JS.Markers.Optional;
+}
+
+function isNullishCoalescing(expression: J): boolean {
+    return expression.kind === JS.Kind.Binary &&
+        (expression as JS.Binary).operator.element === JS.Binary.Type.QuestionQuestion;
+}
+
+function isLogicalAndOr(expression: J): boolean {
+    if (expression.kind !== J.Kind.Binary) {
+        return false;
+    }
+    const operator = (expression as J.Binary).operator.element;
+    return operator === J.Binary.Type.And || operator === J.Binary.Type.Or;
+}
+
+/** `??` beside `||` or `&&` is a syntax error rather than a re-association, so precedence misses it. */
+function mixesNullishWithLogical(parent: J, child: J): boolean {
+    return (isNullishCoalescing(parent) && isLogicalAndOr(child)) ||
+        (isLogicalAndOr(parent) && isNullishCoalescing(child));
+}
+
+/** Whether a `+`/`-` would fuse with the sign after it into `++`/`--`, turning `-(-a)` into `--a`. */
+function wouldFuseSigns(parent: J, childId: string, child: J): boolean {
+    const preceding = precedingSign(parent, childId);
+    return preceding !== undefined && preceding === leadingSign(child) && !isSeparated(child);
+}
+
+/** The sign the parent prints immediately before the slot holding `childId`, if any. */
+function precedingSign(parent: J, childId: string): Sign | undefined {
+    if (parent.kind === J.Kind.Unary) {
+        const unary = parent as J.Unary;
+        return unary.expression?.id === childId ? signOf(unary.operator.element) : undefined;
+    }
+    if (parent.kind === J.Kind.Binary) {
+        const binary = parent as J.Binary;
+        if (binary.right?.id !== childId) {
+            return undefined;
+        }
+        switch (binary.operator.element) {
+            case J.Binary.Type.Subtraction:
+                return 'minus';
+            case J.Binary.Type.Addition:
+                return 'plus';
+            default:
+                return undefined;
+        }
+    }
+    return undefined;
+}
+
+/** The sign the expression prints first, if any; it can sit arbitrarily deep on the left spine. */
+function leadingSign(expression: J): Sign | undefined {
+    const leftmost = leftmostExpression(expression);
+    return leftmost.kind === J.Kind.Unary ? signOf((leftmost as J.Unary).operator.element) : undefined;
+}
+
+/** Whether anything is printed between the expression and the token that precedes it. */
+function isSeparated(expression: J): boolean {
+    for (let current: J | undefined = expression; current; current = leftmostChild(current)) {
+        if (current.prefix.whitespace || current.prefix.comments.length > 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+type Sign = 'minus' | 'plus';
+
+function signOf(operator: J.Unary.Type): Sign | undefined {
+    switch (operator) {
+        case J.Unary.Type.Negative:
+        case J.Unary.Type.PreDecrement:
+            return 'minus';
+        case J.Unary.Type.Positive:
+        case J.Unary.Type.PreIncrement:
+            return 'plus';
+        default:
+            return undefined;
+    }
+}

--- a/rewrite-javascript/rewrite/test/javascript/templating/precedence.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/precedence.test.ts
@@ -1,0 +1,586 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {javascript, JavaScriptVisitor, RewriteRule} from "../../../src/javascript";
+import {capture, pattern, rewrite, template} from "../../../src/javascript";
+import {J} from "../../../src/java";
+
+/** Applies `rule` to every `marker(...)` call, keeping each test's rewrite to one trigger point. */
+function onCall(rule: RewriteRule) {
+    return fromVisitor(new class extends JavaScriptVisitor<any> {
+        override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+            const visited = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+            return await rule.tryOn(this.cursor, visited) || visited;
+        }
+    });
+}
+
+describe('template precedence', () => {
+    const spec = new RecipeSpec();
+
+    describe('a substituted capture that binds more loosely than its slot', () => {
+        test('under a prefix operator', () => {
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitTernary(ternary: J.Ternary, p: any): Promise<J | undefined> {
+                    const visited = await super.visitTernary(ternary, p) as J.Ternary;
+                    const t = capture();
+                    return await rewrite(() => ({
+                        before: pattern`${t} ? false : true`,
+                        after: template`!${t}`
+                    })).tryOn(this.cursor, visited) || visited;
+                }
+            });
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const x = a || b ? false : true;
+                    const y = a === b ? false : true;
+                    const z = foo() ? false : true;
+                    const w = a.b ? false : true;
+                `,
+                `
+                    const x = !(a || b);
+                    const y = !(a === b);
+                    const z = !foo();
+                    const w = !a.b;
+                `));
+        });
+
+        test('as the left operand of a tighter-binding operator', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`square(${x})`,
+                after: template`${x} * ${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = square(n + 1);
+                    const b = square(n / 2);
+                `,
+                `
+                    const a = (n + 1) * (n + 1);
+                    const b = n / 2 * (n / 2);
+                `));
+        });
+
+        test('as the right operand of an equally binding operator', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`below(${x})`,
+                after: template`10 - ${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = below(n - 1);
+                    const b = below(n * 2);
+                `,
+                `
+                    const a = 10 - (n - 1);
+                    const b = 10 - n * 2;
+                `));
+        });
+
+        test('as the operand of typeof', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`isBool(${x})`,
+                after: template`typeof ${x} === 'boolean'`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = isBool(p || q);
+                    const b = isBool(flag);
+                `,
+                `
+                    const a = typeof (p || q) === 'boolean';
+                    const b = typeof flag === 'boolean';
+                `));
+        });
+
+        test('as the target of a member access', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`size(${x})`,
+                after: template`${x}.length`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = size(p || q);
+                    const b = size(items);
+                `,
+                `
+                    const a = (p || q).length;
+                    const b = items.length;
+                `));
+        });
+
+        test('as the select of a method call', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`str(${x})`,
+                after: template`${x}.toString()`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = str(p ? q : r);
+                    const b = str(value);
+                `,
+                `
+                    const a = (p ? q : r).toString();
+                    const b = value.toString();
+                `));
+        });
+
+        test('as the condition of a ternary', () => {
+            const c = capture(), t = capture(), f = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`pick(${c}, ${t}, ${f})`,
+                after: template`${c} ? ${t} : ${f}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = pick(p ? q : r, one, two);
+                    const b = pick(p && q, one, two);
+                `,
+                `
+                    const a = (p ? q : r) ? one : two;
+                    const b = p && q ? one : two;
+                `));
+        });
+
+        test('as an argument, where nothing binds it', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`old(${x})`,
+                after: template`renamed(${x})`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = old(p || q);`,
+                `const a = renamed(p || q);`));
+        });
+
+        test('does not double up on parentheses the template already writes', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`group(${x})`,
+                after: template`(${x})`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = group(p || q);`,
+                `const a = (p || q);`));
+        });
+
+        test('keeps a trailing `!` outside the parentheses', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`size(${x})`,
+                after: template`${x}!.length`
+            })));
+            //language=typescript
+            return spec.rewriteRun(javascript(
+                `const a = size(p || q);`,
+                `const a = (p || q)!.length;`));
+        });
+
+        test('keeps a trailing `?.` outside the parentheses', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`size(${x})`,
+                after: template`${x}?.length`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = size(p || q);`,
+                `const a = (p || q)?.length;`));
+        });
+
+        test('does not double up on parentheses the capture already carries', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`not(${x})`,
+                after: template`!${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = not((p || q));`,
+                `const a = !(p || q);`));
+        });
+    });
+
+    describe('operand restrictions that precedence alone does not express', () => {
+        test('`??` may not sit next to `||` or `&&`', () => {
+            const x = capture(), y = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`orDefault(${x}, ${y})`,
+                after: template`${x} ?? ${y}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = orDefault(p || q, fallback);
+                    const b = orDefault(p & q, fallback);
+                `,
+                `
+                    const a = (p || q) ?? fallback;
+                    const b = p & q ?? fallback;
+                `));
+        });
+
+        test('`||` may not sit next to `??`', () => {
+            const x = capture(), y = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`either(${x}, ${y})`,
+                after: template`${x} || ${y}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = either(p ?? q, r);`,
+                `const a = (p ?? q) || r;`));
+        });
+
+        test('the base of `**` may not be a prefix expression', () => {
+            const x = capture(), y = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`pow(${x}, ${y})`,
+                after: template`${x} ** ${y}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = pow(-n, 2);
+                    const b = pow(n, m ** 2);
+                    const c = pow(n ** m, 2);
+                `,
+                `
+                    const a = (-n) ** 2;
+                    const b = n ** m ** 2;
+                    const c = (n ** m) ** 2;
+                `));
+        });
+
+        test('a sign may not fuse with the sign that precedes it', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`negate(${x})`,
+                after: template`-${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = -negate(n);
+                    const b = 1 -negate(n);
+                    const c = 1 - negate(n);
+                    const d = 1 +negate(n);
+                `,
+                `
+                    const a = -(-n);
+                    const b = 1 -(-n);
+                    const c = 1 - -n;
+                    const d = 1 +-n;
+                `));
+        });
+
+        test('a prefix operator may not fuse with the one below it', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`negate(${x})`,
+                after: template`-${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = negate(-n);
+                    const b = negate(+n);
+                    const c = negate(n);
+                `,
+                `
+                    const a = -(-n);
+                    const b = -+n;
+                    const c = -n;
+                `));
+        });
+    });
+
+    describe('slots that restrict the shape of their operand, not just its precedence', () => {
+        test('an object literal as an arrow function body reads as a block', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`thunk(${x})`,
+                after: template`() => ${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = thunk({k: 1});
+                    const b = thunk({k: 1}.k);
+                    const c = thunk(n + 1);
+                `,
+                `
+                    const a = () => ({k: 1});
+                    const b = () => ({k: 1}.k);
+                    const c = () => n + 1;
+                `));
+        });
+
+        test('the callee of `new` may not be a call', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`mk(${x})`,
+                after: template`new ${x}()`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = mk(factory());
+                    const b = mk(registry().Cls);
+                    const c = mk(ns.Cls);
+                `,
+                `
+                    const a = new (factory())();
+                    const b = new (registry().Cls)();
+                    const c = new ns.Cls();
+                `));
+        });
+
+        test('the callee of `new` may not be an optional chain', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`mk(${x})`,
+                after: template`new ${x}()`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = mk(ns?.Cls);`,
+                `const a = new (ns?.Cls)();`));
+        });
+
+        test('the tag of a tagged template may not be an optional chain', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`t(${x})`,
+                after: template`${x}\`hi\``
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = t(o?.tag);
+                    const b = t(o.tag);
+                `,
+                `
+                    const a = (o?.tag)\`hi\`;
+                    const b = o.tag\`hi\`;
+                `));
+        });
+
+        test('an integer literal followed by `.` would lex as a decimal point', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`str(${x})`,
+                after: template`${x}.toString()`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = str(1);
+                    const b = str(1.5);
+                    const c = str(0x10);
+                `,
+                `
+                    const a = (1).toString();
+                    const b = 1.5.toString();
+                    const c = 0x10.toString();
+                `));
+        });
+
+        test('an optional access ends the number, so no parentheses are needed', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`str(${x})`,
+                after: template`${x}?.length`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = str(1);`,
+                `const a = 1?.length;`));
+        });
+
+        test('an object literal at the start of a statement reads as a block', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`use(${x})`,
+                after: template`${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    use({k: 1});
+                    use({k: 1}.k);
+                    use({k: 1} && f());
+                    use([1, 2]);
+                `,
+                `
+                    ({k: 1});
+                    ({k: 1}.k);
+                    ({k: 1} && f());
+                    [1, 2];
+                `));
+        });
+
+        test('a function or class expression at the start of a statement reads as a declaration', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`use(${x})`,
+                after: template`${x}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    function h() {
+                        use(function () {});
+                        use(class {});
+                    }
+                `,
+                `
+                    function h() {
+                        (function () {
+                        });
+                        (class {
+                        });
+                    }
+                `));
+        });
+
+        test('a class heritage clause takes a left-hand-side expression', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`base(${x})`,
+                after: template`class A extends ${x} {}`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = base(p || q);`,
+                `const a = class A extends (p || q) {\n};`));
+        });
+    });
+
+    describe('a template result that binds more loosely than the tree it replaces', () => {
+        const notEquals = () => {
+            const a = capture(), b = capture();
+            return rewrite(() => ({
+                before: pattern`!(${a} === ${b})`,
+                after: template`${a} !== ${b}`
+            }));
+        };
+
+        test('under a tighter-binding parent', () => {
+            const rule = notEquals();
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitUnary(unary: J.Unary, p: any): Promise<J | undefined> {
+                    const visited = await super.visitUnary(unary, p) as J.Unary;
+                    return await rule.tryOn(this.cursor, visited) || visited;
+                }
+            });
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = !(x === y) + 1;
+                    const b = !(x === y) * 2;
+                    const c = -!(x === y);
+                `,
+                `
+                    const a = (x !== y) + 1;
+                    const b = (x !== y) * 2;
+                    const c = -(x !== y);
+                `));
+        });
+
+        test('under a parent that binds it loosely enough', () => {
+            const rule = notEquals();
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitUnary(unary: J.Unary, p: any): Promise<J | undefined> {
+                    const visited = await super.visitUnary(unary, p) as J.Unary;
+                    return await rule.tryOn(this.cursor, visited) || visited;
+                }
+            });
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    const a = !(x === y);
+                    const b = !(x === y) && z;
+                    const c = foo(!(x === y));
+                    const d = !(x === y) ? 1 : 2;
+                    const e = [!(x === y)];
+                `,
+                `
+                    const a = x !== y;
+                    const b = x !== y && z;
+                    const c = foo(x !== y);
+                    const d = x !== y ? 1 : 2;
+                    const e = [x !== y];
+                `));
+        });
+
+        test('when the result becomes the select of a member access', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`inc(${x})`,
+                after: template`${x} + 1`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = inc(n).toString();`,
+                `const a = (n + 1).toString();`));
+        });
+
+        test('when the result comes from a chained rule', () => {
+            const x = capture(), y = capture();
+            spec.recipe = onCall(
+                rewrite(() => ({before: pattern`outer(${x})`, after: template`inner(${x})`}))
+                    .andThen(rewrite(() => ({before: pattern`inner(${y})`, after: template`${y} + 1`}))));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const a = outer(n).toString();`,
+                `const a = (n + 1).toString();`));
+        });
+
+        test('the parentheses the source already had are kept', () => {
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitTernary(ternary: J.Ternary, p: any): Promise<J | undefined> {
+                    const visited = await super.visitTernary(ternary, p) as J.Ternary;
+                    const t = capture();
+                    return await rewrite(() => ({
+                        before: pattern`${t} ? false : true`,
+                        after: template`!${t}`
+                    })).tryOn(this.cursor, visited) || visited;
+                }
+            });
+            // The parentheses came from the source and are not the engine's to remove
+
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `const y = 1 + (a === b ? false : true);`,
+                `const y = 1 + (!(a === b));`));
+        });
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/precedence.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/precedence.test.ts
@@ -191,28 +191,21 @@ describe('template precedence', () => {
                 `const a = (p || q);`));
         });
 
-        test('keeps a trailing `!` outside the parentheses', () => {
-            const x = capture();
-            spec.recipe = onCall(rewrite(() => ({
-                before: pattern`size(${x})`,
-                after: template`${x}!.length`
-            })));
+        test('keeps a trailing `!` or `?.` outside the parentheses', () => {
+            const x = capture(), y = capture();
+            spec.recipe = onCall(
+                rewrite(() => ({before: pattern`nonNull(${x})`, after: template`${x}!.length`}))
+                    .orElse(rewrite(() => ({before: pattern`optional(${y})`, after: template`${y}?.length`}))));
             //language=typescript
             return spec.rewriteRun(javascript(
-                `const a = size(p || q);`,
-                `const a = (p || q)!.length;`));
-        });
-
-        test('keeps a trailing `?.` outside the parentheses', () => {
-            const x = capture();
-            spec.recipe = onCall(rewrite(() => ({
-                before: pattern`size(${x})`,
-                after: template`${x}?.length`
-            })));
-            //language=javascript
-            return spec.rewriteRun(javascript(
-                `const a = size(p || q);`,
-                `const a = (p || q)?.length;`));
+                `
+                    const a = nonNull(p || q);
+                    const b = optional(p || q);
+                `,
+                `
+                    const a = (p || q)!.length;
+                    const b = (p || q)?.length;
+                `));
         });
 
         test('does not double up on parentheses the capture already carries', () => {


### PR DESCRIPTION
`template` splices a captured expression into its slot as-is, and the JS printer never adds parentheses of its own. Anything binding more loosely than the slot around it re-associated silently:

| what the recipe wrote | printed | what that means |
|---|---|---|
| `` template`!${t}` `` with `t` bound to `a \|\| b` | `!a \|\| b` | `(!a) \|\| b` |
| `` template`${a} !== ${b}` `` replacing the `!(a === b)` in `!(a === b) + 1` | `a !== b + 1` | `a !== (b + 1)` |

Both parse. Neither means what the recipe wrote. `BooleanChecksNotInverted` in `recipes-javascript` shipped with the second one.

## The change

`src/javascript/templating/precedence.ts` models what each slot of the JS/TS expression grammar demands of whatever sits in it. It is consulted at the two points where an expression changes position: in `PlaceholderReplacementVisitor`, when a capture replaces a placeholder inside a template, and in `TemplateApplier`, when the template result replaces the target tree.

It wraps only where the slot demands it. A capture that already binds tightly enough is untouched, as is one landing in a slot that already has parentheses, so `` template`(${x})` `` still emits a single pair.

Precedence is not the whole story. Several slots restrict the *shape* of their operand, and those are the quiet failures:

| slot | what it printed before |
|---|---|
| `new` callee | `` template`new ${x}()` `` over a captured `factory()` gave `new factory()()`, which runs as `(new factory())()` |
| arrow body | `` template`() => ${x}` `` over `{k: 1}` gave `() => {k: 1}`, an arrow returning `undefined` |
| statement start | an object literal reads as a block; an anonymous `function` or `class` does not parse at all |
| `??` next to `\|\|` or `&&` | syntax error |
| base of `**` | a prefix expression there is a syntax error |
| `new` callee, tagged-template tag | an optional chain there is a syntax error |
| class heritage clause | any operator expression is a syntax error |
| member access target | `1.toString()`, where the dot lexes into the number |
| after a `+` or `-` | a following sign fuses into `++` or `--` |

A trailing `!` or `?.` written in the template moves out to the parentheses, so `${x}!` around a captured `a || b` prints `(a || b)!`.

The model is exported (`Precedence`, `precedenceOf`, `slotConstraints`, `requiredPrecedence`, `maybeParenthesize`, `parenthesize`) so hand-written visitors can reuse the same rules instead of carrying their own parenthesization.

## Known gap

A bare `in` at the top level of a C-style for-loop initializer still needs parentheses that nothing here adds. Deciding that requires the whole enclosing for-head rather than the slot the expression lands in, so it is marked in the source rather than half-handled.

## Testing

31 cases in `test/javascript/templating/precedence.test.ts`, covering each slot above alongside the cases where no parentheses should appear. Full JS and Java suites pass: 143 files, 1632 tests. No existing expectation needed changing.

- Closes moderneinc/customer-requests#3056
