### PR TITLE
JavaScript: spacing owns the gap between an inline `type` and its name

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -400,6 +400,15 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         })
     }
 
+    protected async visitImportSpecifier(importSpecifier: JS.ImportSpecifier, p: P): Promise<J | undefined> {
+        const ret = await super.visitImportSpecifier(importSpecifier, p) as JS.ImportSpecifier;
+        return produce(ret, draft => {
+            // The specifier's leading space is the brace and comma rules'; this is the
+            // gap between `type` and the name, which the name's own prefix carries
+            draft.specifier.prefix.whitespace = draft.importType.element ? " " : "";
+        });
+    }
+
     protected async visitIndexSignatureDeclaration(indexSignatureDeclaration: JS.IndexSignatureDeclaration, p: P): Promise<J | undefined> {
         const ret = await super.visitIndexSignatureDeclaration(indexSignatureDeclaration, p) as JS.IndexSignatureDeclaration;
         return produce(ret, draft => {

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -40,9 +40,15 @@ import {
     autoFormat,
     AutoformatVisitor,
     JavaScriptVisitor,
+    JS,
+    prettierStyle,
     typescript,
     withDetectedStyle
 } from "../../../src/javascript";
+import {J} from "../../../src/java";
+import {ExecutionContext} from "../../../src/execution";
+import {NamedStyles, randomId} from "../../../src";
+import {create as produce, Draft} from "mutative";
 
 
 describe('AutoformatVisitor', () => {
@@ -711,5 +717,47 @@ const x = 1;`
         })
     });
 
+    test('an edited import is laid out the same by the detected style as by Prettier', async () => {
+        const before = `
+            import { type A, type B } from 'm';
+            `;
+        const after = `
+            import type { A, B } from 'm';
+            `;
+
+        const detected = new RecipeSpec();
+        detected.recipe = fromVisitor(new HoistInlineTypeAndFormat());
+        await detected.rewriteRun({...typescript(before, after), beforeRecipe: withDetectedStyle});
+
+        // The file writes what Prettier's defaults would write, so the two agree exactly
+        const prettier = new RecipeSpec();
+        prettier.recipe = fromVisitor(new HoistInlineTypeAndFormat([prettierStyle(randomId(), {singleQuote: true})]));
+        await prettier.rewriteRun(typescript(before, after));
+    });
+
 });
 
+/** The edit `eslint-plugin-import-x`'s `consistent-type-specifier-style` makes, plus a layout pass. */
+class HoistInlineTypeAndFormat extends JavaScriptVisitor<ExecutionContext> {
+    constructor(private readonly styles?: NamedStyles<string>[]) {
+        super();
+    }
+
+    protected override async visitJsCompilationUnit(cu: JS.CompilationUnit, ctx: ExecutionContext): Promise<J | undefined> {
+        const edited = await super.visitJsCompilationUnit(cu, ctx) as JS.CompilationUnit;
+        return autoFormat(edited, ctx, undefined, undefined, this.styles);
+    }
+
+    protected override async visitImportDeclaration(jsImport: JS.Import, ctx: ExecutionContext): Promise<J | undefined> {
+        return produce(jsImport, draft => {
+            const clause = draft.importClause;
+            if (clause?.namedBindings?.kind !== JS.Kind.NamedImports) {
+                return;
+            }
+            clause.typeOnly = true;
+            for (const element of (clause.namedBindings as Draft<JS.NamedImports>).elements.elements) {
+                element.element.importType.element = false;
+            }
+        });
+    }
+}

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -104,7 +104,7 @@ describe('SpacesVisitor', () => {
             ));
     });
 
-    test('an inline type specifier keeps one space before the name it qualifies', () => {
+    test('an inline type specifier in an export keeps one space before the name it qualifies', () => {
         spec.recipe = fromVisitor(new SpacesVisitor(spaces()));
         return spec.rewriteRun(
             // @formatter:off
@@ -129,6 +129,21 @@ describe('SpacesVisitor', () => {
                 `,
                 `
                 export {A, B as C, d} from 'm';
+                `
+                // @formatter:on
+            ));
+    });
+
+    test('an inline type specifier in an import keeps one space before the name it qualifies', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(`
+                import {type  A, type	B as C, d} from 'm';
+                `,
+                `
+                import {type A, type B as C, d} from 'm';
                 `
                 // @formatter:on
             ));


### PR DESCRIPTION
- `autoFormat` leaves a doubled space inside an import specifier whose inline `type` a recipe has cleared, but only in projects with no Prettier configuration. Clearing the marker on `import { type A, type B } from 'm';` and hoisting `type` onto the clause prints `import type {  A,  B } from 'm';` under an `Autodetect` style, against `import type { A, B } from 'm';` under a `PrettierStyle`. This is a follow-up to #8713 and stacks on it — the two paths only became comparable once that branch wired the Prettier layout path.

## The mechanism

`JS.ImportSpecifier` has two spaces, and they live in different slots than the shape suggests. `importType` is a `J.LeftPadded<boolean>`, so `importType.before` looks like it should hold the space before the keyword — it doesn't. The parser writes:

```
import { type A, B } from 'm';
         ^    ^
         |    specifier.prefix = " "
         ImportSpecifier.prefix = " ", importType.before = ""
```

The leading space is the specifier's own prefix, which the brace and after-comma rules in `SpacesVisitor` already owned. The keyword-to-name space is the *name's* prefix, and nothing owned it. So clearing `importType.element` stops the printer emitting `type` while `specifier.prefix` keeps the space that separated it, and the specifier prints one space wider than it should. The Prettier path never sees this because it reprints the statement from scratch; `SpacesVisitor` is the whole difference between the two.

`SpacesVisitor` now decides that space the way it already decides the one between an `export` and its `type` in `visitExportDeclaration`.

## Why `importType.before` is left alone

The parser writes it empty and the printer emits it immediately before `type`, so a recipe flipping the marker in either direction needs nothing from the formatter there. Normalizing it would have been a line no reachable case exercises.

## Two things reported into this work that are not fixed here, because they are not defects

**Adjacent statements not separated.** Reported as a second gap: a split import printing `import { b } from 'm';import type { A as X } from 'm';`. It reproduces only when the two halves share a `Tree.id` — a split built by spreading the original twice. `BlankLinesVisitor` identifies the first statement with `statements[0].element.id != draft.id`, so the second half identifies as the first and keeps its prefix.

Hardening that check to object identity breaks 48 templating tests. `template.apply(node, this.cursor, …)` formats a *replacement* node under the *original* node's cursor, and the replacement deliberately carries the original's id; identity there reports "not the first statement" and prepends a line break to the first line of the file. Position lookup fails the same way — the padding wrapper on the cursor and the statement list being searched come from different generations of the tree. The id is the only handle stable across the calls that formatting-with-a-cursor makes, so a duplicate id is genuinely indistinguishable from a legitimate substitution. Duplicate ids break more than layout (cursor lookups, `stopAfter` scoping, diff attribution); special-casing one symptom here would suggest a tolerance the tree does not have.

**Brace spacing on a freshly built `NamedImports`.** `import * as ns from 'm'` rewritten to named imports emits `{a, b}` under `Autodetect` and `{ a, b }` under Prettier. `SpacesStatistics.getSpacesStyle` computes `es6ImportExportBraces: withSpace > withoutSpace`, so a file with no braces to sample scores `0 > 0` and lands on IntelliJ's default. That is `Autodetect` choosing a style with no evidence, not a layout gap — a project wanting Prettier's answer carries a `PrettierStyle` marker. Changing the zero-sample default would move every unsampled file in every recipe and needs its own proposal.

Both were confirmed against the consuming recipes: 24 import-x recipe tests green on this commit, and the two above were fixed on the recipe side by sampling a sibling import and by minting a fresh id.

## Tests

`spaces-visitor.test.ts` pins the keyword-present arm from parsed input — `{type  A, type\tB as C, d}` normalizes to `{type A, type B as C, d}`. `format.test.ts` runs the same `consistent-type-specifier-style` edit under `Autodetect` and under `prettierStyle({singleQuote: true})` and asserts both against one expected text; the fixture's own style is what Prettier's defaults would write, so the two paths have to agree exactly rather than modulo a normalization. That is the property the recipes depend on — they do no whitespace handling and delegate layout entirely to the formatter.

## Scope

`JS.ExportSpecifier` has the identical shape (`typeOnly: J.LeftPadded<boolean>` plus `specifier`) and the identical gap, so `export { type A }` edited the same way prints `export {  A }`. Nothing rewrites exports today — `consistent-type-specifier-style` upstream only handles `ImportDeclaration` — so it is filed separately rather than widening this diff. Whether `typeOnly.before` needs anything there is worth checking rather than assuming it mirrors the import side.
