### PR TITLE
Go: unify comment parsing with other languages

### DIFF
--- a/rewrite-go/pkg/format/doc_comments.go
+++ b/rewrite-go/pkg/format/doc_comments.go
@@ -136,13 +136,10 @@ func canonicalDocComment(run []java.Comment) ([]java.Comment, bool) {
 	var prose strings.Builder
 	var directives []java.Comment
 	for _, c := range run {
-		if c.Kind != java.LineComment {
+		if c.Multiline {
 			return nil, false
 		}
-		body, found := strings.CutPrefix(c.Text, "//")
-		if !found {
-			return nil, false
-		}
+		body := c.Text
 		if isDirective(body) {
 			directives = append(directives, c)
 			continue
@@ -164,16 +161,16 @@ func canonicalDocComment(run []java.Comment) ([]java.Comment, bool) {
 		line, text, _ = strings.Cut(text, "\n")
 		switch {
 		case line == "":
-			line = "//"
+			line = ""
 		case strings.HasPrefix(line, "\t"):
-			line = "//" + line
+			// code-indented line keeps its tab; the delimiter is added on print
 		default:
-			line = "// " + line
+			line = " " + line
 		}
 		out = append(out, docLine(run[0], line))
 	}
 	if len(directives) > 0 {
-		out = append(out, docLine(run[0], "//"))
+		out = append(out, docLine(run[0], ""))
 		out = append(out, directives...)
 	}
 	if len(out) == 0 {

--- a/rewrite-go/pkg/format/whitespace_splice.go
+++ b/rewrite-go/pkg/format/whitespace_splice.go
@@ -247,7 +247,7 @@ func spaceContentEqual(a, b java.Space) bool {
 	}
 	for i := range a.Comments {
 		x, y := a.Comments[i], b.Comments[i]
-		if x.Kind != y.Kind || x.Text != y.Text || x.Suffix != y.Suffix || x.Multiline != y.Multiline {
+		if x.Multiline != y.Multiline || x.Text != y.Text || x.Suffix != y.Suffix {
 			return false
 		}
 	}

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -3709,7 +3709,7 @@ func extractDirectives(s java.Space) (anns []*java.Annotation, residual java.Spa
 	i := 0
 	for i < len(s.Comments) {
 		c := s.Comments[i]
-		if c.Kind != java.LineComment {
+		if c.Multiline {
 			break
 		}
 		name, sep, args, ok := parseDirective(c.Text)
@@ -3740,10 +3740,7 @@ func extractDirectives(s java.Space) (anns []*java.Annotation, residual java.Spa
 // like `nolint` aren't of the form `PREFIX:NAME` and are left as
 // regular comments.)
 func parseDirective(text string) (name, sep, args string, ok bool) {
-	if !strings.HasPrefix(text, "//") {
-		return "", "", "", false
-	}
-	inner := text[2:]
+	inner := text
 	colonIdx := strings.Index(inner, ":")
 	if colonIdx <= 0 {
 		return "", "", "", false

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -1441,8 +1441,23 @@ func (p *GoPrinter) VisitEmpty(empty *java.Empty, param any) java.J {
 func (p *GoPrinter) visitSpace(space java.Space, out *PrintOutputCapture) {
 	out.Append(space.Whitespace)
 	for _, comment := range space.Comments {
-		out.Append(comment.Text)
+		printComment(comment, out)
 		out.Append(comment.Suffix)
+	}
+}
+
+// printComment emits a comment's source, re-adding the `//` or `/* */`
+// delimiters around its delimiter-free Text. Mirrors Java's
+// TextComment.printComment, which likewise reconstructs the delimiters from
+// the comment kind rather than storing them in the text.
+func printComment(comment java.Comment, out *PrintOutputCapture) {
+	if comment.Multiline {
+		out.Append("/*")
+		out.Append(comment.Text)
+		out.Append("*/")
+	} else {
+		out.Append("//")
+		out.Append(comment.Text)
 	}
 }
 

--- a/rewrite-go/pkg/printer/gomod_printer.go
+++ b/rewrite-go/pkg/printer/gomod_printer.go
@@ -97,7 +97,7 @@ func printGoModBlock(b *golang.GoModBlock, out *PrintOutputCapture) {
 func printGoModSpace(space java.Space, out *PrintOutputCapture) {
 	out.Append(space.Whitespace)
 	for _, comment := range space.Comments {
-		out.Append(comment.Text)
+		printComment(comment, out)
 		out.Append(comment.Suffix)
 	}
 }

--- a/rewrite-go/pkg/recipe/golang/whitespace_validation_service.go
+++ b/rewrite-go/pkg/recipe/golang/whitespace_validation_service.go
@@ -26,10 +26,11 @@ import (
 )
 
 // WhitespaceValidationService walks a tree and reports any Space whose
-// Whitespace or Comment.Suffix contains non-whitespace characters, or
-// any Comment.Text that doesn't begin with `//` or `/*`. Such content
-// indicates a parser bug — the printer would otherwise re-emit
-// non-whitespace as if it were spacing, silently corrupting the source.
+// Whitespace or Comment.Suffix contains non-whitespace characters, a line
+// Comment.Text spanning a newline, or a block Comment.Text containing `*/`.
+// Comment.Text is delimiter-free (like Java's TextComment); a newline in a
+// line comment or a premature `*/` in a block comment indicates a parser bug —
+// the printer would re-emit corrupted source.
 //
 // Recipes get one via recipe.Service:
 //
@@ -131,8 +132,11 @@ func (w *spaceWalker) checkSpace(s java.Space, path string) {
 		if c.Suffix != "" && !isWhitespaceOnly(c.Suffix) {
 			w.errs = append(w.errs, fmt.Sprintf("%s: Comment[%d].Suffix contains non-whitespace: %q", path, i, truncateForError(c.Suffix, 80)))
 		}
-		if c.Text != "" && !strings.HasPrefix(c.Text, "//") && !strings.HasPrefix(c.Text, "/*") {
-			w.errs = append(w.errs, fmt.Sprintf("%s: Comment[%d].Text is not a comment: %q", path, i, truncateForError(c.Text, 80)))
+		if !c.Multiline && strings.ContainsAny(c.Text, "\n\r") {
+			w.errs = append(w.errs, fmt.Sprintf("%s: Comment[%d].Text (line comment) spans a newline: %q", path, i, truncateForError(c.Text, 80)))
+		}
+		if c.Multiline && strings.Contains(c.Text, "*/") {
+			w.errs = append(w.errs, fmt.Sprintf("%s: Comment[%d].Text (block comment) contains %q: %q", path, i, "*/", truncateForError(c.Text, 80)))
 		}
 	}
 }

--- a/rewrite-go/pkg/tree/java/space.go
+++ b/rewrite-go/pkg/tree/java/space.go
@@ -19,19 +19,15 @@ package java
 import "strings"
 
 type Comment struct {
-	Kind      CommentKind
-	Text      string
-	Suffix    string // whitespace after the comment, before the next token
+	// Multiline reports whether this is a block comment (/* */) rather than a
+	// line comment (//). Named to match Java's TextComment.multiline (and the
+	// JS/Python/C# equivalents), where the flag likewise means "is a block
+	// comment", not "spans more than one line".
 	Multiline bool
+	Text      string // content between the delimiters, delimiter-free (like Java's TextComment)
+	Suffix    string // whitespace after the comment, before the next token
 	Markers   Markers
 }
-
-type CommentKind int
-
-const (
-	LineComment CommentKind = iota
-	BlockComment
-)
 
 // This is the fundamental unit of formatting preservation in OpenRewrite.
 type Space struct {
@@ -63,7 +59,8 @@ func (s Space) Indent() string {
 //   - Space.Whitespace = whitespace BEFORE the first comment
 //   - Comment.Suffix = whitespace AFTER each comment
 //
-// The printer emits: Whitespace + (Comment.Text + Comment.Suffix)* to reconstruct the original text.
+// The printer emits Whitespace, then each comment (its `//` or `/* */` delimiters
+// wrapped around Comment.Text) followed by Comment.Suffix, to reconstruct the original text.
 func ParseSpace(raw string) Space {
 	if raw == "" {
 		return EmptySpace
@@ -83,31 +80,30 @@ func ParseSpace(raw string) Space {
 			end := strings.IndexByte(raw[i:], '\n')
 			var text string
 			if end < 0 {
-				text = raw[i:]
+				text = raw[i+2:]
 				i = len(raw)
 			} else {
-				text = raw[i : i+end]
+				text = raw[i+2 : i+end]
 				i = i + end // i now points at \n
 			}
 			suffixEnd := findCommentStart(raw, i)
 			suffix := raw[i:suffixEnd]
 			i = suffixEnd
-			comments = append(comments, Comment{Kind: LineComment, Text: text, Suffix: suffix})
+			comments = append(comments, Comment{Text: text, Suffix: suffix})
 		} else if i+1 < len(raw) && raw[i] == '/' && raw[i+1] == '*' {
 			end := strings.Index(raw[i+2:], "*/")
 			var text string
 			if end < 0 {
-				text = raw[i:]
+				text = raw[i+2:]
 				i = len(raw)
 			} else {
-				text = raw[i : i+2+end+2]
+				text = raw[i+2 : i+2+end]
 				i = i + 2 + end + 2
 			}
-			multiline := strings.Contains(text, "\n")
 			suffixEnd := findCommentStart(raw, i)
 			suffix := raw[i:suffixEnd]
 			i = suffixEnd
-			comments = append(comments, Comment{Kind: BlockComment, Text: text, Suffix: suffix, Multiline: multiline})
+			comments = append(comments, Comment{Multiline: true, Text: text, Suffix: suffix})
 		} else {
 			// Should not happen if findCommentStart works correctly
 			i++

--- a/rewrite-go/pkg/tree/java/space_comment_test.go
+++ b/rewrite-go/pkg/tree/java/space_comment_test.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package java
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParseSpaceCommentTextIsDelimiterFree pins the Java-aligned contract:
+// Comment.Text holds only the content between the delimiters (no `//` or
+// `/* */`), and Multiline distinguishes block comments from line comments.
+func TestParseSpaceCommentTextIsDelimiterFree(t *testing.T) {
+	cases := []struct {
+		name          string
+		raw           string
+		wantMultiline bool
+		wantText      string
+	}{
+		{"line", "// Package anwil\n", false, " Package anwil"},
+		{"line no trailing newline", "//x", false, "x"},
+		{"empty line comment", "//\n", false, ""},
+		{"single-line block", "/* x */ ", true, " x "},
+		{"multi-line block", "/* a\n   b */\n", true, " a\n   b "},
+		{"go directive", "//go:build linux\n", false, "go:build linux"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// when
+			space := ParseSpace(tc.raw)
+
+			// then
+			if len(space.Comments) != 1 {
+				t.Fatalf("want 1 comment, got %d for %q", len(space.Comments), tc.raw)
+			}
+			c := space.Comments[0]
+			if c.Multiline != tc.wantMultiline {
+				t.Errorf("Multiline: want %v, got %v", tc.wantMultiline, c.Multiline)
+			}
+			if c.Text != tc.wantText {
+				t.Errorf("Text: want %q, got %q", tc.wantText, c.Text)
+			}
+			if strings.HasPrefix(c.Text, "//") || strings.HasPrefix(c.Text, "/*") {
+				t.Errorf("Text should be delimiter-free, got %q", c.Text)
+			}
+		})
+	}
+}
+
+// TestParseSpaceRoundTrips verifies that reconstructing the source from the
+// parsed Space (Whitespace, then the delimiters re-added around each comment's
+// Text, then its Suffix) reproduces the input exactly, so stripping the
+// delimiters into Multiline loses nothing.
+func TestParseSpaceRoundTrips(t *testing.T) {
+	inputs := []string{
+		"",
+		"   ",
+		"\n\t",
+		"// leading\n",
+		"  // indented comment\n\t",
+		"/* block */ ",
+		"/* multi\n line\n block */\n",
+		"//go:build linux\n",
+		"\n// first\n// second\nx",
+		"/*a*//*b*/",
+	}
+	for _, in := range inputs {
+		space := ParseSpace(in)
+		var sb strings.Builder
+		sb.WriteString(space.Whitespace)
+		for _, c := range space.Comments {
+			if c.Multiline {
+				sb.WriteString("/*" + c.Text + "*/")
+			} else {
+				sb.WriteString("//" + c.Text)
+			}
+			sb.WriteString(c.Suffix)
+		}
+		if got := sb.String(); got != in {
+			t.Errorf("round-trip mismatch:\n  in:  %q\n  got: %q", in, got)
+		}
+	}
+}

--- a/rewrite-go/test/whitespace_validation_service_test.go
+++ b/rewrite-go/test/whitespace_validation_service_test.go
@@ -68,18 +68,26 @@ func TestWhitespaceValidationService_DetectsCorruption(t *testing.T) {
 	assert.False(t, svc.IsValid(cu), "IsValid should be false when Validate returned errors")
 }
 
-// TestWhitespaceValidationService_DetectsBadComment crafts a Comment
-// whose Text doesn't begin with `//` or `/*` — the printer would emit
-// it raw, so the validator must catch it.
+// TestWhitespaceValidationService_DetectsBadComment crafts comments whose
+// delimiter-free Text carries content it cannot hold — a line comment spanning
+// a newline and a block comment containing `*/` — which the printer would
+// re-emit as corrupted source, so the validator must catch both.
 func TestWhitespaceValidationService_DetectsBadComment(t *testing.T) {
-	cu := &golang.CompilationUnit{
+	lineSpansNewline := &golang.CompilationUnit{
 		Prefix: java.Space{
-			Comments: []java.Comment{{Text: "this is not a comment", Suffix: "\n"}},
+			Comments: []java.Comment{{Multiline: false, Text: "a\nb", Suffix: "\n"}},
+		},
+	}
+	blockClosesEarly := &golang.CompilationUnit{
+		Prefix: java.Space{
+			Comments: []java.Comment{{Multiline: true, Text: " x */ y ", Suffix: "\n"}},
 		},
 	}
 	svc := &recipes.WhitespaceValidationService{}
-	errs := svc.Validate(cu)
-	if len(errs) == 0 {
-		t.Fatal("expected validator to flag a non-comment Text")
+	if errs := svc.Validate(lineSpansNewline); len(errs) == 0 {
+		t.Fatal("expected validator to flag a line comment spanning a newline")
+	}
+	if errs := svc.Validate(blockClosesEarly); len(errs) == 0 {
+		t.Fatal("expected validator to flag a block comment containing */")
 	}
 }


### PR DESCRIPTION
**What**: Fix/Amend how comments are parsed in Go language, including:
- removing the redundant `Kind` field in `Comment`, `Multiline` is the field to distinguish between `//` and `/* */`
- making sure the opening `//` characters are not part of the `Comment.Text`

**Why**

- Unify with other languages