### PR TITLE
JavaScript: maybeBind binds afresh where the name it would reuse is shadowed

### DIFF
--- a/rewrite-javascript/rewrite/CLAUDE.md
+++ b/rewrite-javascript/rewrite/CLAUDE.md
@@ -220,12 +220,18 @@ only be appended at the end. Nothing in the LST enforces that pairing, and a mis
 prints plausibly while binding later modules to the wrong names — so every edit keeps the two
 lists index-aligned, and an operation that cannot is refused rather than guessed.
 
+A binding is reused only where its name still resolves to it at the cursor. Where something nearer
+shadows it, `maybeBind` binds the module again under a name that reaches — a second import, or a
+second AMD dependency — because a caller mid-rewrite needs a name it can emit. `maybeRebind` answers
+with the name its binding already carries, which is what keeps existing references resolving, so it
+reports that name whether or not the cursor reaches it.
+
 ### When `maybeBind` returns `undefined`
 
 - the block's dependency and parameter counts already disagree, in either direction
 - a `member` is requested on the AMD lane, which binds whole modules only
 - the file binds its modules with `require` and one would have to be created (`ImportStyle.CommonJS`
-  has no add path); reuse of an existing `require` is always allowed
+  has no add path), which covers an existing `require` shadowed where the caller asked
 - no legal identifier can be derived from the module's last path segment and no `preferredName`
   or `alias` was given — `lodash-es`, `node:fs`, `@scope/my-lib`, `a/class`
 - a pinned `alias` cannot be bound verbatim, since deconflicting it would leave code the caller

--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -4,7 +4,7 @@ import {JS, JSX} from "./tree";
 import {randomId} from "../uuid";
 import {emptyMarkers, markers} from "../markers";
 import {getStyle, PrettierStyle, SpacesStyle, StyleKind} from "./style";
-import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, namesDeclaredIn} from "./scope";
+import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, namesDeclaredIn, scopeOf} from "./scope";
 import {create as produce, Draft} from "mutative";
 
 export type QuoteChar = "'" | '"';
@@ -130,9 +130,10 @@ export function bindImport(
     // derive a suffixed name from the binding this call just added. A caller that named a preference
     // takes whatever comes back; one that did not assumes the name it derived, so a binding under
     // any other name would leave the references it emits unbound.
+    const scope = scopeOf(cursor);
     for (const binding of moduleScopeBindings(cu)) {
         if (binding.module === module && binding.member === memberName(options.member) &&
-            binding.typeOnly === typeOnly &&
+            binding.typeOnly === typeOnly && scope.declaringScope(binding.name) === cu &&
             (options.preferredName !== undefined || anyNameAnswers(options) ||
                 binding.name === derived)) {
             return binding.name;

--- a/rewrite-javascript/rewrite/src/javascript/amd.ts
+++ b/rewrite-javascript/rewrite/src/javascript/amd.ts
@@ -29,7 +29,7 @@ import {
     TrailingComma
 } from "../java";
 import {JS} from "./tree";
-import {cursorOf, deconflict, namesDeclaredWithin} from "./scope";
+import {cursorOf, deconflict, namesDeclaredWithin, scopeOf} from "./scope";
 import {JavaScriptVisitor} from "./visitor";
 import {ExecutionContext} from "../execution";
 
@@ -619,7 +619,18 @@ export function bindAmd(
 
     const declared = module === "" ? -1 : modules.indexOf(module);
     if (declared >= 0) {
-        return bindings[declared];
+        const bound = bindings[declared];
+        if (bound === undefined) {
+            // A parameter that is not a plain name gives the module no binding to hand back.
+            return undefined;
+        }
+        // Only code the factory encloses can shadow its parameter, so a cursor elsewhere in the
+        // block — on the `define` call, or on its dependency array — has nothing to measure.
+        const cursor = cursorOf(visitor);
+        const withinFactory = cursor?.firstEnclosing((v): v is J => v === amd.block.factory);
+        if (withinFactory === undefined || scopeOf(cursor!).declaringScope(bound) === amd.block.factory) {
+            return bound;
+        }
     }
 
     // Two calls naming the same module at the same block are the same request (ADR 0013),

--- a/rewrite-javascript/rewrite/src/javascript/binding.ts
+++ b/rewrite-javascript/rewrite/src/javascript/binding.ts
@@ -16,7 +16,7 @@
 import {J} from "../java";
 import {JS} from "./tree";
 import {JavaScriptVisitor} from "./visitor";
-import {compilationUnitOf, cursorOf, declarationsOf, walk} from "./scope";
+import {compilationUnitOf, cursorOf, declarationsOf, scopeOf, walk} from "./scope";
 import {AddImportOptions, bindImport, existingImportBinding, memberName, moduleNameOf, RebindImport, requiredModuleOf} from "./add-import";
 import {RemoveImport} from "./remove-import";
 import {
@@ -312,12 +312,14 @@ export function maybeBind(
 
     const cu = compilationUnitOf(visitor);
     const isWholeModule = !options.sideEffectOnly && (key === undefined || key === "*");
-    if (isWholeModule) {
-        const bound = cu && moduleObjectBindings(cu).find(b =>
+    if (isWholeModule && cu) {
+        const scope = scopeOf(cursorOf(visitor)!);
+        const bound = moduleObjectBindings(cu).find(b =>
             b.module === module && answersWholeModuleRequest(b, key === "*", options.typeOnly ?? false) &&
             // A pinned alias asks for a binding of that name, so another name for the same
             // module does not answer it; `bindImport`'s own lookup applies the same rule.
-            (options.alias === undefined || b.name === options.alias));
+            (options.alias === undefined || b.name === options.alias) &&
+            scope.declaringScope(b.name) === cu);
         if (bound !== undefined) {
             return bound.name;
         }

--- a/rewrite-javascript/rewrite/src/javascript/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/index.ts
@@ -32,7 +32,7 @@ export * from "./tree-debug";
 export * from "./project-parser";
 
 export type {Scope} from "./scope";
-export {scopeOf, namesDeclaredIn, bindingNames} from "./scope";
+export {scopeOf, namesInScope, namesDeclaredIn, bindingNames} from "./scope";
 export type {QuoteChar, AddImportOptions} from "./add-import";
 export {ImportStyle, moduleNameOf, AddImport} from "./add-import";
 // AMD mechanics `recipes-ui5` builds on directly, beyond the `maybeBind` surface below.

--- a/rewrite-javascript/rewrite/src/javascript/scope.ts
+++ b/rewrite-javascript/rewrite/src/javascript/scope.ts
@@ -19,12 +19,18 @@ import {JS} from "./tree";
 // scope.ts sits below the visitor, so this stays type-only.
 import type {JavaScriptVisitor} from "./visitor";
 
-/** The names code at some position can reach unqualified. */
+/** Which names code at some position can reach unqualified, and where each of them comes from. */
 export interface Scope {
     /** Whether this scope or one enclosing it binds `name`. */
     declares(name: string): boolean;
 
-    names(): ReadonlySet<string>;
+    /**
+     * The node owning the innermost scope that binds `name` — the compilation unit for a
+     * module-scope binding, otherwise the function, block or loop holding it — or undefined where
+     * nothing in scope does. A caller holding a declaration asks whether this is the node it came
+     * from: anything nearer shadows it.
+     */
+    declaringScope(name: string): J | undefined;
 }
 
 /**
@@ -34,9 +40,10 @@ export interface Scope {
  * reach the cursor.
  */
 export function scopeOf(cursor: Cursor): Scope {
-    let resolved: Set<string> | undefined;
-    const names = () => resolved ??= namesInScope(cursor);
-    return {declares: name => names().has(name), names};
+    return {
+        declares: name => declaringScopeOf(cursor, name) !== undefined,
+        declaringScope: name => declaringScopeOf(cursor, name)
+    };
 }
 
 /**
@@ -114,7 +121,17 @@ function unnamedMembers(bound: { name: string }[]): { name: string }[] {
     return bound.map(({name}) => ({name}));
 }
 
-function namesInScope(cursor: Cursor): Set<string> {
+function declaringScopeOf(cursor: Cursor, name: string): J | undefined {
+    for (let c: Cursor | undefined = cursor; c; c = c.parent) {
+        if (frameBindings(c.value, c.parent?.value).includes(name)) {
+            return c.value;
+        }
+    }
+    return undefined;
+}
+
+/** Every name {@link scopeOf} answers `declares` for, when a caller has none in mind to ask about. */
+export function namesInScope(cursor: Cursor): ReadonlySet<string> {
     const names = new Set<string>();
     for (let c: Cursor | undefined = cursor; c; c = c.parent) {
         for (const name of frameBindings(c.value, c.parent?.value)) {
@@ -124,26 +141,46 @@ function namesInScope(cursor: Cursor): Set<string> {
     return names;
 }
 
-/** What one node on the cursor path binds, `parent` being the node it hangs from. */
+/**
+ * What one node on the cursor path binds, `parent` being the node it hangs from. Only these two
+ * answers turn on the parent; a node alone settles the rest, which is what makes them cacheable.
+ */
 function frameBindings(node: any, parent: any): string[] {
-    switch (node?.kind) {
+    // A class body holds members, which are reached through an instance rather than by name.
+    if (node?.kind === J.Kind.Block && parent?.kind === J.Kind.ClassDeclaration) {
+        return [];
+    }
+    // A function expression is the only function whose own name its body reaches: a declaration's
+    // name belongs to the enclosing block, a method's to an instance.
+    if (node?.kind === J.Kind.MethodDeclaration && parent?.kind === JS.Kind.StatementExpression) {
+        const self = bindingNames((node as J.MethodDeclaration).name).map(bound => bound.name);
+        return [...self, ...ownBindings(node)];
+    }
+    return ownBindings(node);
+}
+
+function ownBindings(node: any): string[] {
+    if (typeof node !== 'object' || node === null) {
+        return [];
+    }
+    let names = frames.get(node);
+    if (!names) {
+        frames.set(node, names = readBindings(node));
+    }
+    return names;
+}
+
+function readBindings(node: any): string[] {
+    switch (node.kind) {
         case JS.Kind.CompilationUnit: {
             const statements = (node as JS.CompilationUnit).statements;
             return [...declaredNames(statements), ...hoistedNames(statements)];
         }
         case J.Kind.Block:
-            // A class body holds members, which are reached through an instance rather than by name.
-            return parent?.kind === J.Kind.ClassDeclaration ? [] : declaredNames((node as J.Block).statements);
+            return blockScopedNames((node as J.Block).statements);
         case J.Kind.MethodDeclaration: {
             const method = node as J.MethodDeclaration;
-            // A function expression is the only function whose own name its body reaches: a
-            // declaration's name belongs to the enclosing block, a method's to an instance.
-            const self = parent?.kind === JS.Kind.StatementExpression ? bindingNames(method.name) : [];
-            return [
-                ...self.map(bound => bound.name),
-                ...declaredNames(method.parameters.elements),
-                ...hoistedNames(method.body)
-            ];
+            return [...declaredNames(method.parameters.elements), ...hoistedNames(method.body)];
         }
         case J.Kind.Lambda: {
             const lambda = node as J.Lambda;
@@ -162,6 +199,31 @@ function frameBindings(node: any, parent: any): string[] {
         default:
             return [];
     }
+}
+
+/**
+ * The names statements bind in the block holding them — the complement of what
+ * {@link hoistedNames} claims, so `function (x) { var x = 1; }` reads as one binding, not two.
+ */
+function blockScopedNames(statements: any[]): string[] {
+    return statements.flatMap(statement => {
+        const element = unwrap(statement);
+        switch (element?.kind) {
+            case J.Kind.MethodDeclaration:
+                return [];
+            case J.Kind.VariableDeclarations:
+            case JS.Kind.ScopedVariableDeclarations:
+                return isBlockScoped(element) ? declarationNames(element) : [];
+            case J.Kind.Case:
+                return blockScopedNames((element as J.Case).statements.elements);
+            default:
+                return declarationNames(element);
+        }
+    });
+}
+
+function isBlockScoped(declaration: any): boolean {
+    return ((declaration.modifiers ?? []) as J.Modifier[]).some(m => blockScoped.has(m.keyword!));
 }
 
 /** The names statements declare directly in the scope holding them. */
@@ -224,10 +286,12 @@ function aliasedName(specifier: J | undefined): string[] {
 const blockScoped = new Set(['let', 'const', 'using']);
 
 // A walk of an immutable subtree has one answer, so it runs once. Keyed on the subtree itself, a
-// replaced one is walked afresh: every call site in a function asks what that body hoists, and every
-// import added to a file asks what that file declares.
+// replaced one is walked afresh: every call site in a function asks what that body hoists, every
+// import added to a file asks what that file declares, and every scope is asked what it binds by
+// each of the call sites it encloses.
 const hoisted = new WeakMap<object, string[]>();
 const declared = new WeakMap<object, ReadonlySet<string>>();
+const frames = new WeakMap<object, string[]>();
 
 /**
  * The names blocks under `scope` hoist out to it. A `var` or function declaration reaches the whole
@@ -251,7 +315,7 @@ function hoistedNames(scope: any): string[] {
                 return false;
             case J.Kind.VariableDeclarations:
             case JS.Kind.ScopedVariableDeclarations:
-                if (!((node.modifiers ?? []) as J.Modifier[]).some(m => blockScoped.has(m.keyword!))) {
+                if (!isBlockScoped(node)) {
                     names.push(...declarationNames(node));
                 }
                 return false;

--- a/rewrite-javascript/rewrite/test/javascript/binding.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/binding.test.ts
@@ -1,7 +1,7 @@
 import {fromVisitor, RecipeSpec} from "../../src/test";
 import {
     JavaScriptVisitor, JS, javascript, typescript, moduleBindings, isAmdBlock, ModuleBindings, maybeBind,
-    maybeAddImport, maybeUnbind, maybeRebind, maybeRemoveImport, removeNewlyUnusedAmdBindings
+    maybeAddImport, MaybeBindOptions, maybeUnbind, maybeRebind, maybeRemoveImport, removeNewlyUnusedAmdBindings
 } from "../../src/javascript";
 import {emptySpace, J, rightPadded} from "../../src/java";
 import {emptyMarkers} from "../../src/markers";
@@ -204,13 +204,13 @@ function withReference(call: J.MethodInvocation, name: string): J.MethodInvocati
 }
 
 /** A caller that uses the answer. */
-function rebind(module: string, bound: {name?: string}) {
+function rebind(options: MaybeBindOptions | string, bound: {name?: string}) {
     return new class extends JavaScriptVisitor<any> {
         override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
             if (m.name.simpleName !== "target") {
                 return super.visitMethodInvocation(m, p);
             }
-            bound.name = maybeBind(this, {module});
+            bound.name = maybeBind(this, options);
             return bound.name === undefined ? m : withReference(m, bound.name);
         }
     };
@@ -522,6 +522,85 @@ describe("maybeBind", () => {
         });
         await contextualKeyword.rewriteRun(typescript(`const x = 1;`));
         expect(contextualKeywordBound.name).toBeUndefined();
+    });
+
+    test("AMD refuses where the declared dependency's parameter is not a name to hand back", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(rebind("a/B", bound));
+        await spec.rewriteRun(javascript(
+            `sap.ui.define(["a/B"], function ({x}) { target(); });`
+        ));
+        expect(bound.name).toBeUndefined();
+    });
+
+    test("AMD reuses a parameter its own body redeclares", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(rebind("a/B", bound));
+        await spec.rewriteRun(javascript(
+            `sap.ui.define(["a/B"], function (B) { var B = B || {}; target(); });`,
+            `sap.ui.define(["a/B"], function (B) { var B = B || {}; B.target(); });`
+        ));
+        expect(bound.name).toBe("B");
+    });
+
+    test("AMD reuses a parameter for a cursor the factory does not enclose", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
+                if (isAmdBlock(m)) {
+                    bound.name = maybeBind(this, "a/B");
+                }
+                return super.visitMethodInvocation(m, p);
+            }
+        });
+        await spec.rewriteRun(javascript(`sap.ui.define(["a/B"], function (B) { B.x(); });`));
+        expect(bound.name).toBe("B");
+    });
+
+    test("AMD binds a module afresh where the parameter it would reuse is shadowed", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(rebind("a/B", bound));
+        await spec.rewriteRun(javascript(
+            `sap.ui.define(["a/B"], function (B) { function inner() { var B = 1; target(); return B; } });`,
+            `sap.ui.define(["a/B", "a/B"], function (B, B_1) { function inner() { var B = 1; B_1.target(); return B; } });`
+        ));
+        expect(bound.name).toBe("B_1");
+    });
+
+    test("ESM binds a module afresh where the import it would reuse is shadowed", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(rebind("sap/m/Button", bound));
+        await spec.rewriteRun(typescript(
+            `import Button from "sap/m/Button";\n\nfunction inner() { const Button = 1; target(); return Button; }`,
+            `import Button from "sap/m/Button";\nimport Button_1 from "sap/m/Button";\n\nfunction inner() { const Button = 1; Button_1.target(); return Button; }`
+        ));
+        expect(bound.name).toBe("Button_1");
+
+        // A `const` binds its whole block, so reaching the import ahead of one is a TDZ error
+        // rather than a reference to the module — the ordering of the two does not change that.
+        const declaredLater = new RecipeSpec();
+        declaredLater.recipe = fromVisitor(rebind("sap/m/Button", bound));
+        await declaredLater.rewriteRun(typescript(
+            `import Button from "sap/m/Button";\n\nfunction inner() { target(); const Button = 1; return Button; }`,
+            `import Button from "sap/m/Button";\nimport Button_1 from "sap/m/Button";\n\nfunction inner() { Button_1.target(); const Button = 1; return Button; }`
+        ));
+        expect(bound.name).toBe("Button_1");
+    });
+
+    test("ESM binds a member afresh where the specifier it would reuse is shadowed", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(rebind({module: "a/lib", member: "Widget"}, bound));
+        await spec.rewriteRun(typescript(
+            `import {Widget} from "a/lib";\n\nfunction inner() { const Widget = 1; target(); return Widget; }`,
+            `import {Widget, Widget as Widget_1} from "a/lib";\n\nfunction inner() { const Widget = 1; Widget_1.target(); return Widget; }`
+        ));
+        expect(bound.name).toBe("Widget_1");
     });
 
     test("ESM reuses a default import bound under another name", async () => {

--- a/rewrite-javascript/rewrite/test/javascript/scope.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/scope.test.ts
@@ -19,11 +19,13 @@ import {
     JavaScriptVisitor,
     JS,
     namesDeclaredIn,
+    namesInScope,
     Scope,
     scopeOf,
     sourceFileCache
 } from "../../src/javascript";
 import {J} from "../../src/java";
+import {Cursor} from "../../src/tree";
 
 const parser = new JavaScriptParser({sourceFileCache});
 
@@ -31,13 +33,13 @@ async function parse(source: string, sourcePath = 'test.ts'): Promise<JS.Compila
     return (await parser.parse({text: source, sourcePath}).next()).value as JS.CompilationUnit;
 }
 
-/** The scope where the source calls `anchor()`. */
-async function scopeAtAnchor(source: string, sourcePath?: string): Promise<Scope> {
-    const found: Scope[] = [];
+/** The position where the source calls `anchor()`. */
+async function cursorAtAnchor(source: string, sourcePath?: string): Promise<Cursor> {
+    const found: Cursor[] = [];
     await new class extends JavaScriptVisitor<undefined> {
         override async visitMethodInvocation(method: J.MethodInvocation, p: undefined): Promise<J | undefined> {
             if ((method.name as J.Identifier)?.simpleName === 'anchor') {
-                found.push(scopeOf(this.cursor));
+                found.push(this.cursor);
             }
             return super.visitMethodInvocation(method, p);
         }
@@ -46,8 +48,12 @@ async function scopeAtAnchor(source: string, sourcePath?: string): Promise<Scope
     return found[0];
 }
 
+async function scopeAtAnchor(source: string, sourcePath?: string): Promise<Scope> {
+    return scopeOf(await cursorAtAnchor(source, sourcePath));
+}
+
 async function namesAtAnchor(source: string, sourcePath?: string): Promise<string[]> {
-    return [...(await scopeAtAnchor(source, sourcePath)).names()].sort();
+    return [...namesInScope(await cursorAtAnchor(source, sourcePath))].sort();
 }
 
 describe('scopeOf', () => {
@@ -195,6 +201,25 @@ describe('scopeOf', () => {
         expect(scope.declares('merge')).toBe(true);
         expect(scope.declares('param')).toBe(true);
         expect(scope.declares('absent')).toBe(false);
+    });
+
+    test('declaringScope names the innermost scope binding a name, not merely one that does', async () => {
+        const shadowed = await scopeAtAnchor(
+            `import B from 'a/B';\nfunction inner() { { var B = 1; } anchor(); }`);
+        // A `var` reaches the whole function, so the function binds it, not the block holding it.
+        expect(shadowed.declaringScope('B')?.kind).toBe(J.Kind.MethodDeclaration);
+        expect(shadowed.declaringScope('absent')).toBeUndefined();
+
+        const reachable = await scopeAtAnchor(`import B from 'a/B';\nfunction inner() { anchor(); }`);
+        expect(reachable.declaringScope('B')?.kind).toBe(JS.Kind.CompilationUnit);
+    });
+
+    test('a var belongs to the function it sits in, a let to the block', async () => {
+        const hoisting = await scopeAtAnchor(`function f(p) { var p = 1; anchor(); }`);
+        expect(hoisting.declaringScope('p')?.kind).toBe(J.Kind.MethodDeclaration);
+
+        const blockScoped = await scopeAtAnchor(`function f(p) { let p = 1; anchor(); }`);
+        expect(blockScoped.declaringScope('p')?.kind).toBe(J.Kind.Block);
     });
 });
 


### PR DESCRIPTION
`maybeBind` reported an existing binding's local name without checking that the name still resolves to that binding where the caller will emit its reference:

```js
sap.ui.define(["a/B"], function (B) {
    function inner() { var B = 1; anchor(); return B; }
});
```

- `maybeBind(this, {module: "a/B"})` at `anchor()` returned `"B"`, so the caller emitted `B.someMethod()` — which reads the local `var`. The ESM lane had the same hole: `import Button from "sap/m/Button"` shadowed by a `const Button = 1` in an inner scope also answered `"Button"`. Not a regression; reuse has behaved this way since the API was written, and #8685 did not touch it.

## Why the scope utility could not answer it

Deconfliction only ever guarded *newly created* bindings. When an existing binding answers a request, nothing asked whether it was reachable — and `scopeOf` could not be asked. It reports which names are in scope, a membership test, and both the module binding and the shadow are in scope. Telling them apart needs which *declaration* a name resolves to at a cursor.

So `Scope` gains `declaringScope(name)`: the node owning the innermost scope that binds the name. A caller holding a declaration compares that against the node it came from, and anything nearer shadows it. The three reuse paths — `maybeBind`'s whole-module lookup, `bindImport`'s member loop, and `bindAmd` — fall through to create when it does not match. The create path already deconflicts against a name reachable at the cursor, so this removes a wrong early return rather than adding logic.

Creating rather than refusing is what `Template.resolveBindings` needs: it types the result `string` and splices it into code at the match site, so a refusal there emits a broken reference. The cost is a second import, or a second AMD dependency, in the rare shadowed case.

## Precision the frames did not have

Two cases where the guard fired although nothing was shadowed, both found in review:

A block claimed every name its statements declared, including a `var` — which belongs to the enclosing function. `function (B) { var B = B || {}; }`, an ordinary AMD idiom, therefore read as a shadow of the parameter rather than the same binding, and produced a duplicate dependency. A block now claims the complement of what `hoistedNames` claims.

`declaringScope(bound) === factory` can only hold where the factory is an ancestor of the cursor, so a recipe positioned on the `define` call itself, or on its dependency array, always failed it. The AMD lane now asks the question only where the factory encloses the cursor; elsewhere no parameter is in scope for anything to shadow.

## Scope is lookup-only

- `declares` is `declaringScope(name) !== undefined`, an early-exit walk, so neither method materialises a set. Enumeration moved to a free `namesInScope(cursor)`, which had no caller outside tests. **This breaks `Scope.names()`**, published in #8686 — `namesInScope` takes a `Cursor`, so it is not a drop-in for code holding a `Scope`.

Frame bindings are memoised per node, which the two parent-dependent cases had to move out of to make sound. Across 150 lookup sites on a file of 180 top-level statements a `declares` lookup went from 16.5 ms to 0.4 ms per pass, though scope lookup was never the bottleneck next to parsing.

## Tests

`scope.test.ts` covers the primitive directly: innermost-wins, an unbound name, and the `var`/`let` split. `binding.test.ts` covers each reuse path through emitted source — module and member requests on ESM, parameter reuse on AMD — plus the two regressions above and the refusal where a declared dependency's parameter is not a plain identifier. The ESM test asserts both orderings of the shadowing declaration, since a `const` *after* the cursor is a TDZ error rather than a reference to the module, so position filtering would be wrong here. Both regression fixes were mutation-checked.

## Not fixed here

`maybeRebind` still reports a shadowed name. That is its contract rather than an oversight: it answers with the name its binding already carries, which is what keeps existing references resolving, and its only caller reads the result as a boolean from the compilation unit — refusing would disable valid rebinds. Separately, `RemoveAmdDependency` removes only the first matching pair, so a duplicate dependency this can now create is not reversible through `maybeUnbind`; that is a pre-existing limit which shadowing newly makes reachable.
