### PR TITLE
JavaScript: a rebind renames a local name the source never chose

### DIFF
--- a/rewrite-javascript/rewrite/CLAUDE.md
+++ b/rewrite-javascript/rewrite/CLAUDE.md
@@ -223,8 +223,31 @@ lists index-aligned, and an operation that cannot is refused rather than guessed
 A binding is reused only where its name still resolves to it at the cursor. Where something nearer
 shadows it, `maybeBind` binds the module again under a name that reaches — a second import, or a
 second AMD dependency — because a caller mid-rewrite needs a name it can emit. `maybeRebind` answers
-with the name its binding already carries, which is what keeps existing references resolving, so it
-reports that name whether or not the cursor reaches it.
+with the name its binding carries after the move, whether or not the cursor reaches it.
+
+### Which name a rebind binds
+
+`to.alias` settles it when given, or refuses the move where the file already spells that name.
+Otherwise a binding the source named itself — an aliased specifier,
+or a default, namespace or AMD binding, whose name never came from a member — keeps that name; an
+unaliased named specifier follows its member to the new name, since that is what the source would
+have written had it imported the member all along — but only where the file spells that name nowhere
+else, since a rename onto a name already in use would capture its references or be captured by them.
+Where it is taken the binding keeps the name it has, as an alias, and the move is otherwise the same.
+
+Where the name changes, the file's references to the binding change with it — the occurrences that
+resolve to the binding, so a name a nearer scope binds and a property that merely reads alike both
+stay put. The rename belongs here rather than in the caller: from the returned name alone a caller
+cannot find those occurrences, since the binding it would resolve them against is already gone.
+
+Two positions spell a name and a reference with one identifier, and the rename splits them: `{a}`
+becomes `{a: renamed}`, keeping the property its object publishes, and `export {a}` becomes
+`export {renamed as a}`, keeping the name the module publishes. In `export {x as a}` only `x` is a
+reference — `a` belongs to the file's consumers and is left alone.
+
+A caller that renames references itself defeats this: the name it writes in is the name the rename
+wants, so the collision check sees it as taken and the binding keeps an alias instead. Drop such a
+pass rather than run it alongside.
 
 ### When `maybeBind` returns `undefined`
 
@@ -241,10 +264,15 @@ reports that name whether or not the cursor reaches it.
 ### When `maybeRebind` returns `undefined`
 
 The four above that still apply, plus: nothing binds `from`; `from` or `to` names a member on the
-AMD lane; or the two differ in default/namespace/named shape while `from`'s statement binds nothing
-else. That last one is a layering boundary rather than an oversight — the only edit available in
-place is a rewrite of the existing clause, and changing shape needs whole-statement replacement
-with the header-preserving prefix transfer that `RemoveImport` does over the statement list.
+AMD lane, or `to` an alias there other than the parameter's own name; `to.alias` is not a legal
+identifier, or is a name the file already spells; or the two differ in default/namespace/named
+shape while `from`'s statement binds nothing else. That last one is a layering boundary rather than an oversight — the only edit
+available in place is a rewrite of the existing clause, and changing shape needs whole-statement
+replacement with the header-preserving prefix transfer that `RemoveImport` does over the statement
+list.
+
+One call moves one binding. Where a second statement binds the same member under a name of its own,
+it is left as it stands: the name read from the first would bind twice if it were applied to both.
 
 ## RPC Sender/Receiver
 

--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -1,11 +1,12 @@
 import {JavaScriptVisitor} from "./visitor";
-import {ElementRemovalFormatter, emptySpace, isIdentifier, J, rightPadded, singleSpace, space, Statement, Type} from "../java";
+import {ElementRemovalFormatter, emptySpace, isIdentifier, J, NameTree, rightPadded, singleSpace, space, Statement, Type} from "../java";
 import {JS, JSX} from "./tree";
 import {randomId} from "../uuid";
 import {emptyMarkers, markers} from "../markers";
 import {getStyle, PrettierStyle, SpacesStyle, StyleKind} from "./style";
-import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, namesDeclaredIn, scopeOf} from "./scope";
+import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, isValueReference, namesDeclaredIn, scopeOf} from "./scope";
 import {create as produce, Draft} from "mutative";
+import {TypeVisitor} from "../java/type-visitor";
 
 export type QuoteChar = "'" | '"';
 
@@ -333,12 +334,12 @@ function importBindings(jsImport: JS.Import): ModuleScopeBinding[] {
 }
 
 /**
- * Names in scope, plus those pending `AddImport`s on the `afterVisit` queue have claimed. A queued
+ * `names`, plus those pending `AddImport`s on the `afterVisit` queue have claimed. A queued
  * `RemoveImport` does not free one: it removes only what the file leaves unused, and binding a name
  * it keeps is an error, where an unnecessary suffix merely reads oddly.
  */
-function takenNames(inScope: ReadonlySet<string>, visitor: JavaScriptVisitor<any>): Set<string> {
-    const taken = new Set<string>(inScope);
+export function takenNames(names: ReadonlySet<string>, visitor: JavaScriptVisitor<any>): Set<string> {
+    const taken = new Set<string>(names);
 
     for (const v of visitor.afterVisit || []) {
         if (v instanceof AddImport && v.bindingName) {
@@ -347,6 +348,12 @@ function takenNames(inScope: ReadonlySet<string>, visitor: JavaScriptVisitor<any
     }
 
     return taken;
+}
+
+/** As {@link takenNames}, for a caller asking about one name rather than probing repeatedly. */
+export function nameTaken(name: string, names: ReadonlySet<string>, visitor: JavaScriptVisitor<any>): boolean {
+    return names.has(name) ||
+        (visitor.afterVisit || []).some(v => v instanceof AddImport && v.bindingName === name);
 }
 
 /**
@@ -1643,6 +1650,9 @@ function isOnlyMember(jsImport: JS.Import): boolean {
 export interface ExistingImportBinding {
     localName: string;
     onlyMemberOfStatement: boolean;
+
+    /** Whether the source states this local name — `import {a as b}` — or takes it from the member. */
+    aliased: boolean;
 }
 
 /**
@@ -1661,16 +1671,21 @@ export function existingImportBinding(
         }
         const localName = importBinds(element as JS.Import, module, member);
         if (localName !== undefined) {
-            return {localName, onlyMemberOfStatement: isOnlyMember(element as JS.Import)};
+            return {
+                localName,
+                onlyMemberOfStatement: isOnlyMember(element as JS.Import),
+                aliased: localName !== memberName(member)
+            };
         }
     }
     return undefined;
 }
 
 /**
- * Binds `member` under the name `local` already carries, so the file's references to it still
- * resolve. `local` itself becomes the alias, keeping the type attribution it holds, and the alias
- * takes its prefix: that whitespace separates the specifier from a `type` keyword before it.
+ * The `member as local` specifier, for an import binding `member` under `local` or an export
+ * publishing `local`'s binding under that name. `local` itself becomes the alias, keeping the type
+ * attribution it holds, and the alias takes its prefix: that whitespace separates the specifier
+ * from a `type` keyword before it.
  */
 function aliasing(local: J.Identifier, member: string): JS.Alias {
     const propertyName: J.Identifier = {
@@ -1756,10 +1771,10 @@ function removeBinding(jsImport: JS.Import, member: string | undefined): JS.Impo
 }
 
 /**
- * Moves the binding `from` names to `to`, keeping the local name it already had. In place when
- * the statement that carries it binds nothing else — module and member specifier rewritten there
- * directly; otherwise the old specifier drops and {@link bindImport} queues the replacement,
- * aliased to the preserved name.
+ * Moves the binding `from` names to `to`, binding it under `boundName`. In place when the
+ * statement that carries it binds nothing else — module and member specifier rewritten there
+ * directly; otherwise the old specifier drops and {@link bindImport} queues the replacement.
+ * A `boundName` of its own renames the binding, and the file's references to it follow.
  *
  * Not built on `RemoveImport`/`maybeUnbind`: those only drop a binding once nothing references
  * it, but a rebind moves one that is still in use — removal here has to be unconditional.
@@ -1768,13 +1783,21 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
     constructor(
         readonly from: {module: string; member?: string},
         readonly to: {module: string; member?: string},
-        readonly localName: string
+        readonly localName: string,
+        readonly boundName: string
     ) {
         super();
     }
 
     private transformedInPlace = false;
     private typeOnly = false;
+    private readonly movedTypes = new MovedTypes(this.from, this.to);
+    /** Identifiers settled as references to the binding, so a parent need not settle it again. */
+    private readonly references = new Set<string>();
+
+    private get renaming(): boolean {
+        return this.boundName !== this.localName;
+    }
 
     override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: P): Promise<J | undefined> {
         const visited = await super.visitJsCompilationUnit(cu, p) as JS.CompilationUnit;
@@ -1782,7 +1805,7 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
             bindImport(this, {
                 module: this.to.module,
                 member: this.to.member,
-                alias: this.localName,
+                alias: this.boundName,
                 typeOnly: this.typeOnly,
                 onlyIfReferenced: false
             });
@@ -1794,7 +1817,9 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
         const imp = await super.visitImportDeclaration(jsImport, p) as JS.Import;
 
         const key = memberName(this.from.member);
-        if (importBinds(imp, this.from.module, this.from.member) === undefined) {
+        // One call moves one binding, and no two imports bind the same local name, so the name
+        // read from the matched statement is what picks it back out of the file.
+        if (importBinds(imp, this.from.module, this.from.member) !== this.localName) {
             return imp;
         }
         // A moved named specifier's own inline `type` marks it type-only even where the clause
@@ -1814,28 +1839,220 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
             const quoteChar = originalSource.startsWith("'") ? "'" : '"';
             literal.valueSource = `${quoteChar}${this.to.module}${quoteChar}`;
 
-            // A named specifier's local name has to stay put in the source, since it is what the
-            // rest of the file already reads; default and namespace imports carry that name on
-            // the clause itself, which needs no edit for a module-only move.
-            const toKey = memberName(this.to.member);
-            if (key !== undefined && key !== '*' && toKey !== undefined && toKey !== key) {
-                const importClause = draft.importClause;
-                if (importClause?.namedBindings?.kind === JS.Kind.NamedImports) {
-                    const namedImports = importClause.namedBindings as Draft<JS.NamedImports>;
-                    for (const elem of namedImports.elements.elements) {
-                        const specifier = elem.element;
-                        if (specifier.specifier.kind === J.Kind.Identifier && specifier.specifier.simpleName === key) {
-                            specifier.specifier = aliasing(specifier.specifier as Draft<J.Identifier>, toKey) as Draft<JS.Alias>;
-                        } else if (specifier.specifier.kind === JS.Kind.Alias) {
-                            const aliasNode = specifier.specifier as Draft<JS.Alias>;
-                            const propertyName = aliasNode.propertyName.element;
-                            if (propertyName.kind === J.Kind.Identifier && propertyName.simpleName === key) {
-                                propertyName.simpleName = toKey;
-                            }
-                        }
-                    }
+            // A default or namespace import carries its local name on the clause itself; a named
+            // one states the member alongside it, in the specifier.
+            if (key === undefined || key === '*') {
+                if (this.boundName !== this.localName) {
+                    renameClauseBinding(draft.importClause, key, this.boundName);
                 }
+                return;
             }
+            rewriteNamedSpecifier(draft.importClause, key, memberName(this.to.member) ?? key, this.boundName);
         });
+    }
+
+    override async visitIdentifier(identifier: J.Identifier, p: P): Promise<J | undefined> {
+        if (!this.referencesBinding(identifier)) {
+            return identifier;
+        }
+        this.references.add(identifier.id);
+        // The name follows the binding, and so does what the name is attributed to; an aliased
+        // binding keeps its name and still resolves somewhere new.
+        const type = await this.movedTypes.visit(identifier.type, undefined);
+        const fieldType = await this.movedTypes.visit(identifier.fieldType, undefined) as Type.Variable | undefined;
+        return !this.renaming && type === identifier.type && fieldType === identifier.fieldType
+            ? identifier
+            : {...identifier, simpleName: this.boundName, type, fieldType} as J.Identifier;
+    }
+
+    override async visitMethodInvocation(method: J.MethodInvocation, p: P): Promise<J | undefined> {
+        const m = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+        // A rewrite keeps the identifier's id, so the name `visitIdentifier` settled is the one
+        // this call carries the method type of.
+        if (!this.references.has(m.name.id)) {
+            return m;
+        }
+        const methodType = await this.movedTypes.visit(m.methodType, undefined) as Type.Method | undefined;
+        return methodType === m.methodType ? m : {...m, methodType} as J.MethodInvocation;
+    }
+
+    /**
+     * A decorator and the other type-name positions reach the tree through this hook, which the
+     * base visitor holds closed; a reference in one of them is a reference like any other.
+     */
+    protected override async visitTypeName<N extends NameTree>(nameTree: N, p: P): Promise<N> {
+        return await this.visit(nameTree, p) as N;
+    }
+
+    /**
+     * An export specifier's own name is the module's public surface, which its consumers read and
+     * the rename leaves alone. See CLAUDE.md: Which name a rebind binds.
+     */
+    override async visitExportSpecifier(exportSpecifier: JS.ExportSpecifier, p: P): Promise<J | undefined> {
+        if (!this.renaming) {
+            return super.visitExportSpecifier(exportSpecifier, p);
+        }
+        // `export {a} from "m"` names `m`'s member rather than anything this file binds.
+        const from = this.cursor.firstEnclosing(
+            (v): v is JS.ExportDeclaration => (v as J | undefined)?.kind === JS.Kind.ExportDeclaration);
+        if (from?.moduleSpecifier !== undefined) {
+            return exportSpecifier;
+        }
+        const specifier = exportSpecifier.specifier;
+        if (specifier.kind === J.Kind.Identifier && (specifier as J.Identifier).simpleName === this.localName) {
+            return {...exportSpecifier, specifier: aliasing(specifier as J.Identifier, this.boundName)} as JS.ExportSpecifier;
+        }
+        if (specifier.kind === JS.Kind.Alias) {
+            const alias = specifier as JS.Alias;
+            const propertyName = alias.propertyName.element;
+            return propertyName.kind === J.Kind.Identifier && (propertyName as J.Identifier).simpleName === this.localName
+                ? {
+                    ...exportSpecifier,
+                    specifier: {
+                        ...alias,
+                        propertyName: {...alias.propertyName, element: {...propertyName, simpleName: this.boundName}}
+                    }
+                } as JS.ExportSpecifier
+                : exportSpecifier;
+        }
+        return super.visitExportSpecifier(exportSpecifier, p);
+    }
+
+    /**
+     * Whether the identifier at the cursor stands for the moved binding: the right name, in a
+     * position that references rather than declares, reaching the module scope that binds it.
+     */
+    private referencesBinding(identifier: J.Identifier): boolean {
+        return identifier.simpleName === this.localName &&
+            // The specifier binding the name is the one edit that is not a reference to it.
+            !this.cursor.firstEnclosing((v): v is JS.Import => (v as J | undefined)?.kind === JS.Kind.Import) &&
+            isValueReference(this.cursor, identifier) &&
+            scopeOf(this.cursor).declaringScope(this.localName)?.kind === JS.Kind.CompilationUnit;
+    }
+
+    /** A shorthand property's name slot is also the reference to the binding. */
+    override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, p: P): Promise<J | undefined> {
+        const name = propertyAssignment.name.element;
+        if (this.renaming && propertyAssignment.initializer === undefined &&
+            name.kind === J.Kind.Identifier && (name as J.Identifier).simpleName === this.localName &&
+            scopeOf(this.cursor).declaringScope(this.localName)?.kind === JS.Kind.CompilationUnit) {
+            // The key names a property rather than the binding, so it carries no attribution,
+            // the same way `aliasing` builds a property name that stands for nothing.
+            return {
+                ...propertyAssignment,
+                name: {...propertyAssignment.name, element: {...name, type: undefined, fieldType: undefined}},
+                assigmentToken: JS.PropertyAssignment.Token.Colon,
+                initializer: {...(name as J.Identifier), prefix: singleSpace, simpleName: this.boundName}
+            } as JS.PropertyAssignment;
+        }
+        return super.visitPropertyAssignment(propertyAssignment, p);
+    }
+}
+
+/**
+ * Rewrites the attribution a move invalidates, onto the module and member it moved to. Applied
+ * only at a reference to the moved binding: a module's type is shared with the siblings imported
+ * beside it, which stay where they are.
+ */
+class MovedTypes extends TypeVisitor<undefined> {
+    private readonly onPath = new Set<Type>();
+    private readonly answered = new Map<Type, Type | undefined>();
+    private readonly renamed: ReadonlyMap<string, string>;
+
+    constructor(from: {module: string; member?: string}, to: {module: string; member?: string}) {
+        super();
+        // Where no member is named the two keys coincide, and both name the module.
+        this.renamed = new Map([[from.module, to.module], [qualifiedName(from), qualifiedName(to)]]);
+    }
+
+    /**
+     * A type reached while it is still being visited is a cycle — a class holds a method whose
+     * declaring type is that class — and answers with itself, which is what ends the walk. Every
+     * reference to a binding shares one type, so a completed walk is remembered for the next.
+     */
+    override async visit<T extends Type>(type: T | undefined, p: undefined): Promise<T | undefined> {
+        if (type === undefined || this.onPath.has(type)) {
+            return type;
+        }
+        if (this.answered.has(type)) {
+            return this.answered.get(type) as T | undefined;
+        }
+        this.onPath.add(type);
+        try {
+            const answer = await super.visit(type, p);
+            // Only a walk that met no cycle stands for the type on its own; one cut short by
+            // `onPath` answered for the path it was on.
+            if (this.onPath.size === 1) {
+                this.answered.set(type, answer);
+            }
+            return answer;
+        } finally {
+            this.onPath.delete(type);
+        }
+    }
+
+    protected override async visitClass(aClass: Type.Class, p: undefined): Promise<Type | undefined> {
+        const visited = await super.visitClass(aClass, p) as Type.Class;
+        const moved = this.renamed.get(visited.fullyQualifiedName);
+        return moved === undefined || moved === visited.fullyQualifiedName
+            ? visited
+            : {...visited, fullyQualifiedName: moved} as Type.Class;
+    }
+}
+
+/** A member's qualified name, or the module's own where no member is named. */
+function qualifiedName(binding: {module: string; member?: string}): string {
+    const key = memberName(binding.member);
+    return key === undefined || key === '*' ? binding.module : `${binding.module}.${key}`;
+}
+
+/** Renames the identifier a default (`key` undefined) or namespace clause binds its module under. */
+function renameClauseBinding(
+    importClause: Draft<JS.ImportClause> | undefined,
+    key: string | undefined,
+    boundName: string
+): void {
+    const bound = key === undefined
+        ? importClause?.name?.element
+        : (importClause?.namedBindings as Draft<JS.Alias> | undefined)?.alias;
+    if (bound?.kind === J.Kind.Identifier) {
+        (bound as Draft<J.Identifier>).simpleName = boundName;
+    }
+}
+
+/**
+ * Rewrites the specifier importing `key` to import `member` under `boundName` — a bare `{member}`
+ * where the two agree, since an alias saying the same thing is noise the source never had.
+ */
+function rewriteNamedSpecifier(
+    importClause: Draft<JS.ImportClause> | undefined,
+    key: string,
+    member: string,
+    boundName: string
+): void {
+    if (importClause?.namedBindings?.kind !== JS.Kind.NamedImports) {
+        return;
+    }
+    for (const elem of (importClause.namedBindings as Draft<JS.NamedImports>).elements.elements) {
+        const specifier = elem.element;
+        const node = specifier.specifier;
+        if (!namedSpecifierImports(node as JS.ImportSpecifier["specifier"], key)) {
+            continue;
+        }
+        const alias = node.kind === JS.Kind.Alias ? node as Draft<JS.Alias> : undefined;
+        const local = (alias?.alias ?? node) as Draft<J.Identifier>;
+        if (local.kind !== J.Kind.Identifier) {
+            continue;
+        }
+        if (boundName === member) {
+            // An alias node holds the specifier's leading whitespace, so the bare identifier
+            // standing in for it takes that prefix.
+            specifier.specifier = {...local, prefix: (alias ?? local).prefix, simpleName: member};
+        } else if (alias) {
+            (alias.propertyName.element as Draft<J.Identifier>).simpleName = member;
+            local.simpleName = boundName;
+        } else {
+            specifier.specifier = aliasing({...local, simpleName: boundName}, member) as Draft<JS.Alias>;
+        }
     }
 }

--- a/rewrite-javascript/rewrite/src/javascript/amd.ts
+++ b/rewrite-javascript/rewrite/src/javascript/amd.ts
@@ -614,7 +614,12 @@ const RESERVED_WORDS = new Set([
  */
 export function derivedBindingName(module: string): string | undefined {
     const segment = lastSegment(module);
-    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(segment) && !RESERVED_WORDS.has(segment) ? segment : undefined;
+    return isBindableName(segment) ? segment : undefined;
+}
+
+/** Whether `name` is one a binding can take. ASCII identifiers only, so a legal name may be refused. */
+export function isBindableName(name: string): boolean {
+    return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name) && !RESERVED_WORDS.has(name);
 }
 
 /** Queued reservations already targeting this block: the shared source for both dedup and deconfliction. */

--- a/rewrite-javascript/rewrite/src/javascript/binding.ts
+++ b/rewrite-javascript/rewrite/src/javascript/binding.ts
@@ -16,12 +16,15 @@
 import {J} from "../java";
 import {JS} from "./tree";
 import {JavaScriptVisitor} from "./visitor";
-import {compilationUnitOf, cursorOf, declarationsOf, scopeOf, walk} from "./scope";
-import {AddImportOptions, bindImport, existingImportBinding, memberName, moduleNameOf, RebindImport, requiredModuleOf} from "./add-import";
+import {compilationUnitOf, cursorOf, declarationsOf, namesUsedIn, scopeOf, walk} from "./scope";
+import {
+    AddImportOptions, bindImport, existingImportBinding, ExistingImportBinding, memberName, moduleNameOf,
+    nameTaken, RebindImport, requiredModuleOf
+} from "./add-import";
 import {RemoveImport} from "./remove-import";
 import {
     AmdCalleeOptions, amdBlockOf, bindAmd, calleesOf, dependencyNames, derivedBindingName, enclosingAmdBlock,
-    parameterNames, RebindAmdDependency, RemoveAmdDependency
+    isBindableName, parameterNames, RebindAmdDependency, RemoveAmdDependency
 } from "./amd";
 
 /**
@@ -48,7 +51,14 @@ export interface MaybeUnbindOptions {
 
 export interface MaybeRebindOptions {
     from: {module: string; member?: string};
-    to: {module: string; member?: string};
+
+    /**
+     * `alias` names the moved binding, taken verbatim. Left unset, an alias on the `from` side
+     * survives the move — `{Old as X}` becomes `{New as X}`, since `X` is a name the file chose —
+     * while an unaliased binding takes the new member's name where that name is free. Pin `alias`
+     * to the old local name to keep it. See CLAUDE.md: Which name a rebind binds.
+     */
+    to: {module: string; member?: string; alias?: string};
 
     /** Callees that introduce an AMD block. UI5 writes `sap.ui.define`, RequireJS and Dojo `define`. */
     amdCallee?: string | readonly string[];
@@ -376,9 +386,10 @@ function bindingShape(member: string | undefined): "default" | "namespace" | "na
 }
 
 /**
- * Moves the binding for `from` to `to`, keeping the local name it already had — the primitive
+ * Moves the binding for `from` to `to` and answers with the name it now carries — the primitive
  * behind a member rename or a module move. Returns `undefined`, changing nothing, where the move
- * is not safely expressible; the refusals are listed in CLAUDE.md: JavaScript module bindings.
+ * is not safely expressible; the refusals and the choice of name are listed in CLAUDE.md:
+ * JavaScript module bindings.
  */
 export function maybeRebind(visitor: JavaScriptVisitor<any>, options: MaybeRebindOptions): string | undefined {
     const amd = enclosingAmdBlock(visitor, options);
@@ -388,7 +399,10 @@ export function maybeRebind(visitor: JavaScriptVisitor<any>, options: MaybeRebin
         }
         const index = dependencyNames(amd.block).indexOf(options.from.module);
         const binding = index < 0 ? undefined : parameterNames(amd.block)[index];
-        if (binding === undefined) {
+        if (binding === undefined ||
+            // An AMD binding's name is its factory parameter, so naming it something else means
+            // rewriting the factory's references, which this lane's dependency swap does not reach.
+            (options.to.alias !== undefined && options.to.alias !== binding)) {
             return undefined;
         }
         const callees = calleesOf(options);
@@ -414,8 +428,39 @@ export function maybeRebind(visitor: JavaScriptVisitor<any>, options: MaybeRebin
     if (!existing.onlyMemberOfStatement && isCommonJs(cu)) {
         return undefined;
     }
-    visitor.afterVisit.push(new RebindImport(options.from, options.to, existing.localName));
-    return existing.localName;
+    const boundName = rebindingName(visitor, cu, options, existing);
+    if (boundName === undefined) {
+        return undefined;
+    }
+    if (!(visitor.afterVisit || []).some(v => v instanceof RebindImport &&
+        v.from.module === options.from.module && v.from.member === options.from.member &&
+        v.localName === existing.localName)) {
+        visitor.afterVisit.push(new RebindImport(options.from, options.to, existing.localName, boundName));
+    }
+    return boundName;
+}
+
+/**
+ * The name the moved binding takes, or undefined where a pinned alias cannot be bound verbatim,
+ * since deconflicting it would leave the references the caller emits unbound. The rule is
+ * CLAUDE.md: Which name a rebind binds.
+ */
+function rebindingName(
+    visitor: JavaScriptVisitor<any>,
+    cu: JS.CompilationUnit,
+    options: MaybeRebindOptions,
+    existing: ExistingImportBinding
+): string | undefined {
+    const taken = (name: string) => nameTaken(name, namesUsedIn(cu), visitor);
+    const alias = options.to.alias;
+    if (alias !== undefined) {
+        return isBindableName(alias) && (alias === existing.localName || !taken(alias)) ? alias : undefined;
+    }
+    const member = memberName(options.to.member);
+    if (existing.aliased || member === undefined || member === '*' || member === existing.localName) {
+        return existing.localName;
+    }
+    return taken(member) ? existing.localName : member;
 }
 
 /**

--- a/rewrite-javascript/rewrite/src/javascript/recipes/change-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/recipes/change-import.ts
@@ -41,15 +41,16 @@ import { create as produce } from "mutative";
  * // After:  import { act } from 'react';
  *
  * @example
- * // Change which member of the module a name is bound to
+ * // Rename a member, carrying the references that resolve to it
  * const recipe = new ChangeImport({
  *     oldModule: "lodash",
  *     oldMember: "extend",
  *     newModule: "lodash",
  *     newMember: "assign"
  * });
- * // Before: import { extend } from 'lodash';
- * // After:  import { assign as extend } from 'lodash';
+ * // Before: import { extend } from 'lodash';  extend({}, {});
+ * // After:  import { assign } from 'lodash';  assign({}, {});
+ * // Adding `newAlias: "extend"` instead binds it as `import { assign as extend }`.
  */
 export class ChangeImport extends Recipe {
     readonly name = "org.openrewrite.javascript.change-import";
@@ -85,11 +86,21 @@ export class ChangeImport extends Recipe {
     })
     newMember?: string;
 
+    @Option({
+        displayName: "New alias",
+        description: "The local name to bind the new member under. Defaults to the alias the import " +
+            "already had, or to the new member name where it had none.",
+        example: "act",
+        required: false
+    })
+    newAlias?: string;
+
     constructor(options?: {
         oldModule?: string;
         oldMember?: string;
         newModule?: string;
         newMember?: string;
+        newAlias?: string;
     }) {
         super(options);
     }
@@ -99,6 +110,7 @@ export class ChangeImport extends Recipe {
         const oldMember = this.oldMember;
         const newModule = this.newModule;
         const newMember = this.newMember ?? oldMember;
+        const newAlias = this.newAlias;
 
         // Build the old and new FQNs for type attribution updates
         const oldFqn = oldMember === 'default' || oldMember === '*'
@@ -114,7 +126,7 @@ export class ChangeImport extends Recipe {
             override async visitJsCompilationUnit(cu: JS.CompilationUnit, ctx: ExecutionContext): Promise<J | undefined> {
                 this.hasOldImport = maybeRebind(this, {
                     from: {module: oldModule, member: oldMember},
-                    to: {module: newModule, member: newMember}
+                    to: {module: newModule, member: newMember, alias: newAlias}
                 }) !== undefined;
 
                 return super.visitJsCompilationUnit(cu, ctx);

--- a/rewrite-javascript/rewrite/src/javascript/scope.ts
+++ b/rewrite-javascript/rewrite/src/javascript/scope.ts
@@ -55,6 +55,26 @@ export function namesDeclaredIn(cu: JS.CompilationUnit): ReadonlySet<string> {
     return namesDeclaredWithin(cu.statements, cu);
 }
 
+/**
+ * Every name the file spells, declared or not — what a name has to be absent from to be free. An
+ * ambient global is spelled and declared nowhere, and binding over one would capture its uses.
+ */
+export function namesUsedIn(cu: JS.CompilationUnit): ReadonlySet<string> {
+    const cached = used.get(cu);
+    if (cached) {
+        return cached;
+    }
+    const names = new Set<string>();
+    walk(cu.statements, node => {
+        if (node.kind === J.Kind.Identifier) {
+            names.add((node as J.Identifier).simpleName);
+        }
+        return true;
+    });
+    used.set(cu, names);
+    return names;
+}
+
 /** As {@link namesDeclaredIn}, over one subtree, for a binding shared across only that much of a file. */
 export function namesDeclaredWithin(node: unknown, cacheKey: object = node as object): ReadonlySet<string> {
     const cached = declared.get(cacheKey);
@@ -291,6 +311,7 @@ const blockScoped = new Set(['let', 'const', 'using']);
 // each of the call sites it encloses.
 const hoisted = new WeakMap<object, string[]>();
 const declared = new WeakMap<object, ReadonlySet<string>>();
+const used = new WeakMap<object, ReadonlySet<string>>();
 const frames = new WeakMap<object, string[]>();
 
 /**
@@ -399,4 +420,35 @@ export function declarationsOf(statement: J | undefined): J.VariableDeclarations
             .filter((v): v is J.VariableDeclarations => v?.kind === J.Kind.VariableDeclarations);
     }
     return [];
+}
+
+/**
+ * Whether the identifier stands for a value binding, which is what tells a rename which
+ * occurrences to follow. A name its parent introduces does not — a property, a method, a
+ * declaration — and neither does one drawn from a namespace of its own: a statement label, whether
+ * declaring (`x:`) or referencing (`break x`), and a JSX attribute's prop.
+ */
+export function isValueReference(cursor: Cursor, identifier: J.Identifier): boolean {
+    let c: Cursor | undefined = cursor.parent;
+    while (c && isPadding(c.value)) {
+        c = c.parent;
+    }
+    const parent = c?.value as
+        { kind?: string; name?: unknown; key?: unknown; label?: unknown; select?: unknown } | undefined;
+
+    // A call names a member of whatever it selects from. With nothing selected there is no member,
+    // and its `name` is a reference to the function being called.
+    if (parent?.kind === J.Kind.MethodInvocation && !parent.select) {
+        return true;
+    }
+
+    // A JSX attribute keeps its prop name on `key`; the three label-bearing nodes keep theirs on
+    // `label`. Every other kind that names rather than references keeps it on `name`.
+    const named = parent?.kind === JS.Kind.JsxAttribute ? parent.key : (parent?.name ?? parent?.label);
+    return named !== identifier && (named as { element?: unknown } | undefined)?.element !== identifier;
+}
+
+function isPadding(value: unknown): boolean {
+    const kind = (value as { kind?: string } | undefined)?.kind;
+    return kind === J.Kind.RightPadded || kind === J.Kind.LeftPadded || kind === J.Kind.Container;
 }

--- a/rewrite-javascript/rewrite/src/javascript/templating/bindings.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/bindings.ts
@@ -15,7 +15,7 @@
  */
 import {J, Type} from '../../java';
 import {JavaScriptVisitor} from '../visitor';
-import {Cursor} from '../../tree';
+import {isValueReference} from '../scope';
 
 /**
  * Renames the identifiers a template uses for its declared bindings to the names the file
@@ -43,33 +43,10 @@ class RenameBindingsVisitor extends JavaScriptVisitor<undefined> {
         const resolved = resolvedModule(identifier);
         const refersToBinding = resolved !== undefined
             ? resolved === this.modules[identifier.simpleName]
-            : !namesItsParent(this.cursor, identifier);
+            : isValueReference(this.cursor, identifier);
 
         return refersToBinding ? {...identifier, simpleName: renamed} as J.Identifier : identifier;
     }
-}
-
-/** Whether the parent is naming this identifier — as a property, a method, a declaration — rather than referencing it. */
-function namesItsParent(cursor: Cursor, identifier: J.Identifier): boolean {
-    let c: Cursor | undefined = cursor.parent;
-    while (c && isPadding(c.value)) {
-        c = c.parent;
-    }
-    const parent = c?.value as { kind?: string; name?: unknown; select?: unknown } | undefined;
-
-    // A call names a member of whatever it selects from. With nothing selected there is no member,
-    // and its `name` is a reference to the function being called.
-    if (parent?.kind === J.Kind.MethodInvocation && !parent.select) {
-        return false;
-    }
-
-    const name = parent?.name;
-    return name === identifier || (name as { element?: unknown } | undefined)?.element === identifier;
-}
-
-function isPadding(value: unknown): boolean {
-    const kind = (value as { kind?: string } | undefined)?.kind;
-    return kind === J.Kind.RightPadded || kind === J.Kind.LeftPadded || kind === J.Kind.Container;
 }
 
 /** The module an identifier's attribution traces back to, following the owning-class chain to its root. */

--- a/rewrite-javascript/rewrite/test/javascript/binding.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/binding.test.ts
@@ -1,9 +1,10 @@
 import {fromVisitor, RecipeSpec} from "../../src/test";
+import {withDir} from "tmp-promise";
 import {
-    JavaScriptVisitor, JS, javascript, typescript, moduleBindings, isAmdBlock, ModuleBindings, maybeBind,
+    JavaScriptVisitor, JS, javascript, npm, packageJson, tsx, typescript, moduleBindings, isAmdBlock, ModuleBindings, maybeBind,
     maybeAddImport, MaybeBindOptions, maybeUnbind, maybeRebind, maybeRemoveImport, removeNewlyUnusedAmdBindings
 } from "../../src/javascript";
-import {emptySpace, J, rightPadded} from "../../src/java";
+import {emptySpace, J, rightPadded, Type} from "../../src/java";
 import {emptyMarkers} from "../../src/markers";
 import {randomId} from "../../src/uuid";
 import {ExecutionContext} from "../../src";
@@ -849,8 +850,17 @@ describe("maybeBind", () => {
         expect(bound.name).toBe("Theming_1");
     });
 
+function rebindOldToNew() {
+    return new class extends JavaScriptVisitor<any> {
+        override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+            maybeRebind(this, {from: {module: "m", member: "Old"}, to: {module: "m2", member: "New"}});
+            return super.visitJsCompilationUnit(cu, p);
+        }
+    };
+}
+
 describe("maybeRebind", () => {
-    test("an ESM member move keeps the local name", async () => {
+    test("an ESM member rename takes the new name, carrying the references that resolve to it", async () => {
         const spec = new RecipeSpec();
         const bound: {name?: string} = {};
         spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
@@ -863,11 +873,289 @@ describe("maybeRebind", () => {
             }
         });
         await spec.rewriteRun(typescript(
-            `import { extend } from "lodash";\n\nextend({}, {});`,
-            `import { assign as extend } from "lodash";\n\nextend({}, {});`
+            `import { extend } from "lodash";\n\nextend({}, {});\nobj.extend();\nfunction f() { const extend = 1; return extend; }`,
+            `import { assign } from "lodash";\n\nassign({}, {});\nobj.extend();\nfunction f() { const extend = 1; return extend; }`
         ));
-        expect(bound.name).toBe("extend");
+        expect(bound.name).toBe("assign");
     });
+
+    test("a pinned alias names the binding, and the references follow it", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                bound.name = maybeRebind(this, {
+                    from: {module: "lodash", member: "extend"},
+                    to: {module: "lodash", member: "assign", alias: "merge"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await spec.rewriteRun(typescript(
+            `import { extend } from "lodash";\n\nextend({}, {});`,
+            `import { assign as merge } from "lodash";\n\nmerge({}, {});`
+        ));
+        expect(bound.name).toBe("merge");
+    });
+
+    test("an aliased member keeps the alias, which is a name of the file's own choosing", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                bound.name = maybeRebind(this, {
+                    from: {module: "lodash", member: "extend"},
+                    to: {module: "lodash", member: "assign"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await spec.rewriteRun(typescript(
+            `import { extend as myExtend } from "lodash";\n\nmyExtend({}, {});`,
+            `import { assign as myExtend } from "lodash";\n\nmyExtend({}, {});`
+        ));
+        expect(bound.name).toBe("myExtend");
+    });
+
+    test("an alias the new member name makes redundant is dropped", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                bound.name = maybeRebind(this, {
+                    from: {module: "lodash", member: "extend"},
+                    to: {module: "lodash", member: "assign"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await spec.rewriteRun(typescript(
+            `import { extend as assign } from "lodash";\n\nassign({}, {});`,
+            `import { assign } from "lodash";\n\nassign({}, {});`
+        ));
+        expect(bound.name).toBe("assign");
+    });
+
+    test("a re-export keeps the name the module publishes, and the binding under it follows", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(rebindOldToNew());
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\nexport { Old };\nconst y = Old;`,
+            `import { New } from "m2";\n\nexport { New as Old };\nconst y = New;`
+        ));
+    });
+
+    test("an aliased re-export renames only the reference beside the name it publishes", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(rebindOldToNew());
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\nconst X = 1;\nexport { Old as Public };\nexport { X as Old };`,
+            `import { New } from "m2";\n\nconst X = 1;\nexport { New as Public };\nexport { X as Old };`
+        ));
+    });
+
+    test("a shorthand property keeps its key and takes the renamed binding as its value", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(rebindOldToNew());
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\nconst p = {Old};\nconst o = {Old: 1};`,
+            `import { New } from "m2";\n\nconst p = {Old: New};\nconst o = {Old: 1};`
+        ));
+    });
+
+    test("a pinned alias the file cannot bind verbatim refuses, leaving the import alone", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                bound.name = maybeRebind(this, {
+                    from: {module: "m", member: "Old"},
+                    to: {module: "m2", member: "New", alias: "taken"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await spec.rewriteRun(typescript(`import { Old } from "m";\n\nconst taken = 1;\nOld();`));
+        expect(bound.name).toBeUndefined();
+    });
+
+    test("an AMD alias pin refuses where it renames the parameter, and passes where it agrees", async () => {
+        const amdRebind = (alias: string, bound: {name?: string}) => new class extends JavaScriptVisitor<any> {
+            override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
+                if (m.name.simpleName !== "target") {
+                    return super.visitMethodInvocation(m, p);
+                }
+                bound.name = maybeRebind(this, {from: {module: "a/Old"}, to: {module: "a/New", alias}});
+                return m;
+            }
+        };
+
+        const renames = new RecipeSpec();
+        const renamesBound: {name?: string} = {};
+        renames.recipe = fromVisitor(amdRebind("Renamed", renamesBound));
+        await renames.rewriteRun(javascript(`sap.ui.define(["a/Old"], function (Old) { target(); });`));
+        expect(renamesBound.name).toBeUndefined();
+
+        const agrees = new RecipeSpec();
+        const agreesBound: {name?: string} = {};
+        agrees.recipe = fromVisitor(amdRebind("Old", agreesBound));
+        await agrees.rewriteRun(javascript(
+            `sap.ui.define(["a/Old"], function (Old) { target(); });`,
+            `sap.ui.define(["a/New"], function (Old) { target(); });`));
+        expect(agreesBound.name).toBe("Old");
+    });
+
+    test("an alias that is not a legal identifier refuses rather than emitting unparseable source", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                bound.name = maybeRebind(this, {
+                    from: {module: "m", member: "Old"},
+                    to: {module: "m2", member: "New", alias: "my-name"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await spec.rewriteRun(typescript(`import { Old } from "m";\n\nconst y = Old;`));
+        expect(bound.name).toBeUndefined();
+    });
+
+    test("a name the file only references, never declares, still counts as taken", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                bound.name = maybeRebind(this, {
+                    from: {module: "m", member: "Old"},
+                    to: {module: "m2", member: "Event"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        // `Event` is an ambient global: the file declares it nowhere, so a check reading only
+        // declarations would call the name free and let the import shadow it here.
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\nfunction f(e: Event) { return Old(e); }`,
+            `import { Event as Old } from "m2";\n\nfunction f(e: Event) { return Old(e); }`
+        ));
+        expect(bound.name).toBe("Old");
+    });
+
+    test("a reference in type-name position renames: a decorator, and a generic's own base", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(rebindOldToNew());
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\n@Old({})\nexport class C {\n    @Old() field: Old<string>;\n}`,
+            `import { New } from "m2";\n\n@New({})\nexport class C {\n    @New() field: New<string>;\n}`
+        ));
+    });
+
+    test("a name a bind queued earlier in the same visit has claimed is taken too", async () => {
+        const spec = new RecipeSpec();
+        const bound: {name?: string} = {};
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                maybeBind(this, {module: "other", member: "New", onlyIfReferenced: false});
+                bound.name = maybeRebind(this, {
+                    from: {module: "m", member: "Old"},
+                    to: {module: "m2", member: "New"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\nconst y = Old;`,
+            `import { New as Old } from "m2";\nimport {New} from "other";\n\nconst y = Old;`
+        ));
+        expect(bound.name).toBe("Old");
+    });
+
+    test("a name in a namespace of its own — a nearer scope, a label — is left alone", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(rebindOldToNew());
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\nconst z = Old;\nOld: for (;;) { break Old; }\nfunction f() { const Old = 1; return {Old}; }`,
+            `import { New } from "m2";\n\nconst z = New;\nOld: for (;;) { break Old; }\nfunction f() { const Old = 1; return {Old}; }`
+        ));
+    });
+
+    test("a re-export from another module names that module's member, not the binding", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(rebindOldToNew());
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\n\nexport { Old } from "./other";\nconst y = Old;`,
+            `import { New } from "m2";\n\nexport { Old } from "./other";\nconst y = New;`
+        ));
+    });
+
+    test("a second statement binding the same member is left intact, not given the first's name", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(rebindOldToNew());
+        // One call moves one binding, so the second statement is a later call's to make; sharing
+        // the name read from the first would bind it twice.
+        await spec.rewriteRun(typescript(
+            `import { Old } from "m";\nimport { Old as Other } from "m";\n\nconst y = Old;\nconst z = Other;`,
+            `import { New } from "m2";\nimport { Old as Other } from "m";\n\nconst y = New;\nconst z = Other;`
+        ));
+    });
+
+    test("the moved binding's attribution names the module it moved to", async () => {
+        const spec = new RecipeSpec();
+        const declaring: (string | undefined)[] = [];
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                maybeRebind(this, {
+                    from: {module: "lodash", member: "extend"},
+                    to: {module: "lodash-es", member: "assign"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await withDir(async (repo) => {
+            await spec.rewriteRun(npm(repo.path, {
+                ...typescript(
+                    `import { extend } from 'lodash';\n\nextend({}, {});\n`,
+                    `import { assign } from 'lodash-es';\n\nassign({}, {});\n`),
+                afterRecipe: async (cu: any) => {
+                    await new class extends JavaScriptVisitor<any> {
+                        override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
+                            const declaringType = m.methodType?.declaringType;
+                            declaring.push(declaringType && Type.isFullyQualified(declaringType)
+                                ? Type.FullyQualified.getFullyQualifiedName(declaringType as any)
+                                : undefined);
+                            return m;
+                        }
+                    }().visit(cu, undefined);
+                }
+            } as any, packageJson(`{"name":"t","dependencies":{"lodash":"^4.17.21","lodash-es":"^4.17.21"}}`)));
+        }, {unsafeCleanup: true});
+        expect(declaring).toEqual(["lodash-es"]);
+    });
+
+    test("a self-referential type on a moved reference terminates", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                maybeRebind(this, {
+                    from: {module: "./util", member: "helper"},
+                    to: {module: "./util2", member: "helper2"}
+                });
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        // A function imported from a relative module is attributed to a class holding a method
+        // whose declaring type is that same class, and a reference carries it whole.
+        await withDir(async (repo) => {
+            await spec.rewriteRun(npm(repo.path,
+                {...typescript(`export function helper() { return 1; }\n`), path: "util.ts"} as any,
+                {...typescript(`export function helper2() { return 1; }\n`), path: "util2.ts"} as any,
+                {...typescript(
+                    `import { helper } from './util';\n\nconst x = helper;\n`,
+                    `import { helper2 } from './util2';\n\nconst x = helper2;\n`), path: "main.ts"} as any,
+                packageJson(`{"name":"t"}`)));
+        }, {unsafeCleanup: true});
+    }, 30000);
 
     test("an AMD dependency swap keeps the parameter and its index", async () => {
         const spec = new RecipeSpec();
@@ -1203,6 +1491,22 @@ describe("removeNewlyUnusedAmdBindings", () => {
         await spec.rewriteRun(javascript(
             `sap.ui.define(["a/A", "a/B", "a/C", "a/D"], function (A, B, C, D) { A.f(); B.f(); C.f(); D.f(); });`,
             `sap.ui.define(["a/A", "a/C"], function (A, C) { A.f(); A.f(); C.f(); C.f(); });`
+        ));
+    });
+});
+
+describe("maybeRebind JSX", () => {
+    test("a JSX attribute key is a name, not a reference", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                maybeRebind(this, {from: {module: "m", member: "Old"}, to: {module: "m2", member: "New"}});
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await spec.rewriteRun(tsx(
+            `import { Old } from "m";\n\nconst e = <div Old="x">{Old}</div>;`,
+            `import { New } from "m2";\n\nconst e = <div Old="x">{New}</div>;`
         ));
     });
 });

--- a/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
@@ -371,6 +371,40 @@ describe("change-import", () => {
             }, { unsafeCleanup: true });
         });
 
+        test("renames an unaliased member and the references that resolve to it", async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = new ChangeImport({
+                oldModule: "primeng/sidebar",
+                oldMember: "SidebarModule",
+                newModule: "primeng/drawer",
+                newMember: "DrawerModule"
+            });
+
+            await withDir(async (repo) => {
+                await spec.rewriteRun(
+                    npm(
+                        repo.path,
+                        typescript(
+                            `
+                            import { SidebarModule } from 'primeng/sidebar';
+
+                            const m = SidebarModule;
+                            `,
+                            `
+                            import { DrawerModule } from 'primeng/drawer';
+
+                            const m = DrawerModule;
+                            `
+                        ),
+                        packageJson(`{
+                            "name": "test",
+                            "dependencies": {}
+                        }`)
+                    )
+                );
+            }, { unsafeCleanup: true });
+        });
+
         test("renames the member but keeps the local name", async () => {
             const spec = new RecipeSpec();
             spec.recipe = new ChangeImport({
@@ -413,13 +447,14 @@ describe("change-import", () => {
             }, { unsafeCleanup: true });
         });
 
-        test("keeps a type-only specifier's type keyword separate", async () => {
+        test("a pinned alias keeps a type-only specifier's type keyword separate", async () => {
             const spec = new RecipeSpec();
             spec.recipe = new ChangeImport({
                 oldModule: "lodash",
                 oldMember: "extend",
                 newModule: "lodash",
-                newMember: "assign"
+                newMember: "assign",
+                newAlias: "extend"
             });
 
             await withDir(async (repo) => {
@@ -449,7 +484,7 @@ describe("change-import", () => {
             }, { unsafeCleanup: true });
         });
 
-        test("keeps the local name when moving a member to another module", async () => {
+        test("moving a member to another module renames it too, leaving its siblings behind", async () => {
             const spec = new RecipeSpec();
             spec.recipe = new ChangeImport({
                 oldModule: "lodash",
@@ -471,9 +506,9 @@ describe("change-import", () => {
                             `,
                             `
                             import { flatten } from 'lodash';
-                            import { assign as extend } from 'lodash-es';
+                            import { assign } from 'lodash-es';
 
-                            extend({}, {});
+                            assign({}, {});
                             flatten([]);
                             `
                         ),


### PR DESCRIPTION
`maybeRebind` kept the local name a moved binding already had, whatever its origin. For a genuine alias that is correct — `import { SidebarModule as SB }` must still bind `SB` after the move. For an unaliased `import { SidebarModule }` it introduced an alias the source never had, because the local name equalled the member name only by default:

```ts
import { SidebarModule } from 'primeng/sidebar';
  →  import { DrawerModule as SidebarModule } from 'primeng/drawer';
```

That made "rename an imported symbol, its binding, and all its usages" inexpressible. `maybeUnbind` + `maybeBind` is not a substitute: `maybeUnbind` runs while the old binding is still referenced, so it emits a duplicated import. It surfaced as ten failing tests across seven recipes in `moderneinc/rewrite-angular` (`recipes-angular/src/libraries/primeng/18/`), each a composite of a `RenameXIdentifiers` visitor plus `ChangeImport`. The two halves stopped agreeing on the name and the emitted code did not compile:

```ts
import { ToastMessageOptions as Message } from 'primeng/api';
const msg: ToastMessageOptions = { ... };   // ToastMessageOptions is unbound
```

## Why preserve-always was never the intent

- 8a86f1a130 (#8688) introduced it to fix the mirror-image bug — the old in-place rewrite renamed the binding and left every reference dangling — and said what was missing: *"Renaming references so the alias can be dropped is the strictly nicer output and wants a scope-correct rename utility, which does not exist in rewrite-javascript yet; this is a clean base for it."* This is that utility.

## Which name a rebind binds

A pinned `to.alias` settles it. Otherwise a binding the source named itself — an aliased specifier, or a default, namespace or AMD binding, whose name never came from a member — keeps that name; an unaliased named specifier follows its member to the new name, but only where the file spells that name nowhere else, since a rename onto a name already in use would capture its references or be captured by them. Where it is taken the binding keeps its name as an alias and the move is otherwise the same.

The check is deliberately over-broad: any identifier anywhere counts, not just declarations. An ambient global is spelled and declared nowhere, so a declarations-only check would call `Event` free and let a new module-scope import shadow it, silently changing what `function f(e: Event)` means. That case is pinned by a test.

- `ChangeImport` regains `newAlias`, removed in #8685 as a declared-but-unconsulted option, now with semantics: it is how a caller asks for the old output.

## Splitting, not renaming

Two positions spell a name and a reference with one identifier, and are split rather than renamed:

| source | result |
|---|---|
| `const p = {Old}` | `{Old: New}` — the property its object publishes stays |
| `export { Old }` | `export { New as Old }` — the name the module publishes stays |

In `export { X as Old }` only `X` is a reference; `Old` belongs to the file's consumers. In `export { Old } from './other'` the specifier names *that* module's member and is left alone entirely.

## Type attribution

`RebindImport` now carries attribution for the binding it moves, which bare `maybeRebind` never did — a direct caller got identifiers printing the new name while `methodType.declaringType` still named the old module. It is reference-scoped, which matters: for a named member import the `declaringType` is the *module* class, shared with every sibling imported beside it, so a rewrite on `JavaVisitor`'s central `visitType` hook drags siblings along. `ChangeImport`'s own unscoped FQN sweep has exactly that bug today (`flatten` comes out `declaringType=lodash-es` after only `extend` moves); consolidating the two is tracked separately.

`MovedTypes` carries a cycle guard. `TypeVisitor.visitMethod` documents that it "does not visit the declaring type to avoid a visitor cycle" while its body does exactly that, and the JS mapper produces a class holding a method whose declaring type is that class. Without the guard, rebinding a non-call reference to a member of a relative module kills the vitest worker. The guard is on the subclass, not the base: `TypeSender`/`TypeReceiver` already terminate cycles via RPC refs, so a second policy underneath a working one, keyed on different object identities on each side, is how a queue desync starts.

Decorators reach the tree only through `visitTypeName`, which the base visitor leaves closed, so `@Component` stayed unbound while the same symbol's value references renamed. That hook covers the annotation and parameterized-type sites both.

## Tests

Nineteen tests in `binding.test.ts`, one added and two re-expected in `change-import.test.ts`. The guards for the two fallbacks — a genuine alias survives, a colliding name aliases — and the reported primeng shape are all pinned. Mutation-checked: the shadowing guard, the property-position guard, the reference-id handoff to `visitMethodInvocation`, and the used-vs-declared name check each fail the suite when removed. The cycle test carries an explicit 30s timeout so a regression fails fast rather than wedging CI.

Validated end-to-end against `moderneinc/rewrite-angular` at `main` by a separate session: 567/568 across 127 files, the one failure being that repo's own `RenameMessageIdentifiers` ordering bug, which passes once the now-redundant visitor is deleted.

## Not in this change

Migrating a barrel `export { X } from 'lib'` with no local import; formatting the import statements `AddImport` inserts; and consolidating `ChangeImport`'s ~190-line FQN remapper onto `MovedTypes`, which also fixes the sibling over-reach above. All three are tracked separately.
