### PR TITLE
JavaScript: an existing binding answers an import request, and a CommonJS file stays CommonJS

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -4,7 +4,7 @@ import {JS, JSX} from "./tree";
 import {randomId, UUID} from "../uuid";
 import {emptyMarkers, markers} from "../markers";
 import {getStyle, SpacesStyle, StyleKind} from "./style";
-import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, isValueReference, namesDeclaredIn, scopeOf} from "./scope";
+import {bindingNames, compilationUnitOf, cursorOf, declarationsOf, deconflict, isValueReference, namesDeclaredIn, scopeOf, walk} from "./scope";
 import {create as produce, Draft} from "mutative";
 import {TypeVisitor} from "../java/type-visitor";
 import {autoFormat} from "./format";
@@ -131,16 +131,13 @@ export function bindImport(
         return derived;
     }
 
-    // An import already serving this request answers it; queuing one would, on the next cycle,
-    // derive a suffixed name from the binding this call just added. A caller that named a preference
-    // takes whatever comes back; one that did not assumes the name it derived, so a binding under
-    // any other name would leave the references it emits unbound.
+    // An import already serving this request answers it, under whatever name the file gave it —
+    // only a pinned alias, returned above, asks for a binding of its own. Queuing a second import
+    // would, on the next cycle, derive a suffixed name from the binding this call just added.
     const scope = scopeOf(cursor);
     for (const binding of moduleScopeBindings(cu)) {
         if (binding.module === module && binding.member === memberName(options.member) &&
-            binding.typeOnly === typeOnly && scope.declaringScope(binding.name) === cu &&
-            (options.preferredName !== undefined || anyNameAnswers(options) ||
-                binding.name === derived)) {
+            binding.typeOnly === typeOnly && scope.declaringScope(binding.name) === cu) {
             return binding.name;
         }
     }
@@ -243,6 +240,65 @@ export function moduleScopeBindings(cu: JS.CompilationUnit): ModuleScopeBinding[
     }
 
     return bindings;
+}
+
+/** Whether a top-level statement already marks the file as a module: an import or any export form. */
+export function hasEsmSyntax(cu: JS.CompilationUnit): boolean {
+    return cu.statements.some(stmt => {
+        const element = stmt.element;
+        // `export {a, b}`, `export * from` and `export default` are their own statement kinds;
+        // `export class`/`function`/`const` instead carry `export` as a modifier on the
+        // declaration itself, the same way TypeScript's own AST models it.
+        const modifiers = (element as {modifiers?: J.Modifier[]} | undefined)?.modifiers;
+        return element?.kind === JS.Kind.Import ||
+            element?.kind === JS.Kind.ExportDeclaration ||
+            element?.kind === JS.Kind.ExportAssignment ||
+            (modifiers?.some(m => m.keyword === "export") ?? false);
+    }) || hasTopLevelAwait(cu);
+}
+
+/**
+ * Whether a statement holds an `await` outside any function of its own — legal only at module
+ * top level, unlike an `await` inside an `async function`, which says nothing about the file.
+ */
+function hasTopLevelAwait(cu: JS.CompilationUnit): boolean {
+    let found = false;
+    walk(cu.statements, node => {
+        if (found) {
+            return false;
+        }
+        if (node.kind === JS.Kind.Await) {
+            found = true;
+            return false;
+        }
+        return node.kind !== J.Kind.MethodDeclaration && node.kind !== J.Kind.Lambda;
+    });
+    return found;
+}
+
+/** Whether the file binds its modules with `require`, which decides whether a create is possible. */
+export function isCommonJs(cu: JS.CompilationUnit): boolean {
+    if (cu.sourcePath.endsWith(".cjs") || cu.sourcePath.endsWith(".cts")) {
+        return true;
+    }
+    // Node treats these as ES modules regardless of what they contain, the same way
+    // `determineImportStyle` reads them as ES6-preferring; `.js`/`.ts`/`.tsx` stay ambiguous and
+    // fall through to the statements below.
+    if (cu.sourcePath.endsWith(".mjs") || cu.sourcePath.endsWith(".mts")) {
+        return false;
+    }
+    if (hasEsmSyntax(cu)) {
+        return false;
+    }
+    return cu.statements.some(stmt =>
+        declarationsOf(stmt.element).some(d => requiredModuleOfDeclaration(d) !== undefined));
+}
+
+/** The module a `const X = require('m')` declaration names, for the one variable it declares. */
+export function requiredModuleOfDeclaration(declaration: J.VariableDeclarations): string | undefined {
+    return declaration.variables.length === 1
+        ? requiredModule(declaration.variables[0].element?.initializer?.element)
+        : undefined;
 }
 
 /** The module a `require('...')` initializer names, `undefined` for an initializer that is anything else. */
@@ -497,6 +553,12 @@ async function formatMergedImport<P>(cu: JS.CompilationUnit, id: UUID, p: P): Pr
     return getPrettierStyle(cu)?.ignored === false ? formatImport(cu, id, p) : cu;
 }
 
+/**
+ * Adds the import {@link AddImportOptions} describes, under the name derived there. An import
+ * already in the file answers where it binds that same name, or where the request expressed no
+ * preference at all. Reuse under some other name belongs to {@link bindImport}, whose caller
+ * learns which name came back; a recipe driving this visitor is stuck with the one it derived.
+ */
 export class AddImport<P> extends JavaScriptVisitor<P> {
     readonly module: string;
     /** Set when the caller supplied the module specifier as a literal; printed verbatim. */
@@ -743,11 +805,12 @@ export class AddImport<P> extends JavaScriptVisitor<P> {
             }
         }
 
-        // Add the import using the appropriate style
-        if (importStyle === ImportStyle.CommonJS) {
-            // TODO: Implement CommonJS require creation
-            // For now, fall back to ES6 imports
-            // return this.addCommonJSRequire(compilationUnit, p);
+        // TODO: create a `require` here. Until then the request goes unserved, since `import` would
+        // make a file that binds its modules with `require` an ES module and change how everything
+        // in it loads — `maybeBind` refuses it for the same reason. An explicit ES6 `style`
+        // overrides, which is how a caller converting the file to ESM asks for one.
+        if (importStyle === ImportStyle.CommonJS && isCommonJs(compilationUnit)) {
+            return compilationUnit;
         }
 
         // Add ES6 import (handles ES6Named, ES6Namespace, ES6Default)

--- a/rewrite-javascript/rewrite/src/javascript/binding.ts
+++ b/rewrite-javascript/rewrite/src/javascript/binding.ts
@@ -16,10 +16,10 @@
 import {J} from "../java";
 import {JS} from "./tree";
 import {JavaScriptVisitor} from "./visitor";
-import {compilationUnitOf, cursorOf, declarationsOf, namesUsedIn, scopeOf, walk} from "./scope";
+import {compilationUnitOf, cursorOf, declarationsOf, namesUsedIn, scopeOf} from "./scope";
 import {
-    AddImportOptions, bindImport, existingImportBinding, ExistingImportBinding, memberName, moduleNameOf,
-    nameTaken, RebindImport, requiredModuleOf
+    AddImportOptions, bindImport, existingImportBinding, ExistingImportBinding, hasEsmSyntax, isCommonJs, memberName,
+    moduleNameOf, nameTaken, RebindImport, requiredModuleOfDeclaration
 } from "./add-import";
 import {RemoveImport} from "./remove-import";
 import {
@@ -127,40 +127,6 @@ export function isAmdBlock(node: J, options?: AmdCalleeOptions): boolean {
         amdBlockOf(node as J.MethodInvocation, calleesOf(options)) !== undefined;
 }
 
-/** Whether a top-level statement already marks the file as a module: an import or any export form. */
-function hasEsmSyntax(cu: JS.CompilationUnit): boolean {
-    return cu.statements.some(stmt => {
-        const element = stmt.element;
-        // `export {a, b}`, `export * from` and `export default` are their own statement kinds;
-        // `export class`/`function`/`const` instead carry `export` as a modifier on the
-        // declaration itself, the same way TypeScript's own AST models it.
-        const modifiers = (element as {modifiers?: J.Modifier[]} | undefined)?.modifiers;
-        return element?.kind === JS.Kind.Import ||
-            element?.kind === JS.Kind.ExportDeclaration ||
-            element?.kind === JS.Kind.ExportAssignment ||
-            (modifiers?.some(m => m.keyword === "export") ?? false);
-    }) || hasTopLevelAwait(cu);
-}
-
-/**
- * Whether a statement holds an `await` outside any function of its own — legal only at module
- * top level, unlike an `await` inside an `async function`, which says nothing about the file.
- */
-function hasTopLevelAwait(cu: JS.CompilationUnit): boolean {
-    let found = false;
-    walk(cu.statements, node => {
-        if (found) {
-            return false;
-        }
-        if (node.kind === JS.Kind.Await) {
-            found = true;
-            return false;
-        }
-        return node.kind !== J.Kind.MethodDeclaration && node.kind !== J.Kind.Lambda;
-    });
-    return found;
-}
-
 interface ModuleObjectBinding {
     name: string;
     module: string;
@@ -175,33 +141,6 @@ interface ModuleObjectBinding {
 
     /** A type-only import erases, so the name it binds stands for no value at runtime. */
     typeOnly: boolean;
-}
-
-/** Whether the file binds its modules with `require`, which decides whether a create is possible. */
-function isCommonJs(cu: JS.CompilationUnit): boolean {
-    if (cu.sourcePath.endsWith(".cjs") || cu.sourcePath.endsWith(".cts")) {
-        return true;
-    }
-    // Node treats these as ES modules regardless of what they contain, the same way
-    // `AddImport`'s own `determineImportStyle` reads them as ES6-preferring; `.js`/`.ts`/`.tsx`
-    // stay ambiguous and fall through to the statements below.
-    if (cu.sourcePath.endsWith(".mjs") || cu.sourcePath.endsWith(".mts")) {
-        return false;
-    }
-    if (hasEsmSyntax(cu)) {
-        return false;
-    }
-    return cu.statements.some(stmt =>
-        declarationsOf(stmt.element).some(d => requiredModule(d) !== undefined));
-}
-
-/** The module a `const X = require("m")` declaration names, for the one variable it declares. */
-function requiredModule(declaration: J.VariableDeclarations): string | undefined {
-    const variables = declaration.variables;
-    const initializer = variables.length === 1 ? variables[0].element?.initializer?.element : undefined;
-    return initializer?.kind === J.Kind.MethodInvocation
-        ? requiredModuleOf(initializer as J.MethodInvocation)
-        : undefined;
 }
 
 /**
@@ -280,7 +219,7 @@ function moduleObjectBindings(cu: JS.CompilationUnit): ModuleObjectBinding[] {
             }
         }
     }
-    bindings.push(...wholeModuleBindingsVia(cu, requiredModule, "require"));
+    bindings.push(...wholeModuleBindingsVia(cu, requiredModuleOfDeclaration, "require"));
     bindings.push(...wholeModuleBindingsVia(cu, dynamicallyImportedModule, "namespace"));
     return bindings;
 }

--- a/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/add-import.test.ts
@@ -396,6 +396,31 @@ describe('AddImport visitor', () => {
                 new AddImport({ module: "react", member: "default" });
             }).toThrow("When member is 'default', the alias parameter is required");
         });
+
+        test('a pinned alias gets a default import of its own beside the one already there', async () => {
+            // The alias is taken verbatim, so the default import already there does not answer the
+            // request; two statements binding the same export are legal.
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({
+                module: 'react',
+                member: 'default',
+                alias: 'R',
+                onlyIfReferenced: false
+            }));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import React from 'react';
+                    `,
+                    `
+                        import React from 'react';
+                        import R from 'react';
+                    `
+                )
+            );
+        });
     });
 
     describe('import positioning', () => {
@@ -656,6 +681,23 @@ describe('AddImport visitor', () => {
                 )
             );
         });
+
+        test('binds the name it was given even where an alias already imports that member', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({module: 'fs', member: 'readFile', onlyIfReferenced: false}));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile as rf} from 'fs';
+                    `,
+                    `
+                        import {readFile, readFile as rf} from 'fs';
+                    `
+                )
+            );
+        });
     });
 
     describe('CommonJS require detection', () => {
@@ -708,6 +750,45 @@ describe('AddImport visitor', () => {
                         function example() {
                             read('test.txt', (err, data) => {});
                         }
+                    `
+                )
+            );
+        });
+
+        test('a CommonJS file gains no import, unlike one that merely requires alongside its imports', async () => {
+            const addReadFile = () => fromVisitor(
+                new AddImport({module: 'fs', member: 'readFile', onlyIfReferenced: false}));
+
+            const commonJs = new RecipeSpec();
+            commonJs.recipe = addReadFile();
+            //language=javascript
+            await commonJs.rewriteRun(
+                javascript(
+                    `
+                        const other = require('other');
+
+                        readFile('test.txt');
+                    `
+                )
+            );
+
+            // The require is the file's only binding of `fs`, so the style it suggests is CommonJS;
+            // the file is an ES module all the same, and that is what decides.
+            const mixed = new RecipeSpec();
+            mixed.recipe = addReadFile();
+            //language=typescript
+            await mixed.rewriteRun(
+                typescript(
+                    `
+                        import path from 'path';
+
+                        const fs = require('fs');
+                    `,
+                    `
+                        import path from 'path';
+                        import {readFile} from 'fs';
+
+                        const fs = require('fs');
                     `
                 )
             );
@@ -1335,6 +1416,22 @@ describe('AddImport visitor', () => {
                 new AddImport({ module: "react", sideEffectOnly: true, onlyIfReferenced: true });
             }).toThrow("Cannot combine sideEffectOnly with onlyIfReferenced");
         });
+
+        test('a file that binds its modules with require gains no side-effect import', async () => {
+            // A side-effect import binds no name, but `import` still makes the file an ES module,
+            // where its own `require` calls do not resolve.
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({module: 'core-js/stable', sideEffectOnly: true}));
+
+            //language=javascript
+            await spec.rewriteRun(
+                javascript(
+                    `
+                        const other = require('other');
+                    `
+                )
+            );
+        });
     });
 
     describe('namespace imports', () => {
@@ -1468,6 +1565,26 @@ describe('AddImport visitor', () => {
                         function example() {
                             const bytes = crypto.randomBytes(16);
                         }
+                    `
+                )
+            );
+        });
+
+        test('a namespace import does not answer a request for a named member', async () => {
+            // The namespace object binds no member name of its own, and one clause holds either
+            // `* as fs` or `{readFile}`, never both, so the named binding needs its own statement.
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new AddImport({module: 'fs', member: 'readFile', onlyIfReferenced: false}));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import * as fs from 'fs';
+                    `,
+                    `
+                        import * as fs from 'fs';
+                        import {readFile} from 'fs';
                     `
                 )
             );
@@ -2890,7 +3007,7 @@ describe('AddImport visitor', () => {
             expect(bound.name).toBe('readFile');
         });
 
-        test('a binding renamed where it is declared does not answer a request that named no preference', async () => {
+        test('a binding renamed where it is declared answers a request that named no preference', async () => {
             const spec = new RecipeSpec();
             const bound: string[] = [];
             spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
@@ -2909,19 +3026,11 @@ describe('AddImport visitor', () => {
 
                         useS(0);
                         wf('x');
-                    `,
-                    `
-                        import {useState as useS, useState} from 'react';
-                        import {writeFile} from 'fs/promises';
-                        const {writeFile: wf} = require('fs/promises');
-
-                        useS(0);
-                        wf('x');
                     `
                 )
             );
 
-            expect(bound).toEqual(['useState', 'writeFile']);
+            expect(bound).toEqual(['useS', 'wf']);
         });
 
         test('a namespace or type declaration shadows an import just as a value declaration does', async () => {


### PR DESCRIPTION
`maybeAddImport(v, {module: 'fs', member: 'readFile'})` into a file that already holds `import {readFile as rf} from 'fs'` emitted a second specifier for a member the file already binds:

```ts
import {readFile, readFile as rf} from 'fs';
```

## The reuse lookup only accepted its own name

`bindImport`'s scan over `moduleScopeBindings` carried a trailing clause that rejected any binding whose local name was not the one the request derived:

```ts
(options.preferredName !== undefined || anyNameAnswers(options) || binding.name === derived)
```

A pinned `alias` returns earlier, so the only requests reaching that clause are member requests with no name preference — exactly the common call. Its stated rationale was that such a caller "assumes the name it derived", but `bindImport` returns the name precisely so callers use it, and the other two arms already reused under a foreign name. The clause went, leaving the loop matching on module, member, `typeOnly` and module-scope declaration. The call above now makes no edit and answers `rf`; the same holds for an aliased destructure, `const {writeFile: wf} = require('fs/promises')`.

Driving `AddImport` directly still emits the second specifier, and that is the point of the split: its caller never learns a substitute name, so it has to bind the one it derived. `bindImport` owns reuse under another name. The `AddImport` class doc now says so, because recipes construct it directly.

## ES module syntax was landing in CommonJS files

```ts
const fs = require('fs');
// AddImport added: import {readFile} from 'fs';
```

`import` makes the file an ES module, where its own `require` calls do not resolve. `ImportStyle.CommonJS` fell through to ES6 creation on a standing TODO. It now leaves the file alone when `isCommonJs` agrees — which is what `maybeBind` already did via `refuseCreate`, and what `CLAUDE.md` documents under "When `maybeBind` returns `undefined`". The two entry points had disagreed: direct `AddImport` wrote the import, `maybeAddImport` returned `undefined`.

Both conjuncts carry weight. A file whose only `fs` binding is a `require` but which also has ES imports is an ES module and still gains one, so keying the refusal on `determineImportStyle` alone would silently no-op there. An explicit ES6 `style` overrides, which is how a caller converting a file to ESM asks for one. This also covers `sideEffectOnly`, where the pre-change behaviour was an outright `SyntaxError` in a file Node loads as CommonJS. Emitting a real `require` stays the TODO.

## Deliberate, and now pinned

Two shapes reached during triage are correct as they stand and gained tests rather than fixes. A namespace import does not answer a request for a named member: the namespace object binds no member name of its own, and one clause holds either `* as fs` or `{readFile}`, never both. A pinned alias gets a default import of its own beside one already there: the alias is taken verbatim because the caller may already have emitted code naming it, and two statements binding the same export are legal.

## Tests

Five added, one changed. `'a binding renamed where it is declared does not answer a request that named no preference'` is the changed one — it encoded the old lookup as deliberate, and now expects no edit and `['useS', 'wf']`. The added ones each pin a distinct line: `answeredBy`'s name conjunct on the merge path and on the default-import path, the new CommonJS guard along with its `isCommonJs` conjunct, that the guard covers `sideEffectOnly`, and `tryMergeIntoExistingImport`'s `kind !== NamedImports` skip.

`isCommonJs`/`hasEsmSyntax` move from `binding.ts` to `add-import.ts`, already the module `binding.ts` pulls its shared file-analysis predicates from, and now a caller itself. The declaration-level `require` helper moves with them so both callers share one copy.
