### PR TITLE
JavaScript: an unparseable template reports the engine's diagnostic

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -31,6 +31,7 @@ import {DependencyWorkspace} from "../dependency-workspace";
 import {ModuleScopeBinding, moduleScopeBindings} from '../add-import';
 import {walk} from '../scope';
 import {isIdentifier} from '../../java';
+import {findMarker, MarkersKind, ParseExceptionResult} from '../../markers';
 
 /** A module a template's context binds, and whether the parse resolved it well enough to attribute. */
 export interface ContextBinding extends ModuleScopeBinding {
@@ -206,6 +207,15 @@ export function clearTemplateCache(): void {
 }
 
 /**
+ * The compiler's diagnostic for code that did not parse, as one line: the marker states it ahead
+ * of a stack, and its positions index the whole parsed text, context statements included.
+ */
+function parseFailureReason(cu: JS.CompilationUnit): string {
+    const failure = findMarker<ParseExceptionResult>(cu, MarkersKind.ParseExceptionResult);
+    return failure ? failure.message.split('\n')[0].replace(/:$/, '') : 'no statements';
+}
+
+/**
  * Internal template engine - handles the core templating logic.
  * Not exported from index, so only visible within the templating module.
  */
@@ -234,7 +244,26 @@ export class TemplateEngine {
         const contextWithPreamble = preamble.length > 0
             ? [...contextStatements, ...preamble]
             : contextStatements;
-        return templateCache.getOrParse(templateString, [], contextWithPreamble, dependencies, types);
+        return TemplateEngine.parseOrThrow('template', templateString, [], contextWithPreamble, dependencies, types);
+    }
+
+    /**
+     * The parse behind every template and pattern. Code that fails to parse yields a compilation
+     * unit with no statements, which every caller goes on to read, so it fails here naming the code.
+     */
+    private static async parseOrThrow(
+        kind: 'template' | 'pattern',
+        templateString: string,
+        captures: (Capture | Any)[],
+        contextStatements: string[],
+        dependencies: Record<string, string>,
+        types: string[] | undefined
+    ): Promise<JS.CompilationUnit> {
+        const cu = await templateCache.getOrParse(templateString, captures, contextStatements, dependencies, types);
+        if (!cu.statements || cu.statements.length === 0) {
+            throw new Error(`Failed to parse ${kind} code (${parseFailureReason(cu)}):\n${templateString}`);
+        }
+        return cu;
     }
 
     /**
@@ -272,11 +301,6 @@ export class TemplateEngine {
         types?: string[]
     ): Promise<J> {
         const cu = await TemplateEngine.parseWithContext(templateParts, parameters, contextStatements, dependencies, types);
-
-        // Check if there are any statements
-        if (!cu.statements || cu.statements.length === 0) {
-            throw new Error(`Failed to parse template code (no statements):\n${TemplateEngine.buildTemplateString(templateParts, parameters)}`);
-        }
 
         // The template code is always the last statement (after context + preamble)
         const lastStatement = cu.statements[cu.statements.length - 1].element;
@@ -567,19 +591,14 @@ export class TemplateEngine {
             !(c instanceof RawCode || (c && typeof c === 'object' && (c as any)[RAW_CODE_SYMBOL]))
         ) as (Capture | Any)[];
 
-        // Use cache to get or parse the compilation unit
-        const cu = await templateCache.getOrParse(
+        const cu = await TemplateEngine.parseOrThrow(
+            'pattern',
             templateString,
             actualCaptures,
             contextWithPreamble,
             dependencies,
             types
         );
-
-        // Check if there are any statements
-        if (!cu.statements || cu.statements.length === 0) {
-            throw new Error(`Failed to parse pattern code (no statements):\n${templateString}`);
-        }
 
         // The pattern code is always the last statement (after context + preamble)
         const lastStatement = cu.statements[cu.statements.length - 1].element;

--- a/rewrite-javascript/rewrite/test/javascript/templating/unparseable-template.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/unparseable-template.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {fromVisitor, RecipeSpec} from "../../../src/test";
+import {capture, JavaScriptVisitor, pattern, raw, rewrite, template, typescript} from "../../../src/javascript";
+import {J} from "../../../src/java";
+
+describe('a template whose code does not parse', () => {
+    const spec = new RecipeSpec();
+
+    /** `raw()` splices verbatim, which is the way to build a template the parser rejects. */
+    function recipeApplying(tmpl: ReturnType<typeof template>) {
+        const rule = rewrite(() => ({before: pattern`use(${capture()})`, after: tmpl}));
+        return fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(method: J.MethodInvocation, p: any): Promise<J | undefined> {
+                method = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                return await rule.tryOn(this.cursor, method, {visitor: this}) || method;
+            }
+        });
+    }
+
+    test('reports the engine error, naming the syntax problem, where the bindings are read', async () => {
+        spec.recipe = recipeApplying(template`new ${raw('() => 1')}()`);
+
+        await expect(spec.rewriteRun(
+            //language=typescript
+            typescript(`use(z);`)
+        )).rejects.toThrow(/Failed to parse template code \(.*expected.*\):/);
+    });
+});


### PR DESCRIPTION
A template whose code does not parse crashes with `TypeError: Cannot read properties of undefined (reading 'slice')` instead of the engine's own error. `TemplateEngine.getContextBindings` reads `cu.statements` off a parse it never checked, and a failed parse yields a `ParseError` with no `statements` property at all:

```
TypeError: Cannot read properties of undefined (reading 'slice')
  at TemplateEngine.getContextBindings (src/javascript/templating/engine.ts:254:59)
  at Template.resolveBindings (src/javascript/templating/template.ts:309:31)
  at RewriteRuleImpl.tryOn (src/javascript/templating/rewrite.ts:62:41)
```

`getTemplateTree` and `getPatternTree` each guarded exactly this condition with a local copy of the same three lines; `getContextBindings` was the third consumer of the parse and had none, so which diagnostic a recipe author got depended on whether the template's context happened to bind a module — `tryOn` reaches `resolveBindings` before it ever reaches the tree.

The guard belongs to the parse rather than to its callers, so `parseOrThrow` wraps `templateCache.getOrParse` and both paths route through it: `parseWithContext` for templates, `getPatternTree` directly for patterns, which builds its own capture-placeholder string and so cannot share the former. Those were the only two `getOrParse` call sites, and no other code in the templating module reads statements off a template parse.

While the message was moving, it picked up the diagnostic the parser had already produced and nothing read — the `ParseError`'s `ParseExceptionResult` marker:

```
Failed to parse template code (Compiler error(s): (1,31): Expression expected. [1109]; (1,33): ';' expected. [1005]):
function __WRAPPER__() { new () => 1() }
```

The marker's `message` is `e.message + ':\n' + e.stack`, so only its first line is quoted. Its positions index the whole parsed text, which prepends the context statements, so they index the printed wrapper only for a template that declares no context; that caveat is recorded at `parseFailureReason` rather than in the message. A parse that fails without the marker keeps the previous `no statements` wording.

`raw()`'s verbatim splice is what makes an unparseable template easy to build (`new ${raw('() => 1')}()`), and it is left alone — it is documented as inserting code with no validation, and its uses (`logger.${raw('info')}(...)`, `${_('value')} ${raw('>=')} threshold`) are fragments that parenthesising would break.

The new `unparseable-template.test.ts` applies that template through `rule.tryOn(..., {visitor: this})` and asserts the engine error names the syntax problem. It was confirmed failing against the reported `TypeError` before the fix, and its regex also dies if `parseFailureReason` stops reading the marker. One test covers both paths deliberately: a second on `getTemplateTree` or the pattern side would break on the same one-line edit in the shared helper. `npm run ci:test`: 186 files / 2164 tests, 0 failures.