### PR TITLE
JS AMD: a bare arrow keeps its space before `=>` when it gains parens

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/amd.ts
+++ b/rewrite-javascript/rewrite/src/javascript/amd.ts
@@ -374,17 +374,19 @@ function withParameters(
 }
 
 /**
- * A bare arrow parameter has no closing delimiter of its own — the space before `=>` sits on
- * the parameter itself. Wrapping it in parens turns that into the space before the new `)`,
- * so it has to move to `arrow` instead, where it will actually print before `=>` again.
+ * A bare arrow parameter has no closing delimiter of its own — the space before `=>` is the
+ * parameter's trailing padding, so parenthesizing moves its whitespace to `arrow` and leaves any
+ * comment with the parameter. The padding comes from the original list, since `elements` stands
+ * in for an emptied list with a placeholder that carries none.
  */
 function parenthesize(lambda: J.Lambda, elements: J.RightPadded<J>[]): J.Lambda {
+    const original = normalizeArrowParameters(lambda.parameters.parameters);
+    const trailing = original[original.length - 1]?.after ?? lambda.arrow;
     const last = elements[elements.length - 1];
-    const arrowSpace = last.after.whitespace === "" ? lambda.arrow : last.after;
     return {
         ...lambda,
         parameters: {...lambda.parameters, parenthesized: true, parameters: [...elements.slice(0, -1), {...last, after: emptySpace}]},
-        arrow: arrowSpace
+        arrow: space(trailing.whitespace)
     };
 }
 

--- a/rewrite-javascript/rewrite/test/javascript/amd.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/amd.test.ts
@@ -128,6 +128,15 @@ describe("withDependency", () => {
         ));
     });
 
+    test("a comment before a bare arrow stays with the parameter it followed as parens go on", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(addDependency("c/D", "D"));
+        await spec.rewriteRun(javascript(
+            `sap.ui.define(["a/B"], B /*x*/ => {});`,
+            `sap.ui.define(["a/B", "c/D"], (B /*x*/ , D) => {});`
+        ));
+    });
+
     test("refuses when the factory already binds fewer parameters than there are dependencies", async () => {
         const call = await firstCall(`define(["a/B", "jquery"], function (B) {});`);
         const block = amdBlockOf(call)!;
@@ -211,6 +220,24 @@ describe("withoutDependencyAt", () => {
             }
         };
     }
+
+    test("removing the only parameter of an unparenthesized arrow keeps the space before the arrow", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(removeFirstDependency());
+        await spec.rewriteRun(javascript(
+            `sap.ui.define(["a/B"], B => {});`,
+            `sap.ui.define([], () => {});`
+        ));
+    });
+
+    test("removing the only parameter of a parenthesized arrow leaves its parens and arrow alone", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(removeFirstDependency());
+        await spec.rewriteRun(javascript(
+            `sap.ui.define(["a/B"], (B) => {});`,
+            `sap.ui.define([], () => {});`
+        ));
+    });
 
     test("removing the first entry moves no comment onto the survivor and drops none of its own", async () => {
         const relabeled = new RecipeSpec();


### PR DESCRIPTION
`withoutDependencyAt` drops the space before `=>` whenever it has to parenthesize a factory written as a bare arrow parameter. Reported from moderneinc/recipes-javascript, which migrated `recipes-ui5/src/amd.ts` onto these primitives and is carrying a local workaround (`spacedArrow`) until this lands:

```
sap.ui.define(["x"], x => {});   ->   sap.ui.define([], ()=> {});
```

`(x) => {}` and `function (x) {}` both come out right, so only the unparenthesized single-parameter shape is affected.

## Mechanism

Emptying the parameter list sends `withParameters` through `parenthesize`, which read the space before `=>` from two places that are both empty for this shape. `elements` is the *replacement* list, and `withParameters` has already substituted `[rightPadded(emptyExpression(), emptySpace)]` for the now-empty one, so `last.after` is empty by construction. The fallback `lambda.arrow` is empty too — the parser splits that space by shape, and a probe of both confirms it:

| source | `lambda.arrow` | parameter's trailing padding |
|---|---|---|
| `B => {}` | `""` | `" "` (on `variables[0].after`, inside the `J.VariableDeclarations` wrapper) |
| `(B) => {}` | `" "` | `""` |

So `parenthesize` was reaching for the arrow space on the one shape where it never sits on `arrow`.

## The fix

The space now comes from the original parameter list, read through `normalizeArrowParameters` — the module's existing reader, which already lifts a bare arrow's padding out of the `J.VariableDeclarations` wrapper onto the list entry. Reading the original rather than `elements` covers both callers with one line: emptying the list replaces the padding with a placeholder, and appending relocates it onto the new last entry, where it is the same value.

Only the whitespace moves. Copying the whole `J.Space` would print a comment twice, since `appendEntry`/`splitTrailingComments` deliberately leave it on the parameter it follows — `sap.ui.define(["a/B"], B /*x*/ => {})` gaining a dependency would come out as `(B /*x*/ , D) /*x*/ => {}`. Dropping the comment on the removal path instead matches what `leadingWhitespaceOf` already does to a removed dependency's comments.

The original spacing is preserved rather than normalized to one space, so `x=>{}` still yields `()=>{}`.

## Scope

The addition path is not affected, contrary to the initial report. `withDependency` on `sap.ui.define([], x => {})` refuses outright — one parameter against zero dependencies trips the pairing guard before `withParameters` is reached — and `sap.ui.define(["a/B"], B => {})` already yields `(B, D) => {}` (existing test, `amd.test.ts:122`). The `parameters.length === 1` early return is unreachable for an unparenthesized lambda: appending makes two parameters, removing makes zero.

## Tests

Three in `amd.test.ts`, each mutation-checked by reverting the line it pins: the bare arrow keeping its space on removal (the reported bug), a comment before a bare arrow staying with its parameter as parens go on (fails with the whole `J.Space` copied), and a parenthesized arrow's removal leaving its `arrow` untouched (fails if the read is hoisted into `withParameters` for both lanes). No fourth test for the function-expression shape — three existing removal tests already cover it.