### PR TITLE
Reject Scala pre-releases so rewrite-scala compiles against the stable compiler

### DIFF
--- a/rewrite-scala/build.gradle.kts
+++ b/rewrite-scala/build.gradle.kts
@@ -8,8 +8,8 @@ dependencies {
     api(project(":rewrite-java"))
 
     // Scala 3 compiler (dotty) and library
-    implementation("org.scala-lang:scala3-compiler_3:latest.release")
-    implementation("org.scala-lang:scala3-library_3:latest.release")
+    implementation("org.scala-lang:scala3-compiler_3:3.+")
+    implementation("org.scala-lang:scala3-library_3:3.+")
 
     compileOnly(project(":rewrite-test"))
     compileOnly("org.slf4j:slf4j-api:1.7.+")
@@ -28,6 +28,23 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     testRuntimeOnly(project(":rewrite-java-21"))
     testRuntimeOnly("org.antlr:antlr4-runtime:4.13.2")
+}
+
+// Scala publishes release candidates as full Maven Central releases (3.10.0-RC1 today), with a
+// compiler API that `ScalaCompilerBridge` does not compile against. `latest.release` would defeat
+// this rule: on a Maven repo it evaluates only the `<release>` version, which is the RC.
+val scalaPreRelease = Regex("-(RC|M|NIGHTLY|ALPHA|BETA)", RegexOption.IGNORE_CASE)
+
+configurations.all {
+    resolutionStrategy {
+        componentSelection {
+            all {
+                if (candidate.group == "org.scala-lang" && scalaPreRelease.containsMatchIn(candidate.version)) {
+                    reject("pre-release")
+                }
+            }
+        }
+    }
 }
 
 // Configure Scala source sets and compilation order


### PR DESCRIPTION
- `:rewrite-scala:compileScala` fails on every PR whose CI resolves dependencies fresh, including changes that cannot touch Scala ([run on #8675](https://github.com/openrewrite/rewrite/actions/runs/33052367817/job/98450736140), a TypeScript-only PR):

```
[Error] rewrite-scala/src/main/scala/org/openrewrite/scala/internal/ScalaCompilerBridge.scala:65:78:
None of the overloaded alternatives of method getDirectory in object AbstractFile with types ...
```

- Nothing in the repo changed — `ScalaCompilerBridge.scala` has been untouched since #8174. A dependency did: `org.scala-lang:scala3-compiler_3` now resolves to `3.10.0-RC1`, whose `AbstractFile.getDirectory` overloads differ from the 3.9.x line the bridge is written against.

The RC gets picked because Scala publishes release candidates as full Maven Central releases. [`maven-metadata.xml`](https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/maven-metadata.xml) declares `<release>3.10.0-RC1</release>`, so `latest.release` is behaving exactly as documented — the upstream metadata is what makes an RC look like a release. The newest stable is `3.9.0`.

## The fix

A `componentSelection` rule rejects `org.scala-lang` versions carrying an `-RC` / `-M` / `-NIGHTLY` / `-ALPHA` / `-BETA` qualifier, and the two coordinates move from `latest.release` to the `3.+` range.

The version-selector change is load-bearing, not cosmetic: on a Maven repository `latest.release` evaluates only the single `<release>` version from the metadata rather than enumerating the version list, so rejecting that one candidate fails resolution outright instead of falling back:

```
Could not find any version that matches org.scala-lang:scala3-compiler_3:latest.release.
Versions rejected by component selection rules: 3.10.0-RC1
```

`3.+` does walk the version list, so the rejection rule lands on the newest non-pre-release. This keeps the module tracking Scala automatically — `3.10.0` will be picked up the day it ships — rather than freezing on a pin. Rejected alternatives: pinning `3.9.0` works but stops tracking upstream and needs a human to notice 3.10.0 final; adapting the bridge to the new `getDirectory` signature chases an API that may still change before 3.10.0 final and risks breaking against 3.9.0.

## Scope

Deliberately confined to `rewrite-scala`. `org.scala-lang` is declared nowhere else in the build, and `rewrite-kotlin`'s `compileOnly(project(":rewrite-scala"))` sees only this module's `api` dependencies, so no other module is exposed. A general "never resolve a pre-release through `latest.release`" rule would apply to the other 30 build files that use the convention, but that belongs in `org.openrewrite.build.*` over in openrewrite/rewrite-build-gradle-plugin, not duplicated here — worth doing, out of scope for unblocking CI.

## Verification

`./gradlew :rewrite-scala:dependencies --configuration compileClasspath` now reports `org.scala-lang:scala3-compiler_3:3.+ -> 3.9.0` (was `latest.release -> 3.10.0-RC1`). `./gradlew :rewrite-scala:compileScala` and `:rewrite-scala:test` both pass locally.
