### PR TITLE
C#: preserve declared dependency version ranges on ResolvedPackage

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
@@ -214,6 +214,10 @@ public class CsprojParserTests
         var edge = Assert.Single(placeholder.Dependencies);
         Assert.Equal("Newtonsoft.Json", edge.Name);
         Assert.Equal("13.0.3", edge.ResolvedVersion); // edge links to the RESOLVED node
+        // The DECLARED range from the lock file is preserved alongside the resolved edge
+        var declaredRange = Assert.Single(placeholder.DependencyRanges);
+        Assert.Equal("Newtonsoft.Json", declaredRange.Key);
+        Assert.Equal("[13.0.1, )", declaredRange.Value);
 
         var newtonsoft = tf.ResolvedPackages.Single(p => p.Name == "Newtonsoft.Json");
         Assert.Equal(1, newtonsoft.Depth); // transitive
@@ -224,5 +228,6 @@ public class CsprojParserTests
         Assert.True(newtonsoft.HasInstallScripts);
         Assert.True(newtonsoft.HasXdtTransforms);
         Assert.True(newtonsoft.HasLegacyContentFolder);
+        Assert.Empty(newtonsoft.DependencyRanges);
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProject.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProject.cs
@@ -257,6 +257,9 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
     /// <summary>Package ships a legacy content/ folder (ignored under PackageReference).</summary>
     public bool HasLegacyContentFolder { get; }
 
+    /// <summary>Declared dependency version range per child package id, lock file <c>dependencies</c> section.</summary>
+    public IDictionary<string, string> DependencyRanges { get; }
+
     public ResolvedPackage(
         string name,
         string resolvedVersion,
@@ -274,7 +277,8 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
         IList<string>? analyzerAssemblies = null,
         bool hasInstallScripts = false,
         bool hasXdtTransforms = false,
-        bool hasLegacyContentFolder = false)
+        bool hasLegacyContentFolder = false,
+        IDictionary<string, string>? dependencyRanges = null)
     {
         Name = name;
         ResolvedVersion = resolvedVersion;
@@ -293,6 +297,7 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
         HasInstallScripts = hasInstallScripts;
         HasXdtTransforms = hasXdtTransforms;
         HasLegacyContentFolder = hasLegacyContentFolder;
+        DependencyRanges = dependencyRanges ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     }
 
     public ResolvedPackage WithName(string name) =>
@@ -307,15 +312,20 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
     public ResolvedPackage WithDepth(int depth) =>
         depth == Depth ? this : Copy(depth: depth);
 
+    public ResolvedPackage WithDependencyRanges(IDictionary<string, string> dependencyRanges) =>
+        ReferenceEquals(dependencyRanges, DependencyRanges) ? this : Copy(dependencyRanges: dependencyRanges);
+
     private ResolvedPackage Copy(
         string? name = null,
         string? resolvedVersion = null,
         IList<ResolvedPackage>? dependencies = null,
-        int? depth = null) =>
+        int? depth = null,
+        IDictionary<string, string>? dependencyRanges = null) =>
         new(name ?? Name, resolvedVersion ?? ResolvedVersion, dependencies ?? Dependencies,
             depth ?? Depth, Type, CompileAssemblies, RuntimeAssemblies, FrameworkAssemblies,
             BuildFiles, BuildMultiTargetingFiles, ContentFiles, RuntimeTargets, ResourceAssemblies,
-            AnalyzerAssemblies, HasInstallScripts, HasXdtTransforms, HasLegacyContentFolder);
+            AnalyzerAssemblies, HasInstallScripts, HasXdtTransforms, HasLegacyContentFolder,
+            dependencyRanges ?? DependencyRanges);
 
     public void RpcSend(ResolvedPackage after, RpcSendQueue q)
     {
@@ -338,6 +348,13 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
         q.GetAndSend(after, rp => rp.HasInstallScripts);
         q.GetAndSend(after, rp => rp.HasXdtTransforms);
         q.GetAndSend(after, rp => rp.HasLegacyContentFolder);
+        // Send map as parallel lists: keys then values
+        q.GetAndSendList(after, rp => (IList<string>)new List<string>(rp.DependencyRanges.Keys),
+            k => k,
+            k => q.GetAndSend(k, x => x));
+        q.GetAndSendList(after, rp => (IList<string>)new List<string>(rp.DependencyRanges.Values),
+            v => v,
+            v => q.GetAndSend(v, x => x));
     }
 
     private static void SendStringList(RpcSendQueue q, ResolvedPackage after,
@@ -365,10 +382,18 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
         var hasInstallScripts = q.ReceiveAndGet<bool, bool>(before.HasInstallScripts, x => x);
         var hasXdtTransforms = q.ReceiveAndGet<bool, bool>(before.HasXdtTransforms, x => x);
         var hasLegacyContentFolder = q.ReceiveAndGet<bool, bool>(before.HasLegacyContentFolder, x => x);
+        // Receive parallel lists and zip into dictionary
+        var rangeKeys = ReceiveStringList(q, new List<string>(before.DependencyRanges.Keys));
+        var rangeValues = ReceiveStringList(q, new List<string>(before.DependencyRanges.Values));
+        var dependencyRanges = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var i = 0; i < rangeKeys.Count && i < rangeValues.Count; i++)
+        {
+            dependencyRanges[rangeKeys[i]] = rangeValues[i];
+        }
         return new ResolvedPackage(name, resolvedVersion, dependencies, depth, type,
             compile, runtime, frameworkAssemblies, buildFiles, buildMultiTargeting, contentFiles,
             runtimeTargets, resourceAssemblies, analyzerAssemblies,
-            hasInstallScripts, hasXdtTransforms, hasLegacyContentFolder);
+            hasInstallScripts, hasXdtTransforms, hasLegacyContentFolder, dependencyRanges);
     }
 
     private static IList<string> ReceiveStringList(RpcReceiveQueue q, IList<string> before)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProject.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProject.cs
@@ -348,11 +348,12 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
         q.GetAndSend(after, rp => rp.HasInstallScripts);
         q.GetAndSend(after, rp => rp.HasXdtTransforms);
         q.GetAndSend(after, rp => rp.HasLegacyContentFolder);
-        // Send map as parallel lists: keys then values
-        q.GetAndSendList(after, rp => (IList<string>)new List<string>(rp.DependencyRanges.Keys),
+        // Send map as parallel lists: keys then values. Instances materialized by the RPC
+        // layer bypass the constructor, so the dictionary can be null.
+        q.GetAndSendList(after, rp => (IList<string>)(rp.DependencyRanges == null ? [] : new List<string>(rp.DependencyRanges.Keys)),
             k => k,
             k => q.GetAndSend(k, x => x));
-        q.GetAndSendList(after, rp => (IList<string>)new List<string>(rp.DependencyRanges.Values),
+        q.GetAndSendList(after, rp => (IList<string>)(rp.DependencyRanges == null ? [] : new List<string>(rp.DependencyRanges.Values)),
             v => v,
             v => q.GetAndSend(v, x => x));
     }
@@ -382,9 +383,11 @@ public sealed class ResolvedPackage : IRpcCodec<ResolvedPackage>
         var hasInstallScripts = q.ReceiveAndGet<bool, bool>(before.HasInstallScripts, x => x);
         var hasXdtTransforms = q.ReceiveAndGet<bool, bool>(before.HasXdtTransforms, x => x);
         var hasLegacyContentFolder = q.ReceiveAndGet<bool, bool>(before.HasLegacyContentFolder, x => x);
-        // Receive parallel lists and zip into dictionary
-        var rangeKeys = ReceiveStringList(q, new List<string>(before.DependencyRanges.Keys));
-        var rangeValues = ReceiveStringList(q, new List<string>(before.DependencyRanges.Values));
+        // Receive parallel lists and zip into dictionary. The before instance can be an
+        // RPC-materialized skeleton whose dictionary is null.
+        var beforeRanges = before.DependencyRanges ?? new Dictionary<string, string>();
+        var rangeKeys = ReceiveStringList(q, new List<string>(beforeRanges.Keys));
+        var rangeValues = ReceiveStringList(q, new List<string>(beforeRanges.Values));
         var dependencyRanges = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         for (var i = 0; i < rangeKeys.Count && i < rangeValues.Count; i++)
         {

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -261,6 +261,16 @@ public static class MSBuildProjectHelper
                     }
                 }
 
+                var dependencyRanges = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                if (library.Dependencies != null)
+                {
+                    foreach (var dependency in library.Dependencies)
+                    {
+                        if (dependency.VersionRange != null)
+                            dependencyRanges[dependency.Id] = dependency.VersionRange.ToNormalizedString();
+                    }
+                }
+
                 var node = new ResolvedPackage(
                     library.Name,
                     library.Version.ToNormalizedString(),
@@ -278,7 +288,8 @@ public static class MSBuildProjectHelper
                     analyzerAssemblies: analyzers,
                     hasInstallScripts: hasInstallScripts,
                     hasXdtTransforms: hasXdt,
-                    hasLegacyContentFolder: hasLegacyContent);
+                    hasLegacyContentFolder: hasLegacyContent,
+                    dependencyRanges: dependencyRanges);
                 nodes[library.Name] = node;
                 dependencyNames[library.Name] =
                     library.Dependencies?.Select(d => d.Id).ToList() ?? new List<string>();

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marker/MSBuildProject.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marker/MSBuildProject.java
@@ -335,9 +335,12 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
             q.getAndSend(after, ResolvedPackage::isHasInstallScripts);
             q.getAndSend(after, ResolvedPackage::isHasXdtTransforms);
             q.getAndSend(after, ResolvedPackage::isHasLegacyContentFolder);
-            // Send map as parallel lists: keys then values
-            sendStringList(q, after, rp -> new ArrayList<>(rp.getDependencyRanges().keySet()));
-            sendStringList(q, after, rp -> new ArrayList<>(rp.getDependencyRanges().values()));
+            // Send map as parallel lists: keys then values. Instances materialized by the RPC
+            // layer bypass the constructor, so the map can be null despite @Builder.Default.
+            sendStringList(q, after, rp -> rp.dependencyRanges == null ?
+                    new ArrayList<>() : new ArrayList<>(rp.dependencyRanges.keySet()));
+            sendStringList(q, after, rp -> rp.dependencyRanges == null ?
+                    new ArrayList<>() : new ArrayList<>(rp.dependencyRanges.values()));
         }
 
         private static void sendStringList(RpcSendQueue q, ResolvedPackage after,
@@ -370,9 +373,11 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
                     .withHasInstallScripts(q.receive(before.hasInstallScripts))
                     .withHasXdtTransforms(q.receive(before.hasXdtTransforms))
                     .withHasLegacyContentFolder(q.receive(before.hasLegacyContentFolder));
-            // Receive parallel lists and zip into map
-            List<String> rangeKeys = receiveStringList(q, new ArrayList<>(before.dependencyRanges.keySet()));
-            List<String> rangeValues = receiveStringList(q, new ArrayList<>(before.dependencyRanges.values()));
+            // Receive parallel lists and zip into map. The before instance can be an RPC-materialized
+            // skeleton whose map is null despite @Builder.Default.
+            Map<String, String> beforeRanges = before.dependencyRanges == null ? emptyMap() : before.dependencyRanges;
+            List<String> rangeKeys = receiveStringList(q, new ArrayList<>(beforeRanges.keySet()));
+            List<String> rangeValues = receiveStringList(q, new ArrayList<>(beforeRanges.values()));
             Map<String, String> ranges = new LinkedHashMap<>();
             if (rangeKeys != null && rangeValues != null) {
                 for (int i = 0; i < rangeKeys.size() && i < rangeValues.size(); i++) {

--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/marker/MSBuildProject.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/marker/MSBuildProject.java
@@ -308,6 +308,12 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
          */
         boolean hasLegacyContentFolder;
 
+        /**
+         * Declared dependency version range per child package id, lock file {@code dependencies} section.
+         */
+        @Builder.Default
+        Map<String, String> dependencyRanges = emptyMap();
+
         @Override
         public void rpcSend(ResolvedPackage after, RpcSendQueue q) {
             q.getAndSend(after, ResolvedPackage::getName);
@@ -329,6 +335,9 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
             q.getAndSend(after, ResolvedPackage::isHasInstallScripts);
             q.getAndSend(after, ResolvedPackage::isHasXdtTransforms);
             q.getAndSend(after, ResolvedPackage::isHasLegacyContentFolder);
+            // Send map as parallel lists: keys then values
+            sendStringList(q, after, rp -> new ArrayList<>(rp.getDependencyRanges().keySet()));
+            sendStringList(q, after, rp -> new ArrayList<>(rp.getDependencyRanges().values()));
         }
 
         private static void sendStringList(RpcSendQueue q, ResolvedPackage after,
@@ -342,7 +351,7 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
 
         @Override
         public ResolvedPackage rpcReceive(ResolvedPackage before, RpcReceiveQueue q) {
-            return before
+            ResolvedPackage result = before
                     .withName(q.receive(before.name))
                     .withResolvedVersion(q.receive(before.resolvedVersion))
                     .withDependencies(q.receiveList(before.dependencies,
@@ -361,6 +370,16 @@ public class MSBuildProject implements Marker, Serializable, RpcCodec<MSBuildPro
                     .withHasInstallScripts(q.receive(before.hasInstallScripts))
                     .withHasXdtTransforms(q.receive(before.hasXdtTransforms))
                     .withHasLegacyContentFolder(q.receive(before.hasLegacyContentFolder));
+            // Receive parallel lists and zip into map
+            List<String> rangeKeys = receiveStringList(q, new ArrayList<>(before.dependencyRanges.keySet()));
+            List<String> rangeValues = receiveStringList(q, new ArrayList<>(before.dependencyRanges.values()));
+            Map<String, String> ranges = new LinkedHashMap<>();
+            if (rangeKeys != null && rangeValues != null) {
+                for (int i = 0; i < rangeKeys.size() && i < rangeValues.size(); i++) {
+                    ranges.put(rangeKeys.get(i), rangeValues.get(i));
+                }
+            }
+            return result.withDependencyRanges(ranges);
         }
     }
 

--- a/rewrite-csharp/src/test/java/org/openrewrite/csharp/marker/MSBuildProjectTest.java
+++ b/rewrite-csharp/src/test/java/org/openrewrite/csharp/marker/MSBuildProjectTest.java
@@ -42,11 +42,22 @@ class MSBuildProjectTest {
         MSBuildProject.PackageReference ref = new MSBuildProject.PackageReference(
           "Newtonsoft.Json", "$(NJVersion)", "13.0.3");
 
+        Map<String, String> dependencyRanges = new LinkedHashMap<>();
+        dependencyRanges.put("Newtonsoft.Json", "[13.0.1, )");
+        MSBuildProject.ResolvedPackage app = MSBuildProject.ResolvedPackage.builder()
+          .name("My.App.Core")
+          .resolvedVersion("1.0.0")
+          .depth(0)
+          .dependencyRanges(dependencyRanges)
+          .build();
+
         MSBuildProject.ResolvedPackage resolved = MSBuildProject.ResolvedPackage.builder()
           .name("Newtonsoft.Json")
           .resolvedVersion("13.0.3")
           .depth(0)
           .build();
+        assertThat(resolved.getDependencyRanges()).isEmpty();
+        assertThat(app.getDependencyRanges()).containsEntry("Newtonsoft.Json", "[13.0.1, )");
 
         MSBuildProject.ProjectReference projRef = new MSBuildProject.ProjectReference("../Lib/Lib.csproj");
 


### PR DESCRIPTION
The NuGet lock file records both a resolved version and the version range each package declared for its children, but only the resolved version was carried into the `MSBuildProject` marker — so consumers could not tell what range a dependency was originally declared with (needed for dependency vulnerability analysis).

This adds a `dependencyRanges` map (child package id → normalized version range) to `ResolvedPackage` on both the Java and C# sides, populates it from the lock file `dependencies` section in `MSBuildProjectHelper`, and serializes it over RPC as parallel key/value lists. Tests were added on both sides covering a package with declared ranges and one without.

`:rewrite-csharp:test --tests "*MSBuildProjectTest*"` and `:rewrite-csharp:csharpTest` (2363 tests) both pass locally.