### PR TITLE
Groovy: Fix AutoFormat behavior for tuple unpacking assignments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyParserVisitor.java
@@ -3166,13 +3166,15 @@ public class GroovyParserVisitor {
             for (int i = 0; i < varExprs.size(); i++) {
                 VariableExpression varExpr = varExprs.get(i);
                 TypeTree innerType = visitVariableExpressionType(varExpr);
+                Space innerPrefix = innerType.getPrefix();
+                innerType = innerType.withPrefix(EMPTY);
                 J.Identifier name = doVisit(varExpr);
                 J.VariableDeclarations.NamedVariable nv = new J.VariableDeclarations.NamedVariable(
                         randomId(), name.getPrefix(), Markers.EMPTY,
                         name.withPrefix(EMPTY), emptyList(), null,
                         typeMapping.variableType(name.getSimpleName(), innerType.getType()));
                 J.VariableDeclarations innerDecl = new J.VariableDeclarations(
-                        randomId(), EMPTY, Markers.EMPTY, emptyList(), emptyList(),
+                        randomId(), innerPrefix, Markers.EMPTY, emptyList(), emptyList(),
                         innerType, null, singletonList(JRightPadded.build(nv)));
                 Space after = i < varExprs.size() - 1 ? sourceBefore(",") : sourceBefore(")");
                 tupleVars.add(JRightPadded.<J.VariableDeclarations>build(innerDecl).withAfter(after));

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MergeSpacesVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MergeSpacesVisitor.java
@@ -210,6 +210,25 @@ public class MergeSpacesVisitor extends GroovyVisitor<Object> {
     }
 
     @Override
+    public J visitTupleExpression(G.TupleExpression tuple, @Nullable Object ctx) {
+        if (tuple == ctx || !(ctx instanceof G.TupleExpression)) {
+            return tuple;
+        }
+        G.TupleExpression newTuple = (G.TupleExpression) ctx;
+        G.TupleExpression t = tuple;
+        t = t.withPrefix(visitSpace(t.getPrefix(), GSpace.Location.TUPLE_PREFIX, newTuple.getPrefix()));
+        t = t.withMarkers(visitMarkers(t.getMarkers(), newTuple.getMarkers()));
+        Expression temp = (Expression) visitExpression(t, newTuple);
+        if (!(temp instanceof G.TupleExpression)) {
+            return temp;
+        } else {
+            t = (G.TupleExpression) temp;
+        }
+        t = t.getPadding().withVariables(visitContainer(t.getPadding().getVariables(), GContainer.Location.TUPLE_ELEMENTS, newTuple.getPadding().getVariables()));
+        return t.withType(visitType(t.getType(), newTuple.getType()));
+    }
+
+    @Override
     public @Nullable J visit(@Nullable Tree tree, Object o) {
         if (o instanceof J.Block && !(tree instanceof J.Block)) {
             //Wrapping can introduce blocks

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MinimumViableSpacingVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/MinimumViableSpacingVisitor.java
@@ -21,6 +21,8 @@ import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.TypeTree;
 
 public class MinimumViableSpacingVisitor<P> extends org.openrewrite.java.format.MinimumViableSpacingVisitor<P> {
     @Nullable
@@ -29,6 +31,27 @@ public class MinimumViableSpacingVisitor<P> extends org.openrewrite.java.format.
     public MinimumViableSpacingVisitor(@Nullable Tree stopAfter) {
         super(stopAfter);
         this.stopAfter = stopAfter;
+    }
+
+    @Override
+    public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, P p) {
+        J.VariableDeclarations v = super.visitVariableDeclarations(multiVariable, p);
+
+        // Groovy's `def`/`var` and destructuring declarations carry an empty (name-less) type expression.
+        // Since it renders nothing, the superclass' "space before the type" and "space before the first
+        // variable" collapse onto the same spot and double up. Keep at most a single separating space,
+        // and only when a modifier or annotation precedes it.
+        TypeTree typeExpression = v.getTypeExpression();
+        if (typeExpression instanceof J.Identifier && ((J.Identifier) typeExpression).getSimpleName().isEmpty()) {
+            boolean needsLeadingSpace = !v.getLeadingAnnotations().isEmpty() || !v.getModifiers().isEmpty();
+            v = v.withTypeExpression(typeExpression.withPrefix(
+                    typeExpression.getPrefix().withWhitespace(needsLeadingSpace ? " " : "")));
+            if (!v.getVariables().isEmpty()) {
+                v = v.withVariables(Space.formatFirstPrefix(v.getVariables(),
+                        v.getVariables().get(0).getPrefix().withWhitespace("")));
+            }
+        }
+        return v;
     }
 
     @Override

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
@@ -30,6 +30,18 @@ class AutoFormatVisitorTest implements RewriteTest {
         spec.recipe(new AutoFormat());
     }
 
+    @Test
+    void tupleDeclaration() {
+        rewriteRun(
+          groovy(
+            """
+              def parts = "org:lib:1.0".split(":")
+              def (group, artifact, version) = parts
+              """
+          )
+        );
+    }
+
     @Issue("https://github.com/openrewrite/rewrite/issues/4531")
     @Test
     void preserveSpaceBeforeAsKeywordInCast() {


### PR DESCRIPTION
## What's changed?

Fix Groovy AutoFormat logic for handling unpacking assignments like:
```
def (group, artifact, version) = parts
```

## What's your motivation?

Otherwise they might fail with:
```
java.lang.ClassCastException: class org.openrewrite.groovy.tree.G$TupleExpression cannot be cast to class org.openrewrite.java.tree.JContainer (org.openrewrite.groovy.tree.G$TupleExpression and org.openrewrite.java.tree.JContainer are in unnamed module of loader 'app')
  org.openrewrite.groovy.format.MergeSpacesVisitor.visitContainer(MergeSpacesVisitor.java:1744)
  org.openrewrite.groovy.format.MergeSpacesVisitor.visitContainer(MergeSpacesVisitor.java:1676)
  org.openrewrite.groovy.GroovyVisitor.visitTupleExpression(GroovyVisitor.java:158)
  org.openrewrite.groovy.tree.G$TupleExpression.acceptGroovy(G.java:1090)
  org.openrewrite.groovy.tree.G.accept(G.java:49)
  org.openrewrite.TreeVisitor.visit(TreeVisitor.java:242)
  org.openrewrite.groovy.format.MergeSpacesVisitor.visit(MergeSpacesVisitor.java:223)
```