### PR TITLE
JavaScript: object literals carry the type the checker resolved

### DIFF
--- a/rewrite-javascript/rewrite/src/java/type.ts
+++ b/rewrite-javascript/rewrite/src/java/type.ts
@@ -21,6 +21,7 @@ export interface Type {
 
 export namespace Type {
     export const FUNCTION_TYPE_NAME = '𝑓';
+    export const OBJECT_TYPE_NAME = '{}';
 
     export const Kind = {
         Annotation: "org.openrewrite.java.tree.JavaType$Annotation",
@@ -254,6 +255,10 @@ export namespace Type {
 
     export function isFunctionType(type?: Type): type is Type.Class {
         return type?.kind === Type.Kind.Class && (type as Type.Class).fullyQualifiedName === FUNCTION_TYPE_NAME;
+    }
+
+    export function isObjectType(type?: Type): type is Type.Class {
+        return type?.kind === Type.Kind.Class && (type as Type.Class).fullyQualifiedName === OBJECT_TYPE_NAME;
     }
 
     export function isMethod(type?: Type): type is Type.Method {

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -17,6 +17,7 @@ import ts from "typescript";
 import * as path from "path";
 import {Type} from "../java";
 import FUNCTION_TYPE_NAME = Type.FUNCTION_TYPE_NAME;
+import OBJECT_TYPE_NAME = Type.OBJECT_TYPE_NAME;
 
 export class JavaScriptTypeMapping {
     // Primary cache: Use type signatures (preferring type.id) as cache keys
@@ -461,12 +462,23 @@ export class JavaScriptTypeMapping {
             return functionType;
         }
 
-        // For anonymous object types that could have circular references
+        // A structural type has no nominal name, so every object literal `{a: 1}` and type
+        // literal `{a: number}` shares the synthetic FQN `{}`, with `members` carrying the shape.
         if (type.flags & ts.TypeFlags.Object) {
             const objectFlags = (type as ts.ObjectType).objectFlags;
             if (objectFlags & ts.ObjectFlags.Anonymous) {
-                return Type.unknownType;
+                const objectType = this.createEmptyObjectType();
+                this.typeCache.set(signature, objectType);
+                this.populateClassType(objectType, type);
+                return objectType;
             }
+        }
+
+        // The `object` keyword: an object of unknown shape.
+        if (type.flags & ts.TypeFlags.NonPrimitive) {
+            const objectType = this.createEmptyObjectType();
+            this.typeCache.set(signature, objectType);
+            return objectType;
         }
 
         // Pre-cache as unknownType before resolving type aliases to prevent infinite
@@ -820,6 +832,29 @@ export class JavaScriptTypeMapping {
     }
 
     methodType(node: ts.Node): Type.Method | undefined {
+        // An object literal is a `J.NewClass`, and `J.NewClass.getType()` reads
+        // `constructorType.returnType`, as it does for a Java anonymous class.
+        if (ts.isObjectLiteralExpression(node)) {
+            const objectType = this.type(node);
+            if (!Type.isFullyQualified(objectType)) {
+                return undefined;
+            }
+            return {
+                kind: Type.Kind.Method,
+                flags: 0,
+                declaringType: objectType,
+                name: '<constructor>',
+                returnType: objectType,
+                parameterNames: [],
+                parameterTypes: [],
+                thrownExceptions: [],
+                annotations: [],
+                declaredFormalTypeNames: [],
+                toJSON: function () {
+                    return Type.signature(this);
+                }
+            } as Type.Method;
+        }
 
         let signature: ts.Signature | undefined;
         let methodName: string;
@@ -1642,6 +1677,23 @@ export class JavaScriptTypeMapping {
         (gtv as any).bounds = bounds;
 
         return gtv;
+    }
+
+    private createEmptyObjectType(): Type.Class {
+        return {
+            kind: Type.Kind.Class,
+            flags: 0,
+            classKind: Type.Class.Kind.Interface,
+            fullyQualifiedName: OBJECT_TYPE_NAME,
+            typeParameters: [],
+            annotations: [],
+            interfaces: [],
+            members: [],
+            methods: [],
+            toJSON: function () {
+                return Type.signature(this);
+            }
+        } as Type.Class;
     }
 
     /**

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
@@ -2153,6 +2153,78 @@ describe('JavaScript type mapping', () => {
             )
         }, {unsafeCleanup: true});
     });
+
+    describe('object types', () => {
+        test('an object literal is attributed as an object type whose members carry each field name and type', async () => {
+            const literals: J.NewClass[] = [];
+            const spec = new RecipeSpec();
+            spec.recipe = markTypes((node, type) => {
+                if (node?.kind !== J.Kind.NewClass) {
+                    return null;
+                }
+                literals.push(node as J.NewClass);
+                return formatObjectType(type);
+            });
+
+            await spec.rewriteRun(
+                //language=typescript
+                typescript(
+                    'const c = {a: 1, b: "x", nested: {deep: true}};',
+                    'const c = /*~~({} a, b, nested)~~>*/{a: 1, b: "x", nested: /*~~({} deep)~~>*/{deep: true}};'
+                )
+            );
+
+            const outer = objectTypeOf(literals, 'a');
+            expect(outer.classKind).toBe(Type.Class.Kind.Interface);
+            expect(outer.members.map(m => [m.name, Type.signature(m.type)])).toEqual([
+                ['a', 'double'],
+                ['b', 'String'],
+                ['nested', '{}']
+            ]);
+            expect(outer.members.every(m => m.owner === outer)).toBe(true);
+
+            const nested = outer.members[2].type as Type.Class;
+            expect(nested.members.map(m => [m.name, Type.signature(m.type)])).toEqual([['deep', 'boolean']]);
+        });
+
+        test('a reference to a variable bound to an object literal keeps the object type and its owning variable', async () => {
+            const references: J.Identifier[] = [];
+            const spec = new RecipeSpec();
+            spec.recipe = markTypes((node, type) => {
+                if (node?.kind !== J.Kind.Identifier || !Type.isObjectType(type)) {
+                    return null;
+                }
+                references.push(node as J.Identifier);
+                return formatObjectType(type);
+            });
+
+            await spec.rewriteRun(
+                //language=typescript
+                typescript(
+                    'const c = {a: 1};\nconsole.log(c);',
+                    'const /*~~({} a)~~>*/c = {a: 1};\nconsole.log(/*~~({} a)~~>*/c);'
+                )
+            );
+
+            const use = references[references.length - 1];
+            expect(use.fieldType!.name).toBe('c');
+            expect(use.fieldType!.type).toBe(use.type);
+            expect((use.type as Type.Class).members.map(m => [m.name, Type.signature(m.type)])).toEqual([['a', 'double']]);
+        });
+
+        test('the object keyword is attributed as an object type with no members', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = markTypes((node, type) => node?.kind === J.Kind.Identifier ? formatObjectType(type) : null);
+
+            await spec.rewriteRun(
+                //language=typescript
+                typescript(
+                    'declare function f(o: object): void;',
+                    'declare function f(/*~~({})~~>*/o: /*~~({})~~>*/object): void;'
+                )
+            );
+        });
+    });
 });
 
 /**
@@ -2211,6 +2283,15 @@ function markTypes(predicate: (node: any, type: Type | undefined) => string | nu
                     return visited;
                 }
 
+                async visitNewClass(newClass: J.NewClass, p: ExecutionContext): Promise<J.NewClass> {
+                    const visited = await super.visitNewClass(newClass, p) as J.NewClass;
+                    const description = predicate(visited, visited.constructorType?.returnType);
+                    if (description) {
+                        return foundSearchResult(visited, description);
+                    }
+                    return visited;
+                }
+
                 async visitMethodInvocation(method: J.MethodInvocation, p: ExecutionContext): Promise<J.MethodInvocation> {
                     const visited = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
                     const description = predicate(visited, visited.methodType);
@@ -2240,4 +2321,20 @@ function markTypes(predicate: (node: any, type: Type | undefined) => string | nu
  */
 function formatPrimitiveType(type: Type | undefined): string | null {
     return Type.isPrimitive(type) ? type.keyword || 'None' : null;
+}
+
+function formatObjectType(type: Type | undefined): string | null {
+    if (!Type.isObjectType(type)) {
+        return null;
+    }
+    return type.members.length === 0 ? '{}' : `{} ${type.members.map(m => m.name).join(', ')}`;
+}
+
+function objectTypeOf(literals: J.NewClass[], memberName: string): Type.Class {
+    const match = literals.find(l => {
+        const type = l.constructorType?.returnType;
+        return Type.isObjectType(type) && type.members.some(m => m.name === memberName);
+    });
+    expect(match, `no object literal with a '${memberName}' member`).toBeDefined();
+    return match!.constructorType!.returnType as Type.Class;
 }


### PR DESCRIPTION
An object literal has no type at all in a JavaScript/TypeScript LST, and an identifier bound to one resolves to `JavaType.Unknown`. Probed against the parser on TypeScript source, so the checker is available:

```
J$NewClass   | undefined                    // {b: 2}
J$Identifier | JavaType$Unknown             // o, bound to {a: 1}
J$Literal    | JavaType$Primitive{null}     // null
```

This is a discard, not an absence. `checker.getTypeAtLocation({a: 1})` returns a fully resolved `ts.Type` — `{ a: number; }`, symbol `__object`, objectFlags `Anonymous|ObjectLiteral|FreshLiteral` — and `getPropertiesOfType` hands back real members with resolvable types. `JavaScriptTypeMapping.getType()` reached them and threw them away:

```ts
if (objectFlags & ts.ObjectFlags.Anonymous) {
    return Type.unknownType;
}
```

Type literals in annotations (`function g(p: {x: number})`) hit that same branch. Separately, the `object` keyword is `ts.TypeFlags.NonPrimitive`, which nothing handled anywhere, so `{} as object` fell through to `Unknown` too.

## Naming a structural type

TypeScript object types are structural; `JavaType.Class` is nominal and wants a name. There is no name to take, and taking one from the type is worse than it looks — `checker.getFullyQualifiedName` on an `__object` symbol returns *the enclosing variable name*, so `const o = {a: 1}` reports the FQN `o`, colliding with any real class called `o`, while the identical shape at an argument position reports `__object`. Hashing the member set is stable but unmatchable, meaningless to a reader, and still collides for two identical shapes with different intent.

So anonymous shapes share one synthetic FQN, `{}`, exactly as every function type already shares `𝑓` (`Type.FUNCTION_TYPE_NAME`). That precedent also settles the objection: `Type.signature` of a `Kind.Class` is its FQN, so `() => number` and `(a: string) => void` already signature identically, and this change accepts the same collision rather than a new kind of one. `{}` is preferred over an identifier-shaped name like `__object` because it is not a legal JavaScript identifier and therefore cannot collide with a user type.

The shape is not lost to the name. `populateClassType` needed no changes to handle anonymous types — its `getBaseTypes` and type-parameter branches no-op on an `ObjectLiteral` symbol — so `members` comes out populated for free:

```ts
const c = {a: 1, b: "x", nested: {deep: true}};
// {}  members: [a: double, b: String, nested: {}]
//              nested -> {}  members: [deep: boolean]
```

Each member is a `JavaType.Variable` with the field name, the field's mapped type, and an `owner` back-pointer to the object class.

## Why the literal needed a constructor type too

`J.NewClass.getType()` is `constructorType.getReturnType()`, and `methodType()` matched none of its branches for an `ObjectLiteralExpression` — it hit the terminal `return undefined`, which is why the literal had no type even once `getType` produced one. It now synthesizes a `<constructor>` whose return type is the object type, the shape javac uses for an anonymous class.

## Scope

Two things this deliberately does not do. The literal's **contextual type** is not recorded, so a literal is not matchable by the nominal interface it satisfies even though the checker knows it (`getContextualType` resolves `Opt` for `h({async: true})`, `Named` for `const named: Named = {n: "x"}`). The faithful way to add it is as a supertype/interface on the `{}` class, mirroring `new Runnable(){}` becoming `Outer$1 implements Runnable` so `TypeUtils.isAssignableTo` works; that needs a node-aware path, since `getContextualType` takes a node and `getType` only sees a `ts.Type`. And **`JavaType.Primitive` has no member for a literal value** — it is a closed set of twelve Java primitives — so `{async: true}` and `{async: false}` both attribute `async` as `boolean`, visible in the new test's `['deep', 'boolean']` row.

Also known and left alone: a nested literal's type appears twice in the graph, because the parent's member type comes from `getTypeOfSymbolAtLocation` (widened) while the literal node's own type comes from `getTypeAtLocation` (fresh), and those carry different `type.id`s. Structurally identical, two instances; fixing it means changing the cache key.

## Tests

Three tests in `type-mapping.test.ts`, using the file's existing search-marker style so each asserts placement and printing alongside the attributed type, then reaches into the `JavaType` itself for member names, member types, `owner`, `classKind`, and the nested shape. They cover the object-literal intercept in `methodType()`, the identifier/variable path (`mapIdentifier`'s `Type.Variable` unwrap), and the `NonPrimitive` branch — three different lines, so none is redundant with another.

No existing test pinned the old `Unknown`. `type-mapping-types-package.test.ts` has a test named `plain JS without @types stays <unknown>`, but it is about `require('express')` returning `any`, not an object type, and is unaffected. Full `test/javascript` suite: 142 files, 1659 passed, 21 skipped. Parse cost over ~10k lines of type-literal-heavy TypeScript was inside run-to-run noise (1599–1882 ms patched vs 1767–2034 ms before).