### PR TITLE
Upgrade rewrite-javascript to TypeScript 6.0

### DIFF
--- a/rewrite-javascript/rewrite/fixtures/tsconfig.json
+++ b/rewrite-javascript/rewrite/fixtures/tsconfig.json
@@ -3,10 +3,9 @@
   "compilerOptions": {
     "rootDir": ".",
     "outDir": "../dist-fixtures",
-    "baseUrl": "..",
     "paths": {
-      "@openrewrite/rewrite": ["./src/index.ts"],
-      "@openrewrite/rewrite/*": ["./src/*/index.ts"]
+      "@openrewrite/rewrite": ["../src/index.ts"],
+      "@openrewrite/rewrite/*": ["../src/*/index.ts"]
     }
   },
   "include": [

--- a/rewrite-javascript/rewrite/package-lock.json
+++ b/rewrite-javascript/rewrite/package-lock.json
@@ -18,7 +18,7 @@
         "picomatch": "^4.0.4",
         "semver": "^7.7.4",
         "tmp-promise": "^3.0.3",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "vscode-jsonrpc": "^8.2.1",
         "yaml": "^2.9.0"
       },
@@ -1614,9 +1614,9 @@
       "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -79,7 +79,7 @@
     "picomatch": "^4.0.4",
     "semver": "^7.7.4",
     "tmp-promise": "^3.0.3",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "vscode-jsonrpc": "^8.2.1",
     "yaml": "^2.9.0"
   },

--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -394,6 +394,7 @@ const excludedCodes = new Set([
     1183, // An implementation cannot be declared in ambient contexts.
     1203, // Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.
     1207, // Decorators cannot be applied to multiple get/set accessors of the same name.
+    1212, // Identifier expected. '{0}' is a reserved word in strict mode. The node is still parsed as an identifier.
     1215, // Invalid use of '{0}'. Modules are automatically in strict mode.
     1238, // Unable to resolve signature of class decorator when called as an expression.
     1239, // Unable to resolve signature of parameter decorator when called as an expression.
@@ -422,6 +423,7 @@ const excludedCodes = new Set([
     1375, // 'await' expressions are only allowed at the top level of a file when that file is a module, but this file has no imports or exports. Consider adding an empty 'export {}' to make this file a module.
     1378, // Top-level 'await' expressions are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
     1432, // Top-level 'for await' loops are only allowed when the 'module' option is set to 'es2022', 'esnext', 'system', 'node16', 'node18', 'node20', 'nodenext', or 'preserve', and the 'target' option is set to 'es2017' or higher.
+    1540, // A 'namespace' declaration should not be declared using the 'module' keyword. The `module` spelling yields a ModuleDeclaration.
 ]);
 
 // Errors to exclude only for JavaScript files (.js, .jsx, .mjs, .cjs)

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -108,6 +108,12 @@ export class JavaScriptParser extends Parser {
             emitDecoratorMetadata: true,
             forceConsistentCasingInFileNames: false,
             jsx: ts.JsxEmit.Preserve,
+            // Strictness is a property of the parsed project rather than of the compiler we pin: under
+            // `strictNullChecks` every nullable type carries an extra `null` union constituent.
+            strict: false,
+            // `types` defaults to `[]`, which attributes ambient `@types/*` packages only when named;
+            // `*` enumerates everything under `node_modules/@types`.
+            types: ["*"],
             baseUrl: relativeTo || process.cwd()
         };
         this.styles = styles;

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
@@ -276,7 +276,7 @@ describe('JavaScript type mapping', () => {
                             memberNames.includes('classList');
 
                         if (hasExpectedProperties) {
-                            return `${type.fullyQualifiedName} (${type.members.length} members)`;
+                            return `${type.fullyQualifiedName} (has expected members)`;
                         }
                         return type.fullyQualifiedName;
                     }
@@ -294,7 +294,7 @@ describe('JavaScript type mapping', () => {
                         element = div;
                     `,
                     `
-                        let element: /*~~(HTMLElement (246 members))~~>*/HTMLElement;
+                        let element: /*~~(HTMLElement (has expected members))~~>*/HTMLElement;
                         const div = document.createElement('div');
                         element = div;
                     `

--- a/rewrite-javascript/rewrite/tsconfig.test.json
+++ b/rewrite-javascript/rewrite/tsconfig.test.json
@@ -2,7 +2,6 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "es2016",
-    "baseUrl": ".",
     "types": ["vitest/globals"],
     "paths": {
       "@openrewrite/rewrite": ["./src/index.ts"],


### PR DESCRIPTION
- `rewrite-javascript` pinned `typescript` at `^5.8.3`, resolving to 5.9.3. TypeScript 7.0 went GA on 2026-07-08 and ships without a compiler API — its package main entry is `lib/version.cjs`, which exports a version string, and the AST and checker live behind `unstable/` subpath exports that the [7.1 iteration plan](https://github.com/microsoft/TypeScript/issues/63703) does not schedule for stabilisation. 6.0 is the last release carrying the classic API this module parses against. Moving now also separates the two halves of the eventual migration: 6.0 changes checker behaviour with the API intact, 7.x changes the API with behaviour already settled.

The module typechecks against 6.0.3 with no source changes. Parse behaviour is a different story — on identical source and dependencies, `test/javascript/parser` and `test/javascript/type-mapping` went from 712/712 passing to 8 failures, from three separate compiler changes.

## `types` no longer enumerates `@types`

- [TS#62195](https://github.com/microsoft/TypeScript/issues/62195) changed the default for `types` from "everything under `node_modules/@types`" to `[]`. `JavaScriptParser` never set `types`, so ambient type packages stopped loading and attribution silently emptied out:

```
import {readFile as rf} from 'fs';
  5.9.3  /*~~(readFile)~~>*/        6.0.3  /*~~(unknown)~~>*/

import * as util from 'util';
  5.9.3  /*~~(util)~~>*/            6.0.3  /*~~(<unknown>)~~>*/
```

Nothing surfaced this: `checkSyntaxErrors` fails a parse only on syntax diagnostics, so the LST was produced intact with its types hollowed out. `typeRoots` does not restore the behaviour; `types: ["*"]` does.

## `strict` now defaults to true

The compiler's own `optionDeclarations` report `strict` flipping from `false` to `true`, with the strict-family flags moving from ``​`false`, unless `strict` is set`` to ``​`true`, unless `strict` is `false```. Under `strictNullChecks` every nullable type gains a `null` union constituent, which is what broke both the `React.Ref` attribution test and the union-arity test — `string | number | boolean | null` mapped to five constituents rather than four, and `Ref<HTMLButtonElement>` picked up a `RefObject<HTMLButtonElement | null>` bound whose type argument is no longer a class.

Strictness is a property of the project being parsed rather than of the compiler this module pins, so `strict: false` is now set explicitly instead of inherited. Adopting null-aware types is a separate decision with a repo-wide blast radius on type-aware recipes.

## Two new non-fatal diagnostics

6.0 reports `1212` on `yield` used as an identifier and `1540` on the legacy `module X {}` namespace spelling. Both join `excludedCodes`. In both cases the AST is byte-identical to 5.9.3 — `ExpressionStatement → Identifier` and `ModuleDeclaration name=porting bodyStmts=1` respectively — verified by parsing the fixtures under both compilers before allowlisting, since these read like syntax errors and syntax errors otherwise cost the whole LST.

## Tests

No new tests. The DOM-types test asserted `HTMLElement (246 members)`, pinning a `lib.dom.d.ts` member count that grew to 248; it now asserts the presence of `innerHTML`, `style` and `classList`, which is the claim it was actually making. The three tests covering the new diagnostic exclusions fail if either code is removed from `excludedCodes`, so the additions carry coverage without a dedicated test that would die to the same one-line edit.

Full suite: 2033 passed, 24 skipped, 0 failed.

## Scope

`JavaScriptParser` still sets `baseUrl`, deprecated in 6.0 and non-functional in 7.0. It does not error today because programmatic `compilerOptions` bypass the tsconfig deprecation check, and removing it can change resolution under `moduleResolution: Bundler`, so it wants its own change. The deprecated `baseUrl` is removed from `tsconfig.test.json` and `fixtures/tsconfig.json`, whose `paths` become parent-relative to compensate.

`types: ["*"]` is rejected by 5.9.3 with `[2688] Cannot find type definition file for '*'`, so the dependency bump and the parser change cannot be split or cherry-picked apart.