### PR TITLE
Python: a decorator is typed as the thing it decorates

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -2314,6 +2314,11 @@ class ParserVisitor(ast.NodeVisitor):
                 decorator_type = self._type_mapping.decorator_type(referenced)
                 if decorator_type is not None:
                     name = name.replace(type=decorator_type)  # ty: ignore[unresolved-attribute]  # recursive call returns unknown
+                    if isinstance(name, j.FieldAccess):
+                        # Both halves of a dotted reference name the same decorator
+                        padded = name.padding.name
+                        name = name.padding.replace(_name=padded.replace(
+                            element=padded.element.replace(type=decorator_type)))
 
         # Wrap name in extra parentheses if present
         if extra_parens:

--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -2307,6 +2307,13 @@ class ParserVisitor(ast.NodeVisitor):
         # When extra_parens is non-empty, this is handled differently (prefix is set on the wrapped paren).
         if not extra_parens:
             name = name.replace(prefix=name_prefix)  # ty: ignore[unresolved-attribute]  # recursive call returns unknown
+            # Name the decorator itself, as Java names an annotation type, rather than
+            # leave the reference typed as what applying it returns.
+            referenced = decorator.func if isinstance(decorator, ast.Call) else decorator
+            if isinstance(referenced, (ast.Name, ast.Attribute)):
+                decorator_type = self._type_mapping.decorator_type(referenced)
+                if decorator_type is not None:
+                    name = name.replace(type=decorator_type)  # ty: ignore[unresolved-attribute]  # recursive call returns unknown
 
         # Wrap name in extra parentheses if present
         if extra_parens:

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -913,26 +913,28 @@ class PythonTypeMapping:
         annotation: the decorating function or class itself, under the module the source
         imported it from — not the type applying it returns.
 
-        A decorator an untyped factory produced (Django's
-        ``require_GET = require_http_methods(["GET"])``) has no type ty can infer at all,
-        so an unshadowed import binding stands in for one.
+        The written name an unshadowed import binding resolves says which module that is:
+        ``@pkg.api.tag`` names ``pkg.api.tag`` where ty names the ``pkg._impl`` defining it.
+        It also names a decorator ty cannot type at all.
         """
         type_id = self._lookup_type_id(node)
         descriptor = self._type_registry.get(type_id) if type_id is not None else None
-        if descriptor is not None:
-            kind = descriptor.get('kind')
-            if kind == 'classLiteral':
-                return self._resolve_type(type_id)
-            # A bound method belongs to its class, whose own type the receiver carries
-            if kind in _FUNCTION_KINDS and not descriptor.get('className'):
-                name = descriptor.get('name')
-                module = descriptor.get('moduleName')
-                if isinstance(node, ast.Name):
-                    module = self._from_import_module(type_id, node.id) or module
-                if module and name:
-                    return self._create_class_type(f"{module}.{name}")
+        if descriptor is not None and descriptor.get('kind') == 'classLiteral':
+            # A resolved class beats the shell the written path would mint
+            return self._resolve_type(type_id)
         fqn = self._import_binding_fqn(node)
-        return self._create_class_type(fqn) if fqn else self.type(node)
+        if fqn:
+            return self._create_class_type(fqn)
+        if descriptor is not None and descriptor.get('kind') in _FUNCTION_KINDS:
+            name = descriptor.get('name')
+            # Keyed on ty's type id, so it resolves names the scope-blind
+            # binding index above treats as shadowed.
+            module = descriptor.get('moduleName')
+            if isinstance(node, ast.Name):
+                module = self._from_import_module(type_id, node.id) or module
+            if module and name and not descriptor.get('className'):
+                return self._create_class_type(f"{module}.{name}")
+        return self.type(node)
 
     def _import_binding_fqn(self, node: ast.expr) -> Optional[str]:
         """The FQN an unshadowed module-level import gives ``node``'s written name."""
@@ -962,7 +964,8 @@ class PythonTypeMapping:
             top_level = set()
 
             def bind(name: str, fqn: Optional[str]) -> None:
-                if fqn is None or name in bindings:
+                # `import a.b` after `import a` re-binds the root to the same FQN
+                if fqn is None or bindings.get(name, fqn) != fqn:
                     shadowed.add(name)
                 else:
                     bindings[name] = fqn

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -203,10 +203,11 @@ class PythonTypeMapping:
         self._byte_offset_cache: Dict[Tuple[int, int], int] = {}
         self._lookup_cache: Dict[tuple, Optional[int]] = {}
 
-        # Lazily populated by _module_ast / _from_import_module
+        # Lazily populated by _module_ast / _from_import_module / _import_bindings
         self._module_ast_parsed = False
         self._module_ast_tree: Optional[ast.Module] = None
         self._from_import_index: Optional[Dict[Tuple[int, str], str]] = None
+        self._import_binding_index: Optional[Dict[str, str]] = None
 
         # ty-types data: populated by _build_index
         self._node_index: Dict[Tuple[int, int], Tuple[int, str]] = {}  # (start, end) -> (type_id, node_kind)
@@ -906,6 +907,103 @@ class PythonTypeMapping:
         if descriptor and self._is_variable_descriptor(descriptor):
             return expr_type, JavaType.Variable(_name=node.attr, _type=expr_type, _owner=receiver_type)
         return expr_type, None
+
+    def decorator_type(self, node: ast.expr) -> Optional[JavaType]:
+        """The type naming the decorator ``node`` applies, the way Java names an
+        annotation: the decorating function or class itself, under the module the source
+        imported it from — not the type applying it returns.
+
+        A decorator an untyped factory produced (Django's
+        ``require_GET = require_http_methods(["GET"])``) has no type ty can infer at all,
+        so an unshadowed import binding stands in for one.
+        """
+        type_id = self._lookup_type_id(node)
+        descriptor = self._type_registry.get(type_id) if type_id is not None else None
+        if descriptor is not None:
+            kind = descriptor.get('kind')
+            if kind == 'classLiteral':
+                return self._resolve_type(type_id)
+            # A bound method belongs to its class, whose own type the receiver carries
+            if kind in _FUNCTION_KINDS and not descriptor.get('className'):
+                name = descriptor.get('name')
+                module = descriptor.get('moduleName')
+                if isinstance(node, ast.Name):
+                    module = self._from_import_module(type_id, node.id) or module
+                if module and name:
+                    return self._create_class_type(f"{module}.{name}")
+        fqn = self._import_binding_fqn(node)
+        return self._create_class_type(fqn) if fqn else self.type(node)
+
+    def _import_binding_fqn(self, node: ast.expr) -> Optional[str]:
+        """The FQN an unshadowed module-level import gives ``node``'s written name."""
+        suffix: List[str] = []
+        while isinstance(node, ast.Attribute):
+            suffix.append(node.attr)
+            node = node.value
+        if not isinstance(node, ast.Name):
+            return None
+        bound = self._import_bindings().get(node.id)
+        return '.'.join([bound, *reversed(suffix)]) if bound else None
+
+    def _import_bindings(self) -> Dict[str, str]:
+        """The FQN each of this file's absolute module-level imports names, keyed by the
+        name it binds, minus every name the file binds a second time.
+
+        Python binds a name once per scope, so an import nothing else rebinds says what a
+        reference to that name means whether or not ty could type it. Anything that could
+        rebind — an assignment, a ``def``, a parameter, a second import — disqualifies the
+        name rather than being scoped precisely, since a decorator naming a shadowed
+        symbol is not worth a false attribution.
+        """
+        if self._import_binding_index is None:
+            tree = self._module_ast()
+            bindings: Dict[str, str] = {}
+            shadowed: Set[str] = set()
+            top_level = set()
+
+            def bind(name: str, fqn: Optional[str]) -> None:
+                if fqn is None or name in bindings:
+                    shadowed.add(name)
+                else:
+                    bindings[name] = fqn
+
+            for stmt in tree.body if tree else ():
+                if isinstance(stmt, (ast.Import, ast.ImportFrom)):
+                    top_level.update(id(alias) for alias in stmt.names)
+                    # A relative import's written form is not a module path
+                    relative = isinstance(stmt, ast.ImportFrom) and (stmt.level or not stmt.module)
+                    for alias in stmt.names:
+                        if isinstance(stmt, ast.Import):
+                            # A non-aliased `import a.b` binds the root package `a`
+                            root = alias.name.split('.')[0]
+                            bind(alias.asname or root, alias.name if alias.asname else root)
+                        elif alias.name == '*':
+                            # A star import can bind any name, so nothing here is decidable
+                            self._import_binding_index = {}
+                            return self._import_binding_index
+                        elif relative:
+                            bind(alias.asname or alias.name, None)
+                        else:
+                            bind(alias.asname or alias.name, f"{stmt.module}.{alias.name}")
+
+            for node in ast.walk(tree) if tree else ():
+                if isinstance(node, ast.Name):
+                    if isinstance(node.ctx, (ast.Store, ast.Del)):
+                        shadowed.add(node.id)
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    shadowed.add(node.name)
+                elif isinstance(node, ast.arg):
+                    shadowed.add(node.arg)
+                elif isinstance(node, ast.ExceptHandler) and node.name:
+                    shadowed.add(node.name)
+                elif isinstance(node, (ast.Global, ast.Nonlocal)):
+                    shadowed.update(node.names)
+                elif isinstance(node, ast.alias) and id(node) not in top_level:
+                    shadowed.add(node.asname or node.name.split('.')[0])
+
+            self._import_binding_index = {name: fqn for name, fqn in bindings.items()
+                                          if name not in shadowed}
+        return self._import_binding_index
 
     def import_alias_type(self, node: ast.alias) -> Optional[JavaType]:
         """The type of the symbol an import name binds, named under the module the

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2515,7 +2515,9 @@ def _parse_with_types(files: dict, main_filename: str = 'm.py'):
     files = {name: dedent(src) for name, src in files.items()}
     tmpdir = tempfile.mkdtemp()
     for name, src in files.items():
-        with open(os.path.join(tmpdir, name), 'w') as f:
+        path = os.path.join(tmpdir, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, 'w') as f:
             f.write(src)
     client = TyTypesClient()
     client.initialize(tmpdir)
@@ -3837,3 +3839,45 @@ class TestDecoratorAttribution:
             'from deco import require\n\nrequire = None\n\n@require\ndef f():\n    pass\n')
         assert not (isinstance(t, JavaType.Class) and
                     t.fully_qualified_name == 'deco.require'), f"falsely attributed {t!r}"
+
+    # A package re-exporting from a private module, the shape pytest and click have
+    PACKAGE = {
+        'pkg/__init__.py': '',
+        'pkg/_impl.py': 'def tag(fn):\n    return fn\n',
+        'pkg/api.py': 'from pkg._impl import tag\n',
+    }
+
+    def _assert_named_in_package(self, src, fqn):
+        cu, tmpdir, client = _parse_with_types({**self.PACKAGE, 'm.py': src})
+        try:
+            t = cu.statements[-1].leading_annotations[0].annotation_type.type
+            assert isinstance(t, JavaType.Class), f"expected Class, got {t!r}"
+            assert t.fully_qualified_name == fqn
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+    def test_dotted_decorator_types_the_identifier_too(self):
+        cu, tmpdir, client = _parse_with_types(
+            {'deco.py': self.DECORATORS, 'm.py': 'import deco\n\n@deco.wrap\ndef f():\n    pass\n'})
+        try:
+            at = cu.statements[-1].leading_annotations[0].annotation_type
+            assert at.type.fully_qualified_name == 'deco.wrap'
+            assert at.name.type is at.type
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+    def test_decorator_the_file_defines_itself(self):
+        self._assert_named('def wrap(fn):\n    return fn\n\n@wrap\ndef f():\n    pass\n', 'm.wrap')
+
+    def test_dotted_decorator_names_the_module_re_exporting_it(self):
+        self._assert_named_in_package(
+            'import pkg.api\n\n@pkg.api.tag\ndef f():\n    pass\n', 'pkg.api.tag')
+
+    def test_re_export_survives_an_unrelated_rebinding_of_the_name(self):
+        self._assert_named_in_package(
+            'from pkg.api import tag\n\ndef g(tag):\n    return tag\n\n@tag\ndef f():\n    pass\n',
+            'pkg.api.tag')
+
+    def test_a_package_and_its_submodule_bind_the_same_root(self):
+        self._assert_named_in_package(
+            'import pkg\nimport pkg.api\n\n@pkg.api.tag\ndef f():\n    pass\n', 'pkg.api.tag')

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3768,3 +3768,72 @@ class TestImportNameAttribution:
     def test_unresolvable_import_stays_untyped(self):
         t = self._qualid_type('from nonexistent_module_xyz import something\n')
         assert t is None or isinstance(t, JavaType.Unknown)
+
+
+@requires_ty_types_cli
+class TestDecoratorAttribution:
+    """A decorator's annotation type names the function or class it applies, under the
+    module the source imported it from — not the type applying it returns."""
+
+    DECORATORS = """
+        def wrap(fn):
+            return fn
+
+
+        def factory(*methods):
+            def decorator(fn):
+                return fn
+            return decorator
+
+
+        require = factory("GET")
+
+
+        class Registered:
+            def __init__(self, cls):
+                self.cls = cls
+    """
+
+    def _decorator_type(self, src):
+        cu, tmpdir, client = _parse_with_types({'deco.py': self.DECORATORS, 'm.py': src})
+        try:
+            return cu.statements[-1].leading_annotations[0].annotation_type.type
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+    def _assert_named(self, src, fqn):
+        t = self._decorator_type(src)
+        assert isinstance(t, JavaType.Class), f"expected Class, got {t!r}"
+        assert t.fully_qualified_name == fqn
+
+    def test_function_decorator(self):
+        self._assert_named('from deco import wrap\n\n@wrap\ndef f():\n    pass\n', 'deco.wrap')
+
+    def test_decorator_factory_call_names_the_factory(self):
+        self._assert_named("from deco import factory\n\n@factory('GET')\ndef f():\n    pass\n",
+                           'deco.factory')
+
+    def test_aliased_decorator_names_the_symbol_imported(self):
+        self._assert_named('from deco import wrap as w\n\n@w\ndef f():\n    pass\n', 'deco.wrap')
+
+    def test_dotted_decorator(self):
+        self._assert_named('import deco\n\n@deco.wrap\ndef f():\n    pass\n', 'deco.wrap')
+
+    def test_class_decorator_keeps_its_class_type(self):
+        self._assert_named('from deco import Registered\n\n@Registered\nclass C:\n    pass\n',
+                           'deco.Registered')
+
+    def test_decorator_an_untyped_factory_produced(self):
+        # ty has no type for `require` at all; the import binding is what names it
+        self._assert_named('from deco import require\n\n@require\ndef f():\n    pass\n',
+                           'deco.require')
+
+    def test_decorator_on_class_from_untyped_factory(self):
+        self._assert_named('from deco import require\n\n@require\nclass C:\n    pass\n',
+                           'deco.require')
+
+    def test_rebound_name_is_not_attributed_from_its_import(self):
+        t = self._decorator_type(
+            'from deco import require\n\nrequire = None\n\n@require\ndef f():\n    pass\n')
+        assert not (isinstance(t, JavaType.Class) and
+                    t.fully_qualified_name == 'deco.require'), f"falsely attributed {t!r}"


### PR DESCRIPTION
## What's wrong

A Python decorator reached the LST typed as *what applying it returns*, not as the thing being applied. `_descriptor_to_java_type` maps a `function` descriptor to its `returnType`, so for

```python
from rest_framework.decorators import api_view

@api_view(['GET'])
def item_list(request): ...
```

`J.Annotation.getAnnotationType().getType()` was:

| dependencies installed | annotation type |
|---|---|
| `djangorestframework` | `Unknown` — DRF is untyped, so ty reports no `returnType` |
| `+ djangorestframework-stubs` | `rest_framework.views.AsView` — the stub's return type |

Neither names the decorator. Downstream, `io.moderne.prethink.calm.FindDjangoEndpoints` had grown a `TypeUtils.isOfClassType(type, "rest_framework.views.AsView")` check to work around it, which only matched in test fixtures that installed stubs and never in a real repository (moderneinc/rewrite-prethink#135).

Django's function-view decorators are worse than untyped. `require_GET` is

```python
require_GET = require_http_methods(["GET"])
```

— the result of an untyped factory. ty reports `{'kind': 'dynamic', 'dynamicKind': 'Unknown'}` and no stub package changes that.

## What this does

Java names an annotation by its own type and a Python decorator maps onto `J.Annotation`, so the annotation type is now the function or class being applied, named `<module>.<name>` under the module the source imported it from — the same naming `method_invocation_type` already gives a call to it:

```
@api_view(['GET'])                      rest_framework.decorators.api_view
@require_http_methods(["GET", "POST"])  django.views.decorators.http.require_http_methods
@require_GET                            django.views.decorators.http.require_GET
```

The last of those comes from the file's imports rather than from ty. That is not a fallback heuristic: Python binds a name once per scope, so an unshadowed module-level `from M import N` **is** the definition of what `N` refers to in that file. `_import_bindings` reads those bindings and disqualifies any name the file binds a second time — an assignment, a `def`/`class`, a parameter, an `except ... as`, a `global`, a nested import — and gives up entirely on a star import. A shadowed name is left to whatever ty said rather than falsely attributed.

`decorator_type` resolves a class decorator to its own class type, since a fully resolved class carries more than the shell a written name would mint. Everything else is named by the written path an import binding resolves, which takes precedence over ty's definition site — ty attributes a symbol where it is defined, which for a re-exported one is a private module nobody imports from:

```
@pytest.fixture     pytest.fixture      (ty: _pytest.fixtures.fixture)
@click.command()    click.command       (ty: click.decorators.command)
@np.vectorize       numpy.vectorize     (ty: numpy.lib.function_base.vectorize)
```

Neither private spelling is a name a recipe author can write in advance, and the stdlib equivalents are platform-dependent besides. Where no binding covers the name — a decorator the file defines itself, or one the conservative disqualification rules out — ty's defining module names it, corrected by any `from M import f` in the file. That correction keys on ty's type id, so it holds where the scope-blind disqualification does not: without it an unrelated `def g(tag)` anywhere in the file flips `@tag` from `pkg.api.tag` to `pkg._impl.tag`.

Both halves of a dotted decorator agree — the `J.Identifier` inside a `J.FieldAccess` carries the same type as the field access — so a recipe matching at identifier level reads the same answer as one matching the parent.

## Scope

A decorator that is a bound method — `@app.route`, `@app.get`, `@app.task` — is named by the variable it is reached through, so `@app.route` on a `Flask` imported from another module is `appmod.app.route`. That names no symbol, and the portable identity is the class-qualified one Flask's own docs use (`Flask.route`), which ty supplies as `className` plus the receiver's supertypes. Carrying it needs somewhere to put it — the shape `CanonicalName` already gives a re-exported import — and is not in this PR.

An import ty cannot resolve still gets a written-path name, which is the opposite of what `test_unresolvable_import_stays_untyped` asserts for an import's own qualid on the same input. That is deliberate: the usual cause is a dependency absent from the parse environment rather than a symbol that does not exist, and that is exactly the population recipes target — suppressing it would drop attribution for every third-party decorator in a repository parsed without its dependencies installed.

## Verification

- 13 cases in `TestDecoratorAttribution`, including the untyped-factory shape, a re-export reached through an attribute chain, a decorator the file defines itself, and negative tests that a rebound name is not attributed from its import.
- `rewrite-python` Python suite: 1951 passed, 65 skipped (excluding `tests/rpc`).
- Ran end-to-end through `rewrite-prethink`'s Django/Flask/FastAPI endpoint recipes against a locally-overlaid build of this package: with it, `@api_view`, `@require_GET` and `@require_http_methods` resolve and every `io.moderne.prethink.calm.*` test passes; without it, all three decorator cases fail.
