### PR TITLE
ChangeImport keeps the local name a moved binding already had

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/recipes/change-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/recipes/change-import.ts
@@ -19,8 +19,36 @@ import { TreeVisitor } from "../../visitor";
 import { ExecutionContext } from "../../execution";
 import { JavaScriptVisitor, JS } from "../index";
 import { maybeAddImport } from "../add-import";
-import { J, isIdentifier, Type } from "../../java";
+import { emptySpace, J, isIdentifier, rightPadded, singleSpace, Type } from "../../java";
 import { create as produce, Draft } from "mutative";
+import { randomId } from "../../uuid";
+import { emptyMarkers } from "../../markers";
+
+/**
+ * Binds `member` under the name `local` already carries, so the file's references to it still
+ * resolve. `local` itself becomes the alias, keeping the type attribution it holds, and the alias
+ * takes its prefix: that whitespace separates the specifier from a `type` keyword before it.
+ */
+function aliasing(local: Draft<J.Identifier>, member: string): JS.Alias {
+    const propertyName: J.Identifier = {
+        id: randomId(),
+        kind: J.Kind.Identifier,
+        prefix: emptySpace,
+        markers: emptyMarkers,
+        annotations: [],
+        simpleName: member,
+        type: undefined,
+        fieldType: undefined
+    };
+    return {
+        id: randomId(),
+        kind: JS.Kind.Alias,
+        prefix: local.prefix,
+        markers: emptyMarkers,
+        propertyName: rightPadded(propertyName, singleSpace),
+        alias: {...local, prefix: singleSpace} as J.Identifier
+    };
+}
 
 /**
  * Changes an import from one module to another, updating all type attributions.
@@ -41,7 +69,7 @@ import { create as produce, Draft } from "mutative";
  * // After:  import { act } from 'react';
  *
  * @example
- * // Change a named import to a different name
+ * // Change which member of the module a name is bound to
  * const recipe = new ChangeImport({
  *     oldModule: "lodash",
  *     oldMember: "extend",
@@ -49,7 +77,7 @@ import { create as produce, Draft } from "mutative";
  *     newMember: "assign"
  * });
  * // Before: import { extend } from 'lodash';
- * // After:  import { assign } from 'lodash';
+ * // After:  import { assign as extend } from 'lodash';
  */
 export class ChangeImport extends Recipe {
     readonly name = "org.openrewrite.javascript.change-import";
@@ -168,10 +196,9 @@ export class ChangeImport extends Recipe {
                         maybeAddImport(this, {
                             module: newModule,
                             member: newMember,
-                            // A moved binding keeps the local name it had. Pinning it also tells
-                            // `maybeAddImport` not to deconflict against the import being replaced,
-                            // which is still present in the tree it reads.
-                            alias: aliasToUse ?? newMember,
+                            // A pinned alias is taken verbatim: `oldMember` is the name this
+                            // import bound, which the file's references to it already read.
+                            alias: aliasToUse ?? oldMember,
                             onlyIfReferenced: false
                         });
                     }
@@ -219,7 +246,7 @@ export class ChangeImport extends Recipe {
                                     const specifier = elem.element;
                                     if (specifier.specifier.kind === J.Kind.Identifier &&
                                         specifier.specifier.simpleName === oldMember) {
-                                        specifier.specifier.simpleName = newMember;
+                                        specifier.specifier = aliasing(specifier.specifier as Draft<J.Identifier>, newMember);
                                     } else if (specifier.specifier.kind === JS.Kind.Alias) {
                                         const aliasNode = specifier.specifier as Draft<JS.Alias>;
                                         const propertyName = aliasNode.propertyName.element;

--- a/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
@@ -339,40 +339,6 @@ describe("change-import", () => {
     });
 
     describe("member renaming", () => {
-        test("renames member when changing import", async () => {
-            const spec = new RecipeSpec();
-            spec.recipe = new ChangeImport({
-                oldModule: "lodash",
-                oldMember: "extend",
-                newModule: "lodash",
-                newMember: "assign"
-            });
-
-            // Note: This test only verifies the import statement change.
-            // The identifier usage in the code would need a separate recipe to rename.
-            await withDir(async (repo) => {
-                await spec.rewriteRun(
-                    npm(
-                        repo.path,
-                        typescript(
-                            `
-                            import { extend } from 'lodash';
-                            `,
-                            `
-                            import { assign } from 'lodash';
-                            `
-                        ),
-                        packageJson(`{
-                            "name": "test",
-                            "dependencies": {
-                                "lodash": "^4.17.21"
-                            }
-                        }`)
-                    )
-                );
-            }, { unsafeCleanup: true });
-        });
-
         test("renames aliased member when changing import", async () => {
             const spec = new RecipeSpec();
             spec.recipe = new ChangeImport({
@@ -392,6 +358,123 @@ describe("change-import", () => {
                             `,
                             `
                             import { assign as myExtend } from 'lodash';
+                            `
+                        ),
+                        packageJson(`{
+                            "name": "test",
+                            "dependencies": {
+                                "lodash": "^4.17.21"
+                            }
+                        }`)
+                    )
+                );
+            }, { unsafeCleanup: true });
+        });
+
+        test("renames the member but keeps the local name", async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = new ChangeImport({
+                oldModule: "lodash",
+                oldMember: "extend",
+                newModule: "lodash",
+                newMember: "assign"
+            });
+
+            await withDir(async (repo) => {
+                await spec.rewriteRun(
+                    npm(
+                        repo.path,
+                        typescript(
+                            `
+                            import { extend } from 'lodash';
+
+                            function assign() {}
+
+                            extend({}, {});
+                            assign();
+                            `,
+                            `
+                            import { assign as extend } from 'lodash';
+
+                            function assign() {}
+
+                            extend({}, {});
+                            assign();
+                            `
+                        ),
+                        packageJson(`{
+                            "name": "test",
+                            "dependencies": {
+                                "lodash": "^4.17.21"
+                            }
+                        }`)
+                    )
+                );
+            }, { unsafeCleanup: true });
+        });
+
+        test("keeps a type-only specifier's type keyword separate", async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = new ChangeImport({
+                oldModule: "lodash",
+                oldMember: "extend",
+                newModule: "lodash",
+                newMember: "assign"
+            });
+
+            await withDir(async (repo) => {
+                await spec.rewriteRun(
+                    npm(
+                        repo.path,
+                        typescript(
+                            `
+                            import { type extend } from 'lodash';
+
+                            let v: extend;
+                            `,
+                            `
+                            import { type assign as extend } from 'lodash';
+
+                            let v: extend;
+                            `
+                        ),
+                        packageJson(`{
+                            "name": "test",
+                            "dependencies": {
+                                "lodash": "^4.17.21"
+                            }
+                        }`)
+                    )
+                );
+            }, { unsafeCleanup: true });
+        });
+
+        test("keeps the local name when moving a member to another module", async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = new ChangeImport({
+                oldModule: "lodash",
+                oldMember: "extend",
+                newModule: "lodash-es",
+                newMember: "assign"
+            });
+
+            await withDir(async (repo) => {
+                await spec.rewriteRun(
+                    npm(
+                        repo.path,
+                        typescript(
+                            `
+                            import { extend, flatten } from 'lodash';
+
+                            extend({}, {});
+                            flatten([]);
+                            `,
+                            `
+                            import { flatten } from 'lodash';
+                            import { assign as extend } from 'lodash-es';
+
+                            extend({}, {});
+                            flatten([]);
                             `
                         ),
                         packageJson(`{


### PR DESCRIPTION
`ChangeImport` changed the local name an import binds without changing anything that read it, so renaming a member left every reference dangling — and where the file already bound the new name, the output did not parse:

```ts
// ChangeImport({oldModule: 'a', oldMember: 'x', newModule: 'b', newMember: 'y'})

import {x} from 'a';        import {y} from 'b';
                        →
function y() {}             function y() {}   // SyntaxError: 'y' has already been declared
x();                        x();              // unbound
```

The dangling reference is not conditional on the collision: with no `y` anywhere in the file, `import {x} from 'a'; x();` still became `import {y} from 'b'; x();`. So the rename is the defect and the collision is downstream of it, which matters because deconflicting alone makes the output worse — `import {y as y_1} from 'b'` still leaves `x()` dangling, now under a stranger name.

## The mechanism

Both paths did it. When the member is the only one from the old module, `visitImportDeclaration` rewrites the specifier in place, assigning `simpleName = newMember`. When it is not, the member is removed and re-added via `maybeAddImport`, which pinned `alias: newMember` — a pinned alias is never deconflicted, so that path collides too.

## The fix

The recipe now changes only where a binding comes from, never what the file calls it, emitting `import {y as x} from 'b'` when the two differ. That is correct on every input without any reference analysis, and it makes the collision unreachable rather than handled: the name it binds is the one the import being replaced already bound. It is also immune to shadowing, which a name-picking fix is not — an inner `const x = 1` still shadows exactly as it did, because the module-scope name never changes.

The alternative is to deconflict and rewrite the references, which gives the strictly nicer `import {y} from 'b'; y();`. It needs a scope-correct rename — shadowing, `obj.x`, shorthand `{x}`, JSX — which `rewrite-javascript` does not have; `scopeOf` in `scope.ts` answers the shadowing half. This is a clean base for that: it drops the alias rather than being replaced by it.

The cost is visible in the documented example, now `import { assign as extend } from 'lodash'` where it was `import { assign } from 'lodash'`. The old output was only correct for a file that never used the import.

On the `maybeAddImport` path the pinned alias stops being a workaround for deconfliction and becomes the intent, so it pins `oldMember` and the comment calling it a workaround is gone.

## Tests

Three tests, one per implementation line, each mutation-checked to fail alone: the in-place rewrite, the `maybeAddImport` operand, and the alias node's prefix. `renames member when changing import` is deleted — it pinned the same line as the first with a strictly weaker fixture (no usages, no colliding binding) and its note that usages "would need a separate recipe to rename" is the assumption this change retires.

The prefix test exists because review caught a regression this PR introduced and mutation testing had pointed at: `import { type extend }` emitted `import { typeassign as extend }`, which does not parse. The space after a `type` keyword lives on the identifier, so the constructed `Alias` has to take it.

## Not fixed here

Two pre-existing defects on the same paths, verified unchanged by this PR. `newAlias` is honoured by the multi-member path and ignored by the single-member one, so `newAlias: 'myAssign'` emits `import {assign as myAssign}` and leaves `extend(...)` unbound — resolving it needs a decision about whether `newAlias` means a user-requested rename, which then needs the reference renaming above. And `oldMember: 'default'` with named siblings binds the same name twice, because `removeNamedImportMember` only filters named specifiers: `import React, { useState } from 'react'` survives while `import {render as React} from 'preact'` is added.
