### PR TITLE
JavaScript: a `with` statement no longer fails the whole TypeScript file

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -385,6 +385,7 @@ const additionalCriticalCodes = new Set([
 const excludedCodes = new Set([
     1039, // Initializers are not allowed in ambient contexts.
     1064, // The return type of an async function or method must be the global Promise<T> type. Did you mean to write 'Promise<{0}>'?
+    1101, // 'with' statements are not allowed in strict mode.
     1107, // Jump target cannot cross function boundary.
     1111, // Private field '{0}' must be declared in an enclosing class.
     1117, // An object literal cannot have multiple properties with the same name.

--- a/rewrite-javascript/rewrite/test/javascript/parser/with.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/with.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {RecipeSpec} from "../../../src/test";
-import {javascript} from "../../../src/javascript";
+import {javascript, typescript} from "../../../src/javascript";
 
 describe('with mapping', () => {
     const spec = new RecipeSpec();
@@ -51,6 +51,18 @@ describe('with mapping', () => {
                 } catch (e) {
                 }
             `)
+        ));
+
+    // TypeScript reports `with` as a strict-mode error, which says the code is illegal there
+    // rather than unrepresentable, so the parser maps it like any other statement.
+    test('with statement in a TypeScript source', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript(`
+                 with (0) {
+                     console.log("aaa");
+                 }
+             `)
         ));
 
     test('with statement with empty body', () =>


### PR DESCRIPTION
`main` is red: `control-parentheses-capture.test.ts > with expression` fails, and with it every PR opened against it.

The parser was yielding a `ParseError` rather than a compilation unit for any `.ts` or `.tsx` source containing a `with` statement. `isCriticalDiagnostic` treats every TypeScript diagnostic between 1000 and 2000 as fatal unless explicitly excluded, and `with` in a strict-mode file raises 1101, `'with' statements are not allowed in strict mode`:

```
code=1101 category=Error :: 'with' statements are not allowed in strict mode.
code=2410 category=Error :: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
```

The second is already ignored for being above 2000. The first is the same kind of complaint: it says the statement is illegal *where it sits*, not that it cannot be represented. TypeScript still returns a complete AST (`statements=1, parseDiagnostics=0` for TS, TSX and JSX alike), and `visitWithStatement` already maps it — a `.js` path with identical source parses to a `JS$WithStatement` today. So 1101 joins 1212, 1215 and 1250–1252 in `excludedCodes`, which are excluded for exactly this reason.

The templating engine parses every pattern as `template.tsx` (`engine.ts:179`), so the failure reached patterns too: ``pattern`with (${capture()}) { a(); }` `` produced `Failed to parse pattern code (no statements)`.

## Why neither PR's CI caught it

- #8692 merged at 10:47:56Z and added the `with` capture test. #8689 upgraded to TypeScript 6.0.3 and merged at 11:15:24Z, 28 minutes later, but its branch was never rebased — `control-parentheses-capture.test.ts` returns a 404 at #8689's head SHA. So #8689 ran green against a base where the test did not exist, and #8692 ran green on TypeScript 5.8.3. Confirmed by bisection: at `2854fa5f4e` the file passes 12/12 on 5.8.3, and at `be9e2839ba` it fails on 6.0.3.

## Tests

Every existing test in `with.test.ts` uses `javascript()`, the path that was never affected, so the TypeScript path had no coverage — which is what let this through. One `typescript()` case added there, in the file a reader would look in; without the exclusion it fails with `Compiler error(s): (2,18): 'with' statements are not allowed in strict mode. [1101]`.

Full suite green: 185 files, 2148 passed.
