### PR TITLE
JavaScript: spacing owns the gap between an inline `type` and the name it exports

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -300,6 +300,14 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         })
     }
 
+    protected async visitExportSpecifier(exportSpecifier: JS.ExportSpecifier, p: P): Promise<J | undefined> {
+        const ret = await super.visitExportSpecifier(exportSpecifier, p) as JS.ExportSpecifier;
+        return produce(ret, draft => {
+            // `type` is separated from the name it qualifies by that name's own prefix
+            draft.specifier.prefix.whitespace = draft.typeOnly.element ? " " : "";
+        });
+    }
+
     protected async visitForLoop(forLoop: J.ForLoop, p: P): Promise<J | undefined> {
         const ret = await super.visitForLoop(forLoop, p) as J.ForLoop;
         return produceAsync(ret, async draft => {

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -28,10 +28,12 @@
  */
 
 import {fromVisitor, RecipeSpec} from "../../../src/test";
-import {BlankLinesStyle, IntelliJ, JavaScriptParser, SpacesStyle, typescript} from "../../../src/javascript";
+import {BlankLinesStyle, IntelliJ, JavaScriptParser, JavaScriptVisitor, JS, SpacesStyle, typescript} from "../../../src/javascript";
 import {AutoformatVisitor, SpacesVisitor} from "../../../src/javascript/format";
 import {create as produce, Draft} from "mutative";
 import {MarkersKind, NamedStyles, randomId, Style} from "../../../src";
+import {J} from "../../../src/java";
+import {ExecutionContext} from "../../../src/execution";
 
 type StyleCustomizer<T extends Style> = (draft: Draft<T>) => void;
 
@@ -89,6 +91,36 @@ describe('SpacesVisitor', () => {
                 import a from 'baz.js';
                 import 'module-without-export.js';
                 import type {Models} from '../models';
+                `
+                // @formatter:on
+            ));
+    });
+
+    test('an inline type specifier keeps one space before the name it qualifies', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+                export {type  A, type	B as C, d} from 'm';
+                `,
+                `
+                export {type A, type B as C, d} from 'm';
+                `
+                // @formatter:on
+            ));
+    });
+
+    test('a cleared inline type marker leaves no space behind', () => {
+        spec.recipe = fromVisitor(new ClearInlineTypeThenSpaces());
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+                export {type A, type B as C, d} from 'm';
+                `,
+                `
+                export {A, B as C, d} from 'm';
                 `
                 // @formatter:on
             ));
@@ -363,3 +395,16 @@ const d = {x, y, z};`
         )
     });
 });
+
+class ClearInlineTypeThenSpaces extends JavaScriptVisitor<ExecutionContext> {
+    protected override async visitJsCompilationUnit(cu: JS.CompilationUnit, ctx: ExecutionContext): Promise<J | undefined> {
+        const edited = await super.visitJsCompilationUnit(cu, ctx) as JS.CompilationUnit;
+        return new SpacesVisitor<ExecutionContext>(spaces()).visit(edited, ctx);
+    }
+
+    protected override async visitExportSpecifier(exportSpecifier: JS.ExportSpecifier, ctx: ExecutionContext): Promise<J | undefined> {
+        return produce(exportSpecifier, draft => {
+            draft.typeOnly.element = false;
+        });
+    }
+}


### PR DESCRIPTION
`SpacesVisitor` has no rule for the gap between an `ExportSpecifier`'s inline `type` keyword and the name it qualifies, so a recipe that clears the marker leaves the keyword's trailing space behind and the clause prints as `export {  A,  B as C, d} from 'm';`. This is the export-side twin of the `ImportSpecifier` gap: same node shape (`typeOnly: J.LeftPadded<boolean>` plus a `specifier`), same defect.

The space lives in the specifier's own prefix, not in the `LeftPadded` — the printer emits `typeOnly.before`, then `type`, then visits the specifier, so the name's prefix is the only thing between the two tokens, and no formatter rule owned it. `visitExportSpecifier` now sets it from the marker, exactly as `visitExportDeclaration` already sets the gap between `export` and `type`. The specifier's *leading* space is untouched: the brace and after-comma rules own that, and they were already right.

`typeOnly.before` is left alone on evidence rather than on symmetry with the import side. The parser builds it from the `type` keyword's own prefix (`parser.ts:3910`), and a throwaway probe over `export {type A}`, a multi-line clause, `export {/*c*/ type A}` and `export { type /*mid*/ A }` reported it empty with zero comments every time — the leading gap and any comment land in the specifier's prefix. A formatter rule there would be writing whitespace the parser never produces.

Two tests in `spaces-visitor.test.ts` pin the two arms. `an inline type specifier keeps one space before the name it qualifies` normalizes a parsed `export {type  A, type\tB as C, d}`; `a cleared inline type marker leaves no space behind` clears the marker and then runs `SpacesVisitor`, which is both what a real recipe does and the only route to the empty arm, since no source parses to a cleared marker with a space still in front of the name. Before the fix the first left its source untouched and the second printed `export { A,  B as C, d}`.

Nothing hits this today — `eslint-plugin-import-x`'s `consistent-type-specifier-style`, which motivated the import-side fix, only rewrites `ImportDeclaration` — so it is latent until the first recipe edits an export's type markers.
