### PR TITLE
Go: a truncated diff hunk header describes the lines it emits

### DIFF
--- a/rewrite-go/pkg/diff/unified.go
+++ b/rewrite-go/pkg/diff/unified.go
@@ -21,6 +21,7 @@ package diff
 
 import (
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -39,11 +40,27 @@ const (
 	noNewlineMarker = `\ No newline at end of file`
 )
 
+// Option adjusts how Unified renders a diff.
+type Option func(*config)
+
+type config struct{ maxLines int }
+
+// Unlimited lifts the maxDiffLines cap, for consumers that feed the output to
+// a patch tool rather than to a reader.
+func Unlimited() Option {
+	return func(c *config) { c.maxLines = math.MaxInt }
+}
+
 // Unified renders a git-style unified diff of before against after,
 // or "" when they are identical.
-func Unified(before, after, path string) string {
+func Unified(before, after, path string, opts ...Option) string {
 	if before == after {
 		return ""
+	}
+
+	cfg := config{maxLines: maxDiffLines}
+	for _, opt := range opts {
+		opt(&cfg)
 	}
 
 	a := splitLines(before)
@@ -69,21 +86,17 @@ func Unified(before, after, path string) string {
 	edits := computeEdits(a, b)
 
 	out := []string{"--- a/" + path, "+++ b/" + path}
-	body := make([]string, 0, maxDiffLines)
+	body := make([]string, 0, min(cfg.maxLines, maxDiffLines))
 	truncated := false
 	for _, hunk := range groupIntoHunks(edits) {
-		if len(body) >= maxDiffLines {
-			truncated = true
-			break
-		}
-		body, truncated = formatHunk(body, maxDiffLines, edits, hunk, a, b, offset)
+		body, truncated = formatHunk(body, cfg.maxLines, edits, hunk, a, b, offset)
 		if truncated {
 			break
 		}
 	}
 	out = append(out, body...)
 	if truncated {
-		out = append(out, fmt.Sprintf("... diff truncated after %d lines", maxDiffLines))
+		out = append(out, fmt.Sprintf("... diff truncated after %d lines", cfg.maxLines))
 	}
 	return strings.Join(out, "\n") + "\n"
 }
@@ -234,9 +247,34 @@ func groupIntoHunks(edits []edit) []hunkRange {
 func formatHunk(out []string, limit int, edits []edit, hunk hunkRange, a, b []string, offset int) ([]string, bool) {
 	hunkEdits := edits[hunk.startEdit : hunk.endEdit+1]
 
+	// The hunk's own header occupies a line of the budget.
+	budget := limit - len(out) - 1
+	if budget <= 0 {
+		return out, true
+	}
+
+	n, truncated := len(hunkEdits), len(hunkEdits) > budget
+	if truncated {
+		// git refuses a hunk that ends on a +/- line before the end of the
+		// file, so the cut lands on the last context line that still leaves a
+		// change above it. A change run longer than the budget offers no such
+		// line and keeps the raw cut: it has no applicable prefix, and the cut
+		// still shows the leading mismatch.
+		n = budget
+		leading := firstChange(hunkEdits)
+		for k := budget; k > leading; k-- {
+			if e := hunkEdits[k-1]; e.kind == editEqual && a[e.aIndex] != noNewlineMarker {
+				n = k
+				break
+			}
+		}
+	}
+
+	// Counting the body first keeps the header's extents equal to what follows.
 	aCount, bCount := 0, 0
 	aStart, bStart := -1, -1
-	for _, e := range hunkEdits {
+	body := make([]string, 0, n)
+	for _, e := range hunkEdits[:n] {
 		if e.kind != editInsert {
 			if aStart < 0 {
 				aStart = e.aIndex
@@ -253,31 +291,36 @@ func formatHunk(out []string, limit int, edits []edit, hunk hunkRange, a, b []st
 				bCount++
 			}
 		}
+		switch {
+		case e.kind == editEqual && a[e.aIndex] == noNewlineMarker:
+			body = append(body, noNewlineMarker)
+		case e.kind == editEqual:
+			body = append(body, " "+a[e.aIndex])
+		case e.kind == editDelete && a[e.aIndex] == noNewlineMarker,
+			e.kind == editInsert && b[e.bIndex] == noNewlineMarker:
+			body = append(body, noNewlineMarker)
+		case e.kind == editDelete:
+			body = append(body, "-"+a[e.aIndex])
+		default:
+			body = append(body, "+"+b[e.bIndex])
+		}
 	}
 
 	out = append(out, fmt.Sprintf("@@ -%d,%d +%d,%d @@",
 		rangeStart(aStart, aCount, offset), aCount,
 		rangeStart(bStart, bCount, offset), bCount))
+	return append(out, body...), truncated
+}
 
-	for _, e := range hunkEdits {
-		if len(out) >= limit {
-			return out, true
-		}
-		switch {
-		case e.kind == editEqual && a[e.aIndex] == noNewlineMarker:
-			out = append(out, noNewlineMarker)
-		case e.kind == editEqual:
-			out = append(out, " "+a[e.aIndex])
-		case e.kind == editDelete && a[e.aIndex] == noNewlineMarker,
-			e.kind == editInsert && b[e.bIndex] == noNewlineMarker:
-			out = append(out, noNewlineMarker)
-		case e.kind == editDelete:
-			out = append(out, "-"+a[e.aIndex])
-		default:
-			out = append(out, "+"+b[e.bIndex])
+// firstChange reports where a hunk's leading context ends: a cut reaching
+// further back would leave the hunk with no changes in it.
+func firstChange(hunkEdits []edit) int {
+	for i, e := range hunkEdits {
+		if e.kind != editEqual {
+			return i
 		}
 	}
-	return out, false
+	return len(hunkEdits)
 }
 
 // rangeStart renders a hunk header's line number, using git's 0 for a side the

--- a/rewrite-go/pkg/diff/unified_test.go
+++ b/rewrite-go/pkg/diff/unified_test.go
@@ -18,10 +18,14 @@ package diff
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func lines(from, to int) string {
@@ -116,6 +120,68 @@ func TestUnifiedTruncatesRunawayDiff(t *testing.T) {
 	out := Unified(before.String(), after.String(), "foo.go")
 	assert.Contains(t, out, "diff truncated")
 	assert.LessOrEqual(t, strings.Count(out, "\n"), maxDiffLines+5)
+	// Pins the cut with no context line to fall back to.
+	assert.Contains(t, out, fmt.Sprintf("@@ -1,%d +0,0 @@", maxDiffLines-1))
+}
+
+// interleaved renders count lines of which every fourth differs, so that
+// truncation lands inside a hunk that mixes context with changes.
+func interleaved(count int) (before, after string) {
+	var a, b strings.Builder
+	for i := 1; i <= count; i++ {
+		fmt.Fprintf(&a, "l%d\n", i)
+		if i%4 == 0 {
+			fmt.Fprintf(&b, "L%d\n", i)
+		} else {
+			fmt.Fprintf(&b, "l%d\n", i)
+		}
+	}
+	return a.String(), b.String()
+}
+
+func TestUnifiedTruncatedDiffStillApplies(t *testing.T) {
+	git, err := exec.LookPath("git")
+	if err != nil {
+		t.Skip("git not on PATH")
+	}
+	before, after := interleaved(maxDiffLines * 2)
+	patch := Unified(before, after, "foo.go")
+	require.Contains(t, patch, "diff truncated")
+
+	dir := t.TempDir()
+	patchFile := filepath.Join(dir, "p.diff")
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "foo.go"), []byte(before), 0o600))
+	require.NoError(t, os.WriteFile(patchFile, []byte(patch), 0o600))
+
+	cmd := exec.Command(git, "apply", "--check", patchFile)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	assert.NoError(t, err, "git apply rejected:\n"+string(out)+"\n"+patch)
+}
+
+func TestUnifiedTruncationKeepsChangesWhenAHunkHasNoInteriorContext(t *testing.T) {
+	var before, after strings.Builder
+	for i := 1; i <= maxDiffLines*3; i++ {
+		fmt.Fprintf(&before, "l%d\n", i)
+		if i > contextLines && i <= maxDiffLines*2 {
+			fmt.Fprintf(&after, "L%d\n", i)
+		} else {
+			fmt.Fprintf(&after, "l%d\n", i)
+		}
+	}
+
+	out := Unified(before.String(), after.String(), "foo.go")
+	require.Contains(t, out, "diff truncated")
+	// A cut reaching past the first change would show only leading context.
+	assert.Contains(t, out, fmt.Sprintf("-l%d", contextLines+1))
+}
+
+func TestUnifiedUnlimitedKeepsTheWholeDiff(t *testing.T) {
+	before, after := interleaved(maxDiffLines * 2)
+
+	out := Unified(before, after, "foo.go", Unlimited())
+	assert.NotContains(t, out, "diff truncated")
+	assert.Contains(t, out, fmt.Sprintf("@@ -1,%d +1,%d @@", maxDiffLines*2, maxDiffLines*2))
 }
 
 func TestUnifiedGiantInputsDoNotBuildFullTable(t *testing.T) {


### PR DESCRIPTION
`diff.Unified` emits a unified diff whose `@@` header advertises the full hunk extents while the body stops at 200 lines, so the output is not a shortened diff but an invalid one. Running a doc-comment recipe over `rewrite-go/pkg/visitor/go_visitor.go` produces `@@ -51,1920 +51,2092 @@` above a 199-line body, and `git apply --check` on it reports `corrupt patch at line 203`. The header looks authoritative, so the output gets trusted: comparing two harnesses over the same tree, one file read as 0 changes in one and 86 in the other, which looked like a behavioural disagreement between them and was a single truncated whole-file hunk.

## Mechanism

`formatHunk` walked all of `hunkEdits` to compute `aCount`/`bCount`, emitted the header from those totals, and only then streamed the body, bailing out mid-loop once `len(out) >= limit`. The header was therefore always written before truncation was known, and never corrected afterwards.

## Why correcting the header is not sufficient on its own

git refuses a hunk that ends on a `+`/`-` line unless the hunk reaches the end of the file, so a header-consistent cut still does not apply. Checked directly against `git apply --check` on a six-line file:

```
REJECTED: ends on +L2      ACCEPTED: one trailing context line
@@ -1,3 +1,3 @@            @@ -1,4 +1,4 @@
 l1                         l1
-l2                        -l2
+L2                        +L2
                            l3
```

So the cut has to land on a context line. It also must not reach *past* the hunk's first change: every hunk begins with up to `contextLines` equal edits, and backing off into those turns a large diff into three unchanged lines under a truncation notice — no diagnostic at all, which is worse than the header bug it would be fixing. `firstChange` bounds the backward scan. A change run longer than the budget offers no valid cut point at all; it keeps the raw cut, which has no applicable prefix but is the only form that still shows the leading mismatch the diagnostic exists to report.

## The line cap is now the caller's

The one in-repo caller is `printIdempotencyError`, which renders the diff into a `ParseError` message where capping at 200 lines is right — nobody wants a ten-thousand-line error string. A machine consumer needs the whole diff. `Unified` takes variadic options and `diff.Unlimited()` lifts the cap; the default and the existing call site are unchanged.

## Tests

`TestUnifiedTruncatedDiffStillApplies` writes the before-content and the truncated diff to a temp directory and runs `git apply --check`, which is the property that actually matters; it reported `corrupt patch at line 203` before the header fix and `patch does not apply` after it but before the context-line cut. `TestUnifiedTruncationKeepsChangesWhenAHunkHasNoInteriorContext` pins the `firstChange` bound and emitted a three-line diff without it. `TestUnifiedTruncatesRunawayDiff` gained an exact header assertion for the no-context path, and `TestUnifiedUnlimitedKeepsTheWholeDiff` covers the option.
