### PR TITLE
JavaScript: resolve modules the way the ecosystem publishes them

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -91,8 +91,11 @@ export class JavaScriptParser extends Parser {
         super({ctx, relativeTo});
         this.compilerOptions = {
             target: ts.ScriptTarget.Latest,
-            module: ts.ModuleKind.CommonJS,
-            moduleResolution: ts.ModuleResolutionKind.Node10,
+            // Bundler matches `exports` conditions leniently, so packages that publish types only under
+            // an `import` condition resolve; it pairs with `preserve`, which `commonjs` cannot (TS5095).
+            // A `node16` module kind makes TS1479 reachable, and that error costs the whole LST.
+            module: ts.ModuleKind.Preserve,
+            moduleResolution: ts.ModuleResolutionKind.Bundler,
             noEmit: true,
             allowJs: true,
             checkJs: true,

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -96,6 +96,9 @@ export class JavaScriptParser extends Parser {
             // A `node16` module kind makes TS1479 reachable, and that error costs the whole LST.
             module: ts.ModuleKind.Preserve,
             moduleResolution: ts.ModuleResolutionKind.Bundler,
+            // Bundler's own condition set omits `node`, which takes the browser branch of packages
+            // that publish one, typing them against an API surface the source does not use.
+            customConditions: ["node"],
             noEmit: true,
             allowJs: true,
             checkJs: true,

--- a/rewrite-javascript/rewrite/test/javascript/module-resolution.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/module-resolution.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {JavaScriptParser, JavaScriptVisitor} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {SourceFile} from "../../src";
+
+async function parseProject(files: Record<string, string>, entry: string): Promise<SourceFile> {
+    const project = fs.mkdtempSync(path.join(os.tmpdir(), "rewrite-module-resolution-"));
+    try {
+        for (const [file, text] of Object.entries(files)) {
+            const target = path.join(project, file);
+            fs.mkdirSync(path.dirname(target), {recursive: true});
+            fs.writeFileSync(target, text);
+        }
+        const parser = new JavaScriptParser({relativeTo: project});
+        for await (const parsed of parser.parse(path.join(project, entry))) {
+            return parsed;
+        }
+        throw new Error("parser yielded nothing");
+    } finally {
+        fs.rmSync(project, {recursive: true, force: true});
+    }
+}
+
+async function firstInvocationReturnType(sourceFile: SourceFile): Promise<Type | undefined> {
+    let found: Type | undefined;
+    const finder = new class extends JavaScriptVisitor<void> {
+        protected override async visitMethodInvocation(method: J.MethodInvocation, p: void) {
+            found ??= method.methodType?.returnType;
+            return super.visitMethodInvocation(method, p);
+        }
+    };
+    await finder.visit(sourceFile, undefined);
+    return found;
+}
+
+test("types published only through exports conditions are attributed", async () => {
+    const exportsOnly = await parseProject({
+        "node_modules/exports-only/package.json": JSON.stringify({
+            name: "exports-only",
+            version: "1.0.0",
+            exports: {".": {types: "./idx.d.ts", default: "./idx.js"}}
+        }),
+        "node_modules/exports-only/idx.d.ts": `export declare function greet(): string;`,
+        "node_modules/exports-only/idx.js": `exports.greet = () => "";`,
+        "uses.ts": `import {greet} from "exports-only";\ngreet();`
+    }, "uses.ts");
+    expect(await firstInvocationReturnType(exportsOnly)).toEqual(Type.Primitive.String);
+
+    // Node16 would match this condition against the importing file's own format and find nothing.
+    const importConditionOnly = await parseProject({
+        "node_modules/import-condition-only/package.json": JSON.stringify({
+            name: "import-condition-only",
+            version: "1.0.0",
+            type: "module",
+            exports: {import: {types: "./idx.d.ts", default: "./idx.js"}}
+        }),
+        "node_modules/import-condition-only/idx.d.ts": `export declare function greet(): string;`,
+        "node_modules/import-condition-only/idx.js": `export const greet = () => "";`,
+        "uses.ts": `import {greet} from "import-condition-only";\ngreet();`
+    }, "uses.ts");
+    expect(await firstInvocationReturnType(importConditionOnly)).toEqual(Type.Primitive.String);
+});


### PR DESCRIPTION
`JavaScriptParser` hardcoded `moduleResolution: ts.ModuleResolutionKind.Node10`, which predates package.json `exports`. A package that publishes its types only through export conditions resolves to nothing — with `node_modules` fully installed and no tsconfig involved — and every import of it loses type attribution. Nothing reports this: resolution failure is TS2307, and `checkSyntaxErrors` only treats codes in the 1000–2000 band as critical, so the file parses fine and simply comes out untyped.

`vite` is the canonical case. It has no `main`, no `types`, and no root `index.d.ts`; its types are reachable only via `exports["."]`.

```
Node10   "vite" UNRESOLVED  createServer() -> <unknown>{name=createServer,return=<unknown>,parameters=[]}
Bundler  "vite" ok          createServer() -> vite{name=createServer,
                                                return=Promise<vite.ViteDevServer>,
                                                parameters=[vite.ResolvedConfig | vite.InlineConfig]}
```

`p-limit` is also exports-only but ships a root `index.d.ts`, which is the only reason Node10 finds it — so whether a package survives depends on its shape, invisibly.

## How big the class is

A green unit suite proves nothing here: the whole suite passes identically under Node10, Node16 and Bundler, because nothing in it resolves through an `exports` map. So this was measured against 28 local repos with real `node_modules`.

Probing 2,352 distinct installed packages as bare specifiers, counting whether a **declaration file** is found rather than merely whether resolution succeeds:

| | gains a `.d.ts` | loses a `.d.ts` |
|---|---|---|
| Bundler vs Node10 | **44** | 8 |

39 of the gains are packages Node10 could not resolve at all; 5 are packages where Node10 landed on a `.cjs`. The gains are the modern tier: `vite`, `tailwindcss`, `tsx`, `typescript`, `@typescript-eslint/*`, `@vitejs/plugin-react`. Of the 893 packages publishing an `exports` map, Node10 fails on 6.6%.

Parsing 1,159 files through `JavaScriptParser`, one run per configuration:

```
                          identifiers w/ known type    calls w/ known return    parse errors
Node10                    297,021  (55.3%)              69.5%                    0
Preserve + Bundler        303,317  (56.5%)              71.3%                    0
  + customConditions node 303,399  (56.5%)              71.3%                    0
```

## What gets worse

Three classes, all measured rather than assumed.

**Eight packages resolve to a source file where Node10 found a declaration file** — `escalade`, `psl`, `estree-walker`, `form-data-encoder`, `safe-stable-stringify`, `cross-dirname`, `@humanwhocodes/module-importer`, `@asamuzakjp/dom-selector`. Their `exports` maps omit a `types` condition, so TypeScript follows the export target to a `.js`/`.mjs` and the top-level `types` field is no longer consulted. They still get types, inferred from source under `allowJs`/`checkJs`, just weaker than the authored declarations. This is the shape `publint` and `arethetypeswrong` flag; all eight are transitive-only, and **zero of the corpus's 1,360 bare import sites name any of them**.

**Three import sites lose attribution entirely**, all `@modelcontextprotocol/sdk/server/index`-style extensionless subpaths into a package whose `exports` uses `"./*"`. Node rejects those specifiers too — `import('@modelcontextprotocol/sdk/server/index')` gives `ERR_MODULE_NOT_FOUND`. Node10 was attributing code the runtime will not load.

**A `typesVersions` redirect for a subpath the `exports` map does not enumerate** resolves under Node10 and not under Bundler. 46 corpus packages carry both fields, though no corpus import site hits the gap.

The obvious worry is the opposite direction — that making the `exports` map authoritative breaks deep subpath imports. Across the corpus's 356 deep-subpath import sites, Bundler **gains 226 and loses 3**: modern packages enumerate their subpaths in `exports`, and Node10 cannot see any of them.

## Why Bundler and not Node16

Node16 and NodeNext match export conditions against the importing file's own ESM/CJS classification, so an `import`-condition-only package — `@humanfs/core`, an eslint dependency — goes untyped for a CommonJS-classified consumer. Bundler resolved a strict superset: across 2,352 packages and 4,247 import sites there is no case Node16 resolves and Bundler does not.

## Why `module: preserve`

Bundler resolution rejects `commonjs` (TS5095). That diagnostic is benign only because `isCriticalDiagnostic` happens to gate on a `code > 1000 && code < 2000` range heuristic; widening that heuristic would turn every file in every parse into a `ParseError`. Under `preserve` the Program emits no diagnostics at all.

`preserve` also removes a trap. `getConditions` only substitutes ESNext for Bundler when `resolutionMode` is undefined, which is true here solely because `resolveModuleNameLiterals` calls `ts.resolveModuleName` without one. Under `module: commonjs` a stock Program takes the `require` condition instead, so threading a resolution mode through that override — an ordinary-looking tidy-up — would silently flip dual-package attribution from ESM to CJS typings. Under `preserve` the `import` condition is intrinsic and that cleanup is safe.

Adopting a project's *`module` kind* remains off the table: TS1479 sits in the critical band, so a CJS-classified file importing an ESM-only package would yield a `ParseError` and no LST at all. It fires only for the `node16`/`node18` module kinds — `preserve` cannot reach it.

## Why `customConditions: ["node"]`

`getConditions` pushes `"node"` for every resolution kind except Bundler. Without it, a package publishing both entry points is typed against its browser surface: `fflate` resolved `esm/browser.d.ts` rather than `lib/index.d.ts`, `when-exit` `dist/browser/index.d.ts`, `apache-arrow` `Arrow.dom.d.ts`. That is *wrong* attribution rather than missing attribution, and an attribution count cannot detect it — both branches resolve and both yield a type. Adding the condition changes 15 of 2,352 packages, costs none, and gains 82 identifiers across the corpus.

## Tests

`module-resolution.test.ts` installs synthetic packages into a temp project and asserts a real return type rather than `JavaType$Unknown`. One test, two cases: a plain exports-only package, which fails under Node10; and an `import`-condition-only package, which fails under Node10 *and* Node16. Together they pin the chosen value against both alternatives — verified by running the test under all three.

`module: preserve` is deliberately not pinned by a test. It is behaviourally identical to `commonjs` through this parser today, so a test would assert on TypeScript's option validation rather than on our own behaviour.

## Not in this PR

`src/javascript/package-exported-types.ts` has the same hardcoded Node10 for transitive dependency resolution. Different subsystem, own tests, tracked separately.

Reading a project's own tsconfig is orthogonal to everything above: no setting in a consuming project can make TypeScript honour a dependency's top-level `types` field once that dependency ships an `exports` map. tsconfig governs `paths`, `baseUrl`, an explicitly configured `moduleResolution`, and `jsx` — handled separately.
