### PR TITLE
Kotlin: fix NPE in return.getType()

### DIFF
--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/tree/K.java
@@ -1586,8 +1586,8 @@ public interface K extends J {
 
         @Override
         public @Nullable JavaType getType() {
-            //noinspection DataFlowIssue
-            return expression.getExpression().getType();
+            Expression returnedExpression = expression.getExpression();
+            return returnedExpression == null ? null : returnedExpression.getType();
         }
 
         @Override

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinVisitorReturnTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinVisitorReturnTest.java
@@ -59,6 +59,48 @@ class KotlinVisitorReturnTest implements RewriteTest {
         );
     }
 
+    /**
+     * A bare valueless {@code return} wraps a {@link J.Return} whose expression is {@code null}. Because
+     * {@code K.Return} is an {@code Expression}, a {@code JavaVisitor.visitExpression} fires on it and may call
+     * {@link Expression#getType()}. That must return {@code null} rather than throwing a {@link NullPointerException}.
+     */
+    @Test
+    void getTypeOnBareReturnDoesNotThrow() {
+        rewriteRun(
+          spec -> spec.recipe(new TouchExpressionType()),
+          kotlin(
+            """
+              fun test() {
+                  return
+              }
+              """
+          )
+        );
+    }
+
+    static class TouchExpressionType extends Recipe {
+        @Override
+        public String getDisplayName() {
+            return "Touch the type of every expression";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Calls `getType()` on every expression to exercise `K.Return.getType()` on a bare return.";
+        }
+
+        @Override
+        public TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new JavaVisitor<ExecutionContext>() {
+                @Override
+                public J visitExpression(Expression expression, ExecutionContext ctx) {
+                    expression.getType();
+                    return super.visitExpression(expression, ctx);
+                }
+            };
+        }
+    }
+
     static class UnwrapReturn extends Recipe {
         @Override
         public String getDisplayName() {


### PR DESCRIPTION
## What's changed?

Adding null-safety check in `getType()` in Kotlin's `Return`.

## What's your motivation?

Otherwise a NPE is thrown for naked (value-less) returns like
```kotlin
fun test() {
   return
}
```
, e.g.
```
java.lang.NullPointerException: Cannot invoke "org.openrewrite.java.tree.Expression.getType()"  because the return value of "org.openrewrite.java.tree.J$Return.getExpression()" is null
  at org.openrewrite.kotlin.tree.K$Return.getType(K.java:1590)
  at <YourRecipe>$1.visitExpression(...)
  at org.openrewrite.kotlin.KotlinVisitor.visitReturn(KotlinVisitor.java
:249)
```