### PR TITLE
Go: `goProject` gives its `.go` sources the sibling go.mod's module context

### DIFF
--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/ThirdPartyTypeAttributionTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/ThirdPartyTypeAttributionTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.golang.internal.ModuleCache;
+import org.openrewrite.golang.rpc.GoRewriteRpc;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpecs;
+import org.openrewrite.test.TypeValidation;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.openrewrite.golang.Assertions.expectMethodType;
+import static org.openrewrite.golang.Assertions.expectType;
+import static org.openrewrite.golang.Assertions.go;
+import static org.openrewrite.golang.Assertions.goMod;
+import static org.openrewrite.golang.Assertions.goProject;
+
+/**
+ * A recipe that matches calls into a dependency needs those calls attributed, and the go.mod
+ * declaring the dependency is all a test gives it to go on.
+ */
+@Timeout(value = 300, unit = TimeUnit.SECONDS)
+class ThirdPartyTypeAttributionTest implements RewriteTest {
+
+    private static final String GIN_VERSION = "v1.10.0";
+
+    private static final String GO_MOD = """
+            module example.com/app
+
+            go 1.21
+
+            require github.com/gin-gonic/gin %s
+            """.formatted(GIN_VERSION);
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        Path binaryPath = Paths.get("build/rewrite-go-rpc").toAbsolutePath();
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+          .goBinaryPath(binaryPath)
+          .log(tempDir.resolve("go-rpc.log"))
+          .traceRpcMessages());
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.typeValidationOptions(TypeValidation.builder()
+          .allowNonWhitespaceInWhitespace(true)
+          .build());
+    }
+
+    @Test
+    void callsIntoARequiredModuleCarryTheirDeclaringType() {
+        SourceSpecs project = goProject("app",
+          goMod(GO_MOD),
+          go(
+            """
+              package main
+
+              import "github.com/gin-gonic/gin"
+
+              func main() {
+              	r := gin.Default()
+              	r.GET("/ping", func(c *gin.Context) {
+              		c.JSON(200, gin.H{"message": "pong"})
+              	})
+              }
+              """,
+            s -> s.afterRecipe(cu -> {
+                expectMethodType(cu, "Default", "github.com/gin-gonic/gin");
+                expectMethodType(cu, "GET", "github.com/gin-gonic/gin.RouterGroup");
+                expectMethodType(cu, "JSON", "github.com/gin-gonic/gin.Context");
+                expectType(cu, "r", "github.com/gin-gonic/gin.Engine");
+            })));
+
+        // Constructing the project is what downloads gin, so the check for it belongs after.
+        assumeTrue(ModuleCache.contains("github.com/gin-gonic/gin", GIN_VERSION),
+          "github.com/gin-gonic/gin " + GIN_VERSION + " is not in the Go module cache");
+
+        rewriteRun(project);
+    }
+}

--- a/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/Assertions.java
@@ -18,7 +18,9 @@ package org.openrewrite.golang;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
+import org.openrewrite.golang.internal.ModuleCache;
 import org.openrewrite.golang.marker.GoProject;
+import org.openrewrite.golang.marker.GoResolutionResult;
 import org.openrewrite.golang.tree.Go;
 import org.openrewrite.golang.tree.GoMod;
 import org.openrewrite.golang.tree.GoSum;
@@ -28,7 +30,11 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.test.SourceSpec;
 import org.openrewrite.test.SourceSpecs;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.function.Consumer;
+
+import static org.openrewrite.internal.StringUtils.trimIndentPreserveCRLF;
 
 public final class Assertions {
     private Assertions() {
@@ -115,13 +121,50 @@ public final class Assertions {
      * not nested inside one another. Recipes that need module-level
      * dependency information look up the sibling go.mod's
      * {@link org.openrewrite.golang.marker.GoResolutionResult}.
+     * <p>
+     * A sibling {@code go.mod} also gives the {@code .go} sources their module
+     * context, so imports of the modules it requires carry real types.
      */
     public static SourceSpecs goProject(String project, SourceSpecs... sources) {
         return goProject(project, spec -> project(spec, project), sources);
     }
 
     public static SourceSpecs goProject(String project, Consumer<SourceSpec<SourceFile>> spec, SourceSpecs... sources) {
+        moduleContext(sources);
         return SourceSpecs.dir(project, spec, sources);
+    }
+
+    /**
+     * The module path and go.mod content of the sibling go.mod, onto the parser of every {@code .go} spec.
+     */
+    private static void moduleContext(SourceSpecs... sources) {
+        String goModContent = null;
+        // Iterating a nested SourceSpecs is what applies its directory prefix, and that is not
+        // idempotent, so only direct children are examined.
+        for (SourceSpecs multiSpec : sources) {
+            if (multiSpec instanceof SourceSpec) {
+                Path sourcePath = ((SourceSpec<?>) multiSpec).getSourcePath();
+                if (sourcePath != null && "go.mod".equals(sourcePath.getFileName().toString())) {
+                    goModContent = trimIndentPreserveCRLF(((SourceSpec<?>) multiSpec).getBefore());
+                    break;
+                }
+            }
+        }
+        if (goModContent == null) {
+            return;
+        }
+        GoResolutionResult resolution = GoModParser.parseMarker(goModContent, Paths.get("go.mod"));
+        if (resolution == null) {
+            return;
+        }
+        ModuleCache.download(goModContent, resolution.getRequires());
+        for (SourceSpecs multiSpec : sources) {
+            if (multiSpec instanceof SourceSpec && ((SourceSpec<?>) multiSpec).getParser() instanceof GolangParser.Builder) {
+                ((GolangParser.Builder) ((SourceSpec<?>) multiSpec).getParser())
+                        .module(resolution.getModulePath())
+                        .goMod(goModContent);
+            }
+        }
     }
 
     /**

--- a/rewrite-go/src/main/java/org/openrewrite/golang/GoModParser.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/GoModParser.java
@@ -150,7 +150,14 @@ public class GoModParser implements Parser {
     }
 
     static @Nullable GoResolutionResult parseMarker(PlainText doc) {
-        String content = doc.getText();
+        return parseMarker(doc.getText(), doc.getSourcePath());
+    }
+
+    /**
+     * The {@code sourcePath} names the go.mod on the returned marker and locates the sibling
+     * go.sum whose hashes enrich it; a path that is not on disk contributes none.
+     */
+    static @Nullable GoResolutionResult parseMarker(@Nullable String content, Path sourcePath) {
         if (content == null || content.isEmpty()) {
             return null;
         }
@@ -221,14 +228,14 @@ public class GoModParser implements Parser {
             return null;
         }
 
-        List<ResolvedDependency> resolved = parseSumSibling(doc.getSourcePath());
+        List<ResolvedDependency> resolved = parseSumSibling(sourcePath);
 
         return new GoResolutionResult(
                 Tree.randomId(),
                 modulePath,
                 goVersion,
                 toolchain,
-                doc.getSourcePath().toString(),
+                sourcePath.toString(),
                 requires,
                 replaces,
                 excludes,

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/ModuleCache.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/ModuleCache.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.golang.internal;
 
+import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.golang.marker.GoResolutionResult.Require;
 
@@ -39,23 +40,21 @@ import java.util.stream.Stream;
  * The Go RPC server's {@code ProjectImporter} type-checks a third-party import against those
  * sources, so real types for a {@code require} start with getting the module into this cache.
  */
-public final class ModuleCache {
+@UtilityClass
+public class ModuleCache {
 
     /**
      * go.mod contents a download has already been attempted for, so a run whose modules are
      * unpublished or whose proxy is unreachable pays that cost once.
      */
-    private static final Set<String> attempted = ConcurrentHashMap.newKeySet();
-
-    private ModuleCache() {
-    }
+    private final Set<String> attempted = ConcurrentHashMap.newKeySet();
 
     /**
      * Mirrors {@code parser.GoModCache()} on the Go side — {@code $GOMODCACHE}, else the first
      * {@code $GOPATH} entry's {@code pkg/mod}, else {@code ~/go/pkg/mod} — so both ends of the
      * RPC agree on which directory holds a module's sources.
      */
-    public static Path location() {
+    public Path location() {
         String goModCache = System.getenv("GOMODCACHE");
         if (goModCache != null && !goModCache.trim().isEmpty()) {
             return Paths.get(goModCache.trim());
@@ -73,8 +72,8 @@ public final class ModuleCache {
     /**
      * Whether {@code modulePath@version} has its sources extracted in the cache.
      */
-    public static boolean contains(String modulePath, String version) {
-        return Files.isDirectory(location().resolve(escapePath(modulePath) + "@" + version));
+    public boolean contains(String modulePath, String version) {
+        return Files.isDirectory(location().resolve(directoryName(modulePath, version)));
     }
 
     /**
@@ -82,7 +81,7 @@ public final class ModuleCache {
      * satisfies needs neither network nor toolchain. A missing {@code go}, or a download that
      * fails, leaves the module absent and the parse that follows attributes it to an empty stub.
      */
-    public static void download(String goModContent, Collection<Require> requires) {
+    public void download(String goModContent, Collection<Require> requires) {
         List<String> missing = new ArrayList<>();
         for (Require require : requires) {
             if (!contains(require.getModulePath(), require.getVersion())) {
@@ -118,13 +117,18 @@ public final class ModuleCache {
     }
 
     /**
-     * Go stores {@code github.com/BurntSushi/toml} under {@code github.com/!burnt!sushi/toml} so
-     * that module paths differing only in case stay distinct on a case-insensitive filesystem.
+     * Go stores {@code github.com/BurntSushi/toml@v1.0.0-RC1} under
+     * {@code github.com/!burnt!sushi/toml@v1.0.0-!r!c1} so that coordinates differing only in case
+     * stay distinct on a case-insensitive filesystem. Path and version take the same escaping.
      */
-    static String escapePath(String modulePath) {
-        StringBuilder escaped = new StringBuilder(modulePath.length());
-        for (int i = 0; i < modulePath.length(); i++) {
-            char c = modulePath.charAt(i);
+    String directoryName(String modulePath, String version) {
+        return escape(modulePath) + "@" + escape(version);
+    }
+
+    private String escape(String pathOrVersion) {
+        StringBuilder escaped = new StringBuilder(pathOrVersion.length());
+        for (int i = 0; i < pathOrVersion.length(); i++) {
+            char c = pathOrVersion.charAt(i);
             if (c >= 'A' && c <= 'Z') {
                 escaped.append('!').append((char) (c - 'A' + 'a'));
             } else {
@@ -134,7 +138,7 @@ public final class ModuleCache {
         return escaped.toString();
     }
 
-    private static void deleteRecursively(@Nullable Path dir) {
+    private void deleteRecursively(@Nullable Path dir) {
         if (dir == null || !Files.exists(dir)) {
             return;
         }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/ModuleCache.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/ModuleCache.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.internal;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.golang.marker.GoResolutionResult.Require;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
+
+/**
+ * Where a module's extracted sources live, and the {@code go mod download} that puts them there.
+ * The Go RPC server's {@code ProjectImporter} type-checks a third-party import against those
+ * sources, so real types for a {@code require} start with getting the module into this cache.
+ */
+public final class ModuleCache {
+
+    /**
+     * go.mod contents a download has already been attempted for, so a run whose modules are
+     * unpublished or whose proxy is unreachable pays that cost once.
+     */
+    private static final Set<String> attempted = ConcurrentHashMap.newKeySet();
+
+    private ModuleCache() {
+    }
+
+    /**
+     * Mirrors {@code parser.GoModCache()} on the Go side — {@code $GOMODCACHE}, else the first
+     * {@code $GOPATH} entry's {@code pkg/mod}, else {@code ~/go/pkg/mod} — so both ends of the
+     * RPC agree on which directory holds a module's sources.
+     */
+    public static Path location() {
+        String goModCache = System.getenv("GOMODCACHE");
+        if (goModCache != null && !goModCache.trim().isEmpty()) {
+            return Paths.get(goModCache.trim());
+        }
+        String goPath = System.getenv("GOPATH");
+        if (goPath == null || goPath.trim().isEmpty()) {
+            goPath = System.getProperty("user.home") + File.separator + "go";
+        } else {
+            int sep = goPath.indexOf(File.pathSeparatorChar);
+            goPath = sep >= 0 ? goPath.substring(0, sep) : goPath;
+        }
+        return Paths.get(goPath.trim(), "pkg", "mod");
+    }
+
+    /**
+     * Whether {@code modulePath@version} has its sources extracted in the cache.
+     */
+    public static boolean contains(String modulePath, String version) {
+        return Files.isDirectory(location().resolve(escapePath(modulePath) + "@" + version));
+    }
+
+    /**
+     * Extract the sources of every {@code require} the cache is missing, so a go.mod it already
+     * satisfies needs neither network nor toolchain. A missing {@code go}, or a download that
+     * fails, leaves the module absent and the parse that follows attributes it to an empty stub.
+     */
+    public static void download(String goModContent, Collection<Require> requires) {
+        List<String> missing = new ArrayList<>();
+        for (Require require : requires) {
+            if (!contains(require.getModulePath(), require.getVersion())) {
+                missing.add(require.getModulePath() + "@" + require.getVersion());
+            }
+        }
+        if (missing.isEmpty() || !attempted.add(goModContent)) {
+            return;
+        }
+        String go = GoExecutor.GO.find();
+        if (go == null) {
+            return;
+        }
+        Path workDir = null;
+        try {
+            workDir = Files.createTempDirectory("openrewrite-go-download");
+            Files.write(workDir.resolve("go.mod"), goModContent.getBytes(StandardCharsets.UTF_8));
+            List<String> args = new ArrayList<>();
+            args.add("mod");
+            args.add("download");
+            args.addAll(missing);
+            // The server reads the cache location from its environment, which the `go env` config
+            // file would override for this download alone; pinning it keeps the two in agreement.
+            Map<String, String> env = new HashMap<>();
+            env.put("GOMODCACHE", location().toString());
+            GoExecutor.GO.run(workDir, go, env, args.toArray(new String[0]));
+        } catch (IOException ignored) {
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        } finally {
+            deleteRecursively(workDir);
+        }
+    }
+
+    /**
+     * Go stores {@code github.com/BurntSushi/toml} under {@code github.com/!burnt!sushi/toml} so
+     * that module paths differing only in case stay distinct on a case-insensitive filesystem.
+     */
+    static String escapePath(String modulePath) {
+        StringBuilder escaped = new StringBuilder(modulePath.length());
+        for (int i = 0; i < modulePath.length(); i++) {
+            char c = modulePath.charAt(i);
+            if (c >= 'A' && c <= 'Z') {
+                escaped.append('!').append((char) (c - 'A' + 'a'));
+            } else {
+                escaped.append(c);
+            }
+        }
+        return escaped.toString();
+    }
+
+    private static void deleteRecursively(@Nullable Path dir) {
+        if (dir == null || !Files.exists(dir)) {
+            return;
+        }
+        try (Stream<Path> walk = Files.walk(dir)) {
+            walk.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.delete(path);
+                } catch (IOException ignored) {
+                }
+            });
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/rewrite-go/src/test/java/org/openrewrite/golang/internal/ModuleCacheTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/internal/ModuleCacheTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.internal;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ModuleCacheTest {
+
+    @Test
+    void onlyUppercaseInAModulePathIsEscaped() {
+        // A miss here is silent: the cached module reads as absent and gets downloaded again.
+        assertThat(ModuleCache.escapePath("github.com/BurntSushi/toml")).isEqualTo("github.com/!burnt!sushi/toml");
+        assertThat(ModuleCache.escapePath("github.com/gin-gonic/gin")).isEqualTo("github.com/gin-gonic/gin");
+    }
+}

--- a/rewrite-go/src/test/java/org/openrewrite/golang/internal/ModuleCacheTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/internal/ModuleCacheTest.java
@@ -22,9 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ModuleCacheTest {
 
     @Test
-    void onlyUppercaseInAModulePathIsEscaped() {
+    void uppercaseIsEscapedInBothHalvesOfACoordinate() {
         // A miss here is silent: the cached module reads as absent and gets downloaded again.
-        assertThat(ModuleCache.escapePath("github.com/BurntSushi/toml")).isEqualTo("github.com/!burnt!sushi/toml");
-        assertThat(ModuleCache.escapePath("github.com/gin-gonic/gin")).isEqualTo("github.com/gin-gonic/gin");
+        assertThat(ModuleCache.directoryName("github.com/BurntSushi/toml", "v1.0.0-RC1"))
+          .isEqualTo("github.com/!burnt!sushi/toml@v1.0.0-!r!c1");
+
+        assertThat(ModuleCache.directoryName("github.com/gin-gonic/gin", "v1.10.0"))
+          .isEqualTo("github.com/gin-gonic/gin@v1.10.0");
     }
 }


### PR DESCRIPTION
Every Go test in this repo parses with third-party types silently absent. `Assertions.go(...)` builds its `SourceSpec` with a bare `GolangParser.builder()`, and `GolangParser.parseInputs` only routes through `GoRewriteRpc.parseWithProject` when `module` is non-null — so a test written with `go(...)`, even alongside a `goMod(...)` sibling declaring `require`s, never gets a `ProjectImporter`. Production has them fully: Moderne CLI's `GoBuildStep` calls `rpc.parseProject`.

Probed against 8.92.0-SNAPSHOT (i.e. with a933cc2d4e in), reading `J.MethodInvocation#getMethodType()` over a gin router:

| how the source is parsed | `gin.Default()` / `r.GET(...)` / `c.JSON(...)` |
|---|---|
| `Assertions.go(...)` + sibling `Assertions.goMod(...)` | `declaring=NULL` for all |
| `GolangParser.builder().module(...).goMod(...)`, gin in `$GOMODCACHE` | `github.com/gin-gonic/gin`, `…gin.RouterGroup`, `…gin.Context` |
| same, required module absent from the cache | `declaring=NULL` for all |

- So the machinery from #8606 works; nothing in the test DSL turns it on, and nothing puts a test's declared `require`s into the module cache.

## The fix

`goProject(name, sources...)` now finds the sibling `go.mod` among its direct children, extracts the modules it requires into `$GOMODCACHE`, and sets `module` + `goMod` on each `.go` spec's parser builder. `SourceSpec.parser` is final but the builder it holds is mutable, and `RewriteTest` clones it before use (`RewriteTest.java:285`), so configuring it in place needs no change to rewrite-test.

**Naming.** The request was for this under `Assertions.goMod`, but `goMod(String)` already returns the single go.mod `SourceSpec`; a `(Path, SourceSpecs...)` overload would mean two unrelated things under one name. `goProject` already has the wrapper shape and already means "these files are a Go module rooted here", so it carries the module context too. Existing overloads are untouched.

**No workspace directory.** The JS and Python equivalents cache a whole materialized dependency tree (`node_modules`, `.venv`) per manifest content, because those resolvers walk up from the importing file and need the tree at a real path. Go has no per-project tree: `$GOMODCACHE` is global and content-addressed, and `ProjectImporter.walkModuleCache` reads `<GOMODCACHE>/<escaped path>@<version>` directly. So instead of a content-hashed marker directory this stats that path per require — cheaper than a marker, accurate across JVMs for free, and correct after a `go clean -modcache`. `ModuleCache.escapePath` reproduces Go's `!lowercase` escaping so `github.com/BurntSushi/toml` finds `github.com/!burnt!sushi/toml`. The only cache kept is an in-JVM set of go.mod contents already *attempted*, so a go.mod naming an unpublished module pays its ~2s failure once rather than per parse. A temp dir appears only as scratch: `go mod download` refuses to run outside a module, so it gets a throwaway go.mod and runs with `GOMODCACHE` pinned to the location the RPC server reads.

**Degradation.** A go.mod the cache already satisfies needs neither network nor toolchain — nothing is executed. A missing `go` on `PATH`, or a download that fails, leaves the module absent and its imports fall back to the require-stub tier, same as today.

## Why not `ParseProject`

It would be richer — `ResolveModuleGraph` registers the whole MVS-selected build list including transitives, plus the vendor tier and a shared importer across the project's files. Three things argue against routing tests through it. The transitive gap is small: `parsePackage` sets `types.Config.Error = func(error){}` and discards `Files()`'s error, so a dependency whose own imports are unregistered still type-checks partially and its funcs keep their `MethodType` and `declaringType` — a hand-written go.mod requiring only gin gives identical attribution to a fully `go mod tidy`-ed one with all 27 indirects. `RewriteTest` keys parse batches on `Parser.Builder` identity and `Parser.Builder` has no `equals`, so every `go(...)` spec is its own batch and each would run its own `go list -m all`. And `ParseProject` discovers a directory tree rather than honouring `parseInputs`' one-SourceFile-per-input contract, so it needs a new parser mode, not an `Assertions` change.

## Tests

`ThirdPartyTypeAttributionTest.callsIntoARequiredModuleCarryTheirDeclaringType` is the first test in the repo that can assert attributed third-party calls: `Default` → `github.com/gin-gonic/gin`, `GET` → `…gin.RouterGroup`, `JSON` → `…gin.Context`, and `r` → `…gin.Engine` via `expectType`. Four assertions rather than one because the stub tier fails partially — the package name resolves while the call sites don't. Mutation-checked: stubbing out the `moduleContext(sources)` call makes it fail. It runs with default type validation (no `identifiers(false)` / `methodInvocations(false)` relaxation) and `assumeTrue`s on the module being in the cache, so a machine that could not fetch gin skips rather than fails.

`ModuleCacheTest.onlyUppercaseInAModulePathIsEscaped` guards the escaping, where a mistake is silent: the cached module reads as absent and gets re-downloaded on every run.

`GoModParser.parseMarker` gains a `(String, Path)` overload so the go.mod scan reuses the existing grammar instead of a second regex parser; the `PlainText` overload delegates to it.

## Downstream

`moderneinc/rewrite-prethink` has ~13 Go recipes gating on `inv.getMethodType() != null` and matching `getDeclaringType()`'s FQN (`FindGoServiceEndpoints`, `FindGoDatabaseConnections`, `FindGoHttpClients`, `FindGoMessagingConnections`, others). None can be tested today. This is the direct-dependency tier those recipes match on, so they can drop the opt-in real-world smoke test.
