### PR TITLE
Python: Add Shebang LST element

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/__init__.py
@@ -36,6 +36,7 @@ from rewrite.python.template import (
 from rewrite.python.tree import (
     Py,
     Async,
+    Shebang,
     Await,
     Binary,
     ChainedAssignment,
@@ -136,6 +137,7 @@ __all__ = [
     "Py",
     # Python-specific types
     "Async",
+    "Shebang",
     "Await",
     "Binary",
     "ChainedAssignment",

--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -2590,6 +2590,14 @@ class ParserVisitor(ast.NodeVisitor):
         )
 
     def visit_Module(self, node: ast.Module) -> py.CompilationUnit:
+        statements = []
+        shebang = self.__shebang()
+        if shebang is not None:
+            statements.append(shebang)
+        if node.body:
+            statements.extend(self.__pad_statement(stmt) for stmt in node.body)
+        elif shebang is None:
+            statements.append(self.__pad_right(j.Empty(random_id(), Space.EMPTY, Markers.EMPTY), Space.EMPTY))
         cu = py.CompilationUnit(
             random_id(),
             Space.EMPTY,
@@ -2600,12 +2608,38 @@ class ParserVisitor(ast.NodeVisitor):
             self._bom_marked,
             None,
             _EMPTY_LIST,
-            [self.__pad_statement(stmt) for stmt in node.body] if node.body else [
-                self.__pad_right(j.Empty(random_id(), Space.EMPTY, Markers.EMPTY), Space.EMPTY)],
+            statements,
             self.__whitespace()
         )
         # Parsing complete - all tokens should be consumed
         return cu
+
+    def __shebang(self) -> Optional[JRightPadded[py.Shebang]]:
+        """Capture a leading ``#!`` line as a first-class Shebang statement.
+
+        Python's tokenizer surfaces the shebang as an ordinary COMMENT token,
+        which would otherwise fold into the first statement's prefix. Mirroring
+        the JS/TS parser, the terminating newline is kept as the node's
+        ``after`` padding while any following blank lines stay with the next
+        statement's prefix.
+        """
+        idx = self._token_idx
+        while idx < len(self._tokens) and self._tokens[idx].type == token.ENCODING:
+            idx += 1
+        if idx >= len(self._tokens):
+            return None
+        tok = self._tokens[idx]
+        if tok.type != token.COMMENT or not tok.string.startswith('#!'):
+            return None
+        self._token_idx = idx + 1
+        shebang = py.Shebang(random_id(), Space.EMPTY, Markers.EMPTY, tok.string)
+        after = Space.EMPTY
+        if self._token_idx < len(self._tokens):
+            nl = self._tokens[self._token_idx]
+            if nl.type in (token.NEWLINE, token.NL):
+                after = Space(_EMPTY_LIST, nl.string)
+                self._token_idx += 1
+        return self.__pad_right(shebang, after)
 
     @contextlib.contextmanager
     def __type_context(self):

--- a/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
@@ -62,6 +62,27 @@ class Py2ParserVisitor:
         else:
             self._bom_marked = False
 
+        # Peel a leading ``#!`` line off before parso sees it, so it becomes a
+        # first-class Shebang statement rather than folding into the first leaf's
+        # prefix as a comment (mirrors the Python 3 parser). The terminating
+        # newline is kept as the node's ``after`` padding; the remainder is parsed
+        # normally so any following blank lines stay with the next statement.
+        self._shebang_text: Optional[str] = None
+        self._shebang_after: str = ''
+        if source.startswith('#!'):
+            line_end = len(source)
+            for idx, ch in enumerate(source):
+                if ch in ('\n', '\r'):
+                    line_end = idx
+                    break
+            self._shebang_text = source[:line_end]
+            if line_end < len(source) and source[line_end] == '\r' and \
+                    line_end + 1 < len(source) and source[line_end + 1] == '\n':
+                self._shebang_after = '\r\n'
+            elif line_end < len(source):
+                self._shebang_after = source[line_end]
+            source = source[line_end + len(self._shebang_after):]
+
         self._source_without_bom = source
 
         # Parse with parso
@@ -78,6 +99,12 @@ class Py2ParserVisitor:
         """
         # Convert parso tree to LST statements
         statements, end_ws = self._convert_module(self._tree)
+
+        # Prepend the peeled shebang as the first statement.
+        if self._shebang_text is not None:
+            shebang = py.Shebang(random_id(), Space.EMPTY, Markers.EMPTY, self._shebang_text)
+            after = Space([], self._shebang_after) if self._shebang_after else Space.EMPTY
+            statements.insert(0, JRightPadded(shebang, after, Markers.EMPTY))
 
         # Combine block end-whitespace (from trailing ``;`` lines) with
         # the file's terminal whitespace recovered from the endmarker.
@@ -114,7 +141,7 @@ class Py2ParserVisitor:
         trailing ``;`` line).
         """
         statements, end_ws = self._convert_stmt_block_children(module.children)
-        if not statements:
+        if not statements and self._shebang_text is None:
             statements.append(JRightPadded(
                 j.Empty(random_id(), Space.EMPTY, Markers.EMPTY),
                 Space.EMPTY,

--- a/rewrite-python/rewrite/src/rewrite/python/printer.py
+++ b/rewrite-python/rewrite/src/rewrite/python/printer.py
@@ -216,6 +216,8 @@ class PythonPrinter:
             return self.visit_named_argument(tree, p)
         elif isinstance(tree, py.Pass):
             return self.visit_pass(tree, p)
+        elif isinstance(tree, py.Shebang):
+            return self.visit_shebang(tree, p)
         elif isinstance(tree, py.Slice):
             return self.visit_slice(tree, p)
         elif isinstance(tree, py.SpecialParameter):
@@ -405,6 +407,13 @@ class PythonPrinter:
         p.append("async")
         self.visit(async_.statement, p)
         return async_
+
+    def visit_shebang(self, shebang: 'py.Shebang', p: PrintOutputCapture) -> J:
+        """Visit a shebang line."""
+        self._before_syntax(shebang, p)
+        p.append(shebang.text)
+        self._after_syntax(shebang, p)
+        return shebang
 
     def visit_await(self, await_: 'py.Await', p: PrintOutputCapture) -> J:
         """Visit an await expression."""

--- a/rewrite-python/rewrite/src/rewrite/python/tree.py
+++ b/rewrite-python/rewrite/src/rewrite/python/tree.py
@@ -51,6 +51,36 @@ class Async(Py, Statement):
 
 # noinspection PyShadowingBuiltins,PyShadowingNames,DuplicatedCode
 @dataclass(frozen=True, eq=False, slots=True)
+class Shebang(Py, Statement):
+    _id: UUID
+
+
+    _prefix: Space
+
+    @property
+    def prefix(self) -> Space:
+        return self._prefix
+
+
+    _markers: Markers
+
+    @property
+    def markers(self) -> Markers:
+        return self._markers
+
+
+    _text: str
+
+    @property
+    def text(self) -> str:
+        return self._text
+
+
+    def accept_python(self, v: PythonVisitor[P], p: P) -> J:
+        return v.visit_shebang(self, p)
+
+# noinspection PyShadowingBuiltins,PyShadowingNames,DuplicatedCode
+@dataclass(frozen=True, eq=False, slots=True)
 class Await(Py, Expression):
     _id: UUID
 

--- a/rewrite-python/rewrite/src/rewrite/python/tree.pyi
+++ b/rewrite-python/rewrite/src/rewrite/python/tree.pyi
@@ -33,6 +33,24 @@ class Async(Py, Statement):
     def accept_python(self, v: PythonVisitor[P], p: P) -> J: ...
 
 @dataclass(frozen=True)
+class Shebang(Py, Statement):
+    _id: UUID
+    _prefix: Space
+    _markers: Markers
+    _text: str
+
+    def replace(self, **kwargs: Any) -> Self: ...
+
+    @property
+    def prefix(self) -> Space: ...
+    @property
+    def markers(self) -> Markers: ...
+    @property
+    def text(self) -> str: ...
+
+    def accept_python(self, v: PythonVisitor[P], p: P) -> J: ...
+
+@dataclass(frozen=True)
 class Await(Py, Expression):
     _id: UUID
     _prefix: Space

--- a/rewrite-python/rewrite/src/rewrite/python/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/visitor.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
         MultiImport,
         NamedArgument,
         Pass,
+        Shebang,
         Slice,
         SpecialParameter,
         Star,
@@ -484,6 +485,18 @@ class PythonVisitor(JavaVisitor[P]):
         pass_ = temp_stmt
         pass_ = pass_.replace(markers=self.visit_markers(pass_.markers, p))
         return pass_
+
+    def visit_shebang(self, shebang: Shebang, p: P) -> Optional[J]:
+        """Visit a shebang line."""
+        shebang = shebang.replace(
+            prefix=self.visit_space(shebang.prefix, p)
+        )
+        temp_stmt = cast(Statement, self.visit_statement(shebang, p))
+        if not isinstance(temp_stmt, type(shebang)):
+            return temp_stmt
+        shebang = temp_stmt
+        shebang = shebang.replace(markers=self.visit_markers(shebang.markers, p))
+        return shebang
 
     def visit_slice(self, slice_: Slice, p: P) -> J:
         """Visit a slice expression."""

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_receiver.py
@@ -29,7 +29,7 @@ from rewrite.python.tree import (
     Async, Await, Binary, ChainedAssignment, ExceptionType,
     LiteralType, TypeHint, ExpressionStatement, ExpressionTypeTree,
     StatementExpression, MultiImport, KeyValue, DictLiteral, CollectionLiteral,
-    FormattedString, Pass, TrailingElseWrapper, ComprehensionExpression,
+    FormattedString, Pass, Shebang, TrailingElseWrapper, ComprehensionExpression,
     TypeAlias, YieldFrom, UnionType, VariableScope, Del, SpecialParameter,
     Star, NamedArgument, TypeHintedExpression, ErrorFrom, MatchCase, Slice
 )
@@ -129,6 +129,8 @@ class PythonRpcReceiver:
             return self._visit_formatted_string(tree, q)
         elif isinstance(tree, Pass):
             return self._visit_pass(tree, q)
+        elif isinstance(tree, Shebang):
+            return self._visit_shebang(tree, q)
         elif isinstance(tree, TrailingElseWrapper):
             return self._visit_trailing_else_wrapper(tree, q)
         elif isinstance(tree, ComprehensionExpression.Condition):
@@ -297,6 +299,10 @@ class PythonRpcReceiver:
     def _visit_pass(self, pass_: Pass, q: RpcReceiveQueue) -> Pass:
         # No additional fields beyond id/prefix/markers
         return pass_
+
+    def _visit_shebang(self, shebang: Shebang, q: RpcReceiveQueue) -> Shebang:
+        text = q.receive(shebang.text)
+        return replace_if_changed(shebang, text=text)
 
     def _visit_trailing_else_wrapper(self, tew: TrailingElseWrapper, q: RpcReceiveQueue) -> TrailingElseWrapper:
         statement = q.receive(tew.statement)

--- a/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/python_sender.py
@@ -15,7 +15,7 @@ from rewrite.python.tree import (
     Async, Await, Binary, ChainedAssignment, ExceptionType,
     LiteralType, TypeHint, ExpressionStatement, ExpressionTypeTree,
     StatementExpression, MultiImport, KeyValue, DictLiteral, CollectionLiteral,
-    FormattedString, Pass, TrailingElseWrapper, ComprehensionExpression,
+    FormattedString, Pass, Shebang, TrailingElseWrapper, ComprehensionExpression,
     TypeAlias, YieldFrom, UnionType, VariableScope, Del, SpecialParameter,
     Star, NamedArgument, TypeHintedExpression, ErrorFrom, MatchCase, Slice
 )
@@ -115,6 +115,8 @@ class PythonRpcSender:
             self._visit_formatted_string(tree, q)
         elif isinstance(tree, Pass):
             self._visit_pass(tree, q)
+        elif isinstance(tree, Shebang):
+            self._visit_shebang(tree, q)
         elif isinstance(tree, TrailingElseWrapper):
             self._visit_trailing_else_wrapper(tree, q)
         elif isinstance(tree, ComprehensionExpression.Condition):
@@ -269,6 +271,9 @@ class PythonRpcSender:
     def _visit_pass(self, pass_: Pass, q: 'RpcSendQueue') -> None:
         # No additional fields beyond id/prefix/markers
         pass
+
+    def _visit_shebang(self, shebang: Shebang, q: 'RpcSendQueue') -> None:
+        q.get_and_send(shebang, lambda x: x.text)
 
     def _visit_trailing_else_wrapper(self, tew: TrailingElseWrapper, q: 'RpcSendQueue') -> None:
         q.get_and_send(tew, lambda x: x.statement, lambda el: self._visit(el, q))

--- a/rewrite-python/rewrite/tests/python/all/tree/shebang_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/shebang_test.py
@@ -1,0 +1,58 @@
+from rewrite.python import CompilationUnit, Shebang
+from rewrite.test import RecipeSpec, python
+
+
+def _first_is_shebang(cu):
+    assert isinstance(cu, CompilationUnit)
+    first = cu.statements[0]
+    assert isinstance(first, Shebang)
+    assert first.text == "#!/usr/bin/env python3"
+
+
+def test_shebang_at_start_of_file():
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        "#!/usr/bin/env python3\nprint(\"Hello, world!\")\n",
+        after_recipe=_first_is_shebang,
+    ))
+
+
+def test_shebang_with_blank_line_after():
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        "#!/usr/bin/env python3\n\nx = 1\n",
+        after_recipe=_first_is_shebang,
+    ))
+
+
+def test_shebang_followed_by_comment():
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        "#!/usr/bin/env python3\n# a comment\nx = 1\n",
+        after_recipe=_first_is_shebang,
+    ))
+
+
+def test_shebang_only():
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        "#!/usr/bin/env python3\n",
+        after_recipe=_first_is_shebang,
+    ))
+
+
+def test_shebang_windows_line_endings():
+    # language=python
+    RecipeSpec().rewrite_run(python("#!/usr/bin/env python3\r\nx = 1\r\n"))
+
+
+def test_leading_comment_is_not_a_shebang():
+    def check(cu):
+        assert isinstance(cu, CompilationUnit)
+        assert not isinstance(cu.statements[0], Shebang)
+
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        "# not a shebang\nx = 1\n",
+        after_recipe=check,
+    ))

--- a/rewrite-python/rewrite/tests/python/py27/shebang_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/shebang_test.py
@@ -1,0 +1,49 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The parso-based Py2 parser models a leading ``#!`` line as a Shebang.
+
+Mirrors the Python 3 parser: the shebang becomes ``statements[0]`` and the
+whole source round-trips byte-for-byte through the printer.
+"""
+
+import pytest
+
+from rewrite.python import Shebang
+from rewrite.python._py2_parser_visitor import Py2ParserVisitor
+from rewrite.python.printer import PythonPrinter
+
+
+def _parse(src):
+    return Py2ParserVisitor(src, "<test>", "2.7").parse()
+
+
+@pytest.mark.parametrize("src", [
+    "#!/usr/bin/env python2\nprint 'hi'\n",
+    "#!/usr/bin/env python2\n\nx = 1\n",
+    "#!/usr/bin/env python2\n# a comment\nx = 1\n",
+    "#!/usr/bin/env python2\n",
+    "#!/usr/bin/env python2\r\nx = 1\r\n",
+])
+def test_shebang_is_first_statement_and_round_trips(src):
+    cu = _parse(src)
+    first = cu.statements[0]
+    assert isinstance(first, Shebang)
+    assert first.text == "#!/usr/bin/env python2"
+    assert PythonPrinter().print(cu) == src
+
+
+def test_leading_comment_is_not_a_shebang():
+    cu = _parse("# not a shebang\nx = 1\n")
+    assert not isinstance(cu.statements[0], Shebang)

--- a/rewrite-python/rewrite/tests/rpc/test_shebang_roundtrip.py
+++ b/rewrite-python/rewrite/tests/rpc/test_shebang_roundtrip.py
@@ -1,0 +1,57 @@
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A leading ``#!`` line survives the RPC round trip as a Py.Shebang statement.
+
+The in-process printer suite exercises parse/print, but only a serialize/
+deserialize round trip covers the sender/receiver codecs for the new node.
+"""
+import ast
+
+import pytest
+
+from rewrite.python import Shebang
+from rewrite.python._parser_visitor import ParserVisitor
+from rewrite.python.printer import PythonPrinter
+from rewrite.rpc.python_receiver import PythonRpcReceiver
+from rewrite.rpc.receive_queue import RpcReceiveQueue
+from rewrite.rpc.send_queue import RpcSendQueue
+
+_CU_TYPE = "org.openrewrite.python.tree.Py$CompilationUnit"
+
+
+def _round_trip(src):
+    cu = ParserVisitor(src, "<m>", None).visit_Module(ast.parse(src))
+    data = list(RpcSendQueue(_CU_TYPE).generate(cu, None))
+
+    def pull():
+        out = data[:]
+        data.clear()
+        return out
+
+    rebuilt = PythonRpcReceiver().receive(None, RpcReceiveQueue({}, _CU_TYPE, pull))
+    return cu, rebuilt
+
+
+@pytest.mark.parametrize("src", [
+    "#!/usr/bin/env python3\nprint(\"hi\")\n",
+    "#!/usr/bin/env python3\n\nx = 1\n",
+    "#!/usr/bin/env python3\n# a comment\nx = 1\n",
+    "#!/usr/bin/env python3\n",
+])
+def test_shebang_survives_rpc(src):
+    cu, rebuilt = _round_trip(src)
+    assert isinstance(rebuilt.statements[0], Shebang)
+    assert rebuilt.statements[0].text == "#!/usr/bin/env python3"
+    assert PythonPrinter().print(rebuilt) == PythonPrinter().print(cu) == src

--- a/rewrite-python/src/integTest/java/org/openrewrite/python/ShebangIntegTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/ShebangIntegTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.python.tree.Py;
+import org.openrewrite.test.RewriteTest;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.python.Assertions.python;
+
+class ShebangIntegTest implements RewriteTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder()
+                .log(tempDir.resolve("python-rpc.log"))
+                .traceRpcMessages()
+        );
+    }
+
+    @AfterEach
+    void after() throws IOException {
+        PythonRewriteRpc.shutdownCurrent();
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder());
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void shebangRoundTripsAndIsAFirstClassStatement() {
+        rewriteRun(
+                python(
+                        """
+                        #!/usr/bin/env python3
+                        print("Hello, world!")
+                        """,
+                        spec -> spec.afterRecipe(cu ->
+                                assertThat(cu.getStatements().get(0))
+                                        .isInstanceOfSatisfying(Py.Shebang.class, shebang ->
+                                                assertThat(shebang.getText()).isEqualTo("#!/usr/bin/env python3")))
+                )
+        );
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void python2ShebangRoutesThroughParsoParserAndIsAShebang() {
+        rewriteRun(
+                python(
+                        """
+                        #!/usr/bin/env python2
+                        print 'Hello, world!'
+                        """,
+                        spec -> spec.afterRecipe(cu ->
+                                assertThat(cu.getStatements().get(0))
+                                        .isInstanceOfSatisfying(Py.Shebang.class, shebang ->
+                                                assertThat(shebang.getText()).isEqualTo("#!/usr/bin/env python2")))
+                )
+        );
+    }
+
+    @Test
+    @Timeout(value = 60, unit = TimeUnit.SECONDS)
+    void shebangWithBlankLineAndComment() {
+        rewriteRun(
+                python(
+                        """
+                        #!/usr/bin/env python3
+
+                        # a comment
+                        x = 1
+                        """
+                )
+        );
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonIsoVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonIsoVisitor.java
@@ -33,6 +33,11 @@ public class PythonIsoVisitor<P> extends PythonVisitor<P>
     }
 
     @Override
+    public Py.Shebang visitShebang(Py.Shebang shebang, P p) {
+        return (Py.Shebang) super.visitShebang(shebang, p);
+    }
+
+    @Override
     public Py.Await visitAwait(Py.Await await, P p) {
         return (Py.Await) super.visitAwait(await, p);
     }

--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
@@ -55,6 +55,17 @@ public class PythonVisitor<P> extends JavaVisitor<P>
         return async.withStatement(visitAndCast(async.getStatement(), p));
     }
 
+    public J visitShebang(Py.Shebang shebang, P p) {
+        shebang = shebang.withPrefix(visitSpace(shebang.getPrefix(), PySpace.Location.SHEBANG_PREFIX, p));
+        Statement tempStatement = (Statement) visitStatement(shebang, p);
+        if (!(tempStatement instanceof Py.Shebang))
+        {
+            return tempStatement;
+        }
+        shebang = (Py.Shebang) tempStatement;
+        return shebang.withMarkers(visitMarkers(shebang.getMarkers(), p));
+    }
+
     public J visitAwait(Py.Await await, P p) {
         await = await.withPrefix(visitSpace(await.getPrefix(), PySpace.Location.AWAIT_PREFIX, p));
         Expression tempExpression = (Expression) visitExpression(await, p);

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/rpc/PythonReceiver.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/rpc/PythonReceiver.java
@@ -83,6 +83,12 @@ public class PythonReceiver extends PythonVisitor<RpcReceiveQueue> {
     }
 
     @Override
+    public J visitShebang(Py.Shebang shebang, RpcReceiveQueue q) {
+        return shebang
+                .withText(q.receive(shebang.getText()));
+    }
+
+    @Override
     public J visitAwait(Py.Await await, RpcReceiveQueue q) {
         return await
                 .withExpression(q.receive(await.getExpression(), expr -> (Expression) visitNonNull(expr, q)))

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/rpc/PythonSender.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/rpc/PythonSender.java
@@ -78,6 +78,12 @@ public class PythonSender extends PythonVisitor<RpcSendQueue> {
     }
 
     @Override
+    public J visitShebang(Py.Shebang shebang, RpcSendQueue q) {
+        q.getAndSend(shebang, Py.Shebang::getText);
+        return shebang;
+    }
+
+    @Override
     public J visitAwait(Py.Await await, RpcSendQueue q) {
         q.getAndSend(await, Py.Await::getExpression, el -> visit(el, q));
         q.getAndSend(await, el -> asRef(el.getType()), el -> visitType(getValueNonNull(el), q));

--- a/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/tree/Py.java
@@ -98,6 +98,36 @@ public interface Py extends J {
     }
 
     @Getter
+    @ToString
+    @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+    @EqualsAndHashCode(callSuper = false)
+    @AllArgsConstructor
+    final class Shebang implements Py, Statement {
+        @With
+        UUID id;
+
+        @With
+        Space prefix;
+
+        @With
+        Markers markers;
+
+        @With
+        String text;
+
+        @Override
+        public <P> J acceptPython(PythonVisitor<P> v, P p) {
+            return v.visitShebang(this, p);
+        }
+
+        @Transient
+        @Override
+        public CoordinateBuilder.Statement getCoordinates() {
+            return new CoordinateBuilder.Statement(this);
+        }
+    }
+
+    @Getter
     @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
     @EqualsAndHashCode(callSuper = false)
     @RequiredArgsConstructor

--- a/rewrite-python/src/main/java/org/openrewrite/python/tree/PySpace.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/tree/PySpace.java
@@ -363,6 +363,7 @@ public final class PySpace {
         NAMED_ARGUMENT,
         NAMED_ARGUMENT_PREFIX,
         PASS_PREFIX,
+        SHEBANG_PREFIX,
         SLICE_PREFIX,
         SLICE_START_SUFFIX,
         SLICE_STEP_SUFFIX,


### PR DESCRIPTION
## What's changed?

Introduce new LST element for Python parsing: Shebang to hold the shebang lines:
```python
#!/usr/bin/env python3

print("Hello world")
```

## What's your motivation?

- Before they were parsed into plain comments and also suffered from idempotency issues (adding whitespace after `#!` in some cases)
- Unify with how it's parsed for other languages - e.g. JS/TS