### PR TITLE
Make C# comments and formatting reachable through visitors

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/CommentReachabilityTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/CommentReachabilityTests.cs
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+using OpenRewrite.Java;
+
+namespace OpenRewrite.Tests.Tree;
+
+public class CommentReachabilityTests
+{
+    private static bool ProbeReachable(string code)
+    {
+        var cu = new CSharpParser().Parse(code);
+        var probe = new SpaceProbe();
+        probe.Visit(cu, 0);
+        return probe.Found;
+    }
+
+    private static void AssertRoundTrips(string code)
+    {
+        Assert.Equal(code, new CSharpPrinter<int>().Print(new CSharpParser().Parse(code, "Test.cs")));
+    }
+
+    private static void AssertReachable(string code)
+    {
+        Assert.True(ProbeReachable(code),
+            "Expected the PROBE comment to be reachable through VisitSpace, but it never was.");
+        AssertRoundTrips(code);
+    }
+
+    [Fact]
+    public void Control()
+    {
+        AssertReachable(
+            """
+            class Test
+            {
+                // PROBE
+                void M() { }
+            }
+            """);
+    }
+
+    [Fact]
+    public void NullableDirectiveTrailingComment() =>
+        AssertReachable("#nullable enable // PROBE\n\nclass Test { }");
+
+    [Fact]
+    public void DefineDirectiveTrailingComment() =>
+        AssertReachable("#define FOO // PROBE\n\nclass Test { }");
+
+    [Fact]
+    public void UndefDirectiveTrailingComment() =>
+        AssertReachable("#undef FOO // PROBE\n\nclass Test { }");
+
+    [Fact]
+    public void PragmaWarningDirectiveTrailingComment() =>
+        AssertReachable("#pragma warning disable CS0618 // PROBE\n\nclass Test { }");
+
+    [Fact(Skip = "#if/#elif/#else/#endif trivia needs the ConditionalDirective text model reworked")]
+    public void ConditionalDirectiveTrailingComment() =>
+        AssertReachable("#if DEBUG // PROBE\nclass Test { }\n#endif\n");
+
+    [Fact]
+    public void EndRegionDirectiveTrailingComment() =>
+        AssertReachable("#region Helpers\nclass Test { }\n#endregion // PROBE\n");
+
+    [Fact]
+    public void LineDirectiveTrailingComment() =>
+        AssertReachable("#line 5 \"f.cs\" // PROBE\n\nclass Test { }");
+
+    [Fact]
+    public void LineHiddenDirectiveTrailingComment() =>
+        AssertReachable("#line hidden // PROBE\n\nclass Test { }");
+
+    [Fact]
+    public void PragmaChecksumDirectiveTrailingComment() =>
+        AssertReachable(
+            "#pragma checksum \"f.cs\" \"{ff1816ec-aa5e-4d10-87f7-6f4963833460}\" \"ab\" // PROBE\n\nclass Test { }");
+
+    [Fact]
+    public void DirectiveBlockComment() =>
+        AssertReachable("#nullable enable /* PROBE */\n\nclass Test { }");
+
+    [Fact]
+    public void InteriorBlockCommentStaysWithDirective() =>
+        AssertRoundTrips("#pragma warning disable /* PROBE */ CS0618\n\nclass Test { }");
+
+    [Theory]
+    [InlineData("#region Helpers // PROBE\nclass Test { }\n#endregion\n")]
+    [InlineData("#error boom // PROBE\n\nclass Test { }")]
+    [InlineData("#warning boom // PROBE\n\nclass Test { }")]
+    public void PreprocessingMessageIsNotAComment(string code)
+    {
+        Assert.False(ProbeReachable(code),
+            "The rest of the line is a preprocessing message, so it must not become trivia.");
+        AssertRoundTrips(code);
+    }
+
+    [Fact]
+    public void AttributeOnModifiedMethod() =>
+        AssertReachable(
+            """
+            class Test
+            {
+                [System.Obsolete] // PROBE
+                public void M() { }
+            }
+            """);
+
+    [Fact]
+    public void AttributeOnUnmodifiedType() =>
+        AssertReachable("[System.Obsolete] // PROBE\nclass Test { }");
+
+    [Fact]
+    public void AttributeOnAccessor() =>
+        AssertReachable(
+            """
+            class Test
+            {
+                int P
+                {
+                    [System.Obsolete] // PROBE
+                    get { return 1; }
+                }
+            }
+            """);
+
+    [Fact]
+    public void TrailingCommaInEnum() =>
+        AssertReachable(
+            """
+            enum E
+            {
+                A = 1,
+                // PROBE
+            }
+            """);
+
+    [Fact]
+    public void TrailingCommaInCollectionInitializer() =>
+        AssertReachable(
+            """
+            using System.Collections.Generic;
+
+            class Test
+            {
+                void M()
+                {
+                    var d = new List<int>
+                    {
+                        1,
+                        // PROBE
+                    };
+                }
+            }
+            """);
+
+    [Fact]
+    public void ArrayRankSpecifier() =>
+        AssertReachable(
+            """
+            class Test
+            {
+                int[ /* PROBE */ ] A;
+            }
+            """);
+
+    [Fact]
+    public void AttributeOnTypeParameter() =>
+        AssertReachable("class C<[System.Obsolete] // PROBE\n T> { }");
+
+    [Fact]
+    public void GenericTypeArgumentLeadingComment() =>
+        AssertReachable(
+            """
+            using System.Collections.Generic;
+
+            class Test
+            {
+                List</* PROBE */ int> A;
+            }
+            """);
+
+    [Fact]
+    public void GenericTypeArgumentTrailingComment() =>
+        AssertReachable(
+            """
+            using System.Collections.Generic;
+
+            class Test
+            {
+                List<int // PROBE
+                    > A;
+            }
+            """);
+
+    private sealed class SpaceProbe : CSharpVisitor<int>
+    {
+        public bool Found { get; private set; }
+
+        public override Space VisitSpace(Space space, int p)
+        {
+            foreach (var comment in space.Comments)
+            {
+                if (comment.Text.Contains("PROBE"))
+                {
+                    Found = true;
+                }
+            }
+
+            return space;
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/WhitespaceValidatorTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Tree/WhitespaceValidatorTests.cs
@@ -218,6 +218,23 @@ public class WhitespaceValidatorTests
     }
 
     [Fact]
+    public void AttributeOnAccessor()
+    {
+        AssertNoViolations(
+            """
+            class Foo {
+                int P
+                {
+                    [Obsolete]
+                    get { return 1; }
+                    [Obsolete]
+                    private set { }
+                }
+            }
+            """);
+    }
+
+    [Fact]
     public void AttributeOnParameter()
     {
         AssertNoViolations(

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -2288,6 +2288,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var prefix = ExtractPrefix(node);
 
+        var attributeLists = new List<AttributeList>();
+        foreach (var attrList in node.AttributeLists)
+        {
+            attributeLists.Add((AttributeList)Visit(attrList)!);
+        }
+
         // Parse modifiers (like 'private' for private set)
         var modifiers = new List<Modifier>();
         foreach (var mod in node.Modifiers)
@@ -2340,7 +2346,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             Guid.NewGuid(),
             prefix,
             Markers.Empty,
-            [],
+            attributeLists,
             modifiers,
             kind,
             body,
@@ -8876,6 +8882,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             while (contentEnd < targetPosition && _source[contentEnd] != '\r' && _source[contentEnd] != '\n')
                 contentEnd++;
 
+            if (!TakesPreprocessingMessage(keyword))
+            {
+                var commentStart = FindTrailingCommentStart(hashPos, contentEnd);
+                if (commentStart >= 0) contentEnd = commentStart;
+            }
+
             var directiveText = _source[hashPos..contentEnd];
             var directive = ParseDirectiveText(prefix, directiveText);
             if (directive != null)
@@ -8956,6 +8968,58 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var start = pos;
         while (pos < maxPos && char.IsLetter(_source[pos])) pos++;
         return pos > start ? _source[start..pos] : "";
+    }
+
+    private static bool TakesPreprocessingMessage(string keyword) =>
+        keyword is "region" or "error" or "warning";
+
+    private int FindTrailingCommentStart(int from, int to)
+    {
+        var comments = new List<(int Start, int End)>();
+        var i = from;
+        while (i < to)
+        {
+            var c = _source[i];
+            if (c == '"')
+            {
+                i++;
+                while (i < to && _source[i] != '"')
+                    i += _source[i] == '\\' ? 2 : 1;
+                i++;
+            }
+            else if (c == '/' && i + 1 < to && _source[i + 1] == '/')
+            {
+                comments.Add((i, to));
+                break;
+            }
+            else if (c == '/' && i + 1 < to && _source[i + 1] == '*')
+            {
+                var start = i;
+                i += 2;
+                while (i + 1 < to && !(_source[i] == '*' && _source[i + 1] == '/')) i++;
+                i = Math.Min(i + 2, to);
+                comments.Add((start, i));
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        var split = to;
+        while (true)
+        {
+            var scan = split;
+            while (scan > from && (_source[scan - 1] == ' ' || _source[scan - 1] == '\t')) scan--;
+            var index = comments.FindLastIndex(x => x.End == scan);
+            if (index < 0) break;
+            split = comments[index].Start;
+        }
+
+        if (split == to) return -1;
+
+        while (split > from && (_source[split - 1] == ' ' || _source[split - 1] == '\t')) split--;
+        return split;
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrinter.cs
@@ -1144,6 +1144,11 @@ public class CSharpPrinter<P> : CSharpVisitor<PrintOutputCapture<P>>
     {
         BeforeSyntax(accessor, p);
 
+        foreach (var attrList in accessor.AttributeLists)
+        {
+            Visit(attrList, p);
+        }
+
         // Print modifiers
         foreach (var mod in accessor.Modifiers)
         {

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpVisitor.cs
@@ -158,6 +158,16 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         MaybeDoAfterVisit(new AddUsing<P>(fullyQualifiedTypeName, onlyIfReferenced));
     }
 
+    public override Marker VisitMarker(Marker marker, P p)
+    {
+        if (marker is TrailingComma trailingComma)
+        {
+            return trailingComma.WithSuffix(VisitSpace(trailingComma.Suffix, p));
+        }
+
+        return base.VisitMarker(marker, p);
+    }
+
     public virtual J VisitCompilationUnit(CompilationUnit compilationUnit, P p)
     {
         return compilationUnit
@@ -180,6 +190,9 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         if (stmtResult is not UsingDirective node) return stmtResult;
 
         return node
+            .WithGlobal(VisitRightPadded(node.Global, p)!)
+            .WithStatic(VisitLeftPadded(node.Static, p)!)
+            .WithUnsafe(VisitLeftPadded(node.Unsafe, p))
             .WithAlias(VisitRightPadded(node.Alias, p))
             .WithNamespaceOrType((TypeTree)Visit(node.NamespaceOrType, p)!);
     }
@@ -195,6 +208,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
         return node
             .WithAttributeLists(ListUtils.Map(node.AttributeLists, al => Visit(al, p) as AttributeList))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithTypeExpression((TypeTree)Visit(node.TypeExpression, p)!)
             .WithInterfaceSpecifier(VisitRightPadded(node.InterfaceSpecifier, p))
             .WithName((Identifier)Visit(node.Name, p)!)
@@ -214,6 +228,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
         return node
             .WithAttributeLists(ListUtils.Map(node.AttributeLists, al => Visit(al, p) as AttributeList))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
+            .WithKind(VisitLeftPadded(node.Kind, p)!)
             .WithBody((Block?)Visit(node.Body, p))
             .WithExpressionBody(VisitLeftPadded(node.ExpressionBody, p));
     }
@@ -418,6 +434,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
         return node
             .WithAttributeLists(ListUtils.Map(node.AttributeLists, al => Visit(al, p) as AttributeList))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithReturnType((TypeTree?)Visit(node.ReturnType, p))
             .WithLambdaExpression((Lambda)VisitLambda(node.LambdaExpression, p)!);
     }
@@ -432,6 +449,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         if (exprResult is not RelationalPattern node) return exprResult;
 
         return node
+            .WithOperator(VisitLeftPadded(node.Operator, p)!)
             .WithValue((Expression)Visit(node.Value, p)!);
     }
 
@@ -456,6 +474,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithPrefix(VisitSpace(ctp.Prefix, p))
             .WithMarkers(VisitMarkers(ctp.Markers, p))
             .WithAttributeLists(ListUtils.Map(ctp.AttributeLists, al => Visit(al, p) as AttributeList))
+            .WithVariance(VisitLeftPadded(ctp.Variance, p))
             .WithName((Identifier)Visit(ctp.Name, p)!)
             .WithWhereConstraint(VisitLeftPadded(ctp.WhereConstraint, p))
             .WithConstraints(VisitContainer(ctp.Constraints, p))
@@ -587,6 +606,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         if (stmtResult is not PragmaWarningDirective node) return stmtResult;
 
         return node
+            .WithKeywordSpacing(VisitSpace(node.KeywordSpacing, p))
+            .WithActionSpacing(VisitSpace(node.ActionSpacing, p))
             .WithWarningCodes(ListUtils.Map(node.WarningCodes, c => VisitRightPadded(c, p)));
     }
 
@@ -599,7 +620,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         var stmtResult = VisitStatement(pragmaChecksumDirective, p);
         if (stmtResult is not PragmaChecksumDirective node) return stmtResult;
 
-        return node;
+        return node.WithKeywordSpacing(VisitSpace(node.KeywordSpacing, p));
     }
 
     public virtual J VisitNullableDirective(NullableDirective nullableDirective, P p)
@@ -802,6 +823,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
         return node
             .WithAttributeLists(ListUtils.Map(node.AttributeLists, al => Visit(al, p) as AttributeList))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithTypeExpressionPadded(VisitLeftPadded(node.TypeExpressionPadded, p)!)
             .WithName((Identifier)Visit(node.Name, p)!)
             .WithInterfaceSpecifier(VisitRightPadded(node.InterfaceSpecifier, p))
@@ -819,6 +841,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
         return node
             .WithLeft((Expression)Visit(node.Left, p)!)
+            .WithOperator(VisitLeftPadded(node.Operator, p)!)
             .WithRight((Expression)Visit(node.Right, p)!)
             .WithType((JavaType?)VisitType(node.Type, p));
     }
@@ -988,6 +1011,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         if (exprResult is not CsUnary node) return exprResult;
 
         return node
+            .WithOperator(VisitLeftPadded(node.Operator, p)!)
             .WithExpression((Expression)Visit(node.Expression, p)!)
             .WithType((JavaType?)VisitType(node.Type, p));
     }
@@ -1142,6 +1166,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         if (stmtResult is not IndexerDeclaration node) return stmtResult;
 
         return node
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithTypeExpression((TypeTree)Visit(node.TypeExpression, p)!)
             .WithExplicitInterfaceSpecifier(VisitRightPadded(node.ExplicitInterfaceSpecifier, p))
             .WithIndexer((Expression)Visit(node.Indexer, p)!)
@@ -1161,6 +1186,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
         return node
             .WithAttributes(ListUtils.Map(node.Attributes, al => Visit(al, p) as AttributeList))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithReturnType(VisitLeftPadded(node.ReturnType, p)!)
             .WithIdentifierName((Identifier)Visit(node.IdentifierName, p)!)
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
@@ -1177,6 +1203,8 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         if (stmtResult is not ConversionOperatorDeclaration node) return stmtResult;
 
         return node
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
+            .WithKind(VisitLeftPadded(node.Kind, p)!)
             .WithInterfaceSpecifier(VisitRightPadded(node.InterfaceSpecifier, p))
             .WithReturnType(VisitLeftPadded(node.ReturnType, p)!)
             .WithParameters(VisitContainer(node.Parameters, p)!)
@@ -1195,9 +1223,11 @@ public class CSharpVisitor<P> : JavaVisitor<P>
 
         return node
             .WithAttributeLists(ListUtils.Map(node.AttributeLists, al => Visit(al, p) as AttributeList))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithExplicitInterfaceSpecifier(VisitRightPadded(node.ExplicitInterfaceSpecifier, p))
             .WithOperatorKeyword((Keyword)Visit(node.OperatorKeyword, p)!)
             .WithCheckedKeyword((Keyword?)Visit(node.CheckedKeyword, p))
+            .WithOperatorToken(VisitLeftPadded(node.OperatorToken, p)!)
             .WithReturnType((TypeTree)Visit(node.ReturnType, p)!)
             .WithParameters(VisitContainer(node.Parameters, p)!)
             .WithBody((Block)Visit(node.Body, p)!)
@@ -1217,6 +1247,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
             .WithAttributeLists(node.AttributeLists != null
                 ? ListUtils.Map(node.AttributeLists, al => Visit(al, p) as AttributeList)
                 : null)
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithNamePadded(VisitLeftPadded(node.NamePadded, p)!)
             .WithBaseType(VisitLeftPadded(node.BaseType, p))
             .WithMembers(VisitContainer(node.Members, p));
@@ -1470,6 +1501,7 @@ public class CSharpVisitor<P> : JavaVisitor<P>
         if (exprResult is not FunctionPointerType node) return exprResult;
 
         return node
+            .WithCallingConvention(VisitLeftPadded(node.CallingConvention, p))
             .WithUnmanagedCallingConventionTypes(VisitContainer(node.UnmanagedCallingConventionTypes, p))
             .WithParameterTypes(VisitContainer(node.ParameterTypes, p)!)
             .WithType((JavaType?)VisitType(node.Type, p));

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/MinimumViableSpacingVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/MinimumViableSpacingVisitor.cs
@@ -30,6 +30,18 @@ namespace OpenRewrite.CSharp.Format;
 /// </summary>
 public class MinimumViableSpacingVisitor : CSharpVisitor<int>
 {
+    public override J VisitAnnotatedStatement(AnnotatedStatement annotatedStatement, int p)
+    {
+        var a = (AnnotatedStatement)base.VisitAnnotatedStatement(annotatedStatement, p);
+
+        if (a.AttributeLists.Count > 0)
+        {
+            a = a.WithStatement((Statement)EnsureSpace(a.Statement));
+        }
+
+        return a;
+    }
+
     public override J VisitClassDeclaration(ClassDeclaration classDecl, int p)
     {
         var c = (ClassDeclaration)base.VisitClassDeclaration(classDecl, p);

--- a/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/JavaVisitor.cs
@@ -29,6 +29,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         return tree switch
         {
             Annotation ann => VisitAnnotation(ann, p),
+            Modifier mod => VisitModifier(mod, p),
             Block blk => VisitBlock(blk, p),
             ClassDeclaration cd => VisitClassDeclaration(cd, p),
             EnumValueSet evs => VisitEnumValueSet(evs, p),
@@ -228,6 +229,19 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithArguments(VisitContainer(node.Arguments, p));
     }
 
+    public virtual J VisitModifier(Modifier modifier, P p)
+    {
+        return modifier
+            .WithPrefix(VisitSpace(modifier.Prefix, p))
+            .WithMarkers(VisitMarkers(modifier.Markers, p))
+            .WithAnnotations(ListUtils.Map(modifier.Annotations, ann => Visit(ann, p) as Annotation));
+    }
+
+    protected IList<Modifier> VisitModifiers(IList<Modifier> modifiers, P p)
+    {
+        return ListUtils.Map(modifiers, m => Visit(m, p) as Modifier);
+    }
+
     // -----------------------------------------------------------------------
     // Block : Statement
     // -----------------------------------------------------------------------
@@ -241,6 +255,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         if (stmtResult is not Block node) return stmtResult;
 
         return node
+            .WithStatic(VisitRightPadded(node.Static, p)!)
             .WithEnd(VisitSpace(node.End, p))
             .WithStatements(ListUtils.Map(node.Statements, stmt => VisitRightPadded(stmt, p)));
     }
@@ -261,7 +276,10 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
         return node
             .WithLeadingAnnotations(ListUtils.Map(node.LeadingAnnotations, ann => Visit(ann, p) as Annotation))
-            .WithClassKind(node.ClassKind.WithAnnotations(newKindAnnotations))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
+            .WithClassKind(node.ClassKind
+                .WithPrefix(VisitSpace(node.ClassKind.Prefix, p))
+                .WithAnnotations(newKindAnnotations))
             .WithName((Identifier)Visit(node.Name, p)!)
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
             .WithPrimaryConstructor(VisitContainer(node.PrimaryConstructor, p))
@@ -315,6 +333,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
         return node
             .WithLeadingAnnotations(ListUtils.Map(node.LeadingAnnotations, ann => Visit(ann, p) as Annotation))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithTypeParameters(VisitContainer(node.TypeParameters, p))
             .WithReturnTypeExpression((TypeTree?)Visit(node.ReturnTypeExpression, p))
             .WithName((Identifier)Visit(node.Name, p)!)
@@ -762,6 +781,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
         return node
             .WithVariable((Expression)Visit(node.Variable, p)!)
+            .WithOperator(VisitLeftPadded(node.Operator, p)!)
             .WithAssignmentValue((Expression)Visit(node.AssignmentValue, p)!)
             .WithType(VisitType(node.Type, p));
     }
@@ -782,6 +802,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         if (exprResult is not Unary node) return exprResult;
 
         return node
+            .WithOperator(VisitLeftPadded(node.Operator, p)!)
             .WithExpression((Expression)Visit(node.Expression, p)!)
             .WithType(VisitType(node.Type, p));
     }
@@ -830,6 +851,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
 
         return node
             .WithLeadingAnnotations(ListUtils.Map(node.LeadingAnnotations, ann => Visit(ann, p) as Annotation))
+            .WithModifiers(VisitModifiers(node.Modifiers, p))
             .WithTypeExpression((TypeTree?)Visit(node.TypeExpression, p))
             .WithVarargs(node.Varargs != null ? VisitSpace(node.Varargs, p) : null)
             .WithVariables(ListUtils.Map(node.Variables, v => VisitRightPadded(v, p)));
@@ -996,10 +1018,18 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
         var exprResult = VisitExpression(at, p);
         if (exprResult is not ArrayType node) return exprResult;
 
-        return node
+        node = node
             .WithElementType((TypeTree)Visit(node.ElementType, p)!)
-            .WithAnnotations(node.Annotations != null ? ListUtils.Map(node.Annotations, ann => Visit(ann, p) as Annotation) : null)
-            .WithType(VisitType(node.Type, p));
+            .WithAnnotations(node.Annotations != null ? ListUtils.Map(node.Annotations, ann => Visit(ann, p) as Annotation) : null);
+
+        if (node.Dimension != null)
+        {
+            node = node.WithDimension(node.Dimension
+                .WithBefore(VisitSpace(node.Dimension.Before, p))
+                .WithElement(VisitSpace(node.Dimension.Element, p)));
+        }
+
+        return node.WithType(VisitType(node.Type, p));
     }
 
     // -----------------------------------------------------------------------
@@ -1192,6 +1222,7 @@ public class JavaVisitor<P> : TreeVisitor<J, P>
             .WithPrefix(VisitSpace(typeParameter.Prefix, p))
             .WithMarkers(VisitMarkers(typeParameter.Markers, p))
             .WithAnnotations(ListUtils.Map(typeParameter.Annotations, ann => Visit(ann, p) as Annotation))
+            .WithModifiers(VisitModifiers(typeParameter.Modifiers, p))
             .WithName((Expression)Visit(typeParameter.Name, p)!)
             .WithBounds(VisitContainer(typeParameter.Bounds, p));
     }


### PR DESCRIPTION
Comments attached to preprocessor directives, accessor attribute lists, array rank specifiers, and trailing commas were unreachable from `VisitSpace`, so visitors could neither see nor rewrite them.

The parser now treats a trailing `//` or `/* */` on a directive as trivia, except for `#region`, `#error`, and `#warning`, where the rest of the line is a preprocessing message rather than a comment. Attribute lists on accessor declarations are now parsed, printed, and visited, and `MinimumViableSpacingVisitor` keeps a space after an annotated statement's attributes.

`JavaVisitor` and `CSharpVisitor` also now descend into many previously-skipped padded/space fields — modifiers (via a new `VisitModifier`), operators, block `static`, array dimensions, type parameter variance, pragma spacing, and the `TrailingComma` marker suffix.

New `CommentReachabilityTests` pins this down with a probe visitor that asserts a marker comment is reachable through `VisitSpace` and that the source round-trips; one `#if`/`#elif` case is skipped pending a rework of the `ConditionalDirective` text model.