### PR TITLE
JS AMD: the helpers a consumer reads a block with are reachable

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/amd.ts
+++ b/rewrite-javascript/rewrite/src/javascript/amd.ts
@@ -30,6 +30,7 @@ import {
 } from "../java";
 import {JS} from "./tree";
 import {cursorOf, deconflict, namesDeclaredWithin, scopeOf} from "./scope";
+import {Cursor} from "../tree";
 import {JavaScriptVisitor} from "./visitor";
 import {ExecutionContext} from "../execution";
 
@@ -470,6 +471,26 @@ export function withDependency(
     return withParts(call, block, dependencies, factory);
 }
 
+/**
+ * Adds a dependency the factory takes no parameter for, as AMD allows for a module loaded only
+ * for its side effects. Refuses where parameters outnumber dependencies, since the appended one
+ * would land on a surplus parameter and bind after all — as it would in `define(factory)`, whose
+ * parameters come from the loader.
+ */
+export function withUnboundDependency(
+    call: J.MethodInvocation,
+    block: AmdBlock,
+    module: string
+): J.MethodInvocation | undefined {
+    if (parametersOf(block).length > elementsOf(block).length) {
+        return undefined;
+    }
+    const dependencies = withElements(
+        block.dependencies,
+        appendEntry(elementsOf(block), dependencyLiteral(module, quoteOf(block)), dependencySlot));
+    return withParts(call, block, dependencies, block.factory);
+}
+
 export function withoutDependencyAt(
     call: J.MethodInvocation,
     block: AmdBlock,
@@ -551,11 +572,11 @@ export function calleesOf(options?: AmdCalleeOptions): readonly string[] {
 
 /** The nearest AMD block the cursor sits inside, which is the one a binding belongs to. */
 export function enclosingAmdBlock(
-    visitor: JavaScriptVisitor<any>,
+    from: Cursor | JavaScriptVisitor<any>,
     options?: AmdCalleeOptions
 ): {call: J.MethodInvocation, block: AmdBlock} | undefined {
     const callees = calleesOf(options);
-    let cursor = cursorOf(visitor);
+    let cursor = from instanceof Cursor ? from : cursorOf(from);
     while (cursor !== undefined) {
         const value = cursor.value as J | undefined;
         if (value?.kind === J.Kind.MethodInvocation) {

--- a/rewrite-javascript/rewrite/src/javascript/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/index.ts
@@ -32,13 +32,15 @@ export * from "./tree-debug";
 export * from "./project-parser";
 
 export type {Scope} from "./scope";
-export {scopeOf, namesInScope, namesDeclaredIn, bindingNames} from "./scope";
+export {scopeOf, namesInScope, namesDeclaredIn, namesDeclaredWithin, bindingNames, deconflict} from "./scope";
 export type {QuoteChar, AddImportOptions} from "./add-import";
 export {ImportStyle, moduleNameOf, AddImport} from "./add-import";
 // AMD mechanics `recipes-ui5` builds on directly, beyond the `maybeBind` surface below.
-export type {AmdBlock} from "./amd";
+export type {AmdBlock, AmdCalleeOptions} from "./amd";
 export {
-    DEFAULT_AMD_CALLEES, amdBlockOf, dependencyNames, parameterNames, withDependency, withoutDependencyAt,
+    DEFAULT_AMD_CALLEES, amdBlockOf, enclosingAmdBlock, present, elementsOf, parametersOf, identifierOf,
+    dependencyNames, parameterNames, bodyOf, references, namesUsed, lastSegment, derivedBindingName,
+    withDependency, withUnboundDependency, withoutDependencyAt,
     RemoveAmdDependency, removeNewlyUnusedAmdBindings
 } from "./amd";
 export type {MaybeBindOptions, MaybeUnbindOptions, MaybeRebindOptions, ModuleBindings} from "./binding";

--- a/rewrite-javascript/rewrite/test/javascript/amd.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/amd.test.ts
@@ -1,9 +1,12 @@
-import {JavaScriptParser} from "../../src/javascript";
 import {J} from "../../src/java";
-import {JS} from "../../src/javascript";
-import {amdBlockOf, dependencyNames, parameterNames, withDependency, withoutDependencyAt} from "../../src/javascript/amd";
+import {Cursor} from "../../src/tree";
+import {
+    amdBlockOf, bodyOf, deconflict, dependencyNames, derivedBindingName, elementsOf, enclosingAmdBlock,
+    identifierOf, javascript, JavaScriptParser, JavaScriptVisitor, JS, lastSegment, namesDeclaredWithin,
+    namesUsed, parameterNames, parametersOf, present, references, withDependency, withoutDependencyAt,
+    withUnboundDependency
+} from "../../src/javascript";
 import {fromVisitor, RecipeSpec} from "../../src/test";
-import {javascript, JavaScriptVisitor} from "../../src/javascript";
 
 async function firstCall(source: string): Promise<J.MethodInvocation> {
     const parser = new JavaScriptParser();
@@ -253,5 +256,56 @@ describe("withoutDependencyAt", () => {
             `sap.ui.define(["a/B", /* about D */ "c/D"], function (B, D) {});`,
             `sap.ui.define([/* about D */ "c/D"], function (D) {});`
         ));
+    });
+});
+
+describe("withUnboundDependency", () => {
+    function addUnbound(module: string) {
+        return new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
+                const block = amdBlockOf(m);
+                return block === undefined ? super.visitMethodInvocation(m, p) :
+                    withUnboundDependency(m, block, module) ?? m;
+            }
+        };
+    }
+
+    test("the appended dependency takes no parameter, whether or not the block already leaves one unbound", async () => {
+        const bound = new RecipeSpec();
+        bound.recipe = fromVisitor(addUnbound("c/D"));
+        await bound.rewriteRun(javascript(
+            `sap.ui.define(["a/B"], function (B) {});`,
+            `sap.ui.define(["a/B", "c/D"], function (B) {});`
+        ));
+
+        const alreadyUnbound = new RecipeSpec();
+        alreadyUnbound.recipe = fromVisitor(addUnbound("e/F"));
+        await alreadyUnbound.rewriteRun(javascript(
+            `sap.ui.define(["a/B", "c/D"], function (B) {});`,
+            `sap.ui.define(["a/B", "c/D", "e/F"], function (B) {});`
+        ));
+    });
+
+    test("a surplus parameter refuses, since the appended dependency would bind to it", async () => {
+        const call = await firstCall(`sap.ui.define(["a/B"], function (B, D) {});`);
+        expect(withUnboundDependency(call, amdBlockOf(call)!, "c/D")).toBeUndefined();
+    });
+});
+
+describe("the surface a consumer builds on", () => {
+    test("a bare cursor finds the block, which then reads entirely through helpers the entry point exports", async () => {
+        const call = await firstCall(`sap.ui.define(["a/B", "c/D"], function (B, D) { return B; });`);
+        const block = enclosingAmdBlock(new Cursor(call))!.block;
+        expect(elementsOf(block)).toHaveLength(2);
+        expect(present(block.dependencies.initializer!.elements)).toHaveLength(2);
+        expect(parametersOf(block).map(padded => identifierOf(padded.element)?.simpleName)).toEqual(["B", "D"]);
+        expect(bodyOf(block)!.kind).toBe(J.Kind.Block);
+        expect(await references(block, "B", false)).toBe(true);
+        expect((await namesUsed(block, false)).has("D")).toBe(false);
+
+        const declared = namesDeclaredWithin(block.factory);
+        expect(lastSegment("a/B")).toBe("B");
+        expect(derivedBindingName("a/B")).toBe("B");
+        expect(deconflict(derivedBindingName("a/B")!, name => declared.has(name))).toBe("B_1");
     });
 });


### PR DESCRIPTION
- `@openrewrite/rewrite/javascript` exports `amdBlockOf`, `withDependency` and `withoutDependencyAt`, but not the readers those three are useless without, and `package.json` maps only `./javascript` with no wildcard subpath, so `@openrewrite/rewrite/javascript/amd` does not resolve either. A consumer that wants `bodyOf` or `namesUsed` has to reimplement them. moderneinc/recipes-javascript#29 (commit 078350a) migrates `recipes-ui5/src/amd.ts` onto this module and gets it from 669 lines to 415; what stayed behind is exactly the unexported set — `bodyOf`, `namesUsed`, local stand-ins for `namesDeclaredWithin` and `deconflict`, `elementsOf`, and ~110 lines of list-editing machinery.

- Newly re-exported from `./amd`: `enclosingAmdBlock`, `present`, `elementsOf`, `parametersOf`, `identifierOf`, `bodyOf`, `references`, `namesUsed`, `lastSegment`, `derivedBindingName`, and `type AmdCalleeOptions`. From `./scope`: `deconflict`, `namesDeclaredWithin` — `namesDeclaredIn` was already public but takes a `JS.CompilationUnit`, so it cannot answer "what does this factory declare", which is what a caller deriving its own binding name needs to avoid reintroducing the `var`-hoisting defect #8686 fixed. These are all pure functions over `AmdBlock`, already public and already taken by `withDependency`, so exporting them commits to no new behaviour. `enclosingAmdBlock` now takes `Cursor | JavaScriptVisitor`, matching `compilationUnitOf`.

## The unbound dependency

Those ~110 lines are one missing operation. AMD allows a dependency loaded only for its side effects — an array entry with no matching factory parameter — and nothing here could express it: `withDependency(call, block, module, binding)` requires a binding, and `maybeBind` refuses outright when `sideEffectOnly` is set on the AMD lane. `withUnboundDependency(call, block, module)` appends the entry and hands the factory back untouched.

Its guard is the mirror of `withDependency`'s. That one refuses unless the two lists are the same length; this one refuses only where parameters *outnumber* dependencies. Appending at index `n = deps.length` leaves the entry unbound exactly when no parameter sits at `n`, which is what `params <= deps` says. The same rule refuses `define(function (require, exports, module) {})`, whose parameters come from the loader rather than from a dependency list — legal AMD, and the one case where surplus parameters are not a malformed block.

## Scope

- `maybeBind({sideEffectOnly: true})` still returns `undefined` on the AMD lane, so a cross-lane recipe asking for a side-effect-only load still no-ops there. Closing that needs a deferred-edit class with different semantics from `AddAmdDependency` — there is no binding, so its "did the caller use the answer" check does not apply — and is not in this PR. A consumer wanting the behaviour calls `withUnboundDependency` directly, which is what recipes-javascript#29 does. `withDependencyModuleAt` stays internal, and there is no wildcard `exports` subpath: `./*` would publish every module under `src/javascript` as API.

## Tests

Three in `amd.test.ts`. One merges the two `withUnboundDependency` append cases — a fully-bound block and one that already leaves a dependency unbound — since both exercise the same guard line; one pins the refusal. The guard was mutation-checked: `>=`, `!==` (a copy of `withDependency`'s rule) and removing it entirely each fail. The third pins the reader surface, and the reachability guard there is the import statement itself: `amd.test.ts` now imports from `../../src/javascript` rather than `../../src/javascript/amd`, so dropping a name from the index re-export fails `npm run typecheck`.

I also wrote and then deleted two tests that turned out to defend nothing new — `binding.test.ts:847` already pins `namesDeclaredWithin`'s subtree scoping and `deconflict`'s suffix via `var Theming` in a nested function, and `binding.test.ts:490,503` already pin `derivedBindingName`'s refusal via `lodash-es` and `a/class`.
