### PR TITLE
JavaScript: minimum viable spacing separates every keyword from its expression

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format/minimum-viable-spacing-visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/minimum-viable-spacing-visitor.ts
@@ -86,9 +86,10 @@ export class MinimumViableSpacingVisitor<P> extends JavaScriptVisitor<P> {
         // e.g., "class DataTable<Row>" not "class DataTable <Row>"
         // Note: body.prefix spacing (space before '{') is handled by SpacesVisitor, not here.
 
-        if (c.extends && c.extends.before.whitespace === "") {
+        if (c.extends) {
             c = produce(c, draft => {
                 this.ensureSpace(draft.extends!.before);
+                this.ensureSpace(draft.extends!.element.prefix);
             });
         }
 
@@ -156,10 +157,9 @@ export class MinimumViableSpacingVisitor<P> extends JavaScriptVisitor<P> {
     protected async visitNewClass(newClass: J.NewClass, p: P): Promise<J | undefined> {
         const ret = await super.visitNewClass(newClass, p) as J.NewClass;
         return produce(ret, draft => {
-            if (draft.class) {
-                if (draft.class.kind == J.Kind.Identifier) {
-                    this.ensureSpace((draft.class as Draft<J.Identifier>).prefix);
-                }
+            // a parenthesized class expression separates itself from `new`
+            if (draft.class && draft.class.kind !== J.Kind.Parentheses) {
+                this.ensureSpace((draft.class as Draft<J>).prefix);
             }
         });
     }
@@ -232,18 +232,207 @@ export class MinimumViableSpacingVisitor<P> extends JavaScriptVisitor<P> {
         return ret;
     }
 
+    protected async visitAlias(alias: JS.Alias, p: P): Promise<J | undefined> {
+        const ret = await super.visitAlias(alias, p) as JS.Alias;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.propertyName.after);
+            this.ensureSpace(draft.alias.prefix);
+        });
+    }
+
+    protected async visitAs(as_: JS.As, p: P): Promise<J | undefined> {
+        const ret = await super.visitAs(as_, p) as JS.As;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.left.after);
+            this.ensureSpace(draft.right.prefix);
+        });
+    }
+
+    protected async visitBinaryExtensions(jsBinary: JS.Binary, p: P): Promise<J | undefined> {
+        const ret = await super.visitBinaryExtensions(jsBinary, p) as JS.Binary;
+        // `in` is the only word operator here; the rest are punctuators that need no separation
+        if (ret.operator.element !== JS.Binary.Type.In) {
+            return ret;
+        }
+        return produce(ret, draft => {
+            this.ensureSpace(draft.operator.before);
+            this.ensureSpace(draft.right.prefix);
+        });
+    }
+
+    protected async visitBreak(breakNode: J.Break, p: P): Promise<J | undefined> {
+        const ret = await super.visitBreak(breakNode, p) as J.Break;
+        return ret.label ? produce(ret, draft => {
+            this.ensureSpace(draft.label!.prefix);
+        }) : ret;
+    }
 
     protected async visitCase(caseNode: J.Case, p: P): Promise<J | undefined> {
-        const c = await super.visitCase(caseNode, p) as J.Case;
+        let c = await super.visitCase(caseNode, p) as J.Case;
+
+        // `default` prints without the `case` keyword, so its label needs no separator
+        const first = c.caseLabels.elements[0]?.element;
+        if (first && (first.kind !== J.Kind.Identifier || (first as J.Identifier).simpleName !== "default")) {
+            c = produce(c, draft => {
+                this.ensureSpace(draft.caseLabels.before);
+            });
+        }
 
         if (c.guard && c.caseLabels.elements.length > 0 && c.caseLabels.elements[c.caseLabels.elements.length - 1].after.whitespace === "") {
-            return produce(c, draft => {
+            c = produce(c, draft => {
                 const last = draft.caseLabels.elements.length - 1;
                 draft.caseLabels.elements[last].after.whitespace = " ";
             });
         }
 
         return c;
+    }
+
+    protected async visitContinue(continueNode: J.Continue, p: P): Promise<J | undefined> {
+        const ret = await super.visitContinue(continueNode, p) as J.Continue;
+        return ret.label ? produce(ret, draft => {
+            this.ensureSpace(draft.label!.prefix);
+        }) : ret;
+    }
+
+    protected async visitDelete(delete_: JS.Delete, p: P): Promise<J | undefined> {
+        const ret = await super.visitDelete(delete_, p) as JS.Delete;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.expression.prefix);
+        });
+    }
+
+    protected async visitExportAssignment(exportAssignment: JS.ExportAssignment, p: P): Promise<J | undefined> {
+        const ret = await super.visitExportAssignment(exportAssignment, p) as JS.ExportAssignment;
+        if (ret.exportEquals) {
+            return ret;
+        }
+        return produce(ret, draft => {
+            this.ensureSpace(draft.expression.before);
+            this.ensureSpace(draft.expression.element.prefix);
+        });
+    }
+
+    protected async visitExportDeclaration(exportDeclaration: JS.ExportDeclaration, p: P): Promise<J | undefined> {
+        const ret = await super.visitExportDeclaration(exportDeclaration, p) as JS.ExportDeclaration;
+        return produce(ret, draft => {
+            if (draft.typeOnly.element) {
+                this.ensureSpace(draft.typeOnly.before);
+            }
+            // a namespace re-export ends its clause with the alias, unlike `}` or a bare `*`
+            if (draft.moduleSpecifier && draft.exportClause?.kind === JS.Kind.Alias) {
+                this.ensureSpace(draft.moduleSpecifier.before);
+            }
+        });
+    }
+
+    protected async visitForInLoop(forInLoop: JS.ForInLoop, p: P): Promise<J | undefined> {
+        const ret = await super.visitForInLoop(forInLoop, p) as JS.ForInLoop;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.control.variable.after);
+            this.ensureSpace(draft.control.iterable.element.prefix);
+        });
+    }
+
+    protected async visitForOfLoop(forOfLoop: JS.ForOfLoop, p: P): Promise<J | undefined> {
+        const ret = await super.visitForOfLoop(forOfLoop, p) as JS.ForOfLoop;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.loop.control.variable.after);
+            this.ensureSpace(draft.loop.control.iterable.element.prefix);
+        });
+    }
+
+    protected async visitImportClause(importClause: JS.ImportClause, p: P): Promise<J | undefined> {
+        const ret = await super.visitImportClause(importClause, p) as JS.ImportClause;
+        return produce(ret, draft => {
+            // named bindings open with a punctuator, which separates itself from `import` and `type`
+            if (draft.typeOnly || draft.name) {
+                this.ensureSpace(draft.prefix);
+            }
+            if (draft.typeOnly && draft.name) {
+                this.ensureSpace(draft.name.element.prefix);
+            }
+        });
+    }
+
+    protected async visitImportDeclaration(jsImport: JS.Import, p: P): Promise<J | undefined> {
+        const ret = await super.visitImportDeclaration(jsImport, p) as JS.Import;
+        // `from` prints only with a clause, and not at all in the `= require(...)` form; `}` separates
+        // named imports from it, and the specifier after it is always a string literal
+        const bindings = ret.importClause?.namedBindings;
+        if (!ret.importClause || !ret.moduleSpecifier || bindings?.kind === JS.Kind.NamedImports) {
+            return ret;
+        }
+        return produce(ret, draft => {
+            this.ensureSpace(draft.moduleSpecifier!.before);
+        });
+    }
+
+    protected async visitInstanceOf(instanceOf: J.InstanceOf, p: P): Promise<J | undefined> {
+        const ret = await super.visitInstanceOf(instanceOf, p) as J.InstanceOf;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.expression.after);
+            this.ensureSpace(draft.class.prefix);
+        });
+    }
+
+    protected async visitSatisfiesExpression(satisfies: JS.SatisfiesExpression, p: P): Promise<J | undefined> {
+        const ret = await super.visitSatisfiesExpression(satisfies, p) as JS.SatisfiesExpression;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.satisfiesType.before);
+            this.ensureSpace(draft.satisfiesType.element.prefix);
+        });
+    }
+
+    protected async visitScopedVariableDeclarations(scoped: JS.ScopedVariableDeclarations, p: P): Promise<J | undefined> {
+        const ret = await super.visitScopedVariableDeclarations(scoped, p) as JS.ScopedVariableDeclarations;
+        if (ret.modifiers.length === 0 || ret.variables.length === 0) {
+            return ret;
+        }
+        return produce(ret, draft => {
+            for (let i = 1; i < draft.modifiers.length; i++) {
+                this.ensureSpace(draft.modifiers[i].prefix);
+            }
+            this.ensureSpace(draft.variables[0].element.prefix);
+        });
+    }
+
+    protected async visitTypeOperator(typeOperator: JS.TypeOperator, p: P): Promise<J | undefined> {
+        const ret = await super.visitTypeOperator(typeOperator, p) as JS.TypeOperator;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.expression.before);
+        });
+    }
+
+    protected async visitTypePredicate(typePredicate: JS.TypePredicate, p: P): Promise<J | undefined> {
+        const ret = await super.visitTypePredicate(typePredicate, p) as JS.TypePredicate;
+        return produce(ret, draft => {
+            if (draft.asserts.element) {
+                this.ensureSpace(draft.parameterName.prefix);
+            }
+            if (draft.expression) {
+                this.ensureSpace(draft.expression.before);
+                this.ensureSpace(draft.expression.element.prefix);
+            }
+        });
+    }
+
+    protected async visitVoid(void_: JS.Void, p: P): Promise<J | undefined> {
+        const ret = await super.visitVoid(void_, p) as JS.Void;
+        return produce(ret, draft => {
+            this.ensureSpace(draft.expression.prefix);
+        });
+    }
+
+    protected async visitYield(aYield: J.Yield, p: P): Promise<J | undefined> {
+        const ret = await super.visitYield(aYield, p) as J.Yield;
+        // `yield*` separates itself from the value
+        if (!ret.value || findMarker(ret, JS.Markers.DelegatedYield)) {
+            return ret;
+        }
+        return produce(ret, draft => {
+            this.ensureSpace(draft.value!.prefix);
+        });
     }
 
     private ensureSpace(spaceDraft: Draft<J.Space>) {

--- a/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/minimum-viable-space-visitor.test.ts
@@ -165,6 +165,227 @@ describe('MinimumViableSpacingVisitor', () => {
             ))
     });
 
+    test('case label', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `switch (x) { case 1: break; default: break; }`,
+                `switch(x){case 1:break;default:break;}`,
+                // @formatter:on
+            ))
+    });
+
+    test('yield value', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `function* g(a) { yield a; yield* a; }`,
+                `function* g(a){yield a;yield*a;}`,
+                // @formatter:on
+            ))
+    });
+
+    test('instanceof operands', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `const b = x instanceof Foo;`,
+                `const b=x instanceof Foo;`,
+                // @formatter:on
+            ))
+    });
+
+    test('in operands', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `const b = "a" in obj; const c = x ?? y;`,
+                `const b="a" in obj;const c=x??y;`,
+                // @formatter:on
+            ))
+    });
+
+    test('export assignment', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `export default 1;`,
+                `export default 1;`,
+                // @formatter:on
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `export = foo;`,
+                `export=foo;`,
+            ))
+    });
+
+    test('void and delete', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `const v = void a; const d = delete a.b;`,
+                `const v=void a;const d=delete a.b;`,
+                // @formatter:on
+            ))
+    });
+
+    test('new class expression', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `const n = new a.B();`,
+                `const n=new a.B();`,
+                // @formatter:on
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `const p = new (getClass())();`,
+                `const p=new (getClass())();`,
+            ))
+    });
+
+    test('type operator', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `type K = keyof T;`,
+                `type K=keyof T;`,
+                // @formatter:on
+            ))
+    });
+
+    test('scoped variable declarations', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `const b = 1, c = 2;`,
+                `const b=1,c=2;`,
+                // @formatter:on
+            ))
+    });
+
+    test('class extends', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `class A extends B {}`,
+                `class A extends B{}`,
+                // @formatter:on
+            ))
+    });
+
+    test('as and satisfies operands', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `const y = x as T; const z = x satisfies T;`,
+                `const y=x as T;const z=x satisfies T;`,
+                // @formatter:on
+            ))
+    });
+
+    test('type predicate', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `function f(a: string): a is T { return true; }`,
+                `function f(a:string):a is T{return true;}`,
+                // @formatter:on
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `function g(a: unknown): asserts a is T {}`,
+                `function g(a:unknown):asserts a is T{}`,
+            ))
+    });
+
+    test('for-of and for-in', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `for (const x of y) {} for (const k in y) {}`,
+                `for(const x of y){}for(const k in y){}`,
+                // @formatter:on
+            ))
+    });
+
+    test('import clause', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `import a from "m";`,
+                `import a from"m";`,
+                // @formatter:on
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `import type b from "n";`,
+                `import type b from"n";`,
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `import { c as d } from "o";`,
+                `import{c as d}from"o";`,
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `import "p";`,
+                `import"p";`,
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `import q = require("r");`,
+                `import q=require("r");`,
+            ))
+    });
+
+    test('export declaration clauses', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `export * as ns from "m";`,
+                `export* as ns from"m";`,
+                // @formatter:on
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `export { a } from "n";`,
+                `export{a}from"n";`,
+            ),
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `export type { a } from "o";`,
+                `export type{a}from"o";`,
+            ))
+    });
+
+    test('break and continue label', () => {
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescriptWithSpacesRemoved(
+                `outer: for (;;) { for (;;) { continue outer; } break outer; }`,
+                `outer:for(;;){for(;;){continue outer;}break outer;}`,
+                // @formatter:on
+            ))
+    });
+
     test('optional catch binding', () => {
         return spec.rewriteRun(
             // @formatter:off


### PR DESCRIPTION
A node's prefix is inherited from the node it replaces, while whether an empty prefix is *legal* depends on the replacement's first token. A recipe substituting an identifier-led node for a punctuator-led one silently welds them. `MinimumViableSpacingVisitor` is the designated repair for that class, and it covered `return`, `throw`, `await` and `typeof` — twenty other keyword positions printed a syntax error, or valid code with different meaning.

- Reported from moderneinc/recipes-javascript#28, where a recipe replaces `(Math).pow(a, b)` with `a ** b`. The original prefix is legally empty because `(` needs no separation from the preceding keyword, so the replacement inherits an empty prefix it cannot use:

```
switch (x) { case(Math).pow(a, b): break; }   ->  casea**b:      SyntaxError
function* g(a, b){ yield(Math).pow(a, b); }   ->  yielda**b;     parses
outer: for(;;){ break outer; }                ->  breakouter;    parses
```

The two that parse are the ones worth fixing first. `yielda` and `breakouter` are valid identifiers, so the file builds and throws a `ReferenceError` at run time with nothing upstream objecting. `x as T` welding to `xasT` is the same failure in TypeScript.

## How the full set was found

Driving one recipe through each position only finds the positions that recipe happens to reach — `void` and `delete` score as passing that way, because that recipe leaves their parentheses in place. Stripping every `Space.whitespace` to `""`, running the visitor and printing probes each position independently of the replacement's first token. That turned up twenty rather than the five a single recipe exposed:

| silent (parses, wrong meaning) | loud (`SyntaxError`) |
| --- | --- |
| `break`/`continue` label, `as`, `satisfies`, `is` | `case`, `in`, `instanceof`, `export default` |
| | `for…of`/`for…in`, `void`, `delete`, `new a.B()` |
| | `import a from`, `import type {a}`, `export type {a}` |
| | `import {a as b}`, `export * as ns from` |
| | `const a=1,b=2`, `class A extends B`, `keyof`/`readonly` |

It also caught a crash in this change's own first draft: `import a = require("m")` has no `moduleSpecifier`, and an unguarded `.before` threw at run time despite type-checking clean.

## Why the guards are guards

Treating the positions uniformly would introduce spaces that aren't needed, so each exception is explicit and each has a test holding it: `default:` carries no `case` keyword, `yield*` separates itself, `new (getClass())()` is punctuator-led, and `import{a}`, `}from` and `from"m"` are all legal. A later simplification to an unconditional `ensureSpace` fails the suite rather than quietly reformatting.

`ensureSpace` was already the right primitive — it writes only where whitespace and comments are both absent, so every addition is a no-op on source that already separates the tokens. This is why no existing test moved.

- The clause-level `type` handled here (`import type {a}`) is a different node from the inline `type` of #8714 and #8715 (`import {type A}`), which `SpacesVisitor` owns.

## Tests

15 tests in `minimum-viable-space-visitor.test.ts`, each named for the position it pins, reusing the file's existing spaces-stripped parser harness. Every one was watched failing against the welded output before the fix. Full suite: 2089 passed, 175 files, no existing expectation changed.

## Scope

The repair stays opt-in: a recipe that never calls the formatter still emits `returnq`, and nothing downstream objects because it parses. Applying minimum viable spacing on the result path would make the whole class unreachable, and since `ensureSpace` only writes where whitespace and comments are absent it would be a no-op for recipes that manage their own spacing. That is a design decision about the result path rather than a hole in this visitor, so it is deliberately not in this PR.

The recipe-side guard in `prefer-exponentiation-operator` that spaces the left of a word operator — commented there as "`Math.pow(a, b)in c` would print as `a**bin c`" — is redundant now that both sides of `in` and `instanceof` are covered. That repository is untouched here.
