### PR TITLE
Remove unused JAXB annotation support from rewrite-maven

### DIFF
--- a/rewrite-maven/build.gradle.kts
+++ b/rewrite-maven/build.gradle.kts
@@ -21,7 +21,6 @@ dependencies {
     implementation("dev.failsafe:failsafe:latest.release")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-smile")
-    implementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8")
 
     // needed by AddDependency

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenXmlMapper.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/MavenXmlMapper.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.dataformat.xml.XmlFactory;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule;
 import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
 import org.jspecify.annotations.Nullable;
 
@@ -70,8 +69,7 @@ public class MavenXmlMapper {
 
         writeMapper = XmlMapper.builder(xmlFactory)
                 .defaultUseWrapper(false)
-                .build()
-                .registerModule(new JaxbAnnotationModule());
+                .build();
     }
 
     private MavenXmlMapper() {

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawGradleModule.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawGradleModule.java
@@ -25,7 +25,6 @@ import lombok.experimental.FieldDefaults;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.maven.tree.GroupArtifactVersion;
 
-import javax.xml.bind.annotation.XmlRootElement;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -46,7 +45,6 @@ import static org.openrewrite.internal.ObjectMappers.propertyBasedMapper;
 @ToString(onlyExplicitlyIncluded = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Data
-@XmlRootElement(name = "project")
 @SuppressWarnings("unused")
 public class RawGradleModule {
 

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/internal/RawPom.java
@@ -28,7 +28,6 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.StringUtils;
 import org.openrewrite.maven.tree.*;
 
-import javax.xml.bind.annotation.XmlRootElement;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -48,7 +47,6 @@ import static org.openrewrite.maven.tree.Plugin.PLUGIN_DEFAULT_GROUPID;
 @ToString(onlyExplicitlyIncluded = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @Data
-@XmlRootElement(name = "project")
 @SuppressWarnings("unused")
 public class RawPom {
 


### PR DESCRIPTION
- Fixes #8669

`rewrite-maven` depended on `com.fasterxml.jackson.module:jackson-module-jaxb-annotations` and the pre-Jakarta `javax.xml.bind` annotations. As suspected in the issue, all of it was dead weight:

- `JaxbAnnotationModule` was only registered on `MavenXmlMapper.writeMapper()`.
- The only JAXB-annotated classes, `RawPom` and `RawGradleModule`, carried `@XmlRootElement(name = "project")` but are exclusively *deserialized* — `RawPom` through `readMapper()` (which never had the module) and `RawGradleModule` through `propertyBasedMapper` (a JSON mapper, so the XML root name was inert there regardless).
- Everything that actually goes through `writeMapper()` already uses Jackson's native XML annotations: `MavenSettings` (`@JacksonXmlRootElement(localName = "settings")`), `AddDevelocityMavenExtension`'s config classes (`@JacksonXmlRootElement`), and `Plugin.getConfiguration(path, Class)` which just round-trips a `JsonNode`.

So this drops the dependency, the module registration, and the two annotations.

Verified with `MavenSettingsTest` (which asserts the exact serialized XML round-trips to the parsed document), `AddDevelocityMavenExtensionTest`, and `RawPomTest` (which covers the `writeMapper` path in `Plugin.getConfiguration`). The three failures in that local run were all Maven Central HTTP 429s, unrelated to the change.