### PR TITLE
Intern repeated JSON object key strings at parse time

### DIFF
--- a/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
+++ b/rewrite-json/src/main/java/org/openrewrite/json/internal/JsonParserVisitor.java
@@ -29,7 +29,9 @@ import java.math.BigInteger;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -48,6 +50,10 @@ public class JsonParserVisitor extends JSON5BaseVisitor<Json> {
 
     private int cursor = 0;
     private int codePointCursor = 0;
+
+    // Keys repeat across a document, so each distinct key string is retained once. Not String.intern(),
+    // whose table is JVM-global and loses throughput at this volume.
+    private final Map<String, String> keyInterner = new HashMap<>();
 
     public JsonParserVisitor(Path path, @Nullable FileAttributes fileAttributes, String source, Charset charset, boolean charsetBomMarked) {
         this.path = path;
@@ -120,14 +126,19 @@ public class JsonParserVisitor extends JSON5BaseVisitor<Json> {
     public JsonKey visitKey(JSON5Parser.KeyContext ctx) {
         if (ctx.IDENTIFIER() != null) {
             return convert(ctx.IDENTIFIER(), (ident, fmt) ->
-                    new Json.Identifier(randomId(), fmt, Markers.EMPTY, ctx.IDENTIFIER().getText()));
+                    new Json.Identifier(randomId(), fmt, Markers.EMPTY, internKey(ctx.IDENTIFIER().getText())));
         }
 
         return convert(ctx.STRING(), (str, prefix) -> {
-            String source = str.getText();
+            String source = internKey(str.getText());
             return new Json.Literal(randomId(), prefix, Markers.EMPTY, source,
-                    source.substring(1, source.length() - 1));
+                    internKey(source.substring(1, source.length() - 1)));
         });
+    }
+
+    private String internKey(String key) {
+        String canonical = keyInterner.putIfAbsent(key, key);
+        return canonical == null ? key : canonical;
     }
 
     @Override

--- a/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
+++ b/rewrite-json/src/test/java/org/openrewrite/json/JsonParserTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.json;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.*;
 import org.openrewrite.json.tree.Json;
+import org.openrewrite.json.tree.JsonKey;
 import org.openrewrite.json.tree.JsonValue;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
@@ -25,6 +26,7 @@ import org.openrewrite.tree.ParseError;
 
 import java.nio.charset.Charset;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -371,6 +373,49 @@ class JsonParserTest implements RewriteTest {
                   }
               }
               """
+          )
+        );
+    }
+
+    @Test
+    void repeatedKeysShareStringInstances() {
+        rewriteRun(
+          json(
+            """
+              {
+                "deps": [
+                  {"name": "a", "version": "1.0"},
+                  {"name": "b", "version": "2.0"}
+                ],
+                unquoted: {unquoted: "nested"}
+              }
+              """,
+            spec -> spec.afterRecipe(doc -> {
+                List<JsonKey> keys = new ArrayList<>();
+                new JsonIsoVisitor<Integer>() {
+                    @Override
+                    public Json.Member visitMember(Json.Member member, Integer p) {
+                        keys.add(member.getKey());
+                        return super.visitMember(member, p);
+                    }
+                }.visit(doc, 0);
+
+                List<Json.Literal> name = keys.stream()
+                  .filter(Json.Literal.class::isInstance)
+                  .map(Json.Literal.class::cast)
+                  .filter(k -> "\"name\"".equals(k.getSource()))
+                  .toList();
+                assertThat(name).hasSize(2);
+                assertThat(name.get(0).getSource()).isSameAs(name.get(1).getSource());
+                assertThat(name.get(0).getValue()).isSameAs(name.get(1).getValue());
+
+                List<Json.Identifier> unquoted = keys.stream()
+                  .filter(Json.Identifier.class::isInstance)
+                  .map(Json.Identifier.class::cast)
+                  .toList();
+                assertThat(unquoted).hasSize(2);
+                assertThat(unquoted.get(0).getName()).isSameAs(unquoted.get(1).getName());
+            })
           )
         );
     }


### PR DESCRIPTION
Parsing a JSON document with recurring keys allocated one `String` per occurrence, and `Json.Literal` stores *both* the quoted `source` and the unquoted `value`, so each occurrence of a key retained two `String`s plus two backing arrays. This is what makes resource formats expand disproportionately on the heap: across the 169 V2 artifacts of openrewrite/rewrite itself, the JSON/YAML/properties scopes grow 24-29x from compressed bytes to heap, against 15-21x for Java. On a synthetic document of 4,000 objects reusing four keys (`name`, `version`, `resolved`, `integrity`) — the shape of a lockfile, an i18n bundle or a large config — the key strings alone measured:

```
32002 key strings, 32002 distinct instances, 10 distinct values, 1664096 bytes retained
```

(instances counted through an `IdentityHashMap`, bytes via JOL `GraphLayout.totalSize()` over the distinct instances.)

`JsonParserVisitor` now canonicalizes key strings through a per-document `HashMap` — the `Json.Identifier` name, and both the `source` and the unquoted `value` of a key `Json.Literal`. The same measurement after:

```
32002 key strings, 10 distinct instances, 10 distinct values, 512 bytes retained
```

The map is per-visitor, and `JsonParser` builds one visitor per input, so it dies with the parse. `String.intern()` would do the same job with no map, but its table is JVM-global and loses throughput at this volume, which is why the comment on the field names it explicitly.

Only object *keys* are interned. In real documents values are mostly distinct (`pkg-0`, `pkg-1`, …), so canonicalizing them would add map churn for no sharing.

### Scope: this is a parse-time win, not a recipe-run win

The Moderne CLI's V2 (Jackson Smile) serializer enables `CHECK_SHARED_STRING_VALUES`, and Smile shares repeated short strings on the wire, so reading a stored LST recovers much of this without any change here — on the document above, those 32,002 key strings decode as 258 instances (1.66 MB → 13 KB). How close a given document gets is a property of that document, not a floor: the writer's table holds `MAX_SHARED_STRING_VALUES = 1024` entries and is cleared wholesale rather than evicted when full (`SmileGenerator._addSeenStringValue`), so unrelated short-value churn costs sharing, and anything over `MAX_SHARED_STRING_LENGTH_BYTES = 65` — lockfile `integrity` hashes, long URLs — is never shared at all. What this change affects is the footprint of a *freshly parsed* LST: parsing/building, and anything else holding parser output in memory. Serialized size is unaffected — Smile's writer-side lookup starts with an identity check and falls back to `equals`, so interning changes what it costs to find a match, not what gets emitted.

`-XX:+UseStringDeduplication` is enabled where this runs in production: the Moderne SaaS recipe worker sets it on the CLI JVM (`RecipeWorkerCliConfiguration`, alongside `-XX:+UseZGC -Xms3g -Xmx12g`), though moderne-cli's own wrapper does not. It overlaps with this change without subsuming it, for two reasons that hold whether or not the flag is on. It shares the backing `byte[]` and leaves all 32,002 `String` objects alive — 768 KB at the 24-byte compressed-oops layout measured here, and more under the worker, since ZGC runs without compressed oops and widens each `String` to 32 bytes. And it acts asynchronously during GC, on strings that have survived `StringDeduplicationAgeThreshold` young collections, so it engages after the parse-time peak has already formed.

### Tests

`JsonParserTest#repeatedKeysShareStringInstances` parses a document with a repeated quoted key and a repeated unquoted (JSON5 identifier) key, and asserts the two occurrences share the same `String` instance for `getSource()`, `getValue()` and `getName()`. It fails on `main` ("to refer to the same object"). Being a `rewriteRun(json(...))`, it also asserts the document prints back byte-identical, alongside the existing round-trip suite in that class.

### Follow-up, not attempted here

`Json.Literal` retaining both the quoted `source` and the unquoted `value` doubles the per-key cost even after interning — 10 instances above would be 5. Deriving `value` lazily from `source` would remove that, but it changes a public LST type and deserves its own discussion.
