### PR TITLE
JavaScript templating: a non-identifier callee becomes a JS.FunctionCall

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -120,6 +120,7 @@ const is_expressions: string[] = [
     JS.Kind.Delete,
     JS.Kind.ExportSpecifier,
     JS.Kind.ExpressionWithTypeArguments,
+    JS.Kind.FunctionCall,
     JS.Kind.FunctionType,
     JS.Kind.ImportType,
     JS.Kind.IndexedAccessType,

--- a/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/placeholder-replacement.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import {Cursor, isTree, Markers} from '../..';
-import {J} from '../../java';
+import {emptySpace, Expression, J, rightPadded} from '../../java';
 import {JS} from '..';
 import {JavaScriptVisitor} from '../visitor';
 import {create as produce} from 'mutative';
@@ -22,6 +22,15 @@ import {PlaceholderUtils} from './utils';
 import {CaptureImpl, TemplateParamImpl, CaptureValue, CAPTURE_NAME_SYMBOL} from './capture';
 import {enclosingTree, maybeParenthesize} from './precedence';
 import {Parameter} from './types';
+
+/**
+ * A name slot spells a name out, so an expression landing in one has no valid form to print;
+ * `computedForm` is the spelling that keys off a value instead.
+ */
+function nameSlotError(value: J, slot: string, computedForm: string): Error {
+    return new Error(`A ${value.kind} cannot be a ${slot}: write \`${computedForm}\` to key off the ` +
+        `value of an expression.`);
+}
 
 /**
  * Visitor that replaces placeholder nodes with actual parameter values.
@@ -68,6 +77,63 @@ export class PlaceholderReplacementVisitor extends JavaScriptVisitor<any> {
         }
 
         return bindingElement;
+    }
+
+    /**
+     * A placeholder in callee position sits in `J.MethodInvocation.name`, a slot only an identifier fills.
+     * `JS.FunctionCall` is the shape that takes an arbitrary callee, so any other value becomes one.
+     */
+    override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+        const slotMarkers = method.name.markers;
+        const visited = await super.visitMethodInvocation(method, p);
+        if (visited?.kind !== J.Kind.MethodInvocation) {
+            return visited;
+        }
+
+        const invocation = visited as J.MethodInvocation;
+        const callee = invocation.name as J;
+        if (callee.kind === J.Kind.Identifier) {
+            return invocation;
+        }
+        if (invocation.select) {
+            throw nameSlotError(callee, 'member name', '${a}[${b}]()');
+        }
+
+        const callOf = (fn: J): JS.FunctionCall => ({
+            kind: JS.Kind.FunctionCall,
+            id: invocation.id,
+            prefix: invocation.prefix,
+            markers: invocation.markers,
+            function: rightPadded(fn as Expression, emptySpace),
+            typeParameters: invocation.typeParameters,
+            arguments: invocation.arguments,
+            methodType: invocation.methodType
+        });
+        const call = callOf(callee);
+        return callOf(maybeParenthesize(call, callee.id, callee, slotMarkers));
+    }
+
+    override async visitFieldAccess(fieldAccess: J.FieldAccess, p: any): Promise<J | undefined> {
+        const visited = await super.visitFieldAccess(fieldAccess, p);
+        if (visited?.kind === J.Kind.FieldAccess) {
+            const name = (visited as J.FieldAccess).name.element as J;
+            if (name.kind !== J.Kind.Identifier) {
+                throw nameSlotError(name, 'member name', '${a}[${b}]');
+            }
+        }
+        return visited;
+    }
+
+    override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, p: any): Promise<J | undefined> {
+        const visited = await super.visitPropertyAssignment(propertyAssignment, p);
+        if (visited?.kind === JS.Kind.PropertyAssignment) {
+            const name = (visited as JS.PropertyAssignment).name.element as J;
+            if (name.kind !== J.Kind.Identifier && name.kind !== J.Kind.Literal &&
+                name.kind !== JS.Kind.ComputedPropertyName) {
+                throw nameSlotError(name, 'property name', '{[${k}]: v}');
+            }
+        }
+        return visited;
     }
 
     /**

--- a/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/precedence.ts
@@ -71,7 +71,7 @@ interface SlotConstraints {
     readonly noOptionalChain?: boolean;
     /** The slot may not start with `{`, which would be read as a block. */
     readonly noLeadingObjectLiteral?: boolean;
-    /** The slot may not start with `{`, `function` or `class`, as a statement may not. */
+    /** The slot may not start with `{`, `function` or `class`, which would open a block or a declaration. */
     readonly noLeadingDeclarationToken?: boolean;
     /** The slot is followed by `.`, so a bare integer literal would lex as a decimal point. */
     readonly followedByDot?: boolean;
@@ -239,7 +239,8 @@ function slotConstraints(parent: J, childId: string): SlotConstraints | undefine
         case JS.Kind.FunctionCall: {
             const call = parent as JS.FunctionCall;
             if (call.function?.element?.id === childId) {
-                return {precedence: Precedence.Call};
+                // Parentheses on the callee keep the call legal in every slot the call itself can sit in
+                return {precedence: Precedence.Call, noLeadingDeclarationToken: true};
             }
             return isContainerElement(call.arguments, childId) ? {precedence: Precedence.Assignment} : undefined;
         }

--- a/rewrite-javascript/rewrite/test/javascript/templating/name-slots.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/name-slots.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {capture, javascript, JavaScriptVisitor, pattern, rewrite, RewriteRule, template} from "../../../src/javascript";
+import {J} from "../../../src/java";
+
+function onCall(rule: RewriteRule) {
+    return fromVisitor(new class extends JavaScriptVisitor<any> {
+        override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+            const visited = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+            return await rule.tryOn(this.cursor, visited) || visited;
+        }
+    });
+}
+
+describe('a slot that spells out a name', () => {
+    const spec = new RecipeSpec();
+
+    test('a member name takes a name, not an expression', async () => {
+        const x = capture();
+        spec.recipe = onCall(rewrite(() => ({
+            before: pattern`read(${x})`,
+            after: template`obj.${x}`
+        })));
+        //language=javascript
+        await expect(spec.rewriteRun(javascript(`read(a || b);`)))
+            .rejects.toThrow(/cannot be a member name: write `\$\{a}\[\$\{b}]`/);
+
+        spec.recipe = onCall(rewrite(() => ({
+            before: pattern`read(${x})`,
+            after: template`obj.${x}()`
+        })));
+        //language=javascript
+        await expect(spec.rewriteRun(javascript(`read(a || b);`)))
+            .rejects.toThrow(/cannot be a member name: write `\$\{a}\[\$\{b}]\(\)`/);
+    });
+
+    test('a property name takes a name, not an expression', () => {
+        const x = capture();
+        spec.recipe = onCall(rewrite(() => ({
+            before: pattern`read(${x})`,
+            after: template`({${x}: 1})`
+        })));
+        //language=javascript
+        return expect(spec.rewriteRun(javascript(`read(a || b);`)))
+            .rejects.toThrow(/cannot be a property name: write `\{\[\$\{k}]: v}`/);
+    });
+
+    test('the forms a property key may take keep working', () => {
+        const x = capture();
+        spec.recipe = onCall(rewrite(() => ({
+            before: pattern`read(${x})`,
+            after: template`({${x}: 1, [${x}]: 2})`
+        })));
+        //language=javascript
+        return spec.rewriteRun(javascript(
+            `
+                read(key);
+                read("a-b");
+            `,
+            `
+                ({key: 1, [key]: 2});
+                ({"a-b": 1, ["a-b"]: 2});
+            `));
+    });
+});

--- a/rewrite-javascript/rewrite/test/javascript/templating/precedence.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/precedence.test.ts
@@ -149,6 +149,26 @@ describe('template precedence', () => {
                 `));
         });
 
+        test('as the callee of a call, which only `JS.FunctionCall` can hold', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`register(${x})`,
+                after: template`${x}()`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `
+                    register(() => 1);
+                    register(handlers.init);
+                    register(initAuth);
+                `,
+                `
+                    (() => 1)();
+                    handlers.init();
+                    initAuth();
+                `));
+        });
+
         test('as the condition of a ternary', () => {
             const c = capture(), t = capture(), f = capture();
             spec.recipe = onCall(rewrite(() => ({
@@ -462,6 +482,18 @@ describe('template precedence', () => {
                         });
                     }
                 `));
+        });
+
+        test('a function expression as a callee reads as a declaration', () => {
+            const x = capture();
+            spec.recipe = onCall(rewrite(() => ({
+                before: pattern`register(${x})`,
+                after: template`${x}()`
+            })));
+            //language=javascript
+            return spec.rewriteRun(javascript(
+                `register(function () { return 1; });`,
+                `(function () {\n    return 1;\n})();`));
         });
 
         test('a class heritage clause takes a left-hand-side expression', () => {


### PR DESCRIPTION
Splicing a template parameter into *callee* position — ``template`${x}()` `` — crashed the printer whenever `x` was not a plain identifier:

```
TypeError: Cannot read properties of undefined (reading 'length')
  at JavaScriptPrinter.visitMethodInvocation (src/javascript/print.ts:805:36)
```

``template`${x}()` `` parses to a `J.MethodInvocation` whose `name` is the placeholder identifier and whose `select` is undefined. `PlaceholderReplacementVisitor.replacePlaceholder` substituted the parameter into whatever slot the placeholder occupied, with no regard for what the slot admits. A `J.MethodInvocation.name` is a `J.Identifier`, so a `J.Lambda` or a function expression left `name.simpleName` undefined and `print.ts:805` read `.length` off it. The tree was invalid before formatting was ever reached, so this was never only a missing-parentheses bug. Captures behave identically to plain nodes here — the defect is structural, not a property of how the value arrived.

- Recipe authors have been working around it by writing the parentheses themselves — `moderneinc/rewrite-angular`'s `replace-initializer-providers.ts` grew a `needsParens` helper in `e4b757b` for exactly this. The unconditional form, `` .code('(').param(x).code(')(') ``, trades the crash for `(initAuth)()`, and those redundant parentheses are what Prettier restructures — the reconciliation failure fixed in #8702.

## The fix

Where the value replacing a placeholder in `J.MethodInvocation.name` is not an identifier and there is no `select`, the node is rebuilt as a `JS.FunctionCall`, whose `function` is an arbitrary expression and which both the printer and the comparator already visit. `maybeParenthesize` then decides the parentheses from the slot, as it does everywhere else:

```ts
template`${mi.arguments.elements[0].element}()`   // one template, three callees

register(initAuth)          →  initAuth();
register(handlers.init)     →  handlers.init();
register(() => 1)           →  (() => 1)();
register(function () { … }) →  (function () { … })();
```

The `JS.FunctionCall` callee slot gains `noLeadingDeclarationToken`, so a callee starting with `function`, `class` or `{` is parenthesized. That is a choice between two legal spellings — `(function () {}())` would also parse, and is what the `JS.ExpressionStatement` slot produces on its own — and it goes on the callee so the call stays legal in every slot a call can sit in, not only where an enclosing statement supplies the parentheses. It is also the form the consumer already emits, which is what lets that recipe drop `needsParens` and write `${factory}(...)`.

`JS.Kind.FunctionCall` was in neither `is_expressions` nor `is_statements` in `parser-utils.ts`. It joins `is_expressions`: `TemplateEngine.wrapTree` reads that predicate to decide whether a template result needs a `JS.ExpressionStatement` around it, which is the shape the parser itself gives a bare `FunctionCall` statement. `is_statements` is left alone deliberately — `parser.ts:2916` reads it to make that very decision at parse time.

## The other narrow slots

`J.FieldAccess.name`, `JS.PropertyAssignment.name` and the `name` of a call that *does* have a `select` all accepted a placeholder too, and printed source that does not parse — ``template`obj.${x}` `` with `x` bound to `a || b` gave `obj.a || b`. Unlike the callee, these are not a representation gap: a name slot spells a name out, and no JavaScript syntax writes `a.<expression>`. There is no shape to rebuild them into, so they report the computed spelling instead:

```
A org.openrewrite.java.tree.J$Binary cannot be a member name: write `${a}[${b}]` to key off the value of an expression.
```

`J.NewClass.class` needed nothing: `slotConstraints` already covers it, and ``template`new ${x}()` `` yields `new (() => 1)()` and `new (a || b)()` today.

## Tests

Two in `precedence.test.ts`, placed with the rule each depends on: `as the callee of a call, which only 'JS.FunctionCall' can hold` covers the three branches that differ — an identifier that is not rebuilt at all, a `handlers.init` that is rebuilt without parentheses, and an arrow that gets them from precedence — and `a function expression as a callee reads as a declaration` sits with the other shape restrictions. `name-slots.test.ts` pins both directions of the name-slot guard: the two member-name spellings and the property name are rejected with the remedy in the message, and identifier, string-literal and computed keys keep working. `npm run ci:test` is green (2164 passed).

## Not in this PR

The mirror on the `pattern` side does not work, and is worse than the task suspected: ``pattern`${x}()` `` binds nothing at all, not even `initAuth()` — the placeholder in `name` carries no `CaptureMarker`, so the comparator compares `J$Identifier#simpleName` literally (`__capt_x__` vs `initAuth`) — and separately a `J.MethodInvocation` pattern aborts on kind-mismatch against a `JS.FunctionCall` target. Both are tracked separately; a rule can write a call with an arbitrary callee after this PR but still cannot match one.

`raw()` splices its string into the template text before parsing, so ``template`${raw('() => 1')}()` `` yields `() => 1()`. That is its documented contract — verbatim, unvalidated, and its documented uses (`` logger.${raw('info')}(…) ``, `` { ${raw(fields.join(', '))} } ``) are fragments that parenthesizing would break. The route for an expression value is `param()`/`capture()`, which is what this PR fixes. An unparseable template does crash with a `TypeError` out of `getContextBindings` rather than the engine's own "Failed to parse template code"; that is tracked separately.