### PR TITLE
JavaTemplate gives repeated parameter occurrences fresh ids

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest.java
@@ -25,7 +25,10 @@ import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.TypeValidation;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.UUID;
 
 import static java.util.Comparator.comparing;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -1736,5 +1739,96 @@ class JavaTemplateTest implements RewriteTest {
               """
           )
         );
+    }
+
+    @Test
+    void repeatedParameterOccurrencesGetFreshIds() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<ExecutionContext>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if (!"indexOf".equals(method.getSimpleName()) || getCursor().firstEnclosing(J.Ternary.class) != null) {
+                      return super.visitMethodInvocation(method, ctx);
+                  }
+                  return JavaTemplate.builder("#{any(java.util.List)} == null ? -1 : #{any(java.util.List)}.indexOf(#{any()})")
+                    .build()
+                    .apply(getCursor(), method.getCoordinates().replace(),
+                      method.getSelect(), method.getSelect(), method.getArguments().getFirst());
+              }
+          })),
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  int m(List<String> l, String s) {
+                      return l.indexOf(s);
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  int m(List<String> l, String s) {
+                      return l == null ? -1 : l.indexOf(s);
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(JavaTemplateTest::assertUniqueIds)
+          )
+        );
+    }
+
+    @Test
+    void repeatedNamedPatternOccurrencesGetFreshIds() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<ExecutionContext>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if (!"indexOf".equals(method.getSimpleName()) || getCursor().firstEnclosing(J.Ternary.class) != null) {
+                      return super.visitMethodInvocation(method, ctx);
+                  }
+                  return JavaTemplate.builder("#{l:any(java.util.List)} == null ? -1 : #{l}.indexOf(#{any()})")
+                    .build()
+                    .apply(getCursor(), method.getCoordinates().replace(),
+                      method.getSelect(), method.getArguments().getFirst());
+              }
+          })),
+          java(
+            """
+              import java.util.List;
+
+              class Test {
+                  int m(List<String> l, String s) {
+                      return l.indexOf(s);
+                  }
+              }
+              """,
+            """
+              import java.util.List;
+
+              class Test {
+                  int m(List<String> l, String s) {
+                      return l == null ? -1 : l.indexOf(s);
+                  }
+              }
+              """,
+            spec -> spec.afterRecipe(JavaTemplateTest::assertUniqueIds)
+          )
+        );
+    }
+
+    private static void assertUniqueIds(J.CompilationUnit cu) {
+        Set<UUID> ids = new HashSet<>();
+        new JavaIsoVisitor<Integer>() {
+            @Override
+            public J postVisit(J tree, Integer p) {
+                assertThat(ids.add(tree.getId()))
+                  .as("Duplicate id %s on %s", tree.getId(), tree.getClass().getSimpleName())
+                  .isTrue();
+                return tree;
+            }
+        }.visit(cu, 0);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -23,6 +23,7 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.PropertyPlaceholderHelper;
 import org.openrewrite.java.JavaTypeVisitor;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.RandomizeIdVisitor;
 import org.openrewrite.java.internal.grammar.TemplateParameterParser;
 import org.openrewrite.java.internal.grammar.TemplateParameterParser.TypeContext;
 import org.openrewrite.java.tree.*;
@@ -48,6 +49,18 @@ public class Substitutions {
             "#{", "}", null);
     @Getter
     private final Set<JavaType.GenericTypeVariable> typeVariables = newSetFromMap(new IdentityHashMap<>());
+    private final Set<UUID> splicedParameterIds = new HashSet<>();
+
+    /**
+     * Parameters are spliced into the parsed template verbatim, so a node serving more than one
+     * occurrence would repeat its {@link org.openrewrite.Tree#getId()}; later occurrences get fresh ids.
+     */
+    private J spliceParameter(int index) {
+        J parameter = (J) parameters[index];
+        return splicedParameterIds.add(parameter.getId()) ?
+                parameter :
+                new RandomizeIdVisitor<Integer>().visitNonNull(parameter, 0);
+    }
 
     public String substitute() {
         Map<String, JavaType.GenericTypeVariable> generics = TypeParameter.parseGenericTypes(genericTypes);
@@ -335,7 +348,7 @@ public class Substitutions {
             public J visitAnnotation(J.Annotation annotation, Integer integer) {
                 if (TypeUtils.isOfClassType(annotation.getType(), "SubAnnotation")) {
                     J.Literal index = (J.Literal) annotation.getArguments().get(0);
-                    J a2 = (J) parameters[(Integer) index.getValue()];
+                    J a2 = spliceParameter((Integer) index.getValue());
                     return a2.withPrefix(a2.getPrefix().withWhitespace(annotation.getPrefix().getWhitespace()));
                 }
                 return super.visitAnnotation(annotation, integer);
@@ -406,7 +419,7 @@ public class Substitutions {
             private @Nullable J maybeParameter(J marker, J replaced) {
                 Integer param = parameterIndex(marker.getPrefix());
                 if (param != null) {
-                    J j2 = (J) parameters[param];
+                    J j2 = spliceParameter(param);
                     return j2.withPrefix(j2.getPrefix().withWhitespace(replaced.getPrefix().getWhitespace()));
                 }
                 return null;


### PR DESCRIPTION
Naming the same parameter twice in a `JavaTemplate` produces two subtrees with identical `Tree.getId()` values. Both of these leave a duplicate id in the result:

```java
// the same object passed twice
JavaTemplate.builder("#{any(java.util.List)} == null ? -1 : #{any(java.util.List)}.indexOf(#{any()})")
        .build().apply(cursor, coords, list, list, needle);

// a named typed pattern referenced again
JavaTemplate.builder("#{l:any(java.util.List)} == null ? -1 : #{l}.indexOf(#{any()})")
```

This is the shape any replacement needs when it has to null-guard its receiver and then call through it, so it is easy to hit by accident. `Tree.getId()` is documented as unique, and a lot of code treats id equality as node identity — `Tree.isScope`, the formatter's `stopAfter` plumbing, blank-line rules asking "is this the first statement in the block", and any recipe that keys on an id to address one node. With two nodes answering to one id, none of them can tell the occurrences apart.

## The mechanism

`JavaTemplate` looks like it sidesteps this by re-parsing: it substitutes `#{...}` placeholders with generated source, parses the whole template, and re-attributes. It does not. `Substitutions.unsubstitute(J)` walks the parsed template looking for the `__pN__` marker comment and puts the caller's original node back — `maybeParameter` returns `parameters[param]` with nothing but `withPrefix` applied, and `visitAnnotation` does the same for annotation parameters. Ids and all, the caller's node lands in the result.

The two shapes reach that point differently. A named reference resolves through `substitute()`'s `typedPatternByName`, so both `#{l}` occurrences map back to the same `__pN__` string and therefore to one parameter index. The same object passed twice occupies *two* indices that happen to hold one node.

## The fix

Both splice sites now go through `spliceParameter`, which runs the existing `RandomizeIdVisitor` over every occurrence past the first.

The guard is keyed on the parameter's `Tree.getId()`, not on the parameter index, because index-keying only covers the named-pattern shape — in the two-arguments-one-object case the indices are distinct, so an index-keyed guard splices both verbatim and the duplicate survives. Keying on the id subsumes both. Identity is not usable as the key either: `substituteTypedPattern` calls `withPrefix(Space.EMPTY)` per index, which returns a fresh instance whenever the prefix is non-empty, giving two distinct objects that still share an id.

`RandomizeIdVisitor` is already scoped correctly for this. It refreshes `J` ids in `postVisit` and does not descend into `JavaType` — `JavaVisitor.visitType` is identity and the visitor does not override it — so the cyclic type graph is shared with the original rather than walked. `Markers` ids are likewise untouched, which keeps the tree-wide shared empty-markers instance intact. Widening it to markers would break that sharing and the RPC ref-dedup that depends on it.

The tracking set lives on the `Substitutions` instance, which `JavaTemplate.doApply` constructs fresh per application, so it spans exactly one apply — including the `unsubstitute(List)` overload that maps over several statements.

Not an RPC bug, for the record: `RpcSendQueue.putListPositions` keys `before` by id and so collides on a repeat, but the resolved positions list travels with the batch, so sender and receiver pick the same baseline and the tree round-trips correctly either way.

## Tests

Two cases in `JavaTemplateTest`, one per shape above, each asserting that every `Tree.getId()` in the resulting compilation unit is distinct. Both fail before the fix with `Duplicate id … on Identifier`. A rendering assertion alone passes either way — the two occurrences print identically — so the id-uniqueness assertion is the one doing the work.

`:rewrite-java:test`, `:rewrite-java-test:test`, `:rewrite-groovy:test` and `:rewrite-kotlin:test` all pass; the latter two cover `GroovySubstitutions` and `KotlinSubstitutions`, which inherit the splice path.
