### PR TITLE
Python: a lone recipe bundle runs in the facade's own process

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
@@ -1,7 +1,11 @@
-"""Facade orchestration: one isolated child per bundle, keyed by distribution name.
+"""Facade orchestration: bundles keyed by distribution name, isolated from each other.
 
-Children are spawned on demand. Recipe ownership is first-wins across bundles. ``venv_ops`` and
-``spawn`` are injectable for testing.
+A lone bundle is hosted in the facade's own process; a second one puts every bundle behind its own
+child, spawned on demand. Recipe ownership is first-wins across bundles.
+
+``activate`` is injected rather than imported: the server runs as ``__main__`` under
+``python -m rewrite.rpc.server``, so importing it by name here binds a second module object with
+its own, empty marketplace. ``venv_ops`` and ``spawn`` are injectable for testing.
 """
 from pathlib import Path
 
@@ -10,14 +14,17 @@ from rewrite.rpc import venv_manager
 from rewrite.rpc.child_connection import ChildConnection, child_command
 
 
-
 class BundleChildren:
-    def __init__(self, python_executable, venvs_root, upstream, *, spawn=None, venv_ops=None):
+    def __init__(self, python_executable, venvs_root, upstream, *, activate, spawn=None,
+                 venv_ops=None):
         self._python = python_executable
         self._venvs_root = Path(venvs_root)
         self._upstream = upstream
         self._spawn = spawn or ChildConnection.spawn
         self._venv_ops = venv_ops or venv_manager
+        self._activate = activate
+        self._hosted = None     # the bundle this process runs itself, if any
+        self._imported = None   # the bundle whose packages it has imported; it never takes another
         self._children = {}     # bundle_dist -> child connection
         self._descriptors = {}  # bundle_dist -> list[marketplace row]
         self._owner = {}        # recipe name -> bundle_dist (first-wins)
@@ -51,7 +58,7 @@ class BundleChildren:
             child.request("Evict", params)
 
     def install(self, bundle_dist: str, spec: str, force: bool = False, attribution_name=None):
-        """Create/reuse the bundle's venv, install ``spec``, spawn its child, cache its recipes.
+        """Create/reuse the bundle's venv, install ``spec``, activate its recipes, cache them.
 
         ``attribution_name`` labels the recipes with the identity the host keys the bundle by (a
         local install's supplied path); by default they carry the distribution's own name.
@@ -66,11 +73,33 @@ class BundleChildren:
             self._venv_ops.create_venv(self._python, venv_dir, clear=venv_dir.exists())
         self._venv_ops.install_into_venv(venv_dir, spec, force=force)
         self._versions[bundle_dist] = self._venv_ops.installed_version(venv_dir, bundle_dist)
-        rows = self._ensure_child(bundle_dist).request("GetMarketplace", {})
+        rows = self._discover(bundle_dist)
         self._descriptors[bundle_dist] = rows
         for row in rows:
             self._owner.setdefault(row["descriptor"]["name"], bundle_dist)  # first-wins
         return rows
+
+    def _discover(self, bundle_dist: str):
+        """Bring a bundle's recipes within reach and return its marketplace rows.
+
+        A bundle installed on its own has nothing to conflict with, so it is hosted here rather
+        than behind a child of its own. Imports are permanent, so only one bundle per process gets
+        the offer — a second one's packages would land beside the first's, venvs notwithstanding.
+        """
+        venv_dir = self._venv_dir(bundle_dist)
+        if (self._imported in (None, bundle_dist) and not self._children
+                and self._venv_ops.built_by_running_interpreter(venv_dir)):
+            self._hosted = self._imported = bundle_dist
+            return self._activate(venv_dir, bundle_dist, self._attribution.get(bundle_dist))
+        if self._hosted is not None:
+            # A bundle install completes before any of its recipes is prepared, so the hosted
+            # bundle has nothing in flight and its child re-reads the same recipes from the venv.
+            self._ensure_child(self._hosted)
+            self._hosted = None
+        return self._ensure_child(bundle_dist).request("GetMarketplace", {})
+
+    def has_children(self) -> bool:
+        return bool(self._children)
 
     def marketplace(self):
         merged, seen = [], set()
@@ -94,6 +123,8 @@ class BundleChildren:
 
     def uninstall(self, bundle_dist: str) -> None:
         bundle_dist = _normalize_package_name(bundle_dist)
+        if self._hosted == bundle_dist:
+            self._hosted = None  # _imported still names it: its modules stay here
         child = self._children.pop(bundle_dist, None)
         if child is not None:
             child.close()

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -1,7 +1,8 @@
 """Facade request handling: route RPC operations across per-bundle children.
 
-In facade mode (``--recipe-install-dir`` set, not a child) the server holds no recipes itself: each
-bundle gets its own venv and child, and recipe execution routes to the owning child.
+In facade mode (``--recipe-install-dir`` set, not a child) each bundle gets its own venv. A lone
+bundle runs in the facade process and nothing here is consulted; from a second bundle on, each gets
+a child and recipe execution routes to the owning one.
 
 ``Print``/``GetObject`` are not routed: the working source file is owned outside the children, so
 a child's edit has to be pulled back into it (``hub_pull``) or it is never seen. That store and the
@@ -25,6 +26,10 @@ class Facade:
         self._is_local_visitor = is_local_visitor or (lambda name: False)
         self._bundle_by_visitor = {}    # visitor name (edit:/scan:) -> bundle
         self._bundle_by_recipe_id = {}  # prepared recipe id -> bundle
+
+    def routes_to_children(self):
+        """False when the only bundle runs in this process and the server's own handlers serve it."""
+        return self._children.has_children()
 
     def _owner(self, visitor_name):
         """The bundle that owns ``visitor_name``, or ``_LOCAL`` when the facade runs it itself."""

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1182,7 +1182,9 @@ def _get_marketplace():
             from rewrite.discovery import discover_root_recipes
             discover_root_recipes(_child_bundle, marketplace=_marketplace, attribution=_attribution,
                                   attribution_name=_attribution_name)
-        else:
+        elif not _facade_mode():
+            # A facade's is scoped the same way, to the bundles activate_bundle_in_process
+            # installs into it; ambient discovery belongs to a plain server.
             from rewrite.discovery import discover_recipes, recipe_name_set
             from rewrite import activate
 
@@ -1536,6 +1538,32 @@ def _collect_marketplace_rows(
         collect(category, [])
 
     return rows
+
+
+def activate_bundle_in_process(venv_dir: Path, bundle_dist: str,
+                               attribution_name: Optional[str] = None) -> List[dict]:
+    """Activate a recipe bundle in the facade's own process and return its marketplace rows.
+
+    The bundle's venv joins this process's path, which is what ``--child-bundle`` on the venv
+    interpreter buys a child. ``addsitedir`` appends, so the engine keeps the precedence
+    ``_child_env`` gives it in a child, and it processes the venv's ``.pth`` files.
+    """
+    import importlib
+    import site
+
+    from rewrite.discovery import discover_root_recipes
+    from rewrite.rpc import venv_manager
+
+    packages = venv_manager.site_packages(venv_dir)
+    if packages is not None:
+        site.addsitedir(str(packages))
+        importlib.invalidate_caches()
+
+    marketplace = _get_marketplace()
+    discover_root_recipes(bundle_dist, marketplace=marketplace, attribution=_attribution,
+                          attribution_name=attribution_name)
+    return _collect_marketplace_rows(
+        marketplace, recipe_filter=_attribution.recipes_for(attribution_name or bundle_dist))
 
 
 def _category_descriptor_to_dict(descriptor) -> dict:
@@ -2517,7 +2545,9 @@ def _get_facade():
         if removed:
             logger.info("Cleared %d pre-venv recipe artifact(s) from %s: %s",
                         len(removed), _recipe_install_dir, ", ".join(removed))
-        _facade = Facade(BundleChildren(sys.executable, _recipe_install_dir, upstream=_serve_child_object),
+        _facade = Facade(BundleChildren(sys.executable, _recipe_install_dir,
+                                        upstream=_serve_child_object,
+                                        activate=activate_bundle_in_process),
                          hub_pull=_hub_pull_child_edit,
                          local_visit=_hub_local_visit,
                          is_local_visitor=_hub_is_builtin_visitor)
@@ -2529,35 +2559,40 @@ def handle_request(method: str, params: dict) -> Any:
     if _facade_mode():
         facade = _get_facade()
 
-        if method == 'Evict':
+        # Bundle lifecycle is always the facade's. SetDataTableStore and Evict have no `return`:
+        # a bundle hosted in this process needs the store and the eviction here too.
+        if method == 'InstallRecipes':
+            return facade.install_recipes(params)
+        if method == 'GetMarketplace':
+            return facade.get_marketplace(params)
+        if method == 'SetDataTableStore':
+            facade.set_data_table_store(params)
+        elif method == 'Evict':
             facade.evict(params)
             _hub_release(params.get('id'))
-            return handle_evict(params)
-        facade_handlers = {
-            'InstallRecipes': facade.install_recipes,
-            'GetMarketplace': facade.get_marketplace,
-            'PrepareRecipe': facade.prepare_recipe,
-            'SetDataTableStore': facade.set_data_table_store,
-            'Visit': facade.visit,
-            'BatchVisit': facade.batch_visit,
-            'Generate': facade.generate,
-        }
-        facade_handler = facade_handlers.get(method)
-        if facade_handler:
-            # Acquire at the top level, before any child runs — acquiring inside a child's
-            # GetObject callback would deadlock (the child waits on us, Java on this request).
-            if method in ('Visit', 'BatchVisit'):
-                _hub_acquire(params.get('treeId'), params.get('sourceFileType'))
-            return facade_handler(params)
-        if method in ('Print', 'GetObject'):
-            obj_id = params.get('treeId') or params.get('id')
-            source_file_type = params.get('sourceFileType')
-            # Java fetches non-tree objects by id as well (the execution context, cursors).
-            # `GetObject.sourceFileType` is nullable and only set for trees, so it is what tells
-            # the two apart. Acquiring a non-tree would hand its property messages to a receiver
-            # that has no codec for them, desynchronizing the queue for every later object.
-            if obj_id is not None and source_file_type and obj_id not in _hub_tree:
-                _hub_acquire(obj_id, source_file_type)
+        elif facade.routes_to_children():
+            facade_handlers = {
+                'PrepareRecipe': facade.prepare_recipe,
+                'Visit': facade.visit,
+                'BatchVisit': facade.batch_visit,
+                'Generate': facade.generate,
+            }
+            facade_handler = facade_handlers.get(method)
+            if facade_handler:
+                # Acquire at the top level, before any child runs — acquiring inside a child's
+                # GetObject callback would deadlock (the child waits on us, Java on this request).
+                if method in ('Visit', 'BatchVisit'):
+                    _hub_acquire(params.get('treeId'), params.get('sourceFileType'))
+                return facade_handler(params)
+            if method in ('Print', 'GetObject'):
+                obj_id = params.get('treeId') or params.get('id')
+                source_file_type = params.get('sourceFileType')
+                # Java fetches non-tree objects by id as well (the execution context, cursors).
+                # `GetObject.sourceFileType` is nullable and only set for trees, so it is what tells
+                # the two apart. Acquiring a non-tree would hand its property messages to a receiver
+                # that has no codec for them, desynchronizing the queue for every later object.
+                if obj_id is not None and source_file_type and obj_id not in _hub_tree:
+                    _hub_acquire(obj_id, source_file_type)
 
     handlers = {
         'Parse': handle_parse,

--- a/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/venv_manager.py
@@ -8,6 +8,7 @@ there is nothing to pip-uninstall.
 import os
 import shutil
 import subprocess
+import sys
 from importlib import metadata
 from pathlib import Path
 from typing import Optional
@@ -21,7 +22,7 @@ def venv_python(venv_dir: Path) -> Path:
     return venv_dir / "bin" / "python"
 
 
-def _site_packages(venv_dir: Path) -> Optional[Path]:
+def site_packages(venv_dir: Path) -> Optional[Path]:
     if os.name == "nt":
         sp = venv_dir / "Lib" / "site-packages"
         return sp if sp.exists() else None
@@ -33,11 +34,11 @@ def installed_version(venv_dir: Path, dist: str) -> Optional[str]:
 
     Read off disk, so the recipe is never imported.
     """
-    site_packages = _site_packages(venv_dir)
-    if site_packages is None:
+    packages = site_packages(venv_dir)
+    if packages is None:
         return None
     target = _normalize_package_name(dist)
-    for distribution in metadata.distributions(path=[str(site_packages)]):
+    for distribution in metadata.distributions(path=[str(packages)]):
         name = distribution.metadata["Name"]
         if name and _normalize_package_name(name) == target:
             return distribution.version
@@ -71,6 +72,23 @@ def is_usable_venv(venv_dir: Path) -> bool:
         key, separator, value = line.partition("=")
         if separator and key.strip() == "home":
             return Path(value.strip()).exists()
+    return False
+
+
+def built_by_running_interpreter(venv_dir: Path) -> bool:
+    """True when this process can import the venv's packages.
+
+    A venv's ``site-packages`` carries bytecode and extension modules for the one interpreter
+    version it was built against; an unrecorded version reads as no match.
+    """
+    config = venv_dir / "pyvenv.cfg"
+    if not config.exists():
+        return False
+    running = [str(part) for part in sys.version_info[:2]]
+    for line in config.read_text().splitlines():
+        key, separator, value = line.partition("=")
+        if separator and key.strip() in ("version", "version_info"):
+            return value.strip().split(".")[:2] == running
     return False
 
 

--- a/rewrite-python/rewrite/tests/rpc/test_bundle_children.py
+++ b/rewrite-python/rewrite/tests/rpc/test_bundle_children.py
@@ -31,6 +31,19 @@ class _FakeChild:
         self.closed = True
 
 
+def _behind_children(venvs_root, spawn, venv_ops):
+    """A fixture past in-process hosting: a lone bundle runs in the facade's own process, and these
+    tests are about the child path a second bundle takes, so one bundle is already behind a child."""
+    bc = BundleChildren("py", venvs_root, upstream=lambda m, p: None, spawn=spawn,
+                        venv_ops=venv_ops, activate=_never_hosted)
+    bc._children["other"] = _FakeChild([])
+    return bc
+
+
+def _never_hosted(venv_dir, bundle_dist, attribution_name):
+    raise AssertionError(f"{bundle_dist} should have gone to a child")
+
+
 def test_install_marketplace_owner_route_uninstall_and_shutdown(tmp_path):
     ops = SimpleNamespace(created=[], installed=[], removed=[])
     ops.venv_python = _fake_venv_python
@@ -39,6 +52,7 @@ def test_install_marketplace_owner_route_uninstall_and_shutdown(tmp_path):
     ops.install_into_venv = lambda d, spec, force=False: ops.installed.append((d, spec, force))
     ops.installed_version = lambda d, dist: f"{dist}-1.0"
     ops.remove_venv = lambda d: ops.removed.append(d)
+    ops.built_by_running_interpreter = lambda d: True
 
     spawned = {}
 
@@ -48,8 +62,7 @@ def test_install_marketplace_owner_route_uninstall_and_shutdown(tmp_path):
         spawned[bundle] = child
         return child
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=ops)
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, ops)
 
     # install: venv created + package installed + child spawned + marketplace cached + ownership
     rows = bc.install("pkga", "pkga==1.0")
@@ -87,6 +100,8 @@ def _ops_recording(created, installed):
     ops.create_venv = lambda py, d, clear=False: (created.append(d), _make_venv(d))
     ops.install_into_venv = lambda d, spec, force=False: installed.append(d)
     ops.installed_version = lambda d, dist: "1.0.0"
+    ops.built_by_running_interpreter = lambda d: True
+    ops.remove_venv = lambda d: None
     return ops
 
 
@@ -97,8 +112,7 @@ def test_set_data_table_store_broadcasts_to_live_children_and_replays_on_spawn(t
         bundle = cmd[cmd.index("--child-bundle") + 1]
         return _FakeChild([{"descriptor": {"name": f"{bundle}.R"}}])
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, _ops_recording(created, installed))
 
     bc.install("pkga", "pkga")                       # a live child before the store is configured
     live = bc._children["pkga"]
@@ -116,8 +130,7 @@ def test_broadcast_evict_fans_out_to_live_children(tmp_path):
         bundle = cmd[cmd.index("--child-bundle") + 1]
         return _FakeChild([{"descriptor": {"name": f"{bundle}.R"}}])
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=_ops_recording([], []))
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, _ops_recording([], []))
     bc.install("pkga", "pkga")
     bc.install("pkgb", "pkgb")
 
@@ -133,8 +146,7 @@ def test_install_reuses_an_existing_venv_but_still_upgrades(tmp_path):
     def fake_spawn(cmd, upstream=None, exclude_paths=()):
         return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, _ops_recording(created, installed))
 
     # a real venv from a prior session (it has an interpreter) is reused, not recreated...
     _make_venv(tmp_path / "venvs" / "pkg")
@@ -152,8 +164,7 @@ def test_install_rebuilds_a_directory_that_is_not_a_venv(tmp_path):
     def fake_spawn(cmd, upstream=None, exclude_paths=()):
         return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, _ops_recording(created, installed))
 
     legacy = tmp_path / "venvs" / "pkg"          # e.g. ~/.moderne/recipes/pip/pkg/__init__.py
     legacy.mkdir(parents=True)
@@ -172,6 +183,7 @@ def test_install_rebuilds_a_venv_orphaned_by_a_python_upgrade(tmp_path):
     ops.create_venv = lambda py, d, clear=False: (ops.created.append((d, clear)), _make_venv(d))
     ops.install_into_venv = lambda d, spec, force=False: ops.installed.append(d)
     ops.installed_version = lambda d, dist: "2.0"
+    ops.built_by_running_interpreter = lambda d: True
 
     def fake_spawn(cmd, upstream=None, exclude_paths=()):
         return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
@@ -179,8 +191,7 @@ def test_install_rebuilds_a_venv_orphaned_by_a_python_upgrade(tmp_path):
     venv_dir = tmp_path / "venvs" / "pkg"
     _make_venv(venv_dir)                           # looks like a venv; its base is gone
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=ops)
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, ops)
     orphaned_child = _FakeChild([])                # a child still bound to the dead venv
     bc._children["pkg"] = orphaned_child
 
@@ -201,8 +212,7 @@ def test_child_is_denied_the_shared_venvs_root_on_its_path(tmp_path):
         return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
 
     venvs_root = tmp_path / "venvs"
-    bc = BundleChildren("py", venvs_root, upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+    bc = _behind_children(venvs_root, fake_spawn, _ops_recording(created, installed))
     bc.install("pkg", "pkg")
 
     assert seen["exclude_paths"] == (str(venvs_root),)
@@ -216,8 +226,7 @@ def test_local_install_spawns_the_child_with_the_supplied_attribution_name(tmp_p
         spawned["cmd"] = cmd
         return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=_ops_recording(created, installed))
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, _ops_recording(created, installed))
     bc.install("my-local-recipes", "/abs/path/to/src", force=True,
                attribution_name="/abs/path/to/src")
 
@@ -240,6 +249,7 @@ def test_install_normalizes_distribution_name_so_spellings_dedup(tmp_path):
     ops.create_venv = _create
     ops.install_into_venv = lambda d, spec, force=False: ops.installed.append(d)
     ops.installed_version = lambda d, dist: "9.9"
+    ops.built_by_running_interpreter = lambda d: True
 
     spawned = []
 
@@ -247,8 +257,7 @@ def test_install_normalizes_distribution_name_so_spellings_dedup(tmp_path):
         spawned.append(cmd[cmd.index("--child-bundle") + 1])
         return _FakeChild([{"descriptor": {"name": "R"}}])
 
-    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
-                        spawn=fake_spawn, venv_ops=ops)
+    bc = _behind_children(tmp_path / "venvs", fake_spawn, ops)
 
     # PEP 503 treats these as the same distribution -> one venv, one child, one normalized key.
     bc.install("Foo-Bar", "Foo-Bar")
@@ -257,3 +266,87 @@ def test_install_normalizes_distribution_name_so_spellings_dedup(tmp_path):
     assert ops.created == [tmp_path / "venvs" / "foo_bar"]        # created once, normalized dir
     assert spawned == ["foo_bar"]                                 # one child, spawned once
     assert bc.request("FOO.BAR", "Visit", {}) == {"ran": "Visit"}  # any spelling routes to it
+
+
+def _hosting(rows_by_dist, hosted):
+    """A stand-in for the server's in-process activation, recording what it was asked to host."""
+    def activate(venv_dir, bundle_dist, attribution_name):
+        hosted.append((venv_dir, bundle_dist, attribution_name))
+        return rows_by_dist(bundle_dist)
+    return activate
+
+
+def test_a_lone_bundle_runs_in_the_facades_own_process(tmp_path):
+    """One bundle has nothing to be isolated from, so it earns no child and no tree relay."""
+    hosted = []
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        raise AssertionError("a lone bundle must not spawn a child")
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording([], []),
+                        activate=_hosting(lambda d: [{"descriptor": {"name": f"{d}.R"}}], hosted))
+
+    rows = bc.install("pkga", "pkga")
+
+    assert hosted == [(tmp_path / "venvs" / "pkga", "pkga", None)]
+    assert rows == [{"descriptor": {"name": "pkga.R"}}]
+    assert bc.owner("pkga.R") == "pkga"      # ownership still resolves...
+    assert bc.has_children() is False        # ...but to this process, so nothing is routed
+
+
+def test_a_second_bundle_puts_the_first_behind_a_child(tmp_path):
+    """Two bundles can conflict, which is what #8275's per-bundle venv and child are for."""
+    spawned = {}
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        bundle = cmd[cmd.index("--child-bundle") + 1]
+        spawned[bundle] = _FakeChild([{"descriptor": {"name": f"{bundle}.R"}}])
+        return spawned[bundle]
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None,
+                        spawn=fake_spawn, venv_ops=_ops_recording([], []),
+                        activate=_hosting(lambda d: [{"descriptor": {"name": f"{d}.R"}}], []))
+
+    bc.install("pkga", "pkga")
+    bc.install("pkgb", "pkgb")
+
+    assert set(spawned) == {"pkga", "pkgb"}   # including the bundle that had been in-process
+    assert bc.has_children() is True
+    assert bc.request("pkga", "Visit", {}) == {"ran": "Visit"}
+
+
+def test_a_venv_built_by_another_python_is_left_to_a_child(tmp_path):
+    """Only a child running on the venv's own interpreter can import its packages."""
+    ops = _ops_recording([], [])
+    ops.built_by_running_interpreter = lambda d: False
+    spawned = []
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        spawned.append(cmd[cmd.index("--child-bundle") + 1])
+        return _FakeChild([{"descriptor": {"name": "pkg.R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None, spawn=fake_spawn,
+                        venv_ops=ops, activate=_never_hosted)
+    bc.install("pkg", "pkg")
+
+    assert spawned == ["pkg"]
+
+
+def test_a_process_hosts_one_bundles_packages_and_no_other(tmp_path):
+    """Uninstalling the hosted bundle does not un-import it, so the next one starts behind a child."""
+    spawned = []
+
+    def fake_spawn(cmd, upstream=None, exclude_paths=()):
+        spawned.append(cmd[cmd.index("--child-bundle") + 1])
+        return _FakeChild([{"descriptor": {"name": "pkgb.R"}}])
+
+    bc = BundleChildren("py", tmp_path / "venvs", upstream=lambda m, p: None, spawn=fake_spawn,
+                        venv_ops=_ops_recording([], []),
+                        activate=lambda venv, dist, name: [{"descriptor": {"name": f"{dist}.R"}}])
+
+    bc.install("pkga", "pkga")
+    bc.uninstall("pkga")
+    bc.install("pkgb", "pkgb")
+
+    assert spawned == ["pkgb"]

--- a/rewrite-python/rewrite/tests/rpc/test_child_mode.py
+++ b/rewrite-python/rewrite/tests/rpc/test_child_mode.py
@@ -1,4 +1,9 @@
+import sys
+
+import pytest
+
 import rewrite.rpc.server as server
+from rewrite.discovery import RecipeAttribution
 
 
 def test_child_mode_scopes_discovery_to_the_root_bundle(monkeypatch):
@@ -21,3 +26,40 @@ def test_child_mode_scopes_discovery_to_the_root_bundle(monkeypatch):
 
     assert called.get("root") == "my-recipes"   # root-scoped discovery
     assert "flat" not in called                 # flat discovery + built-in activate skipped
+
+
+def test_a_hosted_bundle_activates_from_its_venv_into_the_facades_marketplace(monkeypatch, tmp_path):
+    """A facade's marketplace holds exactly the bundles installed into it, the way a child's holds
+    exactly ``--child-bundle`` — nothing ambient, and the bundle's venv is what makes it reachable.
+    """
+    from rewrite import CategoryDescriptor, Recipe
+
+    class _Demo(Recipe):
+        @property
+        def name(self): return "org.example.Demo"
+        @property
+        def display_name(self): return "Demo"
+        @property
+        def description(self): return "d"
+
+    def fake_root(root_dist_name, marketplace=None, attribution=None, attribution_name=None):
+        marketplace.install(_Demo, [CategoryDescriptor(display_name="Test")])
+        attribution.record(attribution_name or root_dist_name, {"org.example.Demo"})
+        return marketplace
+
+    monkeypatch.setattr("rewrite.discovery.discover_root_recipes", fake_root)
+    monkeypatch.setattr("rewrite.discovery.discover_recipes",
+                        lambda *a, **k: pytest.fail("a facade discovers no ambient recipes"))
+    monkeypatch.setattr(server, "_marketplace", None)
+    monkeypatch.setattr(server, "_attribution", RecipeAttribution())
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)   # facade mode on
+
+    site_packages = tmp_path / "venvs" / "demo" / "lib" / "python3.12" / "site-packages"
+    site_packages.mkdir(parents=True)
+    monkeypatch.setattr(sys, "path", list(sys.path))
+
+    rows = server.activate_bundle_in_process(tmp_path / "venvs" / "demo", "demo-recipes", None)
+
+    assert str(site_packages) in sys.path      # the bundle's venv is how its recipes are importable
+    assert [row["descriptor"]["name"] for row in rows] == ["org.example.Demo"]

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -204,6 +204,7 @@ def test_handle_request_answers_print_from_the_facades_own_tree(monkeypatch, tmp
     import rewrite.rpc.server as server
 
     class _FakeFacade:
+        def routes_to_children(self): return True
         def get_marketplace(self, params): ...
         def install_recipes(self, params): ...
         def prepare_recipe(self, params): ...
@@ -233,6 +234,7 @@ def test_handle_request_does_not_acquire_non_tree_objects(monkeypatch, tmp_path)
     import rewrite.rpc.server as server
 
     class _FakeFacade:
+        def routes_to_children(self): return True
         def get_marketplace(self, params): ...
         def install_recipes(self, params): ...
         def prepare_recipe(self, params): ...
@@ -264,6 +266,8 @@ def test_handle_request_routes_to_facade_in_facade_mode(monkeypatch, tmp_path):
     routed = {}
 
     class _FakeFacade:
+        def routes_to_children(self): return True
+
         def get_marketplace(self, params):
             routed["marketplace"] = True
             return ["facade-rows"]
@@ -528,3 +532,59 @@ def test_an_unknown_visitor_is_still_an_error():
         assert False, "expected a ValueError for a visitor no child owns"
     except ValueError as e:
         assert "No child owns visitor" in str(e)
+
+
+class _HostingFacade:
+    """A facade whose only bundle runs in this process, so there is nothing to route to."""
+
+    def routes_to_children(self): return False
+    def install_recipes(self, params): ...
+    def get_marketplace(self, params): ...
+    def evict(self, params): ...
+    def set_data_table_store(self, params): return True
+
+    def prepare_recipe(self, params): raise AssertionError("routed with no child to route to")
+    def visit(self, params): raise AssertionError("routed with no child to route to")
+    def batch_visit(self, params): raise AssertionError("routed with no child to route to")
+    def generate(self, params): raise AssertionError("routed with no child to route to")
+
+
+def test_a_lone_bundle_is_served_by_the_servers_own_handlers(monkeypatch, tmp_path):
+    """With one bundle the facade is a plain server: nothing is relayed, so the tree is never
+    materialized a second time in ``_hub_tree``."""
+    import rewrite.rpc.server as server
+
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)   # facade mode on
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_facade", _HostingFacade())
+    monkeypatch.setattr(server, "handle_batch_visit", lambda p: "local-batch")
+    monkeypatch.setattr(server, "handle_visit", lambda p: "local-visit")
+    monkeypatch.setattr(server, "handle_prepare_recipe", lambda p: "local-prepare")
+    monkeypatch.setattr(server, "handle_print", lambda p: "local-print")
+
+    acquired = []
+    monkeypatch.setattr(server, "_hub_acquire", lambda oid, sft: acquired.append(oid))
+
+    tree = {"treeId": "T", "sourceFileType": "py"}
+    assert server.handle_request("PrepareRecipe", {"id": "pkg.R"}) == "local-prepare"
+    assert server.handle_request("BatchVisit", tree) == "local-batch"
+    assert server.handle_request("Visit", tree) == "local-visit"
+    assert server.handle_request("Print", tree) == "local-print"
+    assert acquired == []
+    assert server._hub_tree == {}
+
+
+def test_the_data_table_store_reaches_a_bundle_hosted_in_this_process(monkeypatch, tmp_path):
+    """A hosted bundle emits its rows from this process, so the store is installed here as well as
+    broadcast to any children."""
+    import rewrite.rpc.server as server
+    from rewrite.data_table import CsvDataTableStore
+
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_facade", _HostingFacade())
+    monkeypatch.setattr(server, "_configured_data_table_store", None)
+
+    assert server.handle_request(
+        "SetDataTableStore", {"kind": "CSV", "outputDir": str(tmp_path / "tables")}) is True
+    assert isinstance(server._configured_data_table_store, CsvDataTableStore)

--- a/rewrite-python/src/integTest/java/org/openrewrite/python/CrossBundleBatchVisitIntegTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/CrossBundleBatchVisitIntegTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+import org.openrewrite.python.rpc.PythonRewriteRpc;
+import org.openrewrite.rpc.DynamicDispatchRpcCodec;
+import org.openrewrite.rpc.RpcRecipe;
+import org.openrewrite.rpc.request.BatchVisit;
+import org.openrewrite.rpc.request.BatchVisitResponse;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * A tree visited by two recipe bundles in one BatchVisit.
+ * <p>
+ * With more than one bundle installed the peer runs each behind its own child process, so the two
+ * visitors here execute in different interpreters. The renames chain — {@code alpha} to
+ * {@code beta} in one bundle, {@code beta} to {@code gamma} in the other — so the result is
+ * {@code gamma} only if the first bundle's edit reached the second bundle's input.
+ */
+class CrossBundleBatchVisitIntegTest {
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void before() {
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder()
+                .recipeInstallDir(tempDir.resolve("bundles"))
+                .log(tempDir.resolve("python-rpc.log")));
+    }
+
+    @AfterEach
+    void after() throws IOException {
+        PythonRewriteRpc.shutdownCurrent();
+        PythonRewriteRpc.setFactory(PythonRewriteRpc.builder());
+        Path log = tempDir.resolve("python-rpc.log");
+        if (Files.exists(log)) {
+            System.out.println("=== Python RPC Log ===");
+            System.out.println(Files.readString(log));
+        }
+    }
+
+    @Test
+    @Timeout(value = 300, unit = TimeUnit.SECONDS)
+    void oneBatchVisitSpansTwoBundles() throws IOException {
+        PythonRewriteRpc rpc = PythonRewriteRpc.getOrStart();
+        String editAlphaToBeta = install(rpc, "alpha_pkg", "AlphaToBeta", "alpha", "beta");
+        String editBetaToGamma = install(rpc, "beta_pkg", "BetaToGamma", "beta", "gamma");
+
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        SourceFile cu = PythonParser.builder().build()
+                .parse(ctx, "alpha = 1\n")
+                .findFirst()
+                .orElseThrow();
+
+        List<BatchVisitResponse.BatchVisitResult> results = rpc.batchVisit(cu, ctx, null,
+                List.of(new BatchVisit.BatchVisitItem(editAlphaToBeta, null),
+                        new BatchVisit.BatchVisitItem(editBetaToGamma, null))).getResults();
+
+        assertThat(results).extracting("modified").containsExactly(true, true);
+        SourceFile after = rpc.getObject(cu.getId().toString(),
+                DynamicDispatchRpcCodec.canonicalSourceFileType(cu.getClass()));
+        assertThat(rpc.print(after)).isEqualTo("gamma = 1\n");
+    }
+
+    /**
+     * Install a bundle holding one identifier-renaming recipe and return its edit visitor.
+     * The entry point is what scopes discovery to this distribution once it is behind a child.
+     */
+    private String install(PythonRewriteRpc rpc, String dist, String recipe, String from, String to)
+            throws IOException {
+        Path pkgRoot = tempDir.resolve(dist);
+        Path module = pkgRoot.resolve(dist);
+        Files.createDirectories(module);
+        Files.writeString(pkgRoot.resolve("pyproject.toml"), """
+                [project]
+                name = "%s"
+                version = "0.0.0"
+
+                [project.entry-points."openrewrite.recipes"]
+                %s = "%s:activate"
+                """.formatted(dist, dist, dist));
+        Files.writeString(module.resolve("__init__.py"), """
+                from rewrite import CategoryDescriptor, Recipe
+                from rewrite.python.visitor import PythonVisitor
+
+
+                class %s(Recipe):
+                    @property
+                    def name(self): return "org.openrewrite.python.test.%s"
+
+                    @property
+                    def display_name(self): return "%s"
+
+                    @property
+                    def description(self): return "Renames `%s` to `%s`."
+
+                    def editor(self):
+                        class _V(PythonVisitor):
+                            def visit_identifier(self, ident, p):
+                                if ident.simple_name == "%s":
+                                    return ident.replace(_simple_name="%s")
+                                return ident
+                        return _V()
+
+
+                def activate(marketplace):
+                    marketplace.install(%s, [CategoryDescriptor(display_name="Test")])
+                """.formatted(recipe, recipe, recipe, from, to, from, to, recipe));
+        rpc.installRecipes(pkgRoot.toFile());
+        return ((RpcRecipe) rpc.prepareRecipe("org.openrewrite.python.test." + recipe, Map.of()))
+                .getEditVisitor();
+    }
+}


### PR DESCRIPTION
A `mod run` of a pip recipe bundle uses two Python processes and sends the whole LST between them. The facade deserializes the tree from Java and re-serializes it to a child that runs the recipes — a hop that produces no edits.

Measured on `jd/tenacity` (20 files, 5,896 LOC) with `org.openrewrite.python.migrate.UpgradeToPython313`, three interleaved pairs:

```
            wall   fix.patch   py CPU   procs   Java→facade   facade→child   child parses
main-1       94s   c0a2a2ab     66.0s     2       2,729,604      1,303,024      1,302,939
main-2      120s   c0a2a2ab     77.0s     2       2,830,075      1,303,024      1,302,939
main-3       86s   c0a2a2ab     61.7s     2       2,854,638      1,303,024      1,302,939
branch-1     68s   c0a2a2ab     49.8s     1       2,806,383              0              0
branch-2     51s   c0a2a2ab     37.5s     1       2,434,323              0              0
branch-3     68s   c0a2a2ab     49.6s     1       2,599,951              0              0
```

Java→facade is untouched by this change, and its spread is `Print` re-fetches — the one flow the baseline document records as non-deterministic. What goes is the hop after it: the facade re-serializing `_hub_tree` through `RpcSendQueue` (1,303,024 messages, identical in all three main arms) and the child parsing it back (1,302,939), in a second process.

`c0a2a2ab…` is the recorded baseline hash, so the patch is byte-identical in all six runs. Another session's RPC server competed for CPU throughout, so wall and CPU are directional; the two zeroed columns are deterministic.

### On a CLI built from this branch

`rewrite` 8.92.0-SNAPSHOT, a fresh CLI home, and the engine installed from a real wheel rather than patched in place, against the same CLI carrying a wheel built from `HEAD^`:

```
custom-main     wall 167s   c0a2a2ab   py CPU 51.5s   2 procs (facade 27.2s + child 24.4s)
custom-branch   wall 107s   c0a2a2ab   py CPU 35.1s   1 proc
```

That home starts with no bundle venv, so the CLI creates one and `built_by_running_interpreter` judges it fresh — the case where a wrong answer would silently disable hosting and still pass the patch gate.

## Why one bundle is the normal case

The facade came from #8275: recipes from different bundles shared one environment, so their dependencies could conflict. Serving each child a diff over that child's ref table means the facade holds the tree as live objects, so every tree is materialized twice.

But a `mod run` executes one recipe, so normally one bundle participates — the multi-bundle case is a YAML composite spanning two pip packages — and a lone bundle has nothing to be isolated from.

## What changed

`BundleChildren._discover` is the one place that decides. A bundle installed while no other exists is activated in this process:

- its venv joins `sys.path` via `site.addsitedir`, which appends, so the engine keeps the precedence `_child_env` gives it in a child
- `discover_root_recipes` scopes discovery to that distribution, as `--child-bundle` does for a child
- a second bundle moves the first behind a child and spawns one for the newcomer

`handle_request` follows that decision. `InstallRecipes` and `GetMarketplace` always go to the facade; `SetDataTableStore` and `Evict` go to the facade *and* the local handler; everything else only when `Facade.routes_to_children()`.

With one bundle that predicate is false, so `PrepareRecipe`, `Visit`, `BatchVisit`, `Generate`, `Print` and `GetObject` reach the plain handlers — the same code a child runs — and no `_hub_*` state is touched.

## What bounds the hosting

- **A venv built by another interpreter is left to a child.** `is_usable_venv` checks only that `pyvenv.cfg`'s `home` still exists, never the version, and a 3.11 `site-packages` appended to a 3.12 path breaks any compiled dependency. `built_by_running_interpreter` reads the recorded version.
- **A process takes one bundle's imports, ever.** Imports are permanent, so `_imported` is sticky where `_hosted` is not: a bundle installed after the hosted one is uninstalled starts behind a child.

## `activate` is injected, not imported

`bundle_children` first reached the hook with `from rewrite.rpc.server import activate_bundle_in_process`. The server runs as `python -m rewrite.rpc.server`, so it *is* `__main__` and that binds a second module object with its own empty marketplace — activation filled that copy while the running server's stayed empty.

`activate` is therefore a required keyword: missing wiring is a `TypeError`, not a silent fall back to the two-process path this change removes. `java_rpc_client.py:137` has the same shape and is untouched.

## Tests

Seven, each pinning one line:

- the hosting branch, and the eviction branch a second install takes
- the interpreter check, and `_imported` outliving `_hosted` across an uninstall
- the `routes_to_children` guard, asserting `_hub_tree` stays empty
- the missing `return` that gets a hosted bundle its data-table store
- the facade-scoped marketplace

`CrossBundleBatchVisitIntegTest` covers the two-bundle path the unit tests fake: two bundles behind two children, one BatchVisit spanning both, renames chained (`alpha`→`beta`, `beta`→`gamma`) so `gamma` proves the first bundle's edit reached the second's input. It drives `batchVisit` from the JVM because the CLI cannot reach this case — it installs only the bundles a recipe needs, and a declarative `recipeList` resolves from the JVM classpath so it cannot name pip recipes. **It has not been executed**: the `integTest` source set does not resolve on my machine (`junit-platform-suite-api` SNAPSHOT, 401), so CI is the first thing to run it.

## Scope

The `_hub_*` block, `child_connection` and the facade's routing are now dead code on the path a `mod run` takes. They stay: they are the multi-bundle fallback, and deleting them would drop multi-bundle support rather than simplify it.

Eviction rests on bundle installs completing before any recipe is prepared, which `PipRecipeBundleResolver` does by running during marketplace resolution. If that stopped holding, a `Visit` fails with `No child owns visitor` — loudly.
