### PR TITLE
JS formatter reads the style marker the build attaches

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -17,7 +17,7 @@ import {JS} from "../tree";
 import {JavaScriptVisitor} from "../visitor";
 import {Comment, J, lastWhitespace, replaceLastWhitespace, Statement} from "../../java";
 import {create as produce, Draft} from "mutative";
-import {Cursor, isScope, Tree} from "../../tree";
+import {Cursor, isScope, isSourceFile, Tree} from "../../tree";
 import {BlankLinesStyle, getStyle, SpacesStyle, StyleKind, TabsAndIndentsStyle, WrappingAndBracesStyle} from "../style";
 import {NamedStyles} from "../../style";
 import {produceAsync} from "../../visitor";
@@ -74,13 +74,16 @@ export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
             return applyPrettierFormatting(tree as R, prettierStyle, p, cursor, this.stopAfter);
         }
 
+        // Style markers live on the source file, which is `tree` itself only when a whole file is being formatted
+        const styleSource = (isSourceFile(tree) ? tree : cursor?.firstEnclosing(isSourceFile)) ?? tree;
+
         const visitors = [
             new NormalizeWhitespaceVisitor(this.stopAfter),
             new MinimumViableSpacingVisitor(this.stopAfter),
-            new BlankLinesVisitor(getStyle(StyleKind.BlankLinesStyle, tree, this.styles) as BlankLinesStyle, this.stopAfter),
-            new WrappingAndBracesVisitor(getStyle(StyleKind.WrappingAndBracesStyle, tree, this.styles) as WrappingAndBracesStyle, this.stopAfter),
-            new SpacesVisitor(getStyle(StyleKind.SpacesStyle, tree, this.styles) as SpacesStyle, this.stopAfter),
-            new TabsAndIndentsVisitor(getStyle(StyleKind.TabsAndIndentsStyle, tree, this.styles) as TabsAndIndentsStyle, this.stopAfter),
+            new BlankLinesVisitor(getStyle(StyleKind.BlankLinesStyle, styleSource, this.styles) as BlankLinesStyle, this.stopAfter),
+            new WrappingAndBracesVisitor(getStyle(StyleKind.WrappingAndBracesStyle, styleSource, this.styles) as WrappingAndBracesStyle, this.stopAfter),
+            new SpacesVisitor(getStyle(StyleKind.SpacesStyle, styleSource, this.styles) as SpacesStyle, this.stopAfter),
+            new TabsAndIndentsVisitor(getStyle(StyleKind.TabsAndIndentsStyle, styleSource, this.styles) as TabsAndIndentsStyle, this.stopAfter),
         ]
 
         let t: R | undefined = tree as R;

--- a/rewrite-javascript/rewrite/src/javascript/format/tabs-and-indents-visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/tabs-and-indents-visitor.ts
@@ -44,6 +44,11 @@ export class TabsAndIndentsVisitor<P> extends JavaScriptVisitor<P> {
         this.useTabCharacter = this.tabsAndIndentsStyle.useTabCharacter;
     }
 
+    /** Width of existing indent whitespace in the unit {@link indentString} takes, where a tab is one indent. */
+    private indentWidth(indent: string): number {
+        return [...indent].reduce((width, ch) => width + (ch === "\t" ? this.indentSize : 1), 0);
+    }
+
     private indentString(indent: number): string {
         if (this.useTabCharacter) {
             return "\t".repeat(Math.floor(indent / this.indentSize));
@@ -647,7 +652,7 @@ export class TabsAndIndentsVisitor<P> extends JavaScriptVisitor<P> {
                 const idx = ws.lastIndexOf('\n');
                 if (idx !== -1) {
                     anchorCursor = c;
-                    anchorIndent = ws.length - idx - 1;
+                    anchorIndent = this.indentWidth(ws.substring(idx + 1));
                 }
             }
 

--- a/rewrite-javascript/rewrite/src/javascript/style.ts
+++ b/rewrite-javascript/rewrite/src/javascript/style.ts
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 
-import {NamedStyles, Style} from "../style";
+import {isNamedStyles, NamedStyles, Style} from "../style";
 import {randomId} from "../uuid";
 import {Tree} from "../tree";
-import {MarkersKind} from "../markers";
 
 export const JavaScriptStyles = {
     IntelliJ: "org.openrewrite.javascript.style.IntelliJ",
@@ -562,13 +561,7 @@ export namespace IntelliJ {
 }
 
 export function styleFromSourceFile(styleKind: string, sourceFile: Tree): Style | undefined {
-    const namedStyles = sourceFile.markers.markers.filter(marker => marker.kind === MarkersKind.NamedStyles) as NamedStyles[];
-    const candidate = namedStyles.map(namedStyle => namedStyle.styles).flat()
-        .find(style => style.kind === styleKind)
-    if (candidate) {
-        return candidate;
-    }
-    return IntelliJ.TypeScript.defaults.styles.find(style => style.kind === styleKind) as Style;
+    return getStyle(styleKind, sourceFile);
 }
 
 /**
@@ -591,8 +584,7 @@ export function getStyle(styleKind: string, sourceFile: Tree, styles?: NamedStyl
     }
 
     // Then check source file markers
-    const namedStyles = sourceFile.markers.markers.filter(marker => marker.kind === MarkersKind.NamedStyles) as NamedStyles[];
-    for (const namedStyle of namedStyles) {
+    for (const namedStyle of sourceFile.markers.markers.filter(isNamedStyles)) {
         const found = namedStyle.styles.find(s => s.kind === styleKind);
         if (found) {
             return found;

--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -17,7 +17,7 @@ import {Cursor, isTree, produceAsync, Tree, updateIfChanged} from '../..';
 import {emptySpace, J, Statement, Type} from '../../java';
 import {Any, Capture, JavaScriptParser, JavaScriptVisitor, JS} from '..';
 import {create as produce} from 'mutative';
-import {CaptureMarker, PlaceholderUtils, randomizeIds, retainIds, treeIds, WRAPPER_FUNCTION_NAME} from './utils';
+import {CaptureMarker, dedentTemplate, PlaceholderUtils, randomizeIds, retainIds, treeIds, WRAPPER_FUNCTION_NAME} from './utils';
 import {CAPTURE_NAME_SYMBOL, CAPTURE_TYPE_SYMBOL, CaptureImpl, CaptureValue, RAW_CODE_SYMBOL, RawCode} from './capture';
 import {PlaceholderReplacementVisitor} from './placeholder-replacement';
 import {maybeParenthesize, parenthesize, requiredPrecedence, startsWithDeclarationToken} from './precedence';
@@ -244,6 +244,7 @@ export class TemplateEngine {
      * @param coordinates The coordinates specifying where and how to insert the generated AST
      * @param values Map of capture names to values to replace the parameters with
      * @param wrappersMap Map of capture names to J.RightPadded wrappers (for preserving markers)
+     * @param format Whether to fit the result to where it lands
      * @returns A Promise resolving to the generated AST node
      */
     static async applyTemplateFromAst(
@@ -252,7 +253,8 @@ export class TemplateEngine {
         cursor: Cursor,
         coordinates: JavaCoordinates,
         values: Pick<Map<string, J>, 'get'> = new Map(),
-        wrappersMap: Pick<Map<string, J.RightPadded<J> | J.RightPadded<J>[]>, 'get'> = new Map()
+        wrappersMap: Pick<Map<string, J.RightPadded<J> | J.RightPadded<J>[]>, 'get'> = new Map(),
+        format: boolean = true
     ): Promise<J | undefined> {
         // Create substitutions map for placeholders
         const substitutions = new Map<string, Parameter>();
@@ -280,7 +282,7 @@ export class TemplateEngine {
         const uniqueAst = await retainIds(unsubstitutedAst, retainable);
 
         // Apply the template to the current AST
-        return new TemplateApplier(cursor, coordinates, uniqueAst).apply();
+        return new TemplateApplier(cursor, coordinates, uniqueAst, format).apply();
     }
 
     /**
@@ -377,7 +379,7 @@ export class TemplateEngine {
 
         // Always wrap in function body - let the parser decide what it is,
         // then we'll extract intelligently based on what was parsed
-        return `function ${WRAPPER_FUNCTION_NAME}() { ${result} }`;
+        return `function ${WRAPPER_FUNCTION_NAME}() { ${dedentTemplate(result)} }`;
     }
 
     /**
@@ -656,7 +658,8 @@ export class TemplateApplier {
     constructor(
         private readonly cursor: Cursor,
         private readonly coordinates: JavaCoordinates,
-        private readonly ast: J
+        private readonly ast: J,
+        private readonly shouldFormat: boolean = true
     ) {
     }
 
@@ -737,6 +740,10 @@ export class TemplateApplier {
             id: originalTree.id,
             prefix: originalTree.prefix
         };
+
+        if (!this.shouldFormat) {
+            return {...result, id: resultToUse.id};
+        }
 
         // Apply auto-formatting to the result
         const formatted =

--- a/rewrite-javascript/rewrite/src/javascript/templating/rewrite.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/rewrite.ts
@@ -28,7 +28,8 @@ class RewriteRuleImpl implements RewriteRule {
         private readonly before: Pattern[],
         private readonly after: Template | ((match: MatchResult) => Template),
         private readonly preMatch?: (node: J, context: PreMatchContext) => boolean | Promise<boolean>,
-        private readonly postMatch?: (node: J, context: PostMatchContext) => boolean | Promise<boolean>
+        private readonly postMatch?: (node: J, context: PostMatchContext) => boolean | Promise<boolean>,
+        private readonly format?: boolean
     ) {
     }
 
@@ -56,13 +57,11 @@ class RewriteRuleImpl implements RewriteRule {
                 // Apply transformation
                 let result: J | undefined;
 
+                const options = { values: match, format: this.format };
                 if (typeof this.after === 'function') {
-                    // Call the function to get a template, then apply it
-                    const template = this.after(match);
-                    result = await template.apply(node, cursor, { values: match });
+                    result = await this.after(match).apply(node, cursor, options);
                 } else {
-                    // Use template.apply() as before
-                    result = await this.after.apply(node, cursor, { values: match });
+                    result = await this.after.apply(node, cursor, options);
                 }
 
                 if (result) {
@@ -171,7 +170,8 @@ export function rewrite(
         Array.isArray(config.before) ? config.before : [config.before],
         config.after,
         config.preMatch,
-        config.postMatch
+        config.postMatch,
+        config.format
     );
 }
 

--- a/rewrite-javascript/rewrite/src/javascript/templating/template.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/template.ts
@@ -359,7 +359,8 @@ export class Template {
                 mode: JavaCoordinates.Mode.Replace
             },
             normalizedValues,
-            wrappersMap
+            wrappersMap,
+            options?.format ?? true
         );
     }
 }

--- a/rewrite-javascript/rewrite/src/javascript/templating/types.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/types.ts
@@ -631,6 +631,9 @@ export interface RewriteConfig {
     before: Pattern | Pattern[];
     after: Template | ((match: MatchResult) => Template);
 
+    /** As {@link ApplyOptions.format}, applied to every node the rule rewrites. */
+    format?: boolean;
+
     /**
      * Optional predicate evaluated BEFORE pattern matching.
      * Use for efficient early filtering based on AST context when captures aren't needed.

--- a/rewrite-javascript/rewrite/src/javascript/templating/types.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/types.ts
@@ -509,6 +509,13 @@ export interface ApplyOptions {
      * ```
      */
     values?: Map<Capture | string, J> | MatchResult | Record<string, J>;
+
+    /**
+     * Whether the result is fitted to where it lands. Defaults to `true`; pass `false` to assemble
+     * several results into one subtree and format that subtree once, rather than once per application.
+     * The anchor supplies the result's prefix either way.
+     */
+    format?: boolean;
 }
 
 /**

--- a/rewrite-javascript/rewrite/src/javascript/templating/utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/utils.ts
@@ -183,6 +183,23 @@ export function retainIds<T extends J>(tree: T, retainable: ReadonlySet<string>)
 }
 
 /**
+ * Strips the indentation a template carries from the recipe source it was written in. Its first
+ * line starts at the opening backtick, so the common indent is the one shared by the lines below.
+ */
+export function dedentTemplate(code: string): string {
+    const lines = code.split("\n");
+    let indent = Infinity;
+    for (const line of lines.slice(1)) {
+        if (line.trim().length > 0) {
+            indent = Math.min(indent, line.length - line.trimStart().length);
+        }
+    }
+    return indent === Infinity || indent === 0 ?
+        code :
+        [lines[0], ...lines.slice(1).map(line => line.slice(indent))].join("\n");
+}
+
+/**
  * Marker that stores capture metadata on pattern AST nodes.
  * This avoids the need to parse capture names from identifiers during matching.
  */

--- a/rewrite-javascript/rewrite/src/style.ts
+++ b/rewrite-javascript/rewrite/src/style.ts
@@ -20,6 +20,11 @@ export interface Style {
     readonly kind: string
 }
 
+/** Style markers carry their own kind (e.g. Autodetect, PrettierStyle), so `styles` is what identifies one. */
+export function isNamedStyles(marker: Marker): marker is NamedStyles<string> {
+    return Array.isArray((marker as Partial<NamedStyles<string>>).styles);
+}
+
 export interface NamedStyles<K extends string = typeof MarkersKind.NamedStyles> extends Marker {
     readonly kind: K
     readonly name: string;

--- a/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
@@ -112,7 +112,7 @@ describe("change-import", () => {
                             `,
                             `
                             import { renderIntoDocument } from 'react-dom/test-utils';
-                            import {act} from 'react';
+                            import { act } from 'react';
 
                             act(() => {});
                             renderIntoDocument(<div />);

--- a/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {Autodetect, javascript, JavaScriptVisitor, JS, Template, template} from "../../../src/javascript";
+import {J} from "../../../src/java";
+import {create as produce} from "mutative";
+import {replaceMarkerByKind} from "../../../src/markers";
+
+/** Stands in for the style marker the project parser attaches to the compilation units it produces. */
+async function withDetectedStyles(cu: JS.CompilationUnit): Promise<JS.CompilationUnit> {
+    const detector = Autodetect.detector();
+    await detector.sample(cu);
+    const marker = detector.build();
+    return produce(cu, draft => {
+        draft.markers = replaceMarkerByKind(draft.markers, marker);
+    });
+}
+
+describe('template formatting', () => {
+    const spec = new RecipeSpec();
+
+    test('generated code follows the styles of the file it lands in', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                const m = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                if (m.name.simpleName !== 'extend') {
+                    return m;
+                }
+                return Template.builder()
+                    .code('merge({}, ')
+                    .param(m.arguments.elements[2].element)
+                    .code(')')
+                    .build()
+                    .apply(m, this.cursor);
+            }
+        });
+        return spec.rewriteRun({
+            //language=javascript
+            ...javascript(
+                `function f() {
+\tvar o = jQuery.sap.extend(true, {}, {
+\t\tname: "x",
+\t\trun: function (a) {
+\t\t\treturn a;
+\t\t}
+\t});
+}
+`,
+                `function f() {
+\tvar o = merge({}, {
+\t\tname: "x",
+\t\trun: function (a) {
+\t\t\treturn a;
+\t\t}
+\t});
+}
+`),
+            beforeRecipe: withDetectedStyles
+        });
+    });
+
+    test('format: false anchors the template without fitting it or the recipe file\'s indentation', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                const m = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                if (m.name.simpleName !== 'target') {
+                    return m;
+                }
+                return template`
+                    wrap(function () {
+                        doThing();
+                    })
+                `.apply(m, this.cursor, {format: false});
+            }
+        });
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `function f() {
+    if (x) {
+        target();
+    }
+}
+`,
+                `function f() {
+    if (x) {
+        wrap(function () {
+    doThing();
+});
+    }
+}
+`));
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {fromVisitor, RecipeSpec} from "../../../src/test";
-import {Autodetect, javascript, JavaScriptVisitor, JS, Template, template} from "../../../src/javascript";
+import {Autodetect, capture, javascript, JavaScriptVisitor, JS, pattern, rewrite, Template, template} from "../../../src/javascript";
 import {J} from "../../../src/java";
 import {create as produce} from "mutative";
 import {replaceMarkerByKind} from "../../../src/markers";
@@ -102,6 +102,29 @@ describe('template formatting', () => {
 });
     }
 }
+`));
+    });
+
+    test('a rewrite rule passes format through to the template it applies', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitTernary(ternary: J.Ternary, p: any): Promise<J | undefined> {
+                const visited = await super.visitTernary(ternary, p) as J.Ternary;
+                const t = capture();
+                return await rewrite(() => ({
+                    before: pattern`${t} ? true : false`,
+                    after: template`${t}`,
+                    format: false
+                })).tryOn(this.cursor, visited) || visited;
+            }
+        });
+        return spec.rewriteRun(
+            //language=javascript
+            javascript(
+                `const c = a <
+  b ? true : false;
+`,
+                `const c = a <
+  b;
 `));
     });
 });


### PR DESCRIPTION
`Template.apply` formatted its result to IntelliJ defaults regardless of the file it was writing into. On a tab-indented UI5 source, a recipe that replaced only a call came back with the spliced object literal at five spaces and its closing brace at one, in a file indented with tabs:

```js
	var o = merge({}, {
     name: "x",
     run: function (a) {
         return a;
     }
 });
```

Passing the missing `styles` argument down to `maybeAutoFormat` would not have fixed it. Three defects stack, and reverting any one reproduces the output above.

## The mechanism

`AutoformatVisitor.visit` called `getStyle(kind, tree, ...)` with the node handed to it. `getStyle` takes a source file, and for a templated subtree `tree` is never one, so the file's markers were never consulted. `getPrettierStyle` already walked the cursor for exactly this reason, which is why the Prettier path worked and the built-in pipeline did not; the built-in one now does the same walk.

Underneath that, `getStyle` filtered markers on `kind === MarkersKind.NamedStyles`. `Autodetect` and `PrettierStyle` declare their own kinds — `NamedStyles<K>` is generic precisely so they can — so the marker the build attaches was invisible on **every** path, whole-file included. `AutoFormat`'s documented "uses auto-detected project style" was never true. Markers are now matched by shape. `styleFromSourceFile`, which `order-imports` uses, had the same bug and delegates.

The existing `change-import` expectation was encoding this: it expected `import {act} from 'react';` inserted into a file written `import { act, renderIntoDocument } from '...'`. It now expects `import { act }`.

With styles finally reaching the visitors, output was still one level short. `TabsAndIndentsVisitor.setupAncestorIndents` measured the anchor's indent as a character count while `indentString` emits one tab per `indentSize` columns, so `\n\t` measured 1 and `indentString(1)` returned `""`. That is also where the five spaces came from: 1 for the tab, plus a 4-space indent.

Nothing here adds auto-detection. `rpc/request/parse-project.ts` and `project-parser.ts` already build the marker and attach it to every compilation unit they yield; this change is the formatter reading it.

## ApplyOptions.format

```ts
template`...`.apply(node, cursor, {format: false})
```

Defaults to `true`. Callers assembling several results into one subtree can turn fitting off and format that subtree once, instead of once per application. The anchor supplies the result's prefix either way, so the result is still placed — only unfitted.

The same option is on `RewriteConfig`, since `tryOn` takes no options and a rule declared with `rewrite({before, after})` otherwise had no route to it. It belongs on the rule rather than the call: a rule is declared once and applied at every node it matches.

```ts
rewrite(() => ({before: pattern`${t} ? true : false`, after: template`${t}`, format: false}))
```

Formatting stays on by default because a template's text is authored inside a recipe file at whatever indentation the template literal sits at. Measured: applying a template written at 20 columns into a doubly-nested position emitted the recipe file's 20 columns verbatim. Flipping the default also breaks 24 tests across 7 files, concentrated in the variadic and multi-statement suites — the cases where unformatted output is worst.

## Dedenting

A template no longer carries the indentation of the source it was written in. The dedent runs before the code is wrapped for parsing: the wrapper appends `" }"` to the last line, which turns a template's trailing whitespace-only line into a content line whose indent becomes the computed minimum, leaving three stray columns on every line. That corrupts `format: false` specifically, which is the case relying on the dedent being exact.

The common indent is measured over the lines *after* the first, since a template's first line begins at the opening backtick and has no indentation of its own. Like the test harness's `dedent`, this is textual and will reindent the contents of a multi-line string or template literal embedded in a template.

## Tests

`templating/formatting.test.ts` has two. The first replays the report — a tab-indented file, an object literal spliced through `Template.builder()`, with the style marker attached the way the project parser attaches it — and fails if any of the three defects returns. The second pins `format: false`: that the pipeline is skipped, that the anchor's prefix is applied ahead of that skip, and that the template's own indentation is gone, including the wrapper-ordering case above. Each line was verified by reverting it individually.

## Not fixed here

`computeMyIndent`'s `TemplateExpressionSpan` branch measures indents in raw characters like the anchor did, so in a tab-indented file `` `text ${\n\t\ta + b\n\t}` `` loses the expression's indentation entirely. Confirmed with a repro, but converting that line to the same helper changes nothing — the value it returns is overridden downstream — so it is left alone rather than half-fixed.
