### PR TITLE
Go: a conversion carries the type it converts to

### DIFF
--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -419,6 +419,8 @@ func TypeOfExpression(expr java.Expression) java.JavaType {
 		return n.Type
 	case *java.AssignmentOperation:
 		return n.Type
+	case *golang.AssignmentOperation:
+		return n.Type
 	}
 	return nil
 }

--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -362,30 +362,48 @@ func TypeOfExpression(expr java.Expression) java.JavaType {
 		return TypeOfExpression(n.Type.Tree.Element)
 	case *java.ControlParentheses:
 		return TypeOfExpression(n.Tree.Element)
-	// A pointer carries the type it points to; the type mapper draws no
-	// distinction between `T` and `*T`.
-	case *golang.PointerType:
-		return TypeOfExpression(n.Elem)
 	case *java.MethodInvocation:
 		if n.MethodType != nil {
 			return n.MethodType.ReturnType
 		}
 	case *golang.Composite:
 		return n.Type
-	// A composite type spelling holds no type slot of its own, so its type is
-	// the one its parts spell out — the same shape the type mapper builds for
-	// the Go type they name.
+	// A type spelling holds what the checker made of it. A spelling no checker
+	// saw — one a recipe built — falls back to its parts, in the shape the type
+	// mapper gives the Go type those parts spell.
+	case *golang.FuncType:
+		return n.Type
+	case *golang.StructType:
+		return n.Type
+	case *golang.InterfaceType:
+		return n.Type
+	// A pointer's parts give the type it points to; the type mapper draws no
+	// distinction between `T` and `*T`.
+	case *golang.PointerType:
+		if n.Type != nil {
+			return n.Type
+		}
+		return TypeOfExpression(n.Elem)
 	case *golang.MapType:
+		if n.Type != nil {
+			return n.Type
+		}
 		return &java.JavaTypeParameterized{
 			Type:           &java.JavaTypeClass{FullyQualifiedName: "map", Kind: "Class"},
 			TypeParameters: []java.JavaType{TypeOfExpression(n.Key.Element), TypeOfExpression(n.Value)},
 		}
 	case *golang.Channel:
+		if n.Type != nil {
+			return n.Type
+		}
 		return &java.JavaTypeParameterized{
 			Type:           &java.JavaTypeClass{FullyQualifiedName: channelName(n.Dir), Kind: "Class"},
 			TypeParameters: []java.JavaType{TypeOfExpression(n.Value)},
 		}
 	case *golang.ArrayType:
+		if n.Type != nil {
+			return n.Type
+		}
 		return &java.JavaTypeArray{ElemType: TypeOfExpression(n.ElementType)}
 	case *golang.Unary:
 		return n.Type

--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -377,6 +377,14 @@ func TypeOfExpression(expr java.Expression) java.JavaType {
 		return n.Type
 	case *golang.InterfaceType:
 		return n.Type
+	case *golang.Union:
+		return n.Type
+	case *golang.TypeList:
+		return n.Type
+	case *golang.Variadic:
+		return n.Type
+	case *golang.IndexList:
+		return n.Type
 	// A pointer's parts give the type it points to; the type mapper draws no
 	// distinction between `T` and `*T`.
 	case *golang.PointerType:

--- a/rewrite-go/pkg/matcher/type_utils.go
+++ b/rewrite-go/pkg/matcher/type_utils.go
@@ -368,9 +368,7 @@ func TypeOfExpression(expr java.Expression) java.JavaType {
 		}
 	case *golang.Composite:
 		return n.Type
-	// A type spelling holds what the checker made of it. A spelling no checker
-	// saw — one a recipe built — falls back to its parts, in the shape the type
-	// mapper gives the Go type those parts spell.
+	// A type spelling holds what the checker made of it.
 	case *golang.FuncType:
 		return n.Type
 	case *golang.StructType:
@@ -385,8 +383,9 @@ func TypeOfExpression(expr java.Expression) java.JavaType {
 		return n.Type
 	case *golang.IndexList:
 		return n.Type
-	// A pointer's parts give the type it points to; the type mapper draws no
-	// distinction between `T` and `*T`.
+	// The four below also read their parts, which is all a spelling no checker
+	// saw — one a recipe built — has to go on. A pointer's parts give the type
+	// it points to; the type mapper draws no distinction between `T` and `*T`.
 	case *golang.PointerType:
 		if n.Type != nil {
 			return n.Type

--- a/rewrite-go/pkg/parser/conversion_test.go
+++ b/rewrite-go/pkg/parser/conversion_test.go
@@ -97,6 +97,8 @@ func TestConversionCarriesTheTypeItNames(t *testing.T) {
 		{"string(b)", "string"},
 		{"[]byte(s)", "byte[]"},
 		{"(*MyInt)(q)", "main.MyInt"},
+		// `interface{}` spells no name; the empty interface is `any`.
+		{"interface{}(s)", "any"},
 	} {
 		t.Run(tc.conversion, func(t *testing.T) {
 			src := "package main\n\nimport \"time\"\n\ntype MyInt int\n\n" +

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -3193,6 +3193,8 @@ func (ctx *parseContext) valueTypeOf(expr ast.Expr) java.JavaType {
 
 // resultsType reads a result list's types off the syntax. A field declaring
 // several names contributes one result per name, the way go/types counts them.
+// A tuple naming one member it could not resolve would read as a type while
+// carrying a hole, so an unattributed member leaves the whole list unattributed.
 func (ctx *parseContext) resultsType(results *ast.FieldList) java.JavaType {
 	var types []java.JavaType
 	for _, field := range results.List {
@@ -3201,7 +3203,11 @@ func (ctx *parseContext) resultsType(results *ast.FieldList) java.JavaType {
 			n = 1
 		}
 		for i := 0; i < n; i++ {
-			types = append(types, ctx.valueTypeOf(field.Type))
+			t := ctx.valueTypeOf(field.Type)
+			if t == nil {
+				return nil
+			}
+			types = append(types, t)
 		}
 	}
 	return tupleType(types)
@@ -3916,8 +3922,9 @@ func (ctx *parseContext) mapFieldListAsInterfaceBody(fl *ast.FieldList) *java.Bl
 	return &java.Block{ID: uuid.New(), Prefix: blockPrefix, Statements: stmts, End: end}
 }
 
-// mapEllipsis maps the `...` standing for an array's elided length in
-// `[...]T{...}`. It names no type, so the slot stays empty.
+// mapEllipsis maps a `...`: a parameter's `...T`, which mapFieldListAsParams
+// unwraps into VariableDeclarations.Varargs, and the elided array length of
+// `[...]T{...}`, which is the form that survives as a golang.Variadic.
 func (ctx *parseContext) mapEllipsis(expr *ast.Ellipsis) java.Expression {
 	prefix := ctx.prefix(expr.Ellipsis)
 	ctx.skip(3) // "..."

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -2919,6 +2919,7 @@ func (ctx *parseContext) mapPointerType(expr *ast.StarExpr) java.Expression {
 		ID:     uuid.New(),
 		Prefix: prefix,
 		Elem:   elem,
+		Type:   ctx.valueTypeOf(expr),
 	}
 }
 
@@ -3040,6 +3041,7 @@ func (ctx *parseContext) mapArrayType(expr *ast.ArrayType) java.Expression {
 			Prefix:      prefix,
 			Length:      java.RightPadded[java.Expression]{Element: length, After: closePrefix},
 			ElementType: elt,
+			Type:        ctx.valueTypeOf(expr),
 		}
 	}
 
@@ -3401,6 +3403,7 @@ func (ctx *parseContext) mapMapType(expr *ast.MapType) java.Expression {
 		OpenBracket: lbrackPrefix,
 		Key:         java.RightPadded[java.Expression]{Element: key, After: rbrackPrefix},
 		Value:       value,
+		Type:        ctx.valueTypeOf(expr),
 	}
 }
 
@@ -3461,6 +3464,7 @@ func (ctx *parseContext) mapChanType(expr *ast.ChanType) java.Expression {
 		Markers: markers,
 		Dir:     dir,
 		Value:   value,
+		Type:    ctx.valueTypeOf(expr),
 	}
 }
 
@@ -3475,6 +3479,7 @@ func (ctx *parseContext) mapFuncType(expr *ast.FuncType) java.Expression {
 		Prefix:     prefix,
 		Parameters: params,
 		ReturnType: returnType,
+		Type:       ctx.valueTypeOf(expr),
 	}
 }
 
@@ -3486,6 +3491,7 @@ func (ctx *parseContext) mapInterfaceType(expr *ast.InterfaceType) java.Expressi
 		ID:     uuid.New(),
 		Prefix: prefix,
 		Body:   body,
+		Type:   ctx.valueTypeOf(expr),
 	}
 }
 
@@ -3497,6 +3503,7 @@ func (ctx *parseContext) mapStructType(expr *ast.StructType) java.Expression {
 		ID:     uuid.New(),
 		Prefix: prefix,
 		Body:   body,
+		Type:   ctx.valueTypeOf(expr),
 	}
 }
 

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -3914,7 +3914,8 @@ func (ctx *parseContext) mapFieldListAsInterfaceBody(fl *ast.FieldList) *java.Bl
 	return &java.Block{ID: uuid.New(), Prefix: blockPrefix, Statements: stmts, End: end}
 }
 
-// mapEllipsis maps `...T` in function parameters (prefix variadic form).
+// mapEllipsis maps the `...` standing for an array's elided length in
+// `[...]T{...}`. It names no type, so the slot stays empty.
 func (ctx *parseContext) mapEllipsis(expr *ast.Ellipsis) java.Expression {
 	prefix := ctx.prefix(expr.Ellipsis)
 	ctx.skip(3) // "..."

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1439,6 +1439,7 @@ func (ctx *parseContext) mapAssignStmt(stmt *ast.AssignStmt) java.Statement {
 				Variable:   lhs,
 				Operator:   java.LeftPadded[golang.AssignmentOperator]{Before: opPrefix, Element: golang.AssignAndNot},
 				Assignment: rhs,
+				Type:       ctx.assignedType(stmt.Lhs[0], stmt.Rhs[0]),
 			}
 		}
 		if op, ok := mapAssignmentOp(stmt.Tok); ok {
@@ -1453,6 +1454,7 @@ func (ctx *parseContext) mapAssignStmt(stmt *ast.AssignStmt) java.Statement {
 				Variable:   lhs,
 				Operator:   java.LeftPadded[java.AssignmentOperator]{Before: opPrefix, Element: op},
 				Assignment: rhs,
+				Type:       ctx.assignedType(stmt.Lhs[0], stmt.Rhs[0]),
 			}
 		}
 	}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1057,6 +1057,7 @@ func (ctx *parseContext) mapReturnType(results *ast.FieldList) java.Expression {
 		return &golang.TypeList{
 			ID:    uuid.New(),
 			Types: java.Container[java.Statement]{Before: before, Elements: elements, Markers: markers},
+			Type:  ctx.resultsType(results),
 		}
 	}
 
@@ -2481,6 +2482,7 @@ func (ctx *parseContext) mapCallExpr(expr *ast.CallExpr) java.Expression {
 				Element: mapped,
 				Dots:    ellipsisPrefix,
 				Postfix: true,
+				Type:    ctx.valueTypeOf(arg),
 			}
 		}
 		after := java.EmptySpace
@@ -2983,7 +2985,7 @@ func (ctx *parseContext) mapUnionType(expr *ast.BinaryExpr) *golang.Union {
 	if len(terms) > 0 {
 		prefix, terms[0].Element = hoistLeftPrefix(terms[0].Element)
 	}
-	return &golang.Union{ID: uuid.New(), Prefix: prefix, Types: terms}
+	return &golang.Union{ID: uuid.New(), Prefix: prefix, Types: terms, Type: ctx.valueTypeOf(expr)}
 }
 
 func (ctx *parseContext) appendUnionTerms(expr ast.Expr, terms *[]java.RightPadded[java.Expression]) {
@@ -3187,6 +3189,22 @@ func (ctx *parseContext) valueTypeOf(expr ast.Expr) java.JavaType {
 	return ctx.mapper.mapType(t)
 }
 
+// resultsType reads a result list's types off the syntax. A field declaring
+// several names contributes one result per name, the way go/types counts them.
+func (ctx *parseContext) resultsType(results *ast.FieldList) java.JavaType {
+	var types []java.JavaType
+	for _, field := range results.List {
+		n := len(field.Names)
+		if n == 0 {
+			n = 1
+		}
+		for i := 0; i < n; i++ {
+			types = append(types, ctx.valueTypeOf(field.Type))
+		}
+	}
+	return tupleType(types)
+}
+
 // mapIndexListExpr maps a multi-index expression like `Map[int, string]` (generic instantiation).
 func (ctx *parseContext) mapIndexListExpr(expr *ast.IndexListExpr) java.Expression {
 	target := ctx.mapExpr(expr.X)
@@ -3216,6 +3234,7 @@ func (ctx *parseContext) mapIndexListExpr(expr *ast.IndexListExpr) java.Expressi
 		Prefix:  prefix,
 		Target:  target,
 		Indices: java.Container[java.Expression]{Before: lbrackPrefix, Elements: elements},
+		Type:    ctx.valueTypeOf(expr),
 	}
 }
 
@@ -3906,6 +3925,7 @@ func (ctx *parseContext) mapEllipsis(expr *ast.Ellipsis) java.Expression {
 		Element: elt,
 		Dots:    java.EmptySpace,
 		Postfix: false,
+		Type:    ctx.valueTypeOf(expr),
 	}
 }
 

--- a/rewrite-go/pkg/parser/partial_types_test.go
+++ b/rewrite-go/pkg/parser/partial_types_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
 
 // hostileImporter fails one import path — by panicking, as a toolchain too old
@@ -234,4 +235,32 @@ func findType(t *testing.T, cu *golang.CompilationUnit, name string) java.JavaTy
 		}
 	}
 	return nil
+}
+
+// A tuple is the one mapped type the parser builds from parts rather than
+// reading whole, so a member it cannot resolve must not become a hole in it:
+// the RPC sender keys a type list on each member's signature and a nil member
+// panics there.
+func TestUnattributedResultListNamesNothing(t *testing.T) {
+	gp := parser.NewGoParser()
+	gp.ParseOnly = true
+	cu, err := gp.Parse("p.go", "package main\n\nfunc f() (int, error) {\n\treturn 0, nil\n}\n")
+	require.NoError(t, err)
+
+	var found int
+	visitor.Init(&typeListWalker{onTypeList: func(tl *golang.TypeList) {
+		found++
+		assert.Nil(t, tl.Type, "a result list nothing attributed still named a type")
+	}}).Visit(cu, nil)
+	require.Equal(t, 1, found, "no result list in the tree")
+}
+
+type typeListWalker struct {
+	visitor.GoVisitor
+	onTypeList func(*golang.TypeList)
+}
+
+func (v *typeListWalker) VisitTypeList(tl *golang.TypeList, p any) java.J {
+	v.onTypeList(tl)
+	return v.GoVisitor.VisitTypeList(tl, p)
 }

--- a/rewrite-go/pkg/parser/type_mapper.go
+++ b/rewrite-go/pkg/parser/type_mapper.go
@@ -382,13 +382,24 @@ func (m *typeMapper) mapChanType(ch *types.Chan) java.JavaType {
 	}
 }
 
+// isNamedClass reports whether a mapped type is a class Go gave a name.
+func isNamedClass(t java.JavaType) bool {
+	cls, ok := t.(*java.JavaTypeClass)
+	return ok && cls.FullyQualifiedName != ""
+}
+
 // structMembers extracts fields from a struct as JavaTypeVariable,
 // recording each field's owner for ownerType to find later.
 func (m *typeMapper) structMembers(s *types.Struct, owner java.JavaType) []*java.JavaTypeVariable {
 	var members []*java.JavaTypeVariable
 	for i := 0; i < s.NumFields(); i++ {
 		f := s.Field(i)
-		m.fieldOwner[f] = owner
+		// A named struct type and the `*types.Struct` it wraps share their field
+		// objects, and a recipe asks a field's owner for the name. An unnamed
+		// spelling therefore claims only a field no named type has claimed.
+		if _, claimed := m.fieldOwner[f]; !claimed || isNamedClass(owner) {
+			m.fieldOwner[f] = owner
+		}
 		members = append(members, &java.JavaTypeVariable{
 			Name:        f.Name(),
 			Owner:       owner,

--- a/rewrite-go/pkg/parser/type_mapper.go
+++ b/rewrite-go/pkg/parser/type_mapper.go
@@ -295,23 +295,11 @@ func (m *typeMapper) mapSignature(sig *types.Signature, name string, declaringTy
 
 	// Return type
 	results := sig.Results()
-	if results.Len() == 0 {
-		mt.ReturnType = &java.JavaTypePrimitive{Keyword: "void"}
-	} else if results.Len() == 1 {
-		mt.ReturnType = m.mapType(results.At(0).Type())
-	} else {
-		tupleParams := make([]java.JavaType, 0, results.Len())
-		for i := 0; i < results.Len(); i++ {
-			tupleParams = append(tupleParams, m.mapType(results.At(i).Type()))
-		}
-		mt.ReturnType = &java.JavaTypeParameterized{
-			Type: &java.JavaTypeClass{
-				FullyQualifiedName: "go.tuple",
-				Kind:               "Class",
-			},
-			TypeParameters: tupleParams,
-		}
+	resultTypes := make([]java.JavaType, 0, results.Len())
+	for i := 0; i < results.Len(); i++ {
+		resultTypes = append(resultTypes, m.mapType(results.At(i).Type()))
 	}
+	mt.ReturnType = tupleType(resultTypes)
 	params := sig.Params()
 	for i := 0; i < params.Len(); i++ {
 		p := params.At(i)
@@ -320,6 +308,22 @@ func (m *typeMapper) mapSignature(sig *types.Signature, name string, declaringTy
 	}
 
 	return mt
+}
+
+// tupleType is what a Go result list yields: nothing, the one type it names,
+// or the several it names bundled under `go.tuple`.
+func tupleType(results []java.JavaType) java.JavaType {
+	switch len(results) {
+	case 0:
+		return &java.JavaTypePrimitive{Keyword: "void"}
+	case 1:
+		return results[0]
+	default:
+		return &java.JavaTypeParameterized{
+			Type:           &java.JavaTypeClass{FullyQualifiedName: "go.tuple", Kind: "Class"},
+			TypeParameters: results,
+		}
+	}
 }
 
 // mapInterface maps an anonymous interface type. The empty one takes the Go

--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -190,6 +190,7 @@ func (r *GoReceiver) VisitGoVariadic(vr *golang.Variadic, p any) java.J {
 	vr.Element = receiveValue(q, vr.Element, func(e java.Expression) any { return r.Visit(e, q) })
 	vr.Dots = receiveValue(q, vr.Dots, func(s java.Space) any { return receiveSpace(s, q) })
 	vr.Postfix = receiveScalar[bool](q, vr.Postfix)
+	vr.Type = r.receiveType(vr.Type, q)
 	return vr
 }
 
@@ -351,6 +352,7 @@ func (r *GoReceiver) VisitTypeList(tl *golang.TypeList, p any) java.J {
 	c := *tl // shallow copy to avoid mutating remoteObjects baseline
 	tl = &c
 	tl.Types = receiveContainer[java.Statement](r, q, tl.Types)
+	tl.Type = r.receiveType(tl.Type, q)
 	return tl
 }
 
@@ -363,6 +365,7 @@ func (r *GoReceiver) VisitUnion(u *golang.Union, p any) java.J {
 		coerceToExpressionRP); after != nil {
 		u.Types = after
 	}
+	u.Type = r.receiveType(u.Type, q)
 	return u
 }
 
@@ -504,5 +507,6 @@ func (r *GoReceiver) VisitIndexList(il *golang.IndexList, p any) java.J {
 	il = &c
 	il.Target = receiveValue(q, il.Target, func(e java.Expression) any { return r.Visit(e, q) })
 	il.Indices = receiveContainer[java.Expression](r, q, il.Indices)
+	il.Type = r.receiveType(il.Type, q)
 	return il
 }

--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -229,6 +229,7 @@ func (r *GoReceiver) VisitGoArrayType(at *golang.ArrayType, p any) java.J {
 		at.Length = coerceToExpressionRP(result)
 	}
 	at.ElementType = receiveValue(q, at.ElementType, func(e java.Expression) any { return r.Visit(e, q) })
+	at.Type = r.receiveType(at.Type, q)
 	return at
 }
 
@@ -258,6 +259,7 @@ func (r *GoReceiver) VisitMapType(mt *golang.MapType, p any) java.J {
 		mt.Key = coerceToExpressionRP(result)
 	}
 	mt.Value = receiveValue(q, mt.Value, func(e java.Expression) any { return r.Visit(e, q) })
+	mt.Type = r.receiveType(mt.Type, q)
 	return mt
 }
 
@@ -294,6 +296,7 @@ func (r *GoReceiver) VisitPointerType(pt *golang.PointerType, p any) java.J {
 	c := *pt
 	pt = &c
 	pt.Elem = receiveValue(q, pt.Elem, func(e java.Expression) any { return r.Visit(e, q) })
+	pt.Type = r.receiveType(pt.Type, q)
 	return pt
 }
 
@@ -311,6 +314,7 @@ func (r *GoReceiver) VisitChannel(ch *golang.Channel, p any) java.J {
 		ch.Dir = golang.ChanRecvOnly
 	}
 	ch.Value = receiveValue(q, ch.Value, func(e java.Expression) any { return r.Visit(e, q) })
+	ch.Type = r.receiveType(ch.Type, q)
 	return ch
 }
 
@@ -320,6 +324,7 @@ func (r *GoReceiver) VisitFuncType(ft *golang.FuncType, p any) java.J {
 	ft = &c
 	ft.Parameters = receiveContainer[java.Statement](r, q, ft.Parameters)
 	ft.ReturnType = receiveValue(q, ft.ReturnType, func(e java.Expression) any { return r.Visit(e, q) })
+	ft.Type = r.receiveType(ft.Type, q)
 	return ft
 }
 
@@ -328,6 +333,7 @@ func (r *GoReceiver) VisitStructType(st *golang.StructType, p any) java.J {
 	c := *st // shallow copy to avoid mutating remoteObjects baseline
 	st = &c
 	st.Body = receiveValue(q, st.Body, func(e *java.Block) any { return r.Visit(e, q) })
+	st.Type = r.receiveType(st.Type, q)
 	return st
 }
 
@@ -336,6 +342,7 @@ func (r *GoReceiver) VisitInterfaceType(it *golang.InterfaceType, p any) java.J 
 	c := *it // shallow copy to avoid mutating remoteObjects baseline
 	it = &c
 	it.Body = receiveValue(q, it.Body, func(e *java.Block) any { return r.Visit(e, q) })
+	it.Type = r.receiveType(it.Type, q)
 	return it
 }
 

--- a/rewrite-go/pkg/rpc/go_receiver.go
+++ b/rewrite-go/pkg/rpc/go_receiver.go
@@ -180,6 +180,7 @@ func (r *GoReceiver) VisitGoAssignmentOperation(a *golang.AssignmentOperation, p
 	a.Variable = receiveValue(q, a.Variable, func(e java.Expression) any { return r.Visit(e, q) })
 	a.Operator = receiveLeftPaddedEnum(r, q, a.Operator, golang.ParseAssignmentOperator)
 	a.Assignment = receiveValue(q, a.Assignment, func(e java.Expression) any { return r.Visit(e, q) })
+	a.Type = r.receiveType(a.Type, q)
 	return a
 }
 

--- a/rewrite-go/pkg/rpc/go_sender.go
+++ b/rewrite-go/pkg/rpc/go_sender.go
@@ -223,6 +223,8 @@ func (s *GoSender) VisitGoArrayType(at *golang.ArrayType, p any) java.J {
 		func(v any) { sendRightPadded(s, v, q) })
 	q.GetAndSend(at, func(v any) any { return v.(*golang.ArrayType).ElementType },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(at, func(v any) any { return AsRef(v.(*golang.ArrayType).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return at
 }
 
@@ -251,6 +253,8 @@ func (s *GoSender) VisitMapType(mt *golang.MapType, p any) java.J {
 		func(v any) { sendRightPadded(s, v, q) })
 	q.GetAndSend(mt, func(v any) any { return v.(*golang.MapType).Value },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(mt, func(v any) any { return AsRef(v.(*golang.MapType).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return mt
 }
 
@@ -283,6 +287,8 @@ func (s *GoSender) VisitPointerType(pt *golang.PointerType, p any) java.J {
 	q := p.(*SendQueue)
 	q.GetAndSend(pt, func(v any) any { return v.(*golang.PointerType).Elem },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(pt, func(v any) any { return AsRef(v.(*golang.PointerType).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return pt
 }
 
@@ -302,6 +308,8 @@ func (s *GoSender) VisitChannel(ch *golang.Channel, p any) java.J {
 	}, nil)
 	q.GetAndSend(ch, func(v any) any { return v.(*golang.Channel).Value },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(ch, func(v any) any { return AsRef(v.(*golang.Channel).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return ch
 }
 
@@ -311,6 +319,8 @@ func (s *GoSender) VisitFuncType(ft *golang.FuncType, p any) java.J {
 		func(v any) { sendContainer(s, v, q) })
 	q.GetAndSend(ft, func(v any) any { return v.(*golang.FuncType).ReturnType },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(ft, func(v any) any { return AsRef(v.(*golang.FuncType).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return ft
 }
 
@@ -318,6 +328,8 @@ func (s *GoSender) VisitStructType(st *golang.StructType, p any) java.J {
 	q := p.(*SendQueue)
 	q.GetAndSend(st, func(v any) any { return v.(*golang.StructType).Body },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(st, func(v any) any { return AsRef(v.(*golang.StructType).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return st
 }
 
@@ -325,6 +337,8 @@ func (s *GoSender) VisitInterfaceType(it *golang.InterfaceType, p any) java.J {
 	q := p.(*SendQueue)
 	q.GetAndSend(it, func(v any) any { return v.(*golang.InterfaceType).Body },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(it, func(v any) any { return AsRef(v.(*golang.InterfaceType).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return it
 }
 

--- a/rewrite-go/pkg/rpc/go_sender.go
+++ b/rewrite-go/pkg/rpc/go_sender.go
@@ -177,6 +177,8 @@ func (s *GoSender) VisitGoAssignmentOperation(a *golang.AssignmentOperation, p a
 	}, func(v any) { sendLeftPadded(s, v, q) })
 	q.GetAndSend(a, func(v any) any { return v.(*golang.AssignmentOperation).Assignment },
 		func(v any) { s.Visit(v.(java.Tree), q) })
+	q.GetAndSend(a, func(v any) any { return AsRef(v.(*golang.AssignmentOperation).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return a
 }
 

--- a/rewrite-go/pkg/rpc/go_sender.go
+++ b/rewrite-go/pkg/rpc/go_sender.go
@@ -187,6 +187,8 @@ func (s *GoSender) VisitGoVariadic(vr *golang.Variadic, p any) java.J {
 	q.GetAndSend(vr, func(v any) any { return v.(*golang.Variadic).Dots },
 		func(v any) { sendSpace(v.(java.Space), q) })
 	q.GetAndSend(vr, func(v any) any { return v.(*golang.Variadic).Postfix }, nil)
+	q.GetAndSend(vr, func(v any) any { return AsRef(v.(*golang.Variadic).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return vr
 }
 
@@ -346,6 +348,8 @@ func (s *GoSender) VisitTypeList(tl *golang.TypeList, p any) java.J {
 	q := p.(*SendQueue)
 	q.GetAndSend(tl, func(v any) any { return v.(*golang.TypeList).Types },
 		func(v any) { sendContainer(s, v, q) })
+	q.GetAndSend(tl, func(v any) any { return AsRef(v.(*golang.TypeList).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return tl
 }
 
@@ -362,6 +366,8 @@ func (s *GoSender) VisitUnion(u *golang.Union, p any) java.J {
 		},
 		func(v any) any { return containerElementID(v) },
 		func(v any) { sendRightPadded(s, v, q) })
+	q.GetAndSend(u, func(v any) any { return AsRef(v.(*golang.Union).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return u
 }
 
@@ -558,5 +564,7 @@ func (s *GoSender) VisitIndexList(il *golang.IndexList, p any) java.J {
 		func(v any) { s.Visit(v.(java.Tree), q) })
 	q.GetAndSend(il, func(v any) any { return v.(*golang.IndexList).Indices },
 		func(v any) { sendContainer(s, v, q) })
+	q.GetAndSend(il, func(v any) any { return AsRef(v.(*golang.IndexList).Type) },
+		func(v any) { s.visitType(GetValueNonNull(v).(java.JavaType), q) })
 	return il
 }

--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -571,6 +571,7 @@ type TypeList struct {
 	Prefix  java.Space
 	Markers java.Markers
 	Types   java.Container[java.Statement] // Before = space before `(`, last After = space before `)`
+	Type    java.JavaType
 }
 
 func (*TypeList) IsTree()       {}
@@ -607,6 +608,7 @@ type Union struct {
 	Prefix  java.Space
 	Markers java.Markers
 	Types   []java.RightPadded[java.Expression]
+	Type    java.JavaType
 }
 
 func (*Union) IsTree()       {}
@@ -1122,6 +1124,7 @@ type IndexList struct {
 	Markers java.Markers
 	Target  java.Expression
 	Indices java.Container[java.Expression] // Before = space before `[`, Elements = type args, last After = space before `]`
+	Type    java.JavaType
 }
 
 func (*IndexList) IsTree()       {}
@@ -1342,6 +1345,7 @@ type Variadic struct {
 	Element java.Expression
 	Dots    java.Space
 	Postfix bool
+	Type    java.JavaType
 }
 
 func (*Variadic) IsTree()       {}

--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -347,6 +347,7 @@ type ArrayType struct {
 	Markers     java.Markers
 	Length      java.RightPadded[java.Expression] // Element = `N` (Prefix = space after `[`), After = space before `]`
 	ElementType java.Expression                   // element type `T` (Prefix = space after `]`)
+	Type        java.JavaType
 }
 
 func (*ArrayType) IsTree()       {}
@@ -378,6 +379,7 @@ type MapType struct {
 	OpenBracket java.Space                        // space before `[`
 	Key         java.RightPadded[java.Expression] // After = space before `]`
 	Value       java.Expression
+	Type        java.JavaType
 }
 
 func (*MapType) IsTree()       {}
@@ -415,6 +417,7 @@ type PointerType struct {
 	Prefix  java.Space
 	Markers java.Markers
 	Elem    java.Expression
+	Type    java.JavaType
 }
 
 func (*PointerType) IsTree()       {}
@@ -445,6 +448,7 @@ type Channel struct {
 	Markers java.Markers
 	Dir     ChanDir
 	Value   java.Expression
+	Type    java.JavaType
 }
 
 func (*Channel) IsTree()       {}
@@ -475,6 +479,7 @@ type FuncType struct {
 	Markers    java.Markers
 	Parameters java.Container[java.Statement]
 	ReturnType java.Expression // nil if no return type
+	Type       java.JavaType
 }
 
 func (*FuncType) IsTree()       {}
@@ -504,6 +509,7 @@ type StructType struct {
 	Prefix  java.Space
 	Markers java.Markers
 	Body    *java.Block // contains VariableDeclarations for fields
+	Type    java.JavaType
 }
 
 func (*StructType) IsTree()       {}
@@ -533,6 +539,7 @@ type InterfaceType struct {
 	Prefix  java.Space
 	Markers java.Markers
 	Body    *java.Block // contains MethodDeclaration (no body) or type refs for embedded interfaces
+	Type    java.JavaType
 }
 
 func (*InterfaceType) IsTree()       {}

--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -1062,7 +1062,7 @@ type TypeAssertion struct {
 	Markers      java.Markers
 	Left         java.RightPadded[java.Expression] // After = space before `.`
 	AssertedType *java.ControlParentheses          // `(T)`
-	Type         java.JavaType                     // the result type (nullable)
+	Type         java.JavaType                     // the result type
 }
 
 func (*TypeAssertion) IsTree()       {}
@@ -1335,9 +1335,11 @@ func (n *AssignmentOperation) WithMarkers(markers java.Markers) *AssignmentOpera
 	return &c
 }
 
-// Variadic represents Go's `...` ellipsis: the `...T` parameter type
+// Variadic represents Go's `...` ellipsis where it stands for something other
+// than a parameter type: an array's elided length in `[...]T{...}`
 // (Postfix=false) and the `args...` call spread (Postfix=true). Dots is the
-// whitespace immediately before the `...` token in the postfix form.
+// whitespace immediately before the `...` token in the postfix form. A
+// parameter's `...T` is a VariableDeclarations whose Varargs slot holds the `...`.
 type Variadic struct {
 	ID      uuid.UUID
 	Prefix  java.Space

--- a/rewrite-go/pkg/tree/golang/go.go
+++ b/rewrite-go/pkg/tree/golang/go.go
@@ -1310,6 +1310,7 @@ type AssignmentOperation struct {
 	Variable   java.Expression
 	Operator   java.LeftPadded[AssignmentOperator] // Before = space before the operator token
 	Assignment java.Expression
+	Type       java.JavaType
 }
 
 func (*AssignmentOperation) IsTree()       {}

--- a/rewrite-go/pkg/tree/java/java_type.go
+++ b/rewrite-go/pkg/tree/java/java_type.go
@@ -18,6 +18,8 @@ package java
 
 import "fmt"
 
+// JavaType is what the type checker made of a node. Every slot holding one is
+// optional — nil is the answer for a node no checker attributed.
 type JavaType interface {
 	isJavaType()
 }

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoTypeAttributionIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoTypeAttributionIntegTest.java
@@ -211,4 +211,72 @@ class GoTypeAttributionIntegTest implements RewriteTest {
                 )
         );
     }
+
+    @Test
+    void aTypeSpellingThatIsNotAConversionTargetCarriesItsTypeToo() {
+        List<JavaType> types = new ArrayList<>();
+        rewriteRun(
+                go(
+                        """
+                                package main
+
+                                type Num interface {
+                                	~int | ~int8
+                                }
+
+                                func sum(xs ...int) (int, error) {
+                                	return 0, nil
+                                }
+
+                                func pick[A any, B any](a A, b B) A {
+                                	return a
+                                }
+
+                                func f(xs []int) {
+                                	_, _ = sum(xs...)
+                                	_ = pick[int, string]
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            new GolangVisitor<ExecutionContext>() {
+                                @Override
+                                public J visitUnion(Go.Union union, ExecutionContext ctx) {
+                                    types.add(union.getType());
+                                    return super.visitUnion(union, ctx);
+                                }
+
+                                @Override
+                                public J visitGoVariadic(Go.Variadic variadic, ExecutionContext ctx) {
+                                    types.add(variadic.getType());
+                                    return super.visitGoVariadic(variadic, ctx);
+                                }
+
+                                @Override
+                                public J visitTypeList(Go.TypeList typeList, ExecutionContext ctx) {
+                                    types.add(typeList.getType());
+                                    return super.visitTypeList(typeList, ctx);
+                                }
+
+                                @Override
+                                public J visitIndexList(Go.IndexList indexList, ExecutionContext ctx) {
+                                    types.add(indexList.getType());
+                                    return super.visitIndexList(indexList, ctx);
+                                }
+                            }.visit(cu, new InMemoryExecutionContext());
+
+                            assertThat(types).hasSize(4).doesNotContainNull();
+
+                            assertThat(types.get(0)).as("~int | ~int8").isInstanceOf(JavaType.Intersection.class);
+
+                            assertThat(types.get(1)).as("(int, error)").isInstanceOfSatisfying(JavaType.Parameterized.class,
+                                    t -> assertThat(t.getFullyQualifiedName()).isEqualTo("go.tuple"));
+
+                            assertThat(types.get(2)).as("xs...").isInstanceOfSatisfying(JavaType.Array.class,
+                                    a -> assertThat(a.getElemType().toString()).isEqualTo("int"));
+
+                            assertThat(types.get(3)).as("pick[int, string]").isInstanceOf(JavaType.Method.class);
+                        })
+                )
+        );
+    }
 }

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoTypeAttributionIntegTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoTypeAttributionIntegTest.java
@@ -154,4 +154,61 @@ class GoTypeAttributionIntegTest implements RewriteTest {
                 )
         );
     }
+
+    @Test
+    void conversionToAnUnnamedTypeCarriesItsType() {
+        List<JavaType> types = new ArrayList<>();
+        rewriteRun(
+                go(
+                        """
+                                package main
+
+                                type T struct{}
+
+                                func f(p *T, b4 [4]byte, m map[string]int, c chan int, fn func(), x any, s struct{ A int }) {
+                                	_ = (*T)(p)
+                                	_ = [4]byte(b4)
+                                	_ = (map[string]int)(m)
+                                	_ = (chan int)(c)
+                                	_ = (func())(fn)
+                                	_ = interface{}(x)
+                                	_ = (struct{ A int })(s)
+                                }
+                                """,
+                        spec -> spec.afterRecipe(cu -> {
+                            new JavaIsoVisitor<ExecutionContext>() {
+                                @Override
+                                public J.TypeCast visitTypeCast(J.TypeCast cast, ExecutionContext ctx) {
+                                    types.add(cast.getType());
+                                    return super.visitTypeCast(cast, ctx);
+                                }
+                            }.visit(cu, new InMemoryExecutionContext());
+
+                            assertThat(types).hasSize(7).doesNotContainNull();
+
+                            assertThat(TypeUtils.asFullyQualified(types.get(0))).as("(*T)(p)")
+                                    .extracting(JavaType.FullyQualified::getFullyQualifiedName)
+                                    .isEqualTo("main.T");
+
+                            assertThat(types.get(1)).as("[4]byte(b4)").isInstanceOfSatisfying(JavaType.Array.class,
+                                    a -> assertThat(a.getElemType().toString()).isEqualTo("byte"));
+
+                            assertThat(types.get(2)).as("(map[string]int)(m)").isInstanceOfSatisfying(JavaType.Parameterized.class,
+                                    t -> assertThat(t.getFullyQualifiedName()).isEqualTo("map"));
+
+                            assertThat(types.get(3)).as("(chan int)(c)").isInstanceOfSatisfying(JavaType.Parameterized.class,
+                                    t -> assertThat(t.getFullyQualifiedName()).isEqualTo("chan"));
+
+                            assertThat(types.get(4)).as("(func())(fn)").isInstanceOf(JavaType.Method.class);
+
+                            assertThat(TypeUtils.asFullyQualified(types.get(5))).as("interface{}(x)")
+                                    .extracting(JavaType.FullyQualified::getFullyQualifiedName)
+                                    .isEqualTo("any");
+
+                            assertThat(types.get(6)).as("(struct{ A int })(s)").isInstanceOfSatisfying(JavaType.Class.class,
+                                    t -> assertThat(t.getMembers()).extracting(JavaType.Variable::getName).containsExactly("A"));
+                        })
+                )
+        );
+    }
 }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
@@ -123,7 +123,8 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
     public J visitGoArrayType(Go.ArrayType arrayType, RpcReceiveQueue q) {
         return arrayType
                 .getPadding().withLength(q.receive(arrayType.getPadding().getLength(), el -> visitRightPadded(el, q)))
-                .withElementType(q.receive(arrayType.getElementType(), expr -> (Expression) visitNonNull(expr, q)));
+                .withElementType(q.receive(arrayType.getElementType(), expr -> (Expression) visitNonNull(expr, q)))
+                .withType(q.receive(arrayType.getType(), type -> visitType(type, q)));
     }
 
     @Override
@@ -131,7 +132,8 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
         return mapType
                 .withOpenBracket(q.receive(mapType.getOpenBracket(), space -> visitSpace(space, q)))
                 .getPadding().withKey(q.receive(mapType.getPadding().getKey(), el -> visitRightPadded(el, q)))
-                .withValue(q.receive(mapType.getValue(), expr -> (Expression) visitNonNull(expr, q)));
+                .withValue(q.receive(mapType.getValue(), expr -> (Expression) visitNonNull(expr, q)))
+                .withType(q.receive(mapType.getType(), type -> visitType(type, q)));
     }
 
     @Override
@@ -158,27 +160,31 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
     @Override
     public J visitPointerType(Go.PointerType pointerType, RpcReceiveQueue q) {
         return pointerType
-                .withElem(q.receive(pointerType.getElem(), expr -> (Expression) visitNonNull(expr, q)));
+                .withElem(q.receive(pointerType.getElem(), expr -> (Expression) visitNonNull(expr, q)))
+                .withType(q.receive(pointerType.getType(), type -> visitType(type, q)));
     }
 
     @Override
     public J visitChannel(Go.Channel channel, RpcReceiveQueue q) {
         return channel
                 .withDir(q.receiveAndGet(channel.getDir(), v -> Go.ChanDir.valueOf((String) v)))
-                .withValue(q.receive(channel.getValue(), expr -> (Expression) visitNonNull(expr, q)));
+                .withValue(q.receive(channel.getValue(), expr -> (Expression) visitNonNull(expr, q)))
+                .withType(q.receive(channel.getType(), type -> visitType(type, q)));
     }
 
     @Override
     public J visitFuncType(Go.FuncType funcType, RpcReceiveQueue q) {
         return funcType
                 .getPadding().withParameters(q.receive(funcType.getPadding().getParameters(), el -> visitContainer(el, q)))
-                .withReturnType(q.receive(funcType.getReturnType(), expr -> (Expression) visitNonNull(expr, q)));
+                .withReturnType(q.receive(funcType.getReturnType(), expr -> (Expression) visitNonNull(expr, q)))
+                .withType(q.receive(funcType.getType(), type -> visitType(type, q)));
     }
 
     @Override
     public J visitStructType(Go.StructType structType, RpcReceiveQueue q) {
         return structType
-                .withBody(q.receive(structType.getBody(), el -> (J.Block) visitNonNull(el, q)));
+                .withBody(q.receive(structType.getBody(), el -> (J.Block) visitNonNull(el, q)))
+                .withType(q.receive(structType.getType(), type -> visitType(type, q)));
     }
 
     @Override
@@ -190,7 +196,8 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
     @Override
     public J visitInterfaceType(Go.InterfaceType interfaceType, RpcReceiveQueue q) {
         return interfaceType
-                .withBody(q.receive(interfaceType.getBody(), el -> (J.Block) visitNonNull(el, q)));
+                .withBody(q.receive(interfaceType.getBody(), el -> (J.Block) visitNonNull(el, q)))
+                .withType(q.receive(interfaceType.getType(), type -> visitType(type, q)));
     }
 
     @Override

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
@@ -304,7 +304,8 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
         return assignOp
                 .withVariable(q.receive(assignOp.getVariable(), expr -> (Expression) visitNonNull(expr, q)))
                 .getPadding().withOperator(q.receive(assignOp.getPadding().getOperator(), o -> visitLeftPadded(o, q, toEnum(Go.AssignmentOperation.Type.class))))
-                .withAssignment(q.receive(assignOp.getAssignment(), expr -> (Expression) visitNonNull(expr, q)));
+                .withAssignment(q.receive(assignOp.getAssignment(), expr -> (Expression) visitNonNull(expr, q)))
+                .withType(q.receive(assignOp.getType(), type -> visitType(type, q)));
     }
 
     @Override

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangReceiver.java
@@ -203,13 +203,15 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
     @Override
     public J visitTypeList(Go.TypeList typeList, RpcReceiveQueue q) {
         return typeList
-                .getPadding().withTypes(q.receive(typeList.getPadding().getTypes(), el -> visitContainer(el, q)));
+                .getPadding().withTypes(q.receive(typeList.getPadding().getTypes(), el -> visitContainer(el, q)))
+                .withType(q.receive(typeList.getType(), type -> visitType(type, q)));
     }
 
     @Override
     public J visitUnion(Go.Union union, RpcReceiveQueue q) {
         return union
-                .getPadding().withTypes(q.receiveList(union.getPadding().getTypes(), t -> visitRightPadded(t, q)));
+                .getPadding().withTypes(q.receiveList(union.getPadding().getTypes(), t -> visitRightPadded(t, q)))
+                .withType(q.receive(union.getType(), type -> visitType(type, q)));
     }
 
     @Override
@@ -277,7 +279,8 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
     public J visitIndexList(Go.IndexList indexList, RpcReceiveQueue q) {
         return indexList
                 .withTarget(q.receive(indexList.getTarget(), expr -> (Expression) visitNonNull(expr, q)))
-                .getPadding().withIndices(q.receive(indexList.getPadding().getIndices(), el -> visitContainer(el, q)));
+                .getPadding().withIndices(q.receive(indexList.getPadding().getIndices(), el -> visitContainer(el, q)))
+                .withType(q.receive(indexList.getType(), type -> visitType(type, q)));
     }
 
     @Override
@@ -309,7 +312,8 @@ public class GolangReceiver extends GolangVisitor<RpcReceiveQueue> {
         return variadic
                 .withElement(q.receive(variadic.getElement(), expr -> (Expression) visitNonNull(expr, q)))
                 .withDots(q.receive(variadic.getDots(), space -> visitSpace(space, q)))
-                .withPostfix(q.receive(variadic.isPostfix()));
+                .withPostfix(q.receive(variadic.isPostfix()))
+                .withType(q.receive(variadic.getType(), type -> visitType(type, q)));
     }
 
     // Delegation methods to JavaReceiver for RPC-specific visit methods

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
@@ -300,6 +300,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
         q.getAndSend(assignOp, Go.AssignmentOperation::getVariable, el -> visit(el, q));
         q.getAndSend(assignOp, a -> a.getPadding().getOperator(), op -> visitLeftPadded(op, q));
         q.getAndSend(assignOp, Go.AssignmentOperation::getAssignment, el -> visit(el, q));
+        q.getAndSend(assignOp, a -> Reference.asRef(a.getType()), type -> visitType(getValueNonNull(type), q));
         return assignOp;
     }
 

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
@@ -120,6 +120,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     public J visitGoArrayType(Go.ArrayType arrayType, RpcSendQueue q) {
         q.getAndSend(arrayType, a -> a.getPadding().getLength(), el -> visitRightPadded(el, q));
         q.getAndSend(arrayType, Go.ArrayType::getElementType, el -> visit(el, q));
+        q.getAndSend(arrayType, a -> Reference.asRef(a.getType()), type -> visitType(getValueNonNull(type), q));
         return arrayType;
     }
 
@@ -128,6 +129,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
         q.getAndSend(mapType, Go.MapType::getOpenBracket, space -> visitSpace(space, q));
         q.getAndSend(mapType, m -> m.getPadding().getKey(), el -> visitRightPadded(el, q));
         q.getAndSend(mapType, Go.MapType::getValue, el -> visit(el, q));
+        q.getAndSend(mapType, m -> Reference.asRef(m.getType()), type -> visitType(getValueNonNull(type), q));
         return mapType;
     }
 
@@ -154,6 +156,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     @Override
     public J visitPointerType(Go.PointerType pointerType, RpcSendQueue q) {
         q.getAndSend(pointerType, Go.PointerType::getElem, el -> visit(el, q));
+        q.getAndSend(pointerType, pt -> Reference.asRef(pt.getType()), type -> visitType(getValueNonNull(type), q));
         return pointerType;
     }
 
@@ -161,6 +164,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     public J visitChannel(Go.Channel channel, RpcSendQueue q) {
         q.getAndSend(channel, c -> c.getDir().name());
         q.getAndSend(channel, Go.Channel::getValue, el -> visit(el, q));
+        q.getAndSend(channel, c -> Reference.asRef(c.getType()), type -> visitType(getValueNonNull(type), q));
         return channel;
     }
 
@@ -168,12 +172,14 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     public J visitFuncType(Go.FuncType funcType, RpcSendQueue q) {
         q.getAndSend(funcType, f -> f.getPadding().getParameters(), el -> visitContainer(el, q));
         q.getAndSend(funcType, Go.FuncType::getReturnType, el -> visit(el, q));
+        q.getAndSend(funcType, f -> Reference.asRef(f.getType()), type -> visitType(getValueNonNull(type), q));
         return funcType;
     }
 
     @Override
     public J visitStructType(Go.StructType structType, RpcSendQueue q) {
         q.getAndSend(structType, Go.StructType::getBody, el -> visit(el, q));
+        q.getAndSend(structType, st -> Reference.asRef(st.getType()), type -> visitType(getValueNonNull(type), q));
         return structType;
     }
 
@@ -186,6 +192,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     @Override
     public J visitInterfaceType(Go.InterfaceType interfaceType, RpcSendQueue q) {
         q.getAndSend(interfaceType, Go.InterfaceType::getBody, el -> visit(el, q));
+        q.getAndSend(interfaceType, it -> Reference.asRef(it.getType()), type -> visitType(getValueNonNull(type), q));
         return interfaceType;
     }
 

--- a/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/internal/rpc/GolangSender.java
@@ -199,12 +199,14 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     @Override
     public J visitTypeList(Go.TypeList typeList, RpcSendQueue q) {
         q.getAndSend(typeList, t -> t.getPadding().getTypes(), el -> visitContainer(el, q));
+        q.getAndSend(typeList, t -> Reference.asRef(t.getType()), type -> visitType(getValueNonNull(type), q));
         return typeList;
     }
 
     @Override
     public J visitUnion(Go.Union union, RpcSendQueue q) {
         q.getAndSendList(union, u -> u.getPadding().getTypes(), t -> t.getElement().getId(), t -> visitRightPadded(t, q));
+        q.getAndSend(union, u -> Reference.asRef(u.getType()), type -> visitType(getValueNonNull(type), q));
         return union;
     }
 
@@ -273,6 +275,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
     public J visitIndexList(Go.IndexList indexList, RpcSendQueue q) {
         q.getAndSend(indexList, Go.IndexList::getTarget, el -> visit(el, q));
         q.getAndSend(indexList, i -> i.getPadding().getIndices(), el -> visitContainer(el, q));
+        q.getAndSend(indexList, i -> Reference.asRef(i.getType()), type -> visitType(getValueNonNull(type), q));
         return indexList;
     }
 
@@ -305,6 +308,7 @@ public class GolangSender extends GolangVisitor<RpcSendQueue> {
         q.getAndSend(variadic, Go.Variadic::getElement, el -> visit(el, q));
         q.getAndSend(variadic, Go.Variadic::getDots, space -> visitSpace(space, q));
         q.getAndSend(variadic, Go.Variadic::isPostfix);
+        q.getAndSend(variadic, v -> Reference.asRef(v.getType()), type -> visitType(getValueNonNull(type), q));
         return variadic;
     }
 

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
@@ -2737,15 +2737,14 @@ public interface Go extends J {
     }
 
     // ---------------------------------------------------------------
-    // Variadic (Go-specific ellipsis: ...T parameter type, args... call spread)
+    // Variadic (Go-specific ellipsis: [...]T elided length, args... call spread)
     // ---------------------------------------------------------------
 
     /**
-     * Go's {@code ...} ellipsis, which is not a unary operator in Go's grammar:
-     * it appears as the parameter type form {@code ...T} (prefix, {@code postfix
-     * == false}) and the call-site spread {@code args...} (postfix, {@code
-     * postfix == true}). {@code dots} is the whitespace immediately before the
-     * {@code ...} token in the postfix form.
+     * Go's {@code ...} ellipsis where it stands for something other than a parameter type: an array's elided
+     * length in {@code [...]T{...}} ({@code postfix == false}) and the call-site spread {@code args...}
+     * ({@code postfix == true}). {@code dots} is the whitespace before the {@code ...} in the postfix form.
+     * A parameter's {@code ...T} is a {@link J.VariableDeclarations} whose {@code varargs} slot holds the dots.
      */
     @ToString
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
@@ -2682,16 +2682,10 @@ public interface Go extends J {
             return getPadding().withOperator(this.operator.withElement(operator));
         }
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -2731,7 +2725,7 @@ public interface Go extends J {
             }
 
             public Go.AssignmentOperation withOperator(JLeftPadded<Type> operator) {
-                return t.operator == operator ? t : new Go.AssignmentOperation(t.padding, t.id, t.prefix, t.markers, t.variable, operator, t.assignment);
+                return t.operator == operator ? t : new Go.AssignmentOperation(t.padding, t.id, t.prefix, t.markers, t.variable, operator, t.assignment, t.type);
             }
         }
     }

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
@@ -896,16 +896,10 @@ public interface Go extends J {
         @Getter
         Expression elementType;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -941,7 +935,7 @@ public interface Go extends J {
             }
 
             public Go.ArrayType withLength(JRightPadded<Expression> length) {
-                return t.length == length ? t : new Go.ArrayType(t.padding, t.id, t.prefix, t.markers, length, t.elementType);
+                return t.length == length ? t : new Go.ArrayType(t.padding, t.id, t.prefix, t.markers, length, t.elementType, t.type);
             }
         }
     }
@@ -991,16 +985,10 @@ public interface Go extends J {
         @Getter
         Expression value;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -1036,7 +1024,7 @@ public interface Go extends J {
             }
 
             public Go.MapType withKey(JRightPadded<Expression> key) {
-                return t.key == key ? t : new Go.MapType(t.padding, t.id, t.prefix, t.markers, t.openBracket, key, t.value);
+                return t.key == key ? t : new Go.MapType(t.padding, t.id, t.prefix, t.markers, t.openBracket, key, t.value, t.type);
             }
         }
     }
@@ -1082,16 +1070,10 @@ public interface Go extends J {
         @Getter
         Expression elem;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -1315,16 +1297,10 @@ public interface Go extends J {
         @Getter
         Expression value;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -1379,16 +1355,10 @@ public interface Go extends J {
         @Nullable
         Expression returnType;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -1424,7 +1394,7 @@ public interface Go extends J {
             }
 
             public Go.FuncType withParameters(JContainer<Statement> parameters) {
-                return t.parameters == parameters ? t : new Go.FuncType(t.padding, t.id, t.prefix, t.markers, parameters, t.returnType);
+                return t.parameters == parameters ? t : new Go.FuncType(t.padding, t.id, t.prefix, t.markers, parameters, t.returnType, t.type);
             }
         }
     }
@@ -1455,16 +1425,10 @@ public interface Go extends J {
         @Getter
         J.Block body;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -1503,16 +1467,10 @@ public interface Go extends J {
         @Getter
         J.Block body;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {

--- a/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/tree/Go.java
@@ -1520,16 +1520,10 @@ public interface Go extends J {
             return getPadding().withTypes(JContainer.withElements(this.types, types));
         }
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -1565,7 +1559,7 @@ public interface Go extends J {
             }
 
             public Go.TypeList withTypes(JContainer<Statement> types) {
-                return t.types == types ? t : new Go.TypeList(t.padding, t.id, t.prefix, t.markers, types);
+                return t.types == types ? t : new Go.TypeList(t.padding, t.id, t.prefix, t.markers, types, t.type);
             }
         }
     }
@@ -1607,16 +1601,10 @@ public interface Go extends J {
             return getPadding().withTypes(JRightPadded.withElements(this.types, types));
         }
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -1652,7 +1640,7 @@ public interface Go extends J {
             }
 
             public Go.Union withTypes(List<JRightPadded<Expression>> types) {
-                return t.types == types ? t : new Go.Union(t.padding, t.id, t.prefix, t.markers, types);
+                return t.types == types ? t : new Go.Union(t.padding, t.id, t.prefix, t.markers, types, t.type);
             }
         }
     }
@@ -2398,16 +2386,10 @@ public interface Go extends J {
             return getPadding().withIndices(JContainer.withElements(this.indices, indices));
         }
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {
@@ -2443,7 +2425,7 @@ public interface Go extends J {
             }
 
             public Go.IndexList withIndices(JContainer<Expression> indices) {
-                return t.indices == indices ? t : new Go.IndexList(t.padding, t.id, t.prefix, t.markers, t.target, indices);
+                return t.indices == indices ? t : new Go.IndexList(t.padding, t.id, t.prefix, t.markers, t.target, indices, t.type);
             }
         }
     }
@@ -2795,16 +2777,10 @@ public interface Go extends J {
         @Getter
         boolean postfix;
 
-        @Override
-        public @Nullable JavaType getType() {
-            return null;
-        }
-
-        @Override
-        public <T extends J> T withType(@Nullable JavaType type) {
-            //noinspection unchecked
-            return (T) this;
-        }
+        @With
+        @Getter
+        @Nullable
+        JavaType type;
 
         @Override
         public <P> @Nullable J acceptGolang(GolangVisitor<P> v, P p) {

--- a/rewrite-go/test/type_attribution_test.go
+++ b/rewrite-go/test/type_attribution_test.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,6 +27,7 @@ import (
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/matcher"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/golang"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
@@ -216,6 +218,26 @@ func TestTypeAttributionAssignment(t *testing.T) {
 	}
 }
 
+func TestTypeAttributionCompoundAssignment(t *testing.T) {
+	src := "package main\n\nfunc f(m map[string]int) {\n" +
+		"\tx := 1\n\tx += 2\n\tm[\"k\"] &^= 4\n\t_ = x\n}\n"
+	cu, err := parser.NewGoParser().Parse("test.go", src)
+	if err != nil {
+		t.Fatalf("parse error: %v", err)
+	}
+	var got []string
+	forEachAssignmentOperation(cu, func(a *java.AssignmentOperation) {
+		got = append(got, matcher.GetFullyQualifiedName(a.Type))
+	})
+	// `&^=` maps to the golang node, so it needs its own walk.
+	forEachGoAssignmentOperation(cu, func(a *golang.AssignmentOperation) {
+		got = append(got, matcher.GetFullyQualifiedName(a.Type))
+	})
+	if want := []string{"int", "int"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("compound assignment types: got %v, want %v", got, want)
+	}
+}
+
 func TestTypeAttributionSliceType(t *testing.T) {
 	src := "package main\n\nvar xs []int\n"
 	cu, err := parser.NewGoParser().Parse("test.go", src)
@@ -237,6 +259,8 @@ func TestTypeAttributionSliceType(t *testing.T) {
 type assignmentWalker struct {
 	visitor.GoVisitor
 	onAssignment        func(*java.Assignment)
+	onAssignmentOp      func(*java.AssignmentOperation)
+	onGoAssignmentOp    func(*golang.AssignmentOperation)
 	onArrayType         func(*java.ArrayType)
 	onMethodDeclaration func(*java.MethodDeclaration)
 	onMethodInvocation  func(*java.MethodInvocation)
@@ -250,6 +274,20 @@ func (v *assignmentWalker) VisitAssignment(a *java.Assignment, p any) java.J {
 	return v.GoVisitor.VisitAssignment(a, p)
 }
 
+func (v *assignmentWalker) VisitAssignmentOperation(a *java.AssignmentOperation, p any) java.J {
+	if v.onAssignmentOp != nil {
+		v.onAssignmentOp(a)
+	}
+	return v.GoVisitor.VisitAssignmentOperation(a, p)
+}
+
+func (v *assignmentWalker) VisitGoAssignmentOperation(a *golang.AssignmentOperation, p any) java.J {
+	if v.onGoAssignmentOp != nil {
+		v.onGoAssignmentOp(a)
+	}
+	return v.GoVisitor.VisitGoAssignmentOperation(a, p)
+}
+
 func (v *assignmentWalker) VisitArrayType(a *java.ArrayType, p any) java.J {
 	if v.onArrayType != nil {
 		v.onArrayType(a)
@@ -259,6 +297,14 @@ func (v *assignmentWalker) VisitArrayType(a *java.ArrayType, p any) java.J {
 
 func forEachAssignment(cu java.Tree, f func(*java.Assignment)) {
 	visitor.Init(&assignmentWalker{onAssignment: f}).Visit(cu, nil)
+}
+
+func forEachAssignmentOperation(cu java.Tree, f func(*java.AssignmentOperation)) {
+	visitor.Init(&assignmentWalker{onAssignmentOp: f}).Visit(cu, nil)
+}
+
+func forEachGoAssignmentOperation(cu java.Tree, f func(*golang.AssignmentOperation)) {
+	visitor.Init(&assignmentWalker{onGoAssignmentOp: f}).Visit(cu, nil)
 }
 
 func forEachArrayType(cu java.Tree, f func(*java.ArrayType)) {


### PR DESCRIPTION
`RemoveRedundantTypeCast` died with an NPE in the Moderne flagship *Java best practices* runs of 2026-08-31 (dev changeset `20260831034135-9xpDX`, app `20260831044606-qU6H6`), on one file of `Netflix/bettertls`:

```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.JavaType.equals(Object)" because "castType" is null
  org.openrewrite.staticanalysis.RemoveRedundantTypeCast$1.visitTypeCast(RemoveRedundantTypeCast.java:140)
  org.openrewrite.java.tree.J$TypeCast.acceptJava(J.java:5840)
  org.openrewrite.golang.GolangVisitor.visitComposite(GolangVisitor.java:134)
```

The recipe reads `visitedTypeCast.getType()` and dereferences it fifty lines later. On a Java LST a `J.TypeCast` always has a type; on the Go LST for `test-suites/test-executor/test_results.pb.go` it did not — the conversions are inside a composite literal, and the second one is a pointer:

```go
var file_test_results_proto_goTypes = []interface{}{
	(TestCaseResult)(0),      // Identifier in the parens — typed
	(*SuiteTestResults)(nil), // Go.PointerType in the parens — null
}
```

## What was null and why

`J.TypeCast.getType()` delegates to `clazz.getType()`, which reads through `J.ControlParentheses` → `J.ParenthesizedTypeTree` → `J.Parentheses` to whatever spells the target type. The chain is sound; the leaf was not. Seven `Go` nodes are `TypeTree`s with no type slot behind a hardcoded answer:

```java
final class PointerType implements Go, Expression, TypeTree {
    public @Nullable JavaType getType() { return null; }
    public <T extends J> T withType(@Nullable JavaType type) { return (T) this; }
```

The same for `ArrayType`, `MapType`, `Channel`, `FuncType`, `StructType` and `InterfaceType`. This is not degraded attribution — the parser resolves `*SuiteTestResults` to `test_executor.SuiteTestResults` even with the file's protobuf imports unresolvable, and `matcher.TypeOfExpression` returns it on the Go side. The model simply had nowhere to put it, so nothing crossed RPC.

Not a one-off, either. Counting conversions in the go1.27 stdlib by the shape of their target:

| spelling | node | count | before |
|---|---|---|---|
| `[]T(x)` | `java.ArrayType` | 4522 | typed |
| `(*T)(x)` | `Go.PointerType` | 3606 | **null** |
| `chan T(x)` | `Go.Channel` | 54 | **null** |
| `map[K]V(x)` | `Go.MapType` | 54 | **null** |
| `[N]T(x)` | `Go.ArrayType` | 32 | **null** |
| `func(…)(x)` | `Go.FuncType` | 23 | **null** |
| `interface{}(x)`, `struct{…}(x)` | `Go.InterfaceType`, `Go.StructType` | 9 | **null** |

Pointer conversions alone are 45% of all conversions in the stdlib.

## The fix

Each of the seven gains a `JavaType type`, filled by the parser from `ctx.valueTypeOf(expr)` where it builds the node — the same call `java.ArrayType` and `java.ParameterizedType` already make for slices and generic instantiations, and the shape `JS.Union`/`JS.Intersection` use in rewrite-javascript. `withType` stops being a no-op. The slot crosses RPC in both directions.

Deriving the type from the node's children instead was the alternative, and it is what `matcher.TypeOfExpression` does on the Go side today. It covers pointer, array, map and channel, but a func, struct or interface spelling names a type only the checker can build, so 32 stdlib conversions would have kept returning null and the recipe would have kept crashing on them. `TypeOfExpression` now prefers the slot and keeps the structural path for a spelling a recipe built rather than the parser saw.

The slots cost nothing in LST size: over 300 stdlib files the tree reaches 62901 distinct `JavaType` objects with the slots populated and 62901 with them cleared. Every type a spelling now names was already reachable from the declaration it belongs to; the wire carries one more reference id per node, not a new type graph.

One thing had to move to make that true. A named struct type and the `*types.Struct` it wraps share their `*types.Var` field objects, so once the unnamed spelling is mapped, `structMembers` ran a second time over the same fields and overwrote `fieldOwner` with the anonymous class. `TestTypeAttributionFieldOwner` caught it — `field N owner: got "", want main.T`. A field now keeps its named owner whichever mapping runs last.

## Tests

`GoTypeAttributionIntegTest.conversionToAnUnnamedTypeCarriesItsType` reads `J.TypeCast.getType()` off the Java-side tree for all seven spellings, which is the end-to-end claim — parser, both codecs and the slot. It fails on `main` with `[null, null, null, null, null, null, null]`. Case one is `(*T)(p)`, the reported crash.

`TestConversionCarriesTheTypeItNames` gains `interface{}(s)` → `any` for the Go-side consumer, the one spelling in the table whose type no structural rule can produce.

`TestTypeAttributionCompoundAssignment` pins both compound-assignment nodes, `x += 2` and `m["k"] &^= 4`. `TestUnattributedResultListNamesNothing` parses with `ParseOnly` and asserts the result list names nothing; it was mutation-checked, failing against the unguarded `resultsType` with `go.tuple` and two nil parameters.

## The rest of the model

`Go.Union`, `TypeList`, `Variadic` and `IndexList` were the remaining nodes answering null, and they get the same treatment in the second commit. None can be a conversion target, so none reaches this crash — but three of the four are `TypeTree`s, which is the assertion that they name a type.

go/types records a type for each expression-backed shape, so `~int | ~int8`, `pick[int, string]` and the spread argument take `ctx.valueTypeOf` like the others:

```
*ast.BinaryExpr     recorded=true  type=~int | ~int8
*ast.IndexListExpr  recorded=true  type=main.Pair[int, string]
```

A result list is the one that differs: it has no expression of its own, and its type is the tuple `mapSignature` already builds for the method. Rather than write that shape a second time in the parser, it moves into `tupleType` and both callers share it — which also collapses `mapSignature`'s three-branch return-type block.

Sharing that shape is what made the extraction worth doing and also what needed guarding. `mapSignature` feeds `tupleType` types from `go/types`, which are never nil; `resultsType` feeds it a `valueTypeOf` per member, which is nil for anything the checker did not see — so a two-result list produced `go.tuple<nil, nil>`, a type on its face while carrying holes. `ParseOnly` never populates `typeInfo.Types`, so `func f() (int, error)` reached that state outright, and the RPC sender keys a type list on each member's signature, which a nil member panics on. An unattributed member now leaves the whole list unattributed. Nothing in the census below shows this: across 254 whole packages no result list was ever partially resolved, which is why a corpus percentage is no substitute for the guard.

Attributing `Variadic` turned up two comments that named the wrong shape. Both models said its prefix form is the `...T` parameter type. It is not — a parameter is a `J.VariableDeclarations` carrying the dots in its `varargs` slot, exactly as Java models `int... xs`, with the element type on the type expression and the slice type on the variable:

```
func sum(xs ...int)   TypeExpr=Identifier("int")  varargs=true  variable type=[]int
func sum(xs ...T)     TypeExpr=Identifier("T")    varargs=true  variable type=[]main.T
```

`mapEllipsis` in fact maps both: a parameter's `...T`, which `mapFieldListAsParams` unwraps into the `varargs` slot, and the elided array length of `[...]T{...}`, which is the form that survives in the tree as a `Go.Variadic`. The comments now say that.

While there: Go has no `@Nullable`, so a `java.JavaType` field is nilable by construction and the contract can only be prose. One of the fourteen slots in the Go model carried `(nullable)` and thirteen said nothing. It moves to `JavaType` itself, where one statement covers every slot in every model rather than fourteen repetitions of a model-wide invariant.

`GoTypeAttributionIntegTest.aTypeSpellingThatIsNotAConversionTargetCarriesItsTypeToo` covers the four.

## What the rest of the model looks like

`test/attribution_census_test.go` counts resolved type slots per (node, field) over a corpus. Run against 254 standard-library package directories, parsed whole through a `ProjectImporter` — single-file parsing halves every number and is not what `mod build` does:

```
slot                                 resolved   unknown       nil  resolved%
TOTAL                                 6931372     48994   1576351    81.01%
java.Identifier.Type                  2937865     39880     81237    96.04%
java.MethodInvocation.MethodType       341410         0     19994    94.47%
java.Assignment.Type                   211146      1066      3885    97.71%
java.AssignmentOperation.Type            5656         1         6    99.88%   was 0.00%
golang.AssignmentOperation.Type           144         0         1    99.31%   was absent
golang.PointerType.Type                 57241      1618       145    97.01%   was absent
golang.ArrayType.Type                   12248        16         1    99.86%   was absent
golang.StructType.Type                   8048         0         2    99.98%   was absent
golang.TypeList.Type                     6126         6         0    99.90%   was absent
golang.MapType.Type                      3651         0         7    99.81%   was absent
golang.FuncType.Type                     2674         0         2    99.93%   was absent
golang.Channel.Type                      2220         0         1    99.95%   was absent
golang.Variadic.Type                     1719         0       368    82.37%   was absent
golang.InterfaceType.Type                 621         0         0   100.00%   was absent
golang.IndexList.Type                     127         0         0   100.00%   was absent
golang.Union.Type                         106         0         0   100.00%   was absent
```

Every slot still short of 100% was chased to a cause, and each one is a node that names no type rather than a lookup that was not made:

- **`golang.Variadic` 82.37%** — the `[...]T{...}` array lengths described above.
- **`golang.TypeAssertion` 79.04%** — the `switch x.(type)` guard, which asserts no single type.
- **`java.Literal` 79.39%** — import paths, struct tags and `//go:` directive arguments, none of them expressions; plus unsigned and complex literals, which `J.Literal.type` cannot hold because it is declared `JavaType.Primitive`, not `JavaType`.
- **`java.Identifier.FieldType` 57.88%** — a method name, type name or package qualifier is not a variable.

## The census asserts nothing

It is `//go:build parityaudit`, skips unless `GO_CORPUS` is set, and ends in `t.Logf`, so it never runs in CI and cannot fail. Nothing ratchets attribution: the `fieldOwner` regression above was caught by `TestTypeAttributionFieldOwner`, a targeted test that happened to name that shape, and a clobber of a shape no test names would have left every suite green. A per-slot floor over `$GOROOT/src` would close that, and is not in this PR.

Two Go tests fail on this branch — `pkg/format TestSubtreeIndentMatchesWholeFileOnStdlib/encoding/json/encode.go` and `test TestParseStdlibJSON`, both "no compilation unit produced". They fail identically at `main`; go1.27 stdlib drift, same family as the `TestParityGap` audit.



