### PR TITLE
JavaScript: TabsAndIndentsVisitor re-indents comments ahead of a closing delimiter

### DIFF
--- a/rewrite-javascript/rewrite/src/java/formatting-utils.ts
+++ b/rewrite-javascript/rewrite/src/java/formatting-utils.ts
@@ -109,33 +109,37 @@ function marginOf(precedingWhitespace: string): string | undefined {
 }
 
 /**
- * Normalizes indentation in an entire Space: whitespace and comment suffixes take the target
- * indent, and the interior lines of a multi-line comment shift with it, so they stay aligned with
- * the opening delimiter that the surrounding whitespace positions.
+ * Normalizes indentation in an entire Space: comment lines take `commentIndent` and the line the
+ * following token lands on takes `targetIndent`, with the interior lines of a multi-line comment
+ * shifting alongside the opening delimiter that the surrounding whitespace positions.
  *
  * @param space The Space to normalize
- * @param targetIndent The indentation to use after newlines
+ * @param targetIndent The indentation for the token this Space precedes
+ * @param commentIndent The indentation for comment lines, which can sit deeper than the token — a
+ *        block's `}` closes at the block's own column while the comments ahead of it belong with
+ *        the block's contents
  * @returns The normalized Space, or the original if unchanged
  */
-export function normalizeSpaceIndent(space: J.Space, targetIndent: string): J.Space {
+export function normalizeSpaceIndent(space: J.Space, targetIndent: string, commentIndent: string = targetIndent): J.Space {
     let changed = false;
+    const lastComment = space.comments.length - 1;
 
-    // Normalize whitespace
+    // Normalize whitespace, which precedes the first comment when there is one
     let newWhitespace = space.whitespace;
     if (space.whitespace.includes("\n")) {
-        newWhitespace = replaceIndentAfterLastNewline(space.whitespace, targetIndent);
+        newWhitespace = replaceIndentAfterLastNewline(space.whitespace, lastComment < 0 ? targetIndent : commentIndent);
         changed = changed || newWhitespace !== space.whitespace;
     }
 
     // Normalize comment suffixes and multi-line comment interiors
     const newComments = space.comments.map((comment, i) => {
         const margin = marginOf(i === 0 ? space.whitespace : space.comments[i - 1].suffix);
-        let result: Comment = margin !== undefined && margin !== targetIndent && isTextComment(comment) ?
-            reindentComment(comment, margin, targetIndent) : comment;
+        let result: Comment = margin !== undefined && margin !== commentIndent && isTextComment(comment) ?
+            reindentComment(comment, margin, commentIndent) : comment;
         changed = changed || result !== comment;
 
         if (result.suffix.includes("\n")) {
-            const newSuffix = replaceIndentAfterLastNewline(result.suffix, targetIndent);
+            const newSuffix = replaceIndentAfterLastNewline(result.suffix, i === lastComment ? targetIndent : commentIndent);
             if (newSuffix !== result.suffix) {
                 changed = true;
                 result = {...result, suffix: newSuffix};

--- a/rewrite-javascript/rewrite/src/javascript/format/tabs-and-indents-visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/tabs-and-indents-visitor.ts
@@ -22,7 +22,6 @@ import {
     lastWhitespace,
     normalizeSpaceIndent,
     replaceIndentAfterLastNewline,
-    replaceLastWhitespace,
     spaceContainsNewline,
     stripLeadingIndent
 } from "../../java";
@@ -395,12 +394,12 @@ export class TabsAndIndentsVisitor<P> extends JavaScriptVisitor<P> {
     }
 
     private normalizeBlockEnd(block: J.Block, myIndent: number): J.Block {
-        const effectiveLastWs = lastWhitespace(block.end);
-        if (!effectiveLastWs.includes("\n")) {
+        if (!spaceContainsNewline(block.end)) {
             return block;
         }
-        return produce(block, draft => {
-            draft.end = replaceLastWhitespace(draft.end, ws => replaceIndentAfterLastNewline(ws, this.indentString(myIndent)));
+        const end = normalizeSpaceIndent(block.end, this.indentString(myIndent), this.indentString(myIndent + this.indentSize));
+        return end === block.end ? block : produce(block, draft => {
+            draft.end = end;
         });
     }
 
@@ -440,12 +439,14 @@ export class TabsAndIndentsVisitor<P> extends JavaScriptVisitor<P> {
         // Normalize the last element's after whitespace (closing delimiter like `)`)
         // The closing delimiter should align with the parent's indent level
         if (container.elements.length > 0) {
-            const effectiveLastWs = lastWhitespace(container.elements[container.elements.length - 1].after);
-            if (effectiveLastWs.includes("\n")) {
-                return produce(container, draft => {
-                    const lastDraft = draft.elements[draft.elements.length - 1];
-                    lastDraft.after = replaceLastWhitespace(lastDraft.after, ws => replaceIndentAfterLastNewline(ws, this.indentString(parentIndent)));
-                });
+            const last = container.elements[container.elements.length - 1];
+            if (spaceContainsNewline(last.after)) {
+                const after = normalizeSpaceIndent(last.after, this.indentString(parentIndent), this.indentString(parentIndent + this.indentSize));
+                if (after !== last.after) {
+                    return produce(container, draft => {
+                        draft.elements[draft.elements.length - 1].after = after;
+                    });
+                }
             }
         }
 

--- a/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/tabs-and-indents-visitor.test.ts
@@ -1471,4 +1471,137 @@ m() {}
             // @formatter:on
         );
     });
+
+    test('re-indents comments that sit before a closing delimiter', () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new TabsAndIndentsVisitor(tabsAndIndents()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+`class A {
+        m() {}
+        /* multi
+           line */
+}
+`,
+`class A {
+    m() {}
+    /* multi
+       line */
+}
+`),
+            //language=typescript
+            typescript(
+`class A {
+m() {}
+/* multi
+   line */
+}
+`,
+`class A {
+    m() {}
+    /* multi
+       line */
+}
+`),
+            //language=typescript
+            typescript(
+`class A {
+        m() {}
+        // trailing note
+}
+`,
+`class A {
+    m() {}
+    // trailing note
+}
+`),
+            //language=typescript
+            typescript(
+`class A {
+    m() {
+                // first
+                /* second
+                   more */
+    }
+}
+`,
+`class A {
+    m() {
+        // first
+        /* second
+           more */
+    }
+}
+`),
+            //language=typescript
+            typescript(
+`outer(
+        inner(
+                x
+                /* inner
+                   c */
+        )
+        /* outer
+           c */
+);
+`,
+`outer(
+    inner(
+        x
+        /* inner
+           c */
+    )
+    /* outer
+       c */
+);
+`),
+            // The last element shares the opening line, so nothing before the comment establishes
+            // the element column.
+            //language=typescript
+            typescript(
+`foo(a
+        /* c */
+);
+`,
+`foo(a
+    /* c */
+);
+`),
+            // The `}` rides along on the comment's line, so the Space's last whitespace holds no
+            // newline even though the comment's own line needs re-indenting.
+            //language=typescript
+            typescript(
+`class A {
+        m() {}
+        /* c */ }
+`,
+`class A {
+    m() {}
+    /* c */ }
+`),
+            // rewrite-java pulls the last comment's interior toward the `}` column instead, a shift
+            // it reapplies on every pass until the interior reaches column 0.
+            //language=typescript
+            typescript(
+`class A {
+        m() {}
+        /* first
+           more */
+        /* second
+           more */
+}
+`,
+`class A {
+    m() {}
+    /* first
+       more */
+    /* second
+       more */
+}
+`)
+            // @formatter:on
+        );
+    });
 });


### PR DESCRIPTION
`TabsAndIndentsVisitor` leaves a comment that sits at a block end — the last thing before the closing `}` — at whatever column the author typed, while correcting every statement around it. Under the IntelliJ TypeScript style, this:

```ts
class A {
        m() {}
        /* multi
           line */
}
```

comes out as this, with `m()` corrected and the comment untouched:

```ts
class A {
    m() {}
        /* multi
           line */
}
```

## Mechanism

A block's `end` Space holds everything between the last statement and the `}`. When that Space carries comments, the whitespace on the *comment's own line* lives in `Space.whitespace`, and only the run after the last comment lives in that comment's `suffix`. `normalizeBlockEnd` re-indented through `replaceLastWhitespace`, which by contract rewrites just the last comment's `suffix`. The `}` moved, the comment did not, and the path never reached `normalizeSpaceIndent` — which is where multi-line interior handling lives.

`JContainer`'s closing-delimiter path had the same gap for the same reason, so a comment before a `)` or `]` was left behind too:

```ts
const a = [
    1
        /* multi
           line */
];
```

## The fix

Both paths go through `normalizeSpaceIndent` now. It walks every line of the Space and shifts a multi-line comment's interior along with its delimiter.

That needs two target columns where the old code passed one: the closing delimiter returns to the enclosing construct's column, while the comments ahead of it belong with the contents. `normalizeSpaceIndent` takes an optional `commentIndent` for this, defaulting to `targetIndent` — each of the three new branches is the identity when the two indents are equal, so the existing prefix callers are unchanged.

I first had the container path read the column its last element actually landed at, on the theory that assuming `parentIndent + indentSize` would be wrong for continuation-indented arguments. That was backwards. When the last element shares the container's opening line, its recorded indent *is* the parent's, and the trailing comment gets dragged out to column 0 — outdented past its own `)`. The arithmetic is right in every case the reading version handled and right in that one too, so the plumbing that published the element's indent is gone. `foo(a\n        /* c */\n);` is now a test spec.

`postVisitLeftPadded` is the third direct `replaceIndentAfterLastNewline` call site, and I checked it rather than assuming: it has no such gap. A comment after `=` parses into the *following element's* prefix, which the prefix path already normalizes, so `const x =\n    /* multi\n       line */\n    1;` formats correctly today. Left alone.

## Where this deviates from rewrite-java, and why

Block-end comments land at `column + indentSize`, matching the `Space.Location.BLOCK_END` branch of rewrite-java's `TabsAndIndentsVisitor`. With a single block-end comment the two agree exactly.

With two or more they diverge, and rewrite-java is the one that is wrong. Its `toColumn` sends the last comment's interior to `column` while that comment's own `/*` stays at `column + indentSize`, pulling the interior away from its delimiter — and the shift is not idempotent. Running `TabsAndIndents` repeatedly over

```java
class A {
    void m() {}
    /* first
       more */
    /* second
           more */
}
```

walks the second comment's interior left on every pass — column 11, then 7, 3, 1, 0 — settling only against the left margin. `RewriteTest` reports it as "Expected recipe to complete in 1 cycle, but took at least one more cycle." Here every comment interior aligns with the block's contents and the result is a fixed point after one pass.

## Tests

One test, `re-indents comments that sit before a closing delimiter`, with seven source specs, each pinning a different line: a block-end comment needing dedent (the report above) and one needing indent, a single-line `//` at a block end (no interior to shift), a nested block (the column comes from the block's own indent, not a constant), nested containers (the container path at two depths), a last element sharing the container's opening line (the case described above), a `}` riding on the comment's line (the guard deciding whether the Space is processed at all), and the multi-comment case that pins the divergence above. Full JS and Java suites: 144 files, 1643 passed, 21 skipped.
