### PR TITLE
JavaScript: a whole-module move carries the types named after the module

### DIFF
--- a/rewrite-javascript/rewrite/CLAUDE.md
+++ b/rewrite-javascript/rewrite/CLAUDE.md
@@ -262,8 +262,8 @@ from the moved binding, say. That boundary is deliberate: reaching those means r
 qualified name across the file, and a qualified name cannot tell a sibling's type from the moved
 one, nor a type another module re-exports from one the move applies to.
 
-Moving a whole module carries nothing, since the mapper attributes what a default or namespace
-binding declares to that declaration's own shape rather than to the module's name.
+Moving a whole module carries the types named after the module itself. A type attributed to a
+binding's own declared shape rather than to the module name stays where it is.
 
 ### When `maybeBind` returns `undefined`
 

--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -2121,7 +2121,6 @@ class MovedTypes extends TypeVisitor<undefined> {
             : {...visited, fullyQualifiedName: moved} as Type.Class;
     }
 
-
     protected override async visitMethod(method: Type.Method, p: undefined): Promise<Type | undefined> {
         const visited = await super.visitMethod(method, p) as Type.Method;
         return this.declaresMovedMember(visited.name, visited.declaringType)

--- a/rewrite-javascript/rewrite/test/javascript/binding.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/binding.test.ts
@@ -1167,6 +1167,34 @@ describe("maybeRebind", () => {
         expect(names).toEqual(["extend"]);
     });
 
+    test("a whole-module move carries the types named after the module", async () => {
+        const spec = new RecipeSpec();
+        const named: (string | undefined)[] = [];
+        spec.recipe = fromVisitor(new class extends JavaScriptVisitor<any> {
+            override async visitJsCompilationUnit(cu: JS.CompilationUnit, p: any): Promise<J | undefined> {
+                maybeRebind(this, {from: {module: "events"}, to: {module: "node:events"}});
+                return super.visitJsCompilationUnit(cu, p);
+            }
+        });
+        await withDir(async (repo) => {
+            await spec.rewriteRun(npm(repo.path, {
+                ...typescript(
+                    `import ev from 'events';\n\nconst e = new ev();\n`,
+                    `import ev from 'node:events';\n\nconst e = new ev();\n`),
+                afterRecipe: async (cu: any) => {
+                    await new class extends JavaScriptVisitor<any> {
+                        override async visitNewClass(nc: J.NewClass, p: any): Promise<J | undefined> {
+                            const d = nc.constructorType?.declaringType;
+                            named.push(d && Type.isFullyQualified(d) ? Type.FullyQualified.getFullyQualifiedName(d as any) : undefined);
+                            return super.visitNewClass(nc, p);
+                        }
+                    }().visit(cu, undefined);
+                }
+            } as any, packageJson(`{"name":"t","dependencies":{"@types/node":"^20.0.0"}}`)));
+        }, {unsafeCleanup: true});
+        expect(named).toEqual(["node:events"]);
+    }, 30000);
+
     test("a constructed reference's attribution moves with the binding", async () => {
         const spec = new RecipeSpec();
         const declaring: (string | undefined)[] = [];


### PR DESCRIPTION
- `rewrite-javascript/rewrite/CLAUDE.md` states that "Moving a whole module carries nothing, since the mapper attributes what a default or namespace binding declares to that declaration's own shape rather than to the module's name." That is not what the code does, and the sentence is the stated justification for narrowing the attribution sweep in #8718.

`MovedTypes` builds its rename map as `new Map([[from.module, to.module], [qualifiedName(from), qualifiedName(to)]])`, and `visitClass` applies it to any class whose `fullyQualifiedName` matches a key. A memberless `from` therefore rewrites every type attributed to the module name. Rebinding `events` to `node:events` over `import ev from 'events'; const e = new ev();` leaves `constructorType.declaringType` reading `node:events` — carried, not left behind.

The docs now draw the distinction `visitClass` actually draws: a whole-module move carries the types named after the module, while a type attributed to a binding's own declared shape stays put. The earlier wording also enumerated "default or namespace"; only the default case is covered by a test, so the replacement states the shape rule rather than naming binding forms it does not verify.

`a whole-module move carries the types named after the module` pins the behaviour. Mutation-checked: making a memberless `from` produce an empty rename map fails that test alone, with the other 99 in the file green — no existing test covered this path, since the neighbouring constructed-reference test is a member move.

- Also drops a stray double blank line left in `MovedTypes` by #8718's revert.