### PR TITLE
JS: a container splice keeps the line breaks and the comment spacing the source wrote

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -230,14 +230,7 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                 // Apply beforeComma rule to all elements except the last
                 // (last element's after is before closing bracket, not a comma)
                 for (let i = 0; i < draft.elements.length - 1; i++) {
-                    const after = draft.elements[i].after;
-                    if (after.comments.length > 0) {
-                        // A comment in the padding owns the space in front of it; only its suffix meets the comma
-                        SpacesVisitor.spaceLastCommentSuffixDraft(after.comments, this.style.other.beforeComma);
-                    } else if (!after.whitespace.includes("\n")) {
-                        // Preserve newlines - only adjust when on same line
-                        after.whitespace = this.style.other.beforeComma ? " " : "";
-                    }
+                    this.spaceAfterRightPaddedDraft(draft.elements[i], this.style.other.beforeComma);
                 }
             }
             if (draft.elements.length > 1) {

--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -230,10 +230,13 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                 // Apply beforeComma rule to all elements except the last
                 // (last element's after is before closing bracket, not a comma)
                 for (let i = 0; i < draft.elements.length - 1; i++) {
-                    const afterWs = draft.elements[i].after.whitespace;
-                    // Preserve newlines - only adjust when on same line
-                    if (!afterWs.includes("\n")) {
-                        draft.elements[i].after.whitespace = this.style.other.beforeComma ? " " : "";
+                    const after = draft.elements[i].after;
+                    if (after.comments.length > 0) {
+                        // A comment in the padding owns the space in front of it; only its suffix meets the comma
+                        SpacesVisitor.spaceLastCommentSuffixDraft(after.comments, this.style.other.beforeComma);
+                    } else if (!after.whitespace.includes("\n")) {
+                        // Preserve newlines - only adjust when on same line
+                        after.whitespace = this.style.other.beforeComma ? " " : "";
                     }
                 }
             }

--- a/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
@@ -82,8 +82,8 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
             return super.visitContainer(container, p);
         }
 
-        // Expand variadic placeholders in the container's elements
-        const newElements = await this.expandVariadicElements(container.elements, undefined, p);
+        // A container's element layout is the author's; a block lays its statements out by indentation
+        const newElements = await this.expandVariadicElements(container.elements, undefined, p, true);
 
         return produce(container, draft => {
             draft.elements = newElements as any;
@@ -175,6 +175,12 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
         };
     }
 
+    /** As `mergePrefix`, but a line break the source wrote and the template did not is the source's layout. */
+    private mergeElementPrefix(sourcePrefix: J.Space, templatePrefix: J.Space): J.Space {
+        return sourcePrefix.whitespace.includes('\n') && !templatePrefix.whitespace.includes('\n') ?
+            sourcePrefix : this.mergePrefix(sourcePrefix, templatePrefix);
+    }
+
     /**
      * Expands variadic placeholders in a list of elements.
      *
@@ -186,7 +192,8 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
     private async expandVariadicElements(
         elements: J.RightPadded<J>[],
         unwrapElement: (element: J) => J = (e) => e,
-        p: any
+        p: any,
+        ownLayout: boolean = false
     ): Promise<J.RightPadded<J>[]> {
         const newElements: J.RightPadded<J>[] = [];
 
@@ -263,7 +270,9 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
                                             if (i === 0 && draft.element) {
                                                 // Merge the placeholder's prefix with the first item's prefix
                                                 // Modify prefix directly within the draft
-                                                draft.element.prefix = this.mergePrefix(draft.element.prefix, element.prefix);
+                                                draft.element.prefix = ownLayout ?
+                                                    this.mergeElementPrefix(draft.element.prefix, element.prefix) :
+                                                    this.mergePrefix(draft.element.prefix, element.prefix);
                                             }
                                             // Keep all other wrapper properties (including markers with Semicolon)
                                         }));
@@ -273,7 +282,9 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
                                         newElements.push(produce(wrapped, draft => {
                                             draft.element = produce(elem, itemDraft => {
                                                 if (i === 0) {
-                                                    itemDraft.prefix = this.mergePrefix(elem.prefix, element.prefix);
+                                                    itemDraft.prefix = ownLayout ?
+                                                        this.mergeElementPrefix(elem.prefix, element.prefix) :
+                                                        this.mergePrefix(elem.prefix, element.prefix);
                                                 }
                                                 // For i > 0, prefix is already correct, no changes needed
                                             });

--- a/rewrite-javascript/rewrite/test/javascript/templating/container-layout.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/container-layout.test.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from '../../../src/test';
+import {javascript, JavaScriptVisitor, template} from '../../../src/javascript';
+import {Expression, J} from '../../../src/java';
+import {ExecutionContext} from '../../../src';
+
+describe('a substituted container keeps the line breaks the source wrote', () => {
+    const spec = new RecipeSpec();
+
+    /** `Array(...)` becomes `[...]`, the same arguments under a different pair of delimiters. */
+    spec.recipe = fromVisitor(new class extends JavaScriptVisitor<ExecutionContext> {
+        override async visitMethodInvocation(method: J.MethodInvocation, p: ExecutionContext): Promise<J | undefined> {
+            const args: J.Container<Expression> = method.arguments;
+            return await template`[${args}]`.apply(method, this.cursor);
+        }
+    });
+
+    /** The line breaks are the source's; the indent between them is the formatter's, as on the JVM. */
+    test('an argument per line', () => spec.rewriteRun(
+        //language=javascript
+        javascript(
+            `
+                Array(
+                  1,
+                  2
+                );
+            `,
+            `
+                [
+                    1,
+                    2
+                ];
+            `)));
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/container-layout.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/container-layout.test.ts
@@ -45,4 +45,8 @@ describe('a substituted container keeps the line breaks the source wrote', () =>
                     2
                 ];
             `)));
+
+    test('an argument carrying a trailing comment', () => spec.rewriteRun(
+        //language=javascript
+        javascript(`Array(1 /* one */, 2 /* two */,);`, `[1 /* one */, 2 /* two */,];`)));
 });


### PR DESCRIPTION
`` template`[${args}]` `` over an argument list written one argument per line pulled the first argument up onto the `[`:

```js
[1,
    2
];
```

The expansion hands the first element the placeholder's whitespace, and a template writes its container on one line. What sits between a container's delimiters is text the author wrote, so a line break there is the author's. `expandVariadicElements` now takes that layout from the source when the source wrote a break and the template did not. The indent between the breaks stays the formatter's, which is the same split the JVM settles on: `MergeSpacesVisitor` keeps the original's whitespace up to and including the last `\n` and the formatter's after it. A block is left alone — it lays its statements out by indentation and the formatter owns that.

The second commit is a formatter bug the first one uncovered. `[1 /* one */, 2 /* two */,]` came back as `[1/* one */, 2 /* two */,]`. The comment lives in the padding after the element, and `SpacesVisitor.visitContainer` open-codes the beforeComma rule over that padding's whitespace, so a comment sitting in it loses the space that separated it from the element. Only the last element kept its space, and only because the loop skips it. `spaceAfterRightPaddedDraft`, twenty lines below, already has the rule this needs: where the padding carries comments, the comma rule applies to the last comment's suffix and the whitespace in front is left alone.

## What this no longer does

An earlier revision added a `Verbatim` marker that exempted every substituted subtree from formatting. It is gone. Two of the four cases it was written for are the formatter behaving the way the JVM behaves: `x  <  y` normalizes to `x < y` there too, and a continuation line written at two columns is re-indented to the style's width, because `MergeSpacesVisitor` takes the whitespace after the last line break from the formatter. Wanting those back is wanting stricter-than-JVM, and `apply(node, cursor, {format: false})` from #8678 already turns the pipeline off for a single application when a recipe wants exactly the text it wrote.

`x  ===  2` surviving where `x  <  y` does not is not this PR's doing. `SpacesVisitor` implements `visitBinary` and no `visitBinaryExtensions`, so `JS.Binary` operators are never reached at all. Filed as moderneinc/customer-requests#3071.

Fixes the container half of moderneinc/customer-requests#3068; the verbatim half is closed as working-as-intended above.
