### PR TITLE
maybeAddImport matches the file's quote style

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -1,9 +1,11 @@
 import {JavaScriptVisitor} from "./visitor";
 import {emptySpace, J, rightPadded, singleSpace, space, Statement, Type} from "../java";
-import {JS} from "./tree";
+import {JS, JSX} from "./tree";
 import {randomId} from "../uuid";
 import {emptyMarkers, markers} from "../markers";
-import {getStyle, SpacesStyle, StyleKind} from "./style";
+import {getStyle, PrettierStyle, SpacesStyle, StyleKind} from "./style";
+
+export type QuoteChar = "'" | '"';
 
 export enum ImportStyle {
     ES6Named,      // import { x } from 'module'
@@ -13,8 +15,10 @@ export enum ImportStyle {
 }
 
 export interface AddImportOptions {
-    /** The module name (e.g., 'fs', 'react') to import from */
-    module: string;
+    /** The module name (e.g., 'fs', 'react') to import from.
+     * Pass a `J.Literal` to reuse its source form verbatim, which carries the quoting,
+     * escapes and unicode form of a specifier being moved from elsewhere in the source. */
+    module: string | J.Literal;
 
     /** Optionally, the specific member to import from the module.
      * If not specified, adds a default import or namespace import.
@@ -46,6 +50,10 @@ export interface AddImportOptions {
 
     /** Optional import style to use. If not specified, auto-detects from file and existing imports */
     style?: ImportStyle;
+
+    /** Quote character for the module specifier. If not specified, detected from the file.
+     * A `J.Literal` module carries its own quoting and takes precedence over this. */
+    quoteStyle?: QuoteChar;
 }
 
 /**
@@ -79,7 +87,8 @@ export function maybeAddImport(
 ) {
     for (const v of visitor.afterVisit || []) {
         if (v instanceof AddImport &&
-            v.module === options.module &&
+            v.module === moduleNameOf(options.module) &&
+            v.quoteStyle === options.quoteStyle &&
             v.member === options.member &&
             v.alias === options.alias &&
             v.sideEffectOnly === (options.sideEffectOnly ?? false) &&
@@ -90,14 +99,134 @@ export function maybeAddImport(
     visitor.afterVisit.push(new AddImport(options));
 }
 
+/**
+ * The parser lifts surrogate pairs out of `valueSource` into `unicodeEscapes` and, when it does,
+ * sets `value` to the quoted source (`parser.ts` `mapLiteral`), so neither field alone is the
+ * module name. Reuniting them and stripping the quotes yields it for either shape of literal.
+ */
+function moduleNameOf(module: string | J.Literal): string {
+    if (typeof module === 'string') {
+        return module;
+    }
+    const source = module.valueSource;
+    if (source === undefined) {
+        return String(module.value);
+    }
+    let restored = '';
+    let cut = 0;
+    for (const escape of module.unicodeEscapes ?? []) {
+        restored += source.slice(cut, escape.valueSourceIndex) + String.fromCharCode(parseInt(escape.codePoint, 16));
+        cut = escape.valueSourceIndex;
+    }
+    restored += source.slice(cut);
+    const quote = restored.charAt(0);
+    return (quote === "'" || quote === '"') && restored.endsWith(quote) && restored.length > 1
+        ? restored.slice(1, -1)
+        : restored;
+}
+
+function quoteOf(expression: J | undefined): QuoteChar | undefined {
+    if (expression?.kind !== J.Kind.Literal) {
+        return undefined;
+    }
+    const source = (expression as J.Literal).valueSource;
+    const quote = source?.charAt(0);
+    // JsxText carries raw text as its `valueSource`, so a leading quote alone does not make a
+    // literal quote-delimited; requiring a matching pair keeps prose out of the tally.
+    return (quote === "'" || quote === '"') && source!.length > 1 && source!.endsWith(quote)
+        ? quote
+        : undefined;
+}
+
+/**
+ * Pick the quote character for a module specifier being added to `cu`, so that it agrees
+ * with the file it lands in. An existing specifier is the most direct precedent; a Prettier
+ * config states intent even where the file itself has not been formatted to match.
+ */
+async function detectQuote(cu: JS.CompilationUnit): Promise<QuoteChar> {
+    // Static imports are top-level, so the highest-ranked signal needs no traversal to find.
+    for (const statement of cu.statements) {
+        const element = statement.element;
+        const topLevelQuote = element?.kind === JS.Kind.Import
+            ? quoteOf((element as JS.Import).moduleSpecifier?.element)
+            : element?.kind === JS.Kind.ExportDeclaration
+                ? quoteOf((element as JS.ExportDeclaration).moduleSpecifier?.element)
+                : undefined;
+        if (topLevelQuote) {
+            return topLevelQuote;
+        }
+    }
+
+    let importQuote: QuoteChar | undefined;
+    let requireQuote: QuoteChar | undefined;
+    let single = 0;
+    let double = 0;
+
+    await new class extends JavaScriptVisitor<void> {
+        override async visitImportDeclaration(jsImport: JS.Import, p: void): Promise<J | undefined> {
+            importQuote ??= quoteOf(jsImport.moduleSpecifier?.element);
+            return super.visitImportDeclaration(jsImport, p);
+        }
+
+        override async visitExportDeclaration(exportDeclaration: JS.ExportDeclaration, p: void): Promise<J | undefined> {
+            importQuote ??= quoteOf(exportDeclaration.moduleSpecifier?.element);
+            return super.visitExportDeclaration(exportDeclaration, p);
+        }
+
+        override async visitMethodInvocation(method: J.MethodInvocation, p: void): Promise<J | undefined> {
+            if (!method.select && method.name?.kind === J.Kind.Identifier &&
+                (method.name as J.Identifier).simpleName === 'require') {
+                requireQuote ??= quoteOf(method.arguments?.elements[0]?.element);
+            }
+            return super.visitMethodInvocation(method, p);
+        }
+
+        override async visitJsxAttribute(attribute: JSX.Attribute, p: void): Promise<J | undefined> {
+            // JSX attribute quoting answers to Prettier's `jsxSingleQuote`, so it is no evidence
+            // about the quote style of ordinary strings.
+            return attribute;
+        }
+
+        override async visitLiteral(literal: J.Literal, p: void): Promise<J | undefined> {
+            const quote = quoteOf(literal);
+            if (quote === "'") {
+                single++;
+            } else if (quote === '"') {
+                double++;
+            }
+            return super.visitLiteral(literal, p);
+        }
+    }().visit(cu, undefined);
+
+    // Imports outrank requires; that ordering is what makes the import-only scan above sound.
+    const specifierQuote = importQuote ?? requireQuote;
+    if (specifierQuote) {
+        return specifierQuote;
+    }
+
+    const prettier = getStyle(StyleKind.PrettierStyle, cu) as PrettierStyle | undefined;
+    if (prettier?.kind === StyleKind.PrettierStyle && !prettier.ignored) {
+        const singleQuote = prettier.config.singleQuote;
+        if (typeof singleQuote === 'boolean') {
+            return singleQuote ? "'" : '"';
+        }
+    }
+
+    return double > single ? '"' : "'";
+}
+
 export class AddImport<P> extends JavaScriptVisitor<P> {
     readonly module: string;
+    /** Set when the caller supplied the module specifier as a literal; printed verbatim. */
+    readonly moduleValueSource?: string;
+    readonly moduleUnicodeEscapes?: J.LiteralUnicodeEscape[];
     readonly member?: string;
     readonly alias?: string;
     readonly onlyIfReferenced: boolean;
     readonly sideEffectOnly: boolean;
     readonly typeOnly: boolean;
     readonly style?: ImportStyle;
+    readonly quoteStyle?: QuoteChar;
 
     constructor(options: AddImportOptions) {
         super();
@@ -128,13 +257,16 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             }
         }
 
-        this.module = options.module;
+        this.module = moduleNameOf(options.module);
+        this.moduleValueSource = typeof options.module === 'string' ? undefined : options.module.valueSource;
+        this.moduleUnicodeEscapes = typeof options.module === 'string' ? undefined : options.module.unicodeEscapes;
         this.member = options.member;
         this.alias = options.alias;
         this.onlyIfReferenced = options.onlyIfReferenced ?? true;
         this.sideEffectOnly = options.sideEffectOnly ?? false;
         this.typeOnly = options.typeOnly ?? false;
         this.style = options.style;
+        this.quoteStyle = options.quoteStyle;
     }
 
     /**
@@ -144,7 +276,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
         if (moduleSpecifier.kind !== J.Kind.Literal) {
             return undefined;
         }
-        return (moduleSpecifier as J.Literal).value?.toString();
+        return moduleNameOf(moduleSpecifier as J.Literal);
     }
 
     /**
@@ -1033,15 +1165,20 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
         // For side-effect imports, use emptySpace since space comes from LeftPadded.before
         // For regular imports with import clause, use emptySpace since space comes from LeftPadded.before
         // However, the printer expects the space after 'from' in the literal's prefix
-        // Note: value contains the unquoted string, valueSource contains the quoted version for printing
+        // Note: value is the unquoted module name; valueSource and unicodeEscapes are its printed form
+        let valueSource = this.moduleValueSource;
+        if (valueSource === undefined) {
+            const quote = this.quoteStyle ?? await detectQuote(compilationUnit);
+            valueSource = `${quote}${this.module}${quote}`;
+        }
         const moduleSpecifier: J.Literal = {
             id: randomId(),
             kind: J.Kind.Literal,
             prefix: this.sideEffectOnly ? emptySpace : singleSpace,
             markers: emptyMarkers,
             value: this.module,
-            valueSource: `'${this.module}'`,
-            unicodeEscapes: [],
+            valueSource,
+            unicodeEscapes: this.moduleUnicodeEscapes,
             type: undefined
         };
 
@@ -1300,7 +1437,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             return undefined;
         }
 
-        return (firstArg as J.Literal).value?.toString();
+        return moduleNameOf(firstArg as J.Literal);
     }
 
     /**

--- a/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
@@ -18,6 +18,7 @@
 import {fromVisitor, RecipeSpec} from "../../src/test";
 import {
     AddImport,
+    AddImportOptions,
     ImportStyle,
     IntelliJ,
     javascript,
@@ -26,6 +27,7 @@ import {
     maybeAddImport,
     npm,
     packageJson,
+    prettierStyle,
     RemoveImport,
     SpacesStyle,
     Template,
@@ -33,6 +35,7 @@ import {
     typescript
 } from "../../src/javascript";
 import {emptySpace, J} from "../../src/java";
+import {emptyMarkers} from "../../src/markers";
 import {MarkersKind, NamedStyles, randomId} from "../../src";
 import {create as produce} from "mutative";
 import {withDir} from "tmp-promise";
@@ -2121,4 +2124,505 @@ describe('AddImport visitor', () => {
             }).toThrow("Cannot combine sideEffectOnly with typeOnly");
         });
     });
+
+    describe('quote style', () => {
+        test('matches the quote style of an existing import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import path from "path";
+                    `,
+                    `
+                        import path from "path";
+                        import {readFile} from "fs";
+                    `
+                )
+            );
+        });
+
+        test('matches the quote style of an existing require call', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                style: ImportStyle.ES6Named,
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                javascript(
+                    `
+                        const path = require("path");
+                    `,
+                    `
+                        import {readFile} from "fs";
+
+                        const path = require("path");
+                    `
+                )
+            );
+        });
+
+        test('an explicit quoteStyle overrides what the file would suggest', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                quoteStyle: '"',
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import path from 'path';
+                    `,
+                    `
+                        import path from 'path';
+                        import {readFile} from "fs";
+                    `
+                )
+            );
+        });
+
+        test('an existing import outranks a require call', async () => {
+            const addReadFile = () => fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                style: ImportStyle.ES6Named,
+                onlyIfReferenced: false
+            }));
+
+            const topLevel = new RecipeSpec();
+            topLevel.recipe = addReadFile();
+            await topLevel.rewriteRun(
+                typescript(
+                    `
+                        declare function require(s: string): any;
+                        const a = require("x");
+                        import b from 'y';
+                    `,
+                    `
+                        declare function require(s: string): any;
+                        const a = require("x");
+                        import b from 'y';
+                        import {readFile} from 'fs';
+                    `
+                )
+            );
+
+            // An import the top-level scan cannot see still outranks the require it can.
+            const nested = new RecipeSpec();
+            nested.recipe = addReadFile();
+            await nested.rewriteRun(
+                typescript(
+                    `
+                        declare function require(s: string): any;
+                        const a = require("x");
+                        declare module "m" {
+                            import b from 'y';
+                        }
+                    `,
+                    `
+                        import {readFile} from 'fs';
+
+                        declare function require(s: string): any;
+                        const a = require("x");
+                        declare module "m" {
+                            import b from 'y';
+                        }
+                    `
+                )
+            );
+        });
+
+        test('falls back to the dominant string literal quote when there are no imports', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const a = "one";
+                        const b = "two";
+                        const c = 'three';
+                    `,
+                    `
+                        import {readFile} from "fs";
+
+                        const a = "one";
+                        const b = "two";
+                        const c = 'three';
+                    `
+                )
+            );
+        });
+
+        test('defaults to single quotes when the file offers no signal', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const x = 1;
+                    `,
+                    `
+                        import {readFile} from 'fs';
+
+                        const x = 1;
+                    `
+                )
+            );
+        });
+
+        test('an existing import outranks the dominant string literal quote', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import path from 'path';
+
+                        const a = "one";
+                        const b = "two";
+                    `,
+                    `
+                        import path from 'path';
+                        import {readFile} from 'fs';
+
+                        const a = "one";
+                        const b = "two";
+                    `
+                )
+            );
+        });
+
+        /** Stands in for a project whose .prettierrc was picked up at parse time. */
+        function createAddImportWithPrettierStyleVisitor(singleQuote: boolean): JavaScriptVisitor<any> {
+            return new class extends JavaScriptVisitor<any> {
+                override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                    const namedStyles: NamedStyles = {
+                        kind: MarkersKind.NamedStyles,
+                        id: randomId(),
+                        name: "test-prettier",
+                        displayName: "Test Prettier",
+                        tags: [],
+                        styles: [prettierStyle(randomId(), {singleQuote})]
+                    };
+
+                    let result: JS.CompilationUnit = {
+                        ...cu,
+                        markers: {
+                            ...cu.markers,
+                            markers: [...cu.markers.markers, namedStyles]
+                        }
+                    };
+
+                    const addImport = new AddImport({
+                        module: 'fs',
+                        member: 'readFile',
+                        onlyIfReferenced: false
+                    });
+                    return await addImport.visit(result, p) as JS.CompilationUnit;
+                }
+            };
+        }
+
+        test('honors a PrettierStyle marker with singleQuote disabled', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(createAddImportWithPrettierStyleVisitor(false));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const x = 1;
+                    `,
+                    `
+                        import {readFile} from "fs";
+
+                        const x = 1;
+                    `
+                )
+            );
+        });
+
+        test('a PrettierStyle marker outranks the dominant string literal quote', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(createAddImportWithPrettierStyleVisitor(true));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const a = "one";
+                        const b = "two";
+                    `,
+                    `
+                        import {readFile} from 'fs';
+
+                        const a = "one";
+                        const b = "two";
+                    `
+                )
+            );
+        });
+
+        test('reuses the value source of a module specifier passed as a literal', async () => {
+            const moduleSpecifier: J.Literal = {
+                id: randomId(),
+                kind: J.Kind.Literal,
+                prefix: emptySpace,
+                markers: emptyMarkers,
+                value: 'sap/m/Über',
+                valueSource: '"sap/m/\\u00dcber"',
+                unicodeEscapes: [],
+                type: undefined
+            };
+
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: moduleSpecifier,
+                member: 'default',
+                alias: 'Ueber',
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const x = 1;
+                    `,
+                    `
+                        import Ueber from "sap/m/\\u00dcber";
+
+                        const x = 1;
+                    `
+                )
+            );
+        });
+
+        /**
+         * Load order is observable for side-effect imports, so imports registered in one pass
+         * have to come out in registration order.
+         */
+        function createAddImportsVisitor(imports: AddImportOptions[]): JavaScriptVisitor<any> {
+            return new class extends JavaScriptVisitor<any> {
+                constructor() {
+                    super();
+                    for (const options of imports) {
+                        maybeAddImport(this, options);
+                    }
+                }
+            };
+        }
+
+        test('adds several imports to an import-less file in call order', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(createAddImportsVisitor([
+                {module: 'sap/m/Button', member: 'default', alias: 'Button', onlyIfReferenced: false},
+                {module: 'my/lib/patches', sideEffectOnly: true},
+                {module: 'sap/m/Text', member: 'default', alias: 'Text', onlyIfReferenced: false},
+                {module: 'sap/ui/core/Control', member: 'default', alias: 'Control', onlyIfReferenced: false}
+            ]));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const x = 1;
+                    `,
+                    `
+                        import Button from 'sap/m/Button';
+                        import 'my/lib/patches';
+                        import Text from 'sap/m/Text';
+                        import Control from 'sap/ui/core/Control';
+
+                        const x = 1;
+                    `
+                )
+            );
+        });
+
+        test('preserves surrogate escapes in a module specifier passed as a literal', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                    const existing = cu.statements[0].element as JS.Import;
+                    return await new AddImport({
+                        module: existing.moduleSpecifier!.element as J.Literal,
+                        member: 'default',
+                        alias: 'B',
+                        onlyIfReferenced: false
+                    }).visit(cu, p);
+                }
+            }());
+
+            await spec.rewriteRun(
+                typescript(
+                    "import a from './e\\uD83D\\uDE00m';",
+                    "import a from './e\\uD83D\\uDE00m';\nimport B from './e\\uD83D\\uDE00m';"
+                )
+            );
+        });
+
+        test('recognizes an existing import whose specifier carries surrogate escapes', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                    const existing = cu.statements[0].element as JS.Import;
+                    return await new AddImport({
+                        module: existing.moduleSpecifier!.element as J.Literal,
+                        member: 'default',
+                        alias: 'a',
+                        onlyIfReferenced: false
+                    }).visit(cu, p);
+                }
+            }());
+
+            await spec.rewriteRun(
+                typescript("import a from './e\\uD83D\\uDE00m';")
+            );
+        });
+
+        test('gives the added literal a value that agrees with its own valueSource', async () => {
+            let added: J.Literal | undefined;
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                    const existing = cu.statements[0].element as JS.Import;
+                    const result = await new AddImport({
+                        module: existing.moduleSpecifier!.element as J.Literal,
+                        member: 'default',
+                        alias: 'B',
+                        onlyIfReferenced: false
+                    }).visit(cu, p) as JS.CompilationUnit;
+                    added = (result.statements[1].element as JS.Import).moduleSpecifier!.element as J.Literal;
+                    return result;
+                }
+            }());
+
+            await spec.rewriteRun(
+                typescript(
+                    "import a from './e\\uD83D\\uDE00m';",
+                    "import a from './e\\uD83D\\uDE00m';\nimport B from './e\\uD83D\\uDE00m';"
+                )
+            );
+
+            expect(added!.value).toBe('./e\u{1F600}m');
+            expect(added!.valueSource).toBe("'./em'");
+        });
+
+        test('ignores a PrettierStyle marker for a file .prettierignore excludes', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                    const namedStyles: NamedStyles = {
+                        kind: MarkersKind.NamedStyles,
+                        id: randomId(),
+                        name: "test-prettier",
+                        displayName: "Test Prettier",
+                        tags: [],
+                        styles: [prettierStyle(randomId(), {singleQuote: true}, undefined, true)]
+                    };
+                    const marked: JS.CompilationUnit = {
+                        ...cu,
+                        markers: {...cu.markers, markers: [...cu.markers.markers, namedStyles]}
+                    };
+                    return await new AddImport({
+                        module: 'fs',
+                        member: 'readFile',
+                        onlyIfReferenced: false
+                    }).visit(marked, p);
+                }
+            }());
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const a = "one";
+                        const b = "two";
+                    `,
+                    `
+                        import {readFile} from "fs";
+
+                        const a = "one";
+                        const b = "two";
+                    `
+                )
+            );
+        });
+
+        test('does not treat a require method call on a receiver as a module specifier', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                style: ImportStyle.ES6Named,
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        declare const loader: any;
+                        const legacy = loader.require('old/thing');
+                        const a = "one";
+                        const b = "two";
+                    `,
+                    `
+                        import {readFile} from "fs";
+
+                        declare const loader: any;
+                        const legacy = loader.require('old/thing');
+                        const a = "one";
+                        const b = "two";
+                    `
+                )
+            );
+        });
+
+        test('does not count JSX attribute quoting toward the dominant quote style', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'fs',
+                member: 'readFile',
+                onlyIfReferenced: false
+            }));
+
+            await spec.rewriteRun(
+                tsx(
+                    `
+                        const a = 'one';
+                        const el = <div className="x" id="y" title="z"/>;
+                    `,
+                    `
+                        import {readFile} from 'fs';
+
+                        const a = 'one';
+                        const el = <div className="x" id="y" title="z"/>;
+                    `
+                )
+            );
+        });
+    });
+
 });


### PR DESCRIPTION
`maybeAddImport` hardcoded single quotes for the module specifier, so a recipe adding an import to a double-quoted file emitted `import Button from 'sap/m/Button';` directly above `const x = "already here";`. For a recipe whose entire output is imports — an AMD-to-ES-module migration, say — every added line disagreed with the file it landed in, and in a repo with a lint rule on quote style that fails CI. Reported while converting UI5's AMD modules, where the dependency strings being converted sit in the same statement, so the mismatch was immediately visible.

## Detection

`detectQuote` resolves in order: an existing module specifier in the same file (`JS.Import`, re-exporting `JS.ExportDeclaration`, or a `require()` argument), then a `PrettierStyle` marker's `singleQuote`, then the dominant quote among the file's string literals, then single quotes. `rewrite-gradle`'s `AddPluginVisitor` already tallies literals this way to pick a delimiter for plugin ids, so this is the established shape for the problem rather than a new one.

Two rungs need justifying. A `PrettierStyle` marker is skipped when `ignored` is set, since Prettier never formats a `.prettierignore`d file and its config is therefore no evidence about that file. JSX attribute values are excluded from the tally because their quoting answers to Prettier's separate `jsxSingleQuote` option.

## Why imports outrank requires

Static imports are top-level, so the highest-ranked signal is reachable without walking the tree, and the fast path takes it. That is only sound because imports rank strictly above requires: without that ordering the scan and the full walk disagree, and `const a = require("x"); import b from 'y';` resolves to `"` or `'` depending on which path answered. Ranking them makes the fast path a pure optimization — disabling it now changes no observable behaviour, which the suite confirms.

## Reusing a specifier verbatim

`AddImportOptions.module` accepts a `J.Literal`, whose source form is reused as-is, so quoting, escapes and unicode form survive a specifier moving between constructs:

```ts
maybeAddImport(visitor, { module: dependencyLiteral, member: 'default', alias: name });
```

This needs both halves of the parser's encoding. `mapLiteral` lifts surrogate pairs out of `valueSource` into `unicodeEscapes` and, when it does, sets `value` to the quoted source — so neither field alone is the module name, and copying `valueSource` while dropping `unicodeEscapes` silently deletes astral characters from the path. `moduleNameOf` reunites them; `getModuleName` uses it too, so duplicate detection compares like with like.

A `quoteStyle` option covers callers that already know, ranked below a `J.Literal` module and above detection.

## Tests

17 tests in a `quote style` describe. 13 have a mutant that kills them and spares every sibling; the rest are the reported bug's own input and the named coverage of the tally rung. The ordering case pins that several imports registered in one pass come out in registration order — load order is observable for side-effect imports, and nothing asserted that before.