### PR TITLE
JavaScript: enumerate dependency types the way packages publish them

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/package-exported-types.ts
+++ b/rewrite-javascript/rewrite/src/javascript/package-exported-types.ts
@@ -18,6 +18,8 @@ import * as path from "path";
 import {Type} from "../java";
 import {JavaScriptTypeMapping} from "./type-mapping";
 
+const TYPESCRIPT_FILE = /\.[cm]?tsx?$/;
+
 // Free functions are not exported-type entries; only nominal types (and value modules, which are
 // descended into for nested types) qualify.
 const TYPE_SYMBOL_FLAGS =
@@ -38,21 +40,13 @@ const TYPE_SYMBOL_FLAGS =
  * @param references node_modules roots / sibling packages used only for symbol resolution
  */
 export function exportedTypes(ownArtifacts: string[], references: string[]): Type.FullyQualified[] {
-    const entries: string[] = [];
-    for (const artifact of ownArtifacts) {
-        const entry = declarationFileEntry(artifact) ?? resolvePackageEntry(artifact);
-        if (entry) {
-            entries.push(path.normalize(entry));
-        }
-    }
-    if (entries.length === 0) {
-        return [];
-    }
-
     const compilerOptions: ts.CompilerOptions = {
         target: ts.ScriptTarget.Latest,
-        module: ts.ModuleKind.CommonJS,
-        moduleResolution: ts.ModuleResolutionKind.Node10,
+        // Mirrors JavaScriptParser's module resolution, so a dependency's own imports resolve here
+        // as they do when its consumers are parsed; the rationale for each option lives there.
+        module: ts.ModuleKind.Preserve,
+        moduleResolution: ts.ModuleResolutionKind.Bundler,
+        customConditions: ["node"],
         noEmit: true,
         allowJs: true,
         checkJs: false,
@@ -79,6 +73,17 @@ export function exportedTypes(ownArtifacts: string[], references: string[]): Typ
             }
             return resolved;
         });
+
+    const entries: string[] = [];
+    for (const artifact of ownArtifacts) {
+        const entry = declarationFileEntry(artifact) ?? resolvePackageEntry(artifact, compilerOptions, host);
+        if (entry) {
+            entries.push(path.normalize(entry));
+        }
+    }
+    if (entries.length === 0) {
+        return [];
+    }
 
     const program = ts.createProgram(entries, compilerOptions, host);
     const checker = program.getTypeChecker();
@@ -156,7 +161,7 @@ function arity(cls: Type.Class): number {
 
 /** A TypeScript declaration/source FILE (e.g. a `lib.*.d.ts` of ambient globals), used directly as a program entry. */
 function declarationFileEntry(artifact: string): string | undefined {
-    return ts.sys.fileExists(artifact) && /\.[cm]?tsx?$/.test(artifact) ? artifact : undefined;
+    return ts.sys.fileExists(artifact) && TYPESCRIPT_FILE.test(artifact) ? artifact : undefined;
 }
 
 /** Top-level ambient type declarations of a script (non-module) file — a `lib.*.d.ts`'s globals; namespaces descended for nested types. */
@@ -186,30 +191,34 @@ function globalTypeSymbols(checker: ts.TypeChecker, sourceFile: ts.SourceFile): 
 }
 
 /**
- * Resolve a package directory to its declaration entry: the package.json `types`/`typings`
- * field, else the `exports["."]` types condition (modern packages declare types only there),
- * else a top-level `index.d.ts` (then `index.ts`).
+ * A package directory's declaration entry, found by resolving the package's own name from inside
+ * it so `types`, `exports` conditions and `typesVersions` all apply; else the declared `types`
+ * file; else a top-level `index.d.ts` (then `index.ts`). Reaching none of them means the package
+ * ships no types, which leaves the caller to fall back to its DefinitelyTyped package.
  */
-function resolvePackageEntry(dir: string): string | undefined {
-    const packageJson = path.join(dir, "package.json");
-    if (ts.sys.fileExists(packageJson)) {
-        try {
-            const pkg = JSON.parse(ts.sys.readFile(packageJson) || "{}");
-            const typesField: unknown = pkg.types ?? pkg.typings;
-            const candidate = typeof typesField === "string"
-                ? typesField
-                : exportsTypesEntry(pkg.exports);
-            if (typeof candidate === "string") {
-                const resolved = path.resolve(dir, candidate);
-                if (ts.sys.fileExists(resolved)) {
-                    return resolved;
-                }
-                if (ts.sys.fileExists(resolved + ".d.ts")) {
-                    return resolved + ".d.ts";
-                }
+function resolvePackageEntry(dir: string, options: ts.CompilerOptions, host: ts.ModuleResolutionHost): string | undefined {
+    const manifest = packageManifest(dir);
+    if (typeof manifest?.name === "string") {
+        const conditions = options.customConditions ?? [];
+        // A package's declarations count under whichever condition carries them, since no
+        // consumer's import mode is choosing between `import` and `require` here.
+        for (const attempt of [conditions, [...conditions, "require"]]) {
+            const resolved = ts.resolveModuleName(manifest.name, path.join(dir, "__entry__.ts"),
+                {...options, customConditions: attempt}, host).resolvedModule?.resolvedFileName;
+            if (resolved && TYPESCRIPT_FILE.test(resolved) && containedIn(dir, resolved)) {
+                return resolved;
             }
-        } catch {
-            // Malformed package.json; fall through to conventional entry points.
+        }
+    }
+    // An `exports` map without a `types` condition takes resolution to the runtime entry and stops
+    // it there, while `types` still names the declarations.
+    const declared = manifest?.types ?? manifest?.typings;
+    if (typeof declared === "string") {
+        const resolved = path.resolve(dir, declared);
+        for (const candidate of [resolved, resolved + ".d.ts"]) {
+            if (ts.sys.fileExists(candidate)) {
+                return candidate;
+            }
         }
     }
     for (const candidate of ["index.d.ts", "index.ts", "index.tsx"]) {
@@ -221,49 +230,26 @@ function resolvePackageEntry(dir: string): string | undefined {
     return undefined;
 }
 
-/** The declaration file for the package's `.` subpath from its `exports` map, if any. */
-function exportsTypesEntry(exports: unknown): string | undefined {
-    if (typeof exports === "string") {
-        return typesFromCondition(exports);
-    }
-    if (!exports || typeof exports !== "object") {
-        return undefined;
-    }
-    const map = exports as Record<string, unknown>;
-    // `exports["."]`, or the whole object when it is condition-only sugar (no subpath keys).
-    const dot = "." in map
-        ? map["."]
-        : (Object.keys(map).some(k => k.startsWith(".")) ? undefined : map);
-    return dot === undefined ? undefined : typesFromCondition(dot);
+/**
+ * Whether `file` belongs to the package installed at `dir`. Resolution by name walks up the tree,
+ * so a same-named package elsewhere can answer — which an npm alias (`"a": "npm:b@1"`) installs by
+ * construction.
+ */
+function containedIn(dir: string, file: string): boolean {
+    return path.resolve(file).startsWith(path.resolve(dir) + path.sep);
 }
 
-/**
- * Pull a declaration file out of an `exports` condition value: an explicit `types` condition,
- * else the `types` nested under `import`/`require`/`default`. A bare target string is a runtime
- * (JS) entry, not types, unless it is itself a declaration file.
- */
-function typesFromCondition(entry: unknown): string | undefined {
-    if (typeof entry === "string") {
-        return /\.d\.[cm]?ts$/.test(entry) ? entry : undefined;
-    }
-    if (!entry || typeof entry !== "object") {
+function packageManifest(dir: string): {name?: unknown, types?: unknown, typings?: unknown} | undefined {
+    const packageJson = path.join(dir, "package.json");
+    if (!ts.sys.fileExists(packageJson)) {
         return undefined;
     }
-    const o = entry as Record<string, unknown>;
-    if (typeof o.types === "string") {
-        return o.types;
+    try {
+        return JSON.parse(ts.sys.readFile(packageJson) || "{}");
+    } catch {
+        // Malformed package.json; fall through to conventional entry points.
+        return undefined;
     }
-    const nestedTypes = typesFromCondition(o.types);
-    if (nestedTypes) {
-        return nestedTypes;
-    }
-    for (const cond of ["import", "require", "default"]) {
-        const nested = typesFromCondition(o[cond]);
-        if (nested) {
-            return nested;
-        }
-    }
-    return undefined;
 }
 
 /**

--- a/rewrite-javascript/rewrite/test/javascript/package-exported-types.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/package-exported-types.test.ts
@@ -208,6 +208,96 @@ declare namespace FakeIntl { interface FakeFormat { format(n: number): string; }
             expect(foo!.methods.map(m => m.name)).toContain("bar");
         }, {unsafeCleanup: true});
     }, 60000);
+
+    test("resolves types published only under a require condition", async () => {
+        await withDir(async (root) => {
+            const {pkg, nodeModules} = writeFiles(root.path, "cjs-fixture", {
+                "package.json": JSON.stringify({
+                    name: "cjs-fixture", version: "1.0.0",
+                    exports: {".": {require: {types: "./dist/index.d.cts", default: "./dist/index.cjs"}}},
+                }),
+                "dist/index.d.cts": `export declare class CjsWidget { w(): void; }\n`,
+                "dist/index.cjs": ``,
+            });
+
+            expect(fqns(exportedTypes([pkg], [nodeModules]))).toContain("cjs-fixture.CjsWidget");
+        }, {unsafeCleanup: true});
+    }, 60000);
+
+    test("takes the entry from the package's own directory, symlinked or not", async () => {
+        await withDir(async (root) => {
+            // npm alias: the directory name differs from the package's own declared name.
+            const {pkg: aliased} = writeFiles(root.path, "alias-fixture", {
+                "package.json": JSON.stringify({name: "real-fixture", version: "1.0.0", types: "index.d.ts"}),
+                "index.d.ts": `export declare class FromAliasCopy { a(): void; }\n`,
+            });
+            writeFiles(root.path, "real-fixture", {
+                "package.json": JSON.stringify({name: "real-fixture", version: "2.0.0", types: "index.d.ts"}),
+                "index.d.ts": `export declare class FromRealCopy { r(): void; }\n`,
+            });
+            expect(fqns(exportedTypes([aliased], []))).toEqual(["alias-fixture.FromAliasCopy"]);
+
+            // pnpm: node_modules/<name> is a symlink into the content-addressed store.
+            const {pkg: stored} = writeFiles(root.path, path.join(".pnpm", "pnpm-fixture@1.0.0", "node_modules", "pnpm-fixture"), {
+                "package.json": JSON.stringify({
+                    name: "pnpm-fixture", version: "1.0.0",
+                    exports: {".": {types: "./dist/index.d.ts", default: "./dist/index.js"}},
+                }),
+                "dist/index.d.ts": `export declare class PnpmWidget { p(): void; }\n`,
+            });
+            const link = path.join(root.path, "node_modules", "pnpm-fixture");
+            fs.symlinkSync(stored, link, "dir");
+            expect(fqns(exportedTypes([link], []))).toContain("pnpm-fixture.PnpmWidget");
+        }, {unsafeCleanup: true});
+    }, 60000);
+
+
+    test("falls back to the declared types file when an exports map has no types condition", async () => {
+        await withDir(async (root) => {
+            const {pkg, nodeModules} = writeFiles(root.path, "mispublished-fixture", {
+                "package.json": JSON.stringify({
+                    name: "mispublished-fixture", version: "1.0.0",
+                    types: "dist/types.d.ts",
+                    exports: {".": "./dist/index.js"},
+                }),
+                "dist/index.js": ``,
+                "dist/types.d.ts": `export declare class Mis { m(): void; }\n`,
+            });
+
+            expect(fqns(exportedTypes([pkg], [nodeModules]))).toContain("mispublished-fixture.Mis");
+        }, {unsafeCleanup: true});
+    }, 60000);
+
+
+    test("types a transitive dependency through its node + import exports conditions", async () => {
+        await withDir(async (root) => {
+            writeFiles(root.path, "modern-dep", {
+                "package.json": JSON.stringify({
+                    name: "modern-dep", version: "1.0.0",
+                    exports: {".": {
+                        browser: {types: "./dist/browser.d.ts", default: "./dist/browser.js"},
+                        node: {
+                            import: {types: "./dist/node.d.ts", default: "./dist/node.mjs"},
+                            require: {types: "./dist/node.d.cts", default: "./dist/node.cjs"},
+                        },
+                    }},
+                }),
+                "dist/node.d.ts": `export declare class Widget { render(): void; }\n`,
+                "dist/node.d.cts": `export declare class RequireWidget { render(): void; }\n`,
+                "dist/browser.d.ts": `export declare class BrowserWidget { render(): void; }\n`,
+            });
+            const {pkg, nodeModules} = writeFiles(root.path, "consumer-fixture", {
+                "package.json": JSON.stringify({name: "consumer-fixture", version: "1.0.0", types: "index.d.ts"}),
+                "index.d.ts": `import {Widget} from "modern-dep";\nexport declare class Consumer { widget(): Widget; }\n`,
+            });
+
+            const consumer = exportedTypes([pkg], [nodeModules])
+                .find(t => Type.FullyQualified.getFullyQualifiedName(t) === "consumer-fixture.Consumer") as Type.Class;
+            const widget = consumer.methods.find(m => m.name === "widget")!;
+            // Only the node/import branch declares `Widget`, so its FQN pins which conditions matched.
+            expect(Type.signature(widget.returnType)).toBe("modern-dep.Widget");
+        }, {unsafeCleanup: true});
+    }, 60000);
 });
 
 /** Register a DependencyTypes handler on a mock connection and return the captured request handler. */


### PR DESCRIPTION
`exportedTypes` — the enumerator behind the `DependencyTypes` RPC request, which answers "what public types does package X define?" — built its `ts.Program` with `moduleResolution: Node10`. Node10 predates package.json `exports`, so asking for a modern package's types returned an empty list with `node_modules` fully installed: `vite` yielded 0 types. Types a dependency borrows from an exports-only package came back `<unknown>` for the same reason.

## Mechanism

Two independent paths were affected. `host.resolveModuleNameLiterals` resolved the imports inside a dependency's `.d.ts` under the Node10 options, so an exports-only transitive dependency resolved to nothing. Separately, `resolvePackageEntry` picked the program's root entry by parsing package.json by hand — a `types`/`typings` field, else a walk of `exports["."]` looking for a `.d.ts` string. That walk missed two shapes TypeScript handles: `exports: {".": "./dist/index.js"}` with a sibling `dist/index.d.ts` (the string is not a declaration file, so it returned nothing), and `typesVersions` redirects (ignored entirely).

## Fix

- Module resolution mirrors `JavaScriptParser`'s (#8672) — `Bundler` with `customConditions: ["node"]` — so a dependency's own imports resolve here as they do when its consumers are parsed, and the two subsystems cannot disagree about which files declare a dependency's types.

Entry resolution asks `ts.resolveModuleName` for the package's own name from inside its directory, which honours `types`, `exports` conditions and `typesVersions` in TypeScript's own precedence. A bare specifier is required: `exports` maps are not consulted for a path. Three fallbacks cover what that cannot reach — a `require` types condition (enumeration wants declarations under whichever condition carries them, since no consumer's import mode is choosing here), the declared `types` file (for an `exports` map with no types condition, where resolution stops at the runtime entry), and a top-level `index.d.ts`. The resolved file must sit inside the package directory, because resolution by name walks up the tree and an npm alias (`"a": "npm:b@1"`) installs a package under a directory named for the alias. Resolving to a runtime entry still means the package ships no types, so the `@types/*` fallback in `packageTypes` is unchanged.

`module` is `preserve` for parity with the parser. This program reads no diagnostics, so the module kind has no observable effect here.

## Measured

- Comparing enumerated type sets across the 80 packages installed in this project, old entry resolution against new: **no package loses a type**. `vite` goes 0 → 409, `@pyroscope/nodejs` 0 → 3, `@rolldown/pluginutils` 0 → 1. Twelve more resolve to a different file carrying an identical set — the CommonJS and ESM twins of one API. This is a smaller corpus than the 2,352 packages #8672 measured against, so treat it as a sample rather than the same evidence base.

## Tests

Four tests in `package-exported-types.test.ts`, each pinning one decision and mutation-checked so that reverting that decision fails only its own test: a transitive dependency resolved through its `node`/`import` conditions (a fixture whose `browser`, `node.import` and `node.require` branches declare differently-named classes, so the resolved FQN identifies the branch); a `require`-only types condition; an `exports` map with no types condition falling back to the declared `types` file; and entry resolution staying inside the package directory, covering both an npm-alias layout it must reject and a pnpm symlink it must not.