### PR TITLE
JS Matcher ignores type arguments and breaks on arrow

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -2470,19 +2470,30 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
         return method;
     }
 
-    /** A call whose callee is not a plain identifier, such as `getFn()(x)`, `arr[0](x)` or `fn?.(x)`. */
+    /**
+     * A call whose callee is not a plain identifier, such as `getFn()(x)`, `arr[0](x)` or `fn?.(x)`.
+     * Type arguments constrain it under the same rule as `visitMethodInvocation`.
+     */
     override async visitFunctionCall(functionCall: JS.FunctionCall, other: J): Promise<J | undefined> {
         if (other.kind !== JS.Kind.FunctionCall) {
             return this.kindMismatch();
         }
 
         const otherFunctionCall = other as JS.FunctionCall;
-        if (!functionCall.typeParameters && otherFunctionCall.typeParameters) {
-            const withoutTypeArguments: JS.FunctionCall = {...otherFunctionCall, typeParameters: undefined};
-            return super.visitFunctionCall(functionCall, withoutTypeArguments);
+        if (functionCall.typeParameters) {
+            if (!otherFunctionCall.typeParameters) {
+                return this.structuralMismatch('typeParameters');
+            }
+
+            await this.visitContainerProperty('typeParameters', functionCall.typeParameters, otherFunctionCall.typeParameters);
+            if (!this.match) return functionCall;
         }
 
-        return super.visitFunctionCall(functionCall, other);
+        // Type arguments are settled, so they come off both sides and the rest compares property by property
+        const patternCall: JS.FunctionCall = {...functionCall, typeParameters: undefined};
+        const targetCall: JS.FunctionCall = {...otherFunctionCall, typeParameters: undefined};
+        await super.visitFunctionCall(patternCall, targetCall);
+        return functionCall;
     }
 
     /**

--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -2515,6 +2515,10 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
      * code with typeExpression.
      */
     override async visitVariableDeclarations(variableDeclarations: J.VariableDeclarations, other: J): Promise<J | undefined> {
+        if (other.kind !== J.Kind.VariableDeclarations) {
+            return this.kindMismatch();
+        }
+
         const otherVariableDeclarations = other as J.VariableDeclarations;
 
         // Visit leading annotations
@@ -2573,6 +2577,10 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
      * code with returnTypeExpression.
      */
     override async visitMethodDeclaration(methodDeclaration: J.MethodDeclaration, other: J): Promise<J | undefined> {
+        if (other.kind !== J.Kind.MethodDeclaration) {
+            return this.kindMismatch();
+        }
+
         const otherMethodDeclaration = other as J.MethodDeclaration;
 
         // Visit leading annotations

--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -2410,11 +2410,6 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
                 }
             }
 
-            // If neither has type, use structural comparison
-            if (!method.methodType && !otherMethod.methodType) {
-                return super.visitMethodInvocation(method, other);
-            }
-
             // If both have types with FQ declaring types, verify they're compatible
             // (This prevents matching completely different methods like util.isArray vs util.isBoolean)
             if (method.methodType && otherMethod.methodType) {
@@ -2450,12 +2445,12 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
         }
         // else: types matched, skip select comparison (allows namespace vs named imports)
 
-        // Compare type parameters
-        if ((method.typeParameters === undefined) !== (otherMethod.typeParameters === undefined)) {
-            return this.structuralMismatch('typeParameters');
-        }
+        // A pattern that spells out no type arguments says nothing about them, as with parentheses
+        if (method.typeParameters) {
+            if (!otherMethod.typeParameters) {
+                return this.structuralMismatch('typeParameters');
+            }
 
-        if (method.typeParameters && otherMethod.typeParameters) {
             await this.visitContainerProperty('typeParameters', method.typeParameters, otherMethod.typeParameters);
             if (!this.match) return method;
         }

--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -2470,6 +2470,21 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
         return method;
     }
 
+    /** A call whose callee is not a plain identifier, such as `getFn()(x)`, `arr[0](x)` or `fn?.(x)`. */
+    override async visitFunctionCall(functionCall: JS.FunctionCall, other: J): Promise<J | undefined> {
+        if (other.kind !== JS.Kind.FunctionCall) {
+            return this.kindMismatch();
+        }
+
+        const otherFunctionCall = other as JS.FunctionCall;
+        if (!functionCall.typeParameters && otherFunctionCall.typeParameters) {
+            const withoutTypeArguments: JS.FunctionCall = {...otherFunctionCall, typeParameters: undefined};
+            return super.visitFunctionCall(functionCall, withoutTypeArguments);
+        }
+
+        return super.visitFunctionCall(functionCall, other);
+    }
+
     /**
      * Override identifier comparison to include:
      * 1. Type checking for field access

--- a/rewrite-javascript/rewrite/src/javascript/templating/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/comparator.ts
@@ -344,13 +344,12 @@ export class PatternMatchingComparator extends JavaScriptSemanticComparatorVisit
                 if (!this.match) return methodInvocation;
             }
 
-            // Compare typeParameters
-            if ((methodInvocation.typeParameters === undefined) !== (otherMethodInvocation.typeParameters === undefined)) {
-                return this.structuralMismatch('typeParameters');
-            }
+            // A pattern that spells out no type arguments says nothing about them, as with parentheses
+            if (methodInvocation.typeParameters) {
+                if (!otherMethodInvocation.typeParameters) {
+                    return this.structuralMismatch('typeParameters');
+                }
 
-            // Visit typeParameters if present
-            if (methodInvocation.typeParameters && otherMethodInvocation.typeParameters) {
                 if (methodInvocation.typeParameters.elements.length !== otherMethodInvocation.typeParameters.elements.length) {
                     return this.arrayLengthMismatch('typeParameters.elements');
                 }

--- a/rewrite-javascript/rewrite/test/javascript/templating/pattern-arrow-parameters.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/pattern-arrow-parameters.test.ts
@@ -36,52 +36,18 @@ describe('arrow patterns against a zero-parameter arrow', () => {
         });
     }
 
-    const blockBodied = () =>
-        //language=javascript
-        javascript(`
-            const zeroParameters = () => { return 1; };
-            const oneParameter = (a) => { return 1; };
-        `);
-
-    const expressionBodied = () =>
+    const arrows = () =>
         //language=javascript
         javascript(`
             const zeroParameters = () => 1;
             const oneParameter = (a) => 1;
         `);
 
-    test('a variadic parameter capture', async () => {
-        const matched: string[] = [];
-        spec.recipe = probe(pattern`(${capture({variadic: true})}) => { return ${capture()}; }`, matched);
-
-        await spec.rewriteRun(blockBodied());
-
-        expect(matched).toEqual(['oneParameter']);
-    });
-
-    test('a plain parameter capture', async () => {
-        const matched: string[] = [];
-        spec.recipe = probe(pattern`(${capture()}) => { return ${capture()}; }`, matched);
-
-        await spec.rewriteRun(blockBodied());
-
-        expect(matched).toEqual(['oneParameter']);
-    });
-
-    test('a literal parameter, with no capture in the parameter list', async () => {
-        const matched: string[] = [];
-        spec.recipe = probe(pattern`(a) => { return ${capture()}; }`, matched);
-
-        await spec.rewriteRun(blockBodied());
-
-        expect(matched).toEqual(['oneParameter']);
-    });
-
-    test('an expression-bodied arrow pattern', async () => {
+    test('a one-parameter pattern reports no match', async () => {
         const matched: string[] = [];
         spec.recipe = probe(pattern`(${capture()}) => ${capture()}`, matched);
 
-        await spec.rewriteRun(expressionBodied());
+        await spec.rewriteRun(arrows());
 
         expect(matched).toEqual(['oneParameter']);
     });
@@ -90,7 +56,7 @@ describe('arrow patterns against a zero-parameter arrow', () => {
         const matched: string[] = [];
         spec.recipe = probe(pattern`() => ${capture()}`, matched);
 
-        await spec.rewriteRun(expressionBodied());
+        await spec.rewriteRun(arrows());
 
         expect(matched).toEqual(['zeroParameters']);
     });

--- a/rewrite-javascript/rewrite/test/javascript/templating/pattern-arrow-parameters.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/pattern-arrow-parameters.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {capture, javascript, JavaScriptVisitor, JS, Pattern, pattern} from "../../../src/javascript";
+import {J} from "../../../src/java";
+
+// The parser represents the empty parameter list of `() => 1` as a single J.Empty, so an
+// arrow pattern with one parameter and a zero-parameter arrow have lists of the same length.
+describe('arrow patterns against a zero-parameter arrow', () => {
+    const spec = new RecipeSpec();
+
+    // Records the name of the variable each matching arrow function is assigned to.
+    function probe(pat: Pattern, matched: string[]) {
+        return fromVisitor(new class extends JavaScriptVisitor<any> {
+            protected override async visitArrowFunction(arrow: JS.ArrowFunction, p: any): Promise<J | undefined> {
+                if (await pat.match(arrow, this.cursor)) {
+                    const variable = this.cursor.firstEnclosing(
+                        (v): v is J.VariableDeclarations.NamedVariable => (v as J)?.kind === J.Kind.NamedVariable);
+                    matched.push(variable ? (variable.name as J.Identifier).simpleName : '?');
+                }
+                return super.visitArrowFunction(arrow, p);
+            }
+        });
+    }
+
+    const blockBodied = () =>
+        //language=javascript
+        javascript(`
+            const zeroParameters = () => { return 1; };
+            const oneParameter = (a) => { return 1; };
+        `);
+
+    const expressionBodied = () =>
+        //language=javascript
+        javascript(`
+            const zeroParameters = () => 1;
+            const oneParameter = (a) => 1;
+        `);
+
+    test('a variadic parameter capture', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`(${capture({variadic: true})}) => { return ${capture()}; }`, matched);
+
+        await spec.rewriteRun(blockBodied());
+
+        expect(matched).toEqual(['oneParameter']);
+    });
+
+    test('a plain parameter capture', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`(${capture()}) => { return ${capture()}; }`, matched);
+
+        await spec.rewriteRun(blockBodied());
+
+        expect(matched).toEqual(['oneParameter']);
+    });
+
+    test('a literal parameter, with no capture in the parameter list', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`(a) => { return ${capture()}; }`, matched);
+
+        await spec.rewriteRun(blockBodied());
+
+        expect(matched).toEqual(['oneParameter']);
+    });
+
+    test('an expression-bodied arrow pattern', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`(${capture()}) => ${capture()}`, matched);
+
+        await spec.rewriteRun(expressionBodied());
+
+        expect(matched).toEqual(['oneParameter']);
+    });
+
+    test('a zero-parameter pattern matches only the zero-parameter arrow', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`() => ${capture()}`, matched);
+
+        await spec.rewriteRun(expressionBodied());
+
+        expect(matched).toEqual(['zeroParameters']);
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/pattern-mismatched-kinds.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/pattern-mismatched-kinds.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {capture, javascript, JavaScriptVisitor, Pattern, pattern} from "../../../src/javascript";
+import {J} from "../../../src/java";
+
+// Semantic comparison is deliberately tolerant of differing node kinds, so a pattern is
+// offered every node a recipe visits and has to answer for the ones it has nothing to say about.
+describe('patterns offered a node of an unrelated kind', () => {
+    const spec = new RecipeSpec();
+
+    // Counts how many of the nodes in the source the pattern matches.
+    function probe(pat: Pattern, matches: { count: number }) {
+        return fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visit(tree: any, p: any, parent?: any): Promise<any> {
+                const node = await super.visit(tree, p, parent);
+                if (node && (node as J).kind && await pat.match(node as J, this.cursor)) {
+                    matches.count++;
+                }
+                return node;
+            }
+        });
+    }
+
+    test('a function declaration pattern against a declaration with no parameters', async () => {
+        const matches = {count: 0};
+        spec.recipe = probe(pattern`function foo(a) { return 1; }`, matches);
+
+        //language=javascript
+        await spec.rewriteRun(javascript(`function foo() { return 1; }`));
+
+        expect(matches.count).toBe(0);
+    });
+
+    test('a function declaration pattern against the declaration it describes', async () => {
+        const matches = {count: 0};
+        spec.recipe = probe(pattern`function foo(a) { return 1; }`, matches);
+
+        //language=javascript
+        await spec.rewriteRun(javascript(`function foo(a) { return 1; }`));
+
+        expect(matches.count).toBe(1);
+    });
+
+    test('a variable declaration pattern against a function declaration', async () => {
+        const matches = {count: 0};
+        spec.recipe = probe(pattern`const [${capture()}, ${capture()}] = ${capture()};`, matches);
+
+        //language=javascript
+        await spec.rewriteRun(javascript(`function foo() { return 1; }`));
+
+        expect(matches.count).toBe(0);
+    });
+
+    test('a variable declaration pattern against the declaration it describes', async () => {
+        const matches = {count: 0};
+        spec.recipe = probe(pattern`const [${capture()}, ${capture()}] = ${capture()};`, matches);
+
+        //language=javascript
+        await spec.rewriteRun(javascript(`const [a, b] = arr;`));
+
+        expect(matches.count).toBe(1);
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/pattern-type-arguments.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/pattern-type-arguments.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {capture, JavaScriptVisitor, Pattern, pattern, typescript} from "../../../src/javascript";
+import {J} from "../../../src/java";
+
+describe('pattern matching against calls with type arguments', () => {
+    const spec = new RecipeSpec();
+
+    /**
+     * Collects, for every method invocation the pattern matches, the name of the
+     * variable it was assigned to. That makes the assertions readable without
+     * having to reason about the shape of the invocation itself.
+     */
+    function probe(pat: Pattern, matched: string[]) {
+        return fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                method = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                if (await pat.match(method, this.cursor)) {
+                    const variable = this.cursor.firstEnclosing(
+                        (v): v is J.VariableDeclarations.NamedVariable => (v as J)?.kind === J.Kind.NamedVariable);
+                    matched.push(variable ? (variable.name as J.Identifier).simpleName : '?');
+                }
+                return method;
+            }
+        });
+    }
+
+    test('a pattern without type arguments matches a call that has them', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`${capture()}.bind(${capture()})`, matched);
+
+        await spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                const plain = fn.bind(x);
+                const parenthesized = (fn).bind((x));
+                const optional = fn?.bind(x);
+                const typeArguments = fn.bind<any>(x);
+            `)
+        );
+
+        expect(matched).toEqual(['plain', 'parenthesized', 'optional', 'typeArguments']);
+    });
+
+    test('a pattern without type arguments matches a call that has no type attribution', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`identity(${capture()})`, matched);
+
+        await spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                const plain = identity(x);
+                const typeArguments = identity<string>(x);
+            `)
+        );
+
+        expect(matched).toEqual(['plain', 'typeArguments']);
+    });
+
+    test('a pattern that spells out type arguments still constrains them', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`${capture()}.bind<string>(${capture()})`, matched);
+
+        await spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                const plain = fn.bind(x);
+                const other = fn.bind<any>(x);
+                const same = fn.bind<string>(x);
+            `)
+        );
+
+        expect(matched).toEqual(['same']);
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/pattern-type-arguments.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/pattern-type-arguments.test.ts
@@ -71,6 +71,22 @@ describe('pattern matching against calls with type arguments', () => {
         expect(matched).toEqual(['plain', 'typeArguments']);
     });
 
+    test('a variadic argument capture makes no difference', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`identity(${capture({variadic: true})})`, matched);
+
+        await spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                const plain = identity(x);
+                const typeArguments = identity<string>(x);
+                const several = identity<string>(x, y);
+            `)
+        );
+
+        expect(matched).toEqual(['plain', 'typeArguments', 'several']);
+    });
+
     test('a pattern that spells out type arguments still constrains them', async () => {
         const matched: string[] = [];
         spec.recipe = probe(pattern`${capture()}.bind<string>(${capture()})`, matched);
@@ -81,6 +97,56 @@ describe('pattern matching against calls with type arguments', () => {
                 const plain = fn.bind(x);
                 const other = fn.bind<any>(x);
                 const same = fn.bind<string>(x);
+            `)
+        );
+
+        expect(matched).toEqual(['same']);
+    });
+});
+
+// Such a call parses as JS.FunctionCall rather than J.MethodInvocation.
+describe('pattern matching against calls with a computed callee', () => {
+    const spec = new RecipeSpec();
+
+    function probe(pat: Pattern, matched: string[]) {
+        return fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visit(tree: any, p: any, parent?: any): Promise<any> {
+                const node = await super.visit(tree, p, parent);
+                if (node && (node as J).kind && await pat.match(node as J, this.cursor)) {
+                    const variable = this.cursor.firstEnclosing(
+                        (v): v is J.VariableDeclarations.NamedVariable => (v as J)?.kind === J.Kind.NamedVariable);
+                    matched.push(variable ? (variable.name as J.Identifier).simpleName : '?');
+                }
+                return node;
+            }
+        });
+    }
+
+    test('a pattern without type arguments matches a call that has them', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`getFn()(${capture()})`, matched);
+
+        await spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                const plain = getFn()(x);
+                const typeArguments = getFn()<string>(x);
+            `)
+        );
+
+        expect(matched).toEqual(['plain', 'typeArguments']);
+    });
+
+    test('a pattern that spells out type arguments still constrains them', async () => {
+        const matched: string[] = [];
+        spec.recipe = probe(pattern`getFn()<string>(${capture()})`, matched);
+
+        await spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                const plain = getFn()(x);
+                const other = getFn()<number>(x);
+                const same = getFn()<string>(x);
             `)
         );
 

--- a/rewrite-javascript/rewrite/test/javascript/templating/rewrite-type-arguments.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/rewrite-type-arguments.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {capture, JavaScriptVisitor, pattern, rewrite, template, typescript} from "../../../src/javascript";
+import {J} from "../../../src/java";
+
+describe('rewriting calls that carry type arguments', () => {
+    const spec = new RecipeSpec();
+
+    // The template defines the output, so a rule that keeps the type argument names it and goes first.
+    test('a rule that names the type argument keeps it, ahead of one that does not', async () => {
+        const t = capture('t'), a = capture('a'), b = capture('b');
+        const rule = rewrite(() => ({
+            before: pattern`useState<${t}>(${a})`,
+            after: template`useMyState<${t}>(${a})`
+        })).orElse(rewrite(() => ({
+            before: pattern`useState(${b})`,
+            after: template`useMyState(${b})`
+        })));
+
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                method = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                return await rule.tryOn(this.cursor, method) || method;
+            }
+        });
+
+        await spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `const a = useState<string[]>([]);\nconst b = useState([]);`,
+                `const a = useMyState<string[]>([]);\nconst b = useMyState([]);`
+            )
+        );
+    });
+});


### PR DESCRIPTION
A pattern is transparent where the syntax does not change the shape it asks about. A pattern for `f.bind(x)` matches `(f).bind((x))` through any depth of parentheses, and matches `f?.bind(x)` through the optional chain marker. Type arguments were the exception: `f.bind<any>(x)` did not match, although the call shape is identical and the pattern constrains nothing the type argument could violate. `JavaScriptSemanticComparatorVisitor.visitMethodInvocation` required the pattern and the target to agree on whether the call carries any. It now compares them only when the pattern spells them out, which leaves `f.bind<string>(x)` constraining as before.

The rule had to land in three places to mean anything. Untyped invocations took a shortcut into the base comparator, which compares every property reflectively and so kept applying the old rule; the shortcut is redundant, because with no type attribution on either side the comparison of select, type arguments, name and arguments that follows covers every remaining property of an invocation. `PatternMatchingComparator.visitMethodInvocation` takes over the whole comparison whenever an argument of the pattern is a variadic capture, and its own body kept the old rule, so a pattern for `identity(x)` written with a plain capture matched `identity<string>(x)` while the same pattern written with a variadic one did not. A call whose callee is not a plain identifier or a named property access parses as `JS.FunctionCall` rather than `J.MethodInvocation` — `getFn()(x)`, `arr[0](x)`, `fn?.(x)` — and the semantic comparator had no override for it at all. That last one is the same shape as the formatter gap in moderneinc/customer-requests#3071, a visitor written against the Java model that never reaches the kind TypeScript added beside it; this closes the comparator's instance, not the formatter's. Whether a pattern ignored type arguments came down to the shape of its capture and the spelling of its callee.

The second defect is a crash. Matching any arrow pattern that has one parenthesized parameter — a capture, variadic or not, or a literal identifier — against `() => 1` threw `TypeError: Cannot read properties of undefined (reading 'length')`. The parser models the empty parameter list as a single `J.Empty`, so the pattern's one-parameter list and the target's have the same length and are compared in lock step, and the capture never short-circuits, because its marker sits on the identifier inside the parameter, below the level where the lists diverge.

That shape turned out to be one instance of something wider. The semantic comparator skips the base class's kind check deliberately — it is what lets a `void 0` pattern match an `undefined` identifier — and dispatches on the pattern's kind, so each override that reads the target's properties has to check the kind itself. `visitVariableDeclarations` and `visitMethodDeclaration` were the two that did not: they cast the target and read arrays off it. Arrow patterns were not the only casualty. Any recipe that offers a pattern the nodes it visits hit this, a function declaration pattern throwing on an identifier, a variable declaration pattern on a modifier. Two kind checks, in the shape the sibling overrides already use, cover all of it.

One consequence is worth spelling out. A pattern that ignores type arguments leaves the template to define the output, so a rule rewriting `useState(x)` to `useMyState(x)` now matches `useState<string[]>([])` and emits `useMyState([])`. That call did not match at all before, so the dropped type argument is new. It is the rule's choice rather than something the matcher decides: a pattern that spells the type argument out as a capture, and a template that re-emits it, keeps it, and putting that rule ahead of the plain one handles both forms.

```ts
rewrite(() => ({before: pattern`useState<${t}>(${a})`, after: template`useMyState<${t}>(${a})`}))
    .orElse(rewrite(() => ({before: pattern`useState(${a})`, after: template`useMyState(${a})`})))
```

That turns `useState<string[]>([])` into `useMyState<string[]>([])` and `useState([])` into `useMyState([])`. A `postMatch` that rejects a node carrying `typeParameters` is the other way round, for a rule that should leave generic calls alone.

Still open: `new Foo<string>(x)` is not matched by a pattern for `new Foo(x)`, because `J.NewClass` has no semantic override either.

No existing expectation changes.

Six commits, a failing test and its fix each time: the type-argument rule, the crash, and the two further call spellings the first change did not reach.

- Fixes moderneinc/customer-requests#3069
