### PR TITLE
JS templates: a spliced capture keeps the markers it was matched with

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Cursor, isTree} from '../..';
+import {Cursor, isTree, Markers} from '../..';
 import {J} from '../../java';
 import {JS} from '..';
 import {JavaScriptVisitor} from '../visitor';
@@ -179,6 +179,16 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
     private mergeElementPrefix(sourcePrefix: J.Space, templatePrefix: J.Space): J.Space {
         return sourcePrefix.whitespace.includes('\n') && !templatePrefix.whitespace.includes('\n') ?
             sourcePrefix : this.mergePrefix(sourcePrefix, templatePrefix);
+    }
+
+    /** As `mergePrefix`, for markers: everything the value was matched with, plus the kinds only the slot wrote. */
+    private mergeMarkers(sourceMarkers: Markers, templateMarkers: Markers): Markers {
+        const added = templateMarkers.markers.filter(
+            template => !sourceMarkers.markers.some(source => source.kind === template.kind));
+        return added.length === 0 ? sourceMarkers : {
+            ...sourceMarkers,
+            markers: [...sourceMarkers.markers, ...added]
+        };
     }
 
     /**
@@ -386,7 +396,7 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
                 if (isTree(propertyValue)) {
                     const propValueAsJ = propertyValue as J;
                     return produce(propValueAsJ, draft => {
-                        draft.markers = placeholder.markers;
+                        draft.markers = this.mergeMarkers(propValueAsJ.markers, placeholder.markers);
                         draft.prefix = this.mergePrefix(propValueAsJ.prefix, placeholder.prefix);
                     });
                 }
@@ -421,7 +431,7 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
             const matchedNode = this.values.get(name);
             if (matchedNode && !Array.isArray(matchedNode)) {
                 return produce(matchedNode, draft => {
-                    draft.markers = placeholder.markers;
+                    draft.markers = this.mergeMarkers(matchedNode.markers, placeholder.markers);
                     draft.prefix = this.mergePrefix(matchedNode.prefix, placeholder.prefix);
                 });
             }
@@ -438,7 +448,7 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
             // Extract the element from the J.RightPadded wrapper
             const element = param.value.element as J;
             return produce(element, draft => {
-                draft.markers = placeholder.markers;
+                draft.markers = this.mergeMarkers(element.markers, placeholder.markers);
                 draft.prefix = this.mergePrefix(element.prefix, placeholder.prefix);
             });
         }
@@ -458,7 +468,7 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
         if (isTree(param.value)) {
             // Return the AST node, preserving comments from the source
             return produce(param.value as J, draft => {
-                draft.markers = placeholder.markers;
+                draft.markers = this.mergeMarkers(param.value.markers, placeholder.markers);
                 draft.prefix = this.mergePrefix(param.value.prefix, placeholder.prefix);
             });
         }

--- a/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
@@ -42,7 +42,7 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
             const replacement = this.replacePlaceholder(tree);
             if (replacement !== tree) {
                 // `this.cursor` is still the enclosing template node: `super.visit()` has not pushed this one
-                return maybeParenthesize(enclosingTree(parent ?? this.cursor), tree.id, replacement, true) as R;
+                return maybeParenthesize(enclosingTree(parent ?? this.cursor), tree.id, replacement, tree.markers) as R;
             }
         }
 

--- a/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
@@ -15,7 +15,7 @@
  */
 import {isTree} from '../..';
 import {emptySpace, J} from '../../java';
-import {emptyMarkers, Marker, markers} from '../../markers';
+import {emptyMarkers, Marker, markers, Markers} from '../../markers';
 import {randomId} from '../../uuid';
 import {JS} from '..';
 
@@ -319,9 +319,12 @@ export function requiredPrecedence(parent: J, childId: string): number | undefin
     return slotConstraints(parent, childId)?.precedence;
 }
 
-/** Parenthesizes `expression` if the slot of `parent` holding `childId` would otherwise reparse it. */
+/**
+ * Parenthesizes `expression` if the slot of `parent` holding `childId` would otherwise reparse it.
+ * `slotMarkers` are the markers the slot contributed; {@link parenthesize} says what they decide.
+ */
 export function maybeParenthesize(parent: J | undefined, childId: string, expression: J,
-                                  slotOwnsTrailingMarkers: boolean = false): J {
+                                  slotMarkers?: Markers): J {
     if (!parent) {
         return expression;
     }
@@ -334,10 +337,10 @@ export function maybeParenthesize(parent: J | undefined, childId: string, expres
     // A statement wrapper is transparent here: the parentheses belong around the expression
     if (expression.kind === JS.Kind.ExpressionStatement) {
         const inner = (expression as JS.ExpressionStatement).expression;
-        const wrapped = wrapIfNeeded(parent, childId, constraints, inner, slotOwnsTrailingMarkers);
+        const wrapped = wrapIfNeeded(parent, childId, constraints, inner, slotMarkers);
         return wrapped === inner ? expression : {...expression, expression: wrapped} as JS.ExpressionStatement;
     }
-    return wrapIfNeeded(parent, childId, constraints, expression, slotOwnsTrailingMarkers);
+    return wrapIfNeeded(parent, childId, constraints, expression, slotMarkers);
 }
 
 /** The nearest enclosing LST node in a cursor path, skipping the padding wrappers visitors push. */
@@ -352,18 +355,23 @@ export function enclosingTree(cursor: { value: any, parent?: any } | undefined):
     return undefined;
 }
 
-/** Wraps in `J.Parentheses`, moving the prefix out so the surrounding whitespace survives. */
-export function parenthesize(expression: J, slotOwnsTrailingMarkers: boolean = false): J.Parentheses<J> {
-    const trailing = slotOwnsTrailingMarkers ? expression.markers.markers.filter(isTrailingMarker) : [];
-    const inner = trailing.length === 0 ? expression : {
+/**
+ * Wraps in `J.Parentheses`, moving the prefix out so the surrounding whitespace survives. A trailing marker
+ * `slotMarkers` also carries belongs to the slot around the expression, so it moves out too: `${x}!` with `x`
+ * bound to `a + b` gives `(a + b)!`, while a bare `${x}` bound to `a!` gives `(a!)`.
+ */
+export function parenthesize(expression: J, slotMarkers?: Markers): J.Parentheses<J> {
+    const hoisted = expression.markers.markers.filter(
+        m => isTrailingMarker(m) && slotMarkers?.markers.some(slot => slot.kind === m.kind));
+    const inner = hoisted.length === 0 ? expression : {
         ...expression,
-        markers: markers(...expression.markers.markers.filter(m => !isTrailingMarker(m)))
+        markers: markers(...expression.markers.markers.filter(m => !hoisted.includes(m)))
     };
     return {
         kind: J.Kind.Parentheses,
         id: randomId(),
         prefix: expression.prefix,
-        markers: trailing.length === 0 ? emptyMarkers : markers(...trailing),
+        markers: hoisted.length === 0 ? emptyMarkers : markers(...hoisted),
         tree: {
             kind: J.Kind.RightPadded,
             element: {...inner, prefix: emptySpace},
@@ -374,7 +382,7 @@ export function parenthesize(expression: J, slotOwnsTrailingMarkers: boolean = f
 }
 
 function wrapIfNeeded(parent: J, childId: string, constraints: SlotConstraints, expression: J,
-                      slotOwnsTrailingMarkers: boolean): J {
+                      slotMarkers: Markers | undefined): J {
     if (precedenceOf(expression) < constraints.precedence ||
         (constraints.noCallShape && isCallShaped(expression)) ||
         (constraints.noOptionalChain && hasOptionalChain(expression)) ||
@@ -383,7 +391,7 @@ function wrapIfNeeded(parent: J, childId: string, constraints: SlotConstraints, 
         (constraints.followedByDot && isDotAdjacentNumber(expression)) ||
         mixesNullishWithLogical(parent, expression) ||
         wouldFuseSigns(parent, childId, expression)) {
-        return parenthesize(expression, slotOwnsTrailingMarkers);
+        return parenthesize(expression, slotMarkers);
     }
     return expression;
 }

--- a/rewrite-javascript/rewrite/test/javascript/templating/replace.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/replace.test.ts
@@ -269,5 +269,33 @@ describe('markers on a spliced capture', () => {
             )
         );
     });
+
+    test('a marker the value owns stays inside parentheses the slot needs', () => {
+        const arg = capture();
+        const rule = rewrite(() => ({before: pattern`g(${arg})`, after: template`new ${arg}()`}));
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                return await rule.tryOn(this.cursor, method) || method;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('g(f()!);', 'new (f()!)();')
+        );
+    });
+
+    test('a marker the template writes wraps those parentheses', () => {
+        const arg = capture();
+        const rule = rewrite(() => ({before: pattern`f(${arg})`, after: template`${arg}!.m()`}));
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                return await rule.tryOn(this.cursor, method) || method;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('f(a + b);', '(a + b)!.m();')
+        );
+    });
 });
 

--- a/rewrite-javascript/rewrite/test/javascript/templating/replace.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/replace.test.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 import {fromVisitor, RecipeSpec} from "../../../src/test";
-import {capture, JavaScriptVisitor, pattern, template, typescript} from "../../../src/javascript";
+import {capture, JavaScriptVisitor, JS, pattern, rewrite, template, typescript} from "../../../src/javascript";
 import {Expression, J} from "../../../src/java";
 import {create as produce} from "mutative";
-import {produceAsync} from "../../../src";
+import {findMarker, markers, produceAsync} from "../../../src";
 
 describe('template2 replace', () => {
     const spec = new RecipeSpec();
@@ -174,3 +174,100 @@ describe('template2 replace', () => {
         );
     });
 });
+
+describe('markers on a spliced capture', () => {
+    const spec = new RecipeSpec();
+
+    /** `t ? true : false` -> `t`: the captured test is handed straight back. */
+    function keepTernaryTest() {
+        const rule = rewrite(() => {
+            const t = capture();
+            return {before: pattern`${t} ? true : false`, after: template`${t}`};
+        });
+        return fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitTernary(ternary: J.Ternary, p: any): Promise<J | undefined> {
+                const visited = await super.visitTernary(ternary, p) as J.Ternary;
+                return await rule.tryOn(this.cursor, visited) || visited;
+            }
+        });
+    }
+
+    test('keeps a non-null assertion the source wrote', () => {
+        spec.recipe = keepTernaryTest();
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                'const a = x! ? true : false;',
+                'const a = x!;'
+            )
+        );
+    });
+
+    test('keeps a non-null assertion spliced into a larger template', () => {
+        const arg = capture();
+        const rule = rewrite(() => ({before: pattern`f(${arg})`, after: template`g(${arg})`}));
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                return await rule.tryOn(this.cursor, method) || method;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('f(x!);', 'g(x!);')
+        );
+    });
+
+    test('a rule that means to drop the assertion still can', () => {
+        const withoutNonNull = (n: J): J => ({
+            ...n,
+            markers: markers(...n.markers.markers.filter(m => m.kind !== JS.Markers.NonNullAssertion))
+        });
+        const o = capture({constraint: (n: J) => !!findMarker(n, JS.Markers.NonNullAssertion)});
+        const rule = rewrite(() => ({
+            before: pattern`${o}.oldApi()`,
+            after: match => template`${withoutNonNull(match.get(o) as J)}.newApi()`
+        }));
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                return await rule.tryOn(this.cursor, method) || method;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `
+                    x!.oldApi();
+                    y.oldApi();
+                `,
+                `
+                    x.newApi();
+                    y.oldApi();
+                `
+            )
+        );
+    });
+
+    test('adds a non-null assertion the template writes, without doubling it', () => {
+        const arg = capture();
+        const rule = rewrite(() => ({before: pattern`f(${arg})`, after: template`g(${arg}!)`}));
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                return await rule.tryOn(this.cursor, method) || method;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                `
+                    f(x);
+                    f(y!);
+                `,
+                `
+                    g(x!);
+                    g(y!);
+                `
+            )
+        );
+    });
+});
+


### PR DESCRIPTION
A rule that captures an operand and splices it back into the replacement deleted TypeScript's non-null assertion, because `!` is a marker on the expression rather than a node of its own:

```ts
// rewrite(() => ({before: pattern`${t} ? true : false`, after: template`${t}`}))

const a = x! ? true : false;   →   const a = x;   // expected: const a = x!;
```

- The output still parses and the recipe's own tests still pass, which is what makes this worth more than a note: under `strictNullChecks` the rewritten file either stops compiling, or compiles with the assertion its author wrote silently gone. Reported in [moderneinc/customer-requests#3080](https://github.com/moderneinc/customer-requests/issues/3080), where it reached seven recipes in the ESLint set through ordinary capture-and-splice rules and was invisible to ~1,700 unit tests.

## The mechanism

`replacePlaceholder` ended each of its four splice branches with `draft.markers = placeholder.markers`. The placeholder is the bare identifier the template parse produced, and its marker list is normally empty, so this did not merge the value's markers with the slot's — it replaced them.

`?.` came through unharmed, which made the defect look specific to `!`. It is not. `Optional` sits on an inner node of the chain rather than on the spliced root, so replacing the root's marker list never reached it; both are trailing markers and both were equally exposed.

## The fix

`mergeMarkers` gives the value everything it was matched with, and lets the placeholder contribute only the kinds the value does not already carry. A template that writes `${x}!` still adds the assertion — `parenthesize` depends on that, and the trailing-marker test in `precedence.test.ts` covers it — and does not double it where the value has one of its own. That mirrors the `mergePrefix` contract beside it: the source's comments, the template's whitespace.

## Dropping an assertion on purpose

Preservation is now the default rather than the only behaviour available. A migration whose new API makes `!` obsolete strips the marker and passes the node as a template parameter, where it lands as the rule built it:

```ts
const o = capture({constraint: n => !!findMarker(n, JS.Markers.NonNullAssertion)});
rewrite(() => ({
    before: pattern`${o}.oldApi()`,
    after: match => template`${withoutNonNull(match.get(o) as J)}.newApi()`
}));
// x!.oldApi() → x.newApi(), and y.oldApi() is left alone
```

The constraint does real work there: the comparator reads only `CaptureMarker` and never a source marker, so a pattern written `f(${x}!)` matches `f(x)` just as happily as `f(x!)`.

## Tests

Four, one per equivalence class, under `markers on a spliced capture`. The root splice and the splice into a larger template both fail on the unpatched source, verified by reverting it; they reach the same branch by different routes, the second through `expandVariadicElements` and its wrapper re-wrap. The third pins the merge direction, so a later "just keep the source's markers" cannot quietly drop an assertion the template writes. The fourth is the deliberate drop above.

Two candidates are deliberately absent. I profiled which of the changed lines each test executes: a `?.` set covers code this change does not touch, and a variadic case executes none of the changed lines at all. Three sources for the root splice — identifier, call, member — collapsed to one, the marker sitting on the spliced root whatever the node kind.

Full JS suite green: 151 files, 1690 passed, 21 skipped.

## Not fixed here

A template that builds a *different* node to replace the matched one — `o["p"]` to `o.p`, where a `J.FieldAccess` replaces a `J.ArrayAccess` — still drops the replaced node's markers, and the recipe carries them across itself. The issue scopes that to the recipe author, though its differential output shows the pre-refactor `DotNotation` preserving the `!`, so it may want its own decision.

The `MatchResult` exported from `src/javascript` is the class in `pattern.ts`, while `RewriteConfig.after` is typed against the interface in `types.ts`. The class is not assignable in parameter position, so `after: (match: MatchResult) => ...` does not compile and the new test leans on contextual typing instead.
