### PR TITLE
JavaScript: parsing type-checks the program to keep only syntax errors

### DIFF
--- a/rewrite-javascript/rewrite/src/execution.ts
+++ b/rewrite-javascript/rewrite/src/execution.ts
@@ -16,9 +16,32 @@
 import {RpcCodec, RpcCodecs, RpcReceiveQueue, RpcSendQueue} from "./rpc";
 
 export class ExecutionContext {
+    /** Mirrors `org.openrewrite.ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT`. */
+    static readonly REQUIRE_PRINT_EQUALS_INPUT = "org.openrewrite.requirePrintEqualsInput";
+
     readonly kind: string = "org.openrewrite.InMemoryExecutionContext"
 
     constructor(public readonly messages: { [key: string | symbol]: any } = {}) {
+    }
+
+    /**
+     * Option maps are loosely typed across peers, so a value that arrived as a string counts the same as
+     * its boolean form. The spellings accepted are Go's `strconv.ParseBool`, which peers parse with;
+     * anything else falls back to `defaultValue`.
+     */
+    getBoolean(key: string, defaultValue: boolean): boolean {
+        const value = this.messages[key];
+        if (typeof value === "boolean") {
+            return value;
+        }
+        switch (value) {
+            case "1": case "t": case "T": case "true": case "TRUE": case "True":
+                return true;
+            case "0": case "f": case "F": case "false": case "FALSE": case "False":
+                return false;
+            default:
+                return defaultValue;
+        }
     }
 }
 

--- a/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser-utils.ts
@@ -351,8 +351,9 @@ export function hasFlowAnnotation(sourceFile: ts.SourceFile) {
 }
 
 export function checkSyntaxErrors(program: ts.Program, sourceFile: ts.SourceFile) {
-    const diagnostics = ts.getPreEmitDiagnostics(program, sourceFile);
-    // checking Parsing and Syntax Errors
+    // Only parse diagnostics decide whether a file gets an LST, so the visitor has to map every slot the
+    // parser fills — including ones the checker would reject — or the file loses text on print.
+    const diagnostics = program.getSyntacticDiagnostics(sourceFile);
     let syntaxErrors : [errorMsg: string, errorCode: number][] = [];
     if (diagnostics.length > 0) {
         const errors = diagnostics.filter(d =>  (d.category === ts.DiagnosticCategory.Error) && isCriticalDiagnostic(d.code, sourceFile));
@@ -372,14 +373,6 @@ export function checkSyntaxErrors(program: ts.Program, sourceFile: ts.SourceFile
     }
     return syntaxErrors;
 }
-
-const additionalCriticalCodes = new Set([
-    // Syntax errors
-    17019, // "'{0}' at the end of a type is not valid TypeScript syntax. Did you mean to write '{1}'?"
-    17020, // "'{0}' at the start of a type is not valid TypeScript syntax. Did you mean to write '{1}'?"
-
-    // Other critical errors
-]);
 
 // errors code description available at https://github.com/microsoft/TypeScript/blob/main/src/compiler/diagnosticMessages.json
 const excludedCodes = new Set([
@@ -447,7 +440,7 @@ function isCriticalDiagnostic(code: number, sourceFile: ts.SourceFile): boolean 
         }
     }
 
-    return (code > 1000 && code < 2000 && !excludedCodes.has(code)) || additionalCriticalCodes.has(code);
+    return code > 1000 && code < 2000 && !excludedCodes.has(code);
 }
 
 export function isValidSurrogateRange(unicodeString: string): boolean {

--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -79,6 +79,15 @@ function getScriptKindFromFileName(fileName: string): ts.ScriptKind {
     }
 }
 
+/**
+ * TypeScript's public typings model valid syntax only, so slots its parser still fills for invalid code —
+ * an initializer on a type member, a modifier on an object literal member — are missing from them.
+ */
+type WithInvalidSyntaxSlots<T> = T & {
+    initializer?: ts.Expression;
+    modifiers?: ts.NodeArray<ts.ModifierLike>;
+};
+
 export class JavaScriptParser extends Parser {
 
     private readonly compilerOptions: ts.CompilerOptions;
@@ -379,14 +388,14 @@ export class JavaScriptParser extends Parser {
             }
 
             try {
-                yield produce(
+                yield await this.requirePrintEqualsInput(produce(
                     new JavaScriptParserVisitor(sourceFile, this.relativePath(input), typeMapping)
                         .visit(sourceFile) as SourceFile,
                     draft => {
                         if (this.styles) {
                             draft.markers = this.styles.reduce((m, s) => replaceMarkerByKind(m, s), draft.markers);
                         }
-                    });
+                    }), input, escapeLoneSurrogates(sourceFile.getFullText()));
             } catch (error) {
                 yield this.error(input, error instanceof Error ? error : new Error('Parser threw unknown error: ' + error));
             }
@@ -573,7 +582,12 @@ export class JavaScriptParserVisitor {
         | ts.FunctionDeclaration | ts.ParameterDeclaration | ts.MethodDeclaration | ts.EnumDeclaration | ts.InterfaceDeclaration
         | ts.PropertySignature | ts.ConstructorDeclaration | ts.ModuleDeclaration | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration
         | ts.ArrowFunction | ts.IndexSignatureDeclaration | ts.TypeAliasDeclaration | ts.ExportDeclaration | ts.ExportAssignment | ts.FunctionExpression
-        | ts.ConstructorTypeNode | ts.TypeParameterDeclaration | ts.ImportDeclaration | ts.ImportEqualsDeclaration): J.Modifier[] {
+        | ts.ConstructorTypeNode | ts.TypeParameterDeclaration | ts.ImportDeclaration | ts.ImportEqualsDeclaration
+        | ts.PropertyAssignment | ts.ShorthandPropertyAssignment): J.Modifier[] {
+        if (ts.isPropertyAssignment(node) || ts.isShorthandPropertyAssignment(node)) {
+            const modifiers = (node as WithInvalidSyntaxSlots<typeof node>).modifiers;
+            return modifiers ? modifiers.filter(ts.isModifier).map(this.mapModifier) : [];
+        }
         if (ts.isVariableStatement(node) || ts.isModuleDeclaration(node) || ts.isClassDeclaration(node) || ts.isEnumDeclaration(node)
             || ts.isInterfaceDeclaration(node) || ts.isPropertyDeclaration(node) || ts.isPropertySignature(node) || ts.isParameter(node)
             || ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node) || ts.isArrowFunction(node)
@@ -1175,6 +1189,8 @@ export class JavaScriptParserVisitor {
     visitPropertySignature(node: ts.PropertySignature): J.VariableDeclarations {
         // FIXME We are mapping the literals in things like type ascii = { " ": 32; "!": 33; } to
         //  named variables, which is not a good use of this construct.
+
+        const initializer = (node as WithInvalidSyntaxSlots<ts.PropertySignature>).initializer;
         return {
             kind: J.Kind.VariableDeclarations,
             id: randomId(),
@@ -1193,6 +1209,7 @@ export class JavaScriptParserVisitor {
                         draft.markers = this.maybeAddOptionalMarker(draft, node);
                     }) as VariableDeclarator,
                     dimensionsAfterName: [],
+                    initializer: initializer && this.leftPadded(this.prefix(node.getChildAt(node.getChildren().indexOf(initializer) - 1)), this.visit(initializer)),
                     variableType: this.mapVariableType(node)
                 },
                 emptySpace
@@ -1355,7 +1372,8 @@ export class JavaScriptParserVisitor {
 
     private mapTypeInfo(node: ts.MethodDeclaration | ts.PropertyDeclaration | ts.VariableDeclaration | ts.ParameterDeclaration
         | ts.PropertySignature | ts.MethodSignature | ts.ArrowFunction | ts.CallSignatureDeclaration | ts.GetAccessorDeclaration
-        | ts.FunctionDeclaration | ts.ConstructSignatureDeclaration | ts.FunctionExpression | ts.NamedTupleMember): JS.TypeInfo | undefined {
+        | ts.FunctionDeclaration | ts.ConstructSignatureDeclaration | ts.FunctionExpression | ts.NamedTupleMember
+        | ts.ConstructorDeclaration | ts.SetAccessorDeclaration): JS.TypeInfo | undefined {
         return node.type && {
             kind: JS.Kind.TypeInfo,
             id: randomId(),
@@ -1397,6 +1415,7 @@ export class JavaScriptParserVisitor {
             leadingAnnotations: this.mapDecorators(node),
             modifiers: this.mapModifiers(node),
             nameAnnotations: [],
+            returnTypeExpression: this.mapTypeInfo(node),
             name: {...this.mapIdentifier(constructorKeyword, constructorKeyword.getText(), false), type: methodType},
             parameters: this.mapCommaSeparatedList(this.getParameterListNodes(node)),
             dimensionsAfterName: [],
@@ -1416,6 +1435,7 @@ export class JavaScriptParserVisitor {
                 markers: emptyMarkers,
                 leadingAnnotations: this.mapDecorators(node),
                 modifiers: this.mapModifiers(node),
+                typeParameters: node.typeParameters && this.mapTypeParametersAsObject(node),
                 returnTypeExpression: this.mapTypeInfo(node),
                 name: name as ComputedPropertyName,
                 parameters: this.mapCommaSeparatedList(this.getParameterListNodes(node)),
@@ -1431,6 +1451,7 @@ export class JavaScriptParserVisitor {
             markers: emptyMarkers,
             leadingAnnotations: this.mapDecorators(node),
             modifiers: this.mapModifiers(node),
+            typeParameters: node.typeParameters && this.mapTypeParametersAsObject(node),
             returnTypeExpression: this.mapTypeInfo(node),
             nameAnnotations: [],
             name: name as J.Identifier,
@@ -1452,6 +1473,8 @@ export class JavaScriptParserVisitor {
                 markers: emptyMarkers,
                 leadingAnnotations: this.mapDecorators(node),
                 modifiers: this.mapModifiers(node),
+                typeParameters: node.typeParameters && this.mapTypeParametersAsObject(node),
+                returnTypeExpression: this.mapTypeInfo(node),
                 name: name as ComputedPropertyName,
                 parameters: this.mapCommaSeparatedList(this.getParameterListNodes(node)),
                 body: node.body && this.convert<J.Block>(node.body),
@@ -1466,6 +1489,8 @@ export class JavaScriptParserVisitor {
             markers: emptyMarkers,
             leadingAnnotations: this.mapDecorators(node),
             modifiers: this.mapModifiers(node),
+            typeParameters: node.typeParameters && this.mapTypeParametersAsObject(node),
+            returnTypeExpression: this.mapTypeInfo(node),
             nameAnnotations: [],
             name: name as J.Identifier,
             parameters: this.mapCommaSeparatedList(this.getParameterListNodes(node)),
@@ -4219,6 +4244,7 @@ export class JavaScriptParserVisitor {
             id: randomId(),
             prefix: this.prefix(node),
             markers: emptyMarkers,
+            modifiers: this.mapModifiers(node),
             name: this.rightPadded(this.visit(node.name), this.suffix(node.name)),
             assigmentToken: JS.PropertyAssignment.Token.Colon,
             initializer: this.visit(node.initializer)
@@ -4231,6 +4257,7 @@ export class JavaScriptParserVisitor {
             id: randomId(),
             prefix: this.prefix(node),
             markers: emptyMarkers,
+            modifiers: this.mapModifiers(node),
             name: this.rightPadded(this.visit(node.name), this.suffix(node.name)),
             assigmentToken: JS.PropertyAssignment.Token.Equals,
             initializer: node.objectAssignmentInitializer && this.visit(node.objectAssignmentInitializer)
@@ -4654,7 +4681,8 @@ export class JavaScriptParserVisitor {
     }
 
     private mapTypeParametersAsObject(node: ts.MethodDeclaration | ts.MethodSignature | ts.FunctionDeclaration
-        | ts.CallSignatureDeclaration | ts.ConstructSignatureDeclaration | ts.FunctionExpression | ts.ArrowFunction | ts.TypeAliasDeclaration | ts.FunctionTypeNode | ts.ConstructorTypeNode): J.TypeParameters | undefined {
+        | ts.CallSignatureDeclaration | ts.ConstructSignatureDeclaration | ts.FunctionExpression | ts.ArrowFunction | ts.TypeAliasDeclaration | ts.FunctionTypeNode | ts.ConstructorTypeNode
+        | ts.GetAccessorDeclaration | ts.SetAccessorDeclaration): J.TypeParameters | undefined {
         const typeParameters = node.typeParameters;
         if (!typeParameters) return undefined;
 
@@ -4806,6 +4834,8 @@ class FlowSyntaxNotSupportedError extends SyntaxError {
 
 const SURR_FIRST = 0xD800;
 const SURR_LAST = 0xDFFF;
+const HIGH_SURR_LAST = 0xDBFF;
+const LOW_SURR_FIRST = 0xDC00;
 
 /**
  * Extracts invalid UTF-16 surrogate pairs from a string literal's value source.
@@ -4819,6 +4849,26 @@ const SURR_LAST = 0xDFFF;
  * 1. Unicode escape sequences (\uXXXX) where XXXX is in the surrogate range
  * 2. Raw surrogate characters in the source (character codes 0xD800-0xDFFF)
  */
+/** The form {@link extractSurrogateEscapes} can hold, against which print idempotence is measured. */
+function escapeLoneSurrogates(source: string): string {
+    let escaped = '';
+    for (let j = 0; j < source.length; j++) {
+        const charCode = source.charCodeAt(j);
+        if (charCode >= SURR_FIRST && charCode <= SURR_LAST) {
+            const next = source.charCodeAt(j + 1);
+            if (charCode <= HIGH_SURR_LAST && next >= LOW_SURR_FIRST && next <= SURR_LAST) {
+                escaped += source.charAt(j) + source.charAt(j + 1);
+                j++;
+                continue;
+            }
+            escaped += "\\u" + charCode.toString(16).toUpperCase().padStart(4, '0');
+            continue;
+        }
+        escaped += source.charAt(j);
+    }
+    return escaped;
+}
+
 function extractSurrogateEscapes(valueSource: string): { cleanedSource: string, unicodeEscapes: J.LiteralUnicodeEscape[] } {
     const unicodeEscapes: J.LiteralUnicodeEscape[] = [];
     let cleanedSource = '';
@@ -4842,8 +4892,17 @@ function extractSurrogateEscapes(valueSource: string): { cleanedSource: string, 
             }
         }
 
-        // Check for raw surrogate characters in the source
+        // A raw surrogate pair spells one code point — an emoji, say — and is carried as itself. A lone
+        // surrogate is not text on its own and does not survive serialization (#6599), so it is held as a
+        // `\uXXXX` escape and prints back as one.
         if (charCode >= SURR_FIRST && charCode <= SURR_LAST) {
+            const next = valueSource.charCodeAt(j + 1);
+            if (charCode <= HIGH_SURR_LAST && next >= LOW_SURR_FIRST && next <= SURR_LAST) {
+                cleanedSource += c + valueSource.charAt(j + 1);
+                cleanedIndex += 2;
+                j++;
+                continue;
+            }
             const codePoint = charCode.toString(16).toUpperCase().padStart(4, '0');
             unicodeEscapes.push({ valueSourceIndex: cleanedIndex, codePoint });
             continue;

--- a/rewrite-javascript/rewrite/src/javascript/print.ts
+++ b/rewrite-javascript/rewrite/src/javascript/print.ts
@@ -950,6 +950,13 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
         return typeDeclaration;
     }
 
+    override async visitUnknownSource(source: J.UnknownSource, p: PrintOutputCapture): Promise<J | undefined> {
+        await this.beforeSyntax(source, p);
+        p.append(source.text);
+        await this.afterSyntax(source, p);
+        return source;
+    }
+
     override async visitLiteralType(literalType: JS.LiteralType, p: PrintOutputCapture): Promise<J | undefined> {
         await this.beforeSyntax(literalType, p);
         await this.visit(literalType.literal, p);
@@ -1413,6 +1420,9 @@ export class JavaScriptPrinter extends JavaScriptVisitor<PrintOutputCapture> {
     override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, p: PrintOutputCapture): Promise<J | undefined> {
         await this.beforeSyntax(propertyAssignment, p);
 
+        for (const m of propertyAssignment.modifiers) {
+            await this.visitModifier(m, p);
+        }
         await this.visitRightPadded(propertyAssignment.name, p);
 
         if (propertyAssignment.initializer) {

--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -229,6 +229,7 @@ class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
     }
 
     override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, q: RpcSendQueue): Promise<J | undefined> {
+        await q.getAndSendList(propertyAssignment, el => el.modifiers, el => el.id, el => this.visit(el, q));
         await q.getAndSend(propertyAssignment, el => el.name, el => this.visitRightPadded(el, q));
         await q.getAndSend(propertyAssignment, el => el.assigmentToken);
         await q.getAndSend(propertyAssignment, el => el.initializer, el => this.visit(el, q));
@@ -816,6 +817,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
 
     override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, q: RpcReceiveQueue): Promise<J | undefined> {
         const updates = {
+            modifiers: await q.receiveList(propertyAssignment.modifiers, el => this.visitDefined<J.Modifier>(el, q)),
             name: await q.receive(propertyAssignment.name, el => this.visitRightPadded(el, q)),
             assigmentToken: await q.receive(propertyAssignment.assigmentToken),
             initializer: await q.receive(propertyAssignment.initializer, el => this.visitDefined<Expression>(el, q))

--- a/rewrite-javascript/rewrite/src/javascript/tree.ts
+++ b/rewrite-javascript/rewrite/src/javascript/tree.ts
@@ -417,6 +417,7 @@ export namespace JS {
      */
     export interface PropertyAssignment extends JS, Statement, TypedTree {
         readonly kind: typeof Kind.PropertyAssignment;
+        readonly modifiers: J.Modifier[];
         readonly name: J.RightPadded<Expression>;
         readonly assigmentToken: PropertyAssignment.Token;
         readonly initializer?: Expression;

--- a/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
+++ b/rewrite-javascript/rewrite/src/javascript/type-mapping.ts
@@ -19,6 +19,20 @@ import {Type} from "../java";
 import FUNCTION_TYPE_NAME = Type.FUNCTION_TYPE_NAME;
 import OBJECT_TYPE_NAME = Type.OBJECT_TYPE_NAME;
 
+/**
+ * TypeScript orders union constituents by internal type id, which varies with what the checker resolved
+ * earlier in the run; ordering by signature keeps a union's signature the same across parses. Intersections
+ * keep the order they were written in and are left alone. Call once `bounds` is attached to its owner, so
+ * a constituent that reaches back into it reads the whole constituent list rather than an empty one.
+ */
+function sortBySignature(bounds: Type[]): void {
+    const keys = new Map<Type, string>(bounds.map(b => [b, Type.signature(b)]));
+    bounds.sort((a, b) => {
+        const ka = keys.get(a)!, kb = keys.get(b)!;
+        return ka < kb ? -1 : ka > kb ? 1 : 0;
+    });
+}
+
 export class JavaScriptTypeMapping {
     // Primary cache: Use type signatures (preferring type.id) as cache keys
     // TypeScript assigns stable IDs to all types, so we don't need secondary caches
@@ -1610,6 +1624,7 @@ export class JavaScriptTypeMapping {
 
         // Update the bounds in the union we created
         (union as any).bounds = bounds;
+        sortBySignature(bounds);
 
         return union;
     }

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -551,6 +551,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
         const updates: any = {
             prefix: await this.visitSpace(propertyAssignment.prefix, p),
             markers: await this.visitMarkers(propertyAssignment.markers, p),
+            modifiers: await mapAsync(propertyAssignment.modifiers, m => this.visitDefined<J.Modifier>(m, p)),
             name: await this.visitRightPadded(propertyAssignment.name, p),
             initializer: propertyAssignment.initializer && await this.visitDefined<Expression>(propertyAssignment.initializer, p)
         };

--- a/rewrite-javascript/rewrite/src/parser.ts
+++ b/rewrite-javascript/rewrite/src/parser.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import {createTwoFilesPatch} from "diff";
 import {ExecutionContext} from "./execution";
 import {SourceFile} from "./tree";
+import {TreePrinters} from "./print";
 import fs, {readFileSync} from "node:fs";
 import {isAbsolute, relative} from "path";
 import {ParseError, ParseErrorKind} from "./parse-error";
@@ -79,6 +81,27 @@ export abstract class Parser {
         return isAbsolute(path) && this.relativeTo ? relative(this.relativeTo, path) : path;
     }
 
+    /**
+     * A parse result that does not print back to its input has silently lost source, so it is reported as
+     * a `ParseError` carrying the tree that lost it. Mirrors `org.openrewrite.Parser`, down to the message.
+     * A parser whose LST cannot hold some byte of its input passes the form it can hold as `source`.
+     */
+    protected async requirePrintEqualsInput(sourceFile: SourceFile, input: ParserInput,
+                                            source: string = parserInputRead(input)): Promise<SourceFile> {
+        if (!this.ctx.getBoolean(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, true)) {
+            return sourceFile;
+        }
+        const printed = await TreePrinters.print(sourceFile);
+        if (printed === source) {
+            return sourceFile;
+        }
+        const path = this.relativePath(input);
+        const diff = createTwoFilesPatch(path, path, source, printed, "", "", {context: 3});
+        const error = this.error(input, new Error(`${sourceFile.sourcePath} is not print idempotent. \n${diff}`));
+        const withErroneous: ParseError = {...error, erroneous: sourceFile};
+        return withErroneous;
+    }
+
     protected error(input: ParserInput, e: Error): ParseError {
         return {
             kind: ParseErrorKind,
@@ -88,7 +111,7 @@ export abstract class Parser {
                 id: randomId(),
                 parserType: this.constructor.name,
                 exceptionType: e.name,
-                message: e.message + ':\n' + e.stack,
+                message: e.stack ?? e.message,
             } satisfies ParseExceptionResult as ParseExceptionResult),
             text: parserInputRead(input),
             sourcePath: this.relativePath(input),

--- a/rewrite-javascript/rewrite/src/print.ts
+++ b/rewrite-javascript/rewrite/src/print.ts
@@ -162,8 +162,11 @@ export class TreePrinters {
         return this._registry.get(sourceFileKind)!;
     }
 
-    static print(sourceFile: SourceFile): Promise<string> {
-        return this.printer(sourceFile).print(sourceFile);
+    static async print(sourceFile: SourceFile): Promise<string> {
+        const printed = await this.printer(sourceFile).print(sourceFile);
+        // The BOM is a property of the file's encoding rather than of its syntax, so it is held on the
+        // source file and put back here. Mirrors `org.openrewrite.Tree.print`.
+        return sourceFile.charsetBomMarked && printed.charAt(0) !== "\uFEFF" ? "\uFEFF" + printed : printed;
     }
 
     static async printTrimmed(sourceFile: SourceFile): Promise<string> {

--- a/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse-project.ts
@@ -55,7 +55,11 @@ export class ParseProject {
          * If not specified, paths are relative to projectPath.
          * Use this when parsing a subdirectory but wanting paths relative to the repository root.
          */
-        private readonly relativeTo?: string
+        private readonly relativeTo?: string,
+        /**
+         * Parser options, as on the `Parse` request.
+         */
+        private readonly options?: { [key: string]: string }
     ) {}
 
     static handle(
@@ -85,7 +89,7 @@ export class ParseProject {
                     const prettierLoader = await projectParser.createPrettierLoader();
 
                     const resultItems: ParseProjectResponseItem[] = [];
-                    const ctx = new ExecutionContext();
+                    const ctx = new ExecutionContext({...request.options});
 
                     // Parse package.json files (these get NodeResolutionResult markers)
                     if (discovered.packageJsonFiles.length > 0) {

--- a/rewrite-javascript/rewrite/src/rpc/request/parse.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/parse.ts
@@ -23,7 +23,12 @@ import * as path from "path";
 
 export class Parse {
     constructor(private readonly inputs: ParserInput[],
-                private readonly relativeTo?: string) {
+                private readonly relativeTo?: string,
+                /**
+                 * Parser options from the peer. Keys this handler does not recognize are ignored, and a
+                 * peer that sends none gets the parser's own defaults.
+                 */
+                private readonly options?: { [key: string]: string }) {
     }
 
     /**
@@ -58,7 +63,7 @@ export class Parse {
                         : "javascript";
 
                     const parser = Parsers.createParser(parserType, {
-                        ctx: new ExecutionContext(),
+                        ctx: new ExecutionContext({...request.options}),
                         relativeTo: request.relativeTo
                     })!;
 

--- a/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/literal.test.ts
@@ -120,7 +120,25 @@ describe('Malformed hex escape sequences (error 1125)', () => {
         }
     }));
 
-    test('should NOT parse in .ts files', () => {
-        return expect(spec.rewriteRun(typescript('/\\x-.*/'))).rejects.toThrow(/Hexadecimal digit expected/);
+    test('should parse in .ts files', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('/\\x-.*/')
+        ));
+
+    test('string escape should parse in .js files', () => spec.rewriteRun(javascript("'\\x'")));
+
+    test('string escape should NOT parse in .ts files', () => {
+        // A regex literal's `\x` is validated by the checker, a string literal's by the scanner, so only
+        // the latter reaches `jsOnlyExcludedCodes`.
+        return expect(spec.rewriteRun(typescript("'\\x'"))).rejects.toThrow(/Hexadecimal digit expected/);
     });
+});
+
+describe('surrogate pairs', () => {
+    test('a character outside the BMP round-trips as itself', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('const s = "\u{1F42D}";')
+        ));
 });

--- a/rewrite-javascript/rewrite/test/javascript/parser/parse-error-recovery.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/parser/parse-error-recovery.test.ts
@@ -30,6 +30,72 @@ describe('parse error recovery', () => {
             )
         ));
 
+    test('a grammar error the checker alone reports is not fatal', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('function f(...a: number[], b: number) {}')
+        ));
+
+    test('a type the visitor does not map keeps its source text', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('type T = string?;')
+        ));
+
+    test('an interface property keeps an initializer', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('interface I { x: number = 1; }')
+        ));
+
+    test('a constructor keeps a return type annotation', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('class C { constructor(): void {} }')
+        ));
+
+    test('an object literal member keeps its modifiers', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('const o = { static readonly x: 1 };')
+        ));
+
+    test('a shorthand object literal member keeps its modifiers', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('const o = { static x };')
+        ));
+
+    test('a file keeps its byte order mark', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('\uFEFFconst a = 1;')
+        ));
+
+    test('a getter keeps type parameters', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('class C { get x<T>() { return 1; } }')
+        ));
+
+    test('a setter keeps type parameters and a return type', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('class C { set x<T>(v: any): void {} }')
+        ));
+
+    test('a computed getter keeps type parameters', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('const k = "a"; class C { get [k]<T>() { return 1; } }')
+        ));
+
+    test('a computed setter keeps type parameters and a return type', () =>
+        spec.rewriteRun(
+            //language=typescript
+            typescript('const k = "a"; class C { set [k]<T>(v: any): void {} }')
+        ));
+
     test('mutually recursive generic types do not cause stack overflow', () =>
         spec.rewriteRun(
             //language=typescript

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping.test.ts
@@ -1193,6 +1193,28 @@ describe('JavaScript type mapping', () => {
             );
         });
 
+        test('should order union constituents by signature, not by TypeScript type id', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = markTypes((node, type) => {
+                if (node?.kind === J.Kind.Identifier && (node as J.Identifier).simpleName === 'value') {
+                    return Type.isUnion(type) ? `Union[${type.bounds.map(b => Type.signature(b)).join(', ')}]` : 'NOT_UNION';
+                }
+                return null;
+            });
+
+            await spec.rewriteRun(
+                //language=typescript
+                typescript(
+                    `
+                        let value: string | Error = "hello";
+                    `,
+                    `
+                        let /*~~(Union[Error, String])~~>*/value: string | Error = "hello";
+                    `
+                )
+            );
+        });
+
         test('should map intersection type', async () => {
             const spec = new RecipeSpec();
             spec.recipe = markTypes((node, type) => {

--- a/rewrite-javascript/rewrite/test/parser.test.ts
+++ b/rewrite-javascript/rewrite/test/parser.test.ts
@@ -13,7 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {ParserSourceReader, readSourceSync} from "../src";
+import {ExecutionContext, Parser, ParserInput, ParserSourceReader, readSourceSync} from "../src";
+import {isParseError} from "../src/parse-error";
+import {PlainText} from "../src/text";
+import {JavaScriptParser} from "../src/javascript";
+import {randomId} from "../src/uuid";
+import {emptyMarkers} from "../src/markers";
+import {SourceFile} from "../src/tree";
+
+/** Parses to whatever text it was constructed with, so its output need not match its input. */
+class FixedTextParser extends Parser {
+    constructor(private readonly parsesTo: string, ctx?: ExecutionContext) {
+        super({ctx});
+    }
+
+    async* parse(...inputs: ParserInput[]): AsyncGenerator<SourceFile> {
+        for (const input of inputs) {
+            const parsed: PlainText = {
+                kind: PlainText.Kind.PlainText,
+                id: randomId(),
+                markers: emptyMarkers,
+                sourcePath: this.relativePath(input),
+                text: this.parsesTo,
+                snippets: []
+            };
+            yield await this.requirePrintEqualsInput(parsed, input);
+        }
+    }
+}
 
 
 describe("parse source reader utility", () => {
@@ -33,5 +60,47 @@ describe("parse source reader utility", () => {
 
     test("read in memory source file", () => {
         expect(readSourceSync(sourceJson)).toEqual(`  { "type": "object" }`);
+    });
+});
+
+describe("print-equals-input check", () => {
+    const input = {text: "hello", sourcePath: "a.txt"};
+
+    test("the option key is the one peers send", () => {
+        expect(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT).toBe("org.openrewrite.requirePrintEqualsInput");
+    });
+
+    test("a parse that prints back to its input passes through", async () => {
+        const parsed = await new FixedTextParser("hello").parseOne(input);
+        expect(isParseError(parsed)).toBe(false);
+    });
+
+    test("a parse that loses source becomes a ParseError carrying the tree that lost it", async () => {
+        const parsed = await new FixedTextParser("hell").parseOne(input);
+        expect(isParseError(parsed)).toBe(true);
+        if (isParseError(parsed)) {
+            expect(parsed.markers.markers[0]).toMatchObject({message: expect.stringContaining("a.txt is not print idempotent.")});
+            expect(parsed.erroneous).toMatchObject({kind: PlainText.Kind.PlainText, text: "hell"});
+        }
+    });
+
+    test.each([
+        ["the option off as a string keeps the tree", "false", false],
+        ["the option off as a boolean keeps the tree", false, false],
+        ["the option off as a digit keeps the tree", "0", false],
+        ["the option off in upper case keeps the tree", "FALSE", false],
+        ["an unparseable option reports the loss", "nonsense", true],
+    ])("%s", async (_, option, expectsParseError) => {
+        const ctx = new ExecutionContext({[ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT]: option});
+        const parsed = await new FixedTextParser("hell", ctx).parseOne(input);
+        expect(isParseError(parsed)).toBe(expectsParseError);
+    });
+});
+
+describe("literals the LST cannot hold verbatim", () => {
+    test("a lone surrogate still parses, held as the escape it prints back as", async () => {
+        const parsed = await new JavaScriptParser({}).parseOne(
+            {text: 'const s = "\uD800";', sourcePath: "a.ts"});
+        expect(isParseError(parsed)).toBe(false);
     });
 });

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptParser.java
@@ -69,7 +69,7 @@ public class JavaScriptParser implements Parser {
         if (!smallFiles.isEmpty()) {
             JavaScriptValidator<Integer> validator = new JavaScriptValidator<>();
             smallFileStream = JavaScriptRewriteRpc.getOrStart().parse(smallFiles, relativeTo, this,
-                    JS.CompilationUnit.class.getName(), ctx).map(source -> {
+                    JS.CompilationUnit.class.getName(), ctx, JavaScriptRewriteRpc.parseOptions(ctx)).map(source -> {
                 try {
                     validator.visit(source, 0);
                     return source;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/JavaScriptVisitor.java
@@ -418,6 +418,7 @@ public class JavaScriptVisitor<P> extends JavaVisitor<P> {
         } else {
             pa = (JS.PropertyAssignment) temp;
         }
+        pa = pa.withModifiers(ListUtils.map(pa.getModifiers(), e -> (J.Modifier) visit(e, p)));
         pa = pa.getPadding().withName(requireNonNull(visitRightPadded(pa.getPadding().getName(), JsRightPadded.Location.PROPERTY_ASSIGNMENT_NAME, p)));
         return pa.withInitializer(visitAndCast(pa.getInitializer(), p));
     }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptReceiver.java
@@ -264,6 +264,7 @@ public class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
     @Override
     public J visitPropertyAssignment(JS.PropertyAssignment propertyAssignment, RpcReceiveQueue q) {
         return propertyAssignment
+                .withModifiers(q.receiveList(propertyAssignment.getModifiers(), mod -> (J.Modifier) visitNonNull(mod, q)))
                 .getPadding().withName(q.receive(propertyAssignment.getPadding().getName(), el -> visitRightPadded(el, q)))
                 .withAssigmentToken(q.receiveAndGet(propertyAssignment.getAssigmentToken(), toEnum(JS.PropertyAssignment.AssigmentToken.class)))
                 .withInitializer(q.receive(propertyAssignment.getInitializer(), expr -> (Expression) visitNonNull(expr, q)));

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptSender.java
@@ -253,6 +253,7 @@ public class JavaScriptSender extends JavaScriptVisitor<RpcSendQueue> {
 
     @Override
     public J visitPropertyAssignment(JS.PropertyAssignment propertyAssignment, RpcSendQueue q) {
+        q.getAndSendList(propertyAssignment, JS.PropertyAssignment::getModifiers, J.Modifier::getId, el -> visit(el, q));
         q.getAndSend(propertyAssignment, el -> el.getPadding().getName(), el -> visitRightPadded(el, q));
         q.getAndSend(propertyAssignment, JS.PropertyAssignment::getAssigmentToken);
         q.getAndSend(propertyAssignment, JS.PropertyAssignment::getInitializer, el -> visit(el, q));

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/internal/rpc/JavaScriptValidator.java
@@ -239,6 +239,7 @@ public class JavaScriptValidator<P> extends JavaScriptIsoVisitor<P> {
 
     @Override
     public JS.PropertyAssignment visitPropertyAssignment(JS.PropertyAssignment propertyAssignment, P p) {
+        visitAndValidate(propertyAssignment.getModifiers(), J.Modifier.class, p);
         visitAndValidateNonNull(propertyAssignment.getName(), Expression.class, p);
         visitAndValidate(propertyAssignment.getInitializer(), Expression.class, p);
         return propertyAssignment;

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpc.java
@@ -132,6 +132,15 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
     }
 
     /**
+     * Parser options forwarded to the Node server with every parse request, carrying this context's
+     * {@link ExecutionContext#REQUIRE_PRINT_EQUALS_INPUT} setting.
+     */
+    public static Map<String, String> parseOptions(ExecutionContext ctx) {
+        return Collections.singletonMap(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT,
+                String.valueOf(ctx.getMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, true)));
+    }
+
+    /**
      * Parses an entire JavaScript/TypeScript project directory.
      * Discovers and parses all relevant source files, package.json files, and lock files.
      *
@@ -182,7 +191,7 @@ public class JavaScriptRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, base), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, base, parseOptions(ctx)), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProject.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/rpc/ParseProject.java
@@ -21,6 +21,7 @@ import org.openrewrite.rpc.request.RpcRequest;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 /**
  * RPC request to parse an entire JavaScript/TypeScript project.
@@ -48,17 +49,25 @@ class ParseProject implements RpcRequest {
     @Nullable
     Path relativeTo;
 
+    /**
+     * Parser options, as on {@link org.openrewrite.rpc.request.Parse#getOptions()}.
+     */
+    @Nullable
+    Map<String, String> options;
+
     ParseProject(Path projectPath) {
-        this(projectPath, null, null);
+        this(projectPath, null, null, null);
     }
 
     ParseProject(Path projectPath, @Nullable List<String> exclusions) {
-        this(projectPath, exclusions, null);
+        this(projectPath, exclusions, null, null);
     }
 
-    ParseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo) {
+    ParseProject(Path projectPath, @Nullable List<String> exclusions, @Nullable Path relativeTo,
+                 @Nullable Map<String, String> options) {
         this.projectPath = projectPath;
         this.exclusions = exclusions;
         this.relativeTo = relativeTo;
+        this.options = options;
     }
 }

--- a/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
+++ b/rewrite-javascript/src/main/java/org/openrewrite/javascript/tree/JS.java
@@ -2390,6 +2390,9 @@ public interface JS extends J {
         @With
         Markers markers;
 
+        @With
+        List<J.Modifier> modifiers;
+
         JRightPadded<Expression> name;
 
         public Expression getName() {
@@ -2415,7 +2418,7 @@ public interface JS extends J {
         @SuppressWarnings("unchecked")
         @Override
         public PropertyAssignment withType(@Nullable JavaType type) {
-            return initializer == null || initializer.getType() == type ? this : new PropertyAssignment(id, prefix, markers, name, assigmentToken, initializer.withType(type));
+            return initializer == null || initializer.getType() == type ? this : new PropertyAssignment(id, prefix, markers, modifiers, name, assigmentToken, initializer.withType(type));
         }
 
         @Override
@@ -2459,7 +2462,7 @@ public interface JS extends J {
             }
 
             public PropertyAssignment withName(JRightPadded<Expression> target) {
-                return t.name == target ? t : new PropertyAssignment(t.id, t.prefix, t.markers, target, t.assigmentToken, t.initializer);
+                return t.name == target ? t : new PropertyAssignment(t.id, t.prefix, t.markers, t.modifiers, target, t.assigmentToken, t.initializer);
             }
         }
     }

--- a/rewrite-javascript/src/test/java/org/openrewrite/javascript/rpc/JavaScriptParseOptionsTest.java
+++ b/rewrite-javascript/src/test/java/org/openrewrite/javascript/rpc/JavaScriptParseOptionsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.rpc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JavaScriptParseOptionsTest {
+
+    @Test
+    void printIdempotencyIsRequestedByDefault() {
+        assertThat(JavaScriptRewriteRpc.parseOptions(new InMemoryExecutionContext()))
+                .containsEntry(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "true");
+    }
+
+    @Test
+    void printIdempotencyFollowsTheExecutionContext() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
+
+        assertThat(JavaScriptRewriteRpc.parseOptions(ctx))
+                .containsEntry(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false");
+    }
+
+    @Test
+    void optionsSerializeUnderTheKeyTheNodeServerReads() throws Exception {
+        // A rename on either side falls back to the default rather than failing.
+        assertThat(new ObjectMapper().writeValueAsString(new ParseProject(Paths.get("."), null, null,
+                Collections.singletonMap(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false"))))
+                .contains("\"options\":{\"org.openrewrite.requirePrintEqualsInput\":\"false\"}");
+    }
+}


### PR DESCRIPTION
Parsing a JavaScript/TypeScript project runs TypeScript's full type checker and then discards every diagnostic it produces. `checkSyntaxErrors` asks for `ts.getPreEmitDiagnostics`, which returns syntactic *and semantic and declaration* diagnostics, and then keeps only what `isCriticalDiagnostic` admits — codes in the 1000-1999 band, which is TypeScript's syntactic and grammar range. Semantic errors start at 2000, so every one of them is computed and thrown away. On `apollographql/apollo-client` at `src` (525 `.ts`/`.tsx` files) that is three quarters of the wall clock.

Reading `program.getSyntacticDiagnostics(sourceFile)` instead, measured by driving `JavaScriptParser.parse()` over those 525 files, interleaved, twice:

| | wall clock | parse errors |
|---|---|---|
| as-is | 70.6 s | 0 |
| this branch | **24.5 s** | 0 |

Printed output is byte-identical for all 525 files, and the LSTs are identical too once TypeScript's internal symbol ids (`__@ApolloErrorMessageHandler@3040`, which vary run to run) are normalised away.

## What the checker was hiding

`isCriticalDiagnostic` admits 224 codes that only the *checker* reports — not two, as a reading of `additionalCriticalCodes` suggests. Most are grammar complaints about a tree the parser built cleanly, and the file is better off with an LST. But seven of them were load-bearing, because the visitor never mapped the slot the parser had filled:

```
interface I { x: number = 1; }      ->  interface I { x: number; }      1246
class C { constructor(): void {} }  ->  class C { constructor() {} }    1093
const o = { static x: 1 };          ->  const o = {  x: 1 };            1042
class C { set x(v: number): void {} } -> class C { set x(v: number) {} } 1095
class C { get x<T>() { return 1; } } -> class C { get x() { return 1; } } 1094
```

The diagnostic rejected the whole file first, so the visitor's output was never printed and the gaps never surfaced. Dropping the diagnostic without mapping the slots would have silently deleted the annotation, initializer or modifier on the next recipe run.

All five slots are mapped now. `JS.PropertyAssignment` gains the `modifiers` field it had nowhere to put one (TS tree/visitor/printer/RPC plus the Java model, sender, receiver and validator, all in the order `modifiers, name, assigmentToken, initializer`). `type T = string?;` parses to `J.Unknown` rather than being rejected, which needed `visitUnknownSource` to append `source.text` — a parity gap against `JavaPrinter.visitUnknownSource:1202`, and one that silently dropped **every** `J.Unknown` on print.

## Keeping the next gap from hiding

- `Parser.requirePrintEqualsInput` is what would have caught all seven, and every JVM parser calls it — but on the RPC path JavaScript uses it was commented out in #6126 with `// TODO this should be handled on the remote side`, and the TypeScript side never picked it up. It does now, mirroring the Go and Python peers: default on, disabled through `org.openrewrite.requirePrintEqualsInput`, accepting the spellings Go's `strconv.ParseBool` does, and wording the failure exactly as `org.openrewrite.Parser` does. Core's `Parse` request already carried an `options` map; `ParseProject` gains one, as Go's already had.

It costs 2.2 s of the 24.5 s and reports 0 failures across all 525 files — but only after two pre-existing printer bugs, either of which would have turned working files into hard parse failures:

- **A BOM was never restored on print.** The JVM does this in `Tree.print`, in a block commented as kept in sync with `printEqualsInput`; `TreePrinters.print` had no equivalent, so every BOM-prefixed file lost its BOM on any print.
- **A well-formed surrogate pair was re-emitted as `\uXXXX`.** `extractSurrogateEscapes` captures raw surrogates so Jackson can serialise *unmatched* ones (#6599). A matched pair is one code point and serialises fine, so it stays raw; a lone surrogate still escapes, and idempotence is measured against the form the LST can hold.

## Reproducibility

Union constituents are ordered by signature. TypeScript orders them by internal type id, assigned as types are created, so `String | RegExp | jest.Constructable | Error` and `String | RegExp | Error | jest.Constructable` came out of two parses of the same file. That accounted for 168 of 525 differing LSTs. Intersections are deliberately left alone: TypeScript preserves their written order (`Zeta & Alpha` and `Alpha & Zeta` stay distinct, while both union spellings collapse), so sorting them would discard a real distinction rather than fix an instability.

## Tests

`parse-error-recovery.test.ts` gains one named test per mapped slot — including the computed-name accessor branches, the shorthand `{ static x }` form and the BOM — and `parser.test.ts` covers the gate: pass-through, the `ParseError` carrying the losing tree as `erroneous`, and the option's spellings. `JavaScriptParseOptionsTest` mirrors `GoParseOptionsTest`. Every fix was mutation-checked by reverting its own line and confirming only the test named for it fails.

`literal.test.ts` changed meaning rather than gaining a test: it asserted `/\x-.*/` fails in `.ts`, but regex-literal `\x` is graded by the checker while a string literal's is graded by the scanner, so only the latter still reaches `jsOnlyExcludedCodes`. Both halves are now pinned from both extensions.

## Before merging

Adding `modifiers` as the first-sent slot of `JS.PropertyAssignment` is a breaking RPC change: both sides are updated here, but the jar and the `@openrewrite/rewrite` npm package version independently, so they need to ship together.

Not fixed here: `parseOnly` applies its own unfiltered diagnostic check and skips the gate, so it still disagrees with `parse` about what is parseable; and TypeScript's internal symbol ids leak into member names, which is why the LST comparison above needs normalising. `excludedCodes` is now largely inert — pruning it on static analysis alone risked silently re-criticalising a code, so it is left as is.
