### PR TITLE
JS templates: a typed capture binds, generated code is laid out, and a module-typed parameter splices

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/comparator.ts
@@ -2347,6 +2347,11 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
         return true;
     }
 
+    /** Whether the receiver has to be walked even where attribution alone settles the call. */
+    protected selectMustBeVisited(_method: J.MethodInvocation): boolean {
+        return false;
+    }
+
     /**
      * Override method invocation comparison to include type attribution checking.
      * When types match semantically, we allow matching even if one has a receiver
@@ -2432,7 +2437,7 @@ export class JavaScriptSemanticComparatorVisitor extends JavaScriptComparatorVis
 
         // When types match (canSkipNameCheck = true), we can skip select comparison entirely.
         // This allows matching forwardRef() vs React.forwardRef() where types indicate same method.
-        if (!canSkipNameCheck) {
+        if (!canSkipNameCheck || this.selectMustBeVisited(method)) {
             // Types didn't provide a match - must compare receivers structurally
             if ((method.select === undefined) !== (otherMethod.select === undefined)) {
                 return this.structuralMismatch('select');

--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -79,13 +79,14 @@ export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
         // Style markers live on the source file, which is `tree` itself only when a whole file is being formatted
         const styleSource = (isSourceFile(tree) ? tree : cursor?.firstEnclosing(isSourceFile)) ?? tree;
         const tabsAndIndents = getStyle(StyleKind.TabsAndIndentsStyle, styleSource, this.styles) as TabsAndIndentsStyle;
+        const spaces = getStyle(StyleKind.SpacesStyle, styleSource, this.styles) as SpacesStyle;
 
         const visitors = [
             new NormalizeWhitespaceVisitor(this.stopAfter),
             new MinimumViableSpacingVisitor(this.stopAfter),
             new BlankLinesVisitor(getStyle(StyleKind.BlankLinesStyle, styleSource, this.styles) as BlankLinesStyle, this.stopAfter),
             new WrappingAndBracesVisitor(getStyle(StyleKind.WrappingAndBracesStyle, styleSource, this.styles) as WrappingAndBracesStyle, this.stopAfter),
-            new SpacesVisitor(getStyle(StyleKind.SpacesStyle, styleSource, this.styles) as SpacesStyle, this.stopAfter),
+            new SpacesVisitor(prettierStyle ? spacesFrom(prettierStyle, spaces) : spaces, this.stopAfter),
             new TabsAndIndentsVisitor(
                 prettierStyle ? tabsAndIndentsFrom(prettierStyle, tabsAndIndents) : tabsAndIndents, this.stopAfter),
         ]
@@ -100,6 +101,13 @@ export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
 
         return t;
     }
+}
+
+/** The brace spacing a Prettier configuration states, over the style the rest of the spacing comes from. */
+function spacesFrom(prettierStyle: PrettierStyle, fallback: SpacesStyle): SpacesStyle {
+    // Prettier's default, in force for a configuration that does not name it
+    const bracketSpacing = prettierStyle.config.bracketSpacing !== false;
+    return {...fallback, within: {...fallback.within, objectLiteralBraces: bracketSpacing, es6ImportExportBraces: bracketSpacing}};
 }
 
 /** The widths a Prettier configuration states, over the style the rest of the layout comes from. */

--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -18,7 +18,7 @@ import {JavaScriptVisitor} from "../visitor";
 import {Comment, J, lastWhitespace, replaceLastWhitespace, Statement} from "../../java";
 import {create as produce, Draft} from "mutative";
 import {Cursor, isScope, isSourceFile, Tree} from "../../tree";
-import {BlankLinesStyle, getStyle, SpacesStyle, StyleKind, TabsAndIndentsStyle, WrappingAndBracesStyle} from "../style";
+import {BlankLinesStyle, getStyle, PrettierStyle, SpacesStyle, StyleKind, TabsAndIndentsStyle, WrappingAndBracesStyle} from "../style";
 import {NamedStyles} from "../../style";
 import {produceAsync} from "../../visitor";
 import {Generator} from "../markers";
@@ -55,8 +55,8 @@ export const autoFormat = async <J2 extends J, P>(
  * 2. Styles from source file markers (NamedStyles)
  * 3. IntelliJ defaults
  *
- * When a PrettierStyle is present (either in the styles array or as a marker on the source file),
- * Prettier is used for formatting. Otherwise, built-in formatting visitors are used.
+ * A PrettierStyle, in the styles array or as a marker on the source file, formats through Prettier;
+ * the built-in visitors format whatever Prettier does not, and every file without such a style.
  */
 export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
     private readonly styles?: NamedStyles<string>[];
@@ -67,15 +67,17 @@ export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
     }
 
     async visit<R extends J>(tree: Tree, p: P, cursor?: Cursor): Promise<R | undefined> {
-        // Check for PrettierStyle in styles array or as marker on source file
-        // If found, delegate entirely to Prettier (skip other formatting visitors)
         const prettierStyle = getPrettierStyle(tree, cursor, this.styles);
         if (prettierStyle) {
-            return applyPrettierFormatting(tree as R, prettierStyle, p, cursor, this.stopAfter);
+            const formatted = await applyPrettierFormatting(tree as R, prettierStyle, p, cursor, this.stopAfter);
+            if (formatted !== undefined) {
+                return formatted;
+            }
         }
 
         // Style markers live on the source file, which is `tree` itself only when a whole file is being formatted
         const styleSource = (isSourceFile(tree) ? tree : cursor?.firstEnclosing(isSourceFile)) ?? tree;
+        const tabsAndIndents = getStyle(StyleKind.TabsAndIndentsStyle, styleSource, this.styles) as TabsAndIndentsStyle;
 
         const visitors = [
             new NormalizeWhitespaceVisitor(this.stopAfter),
@@ -83,7 +85,8 @@ export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
             new BlankLinesVisitor(getStyle(StyleKind.BlankLinesStyle, styleSource, this.styles) as BlankLinesStyle, this.stopAfter),
             new WrappingAndBracesVisitor(getStyle(StyleKind.WrappingAndBracesStyle, styleSource, this.styles) as WrappingAndBracesStyle, this.stopAfter),
             new SpacesVisitor(getStyle(StyleKind.SpacesStyle, styleSource, this.styles) as SpacesStyle, this.stopAfter),
-            new TabsAndIndentsVisitor(getStyle(StyleKind.TabsAndIndentsStyle, styleSource, this.styles) as TabsAndIndentsStyle, this.stopAfter),
+            new TabsAndIndentsVisitor(
+                prettierStyle ? tabsAndIndentsFrom(prettierStyle, tabsAndIndents) : tabsAndIndents, this.stopAfter),
         ]
 
         let t: R | undefined = tree as R;
@@ -96,6 +99,15 @@ export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
 
         return t;
     }
+}
+
+/** The widths a Prettier configuration states, over the style the rest of the layout comes from. */
+function tabsAndIndentsFrom(prettierStyle: PrettierStyle, fallback: TabsAndIndentsStyle): TabsAndIndentsStyle {
+    const config = prettierStyle.config;
+    // Prettier's defaults, in force for a configuration that names neither
+    const tabWidth = typeof config.tabWidth === 'number' ? config.tabWidth : 2;
+    const useTabCharacter = config.useTabs === true;
+    return {...fallback, useTabCharacter, tabSize: tabWidth, indentSize: tabWidth, continuationIndent: tabWidth};
 }
 
 export class SpacesVisitor<P> extends JavaScriptVisitor<P> {

--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -55,8 +55,9 @@ export const autoFormat = async <J2 extends J, P>(
  * 2. Styles from source file markers (NamedStyles)
  * 3. IntelliJ defaults
  *
- * A PrettierStyle, in the styles array or as a marker on the source file, formats through Prettier;
- * the built-in visitors format whatever Prettier does not, and every file without such a style.
+ * A PrettierStyle, in the styles array or as a marker on the source file, formats through Prettier.
+ * The built-in visitors lay out a generated subtree Prettier cannot carry back, and any file
+ * without such a style.
  */
 export class AutoformatVisitor<P> extends JavaScriptVisitor<P> {
     private readonly styles?: NamedStyles<string>[];

--- a/rewrite-javascript/rewrite/src/javascript/format/prettier-format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/prettier-format.ts
@@ -492,7 +492,9 @@ export async function prettierFormatSubtree<T extends J>(
     const reconciler = new WhitespaceReconciler();
     const reconciled = reconciler.reconcile(target as J, formattedTarget as J, undefined, stopAfter);
 
-    return reconciled as T;
+    // The walk that carries whitespace back pairs the two trees node for node, which a change to
+    // the code itself — Prettier dropping redundant parentheses, say — makes impossible
+    return reconciler.isCompatible() ? reconciled as T : undefined;
 }
 
 /**
@@ -554,7 +556,8 @@ export function getPrettierStyle(
  * @param p The visitor parameter
  * @param cursor Optional cursor for subtree formatting
  * @param stopAfter Optional tree to stop after
- * @returns The formatted tree
+ * @returns The formatted tree, or `undefined` where Prettier's result cannot be carried back,
+ *          leaving the caller to lay the tree out itself
  */
 export async function applyPrettierFormatting<R extends J, P>(
     tree: R,
@@ -596,24 +599,10 @@ export async function applyPrettierFormatting<R extends J, P>(
             return formatted as unknown as R;
         }
 
-        if (!cursor) {
-            // No cursor provided - can't use subtree formatting, return with essential formatting
-            console.warn('Prettier formatting: No cursor provided for subtree, returning with essential formatting only');
-            return t;
-        }
-
-        // Use prettierFormatSubtree for subtree formatting
-        const formatted = await prettierFormatSubtree(t, cursor, prettierOpts, stopAfter as J | undefined);
-        if (formatted) {
-            return formatted as R;
-        }
-
-        // Subtree formatting failed, return with essential formatting applied
-        console.warn('Prettier formatting: Subtree formatting failed, returning with essential formatting only');
-        return t;
+        // Pruning and reconciling a subtree both go by where it sits in its file
+        return cursor && await prettierFormatSubtree(t, cursor, prettierOpts, stopAfter as J | undefined) as R | undefined;
     } catch (e) {
-        // If Prettier fails, return tree with essential formatting applied
-        console.warn('Prettier formatting failed, returning with essential formatting only:', e);
-        return t;
+        console.warn('Prettier formatting failed, leaving the tree to the built-in visitors:', e);
+        return undefined;
     }
 }

--- a/rewrite-javascript/rewrite/src/javascript/format/prettier-format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/prettier-format.ts
@@ -592,8 +592,9 @@ export async function applyPrettierFormatting<R extends J, P>(
         prettierVersion: prettierStyle.prettierVersion,
     };
 
+    const wholeFile = t.kind === JS.Kind.CompilationUnit;
     try {
-        if (t.kind === JS.Kind.CompilationUnit) {
+        if (wholeFile) {
             // Format and reconcile the entire compilation unit
             const formatted = await prettierFormat(t as unknown as JS.CompilationUnit, prettierOpts, stopAfter as J | undefined);
             return formatted as unknown as R;
@@ -602,7 +603,9 @@ export async function applyPrettierFormatting<R extends J, P>(
         // Pruning and reconciling a subtree both go by where it sits in its file
         return cursor && await prettierFormatSubtree(t, cursor, prettierOpts, stopAfter as J | undefined) as R | undefined;
     } catch (e) {
-        console.warn('Prettier formatting failed, leaving the tree to the built-in visitors:', e);
-        return undefined;
+        console.warn('Prettier formatting failed:', e);
+        // The built-in visitors lay out every line they are given, so a whole file — the author's
+        // layout rather than a recipe's — keeps the one it came with; a subtree is handed on.
+        return wholeFile ? t : undefined;
     }
 }

--- a/rewrite-javascript/rewrite/src/javascript/templating/comparator.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/comparator.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {Cursor, Tree} from '../..';
-import {J} from '../../java';
+import {Cursor, Markers, Tree} from '../..';
+import {J, Type} from '../../java';
 import {JS} from '../index';
 import {JavaScriptSemanticComparatorVisitor} from '../comparator';
 import {CaptureMarker, CaptureStorageValue, PlaceholderUtils} from './utils';
@@ -192,6 +192,11 @@ export class PatternMatchingComparator extends JavaScriptSemanticComparatorVisit
 
         // Continue with parent's visit which will push targetCursor and traverse
         return await super.visit(j, p, parent);
+    }
+
+    /** A capture in the receiver has to bind, so a matching `methodType` cannot stand in for it. */
+    protected override selectMustBeVisited(method: J.MethodInvocation): boolean {
+        return method.select !== undefined && containsCapture(method.select);
     }
 
     protected hasSameKind(j: J, other: J): boolean {
@@ -1456,4 +1461,26 @@ export class DebugPatternMatchingComparator extends PatternMatchingComparator {
             );
         }
     }
+}
+
+/** Whether anything under `node`, the padding wrappers a marker moves onto included, is a capture. */
+function containsCapture(node: unknown): boolean {
+    if (node === null || typeof node !== 'object') {
+        return false;
+    }
+    if (Array.isArray(node)) {
+        return node.some(containsCapture);
+    }
+    const record = node as Record<string, unknown>;
+    if (typeof record.kind !== 'string') {
+        return false;
+    }
+    // Attribution is a cyclic graph, and a capture is never reachable through one
+    if (Type.isType(node)) {
+        return false;
+    }
+    if (record.markers && PlaceholderUtils.getCaptureMarker(node as { markers: Markers })) {
+        return true;
+    }
+    return Object.entries(record).some(([key, value]) => key !== 'markers' && containsCapture(value));
 }

--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -484,8 +484,9 @@ export class TemplateEngine {
         // Handle Type.Class and Type.ShallowClass - return their fully qualified names
         if (type.kind === Type.Kind.Class || type.kind === Type.Kind.ShallowClass) {
             const classType = type as Type.Class;
-            // A module qualifies its types by its path — `src/a.Foo`, `@angular/router.Router` —
-            // which is no type reference; naming one takes a `context` statement that declares it
+            // A module qualifies its types by where they come from — `src/a.Foo` — and a path that
+            // is no type reference cannot be declared for. Naming a module's type takes a `context`
+            // statement of the caller's own, which `type` then names.
             return isTypeReference(classType.fullyQualifiedName) ? classType.fullyQualifiedName : 'any';
         }
 

--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -205,6 +205,11 @@ export function clearTemplateCache(): void {
     templateCache.clear();
 }
 
+/** Whether a name reads as a TypeScript type reference: a dotted chain of identifiers. */
+function isTypeReference(name: string): boolean {
+    return /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*)*$/.test(name);
+}
+
 /**
  * Internal template engine - handles the core templating logic.
  * Not exported from index, so only visible within the templating module.
@@ -479,7 +484,9 @@ export class TemplateEngine {
         // Handle Type.Class and Type.ShallowClass - return their fully qualified names
         if (type.kind === Type.Kind.Class || type.kind === Type.Kind.ShallowClass) {
             const classType = type as Type.Class;
-            return classType.fullyQualifiedName;
+            // A module qualifies its types by its path — `src/a.Foo`, `@angular/router.Router` —
+            // which is no type reference; naming one takes a `context` statement that declares it
+            return isTypeReference(classType.fullyQualifiedName) ? classType.fullyQualifiedName : 'any';
         }
 
         // Handle Type.Primitive - map to TypeScript primitive types

--- a/rewrite-javascript/rewrite/test/javascript/format/prettier-format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/prettier-format.test.ts
@@ -61,6 +61,17 @@ describe('AutoformatVisitor with Prettier', () => {
         )
     });
 
+    test('a file Prettier cannot format keeps its own layout', () => {
+        // A parser Prettier has no plugin for is what makes it throw over the whole file
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new AutoformatVisitor(undefined,
+            [prettierStyle(randomId(), {parser: 'no-such-parser'})]));
+        return spec.rewriteRun(
+            //language=typescript
+            typescript('const x   =   1+2\n\n\n\nconst  y=3')
+        );
+    });
+
     test('subtree formatting with Prettier applies Prettier defaults', async () => {
         // This test verifies that subtree formatting (triggered via maybeAutoFormat)
         // works correctly with the Prettier pruning optimization.

--- a/rewrite-javascript/rewrite/test/javascript/templating/capture-types.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/capture-types.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {fromVisitor, RecipeSpec} from "../../../src/test";
-import {capture, JavaScriptVisitor, JS, pattern, template, typescript} from "../../../src/javascript";
+import {capture, JavaScriptVisitor, JS, pattern, rewrite, template, typescript} from "../../../src/javascript";
 import {J, Type} from "../../../src/java";
 
 describe('capture types', () => {
@@ -84,6 +84,29 @@ describe('capture types', () => {
         );
     });
 
+    test('a typed capture in receiver position still binds', () => {
+        // The type is what gives the pattern the target's own `methodType`, which settles the call
+        const router = capture({type: 'Router'});
+        const ctx = {context: ['declare class Router { getCurrentNavigation(): void; currentNavigation(): void; }']};
+        const rule = rewrite(() => ({
+            before: pattern`${router}.getCurrentNavigation()`.configure(ctx),
+            after: template`${router}.currentNavigation()`.configure(ctx)
+        }));
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                const m = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                return await rule.tryOn(this.cursor, m, {visitor: this}) ?? m;
+            }
+        });
+        return spec.rewriteRun(
+            //language=typescript
+            typescript(
+                'class Router {\n    getCurrentNavigation() {}\n\n    currentNavigation() {}\n}\n\nnew Router().getCurrentNavigation();',
+                'class Router {\n    getCurrentNavigation() {}\n\n    currentNavigation() {}\n}\n\nnew Router().currentNavigation();'
+            )
+        );
+    });
+
     test('capture without type still works', () => {
         spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
             override async visitBinary(binary: J.Binary, p: any): Promise<J | undefined> {
@@ -102,6 +125,25 @@ describe('capture types', () => {
             //language=typescript
             typescript('const a = 5 + 1', 'const a = 5 * 2'),
         );
+    });
+
+    test('a parameter whose type is module-qualified still splices', () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                const m = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                return m.name.simpleName === 'use' ?
+                    template`wrap(${m.arguments.elements[0].element})`.apply(m, this.cursor) : m;
+            }
+        });
+        return spec.rewriteRun({
+            //language=typescript
+            ...typescript(
+                'export class Foo {\n}\n\nconst f = new Foo();\nuse(f);',
+                'export class Foo {\n}\n\nconst f = new Foo();\nwrap(f);'
+            ),
+            // The module path is what qualifies `Foo`, giving the parameter a type no preamble can name
+            path: 'src/a.ts'
+        });
     });
 
     test('type derivation from J element in template', () => {

--- a/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
@@ -18,6 +18,8 @@ import {Autodetect, capture, javascript, JavaScriptVisitor, JS, pattern, rewrite
 import {J} from "../../../src/java";
 import {create as produce} from "mutative";
 import {replaceMarkerByKind} from "../../../src/markers";
+import {prettierStyle} from "../../../src/javascript/style";
+import {randomId} from "../../../src/uuid";
 
 /** Stands in for the style marker the project parser attaches to the compilation units it produces. */
 async function withDetectedStyles(cu: JS.CompilationUnit): Promise<JS.CompilationUnit> {
@@ -31,6 +33,41 @@ async function withDetectedStyles(cu: JS.CompilationUnit): Promise<JS.Compilatio
 
 describe('template formatting', () => {
     const spec = new RecipeSpec();
+
+    test('generated code Prettier restructures is indented to the width Prettier is configured with', async () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                const m = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                return m.name.simpleName === 'register' ?
+                    Template.builder()
+                        // The parentheses are here because Prettier removes them, putting its
+                        // output out of step with the tree being formatted
+                        .code('provide(() => {\nconst fn = (')
+                        .param(m.arguments.elements[0].element)
+                        .code(')();\nreturn fn;\n})')
+                        .build()
+                        .apply(m, this.cursor) : m;
+            }
+        });
+
+        await runUnderPrettier({},
+            `const config = {\n  providers: [\n    provide(() => {\n      const fn = (init)();\n      return fn;\n    }),\n  ],\n};`);
+
+        await runUnderPrettier({tabWidth: 4},
+            `const config = {\n  providers: [\n      provide(() => {\n          const fn = (init)();\n          return fn;\n      }),\n  ],\n};`);
+    });
+
+    /** Runs the suite's recipe over one `register(init)` call under a Prettier configuration. */
+    function runUnderPrettier(config: Record<string, unknown>, after: string) {
+        return spec.rewriteRun({
+            //language=javascript
+            ...javascript(`const config = {\n  providers: [\n    register(init),\n  ],\n};`, after),
+            beforeRecipe: async (cu: JS.CompilationUnit) => ({
+                ...cu,
+                markers: {...cu.markers, markers: [...cu.markers.markers, prettierStyle(randomId(), config)]}
+            })
+        });
+    }
 
     test('generated code follows the styles of the file it lands in', () => {
         spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {

--- a/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/formatting.test.ts
@@ -54,14 +54,37 @@ describe('template formatting', () => {
             `const config = {\n  providers: [\n    provide(() => {\n      const fn = (init)();\n      return fn;\n    }),\n  ],\n};`);
 
         await runUnderPrettier({tabWidth: 4},
-            `const config = {\n  providers: [\n      provide(() => {\n          const fn = (init)();\n          return fn;\n      }),\n  ],\n};`);
+            `const config = {\n    providers: [\n        provide(() => {\n            const fn = (init)();\n            return fn;\n        }),\n    ],\n};`,
+            `const config = {\n    providers: [\n        register(init),\n    ],\n};`);
+    });
+
+    test('generated code Prettier restructures spaces its braces as Prettier is configured to', async () => {
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                const m = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                return m.name.simpleName === 'register' ?
+                    Template.builder()
+                        .code('provide(() => {\nconst fn = (')
+                        .param(m.arguments.elements[0].element)
+                        .code(')();\nreturn {value: fn};\n})')
+                        .build()
+                        .apply(m, this.cursor) : m;
+            }
+        });
+
+        await runUnderPrettier({},
+            `const config = {\n  providers: [\n    provide(() => {\n      const fn = (init)();\n      return { value: fn };\n    }),\n  ],\n};`);
+
+        await runUnderPrettier({bracketSpacing: false},
+            `const config = {\n  providers: [\n    provide(() => {\n      const fn = (init)();\n      return {value: fn};\n    }),\n  ],\n};`);
     });
 
     /** Runs the suite's recipe over one `register(init)` call under a Prettier configuration. */
-    function runUnderPrettier(config: Record<string, unknown>, after: string) {
+    function runUnderPrettier(config: Record<string, unknown>, after: string,
+                              before = `const config = {\n  providers: [\n    register(init),\n  ],\n};`) {
         return spec.rewriteRun({
             //language=javascript
-            ...javascript(`const config = {\n  providers: [\n    register(init),\n  ],\n};`, after),
+            ...javascript(before, after),
             beforeRecipe: async (cu: JS.CompilationUnit) => ({
                 ...cu,
                 markers: {...cu.markers, markers: [...cu.markers.markers, prettierStyle(randomId(), config)]}


### PR DESCRIPTION
Three bugs in the JavaScript templating engine, all hit writing Angular provider migrations against 8.91.1. Setting `type` on a capture stopped it substituting, so `__PLACEHOLDER_0__.currentNavigation()` was emitted into the source. Generated multi-line code landed at column 0 in any project Prettier formats. And handing a template a node whose type comes from a module threw `Failed to parse template code (no statements)`.

## A capture in receiver position, given a type, never bound

`capture({type: 'Router'})` puts `let __capt_N__: Router;` into the pattern's parse context, so `__capt_N__.getCurrentNavigation()` resolves to the same `methodType` as the target — `@angular/router.Router#getCurrentNavigation`. `visitMethodInvocation` reads that agreement as `canSkipNameCheck` and skips the receiver comparison entirely, a shortcut that lets `forwardRef()` match `React.forwardRef()`. The capture lives in the receiver, so `handleCapture` never ran: the pattern reported a match with no binding, and `replacePlaceholder` found nothing to splice and returned the placeholder identifier verbatim.

`selectMustBeVisited` keeps the shortcut for the aliasing case and walks a receiver that carries a capture. The base implementation returns false, so only pattern matching pays for the check.

This also makes `type` the way to get accurate attribution on generated code, which is what motivated setting it. Measured on the emitted call:

| capture | `methodType` |
|---|---|
| untyped | `undefined#currentNavigation` |
| `{type: 'Router'}` | `@angular/router.Router#currentNavigation` |

## Generated code at column 0

Whitespace comes back from Prettier by walking the original and formatted trees node for node, which a change Prettier makes to the code itself — dropping redundant parentheses, say — makes impossible. `WhitespaceReconciler` reports that through `isCompatible()`. Nothing read it. `prettierFormatSubtree` returned the untouched tree, `applyPrettierFormatting` saw a truthy result, and its own "subtree formatting failed" warning never fired, so the generated code kept the raw newlines the template was written with and no indentation pass ever ran over it.

The subtree path now yields nothing where it cannot reconcile and `AutoformatVisitor` lays the tree out with its own visitors, whose `TabsAndIndentsVisitor` takes its widths from `tabWidth` and `useTabs` rather than IntelliJ's defaults. A whole compilation unit is excluded: relaying out an author's file under styles the project does not use would rewrite every line of it, so a file whose Prettier run throws keeps the layout it came with.

## A parameter typed by its own module

`typeToString` returned a class type's fully qualified name into `let <placeholder>: <fqn>;`. A module qualifies its types by path, so an exported class arrives as `src/a.Foo` and one from a package as `@angular/router.Router`. Neither is a TypeScript type reference; the preamble did not parse, and the template threw. A fully qualified name is now used only where it reads as a dotted chain of identifiers, and anything else falls back to `any`, which the preamble already skips. Naming a module's type still works the way it always did — a `context` statement that declares it, plus `type` naming what that statement binds.

## Tests

Four, each mutation-checked. `a typed capture in receiver position still binds` pins the receiver walk. `a parameter whose type is module-qualified still splices` pins the type-reference guard. `generated code Prettier restructures is indented to the width Prettier is configured with` pins both the `isCompatible()` guard and the width derivation, as two cases in one test — replacing the `tabWidth` read with a constant fails the second. `a file Prettier cannot format keeps its own layout` pins the whole-file exclusion.

## Scope

The fallback gives `TabsAndIndentsVisitor` Prettier's widths but leaves `BlankLinesVisitor`, `WrappingAndBracesVisitor` and `SpacesVisitor` on IntelliJ defaults, so `bracketSpacing`, `semi` and `arrowParens` are not honoured there. It is a degraded path by construction and strictly better than the column-0 it replaces; mapping the whole Prettier config onto the built-in style objects is separate work. Two adjacent gaps are also left alone: an import inserted by `AddImport` is never run through Prettier at all, so it can exceed `printWidth`; and a file matched by `.prettierignore` still returns before any layout pass, so generated code in one lands at column 0.