### PR TITLE
JavaScript: a recipe reaches the scope helpers it was reimplementing

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/index.ts
@@ -32,7 +32,12 @@ export * from "./tree-debug";
 export * from "./project-parser";
 
 export type {Scope} from "./scope";
-export {scopeOf, namesInScope, namesDeclaredIn, namesDeclaredWithin, bindingNames, deconflict} from "./scope";
+// `cursorOf` is deliberately absent: a visitor of one's own reaches `this.cursor` directly, and
+// the free functions that have no visitor to reach it through are already in this list.
+export {
+    scopeOf, namesDeclaredIn, namesDeclaredWithin, namesUsedIn, bindingNames, deconflict,
+    isValueReference, declarationsOf, compilationUnitOf, walk
+} from "./scope";
 export type {QuoteChar, AddImportOptions} from "./add-import";
 export {ImportStyle, moduleNameOf, AddImport} from "./add-import";
 // AMD mechanics `recipes-ui5` builds on directly, beyond the `maybeBind` surface below.

--- a/rewrite-javascript/rewrite/src/javascript/scope.ts
+++ b/rewrite-javascript/rewrite/src/javascript/scope.ts
@@ -19,8 +19,20 @@ import {JS} from "./tree";
 // scope.ts sits below the visitor, so this stays type-only.
 import type {JavaScriptVisitor} from "./visitor";
 
-/** Which names code at some position can reach unqualified, and where each of them comes from. */
+const noNames: ReadonlySet<string> = new Set();
+
+/** One scope: the names it binds itself, the scopes around it, and what they answer together. */
 export interface Scope {
+    /** The names this scope binds itself, which is not what it reaches: for that, ask `declares`. */
+    names(): ReadonlySet<string>;
+
+    /**
+     * Visits this scope and then each one enclosing it, innermost first, stopping where `visit`
+     * returns false. Builds a scope per step, so `declares` is the cheaper way to ask about a
+     * name already in hand.
+     */
+    walk(visit: (scope: Scope) => boolean): void;
+
     /** Whether this scope or one enclosing it binds `name`. */
     declares(name: string): boolean;
 
@@ -34,17 +46,43 @@ export interface Scope {
 }
 
 /**
- * What the code at `cursor` can name: what every enclosing scope binds, plus the declarations that
- * hoist into those scopes from blocks that do not enclose it. Where a declaration's shape leaves its
- * reach unreadable the answer counts it rather than miss it, so a name reported here may not truly
- * reach the cursor.
+ * The innermost scope holding `cursor`, which a visitor's own cursor rarely is: it stands on
+ * whatever node it is visiting. Where a declaration's shape leaves its reach unreadable the answer
+ * counts it rather than miss it, so a name reported here may not truly reach the cursor.
  */
 export function scopeOf(cursor: Cursor): Scope {
+    return scopeAt(enclosingScopeCursor(cursor) ?? cursor);
+}
+
+function scopeAt(cursor: Cursor): Scope {
     return {
+        names: () => frameBindings(cursor.value, cursor.parent?.value),
+        walk: visit => {
+            for (let c: Cursor | undefined = cursor; c; c = enclosingScopeCursor(c.parent)) {
+                if (!visit(scopeAt(c))) {
+                    return;
+                }
+            }
+        },
         declares: name => declaringScopeOf(cursor, name) !== undefined,
         declaringScope: name => declaringScopeOf(cursor, name)
     };
 }
+
+function enclosingScopeCursor(from: Cursor | undefined): Cursor | undefined {
+    for (let c = from; c; c = c.parent) {
+        if (scopeKinds.has((c.value as { kind?: string } | undefined)?.kind!)) {
+            return c;
+        }
+    }
+    return undefined;
+}
+
+/** The nodes {@link readBindings} answers for; everything else binds nothing and is not a scope. */
+const scopeKinds = new Set<string>([
+    JS.Kind.CompilationUnit, J.Kind.Block, J.Kind.MethodDeclaration, J.Kind.Lambda,
+    J.Kind.ClassDeclaration, J.Kind.TryCatch, J.Kind.ForLoop, J.Kind.ForEachLoop, JS.Kind.ForInLoop
+]);
 
 /**
  * Every name the file declares, wherever it sits. A binding the whole file shares is referenced from
@@ -52,7 +90,7 @@ export function scopeOf(cursor: Cursor): Scope {
  * shadow it at one of them.
  */
 export function namesDeclaredIn(cu: JS.CompilationUnit): ReadonlySet<string> {
-    return namesDeclaredWithin(cu.statements, cu);
+    return namesDeclaredWithin(cu);
 }
 
 /**
@@ -60,23 +98,34 @@ export function namesDeclaredIn(cu: JS.CompilationUnit): ReadonlySet<string> {
  * ambient global is spelled and declared nowhere, and binding over one would capture its uses.
  */
 export function namesUsedIn(cu: JS.CompilationUnit): ReadonlySet<string> {
-    const cached = used.get(cu);
+    return namesUsedWithin(cu);
+}
+
+/** As {@link namesUsedIn}, over one subtree, for a name that only has to be free across that much. */
+export function namesUsedWithin(node: unknown, cacheKey: object = node as object): ReadonlySet<string> {
+    if (cacheKey === null || typeof cacheKey !== 'object') {
+        return noNames;
+    }
+    const cached = used.get(cacheKey);
     if (cached) {
         return cached;
     }
     const names = new Set<string>();
-    walk(cu.statements, node => {
+    walk(node, node => {
         if (node.kind === J.Kind.Identifier) {
             names.add((node as J.Identifier).simpleName);
         }
         return true;
     });
-    used.set(cu, names);
+    used.set(cacheKey, names);
     return names;
 }
 
 /** As {@link namesDeclaredIn}, over one subtree, for a binding shared across only that much of a file. */
 export function namesDeclaredWithin(node: unknown, cacheKey: object = node as object): ReadonlySet<string> {
+    if (cacheKey === null || typeof cacheKey !== 'object') {
+        return noNames;
+    }
     const cached = declared.get(cacheKey);
     if (cached) {
         return cached;
@@ -88,6 +137,8 @@ export function namesDeclaredWithin(node: unknown, cacheKey: object = node as ob
         if (node.kind !== J.Kind.ClassDeclaration) {
             return true;
         }
+        // The walk ends at this branch, so the class's own type parameters are read here.
+        typeParameterNames(node).forEach(name => names.add(name));
         // A member's name is not one the file binds, though the code inside one still declares names.
         for (const member of (node as J.ClassDeclaration).body?.statements ?? []) {
             const element = unwrap(member);
@@ -143,52 +194,42 @@ function unnamedMembers(bound: { name: string }[]): { name: string }[] {
 
 function declaringScopeOf(cursor: Cursor, name: string): J | undefined {
     for (let c: Cursor | undefined = cursor; c; c = c.parent) {
-        if (frameBindings(c.value, c.parent?.value).includes(name)) {
+        if (frameBindings(c.value, c.parent?.value).has(name)) {
             return c.value;
         }
     }
     return undefined;
 }
 
-/** Every name {@link scopeOf} answers `declares` for, when a caller has none in mind to ask about. */
-export function namesInScope(cursor: Cursor): ReadonlySet<string> {
-    const names = new Set<string>();
-    for (let c: Cursor | undefined = cursor; c; c = c.parent) {
-        for (const name of frameBindings(c.value, c.parent?.value)) {
-            names.add(name);
-        }
-    }
-    return names;
-}
-
 /**
  * What one node on the cursor path binds, `parent` being the node it hangs from. Only these two
  * answers turn on the parent; a node alone settles the rest, which is what makes them cacheable.
  */
-function frameBindings(node: any, parent: any): string[] {
+function frameBindings(node: any, parent: any): ReadonlySet<string> {
     // A class body holds members, which are reached through an instance rather than by name.
     if (node?.kind === J.Kind.Block && parent?.kind === J.Kind.ClassDeclaration) {
-        return [];
+        return noNames;
     }
     // A function expression is the only function whose own name its body reaches: a declaration's
     // name belongs to the enclosing block, a method's to an instance.
     if (node?.kind === J.Kind.MethodDeclaration && parent?.kind === JS.Kind.StatementExpression) {
         const self = bindingNames((node as J.MethodDeclaration).name).map(bound => bound.name);
-        return [...self, ...ownBindings(node)];
+        return new Set([...self, ...ownBindings(node)]);
     }
     return ownBindings(node);
 }
 
-function ownBindings(node: any): string[] {
+function ownBindings(node: any): ReadonlySet<string> {
     if (typeof node !== 'object' || node === null) {
-        return [];
+        return noNames;
     }
     let names = frames.get(node);
     if (!names) {
-        frames.set(node, names = readBindings(node));
+        frames.set(node, names = new Set(readBindings(node)));
     }
     return names;
 }
+
 
 function readBindings(node: any): string[] {
     switch (node.kind) {
@@ -269,12 +310,28 @@ function declarationNames(statement: any): string[] {
             return bindingNames(unwrap((statement as JS.NamespaceDeclaration).name)).map(bound => bound.name);
         case JS.Kind.TypeDeclaration:
             return bindingNames(unwrap((statement as JS.TypeDeclaration).name)).map(bound => bound.name);
+        case J.Kind.TypeParameter:
+            // Reached by namesDeclaredWithin's walk, never through a statement list: a type
+            // parameter binds across the declaration carrying it, not in the scope that one sits in.
+            return bindingNames((statement as J.TypeParameter).name).map(bound => bound.name);
         case J.Kind.Case:
             // The cases of a switch share the block it opens, so each one's declarations bind in all.
             return declaredNames((statement as J.Case).statements.elements);
         default:
             return [];
     }
+}
+
+/**
+ * The names a declaration's type parameters bind. A class keeps them in a container and everything
+ * else in a `J.TypeParameters`, and both hold the same right-padded list.
+ */
+function typeParameterNames(node: any): string[] {
+    const held = node?.typeParameters;
+    const parameters = held?.kind === J.Kind.TypeParameters
+        ? (held as J.TypeParameters).typeParameters
+        : (held as J.Container<J.TypeParameter> | undefined)?.elements;
+    return (parameters ?? []).flatMap(parameter => declarationNames(unwrap(parameter)));
 }
 
 /** The names an import binds, which for an aliased or namespace specifier is the alias. */
@@ -312,7 +369,7 @@ const blockScoped = new Set(['let', 'const', 'using']);
 const hoisted = new WeakMap<object, string[]>();
 const declared = new WeakMap<object, ReadonlySet<string>>();
 const used = new WeakMap<object, ReadonlySet<string>>();
-const frames = new WeakMap<object, string[]>();
+const frames = new WeakMap<object, ReadonlySet<string>>();
 
 /**
  * The names blocks under `scope` hoist out to it. A `var` or function declaration reaches the whole
@@ -359,7 +416,12 @@ function hoistedNames(scope: any): string[] {
     return names;
 }
 
-/** Visits every LST node under `node`, leaving a subtree unvisited where `visit` returns false. */
+/**
+ * Visits every LST node under `node`, leaving a subtree unvisited where `visit` returns false.
+ * `visit` sees nodes, never the padding holding them. Only what `isTree` accepts is descended
+ * into, which a `JavaType` is not, so the walk stays in the tree the source spells rather than
+ * entering the type graph — cyclic and shared, where it would not terminate.
+ */
 export function walk(node: unknown, visit: (node: any) => boolean): void {
     if (Array.isArray(node)) {
         node.forEach(child => walk(child, visit));
@@ -423,10 +485,11 @@ export function declarationsOf(statement: J | undefined): J.VariableDeclarations
 }
 
 /**
- * Whether the identifier stands for a value binding, which is what tells a rename which
- * occurrences to follow. A name its parent introduces does not — a property, a method, a
- * declaration — and neither does one drawn from a namespace of its own: a statement label, whether
- * declaring (`x:`) or referencing (`break x`), and a JSX attribute's prop.
+ * Whether the identifier references a binding rather than naming one, which is what tells a rename
+ * which occurrences to follow. A name its parent introduces does not — a property, a method, a
+ * variable, a type parameter — nor one drawn from a namespace of its own: a statement label,
+ * declaring (`x:`) or referencing (`break x`), and a JSX attribute's prop. Position is all this
+ * reads: an import specifier's own name answers true, and a type position reads alike to a value.
  */
 export function isValueReference(cursor: Cursor, identifier: J.Identifier): boolean {
     let c: Cursor | undefined = cursor.parent;

--- a/rewrite-javascript/rewrite/test/javascript/scope.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/scope.test.ts
@@ -18,12 +18,15 @@ import {
     JavaScriptParser,
     JavaScriptVisitor,
     JS,
+    isValueReference,
     namesDeclaredIn,
-    namesInScope,
+    namesDeclaredWithin,
     Scope,
     scopeOf,
-    sourceFileCache
+    sourceFileCache,
+    walk
 } from "../../src/javascript";
+import {namesUsedWithin} from "../../src/javascript/scope";
 import {J} from "../../src/java";
 import {Cursor} from "../../src/tree";
 
@@ -53,7 +56,14 @@ async function scopeAtAnchor(source: string, sourcePath?: string): Promise<Scope
 }
 
 async function namesAtAnchor(source: string, sourcePath?: string): Promise<string[]> {
-    return [...namesInScope(await cursorAtAnchor(source, sourcePath))].sort();
+    const names = new Set<string>();
+    scopeOf(await cursorAtAnchor(source, sourcePath)).walk(scope => {
+        for (const name of scope.names()) {
+            names.add(name);
+        }
+        return true;
+    });
+    return [...names].sort();
 }
 
 describe('scopeOf', () => {
@@ -169,10 +179,14 @@ describe('scopeOf', () => {
         expect(names).toEqual(['inner', 'outer']);
     });
 
-    test('a function expression binds the name it gives itself, and only there', async () => {
+    test('a function or class expression binds the name it gives itself, and only there', async () => {
         expect(await namesAtAnchor(`const f = function named() { anchor(); };`)).toContain('named');
 
         expect(await namesAtAnchor(`function f() { (function named() {})(); anchor(); }`)).not.toContain('named');
+
+        expect(await namesAtAnchor(`const C = class Named { m() { anchor(); } };`)).toContain('Named');
+
+        expect(await namesAtAnchor(`const C = class Named {}; anchor();`)).not.toContain('Named');
     });
 
     test('a scope reaches through the JSX between it and the cursor', async () => {
@@ -223,6 +237,24 @@ describe('scopeOf', () => {
     });
 });
 
+describe('Scope', () => {
+    test('each scope binds its own names, out to the compilation unit', async () => {
+        const bound: string[][] = [];
+        (await scopeAtAnchor('const top = 1;\nfunction fn(param) { const local = 2; anchor(); }'))
+            .walk(scope => (bound.push([...scope.names()].sort()), true));
+
+        expect(bound).toEqual([['local'], ['param'], ['fn', 'top']]);
+    });
+
+    test('walking outward visits the innermost scope first and stops where the caller says', async () => {
+        const visited: string[][] = [];
+        (await scopeAtAnchor('const top = 1;\nfunction fn(param) { const local = 2; anchor(); }'))
+            .walk(scope => (visited.push([...scope.names()]), visited.length < 2));
+
+        expect(visited).toEqual([['local'], ['param']]);
+    });
+});
+
 describe('namesDeclaredIn', () => {
     test('a name declared in any scope is a name the file has', async () => {
         expect([...namesDeclaredIn(await parse(`
@@ -245,5 +277,88 @@ describe('namesDeclaredIn', () => {
                 field = (bound) => bound;
             }
         `))].sort()).toEqual(['K', 'bound', 'local', 'param']);
+    });
+
+    test('a type parameter is a name that shadows, so the file declares it', async () => {
+        expect([...namesDeclaredIn(await parse(`
+            import {Node} from 'm';
+            function sortKeys<Bound extends Node>(node: Bound) {}
+            class Holder<Owned> {}
+        `))].sort()).toEqual(['Bound', 'Holder', 'Node', 'Owned', 'node', 'sortKeys'].sort());
+    });
+});
+
+describe('namesUsedWithin', () => {
+    test('a subtree spells what it reads, not only what it declares', async () => {
+        const fn = (await parse('const outer = 1;\nfunction fn() { return ambient(outer); }')).statements[1].element;
+
+        expect([...namesUsedWithin(fn)].sort()).toEqual(['ambient', 'fn', 'outer']);
+        expect([...namesDeclaredWithin(fn)].sort()).toEqual(['fn']);
+    });
+
+    test('a subtree that is absent holds no names', async () => {
+        // What a caller reaches these with: a method declared without a body.
+        expect([namesUsedWithin(undefined).size, namesDeclaredWithin(undefined).size]).toEqual([0, 0]);
+    });
+});
+
+describe('walk', () => {
+    test('visits LST nodes only, so a cyclic type graph never traps it', async () => {
+        // A method returning its own class makes the type graph cyclic; the LST it hangs off is not.
+        const cu = await parse('class A { m(): A { return this; } }\nconst a = new A(); a.m().m();');
+        const offTree: unknown[] = [];
+        const seen = new Set<unknown>();
+        let visited = 0;
+        walk(cu, node => {
+            visited++;
+            seen.add(node);
+            // Padding carries markers but no id, and a JavaType carries neither.
+            if (!('id' in node && 'markers' in node)) {
+                offTree.push(node.kind);
+            }
+            return true;
+        });
+
+        expect(offTree).toEqual([]);
+        expect(visited).toBe(seen.size);
+        expect(seen.size).toBeGreaterThan(10);
+    });
+});
+
+/** What `isValueReference` answers for each occurrence of `target` in `source`. */
+async function targetsReference(source: string, sourcePath?: string): Promise<boolean[]> {
+    const answers: boolean[] = [];
+    await new class extends JavaScriptVisitor<undefined> {
+        override async visitIdentifier(identifier: J.Identifier, p: undefined): Promise<J | undefined> {
+            if (identifier.simpleName === 'target') {
+                answers.push(isValueReference(this.cursor, identifier));
+            }
+            return identifier;
+        }
+    }().visit(await parse(source, sourcePath), undefined);
+    expect(answers.length).toBeGreaterThan(0);
+    return answers;
+}
+
+describe('isValueReference', () => {
+    test('a name its parent introduces, or one from a namespace of its own, is not a reference', async () => {
+        for (const source of ['const o = {target: 1};', 'o.target;', 'target: while (c) { break target; }']) {
+            expect(await targetsReference(source)).not.toContain(true);
+        }
+
+        expect(await targetsReference('<E target="v"/>;', 'test.tsx')).not.toContain(true);
+    });
+
+    test('a read, and the callee of a call selecting nothing, are references', async () => {
+        for (const source of ['use(target);', 'target();']) {
+            expect(await targetsReference(source)).not.toContain(false);
+        }
+    });
+
+    test('position is all it reads, so a binding import and a type both answer as a reference', async () => {
+        // A caller that must tell these apart adds the test itself, as AddImport's rename does.
+        for (const source of ["import {target} from 'm';", 'let v: target;']) {
+            expect(await targetsReference(source)).not.toContain(false);
+        }
     });
 });


### PR DESCRIPTION
`rewrite-javascript`'s package barrel re-exported six of `scope.ts`'s helpers and left the two a recipe most needs unreachable: `typeof require("@openrewrite/rewrite/javascript").isValueReference` was `"undefined"`, and the same for `walk`. Consumers in `moderneinc/recipes-javascript` reimplemented both, and each reimplementation shipped a defect — a hand-rolled traversal that died with `RangeError: Maximum call stack size exceeded` on `puppeteer`, and a name-based reference check that counted a property key and a member name as uses of an import, declining valid rewrites on nine files in `sveltejs/svelte` that `eslint-plugin-import-x` handles.

## Which absences were decisions

Not all of them. `8c1f024289` deliberately replaced `export * from "./scope"` with an explicit list, and said why: "narrowed index.ts's scope export to an explicit list so `walk` doesn't leak into the public API". But `isValueReference` was added later, in `4ba322b63d` — after that narrowing — so it was never considered for the list. Its absence was an omission; `walk`'s was a decision, reversed here on the grounds that keeping a generic traversal internal does not prevent the traversal, it only guarantees a worse one.

`cursorOf` stays internal: `TreeVisitor.cursor` is `protected`, so a consumer's own visitor subclass reaches `this.cursor` directly, and the free functions that cannot are now all exported.

## `walk` was already cycle-safe; nothing said so

It descends only into arrays, padding, containers, and values `isTree` accepts — and `isTree` requires both `id` and `markers`, which no `JavaType` carries. The type graph is therefore unreachable by construction, at O(1) memory rather than via a visited set. Recursion depth is not a practical limit either, because the parser fails first:

```
paren depth  500: parse OK, walk OK (506 nodes)
paren depth 1000: PARSE failed: RangeError
```

The gap was the unwritten contract, so exporting it alone would have moved the trap rather than closed it. The doc now names the guard, and the test asserts the invariant directly — every node handed to `visit` carries `id` and `markers` — rather than asserting a downstream symptom.

## `Scope` is now a scope

It was a view from a cursor position: `declares` and `declaringScope` walked the whole chain from wherever the visitor happened to stand. A visitor's cursor stands on the node it is visiting — measured on `function outer(p) { const local = 1; return target; }`, the cursor sits on `Identifier` while the scopes are three, four and six levels up — and `readBindings` answers nothing for non-scope nodes, so any per-frame accessor hung off that model would have returned empty for nearly every real cursor.

`scopeOf` now snaps to the innermost enclosing scope, `names()` answers for that frame alone, and `walk(visit)` ascends the chain stopping where `visit` returns false, matching the module's existing traversal idiom. `declares` and `declaringScope` are unchanged in behaviour: non-scope nodes contribute no bindings, so walking from the raw cursor and from the snapped scope give the same answer.

`namesInScope` is deleted. It was the eager union of exactly what `declares` answers lazily with early exit, and it had zero consumers across seven `recipes-javascript` worktrees plus main and this entire repository. Proposing an available name needs no flat list at either scope: `deconflict(preferred, n => scopeOf(cursor).declares(n))` resolves in four predicate calls with nothing allocated.

`frames` now caches a `ReadonlySet` per node instead of an array, so `declares` tests membership rather than scanning.

## Type parameters

`namesDeclaredIn` reported none, so a recipe binding `Node` into a file declaring `<Node>` turned `function sortKeys<Node extends TSESTree.Node>` into `<Node extends Node>`. Two fixes were needed rather than one: a `J.Kind.TypeParameter` case in `declarationNames`, and a separate read in `namesDeclaredWithin`, which prunes its walk at `ClassDeclaration` to skip member names and so missed `class Holder<Owned>` after the first fix alone.

## Tests

`scope.test.ts` gains coverage for `Scope`'s chain and its early exit, `walk`'s node-only contract, `isValueReference`'s naming-versus-referencing split including its two documented limits, the type-parameter fix across all three carriers, and an absent subtree. The eighteen pre-existing scoping tests — catch parameters, loops, function expressions, destructured parameters, shadowing — now run through `scope.walk()` and `scope.names()` unmodified, which is the evidence that the reshape preserved semantics.

`walk`'s guard was mutation-checked: replacing `isTree` with a `typeof node.kind === "string"` test fails the invariant assertion with 59 off-tree nodes named.

## Reviewed against a real consumer

`moderneinc/recipes-javascript` built this branch, installed it over their pinned engine, and ran their suite — 48 files, 1736 tests — unmodified and green, plus adversarial probes at named function expressions, class expressions, `catch` parameters and nested blocks. That review also found two bugs since fixed: `namesDeclaredWithin(undefined)` threw `TypeError: Invalid value used as weak map key`, reachable through the natural `namesDeclaredWithin(method.body)` on a body-less method; and `namesUsedIn(cu)` cached under `cu` while walking `cu.statements`, so a direct `namesUsedWithin(cu)` would have collided on that key with a different walk root.

## What this deliberately does not fix

`scopeOf` still omits type parameters, unlike `namesDeclaredIn`. The asymmetry is intentional. Over-counting in `namesDeclaredIn` only makes `deconflict` pick a longer name, but `scopeOf` drives binding reuse, and TypeScript's type and value namespaces are separate — `<Node>` shadows an imported `Node` in a type position and not in a value one. `scopeOf` has no notion of which position is asking, so closing it needs that distinction rather than another case. `namesUsedWithin` exists and `namesUsedIn` delegates to it, but it is not exported: measured across 1,765 files, the one call site that wanted it fires on 2.4% with a maximum of 15 candidates, where a pruning `walk` beats memoisation.