### PR TITLE
Maven: pin the repository in two mirror-sensitive failure tests

### DIFF
--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddDependencyTest.java
@@ -17,16 +17,19 @@ package org.openrewrite.maven;
 
 import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
+import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.ChangePackage;
 import org.openrewrite.java.JavaParser;
+import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
 
 import static org.openrewrite.java.Assertions.*;
 import static org.openrewrite.maven.Assertions.pomXml;
@@ -84,11 +87,14 @@ class AddDependencyTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void dontAddDuplicateIfUpdateModelOnPriorRecipeCycleFailed() {
         rewriteRun(
           spec -> spec
-            .recipe(addDependency("doesnotexist:doesnotexist:1", "com.google.common.math.IntMath")),
+            .recipe(addDependency("doesnotexist:doesnotexist:1", "com.google.common.math.IntMath"))
+            // Pin the repository so the "Tried repositories" list below is not rewritten by a
+            // mirror configured in ~/.m2/settings.xml.
+            .executionContext(centralOnly())
+            .recipeExecutionContext(centralOnly()),
           mavenProject("project",
             srcMainJava(
               java(usingGuavaIntMath)
@@ -2454,6 +2460,15 @@ class AddDependencyTest implements RewriteTest {
               """
           )
         );
+    }
+
+    private static MavenExecutionContextView centralOnly() {
+        return MavenExecutionContextView.view(new InMemoryExecutionContext())
+          .setRepositories(List.of(MavenRepository.builder()
+            .id("central")
+            .uri("https://repo.maven.apache.org/maven2")
+            .knownToExist(true)
+            .build()));
     }
 
     private AddDependency addDependency(@SuppressWarnings("SameParameterValue") String gav) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/MavenDependencyFailuresTest.java
@@ -79,14 +79,17 @@ class MavenDependencyFailuresTest implements RewriteTest {
     }
 
     @Test
-    @Disabled("2026-05-04 temporarily disabled after Artifactory introduction")
     void unresolvableMavenMetadata() {
         rewriteRun(
           spec -> spec
             .recipe(new UpgradeDependencyVersion("*", "*", "latest.patch", null, null, null))
             .executionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
               .setRepositories(List.of(MavenRepository.builder().id("jenkins").uri("https://repo.jenkins-ci.org/public").build())))
-            .recipeExecutionContext(new InMemoryExecutionContext())
+            // Pin the recipe context too: left as a bare context it picks up a mirror from
+            // ~/.m2/settings.xml, and the failed-repository URI asserted below becomes the
+            // mirror's rather than Maven Central's.
+            .recipeExecutionContext(MavenExecutionContextView.view(new InMemoryExecutionContext())
+              .setRepositories(List.of(MavenRepository.builder().id("central").uri("https://repo.maven.apache.org/maven2").knownToExist(true).build())))
             .cycles(1)
             .expectedCyclesThatMakeChanges(1)
             .dataTable(MavenMetadataFailures.Row.class, failures ->


### PR DESCRIPTION
## What's changed?

Re-enables two of the six tests disabled on 2026-05-04 after the Artifactory switch, by making their assertions independent of whatever mirror is configured rather than by skipping them.

- `AddDependencyTest.dontAddDuplicateIfUpdateModelOnPriorRecipeCycleFailed`
- `MavenDependencyFailuresTest.unresolvableMavenMetadata`

## Root cause

Both assert on a concrete repository URL, and a mirror rewrites it. Reproduced locally by pointing a wildcard `<mirrorOf>*</mirrorOf>` at `repo1.maven.org` (standing in for Artifactory) with the `@Disabled` removed:

```
-https://repo.maven.apache.org/maven2: HTTP 404)~~>--><dependency>
+https://repo1.maven.org/maven2/: HTTP 404)~~>--><dependency>
```

```
Expecting actual:  ["https://repo1.maven.org/maven2/"]
to contain exactly in any order:  ["https://repo.maven.apache.org/maven2"]
```

The mirror reaches them because `Assertions.customizeExecutionContext` (and `MavenSettingsAutoLoadingExtension`) load `~/.m2/settings.xml` whenever the context has nothing configured. `unresolvableMavenMetadata` already pins its parser context, but left `recipeExecutionContext` a bare `InMemoryExecutionContext`, which is the one the metadata lookup uses.

## Approach

- Both guards load settings only when *nothing* is configured, so pinning the repository opts out. That keeps the tests running in CI rather than skipping them there, which is why I went this way instead of the `@DisabledIfEnvironmentVariable` treatment #7566 applied to the `emptyRepositories` tests.

Worth noting `Assertions.customizeExecutionContext` ships in `rewrite-maven` main, not test — so this sensitivity affects downstream users whose `~/.m2/settings.xml` has a mirror, not only this repo's CI.

## What it costs

The pinned context no longer honours a user's mirror for these two tests, which is the point but does mean they exercise a slightly narrower path than a default-context test. Both are failure-path tests asserting an exact message, so there is nothing a mirror would usefully add.

## Tests

`AddDependencyTest` + `MavenDependencyFailuresTest`, run both ways:

| | no mirror | wildcard mirror |
|---|---|---|
| before (`@Disabled` removed, unpinned) | pass | **fail** (output above) |
| after (pinned) | **pass** | **pass** |

Final state: **59 tests, 0 failures, 0 errors, 1 skipped** — identical with and without a mirror. The 1 skip is `unresolvableParent`, left disabled (below).

## The other four

Deliberately untouched. I could not reproduce failures for `MavenDependencyFailuresTest.unresolvableParent`, `UpgradePluginVersionTest$PluginRepos.repoUnreachable`, or `UpgradePluginVersionTest$PluginRepos.noNewerVersion` — but my stand-in mirror is not a faithful Artifactory: it does not proxy Red Hat GA or the Jenkins repo. The tell is that the currently-enabled `UpgradePluginVersionTest$PluginRepos.update` *fails* under my stand-in because Central has no `3.15.3.redhat-00002`. All three of those tests depend on those same non-Central repositories, so "didn't reproduce here" is not evidence they'd pass against the real cache — someone who can run CI against Artifactory is better placed to settle them.

- The sixth, `rewrite-gradle`'s `UpgradeDependencyVersionTest.cannotDownloadMetaDataWhenNoRepositoriesAreDefined`, has a different root cause and is handled separately in #8664.
