### PR TITLE
Reach the TypeScript 7 AST and program through unstable/ast

### DIFF
--- a/rewrite-javascript/rewrite/CLAUDE.md
+++ b/rewrite-javascript/rewrite/CLAUDE.md
@@ -22,7 +22,8 @@ Via Gradle (from repo root):
 ./gradlew :rewrite-javascript:npm_run_build
 ```
 
-Requires Node.js 18+.
+Requires Node.js 22.12+, which supports `require(esm)`. The build uses `module: node20` so this
+CommonJS package can reach the ESM-only `typescript7`.
 
 ## Running Tests
 

--- a/rewrite-javascript/rewrite/package-lock.json
+++ b/rewrite-javascript/rewrite/package-lock.json
@@ -34,6 +34,7 @@
         "benchmark": "^2.1.4",
         "bun": "^1.3.5",
         "prettier": "^3.7.4",
+        "typescript7": "npm:typescript@^7.0.2",
         "vitest": "^4.1.8"
       },
       "optionalDependencies": {
@@ -701,6 +702,346 @@
       "integrity": "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.8",
@@ -1624,6 +1965,42 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript7": {
+      "name": "typescript",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -92,6 +92,7 @@
     "benchmark": "^2.1.4",
     "bun": "^1.3.5",
     "prettier": "^3.7.4",
+    "typescript7": "npm:typescript@^7.0.2",
     "vitest": "^4.1.8"
   },
   "optionalDependencies": {

--- a/rewrite-javascript/rewrite/package.json
+++ b/rewrite-javascript/rewrite/package.json
@@ -2,6 +2,9 @@
   "name": "@openrewrite/rewrite",
   "version": "0.0.0",
   "license": "Moderne Source Available License",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "description": "OpenRewrite JavaScript.",
   "repository": {
     "type": "git",

--- a/rewrite-javascript/rewrite/src/javascript/ts7/program.ts
+++ b/rewrite-javascript/rewrite/src/javascript/ts7/program.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {API, type Project} from "typescript7/unstable/sync";
+import type {FileSystem} from "typescript7/unstable/fs";
+
+// The TypeScript 7 compiler runs as a Go process that owns parsing and module resolution, so a
+// program is described to it rather than built here: sources the parser holds in memory are served
+// through filesystem callbacks, and returning undefined defers to the real filesystem for
+// node_modules and the bundled lib files, which the server then resolves against on its own.
+
+export interface ParseSession {
+    readonly project: Project;
+
+    close(): void;
+}
+
+/**
+ * Opens a project over `sources`, which are keyed by absolute path and exist only in memory.
+ * `compilerOptions` is written into the tsconfig the Go server reads.
+ */
+export function openSession(
+    root: string,
+    sources: ReadonlyMap<string, string>,
+    compilerOptions: Record<string, unknown>,
+): ParseSession {
+    const configPath = path.join(root, "tsconfig.json");
+    const files = new Map(sources);
+    files.set(configPath, JSON.stringify({
+        compilerOptions,
+        include: ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+    }));
+
+    const fileSystem: FileSystem = {
+        readFile: file => files.get(file),
+        fileExists: file => (files.has(file) ? true : undefined),
+        directoryExists: () => undefined,
+        getAccessibleEntries: directory => {
+            const virtual = [...files.keys()]
+                .filter(file => path.dirname(file) === directory)
+                .map(file => path.basename(file));
+            if (virtual.length === 0) {
+                return undefined;
+            }
+            // A directory holding in-memory sources may also exist on disk, and the server needs
+            // one listing covering both.
+            const entries = {files: [] as string[], directories: [] as string[]};
+            try {
+                for (const entry of fs.readdirSync(directory, {withFileTypes: true})) {
+                    (entry.isDirectory() ? entries.directories : entries.files).push(entry.name);
+                }
+            } catch {
+                // Purely virtual directory.
+            }
+            return {files: [...new Set([...entries.files, ...virtual])], directories: entries.directories};
+        },
+        realpath: () => undefined,
+    };
+
+    const api = new API({cwd: root, fs: fileSystem});
+    const project = api.updateSnapshot({openProjects: [configPath]}).getProjects()[0];
+    if (!project) {
+        api.close();
+        throw new Error(`TypeScript did not open a project at ${configPath}`);
+    }
+    return {project, close: () => api.close()};
+}

--- a/rewrite-javascript/rewrite/src/javascript/ts7/token-navigation.ts
+++ b/rewrite-javascript/rewrite/src/javascript/ts7/token-navigation.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {createScanner, LanguageVariant, type Node, type NodeArray, type SourceFile, SyntaxKind} from "typescript7/unstable/ast";
+
+// The TypeScript 7 AST arrives deserialised from the Go compiler, which carries only the semantic
+// children; `forEachChild` therefore skips punctuation. Scanning each gap between children recovers
+// the tokens whose offsets the LST hangs whitespace on. ../token-navigation.ts is the same surface
+// over the TypeScript 6 AST, where the compiler supplies these children directly.
+
+/** A scanned token. It has no place in the Go compiler's tree, so it carries only what callers read. */
+interface SyntheticToken {
+    readonly kind: SyntaxKind;
+    readonly pos: number;
+    readonly end: number;
+}
+
+/** Wraps a NodeArray so a list's own punctuation stays reachable, mirroring TypeScript's SyntaxList. */
+interface SyntaxListNode extends SyntheticToken {
+    readonly [SYNTAX_LIST]: NodeArray<Node>;
+}
+
+// Real nodes carry fields like `elements` and `types`, so the wrapper is tagged with a symbol that
+// nothing in the compiler's tree can collide with.
+const SYNTAX_LIST = Symbol("syntaxList");
+
+export type Child = Node | SyntheticToken | SyntaxListNode;
+
+const isSyntaxList = (n: Child): n is SyntaxListNode => (n as SyntaxListNode)[SYNTAX_LIST] !== undefined;
+const isToken = (k: SyntaxKind) => k >= SyntaxKind.FirstToken && k <= SyntaxKind.LastToken;
+const isJSDoc = (k: SyntaxKind) => k >= SyntaxKind.FirstJSDocNode && k <= SyntaxKind.LastJSDocNode;
+
+function scanBetween(sf: SourceFile, from: number, to: number, out: Child[]): void {
+    if (to <= from) {
+        return;
+    }
+    const scanner = createScanner(true, sf.languageVariant ?? LanguageVariant.Standard, sf.text);
+    scanner.setText(sf.text, from, to - from);
+    for (; ;) {
+        const kind = scanner.scan();
+        if (kind === SyntaxKind.EndOfFile) {
+            break;
+        }
+        // A token's `pos` runs from the end of the previous one, so leading trivia belongs to it.
+        out.push({kind, pos: scanner.getTokenFullStart(), end: scanner.getTokenEnd()});
+    }
+}
+
+export function childrenOf(node: Child, sourceFile: SourceFile): Child[] {
+    if (isSyntaxList(node)) {
+        return syntaxListChildren(node, sourceFile);
+    }
+    if (isToken(node.kind)) {
+        return [];
+    }
+    const children: Child[] = [];
+    let pos = node.pos;
+    // JSDoc reaches the tree only through `node.jsDoc`, and the parser asks for none of it, so the
+    // children stop at what `forEachChild` yields.
+    (node as Node).forEachChild(
+        child => {
+            scanBetween(sourceFile, pos, child.pos, children);
+            children.push(child);
+            pos = child.end;
+            return undefined;
+        },
+        nodes => {
+            scanBetween(sourceFile, pos, nodes.pos, children);
+            children.push({kind: SyntaxKind.SyntaxList, pos: nodes.pos, end: nodes.end, [SYNTAX_LIST]: nodes});
+            pos = nodes.end;
+            return undefined;
+        });
+    scanBetween(sourceFile, pos, node.end, children);
+    return children;
+}
+
+function syntaxListChildren(list: SyntaxListNode, sourceFile: SourceFile): Child[] {
+    const out: Child[] = [];
+    let pos = list.pos;
+    for (const element of list[SYNTAX_LIST]) {
+        scanBetween(sourceFile, pos, element.pos, out);
+        out.push(element);
+        pos = element.end;
+    }
+    scanBetween(sourceFile, pos, list.end, out);
+    return out;
+}
+
+export function childCountOf(node: Child, sourceFile: SourceFile): number {
+    return childrenOf(node, sourceFile).length;
+}
+
+export function childAt(node: Child, index: number, sourceFile: SourceFile): Child | undefined {
+    return childrenOf(node, sourceFile)[index];
+}
+
+export function firstTokenOf(node: Child, sourceFile: SourceFile): Child | undefined {
+    const child = childrenOf(node, sourceFile).find(c => !isJSDoc(c.kind));
+    if (!child) {
+        return undefined;
+    }
+    return child.kind < SyntaxKind.FirstNode ? child : firstTokenOf(child, sourceFile);
+}
+
+export function lastTokenOf(node: Child, sourceFile: SourceFile): Child | undefined {
+    const children = childrenOf(node, sourceFile);
+    const child = children[children.length - 1];
+    if (!child) {
+        return undefined;
+    }
+    return child.kind < SyntaxKind.FirstNode ? child : lastTokenOf(child, sourceFile);
+}

--- a/rewrite-javascript/rewrite/test/javascript/ts7-conformance.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/ts7-conformance.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+import {SyntaxKind as SyntaxKind7, type SourceFile as SourceFile7} from "typescript7/unstable/ast";
+import {type Child, childrenOf} from "../../src/javascript/ts7/token-navigation";
+import {openSession} from "../../src/javascript/ts7/program";
+
+// TypeScript 7 renumbers every SyntaxKind, so trees are compared by kind *name*. Where 7 renames a
+// kind or models a construct differently, the mapping is recorded here rather than skipped: a
+// deviation that is not in this table fails the test, which is how new drift gets noticed.
+const TS7_EQUIVALENT: Record<string, string> = {
+    EndOfFile: "EndOfFileToken",
+};
+
+/** TypeScript 6's name for a node 7 models differently, or 7's own name when the two agree. */
+function equivalentName(name: string, pos: number, end: number): string {
+    // An elision in a binding pattern (`const [a, , b] = ...`) is a zero-width BindingElement in 7
+    // where 6 emits an OmittedExpression. Non-empty BindingElements mean the same thing in both.
+    if (name === "BindingElement" && pos === end) {
+        return "OmittedExpression";
+    }
+    return TS7_EQUIVALENT[name] ?? name;
+}
+
+/** Reverse a SyntaxKind enum to the first name per value, the way parser.ts dispatches. */
+function firstNames(kinds: Record<string, unknown>): Map<number, string> {
+    const names = new Map<number, string>();
+    for (const [name, value] of Object.entries(kinds)) {
+        if (typeof value === "number" && !names.has(value)) {
+            names.set(value, name);
+        }
+    }
+    return names;
+}
+
+const NAMES_6 = firstNames(ts.SyntaxKind as unknown as Record<string, unknown>);
+const NAMES_7 = firstNames(SyntaxKind7 as unknown as Record<string, unknown>);
+
+function stream6(node: ts.Node, sourceFile: ts.SourceFile, out: string[]): string[] {
+    for (const child of node.getChildren(sourceFile)) {
+        out.push(`${NAMES_6.get(child.kind)}@${child.pos}:${child.end}`);
+        if (child.kind === ts.SyntaxKind.SyntaxList || child.getChildren(sourceFile).length > 0) {
+            stream6(child, sourceFile, out);
+        }
+    }
+    return out;
+}
+
+function stream7(node: Child, sourceFile: SourceFile7, out: string[]): string[] {
+    for (const child of childrenOf(node, sourceFile)) {
+        const name = NAMES_7.get(child.kind)!;
+        out.push(`${equivalentName(name, child.pos, child.end)}@${child.pos}:${child.end}`);
+        if (childrenOf(child, sourceFile).length > 0) {
+            stream7(child, sourceFile, out);
+        }
+    }
+    return out;
+}
+
+const CORPUS = fs.readdirSync(path.join(__dirname, "../../src/javascript"))
+    .filter(f => f.endsWith(".ts"))
+    .map(f => path.join(__dirname, "../../src/javascript", f));
+
+describe("TypeScript 7 AST conformance", () => {
+    test("reconstructed token stream matches TypeScript 6 across the parser's own sources", () => {
+        const root = "/ts7conformance";
+        const sources = new Map(CORPUS.map(f => [`${root}/${path.basename(f)}`, fs.readFileSync(f, "utf8")]));
+        const session = openSession(root, sources, {
+            target: "esnext", module: "preserve", moduleResolution: "bundler",
+            noEmit: true, allowJs: true, strict: false,
+        });
+        try {
+            const mismatches: string[] = [];
+            for (const [virtualPath, text] of sources) {
+                // The parser turns JSDoc parsing off, so neither side should see JSDoc nodes.
+                const sourceFile6 = ts.createSourceFile(virtualPath, text,
+                    {languageVersion: ts.ScriptTarget.Latest, jsDocParsingMode: ts.JSDocParsingMode.ParseNone},
+                    true, ts.ScriptKind.TS);
+                const sourceFile7 = session.project.program.getSourceFile(virtualPath);
+                expect(sourceFile7, `TypeScript 7 did not parse ${virtualPath}`).toBeDefined();
+
+                const expected = stream6(sourceFile6, sourceFile6, []);
+                const actual = stream7(sourceFile7 as unknown as Child, sourceFile7!, []);
+                const at = expected.findIndex((token, i) => token !== actual[i]);
+                if (at !== -1 || expected.length !== actual.length) {
+                    mismatches.push(`${path.basename(virtualPath)} at #${at}: `
+                        + `ts6=${expected[at] ?? "<end>"} ts7=${actual[at] ?? "<end>"}`);
+                }
+            }
+            expect(mismatches).toEqual([]);
+        } finally {
+            session.close();
+        }
+    }, 120_000);
+});

--- a/rewrite-javascript/rewrite/tsconfig.build.json
+++ b/rewrite-javascript/rewrite/tsconfig.build.json
@@ -11,5 +11,10 @@
   },
   "include": [
     "src/**/*"
+  ],
+  // The ts7 modules run against `typescript7`, a devDependency, and only the conformance test
+  // loads them; shipping them would put an unresolvable require in the published package.
+  "exclude": [
+    "src/javascript/ts7/**"
   ]
 }

--- a/rewrite-javascript/rewrite/tsconfig.json
+++ b/rewrite-javascript/rewrite/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2017",
-    "module": "Node16",
-    "moduleResolution": "node16",
+    "module": "node20",
+    "moduleResolution": "nodenext",
     "isolatedModules": true,
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
- Stacked on #8690, which is stacked on #8689 — review those first.

- TypeScript 7.0 ships no compiler API. `typescript`'s main entry is `lib/version.cjs`, which exports a version string; the AST, checker and program construction live behind `unstable/*` subpath exports that the [7.1 iteration plan](https://github.com/microsoft/TypeScript/issues/63703) does not schedule for stabilisation. This adds the two pieces the parser will need from there, each pinned by a conformance test against the TypeScript 6 tree it has to reproduce. The parser still runs on 6.

## Token navigation

`ts7/token-navigation.ts` rebuilds the five calls 7 does not expose, from `forEachChild` (a `Node` method in 7, not a free function), `createScanner`, and the source text. Across the parser's own 26 sources the reconstructed token stream is identical to TypeScript 6's native one — kinds, order **and offsets** — once two equivalences hold:

- `EndOfFileToken` is renamed `EndOfFile`.
- An elision in a binding pattern (`const [a, , b] = …`) is a zero-width `BindingElement` in 7 where 6 emits an `OmittedExpression`. The equivalence is conditional on zero width; a non-empty `BindingElement` means the same thing in both.

Both are recorded in the test rather than skipped, so a deviation that is not in that table fails.

Four things had to be right for the offsets to line up, and each was found by the test rather than by reading:

- A synthetic token's `pos` is its *full* start, so `getTokenFullStart()` is the source, not `getTokenStart()`.
- A SyntaxList is re-scanned rather than yielding its raw elements, or the leading `|` of `| "a" | "b"` disappears.
- The SyntaxList wrapper is tagged with a `Symbol`. Tagging it with an `elements` field silently captured real nodes — `NamedImports`, `ArrayLiteralExpression` and others already have `elements`, so their braces and brackets vanished from the stream.
- JSDoc is omitted entirely, which matches the parser: it sets `jsDocParsingMode: ParseNone`, so JSDoc never enters the tree. In 7, JSDoc is reachable only through `node.jsDoc` and never through `forEachChild`, and malformed JSDoc raises no syntactic diagnostic — which was the reason `ParseNone` was set. The 44 `visitJSDoc*` methods in `parser.ts` are unreachable under both compilers.

## Program construction

`ts7/program.ts` replaces `createProgram` and the `CompilerHost`, neither of which exists in 7. The Go process owns parsing and module resolution, so a program is described to it: in-memory sources are served over filesystem callbacks, and returning `undefined` defers to the real filesystem. An in-memory file importing another in-memory file, and one importing `@types/node` from real `node_modules`, both resolve with full type attribution and no diagnostics. `resolveModuleNameLiterals`, which `parser.ts` overrides today because its sources are not on disk, has no counterpart to port.

## Why `module: node20`

TypeScript 7 is ESM-only and this package is CommonJS. Under `node16` every `unstable/*` import is TS1479 (`cannot be imported with 'require'`). `node20` permits `require(esm)`, which Node supports from 22.12.

That floor is now declared — `engines.node` and the module's CLAUDE.md, which said `18+`. It constrains building and testing rather than consumers: with the ts7 modules excluded from the build, the emit under `node20` is byte-identical to `node16`, so nothing about the published output changes.

The ts7 modules were reaching `dist` while `typescript7` is a devDependency, which would have left an unresolvable `require` in the published package. Only the conformance test loads them, so `tsconfig.build.json` skips them.

## What this deliberately does not do

The parser still runs on TypeScript 6. A visitor cannot span both compilers: kind *numbers* differ, and it compares `node.kind` against named members of one enum. Switching is therefore all-at-once, behind a single module that re-exports `SyntaxKind` and the type guards. Encouragingly all 109 `SyntaxKind` members and all the `isXxx` guards the parser uses exist in 7, three under consistency renames (`isParameter` → `isParameterDeclaration`, and the same for `isMethodSignature`/`isPropertySignature`).

Node field drift is likewise small: 87 interfaces are field-identical, and the real changes are `ImportAttributes.elements` → `.attributes`, `TypeParameterDeclaration.default` → `.defaultType`, `Identifier.escapedText` → `.text`, and `ImportClause.isTypeOnly: boolean` → `.phaseModifier`, an enum carrying `import defer`/`import source`. Only the last needs more than a rename.

The checker is not ported here.

Full suite: 2034 passed, 24 skipped, 0 failed.
