### PR TITLE
Fix XML attribute continuation indentation

### DIFF
--- a/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndentsVisitor.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/format/TabsAndIndentsVisitor.java
@@ -43,13 +43,13 @@ public class TabsAndIndentsVisitor<P> extends XmlIsoVisitor<P> {
             String prefix = x.getPrefix();
             if (prefix.contains("\n")) {
                 int indentMultiple = (int) getCursor().getPathAsStream().filter(Xml.Tag.class::isInstance).count() - 1;
+                boolean attributeContinuation = x instanceof Xml.Attribute;
                 boolean docTypeContinuation = isDocTypeContinuation(x);
-                boolean continuationIndent = x instanceof Xml.Attribute || docTypeContinuation;
-                if (getCursor().getValue() instanceof Xml.Attribute ||
+                if (!attributeContinuation && (getCursor().getValue() instanceof Xml.Attribute ||
                         getCursor().getValue() instanceof Xml.CharData ||
                         getCursor().getValue() instanceof Xml.Comment ||
                         getCursor().getValue() instanceof Xml.ProcessingInstruction ||
-                        docTypeContinuation) {
+                        docTypeContinuation)) {
                     indentMultiple++;
                 }
                 if (docTypeContinuation) {
@@ -61,10 +61,16 @@ public class TabsAndIndentsVisitor<P> extends XmlIsoVisitor<P> {
                     if(style.getUseTabCharacter()) {
                         shiftedPrefixBuilder.append("\t");
                     } else {
-                        int indentSize = continuationIndent ? style.getContinuationIndentSize() : style.getIndentSize();
+                        int indentSize = docTypeContinuation ? style.getContinuationIndentSize() : style.getIndentSize();
                         for(int j = 0; j < indentSize; j++) {
                             shiftedPrefixBuilder.append(" ");
                         }
+                    }
+                }
+                if (attributeContinuation) {
+                    String continuationIndent = style.getUseTabCharacter() ? "\t" : " ";
+                    for (int i = 0; i < style.getContinuationIndentSize(); i++) {
+                        shiftedPrefixBuilder.append(continuationIndent);
                     }
                 }
 

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/style/Autodetect.java
@@ -75,7 +75,7 @@ public class Autodetect extends NamedStyles {
 
         public TabsAndIndentsStyle getTabsAndIndentsStyle() {
             TabsAndIndentsStyle style = indentFrequencies.getTabsAndIndentsStyle();
-            return continuationIndentFrequencies.hasEnoughSamples() ?
+            return continuationIndentFrequencies.hasSamples() ?
                     style.withContinuationIndentSize(continuationIndentFrequencies.getTabsAndIndentsStyle().getIndentSize()) :
                     style;
         }
@@ -91,8 +91,8 @@ public class Autodetect extends NamedStyles {
             return linesWithSpaceIndents >= linesWithTabIndents;
         }
 
-        public boolean hasEnoughSamples() {
-            return linesWithSpaceIndents + linesWithTabIndents > 1;
+        public boolean hasSamples() {
+            return linesWithSpaceIndents + linesWithTabIndents > 0;
         }
 
         private TabsAndIndentsStyle getTabsAndIndentsStyle() {
@@ -165,11 +165,16 @@ public class Autodetect extends NamedStyles {
 
         @Override
         public Xml visitAttribute(Xml.Attribute attribute, IndentStatistics stats) {
-            measureFrequencies(attribute.getPrefix(), stats.continuationIndentFrequencies);
+            Xml.Tag parent = getCursor().firstEnclosing(Xml.Tag.class);
+            measureFrequencies(attribute.getPrefix(), parent == null ? "" : parent.getPrefix(), stats.continuationIndentFrequencies);
             return super.visitAttribute(attribute, stats);
         }
 
         private void measureFrequencies(String prefix, IndentFrequencies frequencies) {
+            measureFrequencies(prefix, "", frequencies);
+        }
+
+        private void measureFrequencies(String prefix, String basePrefix, IndentFrequencies frequencies) {
             AtomicBoolean takeWhile = new AtomicBoolean(true);
             if (prefix.chars()
                         .filter(c -> {
@@ -209,6 +214,10 @@ public class Autodetect extends NamedStyles {
                     }
                 }
 
+                int[] baseIndent = countIndent(basePrefix);
+                spaceIndent = Math.max(0, spaceIndent - baseIndent[0]);
+                tabIndent = Math.max(0, tabIndent - baseIndent[1]);
+
                 frequencies.spaceIndentFrequencies.merge(spaceIndent, 1L, Long::sum);
                 frequencies.tabIndentFrequencies.merge(tabIndent, 1L, Long::sum);
 
@@ -232,6 +241,29 @@ public class Autodetect extends NamedStyles {
                     frequencies.linesWithTabIndents++;
                 }
             }
+        }
+
+        private int[] countIndent(String prefix) {
+            int spaceIndent = 0;
+            int tabIndent = 0;
+            int lastNewline = Math.max(prefix.lastIndexOf('\n'), prefix.lastIndexOf('\r'));
+            for (int i = lastNewline + 1; i < prefix.length(); i++) {
+                char c = prefix.charAt(i);
+                if (c == ' ') {
+                    if (tabIndent > 0) {
+                        return new int[]{0, 0};
+                    }
+                    spaceIndent++;
+                } else if (Character.isWhitespace(c)) {
+                    if (spaceIndent > 0) {
+                        return new int[]{0, 0};
+                    }
+                    tabIndent++;
+                } else {
+                    break;
+                }
+            }
+            return new int[]{spaceIndent, tabIndent};
         }
     }
 

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/format/AutoFormatTest.java
@@ -88,6 +88,38 @@ class AutoFormatTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3648")
+    @Test
+    void preserveAttributeContinuationIndent() {
+        rewriteRun(
+          xml(
+            """
+              <a b="c"
+                 d="e"/>
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/issues/3648")
+    @Test
+    void preserveNestedAttributeContinuationIndent() {
+        rewriteRun(
+          xml(
+            """
+              <root>
+                <parent>
+                  <child first="1"
+                         second="2"/>
+                  <other first="1"
+                         second="2"/>
+                </parent>
+              </root>
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/1503")
     @Test
     void autoFormatXmlDecl() {

--- a/rewrite-xml/src/test/java/org/openrewrite/xml/format/TabsAndIndentsTest.java
+++ b/rewrite-xml/src/test/java/org/openrewrite/xml/format/TabsAndIndentsTest.java
@@ -54,6 +54,30 @@ class TabsAndIndentsTest implements RewriteTest {
         );
     }
 
+    @Issue("https://github.com/openrewrite/rewrite/issues/3648")
+    @Test
+    void continuationIndentIsRelativeToTagDepth() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new TabsAndIndentsVisitor<>(
+            TabsAndIndentsStyle.DEFAULT.withIndentSize(2).withContinuationIndentSize(5)
+          ))),
+          xml(
+            """
+              <root>
+              <child first="1"
+               second="2"/>
+              </root>
+              """,
+            """
+              <root>
+                <child first="1"
+                     second="2"/>
+              </root>
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4234")
     @Test
     void continuationIndentsWithinDOCTYPE() {


### PR DESCRIPTION
## What's changed?
- Detect XML attribute continuation indentation relative to the parent tag instead of as an absolute column.
- Apply normal tag-depth indentation plus one continuation indent, preventing indentation from multiplying across recipe cycles.
- Add regression coverage for a single continuation sample, nested attributes, and explicitly styled indentation.

## What's your motivation?
- Fixes #3648.

`AutoFormat` could repeatedly expand the leading whitespace of continued XML attributes. The detected continuation indent included the parent tag's existing indentation, while the formatter multiplied that absolute value by the tag depth on every cycle.

## Anything in particular you'd like reviewers to focus on?
Please review the relative indentation calculation in `Autodetect` and the handling of attribute continuations in `TabsAndIndentsVisitor`.

## Have you considered any alternatives or workarounds?
Changing only `TabsAndIndentsVisitor` would stop the multiplicative growth, but autodetection would still treat the absolute column as the continuation width and move nested attributes on subsequent cycles. The change therefore keeps detection and application consistent.

## Any additional context
Validated after merging the latest `main` with:
- `./gradlew :rewrite-xml:check` (includes the complete `rewrite-xml` test suite, license checks, and recipe CSV validation)
- `./gradlew :rewrite-docker:test --tests org.openrewrite.docker.search.FindEndOfLifeImagesTest.mixedEolAndCurrent`
- `git diff --check`

The initial CI failure was limited to the unrelated `rewrite-docker` end-of-life fixture. It reproduced on the then-current upstream `main` and was fixed upstream by #8661; the previously failing test now passes after syncing this branch with `main`. No Docker code or tests are changed by this PR.

Tests were run with configuration-on-demand and a local Java 8 toolchain on Windows.

### Checklist
- [x] I've added unit tests to cover both positive and negative cases
- [x] I've run the complete `rewrite-xml` test and check tasks
- [x] I've formatted only the lines I changed, without reformatting unrelated code