### PR TITLE
RFC: model XAML in the XML LST (type attestation + value layer)

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/Xml/TagExtensions.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/TagExtensions.cs
@@ -71,7 +71,7 @@ public static class TagExtensions
         foreach (var attr in tag.Attributes)
         {
             if (string.Equals(attr.Key.Name, attrName, StringComparison.OrdinalIgnoreCase))
-                return attr.Val.Val;
+                return attr.Val is Attribute.Value value ? value.Val : null;
         }
         return null;
     }
@@ -86,7 +86,9 @@ public static class TagExtensions
         {
             if (string.Equals(attrs[i].Key.Name, attrName, StringComparison.OrdinalIgnoreCase))
             {
-                attrs[i] = attrs[i].WithVal(attrs[i].Val.WithVal(newValue));
+                if (attrs[i].Val is not Attribute.Value value)
+                    return tag;
+                attrs[i] = attrs[i].WithVal(value.WithVal(newValue));
                 return tag.WithAttributes(attrs);
             }
         }

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/Xml.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/Xml.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 using OpenRewrite.Core;
+using OpenRewrite.Java;
 
 namespace OpenRewrite.Xml;
 
@@ -173,7 +174,23 @@ public sealed class Tag : Xml, Content
     public Closing? ClosingTag { get; }
     public string BeforeTagDelimiterPrefix { get; }
 
-    public Tag(Guid id, string prefix, Markers markers, string name, IList<Attribute> attributes, IList<Content>? contentList, Closing? closingTag, string beforeTagDelimiterPrefix)
+    /// <summary>
+    /// XAML attestation: the resolved type of the element this tag denotes. Null for
+    /// plain XML documents and for unresolved XAML.
+    ///
+    ///   object element            &lt;Button ...&gt;         the control class
+    ///   property element          &lt;Button.Content&gt;     the property on the enclosing
+    ///                                                  element's type
+    ///   attached property element &lt;Grid.Row&gt; (inside a  the attached member on the
+    ///                             non-Grid child)      foreign owner type
+    ///
+    /// The name string stays verbatim (possibly xmlns-prefixed and/or dotted);
+    /// attestation resolves the parts. Distinguishing the three roles is this slot's
+    /// job, never a node-shape difference.
+    /// </summary>
+    public JavaType? Type { get; }
+
+    public Tag(Guid id, string prefix, Markers markers, string name, IList<Attribute> attributes, IList<Content>? contentList, Closing? closingTag, string beforeTagDelimiterPrefix, JavaType? type = null)
     {
         Id = id;
         Prefix = prefix;
@@ -183,16 +200,18 @@ public sealed class Tag : Xml, Content
         ContentList = contentList;
         ClosingTag = closingTag;
         BeforeTagDelimiterPrefix = beforeTagDelimiterPrefix;
+        Type = type;
     }
 
-    public Tree WithId(Guid id) => id == Id ? this : new Tag(id, Prefix, Markers, Name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix);
-    public Tag WithPrefix(string prefix) => prefix == Prefix ? this : new Tag(Id, prefix, Markers, Name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix);
-    public Tag WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Tag(Id, Prefix, markers, Name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix);
-    public Tag WithName(string name) => name == Name ? this : new Tag(Id, Prefix, Markers, name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix);
-    public Tag WithAttributes(IList<Attribute> attributes) => ReferenceEquals(attributes, Attributes) ? this : new Tag(Id, Prefix, Markers, Name, attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix);
-    public Tag WithContentList(IList<Content>? contentList) => ReferenceEquals(contentList, ContentList) ? this : new Tag(Id, Prefix, Markers, Name, Attributes, contentList, ClosingTag, BeforeTagDelimiterPrefix);
-    public Tag WithClosingTag(Closing? closingTag) => ReferenceEquals(closingTag, ClosingTag) ? this : new Tag(Id, Prefix, Markers, Name, Attributes, ContentList, closingTag, BeforeTagDelimiterPrefix);
-    public Tag WithBeforeTagDelimiterPrefix(string beforeTagDelimiterPrefix) => beforeTagDelimiterPrefix == BeforeTagDelimiterPrefix ? this : new Tag(Id, Prefix, Markers, Name, Attributes, ContentList, ClosingTag, beforeTagDelimiterPrefix);
+    public Tree WithId(Guid id) => id == Id ? this : new Tag(id, Prefix, Markers, Name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix, Type);
+    public Tag WithPrefix(string prefix) => prefix == Prefix ? this : new Tag(Id, prefix, Markers, Name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix, Type);
+    public Tag WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Tag(Id, Prefix, markers, Name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix, Type);
+    public Tag WithName(string name) => name == Name ? this : new Tag(Id, Prefix, Markers, name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix, Type);
+    public Tag WithAttributes(IList<Attribute> attributes) => ReferenceEquals(attributes, Attributes) ? this : new Tag(Id, Prefix, Markers, Name, attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix, Type);
+    public Tag WithContentList(IList<Content>? contentList) => ReferenceEquals(contentList, ContentList) ? this : new Tag(Id, Prefix, Markers, Name, Attributes, contentList, ClosingTag, BeforeTagDelimiterPrefix, Type);
+    public Tag WithClosingTag(Closing? closingTag) => ReferenceEquals(closingTag, ClosingTag) ? this : new Tag(Id, Prefix, Markers, Name, Attributes, ContentList, closingTag, BeforeTagDelimiterPrefix, Type);
+    public Tag WithBeforeTagDelimiterPrefix(string beforeTagDelimiterPrefix) => beforeTagDelimiterPrefix == BeforeTagDelimiterPrefix ? this : new Tag(Id, Prefix, Markers, Name, Attributes, ContentList, ClosingTag, beforeTagDelimiterPrefix, Type);
+    public Tag WithType(JavaType? type) => ReferenceEquals(type, Type) ? this : new Tag(Id, Prefix, Markers, Name, Attributes, ContentList, ClosingTag, BeforeTagDelimiterPrefix, type);
 
     public sealed class Closing : Xml
     {
@@ -226,9 +245,9 @@ public sealed class Attribute : Xml
     public Markers Markers { get; }
     public Ident Key { get; }
     public string BeforeEquals { get; }
-    public Value Val { get; }
+    public AttributeValue Val { get; }
 
-    public Attribute(Guid id, string prefix, Markers markers, Ident key, string beforeEquals, Value val)
+    public Attribute(Guid id, string prefix, Markers markers, Ident key, string beforeEquals, AttributeValue val)
     {
         Id = id;
         Prefix = prefix;
@@ -243,9 +262,65 @@ public sealed class Attribute : Xml
     public Attribute WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Attribute(Id, Prefix, markers, Key, BeforeEquals, Val);
     public Attribute WithKey(Ident key) => ReferenceEquals(key, Key) ? this : new Attribute(Id, Prefix, Markers, key, BeforeEquals, Val);
     public Attribute WithBeforeEquals(string beforeEquals) => beforeEquals == BeforeEquals ? this : new Attribute(Id, Prefix, Markers, Key, beforeEquals, Val);
-    public Attribute WithVal(Value val) => ReferenceEquals(val, Val) ? this : new Attribute(Id, Prefix, Markers, Key, BeforeEquals, val);
+    public Attribute WithVal(AttributeValue val) => ReferenceEquals(val, Val) ? this : new Attribute(Id, Prefix, Markers, Key, BeforeEquals, val);
 
-    public sealed class Value : Xml
+    /// <summary>
+    /// The polymorphic attribute-value slot — THE structural change XAML requires
+    /// of the XML model. Plain XML attribute values are string leaves (Value,
+    /// unchanged); XAML attribute values may instead carry a parsed expression tree
+    /// (ExpressionValue) because markup extensions nest:
+    ///
+    ///   Text="hello"                              Value (exactly as today)
+    ///   Text="{Binding Path=FirstName}"           ExpressionValue(MarkupExtension)
+    ///   Text="{Binding Converter={StaticResource c}}"  nested extension tree
+    ///   Text="{}{not an extension}"               Value — a value starting with the
+    ///                                             {} escape is by definition plain
+    ///                                             text, never an extension
+    ///
+    /// XML documents are untouched: their values remain Value instances, so existing
+    /// serialized LSTs deserialize unchanged.
+    /// </summary>
+    public interface AttributeValue : Xml
+    {
+    }
+
+    /// <summary>
+    /// A XAML attribute value holding a parsed expression rather than a raw string.
+    /// Quote style is preserved exactly as in Value; After captures the gap between
+    /// the end of the expression and the closing quote:
+    ///
+    ///   Text="{Binding X} "     After = " "  (WPF rejects trailing whitespace at
+    ///                           load — SR.WhitespaceAfterME — but files ship with
+    ///                           it, so the model must round-trip it)
+    /// </summary>
+    public sealed class ExpressionValue : AttributeValue
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public Value.Quote QuoteStyle { get; }
+        public Expression Expr { get; }
+        public string After { get; }
+
+        public ExpressionValue(Guid id, string prefix, Markers markers, Value.Quote quoteStyle, Expression expr, string after)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            QuoteStyle = quoteStyle;
+            Expr = expr;
+            After = after;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new ExpressionValue(id, Prefix, Markers, QuoteStyle, Expr, After);
+        public ExpressionValue WithPrefix(string prefix) => prefix == Prefix ? this : new ExpressionValue(Id, prefix, Markers, QuoteStyle, Expr, After);
+        public ExpressionValue WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new ExpressionValue(Id, Prefix, markers, QuoteStyle, Expr, After);
+        public ExpressionValue WithQuoteStyle(Value.Quote quoteStyle) => quoteStyle == QuoteStyle ? this : new ExpressionValue(Id, Prefix, Markers, quoteStyle, Expr, After);
+        public ExpressionValue WithExpr(Expression expr) => ReferenceEquals(expr, Expr) ? this : new ExpressionValue(Id, Prefix, Markers, QuoteStyle, expr, After);
+        public ExpressionValue WithAfter(string after) => after == After ? this : new ExpressionValue(Id, Prefix, Markers, QuoteStyle, Expr, after);
+    }
+
+    public sealed class Value : AttributeValue
     {
         public enum Quote { Double, Single }
 
@@ -408,18 +483,40 @@ public sealed class Ident : Xml
     public Markers Markers { get; }
     public string Name { get; }
 
-    public Ident(Guid id, string prefix, Markers markers, string name)
+    /// <summary>
+    /// XAML attestation: the resolved meaning of this name token. Null for plain XML
+    /// and for unresolved XAML. This slot is what gives tokens semantic identity
+    /// WITHOUT node-type proliferation:
+    ///
+    ///   attribute key      Mode           the Binding.Mode property
+    ///   attribute key      Click          the routed event
+    ///   directive key      x:Name         the XAML language directive
+    ///   extension name     Binding        the extension class (spelling verbatim,
+    ///                                     incl. the optional "Extension" suffix)
+    ///   path member        Customer       the CLR property (JavaType.Variable) —
+    ///                                     the hook that propagates ViewModel
+    ///                                     renames into XAML
+    ///
+    /// The name string is verbatim source, including any xmlns prefix and dots
+    /// (local:MyControl, Grid.Column); attestation resolves the parts. Never
+    /// normalized.
+    /// </summary>
+    public JavaType? Type { get; }
+
+    public Ident(Guid id, string prefix, Markers markers, string name, JavaType? type = null)
     {
         Id = id;
         Prefix = prefix;
         Markers = markers;
         Name = name;
+        Type = type;
     }
 
-    public Tree WithId(Guid id) => id == Id ? this : new Ident(id, Prefix, Markers, Name);
-    public Ident WithPrefix(string prefix) => prefix == Prefix ? this : new Ident(Id, prefix, Markers, Name);
-    public Ident WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Ident(Id, Prefix, markers, Name);
-    public Ident WithName(string name) => name == Name ? this : new Ident(Id, Prefix, Markers, name);
+    public Tree WithId(Guid id) => id == Id ? this : new Ident(id, Prefix, Markers, Name, Type);
+    public Ident WithPrefix(string prefix) => prefix == Prefix ? this : new Ident(Id, prefix, Markers, Name, Type);
+    public Ident WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Ident(Id, Prefix, markers, Name, Type);
+    public Ident WithName(string name) => name == Name ? this : new Ident(Id, Prefix, Markers, name, Type);
+    public Ident WithType(JavaType? type) => ReferenceEquals(type, Type) ? this : new Ident(Id, Prefix, Markers, Name, type);
 }
 
 public sealed class JspDirective : Xml, Content
@@ -534,4 +631,700 @@ public sealed class JspComment : Xml, Content, Misc
     public JspComment WithPrefix(string prefix) => prefix == Prefix ? this : new JspComment(Id, prefix, Markers, JspContent);
     public JspComment WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new JspComment(Id, Prefix, markers, JspContent);
     public JspComment WithJspContent(string jspContent) => jspContent == JspContent ? this : new JspComment(Id, Prefix, Markers, jspContent);
+}
+
+// ============================================================================
+// XAML VALUE LAYER — the attribute-value / binding mini-language.
+//
+// Everything below exists to cover XAML (WPF, UWP/WinUI incl. x:Bind,
+// Xamarin.Forms / .NET MAUI, Avalonia, legacy Silverlight) on top of the XML
+// model. Plain XML documents never contain these nodes. This section MUST stay in
+// perfect structural sync with the Java side (Xml.java, XAML VALUE LAYER).
+//
+// Modelling rules (same as the rest of this file): prefix = all whitespace left
+// of the node's first token; interior gaps get named Before* fields; punctuation
+// is implicit (an optional token's presence is a non-null Before* field). Parse
+// is purely syntactic — semantics attach afterwards as JavaType attestation.
+// Literal text is the RAW source slice (quotes kept, escapes unresolved); any
+// value text outside the closed grammar stays a verbatim Literal, never a parse
+// error (e.g. MAUI expression bindings "{Binding Price * this.TaxRate}").
+// ============================================================================
+
+/// <summary>
+/// Anything legal in a XAML value position: an attribute value expression, a
+/// markup-extension argument, a function-call argument. Implementations:
+/// Literal, MarkupExtension, PropertyPath, Negation, TypeName.
+/// </summary>
+public interface Expression : Xml;
+
+/// <summary>
+/// Verbatim uninterpreted text in a value position — the most common node.
+/// Text is the EXACT source slice: surrounding ' or " quotes kept, backslash
+/// escapes (WPF/MAUI) and caret escapes (WPF indexer params) unresolved, leading
+/// {} escape kept, interior whitespace kept. Covers plain values, enum keyword
+/// tokens (Mode=TwoWay, FindAncestor — attest to the enum member), event handler
+/// names (attest to the handler method), resource keys, quoted args
+/// (ConverterParameter='a, b'), mixed quoting (Text=abc'def', MAUI), balanced
+/// braces inside unquoted values ({Binding Foo{Bar}}, WPF v3 compat), x:Bind
+/// constants, and the fallback for any value text outside the closed grammar.
+/// </summary>
+public sealed class Literal : Expression
+{
+    public Guid Id { get; }
+    public string Prefix { get; }
+    public Markers Markers { get; }
+    public string Text { get; }
+    public JavaType? Type { get; }
+
+    public Literal(Guid id, string prefix, Markers markers, string text, JavaType? type = null)
+    {
+        Id = id;
+        Prefix = prefix;
+        Markers = markers;
+        Text = text;
+        Type = type;
+    }
+
+    public Tree WithId(Guid id) => id == Id ? this : new Literal(id, Prefix, Markers, Text, Type);
+    public Literal WithPrefix(string prefix) => prefix == Prefix ? this : new Literal(Id, prefix, Markers, Text, Type);
+    public Literal WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Literal(Id, Prefix, markers, Text, Type);
+    public Literal WithText(string text) => text == Text ? this : new Literal(Id, Prefix, Markers, text, Type);
+    public Literal WithType(JavaType? type) => ReferenceEquals(type, Type) ? this : new Literal(Id, Prefix, Markers, Text, type);
+}
+
+/// <summary>
+/// A markup extension — ONE node type for every extension kind in every dialect
+/// (WPF {Binding}/{StaticResource}/{RelativeSource}/{x:Static}/..., WinUI
+/// {ThemeResource}/{x:Bind}, MAUI {AppThemeBinding}/{OnPlatform}, Avalonia
+/// {CompiledBinding}/{ReflectionBinding}, any third-party extension). Which one it
+/// is = attestation on TypeName (xmlns resolution; WPF/MAUI try both the literal
+/// name and name+"Extension" — TypeName keeps the source spelling), never a
+/// subclass.
+///
+/// Token/field map for "{ Binding  Path=FirstName , Mode=TwoWay }": Prefix before
+/// the brace (or before the quote when quoted); TypeName.Prefix after the brace;
+/// each Argument owns its leading trivia via Prefix and the gap before its
+/// trailing comma via BeforeComma; BeforeClosingBrace before the closing brace.
+/// Nesting is direct tree recursion ({Binding Converter={StaticResource conv}});
+/// a nested extension may itself be QUOTED (Converter='{...}') — non-null Quote,
+/// wrapping the braces tightly. WPF enforces positional-before-named; MAUI allows
+/// interleaving — the order-preserving list represents both.
+///
+/// Implements Content: extension syntax is legal initialization text —
+/// &lt;TextBlock.Text&gt;{Binding Foo}&lt;/TextBlock.Text&gt;.
+/// </summary>
+public sealed class MarkupExtension : Expression, Content
+{
+    public Guid Id { get; }
+    public string Prefix { get; }
+    public Markers Markers { get; }
+    public Attribute.Value.Quote? Quote { get; }
+    public Ident TypeName { get; }
+    public IList<Argument> Arguments { get; }
+    public string BeforeClosingBrace { get; }
+
+    public MarkupExtension(Guid id, string prefix, Markers markers, Attribute.Value.Quote? quote, Ident typeName, IList<Argument> arguments, string beforeClosingBrace)
+    {
+        Id = id;
+        Prefix = prefix;
+        Markers = markers;
+        Quote = quote;
+        TypeName = typeName;
+        Arguments = arguments;
+        BeforeClosingBrace = beforeClosingBrace;
+    }
+
+    public Tree WithId(Guid id) => id == Id ? this : new MarkupExtension(id, Prefix, Markers, Quote, TypeName, Arguments, BeforeClosingBrace);
+    public MarkupExtension WithPrefix(string prefix) => prefix == Prefix ? this : new MarkupExtension(Id, prefix, Markers, Quote, TypeName, Arguments, BeforeClosingBrace);
+    public MarkupExtension WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new MarkupExtension(Id, Prefix, markers, Quote, TypeName, Arguments, BeforeClosingBrace);
+    public MarkupExtension WithQuote(Attribute.Value.Quote? quote) => quote == Quote ? this : new MarkupExtension(Id, Prefix, Markers, quote, TypeName, Arguments, BeforeClosingBrace);
+    public MarkupExtension WithTypeName(Ident typeName) => ReferenceEquals(typeName, TypeName) ? this : new MarkupExtension(Id, Prefix, Markers, Quote, typeName, Arguments, BeforeClosingBrace);
+    public MarkupExtension WithArguments(IList<Argument> arguments) => ReferenceEquals(arguments, Arguments) ? this : new MarkupExtension(Id, Prefix, Markers, Quote, TypeName, arguments, BeforeClosingBrace);
+    public MarkupExtension WithBeforeClosingBrace(string beforeClosingBrace) => beforeClosingBrace == BeforeClosingBrace ? this : new MarkupExtension(Id, Prefix, Markers, Quote, TypeName, Arguments, beforeClosingBrace);
+}
+
+/// <summary>
+/// One argument of a MarkupExtension or an x:Bind function call. Positional and
+/// named forms are ONE node distinguished by Name nullability — mirroring how the
+/// WPF scanner itself disambiguates (a value run that hits '=' is re-labelled
+/// PropertyName; there is no parser lookahead). Positional: {Binding FirstName}
+/// (Name null, Value PropertyPath), {StaticResource key} (Value Literal). Named:
+/// Mode=TwoWay (Name attests to Binding.Mode, Value attests to the enum member).
+/// BeforeComma is the gap before the trailing comma separator, null on the last
+/// argument (the gap before the closing brace is
+/// MarkupExtension.BeforeClosingBrace).
+/// </summary>
+public sealed class Argument : Xml
+{
+    public Guid Id { get; }
+    public string Prefix { get; }
+    public Markers Markers { get; }
+    public Ident? Name { get; }
+    /// <summary>Whitespace before '='; null iff positional.</summary>
+    public string? BeforeEquals { get; }
+    public Expression Value { get; }
+    /// <summary>Whitespace before the following ','; null on the last argument.</summary>
+    public string? BeforeComma { get; }
+
+    public Argument(Guid id, string prefix, Markers markers, Ident? name, string? beforeEquals, Expression value, string? beforeComma)
+    {
+        Id = id;
+        Prefix = prefix;
+        Markers = markers;
+        Name = name;
+        BeforeEquals = beforeEquals;
+        Value = value;
+        BeforeComma = beforeComma;
+    }
+
+    public Tree WithId(Guid id) => id == Id ? this : new Argument(id, Prefix, Markers, Name, BeforeEquals, Value, BeforeComma);
+    public Argument WithPrefix(string prefix) => prefix == Prefix ? this : new Argument(Id, prefix, Markers, Name, BeforeEquals, Value, BeforeComma);
+    public Argument WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Argument(Id, Prefix, markers, Name, BeforeEquals, Value, BeforeComma);
+    public Argument WithName(Ident? name) => ReferenceEquals(name, Name) ? this : new Argument(Id, Prefix, Markers, name, BeforeEquals, Value, BeforeComma);
+    public Argument WithBeforeEquals(string? beforeEquals) => beforeEquals == BeforeEquals ? this : new Argument(Id, Prefix, Markers, Name, beforeEquals, Value, BeforeComma);
+    public Argument WithValue(Expression value) => ReferenceEquals(value, Value) ? this : new Argument(Id, Prefix, Markers, Name, BeforeEquals, value, BeforeComma);
+    public Argument WithBeforeComma(string? beforeComma) => beforeComma == BeforeComma ? this : new Argument(Id, Prefix, Markers, Name, BeforeEquals, Value, beforeComma);
+}
+
+/// <summary>
+/// The property-path mini-language: the value of Path= / the positional path of
+/// {Binding}, {x:Bind}, {TemplateBinding}, {CompiledBinding}, MAUI/XF bindings.
+/// A flat sequence of segments; each segment records the ACCESSOR token that
+/// precedes it. There is no whole-path stream flag — the caret is a segment
+/// (Avalonia allows it mid-path and repeated).
+///
+///   Customer.Address[0].(Validation.Errors)[0].ErrorContent
+///
+/// Special shapes: empty path ({Binding} — Segments empty, bind to the source);
+/// bare dot (Path=. — one Property, accessor Dot, empty name); leading slash
+/// (/Items/Name — WPF collection-view current item); leading dots kept in member
+/// names (.Foo, WPF XLinq); Avalonia streams (Foo^.Bar^, ^, .^); null-conditional
+/// (Foo?.Bar). Path text outside this closed grammar stays a verbatim Literal.
+/// WPF trims segment-interior whitespace when it parses; this model stores
+/// exactly what the source had.
+/// </summary>
+public sealed class PropertyPath : Expression
+{
+    public Guid Id { get; }
+    public string Prefix { get; }
+    public Markers Markers { get; }
+    public IList<Segment> Segments { get; }
+
+    public PropertyPath(Guid id, string prefix, Markers markers, IList<Segment> segments)
+    {
+        Id = id;
+        Prefix = prefix;
+        Markers = markers;
+        Segments = segments;
+    }
+
+    public Tree WithId(Guid id) => id == Id ? this : new PropertyPath(id, Prefix, Markers, Segments);
+    public PropertyPath WithPrefix(string prefix) => prefix == Prefix ? this : new PropertyPath(Id, prefix, Markers, Segments);
+    public PropertyPath WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new PropertyPath(Id, Prefix, markers, Segments);
+    public PropertyPath WithSegments(IList<Segment> segments) => ReferenceEquals(segments, Segments) ? this : new PropertyPath(Id, Prefix, Markers, segments);
+
+    /// <summary>
+    /// A step in a PropertyPath. The accessor is the token PRECEDING the step; the
+    /// step's Prefix is the whitespace before that token (or before the step's
+    /// first own token when None). None = first segment or direct attachment
+    /// (Foo[0]); Dot = member step (all dialects); Slash = WPF collection-view
+    /// current-item drill-in (may precede an Indexer: /Items/[0]);
+    /// NullConditional = Avalonia ?. member access.
+    /// </summary>
+    public interface Segment : Xml
+    {
+        AccessorKind Accessor { get; }
+    }
+
+    public enum AccessorKind { None, Dot, Slash, NullConditional }
+
+    /// <summary>
+    /// A plain member step: Customer, Address. Name.Type attests to the resolved
+    /// CLR property (JavaType.Variable) — the hook that propagates ViewModel
+    /// renames into XAML. Exact under compiled bindings (x:Bind, x:DataType);
+    /// heuristic under reflection bindings. In Avalonia a trailing member may
+    /// resolve to a METHOD (command binding) — same syntax, method attestation,
+    /// no parentheses involved.
+    /// </summary>
+    public sealed class Property : Segment
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+        public Ident Name { get; }
+
+        public Property(Guid id, string prefix, Markers markers, AccessorKind accessor, Ident name)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+            Name = name;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new Property(id, Prefix, Markers, Accessor, Name);
+        public Property WithPrefix(string prefix) => prefix == Prefix ? this : new Property(Id, prefix, Markers, Accessor, Name);
+        public Property WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Property(Id, Prefix, markers, Accessor, Name);
+        public Property WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new Property(Id, Prefix, Markers, accessor, Name);
+        public Property WithName(Ident name) => ReferenceEquals(name, Name) ? this : new Property(Id, Prefix, Markers, Accessor, name);
+    }
+
+    /// <summary>
+    /// An indexer step: [0], [FirstName], [a,b], [(sys:Int32)42], [15][16].
+    /// Prefix is the gap before the opening bracket. Each parameter is an optional
+    /// parenthesized group followed by an optional value literal — the paren
+    /// group's meaning is three-way in WPF and resolved by ATTESTATION, never by
+    /// node shape: [(sys:Int32)42] typed param; [(2)] parameter index; [(abc)]
+    /// literal paren string; [foo] plain value. Param values are verbatim
+    /// Literals: WPF's indexer escape char is CARET (a different escape rule than
+    /// the extension level's backslash), nested balanced brackets are legal, and
+    /// MAUI allows quoted commas (['x, y']) — the parser splits params only on
+    /// commas outside quotes/brackets.
+    /// </summary>
+    public sealed class Indexer : Segment
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+        public IList<Param> Parameters { get; }
+        public string BeforeClosingBracket { get; }
+
+        public Indexer(Guid id, string prefix, Markers markers, AccessorKind accessor, IList<Param> parameters, string beforeClosingBracket)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+            Parameters = parameters;
+            BeforeClosingBracket = beforeClosingBracket;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new Indexer(id, Prefix, Markers, Accessor, Parameters, BeforeClosingBracket);
+        public Indexer WithPrefix(string prefix) => prefix == Prefix ? this : new Indexer(Id, prefix, Markers, Accessor, Parameters, BeforeClosingBracket);
+        public Indexer WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Indexer(Id, Prefix, markers, Accessor, Parameters, BeforeClosingBracket);
+        public Indexer WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new Indexer(Id, Prefix, Markers, accessor, Parameters, BeforeClosingBracket);
+        public Indexer WithParameters(IList<Param> parameters) => ReferenceEquals(parameters, Parameters) ? this : new Indexer(Id, Prefix, Markers, Accessor, parameters, BeforeClosingBracket);
+        public Indexer WithBeforeClosingBracket(string beforeClosingBracket) => beforeClosingBracket == BeforeClosingBracket ? this : new Indexer(Id, Prefix, Markers, Accessor, Parameters, beforeClosingBracket);
+
+        /// <summary>One indexer parameter.</summary>
+        public sealed class Param : Xml
+        {
+            public Guid Id { get; }
+            public string Prefix { get; }
+            public Markers Markers { get; }
+            public ParenGroup? Paren { get; }
+            public Literal? Value { get; }
+            /// <summary>Before the trailing ','; null on the last parameter.</summary>
+            public string? BeforeComma { get; }
+
+            public Param(Guid id, string prefix, Markers markers, ParenGroup? paren, Literal? value, string? beforeComma)
+            {
+                Id = id;
+                Prefix = prefix;
+                Markers = markers;
+                Paren = paren;
+                Value = value;
+                BeforeComma = beforeComma;
+            }
+
+            public Tree WithId(Guid id) => id == Id ? this : new Param(id, Prefix, Markers, Paren, Value, BeforeComma);
+            public Param WithPrefix(string prefix) => prefix == Prefix ? this : new Param(Id, prefix, Markers, Paren, Value, BeforeComma);
+            public Param WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Param(Id, Prefix, markers, Paren, Value, BeforeComma);
+            public Param WithParen(ParenGroup? paren) => ReferenceEquals(paren, Paren) ? this : new Param(Id, Prefix, Markers, paren, Value, BeforeComma);
+            public Param WithValue(Literal? value) => ReferenceEquals(value, Value) ? this : new Param(Id, Prefix, Markers, Paren, value, BeforeComma);
+            public Param WithBeforeComma(string? beforeComma) => beforeComma == BeforeComma ? this : new Param(Id, Prefix, Markers, Paren, Value, beforeComma);
+        }
+    }
+
+    /// <summary>
+    /// A parenthesized path step — one grammar, several dialect meanings, all
+    /// resolved by attestation (WPF splits on the LAST dot, so a dotted owner is
+    /// legal): (Grid.Row) attached; (local:Owner.Prop) prefixed attached; (A.B.C)
+    /// owner A.B + member C; (Foo) WPF simple paren member / Avalonia type CAST
+    /// (owner null, attestation decides); (0) WPF parameter index; (abc) WPF
+    /// literal paren string. Avalonia disambiguates cast-vs-attached the same
+    /// lexical way (no dot means cast), so one node suffices; only the
+    /// double-paren cast form gets its own node (Cast).
+    /// </summary>
+    public sealed class Paren : Segment
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+        public Ident? Owner { get; }
+        /// <summary>Whitespace before the owner/member dot; null when Owner is null.</summary>
+        public string? BeforeDot { get; }
+        public Ident Member { get; }
+        public string BeforeClosingParen { get; }
+
+        public Paren(Guid id, string prefix, Markers markers, AccessorKind accessor, Ident? owner, string? beforeDot, Ident member, string beforeClosingParen)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+            Owner = owner;
+            BeforeDot = beforeDot;
+            Member = member;
+            BeforeClosingParen = beforeClosingParen;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new Paren(id, Prefix, Markers, Accessor, Owner, BeforeDot, Member, BeforeClosingParen);
+        public Paren WithPrefix(string prefix) => prefix == Prefix ? this : new Paren(Id, prefix, Markers, Accessor, Owner, BeforeDot, Member, BeforeClosingParen);
+        public Paren WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Paren(Id, Prefix, markers, Accessor, Owner, BeforeDot, Member, BeforeClosingParen);
+        public Paren WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new Paren(Id, Prefix, Markers, accessor, Owner, BeforeDot, Member, BeforeClosingParen);
+        public Paren WithOwner(Ident? owner) => ReferenceEquals(owner, Owner) ? this : new Paren(Id, Prefix, Markers, Accessor, owner, BeforeDot, Member, BeforeClosingParen);
+        public Paren WithBeforeDot(string? beforeDot) => beforeDot == BeforeDot ? this : new Paren(Id, Prefix, Markers, Accessor, Owner, beforeDot, Member, BeforeClosingParen);
+        public Paren WithMember(Ident member) => ReferenceEquals(member, Member) ? this : new Paren(Id, Prefix, Markers, Accessor, Owner, BeforeDot, member, BeforeClosingParen);
+        public Paren WithBeforeClosingParen(string beforeClosingParen) => beforeClosingParen == BeforeClosingParen ? this : new Paren(Id, Prefix, Markers, Accessor, Owner, BeforeDot, Member, beforeClosingParen);
+    }
+
+    /// <summary>
+    /// The double-paren cast form — shared grammar of WinUI x:Bind and Avalonia
+    /// bindings (Avalonia allows it mid-path in ordinary {Binding}):
+    /// ((TextBox)obj).Text; $parent.((Button)DataContext).Tag. Prefix is before
+    /// the OUTER paren; Type is the inner (ns:Type) group; the operand (member and
+    /// optional indexer) sits inside the outer parens.
+    /// </summary>
+    public sealed class Cast : Segment
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+        public ParenGroup Type { get; }
+        public PropertyPath Operand { get; }
+        public string BeforeClosingParen { get; }
+
+        public Cast(Guid id, string prefix, Markers markers, AccessorKind accessor, ParenGroup type, PropertyPath operand, string beforeClosingParen)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+            Type = type;
+            Operand = operand;
+            BeforeClosingParen = beforeClosingParen;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new Cast(id, Prefix, Markers, Accessor, Type, Operand, BeforeClosingParen);
+        public Cast WithPrefix(string prefix) => prefix == Prefix ? this : new Cast(Id, prefix, Markers, Accessor, Type, Operand, BeforeClosingParen);
+        public Cast WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Cast(Id, Prefix, markers, Accessor, Type, Operand, BeforeClosingParen);
+        public Cast WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new Cast(Id, Prefix, Markers, accessor, Type, Operand, BeforeClosingParen);
+        public Cast WithType(ParenGroup type) => ReferenceEquals(type, Type) ? this : new Cast(Id, Prefix, Markers, Accessor, type, Operand, BeforeClosingParen);
+        public Cast WithOperand(PropertyPath operand) => ReferenceEquals(operand, Operand) ? this : new Cast(Id, Prefix, Markers, Accessor, Type, operand, BeforeClosingParen);
+        public Cast WithBeforeClosingParen(string beforeClosingParen) => beforeClosingParen == BeforeClosingParen ? this : new Cast(Id, Prefix, Markers, Accessor, Type, Operand, beforeClosingParen);
+    }
+
+    /// <summary>
+    /// WinUI/UWP x:Bind function binding — the one dialect where a path step takes
+    /// arguments: {x:Bind ViewModel.Format(Item.Value, 'N2'), Mode=OneWay}.
+    /// Arguments reuse Argument (always positional; values are PropertyPaths or
+    /// Literal constants). Name.Type attests to the resolved method. Gated on the
+    /// x:Bind context, which is syntactic (x: resolves via in-document xmlns). NOT
+    /// valid in WPF, MAUI, or Avalonia paths — Avalonia method/command bindings
+    /// are a bare identifier, never a call.
+    /// </summary>
+    public sealed class FunctionCall : Segment
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+        public Ident Name { get; }
+        public string BeforeOpenParen { get; }
+        public IList<Argument> Arguments { get; }
+        public string BeforeClosingParen { get; }
+
+        public FunctionCall(Guid id, string prefix, Markers markers, AccessorKind accessor, Ident name, string beforeOpenParen, IList<Argument> arguments, string beforeClosingParen)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+            Name = name;
+            BeforeOpenParen = beforeOpenParen;
+            Arguments = arguments;
+            BeforeClosingParen = beforeClosingParen;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new FunctionCall(id, Prefix, Markers, Accessor, Name, BeforeOpenParen, Arguments, BeforeClosingParen);
+        public FunctionCall WithPrefix(string prefix) => prefix == Prefix ? this : new FunctionCall(Id, prefix, Markers, Accessor, Name, BeforeOpenParen, Arguments, BeforeClosingParen);
+        public FunctionCall WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new FunctionCall(Id, Prefix, markers, Accessor, Name, BeforeOpenParen, Arguments, BeforeClosingParen);
+        public FunctionCall WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new FunctionCall(Id, Prefix, Markers, accessor, Name, BeforeOpenParen, Arguments, BeforeClosingParen);
+        public FunctionCall WithName(Ident name) => ReferenceEquals(name, Name) ? this : new FunctionCall(Id, Prefix, Markers, Accessor, name, BeforeOpenParen, Arguments, BeforeClosingParen);
+        public FunctionCall WithBeforeOpenParen(string beforeOpenParen) => beforeOpenParen == BeforeOpenParen ? this : new FunctionCall(Id, Prefix, Markers, Accessor, Name, beforeOpenParen, Arguments, BeforeClosingParen);
+        public FunctionCall WithArguments(IList<Argument> arguments) => ReferenceEquals(arguments, Arguments) ? this : new FunctionCall(Id, Prefix, Markers, Accessor, Name, BeforeOpenParen, arguments, BeforeClosingParen);
+        public FunctionCall WithBeforeClosingParen(string beforeClosingParen) => beforeClosingParen == BeforeClosingParen ? this : new FunctionCall(Id, Prefix, Markers, Accessor, Name, BeforeOpenParen, Arguments, beforeClosingParen);
+    }
+
+    /// <summary>
+    /// Avalonia element-name step: {Binding #slider.Value}. WPF's ElementName=
+    /// concept expressed inside the path grammar (root-only in Avalonia), hence a
+    /// distinct-grammar node. Name.Type attests to the x:Name'd element's type.
+    /// Prefix is before the hash.
+    /// </summary>
+    public sealed class Element : Segment
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+        public Ident Name { get; }
+
+        public Element(Guid id, string prefix, Markers markers, AccessorKind accessor, Ident name)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+            Name = name;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new Element(id, Prefix, Markers, Accessor, Name);
+        public Element WithPrefix(string prefix) => prefix == Prefix ? this : new Element(Id, prefix, Markers, Accessor, Name);
+        public Element WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Element(Id, Prefix, markers, Accessor, Name);
+        public Element WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new Element(Id, Prefix, Markers, accessor, Name);
+        public Element WithName(Ident name) => ReferenceEquals(name, Name) ? this : new Element(Id, Prefix, Markers, Accessor, name);
+    }
+
+    /// <summary>
+    /// Avalonia relative-source step (root-only): $self; $parent; $parent[Border]
+    /// (ancestorType only); $parent[2] (ancestorLevel only — an integer token is
+    /// parsed into AncestorLevel, not a type; lexical: digits cannot start a type
+    /// name); $parent[local:MyControl;1] (both, SEMICOLON separated). Nullable
+    /// Before* fields encode which tokens are present. WPF's equivalent
+    /// ({RelativeSource FindAncestor, AncestorType={x:Type Border}}) needs NO
+    /// nodes here — it is plain MarkupExtension structure; only Avalonia gave the
+    /// concept its own grammar. Prefix is before the dollar sign.
+    /// </summary>
+    public sealed class Relative : Segment
+    {
+        public enum RelativeKind { Self, Parent }
+
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+        public RelativeKind Kind { get; }
+        public string? BeforeOpenBracket { get; }
+        public Ident? AncestorType { get; }
+        public string? BeforeSemicolon { get; }
+        public Literal? AncestorLevel { get; }
+        public string? BeforeClosingBracket { get; }
+
+        public Relative(Guid id, string prefix, Markers markers, AccessorKind accessor, RelativeKind kind, string? beforeOpenBracket, Ident? ancestorType, string? beforeSemicolon, Literal? ancestorLevel, string? beforeClosingBracket)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+            Kind = kind;
+            BeforeOpenBracket = beforeOpenBracket;
+            AncestorType = ancestorType;
+            BeforeSemicolon = beforeSemicolon;
+            AncestorLevel = ancestorLevel;
+            BeforeClosingBracket = beforeClosingBracket;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new Relative(id, Prefix, Markers, Accessor, Kind, BeforeOpenBracket, AncestorType, BeforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithPrefix(string prefix) => prefix == Prefix ? this : new Relative(Id, prefix, Markers, Accessor, Kind, BeforeOpenBracket, AncestorType, BeforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Relative(Id, Prefix, markers, Accessor, Kind, BeforeOpenBracket, AncestorType, BeforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new Relative(Id, Prefix, Markers, accessor, Kind, BeforeOpenBracket, AncestorType, BeforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithKind(RelativeKind kind) => kind == Kind ? this : new Relative(Id, Prefix, Markers, Accessor, kind, BeforeOpenBracket, AncestorType, BeforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithBeforeOpenBracket(string? beforeOpenBracket) => beforeOpenBracket == BeforeOpenBracket ? this : new Relative(Id, Prefix, Markers, Accessor, Kind, beforeOpenBracket, AncestorType, BeforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithAncestorType(Ident? ancestorType) => ReferenceEquals(ancestorType, AncestorType) ? this : new Relative(Id, Prefix, Markers, Accessor, Kind, BeforeOpenBracket, ancestorType, BeforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithBeforeSemicolon(string? beforeSemicolon) => beforeSemicolon == BeforeSemicolon ? this : new Relative(Id, Prefix, Markers, Accessor, Kind, BeforeOpenBracket, AncestorType, beforeSemicolon, AncestorLevel, BeforeClosingBracket);
+        public Relative WithAncestorLevel(Literal? ancestorLevel) => ReferenceEquals(ancestorLevel, AncestorLevel) ? this : new Relative(Id, Prefix, Markers, Accessor, Kind, BeforeOpenBracket, AncestorType, BeforeSemicolon, ancestorLevel, BeforeClosingBracket);
+        public Relative WithBeforeClosingBracket(string? beforeClosingBracket) => beforeClosingBracket == BeforeClosingBracket ? this : new Relative(Id, Prefix, Markers, Accessor, Kind, BeforeOpenBracket, AncestorType, BeforeSemicolon, AncestorLevel, beforeClosingBracket);
+    }
+
+    /// <summary>
+    /// The Avalonia stream operator as a path STEP — it binds the value produced
+    /// so far (IObservable/Task), may appear mid-path and repeatedly, so it cannot
+    /// be a whole-path flag: Activity^; Foo^.Bar^; ^ (stream of the source
+    /// itself); .^. Prefix is before the caret. Not valid in WPF/WinUI/MAUI.
+    /// </summary>
+    public sealed class Stream : Segment
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public AccessorKind Accessor { get; }
+
+        public Stream(Guid id, string prefix, Markers markers, AccessorKind accessor)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Accessor = accessor;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new Stream(id, Prefix, Markers, Accessor);
+        public Stream WithPrefix(string prefix) => prefix == Prefix ? this : new Stream(Id, prefix, Markers, Accessor);
+        public Stream WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Stream(Id, Prefix, markers, Accessor);
+        public Stream WithAccessor(AccessorKind accessor) => accessor == Accessor ? this : new Stream(Id, Prefix, Markers, accessor);
+    }
+}
+
+/// <summary>
+/// Avalonia logical-negation prefix on a binding value: {Binding !IsEnabled}.
+/// Wraps its operand, so the to-bool double-negation !!Items.Count is two nested
+/// Negations — nesting matches the operator semantics and keeps this one node
+/// type. Only legal as a leading run (Avalonia rejects mid-path bangs); that is a
+/// parser/validation concern, not a shape. Prefix is before the bang. Not valid
+/// WPF/WinUI/MAUI grammar.
+/// </summary>
+public sealed class Negation : Expression
+{
+    public Guid Id { get; }
+    public string Prefix { get; }
+    public Markers Markers { get; }
+    public Expression Operand { get; }
+
+    public Negation(Guid id, string prefix, Markers markers, Expression operand)
+    {
+        Id = id;
+        Prefix = prefix;
+        Markers = markers;
+        Operand = operand;
+    }
+
+    public Tree WithId(Guid id) => id == Id ? this : new Negation(id, Prefix, Markers, Operand);
+    public Negation WithPrefix(string prefix) => prefix == Prefix ? this : new Negation(Id, prefix, Markers, Operand);
+    public Negation WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new Negation(Id, Prefix, markers, Operand);
+    public Negation WithOperand(Expression operand) => ReferenceEquals(operand, Operand) ? this : new Negation(Id, Prefix, Markers, operand);
+}
+
+/// <summary>
+/// A XAML type-name with optional generic arguments and array subscripts — XAML's
+/// generic syntax uses PARENTHESES, and WPF's GenericTypeNameParser additionally
+/// accepts array subscripts folded onto the name:
+///
+///   x:TypeArguments="scg:Dictionary(sys:String, scg:List(sys:Int32))"  nests
+///   x:TypeArguments="sys:String[]"    Subscript = "[]"
+///   x:TypeArguments="sys:Int32[,][]"  Subscript = "[,][]" (verbatim; rank
+///                                     derivable; interior spaces legal and kept)
+///
+/// Parsed as TypeName only where the grammar guarantees a type: x:TypeArguments
+/// values (the x: prefix resolves syntactically via in-document xmlns). Everywhere
+/// else type-valued tokens ({x:Type Grid}'s positional arg, DataType=, cast and
+/// ancestor type tokens) are lexically ordinary tokens and stay Literal/Ident with
+/// JavaType attestation — parse shape must not depend on resolution.
+/// </summary>
+public sealed class TypeName : Expression
+{
+    public Guid Id { get; }
+    public string Prefix { get; }
+    public Markers Markers { get; }
+    /// <summary>Verbatim, possibly xmlns-prefixed: scg:List — resolved type in Name.Type.</summary>
+    public Ident Name { get; }
+    /// <summary>Null when non-generic.</summary>
+    public GenericArguments? TypeArguments { get; }
+    /// <summary>Verbatim array subscript run incl. any interior whitespace; null if none.</summary>
+    public string? Subscript { get; }
+
+    public TypeName(Guid id, string prefix, Markers markers, Ident name, GenericArguments? typeArguments, string? subscript)
+    {
+        Id = id;
+        Prefix = prefix;
+        Markers = markers;
+        Name = name;
+        TypeArguments = typeArguments;
+        Subscript = subscript;
+    }
+
+    public Tree WithId(Guid id) => id == Id ? this : new TypeName(id, Prefix, Markers, Name, TypeArguments, Subscript);
+    public TypeName WithPrefix(string prefix) => prefix == Prefix ? this : new TypeName(Id, prefix, Markers, Name, TypeArguments, Subscript);
+    public TypeName WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new TypeName(Id, Prefix, markers, Name, TypeArguments, Subscript);
+    public TypeName WithName(Ident name) => ReferenceEquals(name, Name) ? this : new TypeName(Id, Prefix, Markers, name, TypeArguments, Subscript);
+    public TypeName WithTypeArguments(GenericArguments? typeArguments) => ReferenceEquals(typeArguments, TypeArguments) ? this : new TypeName(Id, Prefix, Markers, Name, typeArguments, Subscript);
+    public TypeName WithSubscript(string? subscript) => subscript == Subscript ? this : new TypeName(Id, Prefix, Markers, Name, TypeArguments, subscript);
+
+    /// <summary>The parenthesized argument list: ( sys:String , sys:Int32 )</summary>
+    public sealed class GenericArguments : Xml
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public IList<TypeArgument> Arguments { get; }
+        public string BeforeClosingParen { get; }
+
+        public GenericArguments(Guid id, string prefix, Markers markers, IList<TypeArgument> arguments, string beforeClosingParen)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Arguments = arguments;
+            BeforeClosingParen = beforeClosingParen;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new GenericArguments(id, Prefix, Markers, Arguments, BeforeClosingParen);
+        public GenericArguments WithPrefix(string prefix) => prefix == Prefix ? this : new GenericArguments(Id, prefix, Markers, Arguments, BeforeClosingParen);
+        public GenericArguments WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new GenericArguments(Id, Prefix, markers, Arguments, BeforeClosingParen);
+        public GenericArguments WithArguments(IList<TypeArgument> arguments) => ReferenceEquals(arguments, Arguments) ? this : new GenericArguments(Id, Prefix, Markers, arguments, BeforeClosingParen);
+        public GenericArguments WithBeforeClosingParen(string beforeClosingParen) => beforeClosingParen == BeforeClosingParen ? this : new GenericArguments(Id, Prefix, Markers, Arguments, beforeClosingParen);
+    }
+
+    /// <summary>One generic argument with its trailing-comma gap.</summary>
+    public sealed class TypeArgument : Xml
+    {
+        public Guid Id { get; }
+        public string Prefix { get; }
+        public Markers Markers { get; }
+        public TypeName Type { get; }
+        /// <summary>Before the trailing ','; null on the last argument.</summary>
+        public string? BeforeComma { get; }
+
+        public TypeArgument(Guid id, string prefix, Markers markers, TypeName type, string? beforeComma)
+        {
+            Id = id;
+            Prefix = prefix;
+            Markers = markers;
+            Type = type;
+            BeforeComma = beforeComma;
+        }
+
+        public Tree WithId(Guid id) => id == Id ? this : new TypeArgument(id, Prefix, Markers, Type, BeforeComma);
+        public TypeArgument WithPrefix(string prefix) => prefix == Prefix ? this : new TypeArgument(Id, prefix, Markers, Type, BeforeComma);
+        public TypeArgument WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new TypeArgument(Id, Prefix, markers, Type, BeforeComma);
+        public TypeArgument WithType(TypeName type) => ReferenceEquals(type, Type) ? this : new TypeArgument(Id, Prefix, Markers, type, BeforeComma);
+        public TypeArgument WithBeforeComma(string? beforeComma) => beforeComma == BeforeComma ? this : new TypeArgument(Id, Prefix, Markers, Type, beforeComma);
+    }
+}
+
+/// <summary>
+/// A parenthesized single token — the shared shape for contexts where parens wrap
+/// one uninterpreted token whose meaning is attestation's job: the indexer param
+/// prefix ([(sys:Int32)42], [(2)], [(abc)] — see Indexer.Param) and the cast
+/// target type (((TextBox)obj) — see Cast). Token is a verbatim Literal
+/// (attestation resolves it to a type, a parameter index, or nothing). Distinct
+/// from the Paren path segment, whose content has owner-dot-member structure.
+/// Prefix is before the opening paren.
+/// </summary>
+public sealed class ParenGroup : Xml
+{
+    public Guid Id { get; }
+    public string Prefix { get; }
+    public Markers Markers { get; }
+    public Literal Token { get; }
+    public string BeforeClosingParen { get; }
+
+    public ParenGroup(Guid id, string prefix, Markers markers, Literal token, string beforeClosingParen)
+    {
+        Id = id;
+        Prefix = prefix;
+        Markers = markers;
+        Token = token;
+        BeforeClosingParen = beforeClosingParen;
+    }
+
+    public Tree WithId(Guid id) => id == Id ? this : new ParenGroup(id, Prefix, Markers, Token, BeforeClosingParen);
+    public ParenGroup WithPrefix(string prefix) => prefix == Prefix ? this : new ParenGroup(Id, prefix, Markers, Token, BeforeClosingParen);
+    public ParenGroup WithMarkers(Markers markers) => ReferenceEquals(markers, Markers) ? this : new ParenGroup(Id, Prefix, markers, Token, BeforeClosingParen);
+    public ParenGroup WithToken(Literal token) => ReferenceEquals(token, Token) ? this : new ParenGroup(Id, Prefix, Markers, token, BeforeClosingParen);
+    public ParenGroup WithBeforeClosingParen(string beforeClosingParen) => beforeClosingParen == BeforeClosingParen ? this : new ParenGroup(Id, Prefix, Markers, Token, beforeClosingParen);
 }

--- a/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
+++ b/rewrite-xml/src/main/java/org/openrewrite/xml/tree/Xml.java
@@ -26,6 +26,7 @@ import org.openrewrite.*;
 import org.openrewrite.internal.CommentService;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.internal.WhitespaceValidationService;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.xml.XmlParser;
 import org.openrewrite.xml.XmlVisitor;
@@ -338,7 +339,7 @@ public interface Xml extends Tree {
             }
             return new Tag(id, prefixUnsafe, markers, name, attributes, content,
                     closing == null ? null : closing.withName(name),
-                    beforeTagDelimiterPrefix);
+                    beforeTagDelimiterPrefix, type);
         }
 
         public Tag withValue(String value) {
@@ -445,7 +446,7 @@ public interface Xml extends Tree {
             }
 
             Tag tag = new Tag(id, prefixUnsafe, markers, name, attributes, content, closing,
-                    beforeTagDelimiterPrefix);
+                    beforeTagDelimiterPrefix, type);
 
             if (closing == null) {
                 if (content != null && !content.isEmpty()) {
@@ -478,6 +479,24 @@ public interface Xml extends Tree {
          */
         @With
         String beforeTagDelimiterPrefix;
+
+        /**
+         * XAML attestation: the resolved type of the element this tag denotes. Null for
+         * plain XML documents and for unresolved XAML.
+         *
+         *   object element            &lt;Button ...&gt;         the control class
+         *   property element          &lt;Button.Content&gt;     the property on the enclosing
+         *                                                  element's type
+         *   attached property element &lt;Grid.Row&gt; (inside a  the attached member on the
+         *                             non-Grid child)      foreign owner type
+         *
+         * The name string stays verbatim (possibly xmlns-prefixed and/or dotted);
+         * attestation resolves the parts. Distinguishing the three roles is this slot's
+         * job, never a node-shape difference.
+         */
+        @With
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> Xml acceptXml(XmlVisitor<P> v, P p) {
@@ -551,17 +570,70 @@ public interface Xml extends Tree {
         Markers markers;
         Ident key;
         String beforeEquals;
-        Value value;
+        AttributeValue value;
 
         @Override
         public <P> Xml acceptXml(XmlVisitor<P> v, P p) {
             return v.visitAttribute(this, p);
         }
 
+        /**
+         * The polymorphic attribute-value slot — THE structural change XAML requires
+         * of the XML model. Plain XML attribute values are string leaves
+         * ({@link Value}, unchanged); XAML attribute values may instead carry a parsed
+         * expression tree ({@link ExpressionValue}) because markup extensions nest:
+         *
+         *   Text="hello"                               Value (exactly as today)
+         *   Text="{Binding Path=FirstName}"            ExpressionValue(MarkupExtension)
+         *   Text="{Binding Converter={StaticResource c}}"   nested extension tree
+         *   Text="{}{not an extension}"                Value — a value starting with
+         *                                              the {} escape is by definition
+         *                                              plain text, never an extension
+         *
+         * XML documents are untouched: their values remain {@link Value} instances, so
+         * existing serialized LSTs deserialize unchanged.
+         */
+        public interface AttributeValue extends Xml {
+        }
+
+        /**
+         * A XAML attribute value holding a parsed expression rather than a raw string.
+         * Quote style is preserved exactly as in {@link Value}; after captures the gap
+         * between the end of the expression and the closing quote:
+         *
+         *   Text="{Binding X} "        after = " "  (WPF rejects trailing whitespace
+         *                              at load — SR.WhitespaceAfterME — but files ship
+         *                              with it, so the model must round-trip it)
+         */
         @lombok.Value
         @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
         @With
-        public static class Value implements Xml {
+        public static class ExpressionValue implements AttributeValue {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public ExpressionValue withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Value.Quote quote;
+            Expression expression;
+            String after;
+        }
+
+        @lombok.Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Value implements AttributeValue {
             public enum Quote {
                 Double, Single
             }
@@ -595,8 +667,13 @@ public interface Xml extends Tree {
             return key.getName();
         }
 
+        /**
+         * The raw string form of the value. For XAML expression values there is no
+         * stored string (the tree is the source of truth); printing the expression is
+         * the printer's job, so this returns empty for {@link ExpressionValue}.
+         */
         public String getValueAsString() {
-            return value.getValue();
+            return value instanceof Value ? ((Value) value).getValue() : "";
         }
 
         @Override
@@ -826,6 +903,27 @@ public interface Xml extends Tree {
         Markers markers;
         String name;
 
+        /**
+         * XAML attestation: the resolved meaning of this name token. Null for plain XML
+         * and for unresolved XAML. This slot is what gives tokens semantic identity
+         * WITHOUT node-type proliferation:
+         *
+         *   attribute key      Mode           the Binding.Mode property
+         *   attribute key      Click          the routed event
+         *   directive key      x:Name         the XAML language directive
+         *   extension name     Binding        the extension class (spelling verbatim,
+         *                                     incl. the optional "Extension" suffix)
+         *   path member        Customer       the CLR property (JavaType.Variable) —
+         *                                     the hook that propagates ViewModel
+         *                                     renames into XAML
+         *
+         * The name string is verbatim source, including any xmlns prefix and dots
+         * (local:MyControl, Grid.Column); attestation resolves the parts. Never
+         * normalized.
+         */
+        @Nullable
+        JavaType type;
+
         @Override
         public <P> Xml acceptXml(XmlVisitor<P> v, P p) {
             return v.visitIdent(this, p);
@@ -1037,5 +1135,838 @@ public interface Xml extends Tree {
         public String toString() {
             return "<%-- " + content + " --%>";
         }
+    }
+
+    // ========================================================================
+    // XAML VALUE LAYER — the attribute-value / binding mini-language.
+    //
+    // Everything below exists to cover XAML (WPF, UWP/WinUI incl. x:Bind,
+    // Xamarin.Forms / .NET MAUI, Avalonia, legacy Silverlight) on top of the XML
+    // model. Plain XML documents never contain these nodes. Grammar was verified
+    // against the platform sources (WPF MeScanner/MePullParser/PathParser/
+    // GenericTypeNameParser, Avalonia BindingExpressionGrammar, MAUI
+    // MarkupExpressionParser, XamlX SystemXamlMarkupExtensionParser).
+    //
+    // Modelling rules (same as the rest of this file):
+    // - prefix = all whitespace left of the node's first token; interior gaps get
+    //   named before* fields. Punctuation is implicit; an optional token's presence
+    //   is encoded by its nullable before* field being non-null.
+    // - Parse is purely syntactic: tree shape never depends on type resolution.
+    //   Semantics attach afterwards as JavaType attestation. Keyword/enum value
+    //   tokens (FindAncestor, TwoWay) are Literal/Ident nodes attested to enum
+    //   members — never distinct node types.
+    // - Literal text is the RAW source slice (quotes kept, backslash/caret escapes
+    //   unresolved, leading {} escape kept). Any value text that does not conform
+    //   to the closed grammar stays a verbatim Literal (e.g. MAUI expression
+    //   bindings such as "{Binding Price * this.TaxRate}") — never a parse error.
+    // ========================================================================
+
+    /**
+     * Anything legal in a XAML value position: an attribute value expression, a
+     * markup-extension argument, a function-call argument. Implementations:
+     * Literal, MarkupExtension, PropertyPath, Negation, TypeName.
+     */
+    interface Expression extends Xml {
+    }
+
+    /**
+     * Verbatim uninterpreted text in a value position — the most common node.
+     * text is the EXACT source slice: surrounding ' or " quotes kept, backslash
+     * escapes (WPF/MAUI) and caret escapes (WPF indexer params) unresolved, leading
+     * {} escape kept, interior whitespace kept. A helper (not a field) can expose
+     * the cooked value per dialect unescaping rules. WPF, Avalonia, MAUI and XamlX
+     * all store only the decoded+trimmed value; the raw slice is what makes this
+     * model lossless.
+     *
+     * Covers, with semantic identity supplied by type attestation:
+     *
+     *   plain values          Text="hello"   Width="120.5"
+     *   enum keyword tokens   Mode=TwoWay    {RelativeSource FindAncestor}'s
+     *                         positional arg — attests to the enum member
+     *   event handler names   Click="Save_Click" — attests to the handler method
+     *   resource keys         {StaticResource accentBrush}
+     *   quoted args           ConverterParameter='a, b'  (comma inert in quotes)
+     *                         StringFormat='{}{0:N2}'
+     *   mixed quoting         Text=abc'def'  (MAUI allows a quote mid-piece)
+     *   embedded braces       {Binding Foo{Bar}} — balanced braces inside an
+     *                         unquoted value are legal WPF v3-compat text
+     *   x:Bind constants      {x:Bind Format(Value, 'N2')}'s second arg
+     *   fallback              any value text outside the closed grammar
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Literal implements Expression {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        String prefixUnsafe;
+
+        @Override
+        public Literal withPrefix(String prefix) {
+            return WithPrefix.onlyIfNotEqual(this, prefix);
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefixUnsafe;
+        }
+
+        Markers markers;
+        String text;
+
+        @Nullable
+        JavaType type;
+    }
+
+    /**
+     * A markup extension — ONE node type for every extension kind in every dialect:
+     *
+     *   WPF       {Binding} {StaticResource} {DynamicResource} {TemplateBinding}
+     *             {RelativeSource} {x:Static} {x:Type} {x:Null} {x:Array}
+     *   WinUI     {ThemeResource} {CustomResource} {x:Bind}
+     *   MAUI/XF   {AppThemeBinding} {OnPlatform} {OnIdiom} {x:Reference}
+     *   Avalonia  {CompiledBinding} {ReflectionBinding}
+     *   any       third-party MarkupExtension subclass
+     *
+     * Which one it is = type attestation (xmlns resolution; WPF/MAUI try both the
+     * literal name and name+"Extension" — typeName keeps the source spelling),
+     * never a subclass.
+     *
+     * Token/field map:
+     *
+     *   { Binding  Path=FirstName , Mode=TwoWay }
+     *   A B       C                D            E
+     *
+     *   A prefix (before the opening brace, or before the quote when quoted)
+     *   B typeName.prefix (after the brace)
+     *   C arguments.get(0).prefix
+     *   D arguments.get(0).beforeComma (gap before the separating comma)
+     *   E beforeClosingBrace
+     *
+     * Nesting is direct tree recursion — the reason this layer exists:
+     *   {Binding Converter={StaticResource conv}, Path=A.B}
+     * A nested extension may itself be QUOTED (WPF scanner token
+     * QuotedMarkupExtension): Converter='{StaticResource conv}' — encoded by
+     * non-null quote; the quote characters wrap the braces tightly.
+     *
+     * Ordering: WPF enforces positional-before-named; MAUI allows interleaving.
+     * The order-preserving arguments list represents both; the invariant is a
+     * dialect validation, not a shape.
+     *
+     * Implements Content: extension syntax is legal initialization text —
+     *   &lt;TextBlock.Text&gt;{Binding Foo}&lt;/TextBlock.Text&gt;
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class MarkupExtension implements Expression, Content {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        String prefixUnsafe;
+
+        @Override
+        public MarkupExtension withPrefix(String prefix) {
+            return WithPrefix.onlyIfNotEqual(this, prefix);
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefixUnsafe;
+        }
+
+        Markers markers;
+
+        /**
+         * Non-null when this nested extension is quoted: Converter='{...}'
+         */
+        Attribute.Value.@Nullable Quote quote;
+
+        /**
+         * Binding, x:Static, local:MyExt — verbatim spelling incl. any Extension
+         * suffix; resolved class in typeName.type.
+         */
+        Ident typeName;
+
+        List<Argument> arguments;
+
+        /**
+         * Whitespace before the closing brace.
+         */
+        String beforeClosingBrace;
+    }
+
+    /**
+     * One argument of a MarkupExtension or an x:Bind function call. Positional and
+     * named forms are ONE node distinguished by name nullability — mirroring how
+     * the WPF scanner itself disambiguates (a value run that hits = is re-labelled
+     * PropertyName; there is no parser lookahead):
+     *
+     *   positional   {Binding FirstName}     name null, value PropertyPath
+     *                {StaticResource key}    name null, value Literal
+     *   named        Mode=TwoWay             name attests to Binding.Mode,
+     *                                        value Literal attests to the enum
+     *
+     * beforeComma is the gap before the trailing comma separator and is null on
+     * the last argument (the gap before the closing brace is
+     * MarkupExtension.beforeClosingBrace).
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Argument implements Xml {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        String prefixUnsafe;
+
+        @Override
+        public Argument withPrefix(String prefix) {
+            return WithPrefix.onlyIfNotEqual(this, prefix);
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefixUnsafe;
+        }
+
+        Markers markers;
+
+        @Nullable
+        Ident name;
+
+        /**
+         * Whitespace before '='; null iff positional.
+         */
+        @Nullable
+        String beforeEquals;
+
+        Expression value;
+
+        /**
+         * Whitespace before the following ','; null on the last argument.
+         */
+        @Nullable
+        String beforeComma;
+    }
+
+    /**
+     * The property-path mini-language: the value of Path= / the positional path of
+     * {Binding}, {x:Bind}, {TemplateBinding}, {CompiledBinding}, MAUI/XF bindings.
+     * A flat sequence of segments; each segment records the ACCESSOR token that
+     * precedes it. There is no whole-path stream flag — the caret is a segment
+     * (Avalonia allows it mid-path and repeated).
+     *
+     *   Customer.Address[0].(Validation.Errors)[0].ErrorContent
+     *   Property Property   Paren               Indexer Property
+     *   NONE     DOT   Indexer(NONE)  DOT       NONE    DOT
+     *
+     * Special shapes (all verified against platform sources):
+     *
+     *   empty path       {Binding}            segments empty — bind to the source
+     *   bare dot         Path=.               one Property, accessor DOT, empty name
+     *   leading slash    /Items/Name          WPF collection-view current item
+     *   leading dots     .Foo  ..Foo          WPF keeps leading dots in the member
+     *                                         name (XLinq); name is verbatim
+     *   Avalonia stream  Foo^.Bar^   ^   .^   Stream segments, repeatable
+     *   null-conditional Foo?.Bar             accessor NULL_CONDITIONAL (Avalonia)
+     *
+     * Fallback: path text not matching this closed grammar (MAUI expression
+     * bindings: {Binding Price * this.TaxRate}) stays a verbatim Literal. WPF trims
+     * segment-interior whitespace when it parses; this model stores exactly what
+     * the source had.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class PropertyPath implements Expression {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        String prefixUnsafe;
+
+        @Override
+        public PropertyPath withPrefix(String prefix) {
+            return WithPrefix.onlyIfNotEqual(this, prefix);
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefixUnsafe;
+        }
+
+        Markers markers;
+        List<Segment> segments;
+
+        /**
+         * A step in a PropertyPath. The accessor is the token PRECEDING the step;
+         * the step's prefix is the whitespace before that token (or before the
+         * step's first own token when NONE).
+         *
+         *   NONE              first segment, or one attaching directly:  Foo[0]
+         *   DOT               .   member step (all dialects)
+         *   SLASH             /   WPF collection-view current-item drill-in;
+         *                         may precede an Indexer too:  /Items/[0]
+         *   NULL_CONDITIONAL  ?.  Avalonia null-conditional member access
+         */
+        public interface Segment extends Xml {
+            Accessor getAccessor();
+
+            enum Accessor {
+                NONE, DOT, SLASH, NULL_CONDITIONAL
+            }
+        }
+
+        /**
+         * A plain member step: Customer, Address. name.type attests to the
+         * resolved CLR property (JavaType.Variable) — the hook that propagates
+         * ViewModel renames into XAML. Exact under compiled bindings (x:Bind,
+         * x:DataType); heuristic under reflection bindings (DataContext inference
+         * ladder). In Avalonia a trailing member may resolve to a METHOD (command
+         * binding) — same syntax, method attestation, no parentheses involved.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Property implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public Property withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+            Ident name;
+        }
+
+        /**
+         * An indexer step:  [0]  [FirstName]  [a,b]  [(sys:Int32)42]  [15][16]
+         * prefix is the gap before the opening bracket. Each parameter is an
+         * optional parenthesized group followed by an optional value literal — the
+         * paren group's meaning is three-way in WPF and resolved by ATTESTATION,
+         * never by node shape:
+         *
+         *   [(sys:Int32)42]  paren = type       value = 42    typed indexer param
+         *   [(2)]            paren = param idx  value absent  PathParameters[2]
+         *   [(abc)]          paren = literal    value absent  the string "(abc)"
+         *   [foo]            paren absent       value = foo
+         *
+         * Param values are verbatim Literals: WPF's indexer escape char is CARET
+         * (escapes comma, parens, bracket and caret itself — a different escape
+         * rule than the extension level's backslash), nested balanced brackets are
+         * legal inside a value, and MAUI treats the whole bracket content as one
+         * opaque string that may contain quoted commas (['x, y']) — the parser
+         * splits params only on commas outside quotes/brackets, and the raw text
+         * survives in the Literals regardless.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Indexer implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public Indexer withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+            List<Param> parameters;
+            String beforeClosingBracket;
+
+            /**
+             * One indexer parameter.
+             */
+            @Value
+            @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+            @With
+            public static class Param implements Xml {
+                @EqualsAndHashCode.Include
+                UUID id;
+
+                String prefixUnsafe;
+
+                @Override
+                public Param withPrefix(String prefix) {
+                    return WithPrefix.onlyIfNotEqual(this, prefix);
+                }
+
+                @Override
+                public String getPrefix() {
+                    return prefixUnsafe;
+                }
+
+                Markers markers;
+
+                @Nullable
+                ParenGroup paren;
+
+                @Nullable
+                Literal value;
+
+                /**
+                 * Before the trailing ','; null on the last parameter.
+                 */
+                @Nullable
+                String beforeComma;
+            }
+        }
+
+        /**
+         * A parenthesized path step — one grammar, several dialect meanings, all
+         * resolved by attestation (WPF splits on the LAST dot, so a dotted owner
+         * is legal):
+         *
+         *   (Grid.Row)              attached property      owner Grid, member Row
+         *   (local:Owner.Prop)      prefixed attached      owner local:Owner
+         *   (A.B.C)                 owner A.B, member C    (last-dot split)
+         *   (Validation.Errors)[0]  attached + indexer step
+         *   (Foo)                   WPF simple paren member / Avalonia type CAST —
+         *                           owner null, member Foo; attestation decides
+         *   (0)                     WPF parameter index into PathParameters
+         *   (abc)                   WPF literal paren string
+         *
+         * Avalonia disambiguates cast-vs-attached the same lexical way (no dot
+         * means cast), so shape-wise one node suffices; only the double-paren cast
+         * form gets its own node (Cast).
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Paren implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public Paren withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+
+            @Nullable
+            Ident owner;
+
+            /**
+             * Whitespace before the owner/member dot; null when owner is null.
+             */
+            @Nullable
+            String beforeDot;
+
+            Ident member;
+            String beforeClosingParen;
+        }
+
+        /**
+         * The double-paren cast form — shared grammar of WinUI x:Bind and Avalonia
+         * bindings (Avalonia allows it mid-path in ordinary {Binding}):
+         *
+         *   ((TextBox)obj).Text                    x:Bind
+         *   $parent.((Button)DataContext).Tag      Avalonia
+         *
+         * prefix is before the OUTER paren; type is the inner (ns:Type) group; the
+         * operand (member and optional indexer) sits inside the outer parens.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Cast implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public Cast withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+            ParenGroup type;
+            PropertyPath operand;
+            String beforeClosingParen;
+        }
+
+        /**
+         * WinUI/UWP x:Bind function binding — the one dialect where a path step
+         * takes arguments:
+         *
+         *   {x:Bind ViewModel.Format(Item.Value, 'N2'), Mode=OneWay}
+         *
+         * Arguments reuse Argument (always positional; values are PropertyPaths or
+         * Literal constants). name.type attests to the resolved method. Gated on
+         * the x:Bind context, which is syntactic (x: resolves via in-document
+         * xmlns). NOT valid in WPF, MAUI, or Avalonia paths — Avalonia
+         * method/command bindings are a bare identifier, never a call.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class FunctionCall implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public FunctionCall withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+            Ident name;
+            String beforeOpenParen;
+            List<Argument> arguments;
+            String beforeClosingParen;
+        }
+
+        /**
+         * Avalonia element-name step:  {Binding #slider.Value}
+         * WPF's ElementName= concept expressed inside the path grammar (root-only
+         * in Avalonia), hence a distinct-grammar node. name.type attests to the
+         * x:Name'd element's type. prefix is before the hash.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Element implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public Element withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+            Ident name;
+        }
+
+        /**
+         * Avalonia relative-source step (root-only):
+         *
+         *   $self
+         *   $parent
+         *   $parent[Border]              ancestorType only
+         *   $parent[2]                   ancestorLevel only (an integer token is
+         *                                parsed into ancestorLevel, not a type —
+         *                                lexical: digits cannot start a type name)
+         *   $parent[local:MyControl;1]   both, SEMICOLON separated
+         *
+         * Nullable before* fields encode which tokens are present. WPF's
+         * equivalent ({RelativeSource FindAncestor, AncestorType={x:Type Border},
+         * AncestorLevel=1}) needs NO nodes here — it is plain MarkupExtension
+         * structure; only Avalonia gave the concept its own grammar. prefix is
+         * before the dollar sign.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Relative implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public Relative withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+            Kind kind;
+
+            @Nullable
+            String beforeOpenBracket;
+
+            @Nullable
+            Ident ancestorType;
+
+            @Nullable
+            String beforeSemicolon;
+
+            @Nullable
+            Literal ancestorLevel;
+
+            @Nullable
+            String beforeClosingBracket;
+
+            public enum Kind {
+                SELF, PARENT
+            }
+        }
+
+        /**
+         * The Avalonia stream operator as a path STEP — it binds the value
+         * produced so far (IObservable/Task), may appear mid-path and repeatedly,
+         * so it cannot be a whole-path flag:
+         *
+         *   Activity^     [Property, Stream(NONE)]
+         *   Foo^.Bar^     [Property, Stream(NONE), Property(DOT), Stream(NONE)]
+         *   ^             [Stream(NONE)]        stream of the source itself
+         *   .^            [Stream(DOT)]
+         *
+         * prefix is before the caret. Not valid in WPF/WinUI/MAUI.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class Stream implements Segment {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public Stream withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            Accessor accessor;
+        }
+    }
+
+    /**
+     * Avalonia logical-negation prefix on a binding value: {Binding !IsEnabled}.
+     * Wraps its operand, so the to-bool double-negation !!Items.Count is two
+     * nested Negations — nesting matches the operator semantics and keeps this one
+     * node type. Only legal as a leading run (Avalonia rejects mid-path bangs);
+     * that is a parser/validation concern, not a shape. prefix is before the bang.
+     * Not valid WPF/WinUI/MAUI grammar.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class Negation implements Expression {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        String prefixUnsafe;
+
+        @Override
+        public Negation withPrefix(String prefix) {
+            return WithPrefix.onlyIfNotEqual(this, prefix);
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefixUnsafe;
+        }
+
+        Markers markers;
+        Expression operand;
+    }
+
+    /**
+     * A XAML type-name with optional generic arguments and array subscripts —
+     * XAML's generic syntax uses PARENTHESES, and WPF's GenericTypeNameParser
+     * additionally accepts array subscripts folded onto the name:
+     *
+     *   x:TypeArguments="sys:String"
+     *   x:TypeArguments="scg:List(sys:String)"
+     *   x:TypeArguments="scg:Dictionary(sys:String, scg:List(sys:Int32))"  nests
+     *   x:TypeArguments="sys:String[]"     subscript = "[]"
+     *   x:TypeArguments="sys:Int32[,][]"   subscript = "[,][]" (verbatim; rank
+     *                                      derivable; interior spaces "[ , ]" are
+     *                                      legal and kept)
+     *
+     * Parsed as TypeName only where the grammar guarantees a type: x:TypeArguments
+     * values (the x: prefix resolves syntactically via in-document xmlns).
+     * Everywhere else type-valued tokens ({x:Type Grid}'s positional arg,
+     * DataType="local:Person", cast/ancestor type tokens) are lexically ordinary
+     * tokens and stay Literal/Ident with JavaType attestation — parse shape must
+     * not depend on resolution.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class TypeName implements Expression {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        String prefixUnsafe;
+
+        @Override
+        public TypeName withPrefix(String prefix) {
+            return WithPrefix.onlyIfNotEqual(this, prefix);
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefixUnsafe;
+        }
+
+        Markers markers;
+
+        /**
+         * Verbatim, possibly xmlns-prefixed: scg:List — resolved type in name.type.
+         */
+        Ident name;
+
+        /**
+         * Null when non-generic.
+         */
+        @Nullable
+        GenericArguments typeArguments;
+
+        /**
+         * Verbatim array subscript run incl. any interior whitespace; null if none.
+         */
+        @Nullable
+        String subscript;
+
+        /**
+         * The parenthesized argument list:  ( sys:String , sys:Int32 )
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class GenericArguments implements Xml {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public GenericArguments withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            List<TypeArgument> arguments;
+            String beforeClosingParen;
+        }
+
+        /**
+         * One generic argument with its trailing-comma gap.
+         */
+        @Value
+        @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+        @With
+        public static class TypeArgument implements Xml {
+            @EqualsAndHashCode.Include
+            UUID id;
+
+            String prefixUnsafe;
+
+            @Override
+            public TypeArgument withPrefix(String prefix) {
+                return WithPrefix.onlyIfNotEqual(this, prefix);
+            }
+
+            @Override
+            public String getPrefix() {
+                return prefixUnsafe;
+            }
+
+            Markers markers;
+            TypeName type;
+
+            /**
+             * Before the trailing ','; null on the last argument.
+             */
+            @Nullable
+            String beforeComma;
+        }
+    }
+
+    /**
+     * A parenthesized single token — the shared shape for contexts where parens
+     * wrap one uninterpreted token whose meaning is attestation's job:
+     *
+     *   indexer param prefix  [(sys:Int32)42]  [(2)]  [(abc)]  see Indexer.Param
+     *   cast target type      ((TextBox)obj)                   see Cast
+     *
+     * token is a verbatim Literal (attestation resolves it to a type, a parameter
+     * index, or nothing). Distinct from the Paren path segment, whose content has
+     * owner-dot-member structure. prefix is before the opening paren.
+     */
+    @Value
+    @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
+    @With
+    class ParenGroup implements Xml {
+        @EqualsAndHashCode.Include
+        UUID id;
+
+        String prefixUnsafe;
+
+        @Override
+        public ParenGroup withPrefix(String prefix) {
+            return WithPrefix.onlyIfNotEqual(this, prefix);
+        }
+
+        @Override
+        public String getPrefix() {
+            return prefixUnsafe;
+        }
+
+        Markers markers;
+        Literal token;
+        String beforeClosingParen;
     }
 }


### PR DESCRIPTION
**Draft / RFC — for discussion only, not ready to merge.** CI is expected to be red; see the blocker below.

Adds a XAML layer to the XML LST, kept in structural sync between `rewrite-xml/.../tree/Xml.java` and `rewrite-csharp/csharp/OpenRewrite/Xml/Xml.cs`: `JavaType` attestation slots on `Tag`, `Ident` and the new `Literal` (semantic identity without node-type proliferation), a polymorphic attribute-value slot (`Attribute.AttributeValue`, implemented by the unchanged `Value` for plain XML plus a new `ExpressionValue` carrying a parsed expression tree), and a value/binding expression layer — `MarkupExtension`/`Argument`, `PropertyPath` with `Property`/`Indexer`/`Paren`/`Cast`/`FunctionCall`/`Element`/`Relative`/`Stream` segments, `Negation`, `TypeName`, `ParenGroup` — covering WPF, WinUI (incl. `x:Bind`), MAUI/Xamarin.Forms, Avalonia and Silverlight. Plain XML documents never contain the new nodes and their values stay `Value` instances, so existing serialized LSTs deserialize unchanged.

**Known blocker, and the main question for reviewers:** `org.openrewrite.java.tree.JavaType` lives in `rewrite-java`, but `rewrite-xml` only depends on `rewrite-core`, so `rewrite-xml:compileJava` fails. Where should the type model live for a non-Java language module that needs attestation? That decision is what this RFC is asking the team to settle before any parser/printer/visitor work starts.