### PR TITLE
JavaScript: an added import is laid out in the file's own style

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -1,11 +1,13 @@
 import {JavaScriptVisitor} from "./visitor";
 import {ElementRemovalFormatter, emptySpace, isIdentifier, J, rightPadded, singleSpace, space, Statement, Type} from "../java";
 import {JS, JSX} from "./tree";
-import {randomId} from "../uuid";
-import {emptyMarkers, markers} from "../markers";
-import {getStyle, PrettierStyle, SpacesStyle, StyleKind} from "./style";
+import {randomId, UUID} from "../uuid";
+import {emptyMarkers, findMarker, markers} from "../markers";
+import {getStyle, SpacesStyle, StyleKind} from "./style";
 import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, namesDeclaredIn, scopeOf} from "./scope";
 import {create as produce, Draft} from "mutative";
+import {autoFormat} from "./format";
+import {getPrettierStyle} from "./format/prettier-format";
 
 export type QuoteChar = "'" | '"';
 
@@ -454,8 +456,8 @@ async function detectQuote(cu: JS.CompilationUnit): Promise<QuoteChar> {
         return specifierQuote;
     }
 
-    const prettier = getStyle(StyleKind.PrettierStyle, cu) as PrettierStyle | undefined;
-    if (prettier?.kind === StyleKind.PrettierStyle && !prettier.ignored) {
+    const prettier = getPrettierStyle(cu);
+    if (prettier && !prettier.ignored) {
         const singleQuote = prettier.config.singleQuote;
         if (typeof singleQuote === 'boolean') {
             return singleQuote ? "'" : '"';
@@ -463,6 +465,27 @@ async function detectQuote(cu: JS.CompilationUnit): Promise<QuoteChar> {
     }
 
     return double > single ? '"' : "'";
+}
+
+/**
+ * Lays out the import statement `AddImport` wrote, so that the file's own style — a Prettier
+ * configuration's brace spacing and print width, say — reaches it.
+ */
+async function formatImport<P>(cu: JS.CompilationUnit, id: UUID, p: P): Promise<JS.CompilationUnit> {
+    return await new class extends JavaScriptVisitor<P> {
+        override async visitImportDeclaration(jsImport: JS.Import, p: P): Promise<J | undefined> {
+            return jsImport.id === id ? await autoFormat(jsImport, p, undefined, this.cursor.parent) : jsImport;
+        }
+    }().visit(cu, p) as JS.CompilationUnit;
+}
+
+/**
+ * As {@link formatImport}, for an import that gained specifiers. Short of a Prettier configuration
+ * deciding the whole line, the statement's own text says more about its spacing than a
+ * repository-wide style does, and the merge reads it directly.
+ */
+async function formatMergedImport<P>(cu: JS.CompilationUnit, id: UUID, p: P): Promise<JS.CompilationUnit> {
+    return findMarker(cu, StyleKind.PrettierStyle) ? formatImport(cu, id, p) : cu;
 }
 
 export class AddImport<P> extends JavaScriptVisitor<P> {
@@ -719,12 +742,11 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
         }
 
         // Add ES6 import (handles ES6Named, ES6Namespace, ES6Default)
-        return this.produceJavaScript(compilationUnit, p, async draft => {
-            // Find the position to insert the import
-            const insertionIndex = this.findImportInsertionIndex(compilationUnit);
+        // Find the position to insert the import
+        const insertionIndex = this.findImportInsertionIndex(compilationUnit);
+        const newImport = await this.createImportStatement(compilationUnit, insertionIndex, p);
 
-            const newImport = await this.createImportStatement(compilationUnit, insertionIndex, p);
-
+        const withImport = await this.produceJavaScript(compilationUnit, p, async draft => {
             // Insert the import at the appropriate position
             // Create semicolon marker for the import statement
             const semicolonMarkers = markers({
@@ -781,6 +803,8 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
                 }
             }
         });
+
+        return formatImport(withImport, newImport.id, p);
     }
 
     /**
@@ -824,7 +848,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
                     }
 
                     // We found a matching import with named bindings - merge into it
-                    return this.produceJavaScript(compilationUnit, p, async draft => {
+                    return formatMergedImport(await this.produceJavaScript(compilationUnit, p, async draft => {
                         const namedImports = importClause.namedBindings as JS.NamedImports;
                         const existingElements = namedImports.elements.elements;
 
@@ -897,13 +921,13 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
                         draft.statements = compilationUnit.statements.map((s, idx) =>
                             idx === i ? {...s, element: updatedImport} : s
                         );
-                    });
+                    }), jsImport.id, p);
                 }
 
                 // Case 2: Default import without named bindings - add named bindings
                 // Transform: import React from 'react' -> import React, { useState } from 'react'
                 if (importClause.name && !importClause.namedBindings) {
-                    return this.produceJavaScript(compilationUnit, p, async draft => {
+                    return formatMergedImport(await this.produceJavaScript(compilationUnit, p, async draft => {
                         const newSpecifier = this.createImportSpecifier();
 
                         // Get the spaces style for brace spacing
@@ -952,7 +976,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
                         draft.statements = compilationUnit.statements.map((s, idx) =>
                             idx === i ? {...s, element: updatedImport} : s
                         );
-                    });
+                    }), jsImport.id, p);
                 }
             }
         }
@@ -1281,10 +1305,8 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
         // Determine the appropriate prefix (spacing before the import)
         const prefix = this.determineImportPrefix(compilationUnit, insertionIndex);
 
-        // Create the module specifier
-        // For side-effect imports, use emptySpace since space comes from LeftPadded.before
-        // For regular imports with import clause, use emptySpace since space comes from LeftPadded.before
-        // However, the printer expects the space after 'from' in the literal's prefix
+        // Whitespace throughout follows the parser's placement, so that formatting the result is a
+        // no-op where the file's style already agrees with it.
         // Note: value is the unquoted module name; valueSource and unicodeEscapes are its printed form
         let valueSource = this.moduleValueSource;
         if (valueSource === undefined) {
@@ -1294,7 +1316,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
         const moduleSpecifier: J.Literal = {
             id: randomId(),
             kind: J.Kind.Literal,
-            prefix: this.sideEffectOnly ? emptySpace : singleSpace,
+            prefix: singleSpace,
             markers: emptyMarkers,
             value: this.module,
             valueSource,
@@ -1334,7 +1356,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             const namespaceBinding: JS.Alias = {
                 id: randomId(),
                 kind: JS.Kind.Alias,
-                prefix: singleSpace,
+                prefix: this.typeOnly ? singleSpace : emptySpace,
                 markers: emptyMarkers,
                 propertyName: rightPadded(propertyName, singleSpace),
                 alias: aliasIdentifier
@@ -1343,7 +1365,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             importClause = {
                 id: randomId(),
                 kind: JS.Kind.ImportClause,
-                prefix: this.typeOnly ? singleSpace : emptySpace,
+                prefix: singleSpace,
                 markers: emptyMarkers,
                 typeOnly: this.typeOnly,
                 name: undefined,
@@ -1355,7 +1377,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             const defaultName: J.Identifier = {
                 id: randomId(),
                 kind: J.Kind.Identifier,
-                prefix: singleSpace,
+                prefix: this.typeOnly ? singleSpace : emptySpace,
                 markers: emptyMarkers,
                 annotations: [],
                 simpleName: this.bindingName!,
@@ -1366,10 +1388,10 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             importClause = {
                 id: randomId(),
                 kind: JS.Kind.ImportClause,
-                prefix: this.typeOnly ? singleSpace : emptySpace,
+                prefix: singleSpace,
                 markers: emptyMarkers,
                 typeOnly: this.typeOnly,
-                name: rightPadded(defaultName, emptySpace),
+                name: rightPadded(defaultName, singleSpace),
                 namedBindings: undefined
             };
         } else {
@@ -1387,11 +1409,11 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             const namedImports: JS.NamedImports = {
                 id: randomId(),
                 kind: JS.Kind.NamedImports,
-                prefix: singleSpace,
+                prefix: emptySpace,
                 markers: emptyMarkers,
                 elements: {
                     kind: J.Kind.Container,
-                    before: emptySpace,
+                    before: this.typeOnly ? singleSpace : emptySpace,
                     elements: [rightPadded(importSpecWithSpacing, braceSpace)],
                     markers: emptyMarkers
                 }
@@ -1400,7 +1422,7 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             importClause = {
                 id: randomId(),
                 kind: JS.Kind.ImportClause,
-                prefix: this.typeOnly ? singleSpace : emptySpace,
+                prefix: singleSpace,
                 markers: emptyMarkers,
                 typeOnly: this.typeOnly,
                 name: undefined,
@@ -1417,7 +1439,8 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             importClause,
             moduleSpecifier: {
                 kind: J.Kind.LeftPadded,
-                before: singleSpace,
+                // A clause ending in a name carries the space before `from` itself; one ending in `}` does not
+                before: importClause?.namedBindings ? singleSpace : emptySpace,
                 element: moduleSpecifier,
                 markers: emptyMarkers
             },

--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -2,7 +2,7 @@ import {JavaScriptVisitor} from "./visitor";
 import {ElementRemovalFormatter, emptySpace, isIdentifier, J, NameTree, rightPadded, singleSpace, space, Statement, Type} from "../java";
 import {JS, JSX} from "./tree";
 import {randomId, UUID} from "../uuid";
-import {emptyMarkers, findMarker, markers} from "../markers";
+import {emptyMarkers, markers} from "../markers";
 import {getStyle, SpacesStyle, StyleKind} from "./style";
 import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, isValueReference, namesDeclaredIn, scopeOf} from "./scope";
 import {create as produce, Draft} from "mutative";
@@ -21,8 +21,9 @@ export enum ImportStyle {
 
 export interface AddImportOptions {
     /** The module name (e.g., 'fs', 'react') to import from.
-     * Pass a `J.Literal` to reuse its source form verbatim, which carries the quoting,
-     * escapes and unicode form of a specifier being moved from elsewhere in the source. */
+     * Pass a `J.Literal` to reuse its source form, which carries the escapes and unicode form of a
+     * specifier being moved from elsewhere in the source. A Prettier configuration settles the
+     * quoting; see `quoteStyle`. */
     module: string | J.Literal;
 
     /** Optionally, the specific member to import from the module.
@@ -64,7 +65,8 @@ export interface AddImportOptions {
     style?: ImportStyle;
 
     /** Quote character for the module specifier. If not specified, detected from the file.
-     * A `J.Literal` module carries its own quoting and takes precedence over this. */
+     * A `J.Literal` module carries its own quoting and takes precedence over this. A Prettier
+     * configuration outranks both, since running Prettier would arrive at its quote anyway. */
     quoteStyle?: QuoteChar;
 }
 
@@ -492,7 +494,7 @@ async function formatImport<P>(cu: JS.CompilationUnit, id: UUID, p: P): Promise<
  * repository-wide style does, and the merge reads it directly.
  */
 async function formatMergedImport<P>(cu: JS.CompilationUnit, id: UUID, p: P): Promise<JS.CompilationUnit> {
-    return findMarker(cu, StyleKind.PrettierStyle) ? formatImport(cu, id, p) : cu;
+    return getPrettierStyle(cu)?.ignored === false ? formatImport(cu, id, p) : cu;
 }
 
 export class AddImport<P> extends JavaScriptVisitor<P> {
@@ -1446,7 +1448,8 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             importClause,
             moduleSpecifier: {
                 kind: J.Kind.LeftPadded,
-                // A clause ending in a name carries the space before `from` itself; one ending in `}` does not
+                // Bindings end at `}`, so the space before `from` sits here; a default import's name
+                // and a side-effect import's literal carry their own
                 before: importClause?.namedBindings ? singleSpace : emptySpace,
                 element: moduleSpecifier,
                 markers: emptyMarkers

--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -362,9 +362,12 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                     const afterClause = draft.importClause.name || draft.importClause.typeOnly ? " " : "";
                     if (draft.importClause.namedBindings.kind == JS.Kind.NamedImports) {
                         const ni = draft.importClause.namedBindings as Draft<JS.NamedImports>;
-                        // For named imports the space before `{` sits in the container, as the parser writes it
-                        ni.prefix.whitespace = "";
-                        ni.elements.before.whitespace = afterClause;
+                        // For named imports the space before `{` sits in the container, as the parser
+                        // writes it; a newline there is layout, which spacing does not decide
+                        if (!ni.prefix.whitespace.includes("\n") && !ni.elements.before.whitespace.includes("\n")) {
+                            ni.prefix.whitespace = "";
+                            ni.elements.before.whitespace = afterClause;
+                        }
                         const isMultiLine = ni.elements.elements.some(e => e.element.prefix.whitespace.includes("\n"));
                         if (!isMultiLine) {
                             const braceSpace = this.style.within.es6ImportExportBraces ? " " : "";

--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -358,12 +358,13 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                         : "";
                 }
                 if (draft.importClause.namedBindings) {
-                    const hasDefaultImport = !!draft.importClause.name;
-                    if (hasDefaultImport || draft.importClause.typeOnly) {
-                        draft.importClause.namedBindings.prefix.whitespace = " ";
-                    }
+                    // `type`, or a default name and its comma, stands between keyword and bindings
+                    const afterClause = draft.importClause.name || draft.importClause.typeOnly ? " " : "";
                     if (draft.importClause.namedBindings.kind == JS.Kind.NamedImports) {
                         const ni = draft.importClause.namedBindings as Draft<JS.NamedImports>;
+                        // For named imports the space before `{` sits in the container, as the parser writes it
+                        ni.prefix.whitespace = "";
+                        ni.elements.before.whitespace = afterClause;
                         const isMultiLine = ni.elements.elements.some(e => e.element.prefix.whitespace.includes("\n"));
                         if (!isMultiLine) {
                             const braceSpace = this.style.within.es6ImportExportBraces ? " " : "";
@@ -376,6 +377,8 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                                 lastAfter.whitespace = this.style.other.beforeComma ? " " : "";
                             }
                         }
+                    } else if (afterClause) {
+                        draft.importClause.namedBindings.prefix.whitespace = afterClause;
                     }
                 }
             }

--- a/rewrite-javascript/rewrite/src/javascript/format/prettier-format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/prettier-format.ts
@@ -357,6 +357,15 @@ function pruneNode(node: any, path: PathSegment[], pathIndex: number, target: an
         return node;
     }
 
+    // A compilation unit's statements are laid out at column 0, so nothing beside the target bears
+    // on how Prettier lays it out and the printed program can be the target alone.
+    if (node.kind === JS.Kind.CompilationUnit && segment.property === 'statements' && segment.index !== undefined) {
+        const statements = value as J.RightPadded<Statement>[];
+        return updateIfChanged(node, {
+            statements: [pruneNode(statements[segment.index], path, pathIndex + 1, target)]
+        });
+    }
+
     // Handle J.Block#statements specially - prune siblings
     if (node.kind === J.Kind.Block && segment.property === 'statements' && segment.index !== undefined) {
         const statements = value as J.RightPadded<Statement>[];
@@ -430,10 +439,10 @@ function findByPath(tree: any, path: PathSegment[]): any {
         if (value == null) return undefined;
 
         if (Array.isArray(value) && segment.index !== undefined) {
-            // For block statements, target is always at the last index
-            // since following siblings are omitted during pruning
-            const isBlockStatements = current.kind === J.Kind.Block && segment.property === 'statements';
-            const index = isBlockStatements ? value.length - 1 : segment.index;
+            // In pruned statement lists the target is last, following siblings having been omitted
+            const isPrunedStatements = segment.property === 'statements' &&
+                (current.kind === J.Kind.Block || current.kind === JS.Kind.CompilationUnit);
+            const index = isPrunedStatements ? value.length - 1 : segment.index;
             const item = value[index];
             if (item == null) return undefined;
             current = item;
@@ -474,6 +483,12 @@ export async function prettierFormatSubtree<T extends J>(
         return undefined;
     }
 
+    // Whatever stands between a statement and the top of its file is the file's business, so a whole
+    // statement keeps the prefix it came with. Prettier sees it, for the directives — a leading
+    // `prettier-ignore` — that a statement's own layout answers to.
+    const wholeStatement = path.length === 2 && path[0].property === 'statements' &&
+        path[0].index !== undefined && path[1].property === 'element';
+
     // Prune the tree for efficient formatting and substitute the (potentially modified) target.
     // This ensures that if the visitor modified the target before calling autoFormat,
     // we format the modified content, not the original from the cursor.
@@ -494,7 +509,10 @@ export async function prettierFormatSubtree<T extends J>(
 
     // The walk that carries whitespace back pairs the two trees node for node, which a change to
     // the code itself — Prettier dropping redundant parentheses, say — makes impossible
-    return reconciler.isCompatible() ? reconciled as T : undefined;
+    if (!reconciler.isCompatible()) {
+        return undefined;
+    }
+    return (wholeStatement ? {...reconciled as T, prefix: target.prefix} : reconciled as T);
 }
 
 /**

--- a/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
@@ -1889,6 +1889,29 @@ describe('AddImport visitor', () => {
             );
         });
 
+        test('a Prettier configuration outranks an explicitly requested quote', async () => {
+            const spec = new RecipeSpec();
+            const addImport = new AddImport({module: 'fs', member: 'readFile', quoteStyle: '"', onlyIfReferenced: false});
+            spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+                override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                    return await addImport.visit(withPrettierStyle(cu, {singleQuote: true}), p);
+                }
+            });
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        const x = 1;
+                    `,
+                    `
+                        import { readFile } from 'fs';
+
+                        const x = 1;
+                    `
+                )
+            );
+        });
+
         test('a merged import Prettier can no longer fit on one line wraps', async () => {
             const spec = new RecipeSpec();
             spec.recipe = fromVisitor(addImportUnderPrettier(

--- a/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
@@ -166,6 +166,23 @@ function createAddImportWithTemplateVisitor(
     };
 }
 
+/** Marks a file the way parsing a project whose .prettierrc was picked up marks it. */
+function withPrettierStyle(cu: JS.CompilationUnit, config: Record<string, unknown>, ignored = false): JS.CompilationUnit {
+    return {
+        ...cu,
+        markers: {...cu.markers, markers: [...cu.markers.markers, prettierStyle(randomId(), config, undefined, ignored)]}
+    };
+}
+
+function addImportUnderPrettier(config: Record<string, unknown>, module: string, member: string): JavaScriptVisitor<any> {
+    const addImport = new AddImport({module, member, onlyIfReferenced: false});
+    return new class extends JavaScriptVisitor<any> {
+        override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+            return await addImport.visit(withPrettierStyle(cu, config), p);
+        }
+    };
+}
+
 describe('AddImport visitor', () => {
     describe('named imports', () => {
         test('should add named import when referenced', async () => {
@@ -1853,6 +1870,44 @@ describe('AddImport visitor', () => {
                 )
             );
         });
+
+        test('a Prettier configuration outranks the brace spacing the file itself writes', async () => {
+            const spec = new RecipeSpec();
+            // The configuration names no `bracketSpacing`, so Prettier's own default of `true` holds
+            spec.recipe = fromVisitor(addImportUnderPrettier({singleQuote: true}, 'lib2', 'New'));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {Old} from 'lib';
+                    `,
+                    `
+                        import {Old} from 'lib';
+                        import { New } from 'lib2';
+                    `
+                )
+            );
+        });
+
+        test('a merged import Prettier can no longer fit on one line wraps', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(addImportUnderPrettier(
+                {printWidth: 80, singleQuote: true}, '@scope/a-long-module', 'SomethingWithAnEvenLongerName'));
+
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import { AlphaComponent } from '@scope/a-long-module';
+                    `,
+                    `
+                        import {
+                          AlphaComponent,
+                          SomethingWithAnEvenLongerName,
+                        } from '@scope/a-long-module';
+                    `
+                )
+            );
+        });
     });
 
     describe('type-only imports', () => {
@@ -2318,40 +2373,9 @@ describe('AddImport visitor', () => {
             );
         });
 
-        /** Stands in for a project whose .prettierrc was picked up at parse time. */
-        function createAddImportWithPrettierStyleVisitor(singleQuote: boolean): JavaScriptVisitor<any> {
-            return new class extends JavaScriptVisitor<any> {
-                override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
-                    const namedStyles: NamedStyles = {
-                        kind: MarkersKind.NamedStyles,
-                        id: randomId(),
-                        name: "test-prettier",
-                        displayName: "Test Prettier",
-                        tags: [],
-                        styles: [prettierStyle(randomId(), {singleQuote})]
-                    };
-
-                    let result: JS.CompilationUnit = {
-                        ...cu,
-                        markers: {
-                            ...cu.markers,
-                            markers: [...cu.markers.markers, namedStyles]
-                        }
-                    };
-
-                    const addImport = new AddImport({
-                        module: 'fs',
-                        member: 'readFile',
-                        onlyIfReferenced: false
-                    });
-                    return await addImport.visit(result, p) as JS.CompilationUnit;
-                }
-            };
-        }
-
         test('honors a PrettierStyle marker with singleQuote disabled', async () => {
             const spec = new RecipeSpec();
-            spec.recipe = fromVisitor(createAddImportWithPrettierStyleVisitor(false));
+            spec.recipe = fromVisitor(addImportUnderPrettier({singleQuote: false}, 'fs', 'readFile'));
 
             await spec.rewriteRun(
                 typescript(
@@ -2359,7 +2383,7 @@ describe('AddImport visitor', () => {
                         const x = 1;
                     `,
                     `
-                        import {readFile} from "fs";
+                        import { readFile } from "fs";
 
                         const x = 1;
                     `
@@ -2369,7 +2393,7 @@ describe('AddImport visitor', () => {
 
         test('a PrettierStyle marker outranks the dominant string literal quote', async () => {
             const spec = new RecipeSpec();
-            spec.recipe = fromVisitor(createAddImportWithPrettierStyleVisitor(true));
+            spec.recipe = fromVisitor(addImportUnderPrettier({singleQuote: true}, 'fs', 'readFile'));
 
             await spec.rewriteRun(
                 typescript(
@@ -2378,7 +2402,7 @@ describe('AddImport visitor', () => {
                         const b = "two";
                     `,
                     `
-                        import {readFile} from 'fs';
+                        import { readFile } from 'fs';
 
                         const a = "one";
                         const b = "two";
@@ -2535,23 +2559,11 @@ describe('AddImport visitor', () => {
             const spec = new RecipeSpec();
             spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
                 override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
-                    const namedStyles: NamedStyles = {
-                        kind: MarkersKind.NamedStyles,
-                        id: randomId(),
-                        name: "test-prettier",
-                        displayName: "Test Prettier",
-                        tags: [],
-                        styles: [prettierStyle(randomId(), {singleQuote: true}, undefined, true)]
-                    };
-                    const marked: JS.CompilationUnit = {
-                        ...cu,
-                        markers: {...cu.markers, markers: [...cu.markers.markers, namedStyles]}
-                    };
                     return await new AddImport({
                         module: 'fs',
                         member: 'readFile',
                         onlyIfReferenced: false
-                    }).visit(marked, p);
+                    }).visit(withPrettierStyle(cu, {singleQuote: true}, true), p);
                 }
             }());
 

--- a/rewrite-javascript/rewrite/test/javascript/format/prettier-format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/prettier-format.test.ts
@@ -122,6 +122,33 @@ describe('AutoformatVisitor with Prettier', () => {
         )
     });
 
+    test('a statement Prettier is told to ignore keeps its own layout', async () => {
+        const visitor = new class extends JavaScriptVisitor<any> {
+            override async visitImportDeclaration(jsImport: any, p: any): Promise<any> {
+                return await autoFormat(jsImport, p, undefined, this.cursor.parent, [defaultPrettierStyle]);
+            }
+        }();
+
+        const testSpec = new RecipeSpec();
+        testSpec.recipe = fromVisitor(visitor);
+        // Reconciling Prettier's answer replaces nodes whether or not it moved any whitespace
+        testSpec.allowEmptyDiff = true;
+
+        return testSpec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `
+                const z = 1;
+
+                // prettier-ignore
+                import {a,   b} from 'x';
+                `
+            )
+            // @formatter:on
+        )
+    });
+
     test('subtree formatting in nested block with Prettier', async () => {
         // This tests the pruning in nested blocks
         const visitor = new class extends JavaScriptVisitor<any> {

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -79,6 +79,8 @@ describe('SpacesVisitor', () => {
                 import a from'baz.js';
                 import'module-without-export.js';
                 import type{Models} from'../models';
+                import c,{d} from 'cd.js';
+                import e, {f} from 'ef.js';
                 `,
                 `
                 export {MyPreciousClass} from './my-precious-class';
@@ -89,6 +91,8 @@ describe('SpacesVisitor', () => {
                 import a from 'baz.js';
                 import 'module-without-export.js';
                 import type {Models} from '../models';
+                import c, {d} from 'cd.js';
+                import e, {f} from 'ef.js';
                 `
                 // @formatter:on
             ));

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -81,6 +81,8 @@ describe('SpacesVisitor', () => {
                 import type{Models} from'../models';
                 import c,{d} from 'cd.js';
                 import e, {f} from 'ef.js';
+                import g,
+                    {h} from 'gh.js';
                 `,
                 `
                 export {MyPreciousClass} from './my-precious-class';
@@ -93,6 +95,8 @@ describe('SpacesVisitor', () => {
                 import type {Models} from '../models';
                 import c, {d} from 'cd.js';
                 import e, {f} from 'ef.js';
+                import g,
+                    {h} from 'gh.js';
                 `
                 // @formatter:on
             ));


### PR DESCRIPTION
In a project with a `.prettierrc`, an import that `AddImport` writes ignores it. A file that already writes `import { Old, Keep } from 'lib';` gets `import {New} from 'lib2';` one line below it, and merging a specifier into an import that then exceeds `printWidth` leaves it on one line. The rewrite-angular recipe audit hit the first; the JS template work hit the second and scoped it out as "a behaviour change with real blast radius across add-import.test.ts".

## Why the configuration was never read

`project-parser` attaches a `PrettierStyle` marker when Prettier is present and an `Autodetect` marker otherwise — never both. `AddImport` read brace spacing from `getStyle(SpacesStyle, cu)`, which a `PrettierStyle` cannot satisfy, so it fell back to IntelliJ's tight-brace default. Under an `Autodetect` marker the spacing was already right, which is why this only shows up in Prettier projects and why a file that writes tight braces looked correct by accident. `AutoformatVisitor` already derives spacing and width from a Prettier config through `spacesFrom`/`tabsAndIndentsFrom`; the import never went through it.

`detectQuote` had the same shape of bug: it looked Prettier up with `getStyle(StyleKind.PrettierStyle, cu)`, which cannot find it, because `PrettierStyle` is itself a `NamedStyles` with an empty `styles` array and so never matches the nested-style search — while every production attachment site installs it as a top-level marker. The tests hid this by wrapping it in an outer `NamedStyles`, a shape parsing never produces.

One documented contract changes as a result. `AddImportOptions` promised a `J.Literal` module would be reused "verbatim" and that `quoteStyle` chose the quote; Prettier's `singleQuote` now settles the specifier's quoting, and the JSDoc says so. Escapes and unicode form still survive — only the quote does not — and whatever quote were written instead, the project's next `prettier --write` would arrive at Prettier's anyway.

## What printWidth actually catches

Prettier never breaks a single-specifier import, at any width. Against the bundled Prettier with `printWidth: 80`:

```
in : import { SomethingWithAnEvenLongerName } from '@scope/a-very-long-module-name-here';   (83 columns)
out: import { SomethingWithAnEvenLongerName } from '@scope/a-very-long-module-name-here';
```

`AddImport` creates exactly one specifier, so `printWidth` cannot bite on a statement it creates — only on a merge that adds a second one. The layout pass therefore runs on the merge paths too, gated there on a `PrettierStyle`: the merge already reads brace spacing off the statement it is editing, which is better evidence than a repository-wide default, and running the formatter unconditionally regressed two "preserve formatting when merging" tests. The rule the gate encodes is that an explicit project configuration beats local evidence, and local evidence beats a repository-wide default.

## Two latent bugs had to go first

Either one turned a layout pass into `import  {x}`:

- `AddImport` distributed whitespace differently from the parser — the space after `import` on `namedBindings.prefix` rather than `importClause.prefix`, the space before `from` on `moduleSpecifier.before` rather than `name.after`. Identical printed text, so nothing caught it until a formatter normalised. This alone was 51 of 111 add-import tests failing in the first prototype.
- `SpacesVisitor` wrote the space before `{` to `namedBindings.prefix` while the parser writes it to the container, so autoformatting a parsed `import a, { b } from 'c'` produced `import a,  { b } from 'c'`.

## Cost of the layout pass

`prettierFormatSubtree` prunes the tree it hands Prettier so a subtree format costs the subtree, but `pruneNode` only recognised `J.Block#statements`. A top-level statement lives in `JS.CompilationUnit#statements` and fell through to the generic branch, printing the whole file, running Prettier over it and reparsing the result — once per import added. Bytes handed to Prettier, from instrumenting `prettierFormat`:

| file | imports added | before | after |
|---|---|---|---|
| 50 lines | 1 | 1,156 | 25 |
| 500 lines | 1 | 12,306 | 25 |
| 500 lines | 5 | 61,800 | 129 |

Withholding the statement's prefix as well would prune further, and I tried it: a `// prettier-ignore` attaches to the statement that follows it and therefore lives in exactly that prefix, so withholding it disabled the directive silently, with the whole suite green. Prettier is shown the prefix and the statement keeps the one it came with.

## Tests

Three tests pin the new behaviour: a Prettier config's brace spacing reaching a created import, a merged import wrapping at `printWidth`, and a Prettier config outranking an explicitly passed `quoteStyle`. `spaces-visitor.test.ts` gains fixtures for the clause-to-brace space — that it is added when missing, not doubled when present, and that a deliberate line break there survives. `prettier-format.test.ts` gains the `prettier-ignore` case. Every one was mutation-checked by reverting the corresponding line and confirming it fails.

Two existing expectations change from `import {readFile}` to `import { readFile }`; that is the fix landing. No test was deleted. Full suite: 155 files, 1845 passed.

## Not fixed here

`AddImport` sometimes adds a second import for something the file already imports. `import { readFile as rf } from 'fs'` plus a request for `readFile` yields `import { readFile, readFile as rf } from 'fs'`; a namespace import does not answer a member request; two default imports from one module are possible; and with `const fs = require('fs')` present the two entry points disagree, `maybeAddImport` returning `undefined` where `AddImport` adds an ES module import into a CommonJS file. All four reproduce on `main` unchanged by this PR, and are tracked separately.
