### PR TITLE
Accept the full packument as a fallback to avoid registry HTTP 406

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/registry/NpmRegistryClient.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/registry/NpmRegistryClient.java
@@ -39,7 +39,9 @@ import java.util.concurrent.ConcurrentHashMap;
  * keyed by (registry, name[, version]). Mirrors the Python {@code SimpleIndexClient}.
  */
 public class NpmRegistryClient {
-    private static final String PACKUMENT_ACCEPT = "application/vnd.npm.install-v1+json";
+    // https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md
+    private static final String PACKUMENT_ACCEPT =
+            "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*";
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/RegistryLockRegenTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/RegistryLockRegenTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.HttpSenderExecutionContextView;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.ipc.http.HttpSender;
+import org.openrewrite.javascript.marker.NodeResolutionResult.PackageManager;
+import org.openrewrite.test.RewriteTest;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.Collections.singletonList;
+import static org.openrewrite.javascript.Assertions.dependency;
+import static org.openrewrite.javascript.Assertions.nodeResolutionResult;
+import static org.openrewrite.javascript.Assertions.packageJson;
+import static org.openrewrite.javascript.Assertions.packageLock;
+
+class RegistryLockRegenTest implements RewriteTest {
+
+    private ExecutionContext ctx;
+    private final Map<String, String> routes = new HashMap<>();
+
+    private Function<HttpSender.Request, HttpSender.Response> responder = request -> null;
+
+    @BeforeEach
+    void setUp() {
+        routes.clear();
+        responder = request -> null;
+        HttpSender http = request -> {
+            HttpSender.Response custom = responder.apply(request);
+            if (custom != null) {
+                return custom;
+            }
+            String body = routes.get(request.getUrl().toString());
+            return new HttpSender.Response(body == null ? 404 : 200,
+                    new ByteArrayInputStream((body == null ? "" : body).getBytes(StandardCharsets.UTF_8)), () -> {
+            });
+        };
+        ctx = new InMemoryExecutionContext(t -> {
+            throw new RuntimeException(t);
+        });
+        HttpSenderExecutionContextView.view(ctx).setHttpSender(http);
+        NodeExecutionContextView.view(ctx).setRegistries(singletonList(
+                new NodeRegistry(null, "https://registry.npmjs.org/", null, null, null, null, false, null, true, false)));
+    }
+
+    /**
+     * An Artifactory-style npm proxy that returns {@code HTTP 406} for the abbreviated packument media type still
+     * serves the full packument to a client that also accepts {@code application/json}, so the bump resolves and
+     * the lock regenerates.
+     */
+    @Test
+    void packumentServedOverJsonFallbackRegeneratesLock() {
+        routes.put("https://registry.npmjs.org/is-odd", resource("lock/npm/v3/http/is-odd"));
+        routes.put("https://registry.npmjs.org/is-odd/3.0.0", resource("lock/npm/v3/http/is-odd-3.0.0"));
+        routes.put("https://registry.npmjs.org/is-odd/3.0.1", resource("lock/npm/v3/http/is-odd-3.0.1"));
+
+        responder = request -> {
+            String accept = request.getRequestHeaders().getOrDefault("Accept", "");
+            if (request.getUrl().toString().endsWith("/is-odd") && !accept.contains("application/json")) {
+                return new HttpSender.Response(406,
+                        new ByteArrayInputStream("Not Acceptable".getBytes(StandardCharsets.UTF_8)), () -> {
+                });
+            }
+            return null;
+        };
+
+        String pkgBefore = "{\n" +
+                "  \"name\": \"npm-lock-v3\",\n" +
+                "  \"version\": \"1.0.0\",\n" +
+                "  \"dependencies\": {\n" +
+                "    \"is-odd\": \"3.0.0\"\n" +
+                "  }\n" +
+                "}\n";
+        String pkgAfter = pkgBefore.replace("\"is-odd\": \"3.0.0\"", "\"is-odd\": \"3.0.1\"");
+
+        rewriteRun(
+                spec -> spec.recipe(new UpgradeDependencyVersion("is-odd", null, "3.0.1")).executionContext(ctx),
+                packageJson(pkgBefore, pkgAfter,
+                        nodeResolutionResult(PackageManager.Npm, dependency("is-odd", "3.0.0"))),
+                packageLock(resource("lock/npm/v3/before"), resource("lock/npm/v3/after"), s -> s.noTrim())
+        );
+    }
+
+    private static String resource(String path) {
+        try (InputStream in = RegistryLockRegenTest.class.getClassLoader().getResourceAsStream(path)) {
+            if (in == null) {
+                throw new IllegalStateException("missing test resource " + path);
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) >= 0) {
+                out.write(buf, 0, n);
+            }
+            return new String(out.toByteArray(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+}

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/registry/NpmRegistryClientTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/registry/NpmRegistryClientTest.java
@@ -44,7 +44,7 @@ class NpmRegistryClientTest {
     }
 
     @Test
-    void packumentSendsInstallV1Accept() {
+    void packumentAcceptsInstallV1WithJsonFallback() {
         StubHttpSender sender = new StubHttpSender();
         sender.enqueueJson(200, "{\"dist-tags\":{\"latest\":\"4.17.21\"}," +
                 "\"versions\":{\"4.17.20\":{},\"4.17.21\":{}}}");
@@ -53,7 +53,8 @@ class NpmRegistryClientTest {
         AbbreviatedPackument packument = client.getPackument(registry(), "lodash");
 
         assertThat(sender.last().getUrl().getPath()).isEqualTo("/lodash");
-        assertThat(sender.last().getRequestHeaders()).containsEntry("Accept", "application/vnd.npm.install-v1+json");
+        assertThat(sender.last().getRequestHeaders())
+                .containsEntry("Accept", "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*");
         assertThat(packument.getVersions()).containsExactly("4.17.20", "4.17.21");
         assertThat(packument.getDistTags()).containsEntry("latest", "4.17.21");
     }


### PR DESCRIPTION
## Problem

Regenerating an npm lock file requests the abbreviated packument with only `Accept: application/vnd.npm.install-v1+json`. A registry that does not serve that media type (for example some Artifactory npm proxies) responds with `HTTP 406`, which surfaces as `REGISTRY_UNREACHABLE` and aborts dependency resolution, even though the registry can serve the full packument.

## Fix

Mirror npm's own `Accept` header and request the full packument as a fallback: `application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*`. A registry that cannot serve the abbreviated form now returns the full packument instead of a 406. The packument parser already tolerates the full document.
