### PR TITLE
JS: a test spec can opt into the style its own source is written in

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/assertions.ts
+++ b/rewrite-javascript/rewrite/src/javascript/assertions.ts
@@ -256,6 +256,21 @@ export function packageLockJson(before: string, after?: AfterRecipeText): Source
     };
 }
 
+/**
+ * Gives a source file the style its own text is written in. A spec that formats its output is
+ * measured against the built-in defaults unless it opts in with
+ * `{...typescript(src), beforeRecipe: withDetectedStyle}`; a file parsed through {@link npm} is
+ * sampled alongside its siblings and needs no opt-in.
+ */
+export async function withDetectedStyle(sourceFile: JS.CompilationUnit): Promise<JS.CompilationUnit> {
+    const detector = Autodetect.detector();
+    await detector.sample(sourceFile);
+    const detected = detector.build();
+    return produce(sourceFile, draft => {
+        draft.markers = replaceMarkerByKind(draft.markers, detected);
+    });
+}
+
 export function javascript(before: string | null, after?: AfterRecipeText): SourceSpec<JS.CompilationUnit> {
     return {
         kind: JS.Kind.CompilationUnit,

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -40,7 +40,8 @@ import {
     autoFormat,
     AutoformatVisitor,
     JavaScriptVisitor,
-    typescript
+    typescript,
+    withDetectedStyle
 } from "../../../src/javascript";
 
 
@@ -700,6 +701,14 @@ const x = 1;`
             )
             // @formatter:on
         )
+    });
+
+    test('a spec opting into its own style keeps the tabs it is written with', () => {
+        return spec.rewriteRun({
+            //language=typescript
+            ...typescript("function f() {\n\tconst x = 1;\n\treturn x;\n}\n"),
+            beforeRecipe: withDetectedStyle
+        })
     });
 
 });


### PR DESCRIPTION
A JS test fixture indented with tabs comes back indented with four spaces from any recipe that formats, so the expectation cannot be written the way the file reads:

```
before:  function f() {\n\tconst x = 1;\n}
after:   function f() {\n    const x = 1;\n}
```

This is the documented style resolution — constructor styles, then `NamedStyles` markers on the source file, then IntelliJ defaults — working as specified. A bare `javascript()`/`typescript()` spec carries no style marker, so it lands on the defaults. Instrumenting `AutoformatVisitor` confirms it: the source file is found, `markers:[]`, `useTabCharacter=false, indentSize=4`. The style-marker code lives only in the `npm()` generator, which samples all specs together; a spec standing on its own never reaches it.

Declaring a style was already possible, but only by hand-building a `NamedStyles` marker and overriding the spec's `parser`. `withDetectedStyle` samples the file and attaches what it finds, wired per spec:

```ts
spec.rewriteRun({
    ...typescript("function f() {\n\tconst x = 1;\n\treturn x;\n}\n"),
    beforeRecipe: withDetectedStyle
})
```

## Why opt-in

Applying it to every spec was the first version and is wrong. Java is the reference: `RewriteTest` has no style handling at all, and a test asks for one with `spec.parser(JavaParser.fromJavaVersion().styles(...))`. That makes the existing JS behaviour symmetric rather than broken — `npm()` ≈ project parsing and autodetects, a bare spec ≈ a bare Java test and does not. Automatic detection also changes what 9 existing tests are measured against, 8 of them in `format.test.ts`, which feed deliberately messy input and assert canonical output; autodetecting *from* that input is self-defeating.

Full detection rather than indentation alone, since an explicit opt-in is a request for the file's style, and no guard against an existing marker, since a caller that asks should get what it asked for.

## Tests

One test, `a spec opting into its own style keeps the tabs it is written with`, pins the whole path — sample, attach, `getStyle` lookup, formatter. It fails without the `beforeRecipe` line (tabs become four spaces), so it catches a marker the lookup cannot find as well as a detector that reads the wrong indent. `autodetect.test.ts` covers the detector's output but never that the marker is consumed. Full JS suite: 1629 passed, 0 failed, no existing test moved.
