### PR TITLE
JavaScript: autoFormat re-indents multi-line comment interiors with their delimiter

### DIFF
--- a/rewrite-javascript/rewrite/src/java/formatting-utils.ts
+++ b/rewrite-javascript/rewrite/src/java/formatting-utils.ts
@@ -83,13 +83,19 @@ function shiftIndent(indent: string, oldMargin: string, newMargin: string): stri
     if (indent.startsWith(oldMargin)) {
         return newMargin + indent.substring(oldMargin.length);
     }
-    // No margin to swap out, so shift by the delta the margin moved, clamped at column 0.
+    // The shift below counts characters, which stand in for columns only while all three indents
+    // use a single whitespace character; without a tab width, a line mixing them stays put.
+    if (new Set(indent + oldMargin + newMargin).size > 1) {
+        return indent;
+    }
     const delta = newMargin.length - oldMargin.length;
     return delta < 0 ? indent.substring(Math.min(-delta, indent.length)) : newMargin.substring(0, delta) + indent;
 }
 
 function reindentComment(comment: TextComment, oldMargin: string, newMargin: string): TextComment {
-    const text = comment.text.replace(/\n([ \t]*)/g, (_match, indent: string) => "\n" + shiftIndent(indent, oldMargin, newMargin));
+    // A blank line has no content to align, and indenting it would only add trailing whitespace.
+    const text = comment.text.replace(/\n([ \t]*)/g, (match, indent: string, offset: number, full: string) =>
+        "\n\r".includes(full[offset + match.length]) ? match : "\n" + shiftIndent(indent, oldMargin, newMargin));
     return text === comment.text ? comment : {...comment, text};
 }
 

--- a/rewrite-javascript/rewrite/src/java/formatting-utils.ts
+++ b/rewrite-javascript/rewrite/src/java/formatting-utils.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import {J} from "../java";
+import {Comment, J, TextComment} from "../java";
 import {create as produce} from "mutative";
 
 /**
@@ -73,9 +73,39 @@ export function spaceContainsNewline(space: J.Space | undefined): boolean {
     return space.comments.some(c => c.suffix.includes("\n"));
 }
 
+const isTextComment = (comment: Comment): comment is TextComment => comment.kind === J.Kind.TextComment;
+
 /**
- * Normalizes indentation in an entire Space, including both whitespace and comment suffixes.
- * Each newline followed by whitespace gets its indentation normalized to the target indent.
+ * Re-indents a line's leading whitespace when the enclosing construct moves from `oldMargin` to
+ * `newMargin`, preserving whatever indentation the line adds beyond the margin.
+ */
+function shiftIndent(indent: string, oldMargin: string, newMargin: string): string {
+    if (indent.startsWith(oldMargin)) {
+        return newMargin + indent.substring(oldMargin.length);
+    }
+    // No margin to swap out, so shift by the delta the margin moved, clamped at column 0.
+    const delta = newMargin.length - oldMargin.length;
+    return delta < 0 ? indent.substring(Math.min(-delta, indent.length)) : newMargin.substring(0, delta) + indent;
+}
+
+function reindentComment(comment: TextComment, oldMargin: string, newMargin: string): TextComment {
+    const text = comment.text.replace(/\n([ \t]*)/g, (_match, indent: string) => "\n" + shiftIndent(indent, oldMargin, newMargin));
+    return text === comment.text ? comment : {...comment, text};
+}
+
+/**
+ * The indentation of the line a comment opens on, or `undefined` when the preceding whitespace
+ * holds no newline — the comment then trails other tokens and its column is not knowable here.
+ */
+function marginOf(precedingWhitespace: string): string | undefined {
+    const lastNewline = precedingWhitespace.lastIndexOf("\n");
+    return lastNewline < 0 ? undefined : precedingWhitespace.substring(lastNewline + 1);
+}
+
+/**
+ * Normalizes indentation in an entire Space: whitespace and comment suffixes take the target
+ * indent, and the interior lines of a multi-line comment shift with it, so they stay aligned with
+ * the opening delimiter that the surrounding whitespace positions.
  *
  * @param space The Space to normalize
  * @param targetIndent The indentation to use after newlines
@@ -91,16 +121,21 @@ export function normalizeSpaceIndent(space: J.Space, targetIndent: string): J.Sp
         changed = changed || newWhitespace !== space.whitespace;
     }
 
-    // Normalize comment suffixes
-    const newComments = space.comments.map(comment => {
-        if (comment.suffix.includes("\n")) {
-            const newSuffix = replaceIndentAfterLastNewline(comment.suffix, targetIndent);
-            if (newSuffix !== comment.suffix) {
+    // Normalize comment suffixes and multi-line comment interiors
+    const newComments = space.comments.map((comment, i) => {
+        const margin = marginOf(i === 0 ? space.whitespace : space.comments[i - 1].suffix);
+        let result: Comment = margin !== undefined && margin !== targetIndent && isTextComment(comment) ?
+            reindentComment(comment, margin, targetIndent) : comment;
+        changed = changed || result !== comment;
+
+        if (result.suffix.includes("\n")) {
+            const newSuffix = replaceIndentAfterLastNewline(result.suffix, targetIndent);
+            if (newSuffix !== result.suffix) {
                 changed = true;
-                return {...comment, suffix: newSuffix};
+                result = {...result, suffix: newSuffix};
             }
         }
-        return comment;
+        return result;
     });
 
     if (!changed) {

--- a/rewrite-javascript/rewrite/src/java/tree.ts
+++ b/rewrite-javascript/rewrite/src/java/tree.ts
@@ -791,7 +791,7 @@ export function isSpace(tree: any): tree is J.Space {
 
 /**
  * Builds a comment-free Space. Assigning one over an existing prefix silently drops the comments
- * that prefix carried; to change only the whitespace and keep them, use `replaceLastWhitespace`.
+ * that prefix carried; spread the prefix to keep them — `{...prefix, whitespace: "\n\n"}`.
  */
 export function space(whitespace: string): J.Space {
     return {

--- a/rewrite-javascript/rewrite/src/java/tree.ts
+++ b/rewrite-javascript/rewrite/src/java/tree.ts
@@ -789,6 +789,10 @@ export function isSpace(tree: any): tree is J.Space {
         tree.kind === J.Kind.Space;
 }
 
+/**
+ * Builds a comment-free Space. Assigning one over an existing prefix silently drops the comments
+ * that prefix carried; to change only the whitespace and keep them, use `replaceLastWhitespace`.
+ */
 export function space(whitespace: string): J.Space {
     return {
         kind: J.Kind.Space,

--- a/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
@@ -1334,4 +1334,104 @@ const { data, error } = await (
             // @formatter:on
         )
     })
+
+    test('re-indents multi-line comment interiors along with the delimiter', () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+`function outer() {
+}
+\t/**
+\t * Does a thing.
+\t * @public
+\t */
+\tfunction helper() {}
+`,
+`function outer() {
+}
+/**
+ * Does a thing.
+ * @public
+ */
+function helper() {}
+`),
+            //language=typescript
+            typescript(
+`class A {
+/**
+ * Doc.
+ */
+m() {}
+}
+`,
+`class A {
+    /**
+     * Doc.
+     */
+    m() {}
+}
+`),
+            //language=typescript
+            typescript(
+`class A {
+        /*
+          a
+            b
+        */
+        m() {}
+}
+`,
+`class A {
+    /*
+      a
+        b
+    */
+    m() {}
+}
+`)
+            // @formatter:on
+        );
+    });
+
+    test('leaves comment interiors alone when their column is unknown or already at zero', () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+`class A {
+        // a line comment
+        m() {} /* trailing
+   still trailing */
+}
+`,
+`class A {
+    // a line comment
+    m() {} /* trailing
+   still trailing */
+}
+`),
+            //language=typescript
+            typescript(
+`class A {
+        /**
+* flush left
+         */
+        m() {}
+}
+`,
+`class A {
+    /**
+* flush left
+     */
+    m() {}
+}
+`)
+            // @formatter:on
+        );
+    });
 });

--- a/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
@@ -1391,12 +1391,65 @@ m() {}
     */
     m() {}
 }
+`),
+            // An interior line sitting at the margin travels with it, column zero included.
+            //language=typescript
+            typescript(
+`class A {
+/**
+* flush
+ */
+m() {}
+}
+`,
+`class A {
+    /**
+    * flush
+     */
+    m() {}
+}
+`),
+            //language=typescript
+            typescript(
+`class A {
+\t/*
+    aligned with spaces
+\t*/
+\tm() {}
+}
+`,
+`class A {
+    /*
+    aligned with spaces
+    */
+    m() {}
+}
+`),
+            //language=typescript
+            typescript(
+`class A {
+/**
+ * one
+
+ * two
+ */
+m() {}
+}
+`,
+`class A {
+    /**
+     * one
+
+     * two
+     */
+    m() {}
+}
 `)
             // @formatter:on
         );
     });
 
-    test('leaves comment interiors alone when their column is unknown or already at zero', () => {
+    test('leaves comment interiors alone when their column is unknown, clamping out-dents at column zero', () => {
         const spec = new RecipeSpec();
         spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents()));
         return spec.rewriteRun(

--- a/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
@@ -1361,22 +1361,6 @@ function helper() {}
             //language=typescript
             typescript(
 `class A {
-/**
- * Doc.
- */
-m() {}
-}
-`,
-`class A {
-    /**
-     * Doc.
-     */
-    m() {}
-}
-`),
-            //language=typescript
-            typescript(
-`class A {
         /*
           a
             b


### PR DESCRIPTION
A recipe that moves a statement between nesting levels leaves every multi-line comment attached to it visibly broken: the opening delimiter travels with the statement and the continuation lines do not. Reported from a UI5 AMD-to-ES-module conversion in `moderneinc/recipes-javascript`, where every converted file dedents its whole body by one level, so every JSDoc in the codebase hits it.

```js
// input                                 // after autoFormat
sap.ui.define(["a"], function (A) {      import A from "a";
	/**
	 * Does a thing.                     /**
	 * @public                           	 * Does a thing.
	 */                                  	 * @public
	function helper() {}                 	 */
	return A;                            function helper() {}
});                                      export default A;
```

## Mechanism

A comment's `/**` sits in the enclosing statement's `prefix` `Space`; its ` * …` lines are characters inside `TextComment.text`. `normalizeSpaceIndent` re-indented `Space.whitespace` and each comment's `suffix` and never looked at `text`, so the two halves of one comment moved independently. Only a non-zero delta is required — a comment shifted within its level breaks the same way, it is just less obvious than a whole-level dedent.

## The fix

Each comment's original margin is recovered from the whitespace preceding it (`Space.whitespace` for the first comment, the previous comment's `suffix` after that), and every continuation line shifts by the same delta that margin moves. Indentation *beyond* the margin is preserved, so ASCII layout and indented code samples inside block comments survive.

I rejected aligning each `*` one column past the `/`, which is the other obvious reading of "correct". It defines an answer only for JSDoc-shaped comments and would flatten the interior of everything else.

The delta shift is not a new judgement call: `rewrite-java`'s `TabsAndIndentsVisitor.indentComment` has re-indented Java comment interiors this way for years, and this brings the JavaScript visitor to parity. **That is worth knowing beyond this PR** — when JS and Java formatting diverge, checking whether `rewrite-java`'s visitor already has an equivalent is the cheapest first move, and it turns what looks like open policy ("should a formatter rewrite comment text at all?") into a question of parity.

Three cases are deliberately left alone:

- A comment trailing other tokens on a line has no recoverable column, because the `Space` does not record what preceded it.
- Line comments cannot contain a newline.
- When the margin and an interior line are built from different whitespace characters, character counts stop standing in for columns. Without a tab width there is nothing to compare, so the line holds its column rather than moving by a count that means nothing. This one is not hypothetical: counting `"    "` against `"\t"` as a delta of 3 pushes a space-aligned interior three columns *past* its own delimiter, which is the exact failure this PR exists to remove.

Blank interior lines are skipped for a different reason — indenting a line with no content only produces trailing whitespace.

## Tests

Two tests in `tabs-and-indents-visitor.test.ts`. The first pins re-indentation: the tab-indented dedent above verbatim, interior depth beyond the margin surviving, a line sitting *at* the margin travelling with it (column zero included), the mixed tab/space case, and a blank interior line staying blank. The second pins what stays put: a trailing comment whose column is unknown, and an out-dent clamping at column zero.

Verified end-to-end through `AutoformatVisitor`, not just the visitor in isolation. Full JS suite green.

## Scope

This only bites projects with no Prettier config — `javascript/format/format.ts` hands formatting to Prettier when a `PrettierStyle` is present, and Prettier reflows comment interiors correctly. The affected population is legacy codebases, which is most of them.

Not fixed here: a multi-line comment at a *block end* is not re-indented at all, not even its delimiter, because `normalizeBlockEnd` uses `replaceLastWhitespace` (which only reaches the last comment's suffix) and so never calls `normalizeSpaceIndent`. That is an absence of formatting where nothing moved, rather than an inconsistency introduced by a move, and fixing it means picking a target column for block-end comments. It is handled in a follow-up stacked on this branch, which reuses the helpers added here.

Also documents that `space()` builds a comment-free `Space`, so assigning one over an existing prefix silently drops that prefix's comments. That is the sibling finding in the same report: a recipe replaced a leading statement's prefix wholesale and deleted a JSDoc, with no error and nothing in the tests to catch it. The note points at spreading the prefix instead, at the point of temptation.
