### PR TITLE
JavaScript: a template's removed `bindings` option fails loudly

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/templating/template.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/template.ts
@@ -222,6 +222,12 @@ export class Template {
      *     })
      */
     configure(options: TemplateOptions): Template {
+        // The `never` applies only where a caller typechecks against it, so JavaScript and pre-#8685
+        // typings reach here, where a silently dropped option leaves the template's names unbound.
+        if ((options as { bindings?: unknown }).bindings !== undefined) {
+            throw new Error("Template option 'bindings' is now 'context': name each module as the " +
+                "import it stands for, e.g. context: [`import {vi} from 'vitest';`].");
+        }
         this.options = {...this.options, ...options};
         // Invalidate cache when configuration changes
         this._cachedTemplate = undefined;

--- a/rewrite-javascript/rewrite/src/javascript/templating/types.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/types.ts
@@ -497,6 +497,12 @@ export interface TemplateOptions {
      * @example `{dependencies: {'@sapui5/types': '^1.120.0'}, types: ['@sapui5/types']}`
      */
     types?: string[];
+
+    /**
+     * @deprecated Name the module in {@link TemplateOptions.context} as the import it stands for:
+     * `bindings: {vi: {module: 'vitest', member: 'vi'}}` is `context: ["import {vi} from 'vitest';"]`.
+     */
+    bindings?: never;
 }
 
 /**

--- a/rewrite-javascript/rewrite/test/javascript/templating/template-bindings.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/template-bindings.test.ts
@@ -152,4 +152,18 @@ describe('templates that declare module bindings', () => {
             typescript(`applyTheme('dark');`)
         )).rejects.toThrow(/needs their local names/);
     });
+
+    test('the removed `bindings` option is rejected by the type and names its replacement', () => {
+        // Neither simplification of this fixture still pins the tombstone: excess property checking
+        // rejects a fresh literal, and the weak-type check rejects a lone `bindings`.
+        const optionsFrom = (member: string) => ({
+            dependencies: {vitest: '^2.0.0'},
+            bindings: {[member]: {module: 'vitest', member}}
+        });
+
+        expect(() => template`vi.fn()`.configure(
+            // @ts-expect-error
+            optionsFrom('vi')
+        )).toThrow(/context/);
+    });
 });


### PR DESCRIPTION
`TemplateOptions.bindings` was removed in #8685 on the reading that it had only ever shipped in dated snapshot builds. It shipped in 8.91.1, and its removal is not a compile error for the way recipes actually build template options. Upgrading moderneinc/recipes-javascript to 8.91.2 (branch `bump-rewrite-8-91-2`, commit 921fcfc, now moderneinc/recipes-javascript#29) took a 33-rule recipe from adding its imports to adding none: the code compiled, ran, emitted `vi.fn()` and left `vi` unbound. It surfaced only as missing `import {vi} from 'vitest'` lines in 23 test fixtures, with nothing pointing at the cause.

## Why `tsc` was silent

Excess property checking only ever runs on a *fresh* object literal checked against a contextual type. Recipes build options in a factory, which has neither:

```ts
// A factory returning a config object: compiles clean on 8.91.2.
const viaFactory = (member: string) => ({
    dependencies: {vitest: '^2.0.0'},
    bindings: {[member]: {module: 'vitest', member}}
});
template`vi.fn()`.configure(viaFactory('vi'));

// The same options at the call site: TS2353, 'bindings' does not exist in type 'TemplateOptions'.
template`vi.fn()`.configure({
    dependencies: {vitest: '^2.0.0'},
    bindings: {vi: {module: 'vitest', member: 'vi'}}
});
```

The factory's return type is inferred against no contextual type, so nothing runs there; the inferred type reaching `configure` is not a fresh literal, so nothing runs there either. TypeScript's weak-type check — every property of the target optional, no property in common with the source — would have caught an object naming only `bindings`. Recipes name `dependencies` alongside it, which supplies the common property and disables it.

The mirror-image half of the same migration is loud: a `context` import that used to be attribution-only now throws `Template binds modules in its context, so applying it needs their local names`. That message is what made the other half obvious. This half had no equivalent.

## The fix

`bindings?: never` makes the factory form fail on **assignability** rather than excess property checking — which is the check that actually reaches it — and the `@deprecated` names the `context` statement each entry becomes. `configure` throws on the key for callers that arrive past the type: plain JavaScript, or code compiled against the 8.91.1 typings and run against a newer runtime.

The option itself is not restored. `context` states the same thing as the import it stands for — default, named, alias, namespace and type-only all have syntax — which is why the downstream migration was mechanical (`bindings: {vi: {module: 'vitest', member: 'vi'}}` becomes `context: ["import {vi} from 'vitest';"]`). The structured form existed only so the engine could tell a binding request from typing context, via the `isResolvable` package-name-prefix heuristic that #8685 removed for being wrong on ambiently-declared modules. Reviving it means reviving that guess, or a second source that `resolveBindings`, `apply`'s rename map and both cache keys have to merge.

## Tests

One test in `template-bindings.test.ts` pins both halves: a `@ts-expect-error` on the factory-shaped argument (asserted by `npm run typecheck`, which `ci:test` runs — removing `bindings?: never` reports TS2578 for the unused directive) and `toThrow(/context/)` on the runtime guard. The fixture keeps the factory *and* the second option deliberately: a fresh literal is rejected by excess property checking and a lone `bindings` by the weak-type check, so either simplification would pass with the tombstone gone.

## The other removal in this range

`ChangeImport.newAlias` (`@Option`, "Optional alias for the new import") was deleted between the same two versions and disappears just as quietly: `Recipe`'s constructor is `Object.assign(this, options)`, so an unrecognised key is absorbed and ignored, and `new ChangeImport({oldModule, newModule, newAlias})` built through a factory compiles and drops the alias.

It gets no tombstone. `ChangeImport` delegates the edit to `maybeRebind`, whose options carry no alias by design: it returns the local name the binding already holds and synthesises the `as` clause when the new member differs from it, so `import {extend} from 'lodash'` becomes `import {assign as extend} from 'lodash'` and an existing `{extend as myExtend}` stays `myExtend`. That preserved name is what `newAlias` defaulted to — `const aliasToUse = newAlias ?? this.oldAlias` — and the override it added on top was unsound: `visitIdentifier` updates type attribution and never renames references, so a `newAlias` differing from the current local name rebound the import and left every reference pointing at the old one, which is this PR's failure shape reached deliberately. Nothing in this repository passed it and no test covered it.

Nothing else in the range removed a public option: `ModuleBinding` was a named type export, whose removal is a compile error at the import site, and `isResolvable`/`bindingContextStatement` were never exported.
