### PR TITLE
Terminate the ChangeMethodInvocationReturnType template in statement position

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
@@ -99,9 +99,6 @@ public class ChangeMethodInvocationReturnType extends Recipe {
                     return mv;
                 }
 
-                // javac only recovers from the `;` that `BlockStatementTemplateGenerator` omits when the
-                // enclosing method is the last member of its class. Terminating it in the generator
-                // instead breaks templates applied in non-statement positions.
                 boolean needsSemicolon = getCursor().getParentTreeCursor().getValue() instanceof J.Block;
                 String template = returnTypeExpression + " __typePlaceholder__" + (needsSemicolon ? ";" : "");
                 JavaTemplate.Builder templateBuilder = JavaTemplate.builder(template).contextSensitive();

--- a/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/ChangeMethodInvocationReturnType.java
@@ -99,7 +99,12 @@ public class ChangeMethodInvocationReturnType extends Recipe {
                     return mv;
                 }
 
-                JavaTemplate.Builder templateBuilder = JavaTemplate.builder(returnTypeExpression + " __typePlaceholder__").contextSensitive();
+                // javac only recovers from the `;` that `BlockStatementTemplateGenerator` omits when the
+                // enclosing method is the last member of its class. Terminating it in the generator
+                // instead breaks templates applied in non-statement positions.
+                boolean needsSemicolon = getCursor().getParentTreeCursor().getValue() instanceof J.Block;
+                String template = returnTypeExpression + " __typePlaceholder__" + (needsSemicolon ? ";" : "");
+                JavaTemplate.Builder templateBuilder = JavaTemplate.builder(template).contextSensitive();
                 List<String> stubs = synthesizeStubsForTypeAttribution(newReturnType);
                 if (!stubs.isEmpty()) {
                     templateBuilder.javaParser(JavaParser.fromJavaVersion().dependsOn(stubs.toArray(new String[0])));

--- a/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodInvocationReturnTypeTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/ChangeMethodInvocationReturnTypeTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.Issue;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.test.RecipeSpec;
@@ -761,6 +762,152 @@ class ChangeMethodInvocationReturnTypeTest implements RewriteTest {
               class Foo {
                   void foo() {
                       List<String> one = Bar.bar();
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Issue("https://github.com/openrewrite/rewrite/pull/8478")
+    @Test
+    void nestedNewReturnTypeInsideAnonymousClassArgument() {
+        // Both the anonymous class in argument position and the member following the enclosing
+        // method are load-bearing; without either one this templates cleanly.
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodInvocationReturnType("okhttp3.mockwebserver.MockResponse setResponseCode(int)", "mockwebserver3.MockResponse.Builder"))
+            .parser(JavaParser.fromJavaVersion()
+              //language=java
+              .dependsOn(
+                """
+                  package okhttp3.mockwebserver;
+                  public class MockResponse {
+                      public MockResponse setResponseCode(int code) {
+                          return this;
+                      }
+                  }
+                  """,
+                """
+                  package okhttp3.mockwebserver;
+                  public class RecordedRequest {
+                  }
+                  """,
+                """
+                  package okhttp3.mockwebserver;
+                  public abstract class Dispatcher {
+                      public abstract MockResponse dispatch(RecordedRequest request);
+                  }
+                  """,
+                """
+                  package okhttp3.mockwebserver;
+                  public class MockWebServer {
+                      public void setDispatcher(Dispatcher dispatcher) {
+                      }
+                  }
+                  """
+              )
+            ),
+          //language=java
+          java(
+            """
+              import okhttp3.mockwebserver.Dispatcher;
+              import okhttp3.mockwebserver.MockResponse;
+              import okhttp3.mockwebserver.MockWebServer;
+              import okhttp3.mockwebserver.RecordedRequest;
+
+              class Foo {
+                  void foo() {
+                      MockWebServer server = new MockWebServer();
+                      server.setDispatcher(new Dispatcher() {
+                          @Override
+                          public MockResponse dispatch(RecordedRequest request) {
+                              MockResponse response = new MockResponse().setResponseCode(200);
+                              return response;
+                          }
+                      });
+                  }
+
+                  void trailing() {
+                  }
+              }
+              """,
+            """
+              import okhttp3.mockwebserver.Dispatcher;
+              import okhttp3.mockwebserver.MockResponse;
+              import okhttp3.mockwebserver.MockWebServer;
+              import okhttp3.mockwebserver.RecordedRequest;
+
+              class Foo {
+                  void foo() {
+                      MockWebServer server = new MockWebServer();
+                      server.setDispatcher(new Dispatcher() {
+                          @Override
+                          public MockResponse dispatch(RecordedRequest request) {
+                              mockwebserver3.MockResponse.Builder response = new MockResponse().setResponseCode(200);
+                              return response;
+                          }
+                      });
+                  }
+
+                  void trailing() {
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(cu -> new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.VariableDeclarations.NamedVariable visitVariable(J.VariableDeclarations.NamedVariable variable, Integer p) {
+                    if ("response".equals(variable.getSimpleName())) {
+                        assertThat(variable.getType()).satisfies(t ->
+                          assertThat(((JavaType.FullyQualified) t).getFullyQualifiedName())
+                            .isEqualTo("mockwebserver3.MockResponse$Builder"));
+                    }
+                    return super.visitVariable(variable, p);
+                }
+            }.visit(cu, 0))
+          )
+        );
+    }
+
+    @Test
+    void newReturnTypeOnATryWithResourcesVariable() {
+        rewriteRun(
+          spec -> spec.recipe(new ChangeMethodInvocationReturnType("bar.Bar reader()", "java.io.LineNumberReader"))
+            .parser(JavaParser.fromJavaVersion()
+              //language=java
+              .dependsOn(
+                """
+                  package bar;
+                  public class Bar {
+                      public static java.io.BufferedReader reader() {
+                          return null;
+                      }
+                  }
+                  """
+              )
+            ),
+          //language=java
+          java(
+            """
+              import bar.Bar;
+
+              import java.io.BufferedReader;
+
+              class Foo {
+                  void foo() throws Exception {
+                      try (BufferedReader one = Bar.reader()) {
+                      }
+                  }
+              }
+              """,
+            """
+              import bar.Bar;
+
+              import java.io.LineNumberReader;
+
+              class Foo {
+                  void foo() throws Exception {
+                      try (LineNumberReader one = Bar.reader()) {
+                      }
                   }
               }
               """


### PR DESCRIPTION
`ChangeMethodInvocationReturnType` crashes on whole source files with `Expected a template that would generate exactly one statement to replace one statement, but generated 0` — reproduced daily against `rewrite-maven`'s own `MavenPomDownloaderTest`.

`BlockStatementTemplateGenerator` splices a template into the stub without a terminator, so the declaration-shaped `<type> __typePlaceholder__` always makes javac report `';' expected`; javac recovers cleanly only when the enclosing method is the last member of its class, and otherwise collapses the statement into an erroneous tree whose raw text keeps the template marker comments but whose LST carries none, so `listTemplatedTrees` finds nothing. This appends the `;` when the declaration really is a block statement, leaving it off in try-with-resources, for-loop init and parameter positions where the enclosing syntax already supplies one.

Terminating centrally in the generator instead is not viable — statement templates are also applied where a `;` is illegal, which breaks `JavaTemplateTest#assignmentWithinIfPredicate` and `#replaceVariableDeclarationWithFinalVar`.

- Note that #8478's description claims "the template application is also wrapped so a template failure leaves the source unchanged rather than throwing, which makes the pre-existing `null`/`JavaType.Unknown` guard reachable" — that wrapping is not in its merged diff, which is why this signature was previously recorded as having no fix.

Three further pre-existing bugs in this recipe were found and each verified to fail independently on `main`; they are deliberately left for separate PRs: the `null`/`JavaType.Unknown` guard returns the post-`super` tree so the recipe never settles; a `void` `newReturnType` throws (`ClassCastException` on a field); and a malformed `newReturnType` such as `null` or `not a type!` passes validation and then crashes mid-run.