### PR TITLE
JavaScript: regenerate npm locks with alias forks and duplicate placements

### DIFF
--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/LockEditSet.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/LockEditSet.java
@@ -51,6 +51,10 @@ public class LockEditSet {
     public static class PackageEdit {
         String name;
 
+        /** For an {@code npm:} alias, the real package name written as the entry's {@code name} field; else {@code null}. */
+        @Nullable
+        String aliasName;
+
         String oldVersion;
 
         /** The resolved target version, or {@code null} for a removal. */

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/NpmGraphBuilder.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/NpmGraphBuilder.java
@@ -40,8 +40,8 @@ import static org.openrewrite.semver.Semver.Ecosystem.NODE;
  * (npm only; see {@link #autoInstallPeers}) and the slice is cleanest — an all-prod closure, the peer
  * a single pure-leaf version required by a single package — the peer is added as a top-level node; every other
  * missing-peer shape fails loud. An {@code npm:<name>@<range>} alias resolves its real package but is keyed and
- * placed by the alias name, reproduced only when self-contained (no un-aliased copy of the same package, no peer
- * entanglement). Version and constraint decisions are delegated entirely to node-semver.
+ * placed by the alias name, reproduced unless it entangles the peer machinery (its real name required as a peer,
+ * or the alias declaring peers). Version and constraint decisions are delegated entirely to node-semver.
  */
 public final class NpmGraphBuilder {
 
@@ -284,28 +284,17 @@ public final class NpmGraphBuilder {
     }
 
     /**
-     * Only a self-contained alias is reproduced byte-exact: the real package must not also resolve un-aliased (nor
-     * be aliased more than once), and it must not entangle the peer machinery (which keys by real name). An alias
-     * that forks with a non-aliased copy, whose real name is required as a peer, or that itself declares peers,
-     * defers with the classic message.
+     * Guard the alias shapes the serializer cannot yet place byte-exact. Every alias lands at its own top-level
+     * slot, so any number of aliases of a package, with or without an un-aliased copy, are reproduced. An alias
+     * whose real name is required as a peer, or that declares peers of its own, still defers because the peer
+     * machinery keys by real name.
      */
     private static void requireResolvableAliases(Map<String, String> aliases, Map<String, Set<String>> chosen,
                                                  Map<String, VersionManifest> manifests) {
         if (aliases.isEmpty()) {
             return;
         }
-        Map<String, Integer> targetCount = new LinkedHashMap<>();
-        for (String realName : aliases.values()) {
-            targetCount.merge(realName, 1, Integer::sum);
-        }
         Set<String> aliasedReal = new HashSet<>(aliases.values());
-        for (Map.Entry<String, String> alias : aliases.entrySet()) {
-            String realName = alias.getValue();
-            if (chosen.containsKey(realName) || targetCount.get(realName) > 1) {
-                throw new EngineFailure(RESOLUTION_REQUIRED, realName, alias.getKey() + " aliases " + realName +
-                        " which also resolves un-aliased (alias fork not yet resolved)");
-            }
-        }
         for (VersionManifest m : manifests.values()) {
             Map<String, String> peers = m.getPeerDependencies();
             if (peers == null) {

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/NpmLockDiff.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/NpmLockDiff.java
@@ -52,8 +52,9 @@ final class NpmLockDiff {
         Lock lock = Lock.parse(existingLock);
         requireRootEntryMirrors(root, lock);
 
-        Map<String, String> bindings = bindNodesToKeys(graph, root, lock);
-        Set<String> fresh = hoistUnbound(graph, root, bindings);
+        Matched matched = bindNodesToKeys(graph, root, lock);
+        Map<String, String> bindings = matched.bindings;
+        Set<String> fresh = hoistUnbound(graph, root, bindings, matched.pinnedPlacements);
         requireReproducibleFreshPlacements(graph, root, bindings, fresh);
 
         Set<String> peerProviders = peerProviderKeys(graph);
@@ -68,31 +69,48 @@ final class NpmLockDiff {
             PackageEdit edit = fresh.contains(nodeKey) ?
                     addEdit(root, slot, node, key, peer) :
                     boundEdit(root, lock, slot, node, key, peer);
+            if (edit != null && matched.duplicatedNodes.contains(nodeKey)) {
+                // The version sits at several node_modules paths; one edit cannot rewrite them all in step.
+                throw new EngineFailure(Reason.RESOLUTION_REQUIRED, slot,
+                        slot + "@" + versionOf(nodeKey) + " is installed at multiple places and changed (not yet patched)");
+            }
             if (edit != null) {
                 prunes |= edit.isPrunesOrphans();
                 edits.add(edit);
             }
         }
 
-        edits.addAll(removalEdits(graph, root, lock, bindings, prunes));
+        edits.addAll(removalEdits(graph, root, lock, bindings, prunes, matched.pinnedPlacements));
         return edits;
     }
 
     // --- matching ----------------------------------------------------------
 
     /**
+     * The outcome of matching graph nodes to installed keys: the primary placement of each node, the extra
+     * (duplicate) placements to pin, and which nodes are placed at more than one path.
+     */
+    private static final class Matched {
+        final Map<String, String> bindings = new LinkedHashMap<>();          // nodeKey -> primary lock key
+        final Map<String, String> pinnedPlacements = new LinkedHashMap<>();  // extra duplicate lock key -> version
+        final Set<String> duplicatedNodes = new LinkedHashSet<>();           // nodeKeys placed at >1 path
+    }
+
+    /**
      * Bind graph nodes to installed keys slot-by-slot: the root importer's declared version claims the
      * top-level slot, remaining versions match keys holding exactly that version, and a lone leftover pair
-     * binds as an in-place move. Anything else is ambiguous and fails loud.
+     * binds as an in-place move. A version npm placed at several node_modules paths (a nested dep that cannot
+     * dedupe across sibling requirers) binds its first placement and pins the rest, so an unchanged closure
+     * preserves every copy. Anything else is ambiguous and fails loud.
      */
-    private static Map<String, String> bindNodesToKeys(ResolutionGraph graph, ResolutionGraph.Importer root,
-                                                       Lock lock) {
+    private static Matched bindNodesToKeys(ResolutionGraph graph, ResolutionGraph.Importer root, Lock lock) {
         Map<String, List<String>> graphSlots = new LinkedHashMap<>();
         for (String nodeKey : graph.getNodes().keySet()) {
             graphSlots.computeIfAbsent(slotOf(nodeKey), k -> new ArrayList<>()).add(nodeKey);
         }
 
-        Map<String, String> bindings = new LinkedHashMap<>();
+        Matched matched = new Matched();
+        Map<String, String> bindings = matched.bindings;
         for (Map.Entry<String, List<String>> e : graphSlots.entrySet()) {
             String slot = e.getKey();
             List<String> nodeKeys = new ArrayList<>(e.getValue());
@@ -114,13 +132,15 @@ final class NpmLockDiff {
                         matches.add(lockKey);
                     }
                 }
-                if (matches.size() > 1) {
-                    throw new EngineFailure(Reason.RESOLUTION_REQUIRED, slot,
-                            slot + "@" + version + " is installed at multiple places (" + matches + ")");
-                }
-                if (matches.size() == 1) {
+                if (!matches.isEmpty()) {
                     bindings.put(nodeKey, matches.get(0));
-                    lockKeys.remove(matches.get(0));
+                    if (matches.size() > 1) {
+                        matched.duplicatedNodes.add(nodeKey);
+                        for (String extra : matches.subList(1, matches.size())) {
+                            matched.pinnedPlacements.put(extra, version);
+                        }
+                    }
+                    lockKeys.removeAll(matches);
                     it.remove();
                 }
             }
@@ -132,7 +152,7 @@ final class NpmLockDiff {
             }
             // Leftover graph versions place fresh; leftover lock keys become removals.
         }
-        return bindings;
+        return matched;
     }
 
     /**
@@ -141,7 +161,7 @@ final class NpmLockDiff {
      * holds the same version, nesting one level deeper past a conflict. Returns the freshly placed node keys.
      */
     private static Set<String> hoistUnbound(ResolutionGraph graph, ResolutionGraph.Importer root,
-                                            Map<String, String> bindings) {
+                                            Map<String, String> bindings, Map<String, String> pinnedPlacements) {
         Map<String, Map<String, String>> shelf = new HashMap<>();
         Set<String> visited = new HashSet<>();
         Deque<String[]> queue = new ArrayDeque<>();
@@ -150,6 +170,10 @@ final class NpmLockDiff {
             shelf.computeIfAbsent(prefixOf(key), k -> new HashMap<>()).put(slotOf(key), versionOf(b.getKey()));
             visited.add(b.getKey());
             queue.add(new String[]{b.getKey(), key});
+        }
+        // A version pinned at extra node_modules paths is seeded too, so the walk dedupes rather than re-placing.
+        for (Map.Entry<String, String> p : pinnedPlacements.entrySet()) {
+            shelf.computeIfAbsent(prefixOf(p.getKey()), k -> new HashMap<>()).put(slotOf(p.getKey()), p.getValue());
         }
         Set<String> fresh = new LinkedHashSet<>();
 
@@ -406,10 +430,8 @@ final class NpmLockDiff {
     private static PackageEdit addEdit(ResolutionGraph.Importer root, String slot, ResolvedNode node,
                                        String key, boolean peer) {
         VersionManifest m = node.getManifest();
-        if (!slot.equals(m.getName())) {
-            throw new EngineFailure(Reason.RESOLUTION_REQUIRED, slot,
-                    slot + " aliases " + m.getName() + "; a fresh alias entry cannot yet be patched in");
-        }
+        // An alias entry sits at its declared slot but records the real package name as its `name` field.
+        String aliasName = slot.equals(m.getName()) ? null : m.getName();
         EntryMetadata metadata = addMetadata(node, peer);
         VersionManifest.Dist dist = m.getDist();
         if (dist == null || dist.getTarball() == null || dist.getIntegrity() == null) {
@@ -418,6 +440,7 @@ final class NpmLockDiff {
         }
         return PackageEdit.builder()
                 .name(slot)
+                .aliasName(aliasName)
                 .oldVersion("")
                 .newVersion(m.getVersion())
                 .newResolved(dist.getTarball())
@@ -728,8 +751,10 @@ final class NpmLockDiff {
      * rides an orphan-pruning bump's GC, and with no such bump nothing can prove it collectable, so it defers.
      */
     private static List<PackageEdit> removalEdits(ResolutionGraph graph, ResolutionGraph.Importer root,
-                                                  Lock lock, Map<String, String> bindings, boolean prunes) {
+                                                  Lock lock, Map<String, String> bindings, boolean prunes,
+                                                  Map<String, String> pinnedPlacements) {
         Set<String> boundKeys = new HashSet<>(bindings.values());
+        boundKeys.addAll(pinnedPlacements.keySet());
         List<PackageEdit> removals = new ArrayList<>();
         for (String key : lock.installedKeys) {
             if (boundKeys.contains(key)) {

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/NpmLockPatcher.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/lock/NpmLockPatcher.java
@@ -381,6 +381,10 @@ public final class NpmLockPatcher implements LockPatcher {
 
         // Site (3): the v2 legacy dependencies tree.
         if (lockfileVersion == 2) {
+            if (edit.getAliasName() != null) {
+                throw new EngineFailure(Reason.RESOLUTION_REQUIRED, name,
+                        name + " is an npm: alias; its lockfileVersion 2 legacy entry is not yet supported");
+            }
             root = insertLegacyEntry(root, edit);
         }
         return root;
@@ -469,6 +473,10 @@ public final class NpmLockPatcher implements LockPatcher {
                 keyIndent.substring(indentOf(closeWs).length()) : "  ";
 
         List<EntryField> fields = new ArrayList<>();
+        // An npm: alias entry leads with the real package name; NpmKeyOrder sorts it ahead of version.
+        if (edit.getAliasName() != null) {
+            fields.add(new EntryField("name", jsonEncode(edit.getAliasName()), false));
+        }
         fields.add(new EntryField("version", jsonEncode(edit.getNewVersion()), false));
         fields.add(new EntryField("resolved", jsonEncode(edit.getNewResolved()), false));
         fields.add(new EntryField("integrity", jsonEncode(edit.getNewIntegrity()), false));

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/lock/NpmAliasForkLockRegenTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/lock/NpmAliasForkLockRegenTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.internal.lock;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.javascript.internal.LockFileRegeneration.Reason;
+import org.openrewrite.javascript.internal.LockFileRegeneration.Result;
+import org.openrewrite.javascript.marker.NodeResolutionResult.PackageManager;
+
+import java.nio.file.Paths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The npm alias-fork case through the whole {@link NativeLockEngine}: one or more {@code npm:} aliases of a real
+ * package (the {@code @isaacs/cliui} {@code string-width} / {@code string-width-cjs} shape), with or without an
+ * un-aliased copy. Every alias lands at its own top-level slot carrying a {@code name} field for the real package
+ * and the real package's {@code resolved}/{@code integrity}. Each byte-exact test replays a fixture entirely
+ * OFFLINE (a stub {@code HttpSender} serves the real package's packument/manifests) and asserts the emitted lock
+ * is BYTE-IDENTICAL to a golden {@code after} recorded from a real
+ * {@code npm install --package-lock-only --lockfile-version 3} (npm 10.9.2).
+ */
+class NpmAliasForkLockRegenTest extends LockRegenTestSupport {
+
+    @Test
+    void aliasForkAddV3() {
+        // The lock already resolves emoji-regex@10.6.0 (the un-aliased copy). Adding an emoji-regex-cjs alias of
+        // emoji-regex@^8 forks the same real package: npm inserts a second top-level entry keyed emoji-regex-cjs
+        // with a `name` field of emoji-regex, leaving the un-aliased entry byte-identical.
+        routes.put(REG + "emoji-regex", resource("lock/npm/alias-fork/http/emoji-regex"));
+        routes.put(REG + "emoji-regex/8.0.0", resource("lock/npm/alias-fork/http/emoji-regex-8.0.0"));
+        routes.put(REG + "emoji-regex/10.6.0", resource("lock/npm/alias-fork/http/emoji-regex-10.6.0"));
+
+        Result result = NativeLockEngine.regenerate(PackageManager.Npm,
+                resource("lock/npm/alias-fork/pkg-after"),
+                resource("lock/npm/alias-fork/pkg-before"),
+                resource("lock/npm/alias-fork/before"),
+                null, Paths.get("package.json"), ctx);
+
+        assertThat(result.isSuccess()).as(String.valueOf(result.getErrorMessage())).isTrue();
+        assertThat(result.getLockFileContent()).isEqualTo(resource("lock/npm/alias-fork/after"));
+    }
+
+    @Test
+    void multiAliasForkAddSameVersionV3() {
+        // er-x already aliases emoji-regex@8; adding a second alias er-y of the same package places an
+        // independent top-level entry and leaves er-x byte-identical.
+        routes.put(REG + "emoji-regex", resource("lock/npm/multi-alias-same/http/emoji-regex"));
+        routes.put(REG + "emoji-regex/8.0.0", resource("lock/npm/multi-alias-same/http/emoji-regex-8.0.0"));
+
+        Result result = NativeLockEngine.regenerate(PackageManager.Npm,
+                resource("lock/npm/multi-alias-same/pkg-after"),
+                resource("lock/npm/multi-alias-same/pkg-before"),
+                resource("lock/npm/multi-alias-same/before"),
+                null, Paths.get("package.json"), ctx);
+
+        assertThat(result.isSuccess()).as(String.valueOf(result.getErrorMessage())).isTrue();
+        assertThat(result.getLockFileContent()).isEqualTo(resource("lock/npm/multi-alias-same/after"));
+    }
+
+    @Test
+    void multiAliasForkAddDifferentVersionsV3() {
+        // er8 aliases emoji-regex@8; adding er10 aliasing emoji-regex@10 places a second alias entry at its own
+        // version, sorted before er8 (er10 < er8) in both the packages map and the importer edges.
+        routes.put(REG + "emoji-regex", resource("lock/npm/multi-alias-diff/http/emoji-regex"));
+        routes.put(REG + "emoji-regex/8.0.0", resource("lock/npm/multi-alias-diff/http/emoji-regex-8.0.0"));
+        routes.put(REG + "emoji-regex/10.6.0", resource("lock/npm/multi-alias-diff/http/emoji-regex-10.6.0"));
+
+        Result result = NativeLockEngine.regenerate(PackageManager.Npm,
+                resource("lock/npm/multi-alias-diff/pkg-after"),
+                resource("lock/npm/multi-alias-diff/pkg-before"),
+                resource("lock/npm/multi-alias-diff/before"),
+                null, Paths.get("package.json"), ctx);
+
+        assertThat(result.isSuccess()).as(String.valueOf(result.getErrorMessage())).isTrue();
+        assertThat(result.getLockFileContent()).isEqualTo(resource("lock/npm/multi-alias-diff/after"));
+    }
+
+    @Test
+    void duplicateNestedPlacementPreservedV3() {
+        // stripa and stripb both alias strip-ansi@6, which needs ansi-regex@5 while the top-level slot holds
+        // ansi-regex@6, so npm nests a private ansi-regex@5 under each. An overrides edit forces whole-closure
+        // re-resolution, which must preserve both copies of the duplicated ansi-regex@5 byte-identically.
+        routes.put(REG + "strip-ansi/6.0.1", resource("lock/npm/dup-placement/http/strip-ansi-6.0.1"));
+        routes.put(REG + "ansi-regex/6.3.0", resource("lock/npm/dup-placement/http/ansi-regex-6.3.0"));
+        routes.put(REG + "ansi-regex/5.0.1", resource("lock/npm/dup-placement/http/ansi-regex-5.0.1"));
+
+        String before = resource("lock/npm/dup-placement/before");
+        String original = resource("lock/npm/dup-placement/pkg-before");
+        String edited = original.trim().replaceFirst("}$", ",\"overrides\":{\"z-nonexistent-xyz\":\"1.0.0\"}}");
+
+        Result result = NativeLockEngine.regenerate(PackageManager.Npm, edited, original, before,
+                null, Paths.get("package.json"), ctx);
+
+        assertThat(result.isSuccess()).as(String.valueOf(result.getErrorMessage())).isTrue();
+        assertThat(result.getLockFileContent()).isEqualTo(before);
+    }
+
+    @Test
+    void aliasAddIntoV2LockDefers() {
+        // The alias resolves through whole-closure, but a fresh alias entry in a lockfileVersion 2 legacy tree is
+        // not yet serialized, so it fails loud rather than emit an unverified layout.
+        routes.put(REG + "emoji-regex", resource("lock/npm/alias-fork/http/emoji-regex"));
+        routes.put(REG + "emoji-regex/8.0.0", resource("lock/npm/alias-fork/http/emoji-regex-8.0.0"));
+        routes.put(REG + "emoji-regex/10.6.0", resource("lock/npm/alias-fork/http/emoji-regex-10.6.0"));
+
+        Result result = NativeLockEngine.regenerate(PackageManager.Npm,
+                resource("lock/npm/alias-fork/pkg-after"),
+                resource("lock/npm/alias-fork/pkg-before"),
+                resource("lock/npm/alias-fork/before-v2"),
+                null, Paths.get("package.json"), ctx);
+
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getFailure().getReason()).isEqualTo(Reason.RESOLUTION_REQUIRED);
+        assertThat(result.getFailure().getDetail()).contains("lockfileVersion 2");
+    }
+}

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/lock/NpmGraphBuilderTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/lock/NpmGraphBuilderTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.javascript.internal.lock.EngineFailure;
 import org.openrewrite.javascript.internal.registry.VersionManifest;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -311,13 +312,38 @@ class NpmGraphBuilderTest {
     }
 
     @Test
-    void defersAliasForkingWithUnaliasedCopy() {
-        // react-is is both a normal dependency and an alias target: the alias would fork a non-aliased copy — defer.
+    void resolvesAliasForkWithUnaliasedCopy() {
+        // react-is is both a normal dependency and an alias target: the alias forks the un-aliased copy and both
+        // resolve at 18.3.1, each keyed by its own slot.
         FakeRegistry registry = new FakeRegistry().add("react-is", "18.3.1", emptyMap());
 
-        assertThatExceptionOfType(EngineFailure.class).isThrownBy(() ->
-                new NpmGraphBuilder(registry).build(singletonMap("",
-                        "{\"dependencies\":{\"react-is\":\"^18.3.1\",\"react-is-18\":\"npm:react-is@^18.3.1\"}}")));
+        ResolutionGraph graph = new NpmGraphBuilder(registry).build(singletonMap("",
+                "{\"dependencies\":{\"react-is\":\"^18.3.1\",\"react-is-18\":\"npm:react-is@^18.3.1\"}}"));
+
+        assertThat(graph.getNodes()).containsOnlyKeys("react-is@18.3.1", "react-is-18@18.3.1");
+        assertThat(graph.node("react-is-18", "18.3.1").getName()).isEqualTo("react-is");
+    }
+
+    @Test
+    void resolvesStringWidthCjsAliasForkWithUnaliasedCopy() {
+        // @isaacs/cliui pins both string-width (^5, ESM) and a string-width-cjs alias of string-width (^4, CJS);
+        // the alias forks the un-aliased copy and both resolve, each keyed by its own slot.
+        Map<String, String> cliuiDeps = new LinkedHashMap<>();
+        cliuiDeps.put("string-width", "^5.1.2");
+        cliuiDeps.put("string-width-cjs", "npm:string-width@^4.2.0");
+        FakeRegistry registry = new FakeRegistry()
+                .add("string-width", "4.2.3", emptyMap())
+                .add("string-width", "5.1.2", emptyMap())
+                .add("@isaacs/cliui", "8.0.2", cliuiDeps);
+
+        ResolutionGraph graph = new NpmGraphBuilder(registry)
+                .build(singletonMap("", "{\"dependencies\":{\"@isaacs/cliui\":\"^8.0.2\"}}"));
+
+        assertThat(graph.getNodes())
+                .containsOnlyKeys("@isaacs/cliui@8.0.2", "string-width@5.1.2", "string-width-cjs@4.2.3");
+        // The alias slot carries the real package's manifest (name string-width), distinct from the un-aliased copy.
+        assertThat(graph.node("string-width-cjs", "4.2.3").getName()).isEqualTo("string-width");
+        assertThat(graph.node("string-width", "5.1.2").getName()).isEqualTo("string-width");
     }
 
     @Test
@@ -328,6 +354,30 @@ class NpmGraphBuilderTest {
         assertThatExceptionOfType(EngineFailure.class).isThrownBy(() ->
                 new NpmGraphBuilder(registry).build(singletonMap("",
                         "{\"dependencies\":{\"dep\":\"npm:foo@github:owner/foo\"}}")));
+    }
+
+    @Test
+    void defersAliasWhoseRealNameIsRequiredAsPeer() {
+        // myx aliases x, and hp requires x as a peer; the peer machinery keys by real name, so the entanglement defers.
+        FakeRegistry registry = new FakeRegistry().add("x", "1.0.0", emptyMap());
+        registry.versionsByName.computeIfAbsent("hp", k -> new TreeSet<>()).add("1.0.0");
+        registry.manifests.put("hp@1.0.0", vm("hp", "1.0.0", emptyMap(), singletonMap("x", ">=1.0.0")));
+
+        assertThatExceptionOfType(EngineFailure.class).isThrownBy(() ->
+                new NpmGraphBuilder(registry).build(singletonMap("",
+                        "{\"dependencies\":{\"myx\":\"npm:x@^1.0.0\",\"hp\":\"^1.0.0\"}}")));
+    }
+
+    @Test
+    void defersAliasThatDeclaresPeers() {
+        // myx aliases x, and x declares its own peerDependencies; the peer machinery keys by real name, so it defers.
+        FakeRegistry registry = new FakeRegistry().add("y", "1.0.0", emptyMap());
+        registry.versionsByName.computeIfAbsent("x", k -> new TreeSet<>()).add("1.0.0");
+        registry.manifests.put("x@1.0.0", vm("x", "1.0.0", emptyMap(), singletonMap("y", ">=1.0.0")));
+
+        assertThatExceptionOfType(EngineFailure.class).isThrownBy(() ->
+                new NpmGraphBuilder(registry).build(singletonMap("",
+                        "{\"dependencies\":{\"myx\":\"npm:x@^1.0.0\"}}")));
     }
 
     @Test

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/lock/NpmLockDiffTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/internal/lock/NpmLockDiffTest.java
@@ -145,6 +145,81 @@ class NpmLockDiffTest {
     }
 
     @Test
+    void preservesDuplicateNestedPlacements() {
+        // a and c each need shared@1, but the top-level slot holds shared@2, so npm nests a private shared@1 under
+        // each requirer. The same version at two paths is pinned and preserved: an unchanged closure yields no edits.
+        FakeRegistry registry = new FakeRegistry()
+                .add("a", "1.0.0", singletonMap("shared", "^1.0.0"))
+                .add("c", "1.0.0", singletonMap("shared", "^1.0.0"))
+                .add("shared", "1.0.0", emptyMap())
+                .add("shared", "2.0.0", emptyMap());
+        String lock = "{\n" +
+                "  \"name\": \"t\",\n" +
+                "  \"version\": \"1.0.0\",\n" +
+                "  \"lockfileVersion\": 3,\n" +
+                "  \"requires\": true,\n" +
+                "  \"packages\": {\n" +
+                "    \"\": {\n" +
+                "      \"name\": \"t\",\n" +
+                "      \"version\": \"1.0.0\",\n" +
+                "      \"dependencies\": {\n" +
+                "        \"a\": \"^1.0.0\",\n" +
+                "        \"c\": \"^1.0.0\",\n" +
+                "        \"shared\": \"^2.0.0\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"node_modules/a\": {\"version\": \"1.0.0\"},\n" +
+                "    \"node_modules/a/node_modules/shared\": {\"version\": \"1.0.0\"},\n" +
+                "    \"node_modules/c\": {\"version\": \"1.0.0\"},\n" +
+                "    \"node_modules/c/node_modules/shared\": {\"version\": \"1.0.0\"},\n" +
+                "    \"node_modules/shared\": {\"version\": \"2.0.0\"}\n" +
+                "  }\n" +
+                "}\n";
+
+        ResolutionGraph graph = new NpmGraphBuilder(registry).build(singletonMap("",
+                "{\"name\":\"t\",\"version\":\"1.0.0\",\"dependencies\":{\"a\":\"^1.0.0\",\"c\":\"^1.0.0\",\"shared\":\"^2.0.0\"}}"));
+        assertThat(NpmLockDiff.diff(graph, lock)).isEmpty();
+    }
+
+    @Test
+    void duplicatePlacementThatChangesDefers() {
+        // shared@1 is placed under both a and c, but the lock marks those copies dev while the resolution has them
+        // prod: a single edit cannot rewrite both copies in step, so it fails loud rather than patch one.
+        FakeRegistry registry = new FakeRegistry()
+                .add("a", "1.0.0", singletonMap("shared", "^1.0.0"))
+                .add("c", "1.0.0", singletonMap("shared", "^1.0.0"))
+                .add("shared", "1.0.0", emptyMap())
+                .add("shared", "2.0.0", emptyMap());
+        String lock = "{\n" +
+                "  \"name\": \"t\",\n" +
+                "  \"version\": \"1.0.0\",\n" +
+                "  \"lockfileVersion\": 3,\n" +
+                "  \"requires\": true,\n" +
+                "  \"packages\": {\n" +
+                "    \"\": {\n" +
+                "      \"name\": \"t\",\n" +
+                "      \"version\": \"1.0.0\",\n" +
+                "      \"dependencies\": {\n" +
+                "        \"a\": \"^1.0.0\",\n" +
+                "        \"c\": \"^1.0.0\",\n" +
+                "        \"shared\": \"^2.0.0\"\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"node_modules/a\": {\"version\": \"1.0.0\"},\n" +
+                "    \"node_modules/a/node_modules/shared\": {\"version\": \"1.0.0\", \"dev\": true},\n" +
+                "    \"node_modules/c\": {\"version\": \"1.0.0\"},\n" +
+                "    \"node_modules/c/node_modules/shared\": {\"version\": \"1.0.0\", \"dev\": true},\n" +
+                "    \"node_modules/shared\": {\"version\": \"2.0.0\"}\n" +
+                "  }\n" +
+                "}\n";
+
+        ResolutionGraph graph = new NpmGraphBuilder(registry).build(singletonMap("",
+                "{\"name\":\"t\",\"version\":\"1.0.0\",\"dependencies\":{\"a\":\"^1.0.0\",\"c\":\"^1.0.0\",\"shared\":\"^2.0.0\"}}"));
+        assertThatExceptionOfType(EngineFailure.class).isThrownBy(() -> NpmLockDiff.diff(graph, lock))
+                .withMessageContaining("installed at multiple places and changed");
+    }
+
+    @Test
     void freshForkMemberWithAutoInstalledPeerDefers() {
         // A fresh fork member's peer provider must be dependency-reached and top-level; an auto-installed
         // provider reshapes the layout, so the fork defers.
@@ -162,15 +237,16 @@ class NpmLockDiffTest {
     }
 
     @Test
-    void freshAliasEntryDefers() {
-        // An in-place alias bump patches fine (the entry keeps its name field), but a brand-new alias entry
-        // needs a serialization the patcher does not have yet.
+    void freshAliasEntryAdds() {
+        // A brand-new alias entry (myb aliasing b) adds at its own slot, carrying b as the entry's name field.
         FakeRegistry registry = new FakeRegistry().add("b", "1.0.0", emptyMap());
 
-        assertThatExceptionOfType(EngineFailure.class).isThrownBy(() ->
-                diff(registry, "{\"name\":\"t\",\"version\":\"1.0.0\"," +
-                        "\"dependencies\":{\"myb\":\"npm:b@^1.0.0\"}}"))
-                .withMessageContaining("alias");
+        List<PackageEdit> edits = diff(registry, "{\"name\":\"t\",\"version\":\"1.0.0\"," +
+                "\"dependencies\":{\"myb\":\"npm:b@^1.0.0\"}}");
+
+        PackageEdit edit = editFor(edits, "myb", "1.0.0");
+        assertThat(edit.getKind()).isEqualTo(PackageEdit.Kind.ADD);
+        assertThat(edit.getAliasName()).isEqualTo("b");
     }
 
     @Test

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/after
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/after
@@ -1,0 +1,29 @@
+{
+  "name": "alias-fork-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "alias-fork-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "emoji-regex-cjs": "npm:emoji-regex@^8.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex-cjs": {
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/before
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/before
@@ -1,0 +1,21 @@
+{
+  "name": "alias-fork-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "alias-fork-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "emoji-regex": "^10.3.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/before-v2
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/before-v2
@@ -1,0 +1,28 @@
+{
+  "name": "alias-fork-fixture",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "alias-fork-fixture",
+      "version": "1.0.0",
+      "dependencies": {
+        "emoji-regex": "^10.3.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    }
+  },
+  "dependencies": {
+    "emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/http/emoji-regex
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/http/emoji-regex
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","dist-tags":{"latest":"10.6.0"},"versions":{"8.0.0":{},"10.6.0":{}}}

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/http/emoji-regex-10.6.0
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/http/emoji-regex-10.6.0
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","version":"10.6.0","license":"MIT","dist":{"tarball":"https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz","integrity":"sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="}}

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/http/emoji-regex-8.0.0
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/http/emoji-regex-8.0.0
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","version":"8.0.0","license":"MIT","dist":{"tarball":"https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz","integrity":"sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="}}

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/pkg-after
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/pkg-after
@@ -1,0 +1,8 @@
+{
+  "name": "alias-fork-fixture",
+  "version": "1.0.0",
+  "dependencies": {
+    "emoji-regex": "^10.3.0",
+    "emoji-regex-cjs": "npm:emoji-regex@^8.0.0"
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/alias-fork/pkg-before
+++ b/rewrite-javascript/src/test/resources/lock/npm/alias-fork/pkg-before
@@ -1,0 +1,7 @@
+{
+  "name": "alias-fork-fixture",
+  "version": "1.0.0",
+  "dependencies": {
+    "emoji-regex": "^10.3.0"
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/dup-placement/before
+++ b/rewrite-javascript/src/test/resources/lock/npm/dup-placement/before
@@ -1,0 +1,73 @@
+{
+  "name": "dup-placement",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "dup-placement",
+      "version": "1.0.0",
+      "dependencies": {
+        "ansi-regex": "^6.0.0",
+        "stripa": "npm:strip-ansi@^6.0.1",
+        "stripb": "npm:strip-ansi@^6.0.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/stripa": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stripa/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stripb": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stripb/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/dup-placement/http/ansi-regex-5.0.1
+++ b/rewrite-javascript/src/test/resources/lock/npm/dup-placement/http/ansi-regex-5.0.1
@@ -1,0 +1,1 @@
+{"name":"ansi-regex","version":"5.0.1"}

--- a/rewrite-javascript/src/test/resources/lock/npm/dup-placement/http/ansi-regex-6.3.0
+++ b/rewrite-javascript/src/test/resources/lock/npm/dup-placement/http/ansi-regex-6.3.0
@@ -1,0 +1,1 @@
+{"name":"ansi-regex","version":"6.3.0"}

--- a/rewrite-javascript/src/test/resources/lock/npm/dup-placement/http/strip-ansi-6.0.1
+++ b/rewrite-javascript/src/test/resources/lock/npm/dup-placement/http/strip-ansi-6.0.1
@@ -1,0 +1,1 @@
+{"name":"strip-ansi","version":"6.0.1","dependencies":{"ansi-regex":"^5.0.1"}}

--- a/rewrite-javascript/src/test/resources/lock/npm/dup-placement/pkg-before
+++ b/rewrite-javascript/src/test/resources/lock/npm/dup-placement/pkg-before
@@ -1,0 +1,9 @@
+{
+  "name": "dup-placement",
+  "version": "1.0.0",
+  "dependencies": {
+    "ansi-regex": "^6.0.0",
+    "stripa": "npm:strip-ansi@^6.0.1",
+    "stripb": "npm:strip-ansi@^6.0.1"
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/after
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/after
@@ -1,0 +1,30 @@
+{
+  "name": "multi-alias-diff",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "multi-alias-diff",
+      "version": "1.0.0",
+      "dependencies": {
+        "er10": "npm:emoji-regex@^10.0.0",
+        "er8": "npm:emoji-regex@^8.0.0"
+      }
+    },
+    "node_modules/er10": {
+      "name": "emoji-regex",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "node_modules/er8": {
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/before
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/before
@@ -1,0 +1,22 @@
+{
+  "name": "multi-alias-diff",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "multi-alias-diff",
+      "version": "1.0.0",
+      "dependencies": {
+        "er8": "npm:emoji-regex@^8.0.0"
+      }
+    },
+    "node_modules/er8": {
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/http/emoji-regex
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/http/emoji-regex
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","dist-tags":{"latest":"10.6.0"},"versions":{"8.0.0":{},"10.6.0":{}}}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/http/emoji-regex-10.6.0
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/http/emoji-regex-10.6.0
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","version":"10.6.0","license":"MIT","dist":{"tarball":"https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz","integrity":"sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="}}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/http/emoji-regex-8.0.0
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/http/emoji-regex-8.0.0
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","version":"8.0.0","license":"MIT","dist":{"tarball":"https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz","integrity":"sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="}}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/pkg-after
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/pkg-after
@@ -1,0 +1,8 @@
+{
+  "name": "multi-alias-diff",
+  "version": "1.0.0",
+  "dependencies": {
+    "er8": "npm:emoji-regex@^8.0.0",
+    "er10": "npm:emoji-regex@^10.0.0"
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/pkg-before
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-diff/pkg-before
@@ -1,0 +1,7 @@
+{
+  "name": "multi-alias-diff",
+  "version": "1.0.0",
+  "dependencies": {
+    "er8": "npm:emoji-regex@^8.0.0"
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/after
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/after
@@ -1,0 +1,30 @@
+{
+  "name": "multi-alias-same",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "multi-alias-same",
+      "version": "1.0.0",
+      "dependencies": {
+        "er-x": "npm:emoji-regex@^8.0.0",
+        "er-y": "npm:emoji-regex@^8.0.0"
+      }
+    },
+    "node_modules/er-x": {
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/er-y": {
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/before
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/before
@@ -1,0 +1,22 @@
+{
+  "name": "multi-alias-same",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "multi-alias-same",
+      "version": "1.0.0",
+      "dependencies": {
+        "er-x": "npm:emoji-regex@^8.0.0"
+      }
+    },
+    "node_modules/er-x": {
+      "name": "emoji-regex",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    }
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/http/emoji-regex
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/http/emoji-regex
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","dist-tags":{"latest":"10.6.0"},"versions":{"8.0.0":{},"10.6.0":{}}}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/http/emoji-regex-8.0.0
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/http/emoji-regex-8.0.0
@@ -1,0 +1,1 @@
+{"name":"emoji-regex","version":"8.0.0","license":"MIT","dist":{"tarball":"https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz","integrity":"sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="}}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/pkg-after
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/pkg-after
@@ -1,0 +1,8 @@
+{
+  "name": "multi-alias-same",
+  "version": "1.0.0",
+  "dependencies": {
+    "er-x": "npm:emoji-regex@^8.0.0",
+    "er-y": "npm:emoji-regex@^8.0.0"
+  }
+}

--- a/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/pkg-before
+++ b/rewrite-javascript/src/test/resources/lock/npm/multi-alias-same/pkg-before
@@ -1,0 +1,7 @@
+{
+  "name": "multi-alias-same",
+  "version": "1.0.0",
+  "dependencies": {
+    "er-x": "npm:emoji-regex@^8.0.0"
+  }
+}


### PR DESCRIPTION
## Problem

Regenerating an npm `package-lock.json` failed for any project that installs a package under an `npm:` alias. For example `@isaacs/cliui` (a transitive dependency of `glob`, `yargs`, and much of the CLI ecosystem) installs the same package under two names:

```json
"dependencies": {
  "string-width":     "^5.1.2",
  "string-width-cjs": "npm:string-width@^4.2.0"
}
```

`string-width-cjs` is the CommonJS build of `string-width` installed alongside the ESM one. Regeneration failed loud on it:

```
lock regeneration failed: RESOLUTION_REQUIRED [string-width]: string-width-cjs aliases string-width which also resolves un-aliased (alias fork not yet resolved)
```

Larger closures hit two related blockers: the same package aliased under several names, and one `name@version` installed at several `node_modules` paths (for example `ansi-regex@5.0.1` nested under three requirers in the `@isaacs/cliui` tree).

## Implementation

An `npm:` alias installs a real package under a directory name you choose, so its lock entry sits at the alias slot but records a `name` field for the real package.

- Resolve alias forks rather than defer: every alias lands at its own top-level slot, so any number of aliases, with or without an un-aliased copy, resolve independently. Only alias and peer entanglement still defers.
- Serialize the alias entry with its `name` field ahead of `version`, pointing `resolved` and `integrity` at the real package.
- Preserve duplicate placements: when npm installs one version at several paths, bind the first and pin the rest so regeneration keeps every copy byte-identical instead of re-deriving npm's nested layout.

Output stays byte-exact against real npm, or fails loud where a layout is not yet reproducible, so it never emits a lock a real install would disagree with.

## Validated against

Regeneration is byte-identical to real `npm install` output for the closures of [`glob@10.4.5`](https://github.com/isaacs/node-glob) and [`@isaacs/cliui@8.0.2`](https://github.com/isaacs/cliui), which install [`string-width`](https://github.com/sindresorhus/string-width), [`strip-ansi`](https://github.com/chalk/strip-ansi), and [`wrap-ansi`](https://github.com/chalk/wrap-ansi) both directly and behind `npm:` aliases, exercising the alias forks and duplicate nested placements above.


## Still deferred

These shapes fail loud (`RESOLUTION_REQUIRED`) rather than emit a divergent lock:

- **Alias/peer entanglement** — the aliased package's real name is required as a peer, or the alias declares its own peers.
- **Non-registry alias target** — `git`/`file`/`link`/url/dist-tag targets (only `npm:<name>@<range>` resolves).
- **v2 legacy-tree alias add** — a fresh alias entry in a lockfileVersion 2 lock (v3 is supported).
- **Fresh duplicate placement** — creating a duplicate nested layout from scratch (only preserving an existing one is supported).
- **A duplicated version that changes** — one edit cannot rewrite every copy in step.
- **Pre-existing engine limits (out of scope)** — some 3+ version forks, certain peer auto-installs, and `git`/`file`/`workspace:` deps.
