### PR TITLE
Gradle: disable the no-repositories metadata test only when a mirror is injected

### DIFF
--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -16,8 +16,8 @@
 package org.openrewrite.gradle;
 
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
@@ -2262,7 +2262,8 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
+    @DisabledIfEnvironmentVariable(named = "REWRITE_GRADLE_MIRROR_URL", matches = ".+",
+            disabledReason = "An injected mirror adds a repository, defeating the empty-repositories scenario.")
     void cannotDownloadMetaDataWhenNoRepositoriesAreDefined() {
         rewriteRun(
           buildGradle(


### PR DESCRIPTION
## What's changed?

- `UpgradeDependencyVersionTest.cannotDownloadMetaDataWhenNoRepositoriesAreDefined` has carried a blanket `@Disabled` since #7566, so it runs nowhere — not in CI, and not for anyone building without a mirror configured. It's the last `@Disabled("...temporarily disabled after Artifactory introduction")` left in `rewrite-gradle`.

- This swaps it for the conditional disable that #7566 already applied to the two tests in the same situation.

## Why it fails under a mirror

The test asserts that a build file declaring no repositories produces an `Unable to download metadata` marker. When `REWRITE_GRADLE_MIRROR_URL` / `_USERNAME` / `_PASSWORD` are all set, `OpenRewriteModelBuilder.mirrorScriptSnippet()` prepends the mirror to `project.repositories` via `gradle.beforeProject`:

```groovy
gradle.beforeProject { project ->
    __rewriteAddMirror(project.buildscript.repositories)
    __rewriteAddMirror(project.repositories)
}
```

So the embedded build no longer has zero repositories, guava metadata resolves, and the recipe upgrades instead of marking. Simply deleting the `@Disabled` reddens CI — with the mirror env set locally (pointed at Maven Central, standing in for Artifactory):

```
UpgradeDependencyVersionTest > cannotDownloadMetaDataWhenNoRepositoriesAreDefined() FAILED
    org.opentest4j.AssertionFailedError: [Unexpected result in "build.gradle":
    @@ -3,5 +3,5 @@
     dependencies {
    -  /*~~(com.google.guava:guava failed. Unable to download metadata.)~~>*/implementation "com.google.guava:guava:29.0-jre"
    +  implementation "com.google.guava:guava:30.1.1-jre"
     }
```

- That is exactly the situation `EffectiveGradleRepositoriesTest.emptyRepositories` and `FindRepositoryOrderTest.emptyRepositories` are in, and #7566 gave those two a conditional disable rather than a blanket one. This applies the same annotation, reusing their `disabledReason` verbatim because the scenario is identical.

## What it costs

**This does not make the test run in CI.** CI always sets the mirror, so it stays skipped there — same as the two `emptyRepositories` tests. What it buys is that the test runs for every contributor and downstream build without a mirror, instead of being dead everywhere.

If you'd rather have the scenario covered in CI too, the alternative is to make the assertion tolerate an injected repository (or to suppress injection for this one build), which is a larger change to `OpenRewriteModelBuilder` — happy to take that on instead if you prefer it.

## Tests

Verified all four combinations locally on `f90af07`:

| annotation | `REWRITE_GRADLE_MIRROR_URL` | result |
|---|---|---|
| `@Disabled` (before) | unset or set | skipped — never runs |
| removed | unset | **passes** |
| removed | set | **fails** (output above) |
| `@DisabledIfEnvironmentVariable` (after) | set | skipped |
| `@DisabledIfEnvironmentVariable` (after) | unset | **passes** |

The middle two are the point: the test is sound off-mirror, and the guard is doing real work rather than being decorative.

The full `UpgradeDependencyVersionTest` class passes with the change: **110 tests, 0 failures, 0 errors, 0 skipped** (no mirror configured, so the guarded test runs).

## Any additional context

- Noticed while looking into #7576. This does **not** fix that issue — the two tests named there, `ChangeDependencyTest.changeDependencyWithLowerVersionAfter` and `ChangePluginTest.changeApplyPluginSyntax`, were re-enabled in #7999 and are green on `main` today. The remaining five `@Disabled("...Artifactory introduction")` tests are all in `rewrite-maven`; I haven't investigated their root causes and deliberately left them alone.
