### PR TITLE
JS patterns: a capture binds as a whole if/while/do-while/switch condition

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/templating/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/comparator.ts
@@ -85,6 +85,17 @@ class CaptureMapImpl implements CaptureMap {
     }
 }
 
+/** A capture found in a pattern, and the target node it binds to. */
+interface CaptureAt {
+    marker: CaptureMarker;
+    target: J;
+}
+
+/** Parentheses that `JavaScriptSemanticComparatorVisitor.unwrap()` sees through. */
+function isParenthesized(j: any): boolean {
+    return j?.kind === J.Kind.Parentheses || j?.kind === J.Kind.ControlParentheses;
+}
+
 /**
  * A comparator for pattern matching that is lenient about optional properties.
  * Allows patterns without type annotations to match actual code with type annotations.
@@ -112,33 +123,59 @@ export class PatternMatchingComparator extends JavaScriptSemanticComparatorVisit
         };
     }
 
+    /** The capture this pattern node stands for, paired with the target node it should bind to. */
+    protected captureAt(j: Tree, p: J): CaptureAt | undefined {
+        const marker = PlaceholderUtils.getCaptureMarker(j as J);
+        return marker ? {marker, target: p} : this.captureBehindParentheses(j, p);
+    }
+
+    /** The marker `attachCaptureMarkers` moved onto a parenthesized capture's `J.RightPadded`, which `unwrap()` skips past. */
+    private captureBehindParentheses(j: Tree, p: J): CaptureAt | undefined {
+        let pattern: any = j;
+        let target: any = p;
+        while (isParenthesized(pattern)) {
+            const padded = pattern.tree as J.RightPadded<J> | undefined;
+            if (!padded) {
+                return undefined;
+            }
+            target = isParenthesized(target) ? target.tree.element : target;
+            const marker = PlaceholderUtils.getCaptureMarker(padded);
+            if (marker) {
+                return {marker, target: target as J};
+            }
+            pattern = padded.element;
+        }
+        return undefined;
+    }
+
     override async visit<R extends J>(j: Tree, p: J, parent?: Cursor): Promise<R | undefined> {
         // Check if the pattern node is a capture - this handles unwrapped captures
         // (Wrapped captures in J.RightPadded are handled by visitRightPadded override)
         // Note: targetCursor will be pushed by parent's visit() method after this check
-        const captureMarker = PlaceholderUtils.getCaptureMarker(j)!;
-        if (captureMarker) {
+        const capture = this.captureAt(j, p);
+        if (capture) {
+            const {marker: captureMarker, target} = capture;
 
             // Push targetCursor to position it at the captured node for constraint evaluation
             // Only create cursor if targetCursor was initialized (meaning user provided one)
             const savedTargetCursor = this.targetCursor;
             const cursorAtCapturedNode = this.targetCursor !== undefined
-                ? new Cursor(p, this.targetCursor)
-                : new Cursor(p);
+                ? new Cursor(target, this.targetCursor)
+                : new Cursor(target);
             this.targetCursor = cursorAtCapturedNode;
             try {
                 // Evaluate constraint with context (cursor + previous captures)
                 // Skip constraint for variadic captures - they're evaluated in matchSequence with the full array
                 if (captureMarker.constraint && !captureMarker.variadicOptions) {
                     const context = this.buildConstraintContext(cursorAtCapturedNode);
-                    if (!captureMarker.constraint(p, context)) {
+                    if (!captureMarker.constraint(target, context)) {
                         const captureName = captureMarker.captureName || 'unnamed';
-                        const targetKind = (p as any).kind || 'unknown';
+                        const targetKind = (target as any).kind || 'unknown';
                         return this.constraintFailed(captureName, targetKind) as R;
                     }
                 }
 
-                const success = this.matcher.handleCapture(captureMarker, p, undefined);
+                const success = this.matcher.handleCapture(captureMarker, target, undefined);
                 if (!success) {
                     const captureName = captureMarker.captureName || 'unnamed';
                     return this.captureConflict(captureName) as R;
@@ -896,26 +933,27 @@ export class DebugPatternMatchingComparator extends PatternMatchingComparator {
     }
 
     override async visit<R extends J>(j: Tree, p: J, parent?: Cursor): Promise<R | undefined> {
-        const captureMarker = PlaceholderUtils.getCaptureMarker(j)!;
-        if (captureMarker) {
+        const capture = this.captureAt(j, p);
+        if (capture) {
+            const {marker: captureMarker, target} = capture;
             const savedTargetCursor = this.targetCursor;
             const cursorAtCapturedNode = this.targetCursor !== undefined
-                ? new Cursor(p, this.targetCursor)
-                : new Cursor(p);
+                ? new Cursor(target, this.targetCursor)
+                : new Cursor(target);
             this.targetCursor = cursorAtCapturedNode;
             try {
                 if (captureMarker.constraint && !captureMarker.variadicOptions) {
                     this.debug.log('debug', 'constraint', `Evaluating constraint for capture: ${captureMarker.captureName}`);
-                    const constraintResult = captureMarker.constraint(p, this.buildConstraintContext(cursorAtCapturedNode));
+                    const constraintResult = captureMarker.constraint(target, this.buildConstraintContext(cursorAtCapturedNode));
                     if (!constraintResult) {
                         this.debug.log('info', 'constraint', `Constraint failed for capture: ${captureMarker.captureName}`);
-                        this.debug.setExplanation('constraint-failed', `Capture ${captureMarker.captureName} with valid constraint`, `Constraint failed for ${(p as any).kind}`, `Constraint evaluation returned false`);
+                        this.debug.setExplanation('constraint-failed', `Capture ${captureMarker.captureName} with valid constraint`, `Constraint failed for ${(target as any).kind}`, `Constraint evaluation returned false`);
                         return this.abort(j) as R;
                     }
                     this.debug.log('debug', 'constraint', `Constraint passed for capture: ${captureMarker.captureName}`);
                 }
 
-                const success = this.matcher.handleCapture(captureMarker, p, undefined);
+                const success = this.matcher.handleCapture(captureMarker, target, undefined);
                 if (!success) {
                     return this.abort(j) as R;
                 }

--- a/rewrite-javascript/rewrite/test/javascript/templating/control-parentheses-capture.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/control-parentheses-capture.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {Cursor, ExecutionContext, SourceFile} from "../../../src";
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {
+    capture,
+    JavaScriptParser,
+    JavaScriptVisitor,
+    JS,
+    MatchResult,
+    Pattern,
+    pattern,
+    rewrite,
+    template,
+    typescript
+} from "../../../src/javascript";
+import {Expression, J} from "../../../src/java";
+
+/** The first node of `kind` in `text`, with the cursor that reached it. */
+async function findFirst(text: string, kind: string): Promise<[J, Cursor]> {
+    const cu: SourceFile = await new JavaScriptParser().parseOne({text, sourcePath: "match.ts"});
+    let found: [J, Cursor] | undefined;
+    const visitor = new class extends JavaScriptVisitor<ExecutionContext> {
+        protected override async postVisit(node: J, ctx: ExecutionContext): Promise<J | undefined> {
+            const visited = await super.postVisit(node, ctx);
+            if (!found && visited && visited.kind === kind) {
+                found = [visited, this.cursor];
+            }
+            return visited;
+        }
+    };
+    await visitor.visit(cu, new ExecutionContext());
+    expect(found).toBeDefined();
+    return found!;
+}
+
+/** Matches `pat` against the first node of `kind` in `text`, returning the match result. */
+async function matchFirst(text: string, kind: string, pat: Pattern): Promise<MatchResult | undefined> {
+    const [node, cursor] = await findFirst(text, kind);
+    return pat.match(node, cursor);
+}
+
+describe('a capture that is a whole ControlParentheses', () => {
+    // Looking through the parentheses must walk past a marker below them, not claim it.
+    test('a capture nested inside a condition still binds only itself', async () => {
+        const n = capture('n');
+        const match = await matchFirst('if (x > 1) { a(); }', J.Kind.If, pattern`if (x > ${n}) { a(); }`);
+        expect((match!.get(n) as Expression).kind).toBe(J.Kind.Literal);
+    });
+
+    test('if condition', async () => {
+        expect(await matchFirst('if (c) { a(); }', J.Kind.If,
+            pattern`if (${capture()}) { a(); }`)).toBeDefined();
+    });
+
+    test('while condition', async () => {
+        expect(await matchFirst('while (c) { a(); }', J.Kind.WhileLoop,
+            pattern`while (${capture()}) { a(); }`)).toBeDefined();
+    });
+
+    test('do-while condition', async () => {
+        expect(await matchFirst('do { a(); } while (c);', J.Kind.DoWhileLoop,
+            pattern`do { a(); } while (${capture()});`)).toBeDefined();
+    });
+
+    test('switch selector', async () => {
+        expect(await matchFirst('switch (c) { case 1: break; }', J.Kind.Switch,
+            pattern`switch (${capture()}) { case 1: break; }`)).toBeDefined();
+    });
+
+    test('with expression', async () => {
+        expect(await matchFirst('with (o) { a(); }', JS.Kind.WithStatement,
+            pattern`with (${capture()}) { a(); }`)).toBeDefined();
+    });
+
+    // The debug comparator has its own copy of the capture check, so it has to be exercised too.
+    test('the debug comparator agrees with the plain one', async () => {
+        const c = capture('c');
+        const [node, cursor] = await findFirst('if (x > 1) { a(); }', J.Kind.If);
+        const attempt = await pattern`if (${c}) { a(); }`.matchWithExplanation(node, cursor);
+        expect(attempt.matched).toBe(true);
+        expect(attempt.result!.get(c)).toBeDefined();
+    });
+
+    test('binds the condition itself, not the parentheses around it', async () => {
+        const c = capture('c');
+        const match = await matchFirst('if (x > 1) { a(); }', J.Kind.If, pattern`if (${c}) { a(); }`);
+        const bound = match!.get(c) as Expression;
+        expect(bound.kind).toBe(J.Kind.Binary);
+    });
+
+    test('a constraint sees the condition it is applied to', async () => {
+        const identifierOnly = capture({name: 'c', constraint: (n: J) => n.kind === J.Kind.Identifier});
+        expect(await matchFirst('if (c) { a(); }', J.Kind.If,
+            pattern`if (${identifierOnly}) { a(); }`)).toBeDefined();
+        expect(await matchFirst('if (x > 1) { a(); }', J.Kind.If,
+            pattern`if (${identifierOnly}) { a(); }`)).toBeUndefined();
+    });
+
+    // The pattern and the source need not agree on how many layers of parentheses they use.
+    test('a parenthesized capture matches an unparenthesized condition', async () => {
+        const c = capture('c');
+        const match = await matchFirst('if (c) { a(); }', J.Kind.If, pattern`if ((${c})) { a(); }`);
+        expect((match!.get(c) as Expression).kind).toBe(J.Kind.Identifier);
+    });
+
+    test('a plain capture keeps the parentheses a redundantly parenthesized condition had', async () => {
+        const c = capture('c');
+        const match = await matchFirst('if ((c)) { a(); }', J.Kind.If, pattern`if (${c}) { a(); }`);
+        expect((match!.get(c) as Expression).kind).toBe(J.Kind.Parentheses);
+    });
+});
+
+describe('rewriting through a captured condition', () => {
+    const spec = new RecipeSpec();
+
+    test('reuses a captured if condition in the replacement', () => {
+        const c = capture('c');
+        const negate = rewrite(() => ({
+            before: pattern`if (${c}) { a(); }`,
+            after: template`if (!(${c})) { a(); }`
+        }));
+
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitIf(iff: J.If, p: any): Promise<J | undefined> {
+                return await negate.tryOn(this.cursor, iff) || super.visitIf(iff, p);
+            }
+        });
+
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `if (x > 1) {
+    a();
+}`,
+                `if (!(x > 1)) {
+    a();
+}`
+            )
+        );
+    });
+});


### PR DESCRIPTION
A capture binds wherever it appears in a pattern, with one exception: the slot modelled by `J.ControlParentheses`. That is the condition of `if`, `while` and `do-while`, the selector of `switch`, and the expression of `with`. There the placeholder identifier was compared literally against the source, so the match failed.

```ts
pattern`if (${capture()}) { a(); }`      // never matched  if (c) { a(); }
pattern`if (x > ${capture()}) { a(); }`  // matched        if (x > 1) { a(); }
```

The second line is what scopes it. A capture one level inside the same condition binds, and so do a ternary condition and a `for` condition — neither of which is wrapped in `J.ControlParentheses`.

### Cause

`attachCaptureMarkers` puts a `CaptureMarker` in one of two places. A capture sitting in a plain `J` property keeps its marker on the node; one sitting in a `J.RightPadded` has the marker *moved* onto the wrapper, because `visitRightPadded` is where the comparator reads it back.

`J.ControlParentheses#tree` is a `J.RightPadded`, so the marker was hoisted onto it — and then nothing ever visited it. `JavaScriptSemanticComparatorVisitor.unwrap()` steps from the parentheses straight to `.tree.element`, past the wrapper holding the marker, and re-dispatches through `JavaScriptVisitor.prototype.visit.call`, which skips the `visit` override that checks for one. Comparison fell through to identifier names, and `__capt_x__` is not `c`.

### Fix

`captureBehindParentheses()` looks through `J.Parentheses` and `J.ControlParentheses` for the marker and descends the target in lock step, so the capture binds to the condition rather than to the parentheses around it. Pattern and source need not agree on how many layers they use: where the source carries a pair the pattern does not, the capture binds the `J.Parentheses`.

`DebugPatternMatchingComparator` keeps its own copy of `visit`, so it goes through the same helper. A fix to the plain path alone passes the entire suite, since the debug comparator only runs under `matchWithExplanation`.

### Tests

`control-parentheses-capture.test.ts` covers the four broken positions plus `with`, with `do-while` called out separately because its condition arrives through a `LeftPadded` rather than a direct property. Beyond that: both parenthesis asymmetries, what the capture binds rather than only whether it matched, the constraint path, the debug comparator, and one `rewrite` that splices a captured condition back out.

Eleven of the twelve fail with the fix reverted. The twelfth is the guard that the new lookup walks past a marker *below* the parentheses instead of claiming it, and passes either way by design.

- Fixes moderneinc/customer-requests#3079
