### PR TITLE
JavaScript: a rebind carries attribution to the references of what moved

### DIFF
--- a/rewrite-javascript/rewrite/CLAUDE.md
+++ b/rewrite-javascript/rewrite/CLAUDE.md
@@ -252,17 +252,18 @@ pass rather than run it alongside.
 ### What a rebind's attribution follows
 
 The move carries the attribution of what it moved, so `UsesType` and any recipe matching on types
-read the new module rather than the old one. A member move carries that member alone — its
-`Type.Method`/`Type.Variable` name is the module's name for it, never the local alias, so it
-follows the member rather than the binding. Siblings imported beside it are named under that same
-module and stay behind, which is why the carry is scoped to references to the moved binding.
+read the new module rather than the old one. It reaches the references of the moved binding and
+nothing else: a member's `Type.Method`/`Type.Variable` name is the module's name for it, never the
+local alias, so it follows the member rather than the binding, while a sibling named under that
+same module stays behind.
 
-A whole-module move instead carries every type the module declares, wherever the file names one,
-which reaches names nothing references — a variable whose type is inferred, say. It does so only
-where the move leaves the module bound nowhere — it takes the module whole, out of a statement
-binding nothing else, in a file that spells that module once, since a `require` or a dynamic
-`import` of it binds it as much as a statement does. Anything a surviving binding names stays,
-which is why a spelling the file keeps refuses the carry rather than risking it.
+A name the move does not reach keeps the attribution it had — a variable whose type is inferred
+from the moved binding, say. That boundary is deliberate: reaching those means rewriting by
+qualified name across the file, and a qualified name cannot tell a sibling's type from the moved
+one, nor a type another module re-exports from one the move applies to.
+
+Moving a whole module carries nothing, since the mapper attributes what a default or namespace
+binding declares to that declaration's own shape rather than to the module's name.
 
 ### When `maybeBind` returns `undefined`
 

--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -1880,7 +1880,6 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
 
     private transformedInPlace = false;
     private typeOnly = false;
-    private movesEveryBinding = false;
     private readonly movedTypes = new MovedTypes(this.from, this.to);
     /** Identifiers settled as references to the binding, so a parent need not settle it again. */
     private readonly references = new Set<string>();
@@ -1890,7 +1889,6 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
     }
 
     override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: P): Promise<J | undefined> {
-        this.movesEveryBinding = movesEveryBindingOf(cu, this.from);
         const visited = await super.visitJsCompilationUnit(cu, p) as JS.CompilationUnit;
         if (!this.transformedInPlace) {
             bindImport(this, {
@@ -1940,15 +1938,6 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
             }
             rewriteNamedSpecifier(draft.importClause, key, memberName(this.to.member) ?? key, this.boundName);
         });
-    }
-
-    /**
-     * A move carrying every binding of its module reaches the types it declares wherever they are
-     * named, which this hook sees; anything narrower is scoped to the references of what moved.
-     * See CLAUDE.md: What a rebind's attribution follows.
-     */
-    protected override async visitType(javaType: Type | undefined, p: P): Promise<Type | undefined> {
-        return this.movesEveryBinding ? await this.movedTypes.visit(javaType, undefined) : javaType;
     }
 
     override async visitIdentifier(identifier: J.Identifier, p: P): Promise<J | undefined> {
@@ -2078,8 +2067,8 @@ export class RebindImport<P> extends JavaScriptVisitor<P> {
 }
 
 /**
- * Rewrites the attribution a move invalidates, onto the module and member it moved to. The caller
- * scopes what it is applied to. See CLAUDE.md: What a rebind's attribution follows.
+ * Rewrites the attribution a move invalidates, onto the module and member it moved to. Applied at
+ * a reference to the moved binding. See CLAUDE.md: What a rebind's attribution follows.
  */
 class MovedTypes extends TypeVisitor<undefined> {
     private readonly onPath = new Set<Type>();
@@ -2088,7 +2077,6 @@ class MovedTypes extends TypeVisitor<undefined> {
     private readonly fromMember?: string;
     private readonly toMember?: string;
     private readonly toModule: string;
-    private readonly movedPrefix?: {from: string; to: string};
 
     constructor(from: {module: string; member?: string}, to: {module: string; member?: string}) {
         super();
@@ -2097,9 +2085,6 @@ class MovedTypes extends TypeVisitor<undefined> {
         this.fromMember = declaredMember(from);
         this.toMember = declaredMember(to);
         this.toModule = to.module;
-        this.movedPrefix = this.fromMember === undefined
-            ? {from: `${from.module}.`, to: `${to.module}.`}
-            : undefined;
     }
 
     /**
@@ -2117,8 +2102,8 @@ class MovedTypes extends TypeVisitor<undefined> {
         this.onPath.add(type);
         try {
             const answer = await super.visit(type, p);
-            // Only a walk that met no cycle stands for the type on its own; one cut short by
-            // `onPath` answered for the path it was on.
+            // Only the type a walk entered at is remembered: one reached inside it may have met
+            // a back edge, which answers with the type itself and so stands for the path it was on.
             if (this.onPath.size === 1) {
                 this.answered.set(type, answer);
             }
@@ -2130,20 +2115,12 @@ class MovedTypes extends TypeVisitor<undefined> {
 
     protected override async visitClass(aClass: Type.Class, p: undefined): Promise<Type | undefined> {
         const visited = await super.visitClass(aClass, p) as Type.Class;
-        const moved = this.renamed.get(visited.fullyQualifiedName) ??
-            this.declaredUnderMovedModule(visited.fullyQualifiedName);
+        const moved = this.renamed.get(visited.fullyQualifiedName);
         return moved === undefined || moved === visited.fullyQualifiedName
             ? visited
             : {...visited, fullyQualifiedName: moved} as Type.Class;
     }
 
-    /** The new name of a type the moved module declares, where the whole module moved. */
-    private declaredUnderMovedModule(fullyQualifiedName: string): string | undefined {
-        const prefix = this.movedPrefix;
-        return prefix !== undefined && fullyQualifiedName.startsWith(prefix.from)
-            ? prefix.to + fullyQualifiedName.substring(prefix.from.length)
-            : undefined;
-    }
 
     protected override async visitMethod(method: Type.Method, p: undefined): Promise<Type | undefined> {
         const visited = await super.visitMethod(method, p) as Type.Method;
@@ -2175,32 +2152,6 @@ class MovedTypes extends TypeVisitor<undefined> {
 function qualifiedName(binding: {module: string; member?: string}): string {
     const key = memberName(binding.member);
     return key === undefined || key === '*' ? binding.module : `${binding.module}.${key}`;
-}
-
-/**
- * Whether the move leaves `from`'s module bound nowhere: it takes the module whole, out of a
- * statement binding nothing else, in a file that spells that module once. Only then does every
- * type the module declares move with it. See CLAUDE.md: What a rebind's attribution follows.
- */
-function movesEveryBindingOf(cu: JS.CompilationUnit, from: {module: string; member?: string}): boolean {
-    return declaredMember(from) === undefined &&
-        (existingImportBinding(cu, from.module, from.member)?.onlyMemberOfStatement ?? false) &&
-        namesModuleOnce(cu, from.module);
-}
-
-/**
- * Whether one place in the file spells `module`. Every spelling counts, since `require` and a
- * dynamic `import` bind a module as much as a statement does.
- */
-function namesModuleOnce(cu: JS.CompilationUnit, module: string): boolean {
-    let named = 0;
-    walk(cu.statements, node => {
-        if (node.kind === J.Kind.Literal && (node as J.Literal).value === module) {
-            named++;
-        }
-        return true;
-    });
-    return named === 1;
 }
 
 /** The member the module declares, where the binding names one: a whole module declares none. */

--- a/rewrite-javascript/rewrite/test/javascript/binding.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/binding.test.ts
@@ -1134,67 +1134,6 @@ describe("maybeRebind", () => {
         expect(attribution).toEqual(["lodash-es.assign", "lodash.flatten"]);
     });
 
-    test("a whole module's move carries a type it declares, named where nothing references it", async () => {
-        const spec = new RecipeSpec();
-        const declared: (string | undefined)[] = [];
-        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
-            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
-                maybeRebind(this, {from: {module: "lodash", member: "*"}, to: {module: "lodash-es", member: "*"}});
-                return super.visitJsCompilationUnit(cu, p);
-            }
-        });
-        await withDir(async (repo) => {
-            await spec.rewriteRun(npm(repo.path, {
-                ...typescript(
-                    `import * as _ from 'lodash';\n\nlet d: _.Dictionary<string>;\n`,
-                    `import * as _ from 'lodash-es';\n\nlet d: _.Dictionary<string>;\n`),
-                afterRecipe: async (cu: any) => {
-                    await new class extends JavaScriptVisitor<any> {
-                        override async visitIdentifier(i: J.Identifier, p: any): Promise<J | undefined> {
-                            if (i.simpleName === "d" && i.type && Type.isFullyQualified(i.type)) {
-                                declared.push(Type.FullyQualified.getFullyQualifiedName(i.type as any));
-                            }
-                            return i;
-                        }
-                    }().visit(cu, undefined);
-                }
-            } as any, packageJson(`{"name":"t","dependencies":{"lodash":"^4.17.21","lodash-es":"^4.17.21","@types/lodash":"^4.14.202","@types/lodash-es":"^4.17.12"}}`)));
-        }, {unsafeCleanup: true});
-        // `d` names the type but references no binding, so only the module's move reaches it.
-        expect(declared).toEqual(["lodash-es../index.Dictionary"]);
-    });
-
-    test("a whole module's move leaves the attribution alone where the file names it elsewhere", async () => {
-        const spec = new RecipeSpec();
-        const declaring: (string | undefined)[] = [];
-        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
-            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
-                maybeRebind(this, {from: {module: "lodash", member: "*"}, to: {module: "lodash-es", member: "*"}});
-                return super.visitJsCompilationUnit(cu, p);
-            }
-        });
-        await withDir(async (repo) => {
-            await spec.rewriteRun(npm(repo.path, {
-                ...typescript(
-                    `import * as _ from 'lodash';\nimport { flatten } from 'lodash';\n\n_.assign({}, {});\nflatten([[1]]);\n`,
-                    `import * as _ from 'lodash-es';\nimport { flatten } from 'lodash';\n\n_.assign({}, {});\nflatten([[1]]);\n`),
-                afterRecipe: async (cu: any) => {
-                    await new class extends JavaScriptVisitor<any> {
-                        override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
-                            if (m.name.simpleName === "flatten") {
-                                const d = m.methodType?.declaringType;
-                                declaring.push(d && Type.isFullyQualified(d) ? Type.FullyQualified.getFullyQualifiedName(d as any) : undefined);
-                            }
-                            return super.visitMethodInvocation(m, p);
-                        }
-                    }().visit(cu, undefined);
-                }
-            } as any, packageJson(`{"name":"t","dependencies":{"lodash":"^4.17.21","lodash-es":"^4.17.21","@types/lodash":"^4.14.202","@types/lodash-es":"^4.17.12","@types/node":"^20.0.0"}}`)));
-        }, {unsafeCleanup: true});
-        // `flatten` is still imported from `lodash`, so the module it names outlives the move.
-        expect(declaring).toEqual(["lodash"]);
-    });
-
     test("a member moved onto a default binding keeps a name, since a default declares none", async () => {
         const spec = new RecipeSpec();
         const names: (string | undefined)[] = [];
@@ -1289,71 +1228,6 @@ describe("maybeRebind", () => {
         }, {unsafeCleanup: true});
         // An optional call is a `JS.FunctionCall`, which carries its own method type.
         expect(attribution).toEqual(["lodash-es.assign"]);
-    });
-
-    test("a whole module's move leaves alone what a `require` of it still binds", async () => {
-        const spec = new RecipeSpec();
-        const declaring: (string | undefined)[] = [];
-        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
-            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
-                maybeRebind(this, {from: {module: "lodash", member: "*"}, to: {module: "lodash-es", member: "*"}});
-                return super.visitJsCompilationUnit(cu, p);
-            }
-        });
-        await withDir(async (repo) => {
-            await spec.rewriteRun(npm(repo.path, {
-                ...typescript(
-                    `import * as _ from 'lodash';\nconst legacy = require('lodash');\n\n_.assign({}, {});\nlegacy.flatten([[1]]);\n`,
-                    `import * as _ from 'lodash-es';\nconst legacy = require('lodash');\n\n_.assign({}, {});\nlegacy.flatten([[1]]);\n`),
-                afterRecipe: async (cu: any) => {
-                    await new class extends JavaScriptVisitor<any> {
-                        override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
-                            if (m.name.simpleName === "flatten") {
-                                const d = m.methodType?.declaringType;
-                                declaring.push(d && Type.isFullyQualified(d) ? Type.FullyQualified.getFullyQualifiedName(d as any) : undefined);
-                            }
-                            return super.visitMethodInvocation(m, p);
-                        }
-                    }().visit(cu, undefined);
-                }
-            } as any, packageJson(`{"name":"t","dependencies":{"lodash":"^4.17.21","lodash-es":"^4.17.21","@types/lodash":"^4.14.202","@types/lodash-es":"^4.17.12","@types/node":"^20.0.0"}}`)));
-        }, {unsafeCleanup: true});
-        // A `require` binds the module without an import statement to count.
-        expect(declaring).toEqual(["lodash"]);
-    });
-
-    test("a whole module's move leaves alone what its own statement still binds", async () => {
-        const spec = new RecipeSpec();
-        const declaring: (string | undefined)[] = [];
-        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
-            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
-                maybeRebind(this, {
-                    from: {module: "lodash", member: "default"},
-                    to: {module: "lodash-es", member: "default"}
-                });
-                return super.visitJsCompilationUnit(cu, p);
-            }
-        });
-        await withDir(async (repo) => {
-            await spec.rewriteRun(npm(repo.path, {
-                ...typescript(
-                    `import _, { flatten } from 'lodash';\n\n_.assign({}, {});\nflatten([[1]]);\n`,
-                    `import { flatten } from 'lodash';\nimport _ from 'lodash-es';\n\n_.assign({}, {});\nflatten([[1]]);\n`),
-                afterRecipe: async (cu: any) => {
-                    await new class extends JavaScriptVisitor<any> {
-                        override async visitMethodInvocation(m: J.MethodInvocation, p: any): Promise<J | undefined> {
-                            if (m.name.simpleName === "flatten") {
-                                const d = m.methodType?.declaringType;
-                                declaring.push(d && Type.isFullyQualified(d) ? Type.FullyQualified.getFullyQualifiedName(d as any) : undefined);
-                            }
-                            return super.visitMethodInvocation(m, p);
-                        }
-                    }().visit(cu, undefined);
-                }
-            } as any, packageJson(`{"name":"t","dependencies":{"lodash":"^4.17.21","lodash-es":"^4.17.21","@types/lodash":"^4.14.202","@types/lodash-es":"^4.17.12"}}`)));
-        }, {unsafeCleanup: true});
-        // One statement binds both, and only the default moves out of it.
-        expect(declaring).toEqual(["lodash"]);
     });
 
     test("a self-referential type on a moved reference terminates", async () => {


### PR DESCRIPTION
- #8717 added a whole-module type sweep to `RebindImport`, and it was a mistake on two counts. It cost three separate correctness bugs during review — each one attribution carried to something that had not moved — and it multiplies the type graph. On `import _ from 'lodash'` with three calls, rebound to `lodash-es` with `@types/lodash` installed:

```
                type nodes   class objects   MapCache copies
parse only         127            28               1
- after #8717        211            66               7
this PR            127            28               1
```

`MemoizedFunction` and `MapCache` each go from one object to seven — one per root that reaches them — and each copy takes its own ref id in `src/reference.ts`, whose `refsById` is a strong `Map` cleared only on an explicit `reset()`. This PR restores parity with an untouched parse: a rebind is now object-count-preserving.

## Why the sweep multiplied objects

- `MovedTypes` memoizes only the type a walk entered at (`onPath.size === 1`). Before #8717 that was harmless: the roots were the three type slots at references to the moved binding, and they shared no sub-nodes, so there was nothing for a wider memo to hit. The `visitType` hook made every type slot in the compilation unit a root, and those roots do share sub-nodes — which is exactly the precondition the memo was missing. Across `binding.test.ts` the walk went from 61 nodes with 2 recomputations to 499 nodes with 316, the worst being compound types rather than singletons (`GenericTypeVariable|T` 449×, `Class|𝑓` 260×).

Widening the memo does not fix it. I tried caching any sub-walk that met no back edge; the heavy duplicates sit under the cyclic `𝑓` shape, so their subtrees always contain one and stay uncacheable — 66 class objects became 64. A real fix needs placeholder-and-patch so a cycle resolves to a single object, which is ~50 lines whose failure mode is silent attribution corruption.

## Why the feature was not worth that

It bought transitive attribution on a whole-module move. Measuring what a whole-module rebind actually carries, it turns out to be nothing: the mapper attributes a default import to `_.LoDashStatic` and a namespace import to an anonymous object, never to `lodash`, so no rule keyed on the module name matches. The sweep was not carrying the moved binding's types — it was rewriting every FQN in the file that started with the module name, which is why it kept catching siblings. All three review findings were instances of that one blunt match, reached through a second import statement, a `require`, and a second binding in the moved statement.

What remains is reference scoping, which has produced none of these. The deleted gate (`movesEveryBindingOf`, `namesModuleOnce`) existed only to constrain the sweep, and the prefix rule (`declaredUnderMovedModule`) only served it — removing that is what takes the census the rest of the way back to 28.

## Tests

Four tests go with it: the one defending the carry, and three defending gate conjuncts that no longer exist. Each pinned a line this PR deletes. That a sibling's attribution stays put is still defended, by the member-move test asserting `["lodash-es.assign", "lodash.flatten"]` — reference scoping is what makes that hold, and it is unchanged. Nothing now covers whole-module attribution because there is nothing to cover; CLAUDE.md states that boundary so the next reader does not re-add a sweep to "fix" it.

Also corrects a comment on `MovedTypes.visit` that described its memo as caching "a walk that met no cycle". It caches on `onPath.size === 1`, which is the entry type — a root walk containing a cycle is cached too. I hit this while measuring: changing the condition to actually mean "met no cycle" collapses caching and takes the census to 175 class objects.

2205 tests pass, typecheck clean.
