### PR TITLE
Docker: EOL image tests hold fixtures the generated dataset does not list

### DIFF
--- a/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
+++ b/rewrite-docker/src/test/java/org/openrewrite/docker/search/FindEndOfLifeImagesTest.java
@@ -16,6 +16,8 @@
 package org.openrewrite.docker.search;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.docker.table.EolDockerImages;
 import org.openrewrite.test.RecipeSpec;
@@ -205,62 +207,17 @@ class FindEndOfLifeImagesTest implements RewriteTest {
         );
     }
 
-    @Test
-    void currentDebianNotFlagged() {
+    // Every tag here has to be one eol-images.yaml does not list; a release reaching EOL is added to
+    // that file, at which point it belongs among the flagged cases above and a newer tag replaces it.
+    @ParameterizedTest
+    @ValueSource(strings = {"debian:trixie", "ubuntu:24.04", "alpine:3.21", "python:3.12", "node:22"})
+    void currentImageNotFlagged(String image) {
         rewriteRun(
           docker(
             """
-              FROM debian:trixie
-              RUN apt-get update
-              """
-          )
-        );
-    }
-
-    @Test
-    void currentUbuntuNotFlagged() {
-        rewriteRun(
-          docker(
-            """
-              FROM ubuntu:24.04
-              RUN apt-get update
-              """
-          )
-        );
-    }
-
-    @Test
-    void currentAlpineNotFlagged() {
-        rewriteRun(
-          docker(
-            """
-              FROM alpine:3.21
-              RUN apk update
-              """
-          )
-        );
-    }
-
-    @Test
-    void currentPythonNotFlagged() {
-        rewriteRun(
-          docker(
-            """
-              FROM python:3.12
-              RUN pip install flask
-              """
-          )
-        );
-    }
-
-    @Test
-    void currentNodeNotFlagged() {
-        rewriteRun(
-          docker(
-            """
-              FROM node:22
-              RUN npm install
-              """
+              FROM %s
+              RUN echo building
+              """.formatted(image)
           )
         );
     }
@@ -331,15 +288,15 @@ class FindEndOfLifeImagesTest implements RewriteTest {
           ),
           docker(
             """
-              FROM golang:1.25 AS builder
-              RUN go build -o app .
+              FROM debian:trixie AS builder
+              RUN ./build.sh
 
               FROM debian:buster
               COPY --from=builder /app /app
               """,
             """
-              FROM golang:1.25 AS builder
-              RUN go build -o app .
+              FROM debian:trixie AS builder
+              RUN ./build.sh
 
               ~~(EOL: debian:buster (ended 2022-09-10, suggest trixie (13)))~~>FROM debian:buster
               COPY --from=builder /app /app

--- a/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeCompilerPluginRegistrarTest.kt
+++ b/rewrite-kotlin/src/test/kotlin/org/openrewrite/kotlin/recipe/internal/RecipeCompilerPluginRegistrarTest.kt
@@ -13,7 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@file:OptIn(org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class)
+@file:OptIn(
+    org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi::class,
+    org.jetbrains.kotlin.config.CompilerConfiguration.Internals::class,
+)
 package org.openrewrite.kotlin.recipe.internal
 
 import com.tschuchort.compiletesting.KotlinCompilation


### PR DESCRIPTION
`main` has been red since 10:32 today. `FindEndOfLifeImagesTest.mixedEolAndCurrent` fails on every PR, including runs whose diff is confined to `rewrite-javascript` ([run 32964011550](https://github.com/openrewrite/rewrite/actions/runs/32964011550) on `1e343d0c45`):

```
expected:
  Dockerfile,,debian,buster,2022-09-10,"trixie (13)"
but was:
  Dockerfile,builder,golang,1.25,2026-08-19,          <- new row
  Dockerfile,,debian,buster,2022-09-10,"trixie (13)"
```

## What happened

`ca8d398ee4` — `[Auto] EOL Docker images as of 2026-08-26T1032` — added five lines to `eol-images.yaml`:

```yaml
- imageName: golang
  tagPatterns: ["1.25", "1.25.*", "1.25-*"]
  eolDate: "2026-08-19"
```

`mixedEolAndCurrent` used `golang:1.25` as its *supported* stage. The bot published Go 1.25's EOL a week after the fact, and the fixture's premise inverted.

The choice of `golang:1.25` was never viable, though, and neither is any replacement picked the same way. The generator emits images that have **already** reached EOL — all 173 entries have a date in the past, and the newest is the `2026-08-19` one that just landed. So `EolImage.findMatch` returning non-null *means* EOL, and "a tag the dataset lists but still supports" cannot exist. A supported fixture has to be one the file does not list yet.

## The fix

The supported stage is now `debian:trixie` — the replacement the same assertion already recommends for buster, so the two halves of the test agree and expire together. Runway is Debian 13's full-support window rather than a Go minor's six months.

The five `current*NotFlagged` tests are one `@ParameterizedTest`. Each pinned the same line — the `eol == null` early return in `getVisitor()` — with a different image, so they were one test wearing five names, and each carried an independent expiry date. `alpine:3.21` was the next due. As a table the tags sit on one line, and a failure reads `[3] image = "alpine:3.21"`, which names what expired instead of leaving a reader to diff a Dockerfile.

`mixedEolAndCurrent` stays: it is the only test covering per-stage attribution, that the marker lands on the EOL stage rather than the file and that exactly one data-table row is emitted. `multiStageDetectsAllEol` cannot cover it, since both of its stages are EOL.

## What this does not fix

The recurrence, only its blast radius and its legibility. Any fixture named here is one the bot will eventually list, and the test will fail again then — correctly, because at that point the `suggestedReplacement` in the same assertion is stale too and both want updating.

Removing the recurrence entirely means letting the recipe's cutoff be set rather than read from `LocalDate.now()`, so a test can pin a date. That is an API question worth its own discussion, and hand-editing `eol-images.yaml` is not an option — it is bot-owned and would be overwritten within the week.
