### PR TITLE
Python: template parenthesization asks what the slot demands

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/template/engine.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/engine.py
@@ -358,7 +358,8 @@ class TemplateEngine:
         cls,
         result: J,
         cursor: 'Cursor',
-        coordinates: PythonCoordinates
+        coordinates: PythonCoordinates,
+        format: bool = True,
     ) -> J:
         """
         Apply coordinate-based adjustments to the result.
@@ -370,6 +371,7 @@ class TemplateEngine:
             result: The template result.
             cursor: Current cursor position.
             coordinates: Insertion coordinates.
+            format: As `Template.apply`.
 
         Returns:
             The adjusted result.
@@ -392,6 +394,9 @@ class TemplateEngine:
                 random_id(),
                 result,
             )
+
+        if not format:
+            return result
 
         # Auto-format the result
         try:

--- a/rewrite-python/rewrite/src/rewrite/python/template/precedence.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/precedence.py
@@ -211,11 +211,23 @@ def slot_constraints(parent: J, child_id: UUID) -> Optional[SlotConstraints]:
             if any(_id_of(element) == child_id for element in parent.elements) else None
 
     if isinstance(parent, py.KeyValue):
-        return SlotConstraints(Precedence.NAMED_EXPRESSION) \
+        # A dict entry and a keyword argument each take an `expression`, which a `:=` is not
+        return SlotConstraints(Precedence.LAMBDA) \
             if child_id in (_id_of(parent.key), _id_of(parent.value)) else None
 
     if isinstance(parent, py.NamedArgument):
-        return SlotConstraints(Precedence.NAMED_EXPRESSION) if _id_of(parent.value) == child_id else None
+        return SlotConstraints(Precedence.LAMBDA) if _id_of(parent.value) == child_id else None
+
+    if isinstance(parent, py.ComprehensionExpression):
+        # A clause is visited without a cursor entry of its own, so its slots are answered here
+        if _id_of(parent.result) == child_id:
+            return SlotConstraints(Precedence.NAMED_EXPRESSION)
+        for clause in parent.clauses:
+            # `for v in x` and `if x` both read an `or_test`, so a conditional here dangles its `else`
+            if _id_of(clause.iterated_list) == child_id or \
+                    any(_id_of(condition.expression) == child_id for condition in clause.conditions or []):
+                return SlotConstraints(Precedence.OR)
+        return None
 
     if isinstance(parent, py.Star):
         return SlotConstraints(Precedence.OR) if _id_of(parent.expression) == child_id else None

--- a/rewrite-python/rewrite/src/rewrite/python/template/precedence.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/precedence.py
@@ -1,0 +1,316 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parenthesization of expressions spliced into a slot that would reparse them."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+from uuid import UUID
+
+from rewrite.java import J, Expression
+from rewrite.java import tree as j
+from rewrite.java.markers import OmitParentheses
+from rewrite.java.support_types import JRightPadded, Space
+from rewrite.markers import Markers
+from rewrite.python import tree as py
+from rewrite.utils import random_id, replace_if_changed
+
+
+class Precedence:
+    """Python operator precedence, as ordered by the reference grammar; higher binds tighter."""
+
+    GENERATOR = 1
+    """`x for x in y` without parentheses, legal only as a call's sole argument."""
+    YIELD = 2
+    """`yield x`, `yield from x`"""
+    TUPLE = 3
+    """`a, b` without parentheses."""
+    NAMED_EXPRESSION = 4
+    """`:=`"""
+    LAMBDA = 5
+    CONDITIONAL = 6
+    """`a if c else b`"""
+    OR = 7
+    AND = 8
+    NOT = 9
+    COMPARISON = 10
+    """`<` `>` `<=` `>=` `==` `!=` `in` `not in` `is` `is not`"""
+    BIT_OR = 11
+    BIT_XOR = 12
+    BIT_AND = 13
+    SHIFT = 14
+    """`<<` `>>`"""
+    ADDITIVE = 15
+    """`+` `-`"""
+    MULTIPLICATIVE = 16
+    """`*` `@` `/` `//` `%`"""
+    UNARY = 17
+    """`+x` `-x` `~x`"""
+    POWER = 18
+    """`**`"""
+    AWAIT = 19
+    CALL = 20
+    """`f(x)` `x[i]` `x.a`"""
+    PRIMARY = 21
+    """Literals, identifiers, and every display form that brackets itself."""
+
+
+@dataclass(frozen=True)
+class SlotConstraints:
+    """What a slot demands of what sits in it, beyond what precedence alone can express."""
+
+    precedence: int
+    """The lowest precedence that can sit here unparenthesized."""
+
+    allows_bare_generator: bool = False
+    """The slot is a call's sole argument, the one place `f(x for x in y)` needs no parentheses."""
+
+    followed_by_dot: bool = False
+    """The slot is followed by `.`, which an integer literal would lex as a decimal point."""
+
+
+_BINARY_PRECEDENCE = {
+    j.Binary.Type.Or: Precedence.OR,
+    j.Binary.Type.And: Precedence.AND,
+    j.Binary.Type.Equal: Precedence.COMPARISON,
+    j.Binary.Type.NotEqual: Precedence.COMPARISON,
+    j.Binary.Type.LessThan: Precedence.COMPARISON,
+    j.Binary.Type.GreaterThan: Precedence.COMPARISON,
+    j.Binary.Type.LessThanOrEqual: Precedence.COMPARISON,
+    j.Binary.Type.GreaterThanOrEqual: Precedence.COMPARISON,
+    j.Binary.Type.BitOr: Precedence.BIT_OR,
+    j.Binary.Type.BitXor: Precedence.BIT_XOR,
+    j.Binary.Type.BitAnd: Precedence.BIT_AND,
+    j.Binary.Type.LeftShift: Precedence.SHIFT,
+    j.Binary.Type.RightShift: Precedence.SHIFT,
+    j.Binary.Type.Addition: Precedence.ADDITIVE,
+    j.Binary.Type.Subtraction: Precedence.ADDITIVE,
+    j.Binary.Type.Multiplication: Precedence.MULTIPLICATIVE,
+    j.Binary.Type.Division: Precedence.MULTIPLICATIVE,
+    j.Binary.Type.Modulo: Precedence.MULTIPLICATIVE,
+}
+
+_PY_BINARY_PRECEDENCE = {
+    py.Binary.Type.In: Precedence.COMPARISON,
+    py.Binary.Type.NotIn: Precedence.COMPARISON,
+    py.Binary.Type.Is: Precedence.COMPARISON,
+    py.Binary.Type.IsNot: Precedence.COMPARISON,
+    py.Binary.Type.FloorDivision: Precedence.MULTIPLICATIVE,
+    py.Binary.Type.MatrixMultiplication: Precedence.MULTIPLICATIVE,
+    py.Binary.Type.Power: Precedence.POWER,
+    py.Binary.Type.StringConcatenation: Precedence.PRIMARY,
+}
+
+_UNARY_PRECEDENCE = {
+    j.Unary.Type.Not: Precedence.NOT,
+    j.Unary.Type.Negative: Precedence.UNARY,
+    j.Unary.Type.Positive: Precedence.UNARY,
+    j.Unary.Type.Complement: Precedence.UNARY,
+}
+
+
+def precedence_of(expression: J) -> int:
+    """The precedence of `expression` as printed; a kind not modelled here counts as PRIMARY."""
+    if isinstance(expression, j.Binary):
+        return _BINARY_PRECEDENCE.get(expression.operator, Precedence.PRIMARY)
+    if isinstance(expression, py.Binary):
+        return _PY_BINARY_PRECEDENCE.get(expression.operator, Precedence.PRIMARY)
+    if isinstance(expression, j.Unary):
+        return _UNARY_PRECEDENCE.get(expression.operator, Precedence.PRIMARY)
+    if isinstance(expression, j.Ternary):
+        return Precedence.CONDITIONAL
+    if isinstance(expression, j.Lambda):
+        return Precedence.LAMBDA
+    if isinstance(expression, j.Assignment):
+        # An assignment prints as `:=` wherever a slot holds it rather than a statement list
+        return Precedence.NAMED_EXPRESSION
+    if isinstance(expression, j.Yield) or isinstance(expression, py.YieldFrom):
+        return Precedence.YIELD
+    if isinstance(expression, py.Await):
+        return Precedence.AWAIT
+    if isinstance(expression, py.TypeHintedExpression):
+        return Precedence.NAMED_EXPRESSION
+    if isinstance(expression, py.CollectionLiteral):
+        return Precedence.TUPLE if _omits_parentheses(expression.padding.elements) else Precedence.PRIMARY
+    if isinstance(expression, py.ComprehensionExpression):
+        return Precedence.GENERATOR if _omits_parentheses(expression) else Precedence.PRIMARY
+    if isinstance(expression, (j.FieldAccess, j.ArrayAccess, j.MethodInvocation)):
+        return Precedence.CALL
+    if isinstance(expression, py.ExpressionStatement):
+        return precedence_of(expression.expression)
+    if isinstance(expression, py.StatementExpression):
+        # `yield x` is parsed as a J.Yield inside a Py.StatementExpression
+        return precedence_of(expression.statement)
+    return Precedence.PRIMARY
+
+
+def slot_constraints(parent: J, child_id: UUID) -> Optional[SlotConstraints]:
+    """What the slot of `parent` holding `child_id` demands, or None for a slot not modelled here."""
+    if isinstance(parent, (j.Parentheses, j.ControlParentheses)):
+        return SlotConstraints(0) if _id_of(parent.tree) == child_id else None
+
+    if isinstance(parent, (j.Binary, py.Binary)):
+        return _binary_slot(parent, child_id)
+
+    if isinstance(parent, j.Unary):
+        if _id_of(parent.expression) != child_id:
+            return None
+        return SlotConstraints(_UNARY_PRECEDENCE.get(parent.operator, Precedence.UNARY))
+
+    if isinstance(parent, j.Ternary):
+        # Both the condition and the true part are `or_test`s; only the else part takes a `test`
+        if _id_of(parent.condition) == child_id or _id_of(parent.true_part) == child_id:
+            return SlotConstraints(Precedence.OR)
+        return SlotConstraints(Precedence.LAMBDA) if _id_of(parent.false_part) == child_id else None
+
+    if isinstance(parent, j.Assignment):
+        if _id_of(parent.variable) == child_id:
+            return SlotConstraints(Precedence.CALL)
+        return SlotConstraints(Precedence.LAMBDA) if _id_of(parent.assignment) == child_id else None
+
+    if isinstance(parent, j.Lambda):
+        return SlotConstraints(Precedence.LAMBDA) if _id_of(parent.body) == child_id else None
+
+    if isinstance(parent, py.Await):
+        return SlotConstraints(Precedence.CALL) if _id_of(parent.expression) == child_id else None
+
+    if isinstance(parent, j.FieldAccess):
+        return SlotConstraints(Precedence.CALL, followed_by_dot=True) \
+            if _id_of(parent.target) == child_id else None
+
+    if isinstance(parent, j.ArrayAccess):
+        if _id_of(parent.indexed) == child_id:
+            return SlotConstraints(Precedence.CALL, followed_by_dot=False)
+        # A subscript reads its index as an expression list, so `a[b, c]` is a tuple rather than two slots
+        return SlotConstraints(Precedence.TUPLE) \
+            if parent.dimension is not None and _id_of(parent.dimension.index) == child_id else None
+
+    if isinstance(parent, j.MethodInvocation):
+        if _id_of(parent.select) == child_id:
+            return SlotConstraints(Precedence.CALL, followed_by_dot=True)
+        arguments = parent.arguments or []
+        if any(_id_of(argument) == child_id for argument in arguments):
+            return SlotConstraints(Precedence.NAMED_EXPRESSION, allows_bare_generator=len(arguments) == 1)
+        return None
+
+    if isinstance(parent, (py.CollectionLiteral, py.DictLiteral)):
+        return SlotConstraints(Precedence.NAMED_EXPRESSION) \
+            if any(_id_of(element) == child_id for element in parent.elements) else None
+
+    if isinstance(parent, py.KeyValue):
+        return SlotConstraints(Precedence.NAMED_EXPRESSION) \
+            if child_id in (_id_of(parent.key), _id_of(parent.value)) else None
+
+    if isinstance(parent, py.NamedArgument):
+        return SlotConstraints(Precedence.NAMED_EXPRESSION) if _id_of(parent.value) == child_id else None
+
+    if isinstance(parent, py.Star):
+        return SlotConstraints(Precedence.OR) if _id_of(parent.expression) == child_id else None
+
+    if isinstance(parent, j.Return):
+        return SlotConstraints(Precedence.TUPLE) if _id_of(parent.expression) == child_id else None
+
+    if isinstance(parent, (j.Yield, py.YieldFrom)):
+        held = parent.value if isinstance(parent, j.Yield) else parent.expression
+        return SlotConstraints(Precedence.TUPLE) if _id_of(held) == child_id else None
+
+    if isinstance(parent, py.ExpressionStatement):
+        # A statement may be a bare tuple or a `yield`, but never a bare generator
+        return SlotConstraints(Precedence.YIELD) if _id_of(parent.expression) == child_id else None
+
+    return None
+
+
+def required_precedence(parent: J, child_id: UUID) -> Optional[int]:
+    """The precedence the slot of `parent` holding `child_id` demands; see `slot_constraints`."""
+    constraints = slot_constraints(parent, child_id)
+    return constraints.precedence if constraints is not None else None
+
+
+def maybe_parenthesize(parent: Optional[J], child_id: UUID, expression: J) -> J:
+    """Parenthesizes `expression` if the slot of `parent` holding `child_id` would reparse it."""
+    if parent is None or not isinstance(expression, Expression):
+        return expression
+
+    constraints = slot_constraints(parent, child_id)
+    if constraints is None:
+        return expression
+
+    if precedence_of(expression) < constraints.precedence:
+        if constraints.allows_bare_generator and precedence_of(expression) == Precedence.GENERATOR:
+            return expression
+        return parenthesize(expression)
+    if constraints.followed_by_dot and _is_dot_adjacent_number(expression):
+        return parenthesize(expression)
+    return expression
+
+
+def parenthesize(expression: Expression) -> j.Parentheses:
+    """Wraps in `J.Parentheses`, moving the prefix out so the surrounding whitespace survives."""
+    return j.Parentheses(
+        _id=random_id(),
+        _prefix=expression.prefix,
+        _markers=Markers.EMPTY,
+        _tree=JRightPadded(
+            replace_if_changed(expression, _prefix=Space([], '')),
+            Space([], ''),
+            Markers.EMPTY,
+        ),
+    )
+
+
+def enclosing_tree(cursor) -> Optional[J]:
+    """The nearest enclosing LST node in a cursor path, skipping the padding wrappers visitors push."""
+    while cursor is not None:
+        if isinstance(cursor.value, J):
+            return cursor.value
+        cursor = cursor.parent
+    return None
+
+
+def _binary_slot(parent, child_id: UUID) -> Optional[SlotConstraints]:
+    precedence = _BINARY_PRECEDENCE.get(parent.operator) if isinstance(parent, j.Binary) \
+        else _PY_BINARY_PRECEDENCE.get(parent.operator)
+    if precedence is None:
+        return None
+
+    is_left = _id_of(parent.left) == child_id
+    if not is_left and _id_of(parent.right) != child_id:
+        return None
+
+    if precedence == Precedence.COMPARISON:
+        # Comparisons chain rather than associate, so `(a < b) < c` and `a < b < c` differ
+        return SlotConstraints(precedence + 1)
+    if precedence == Precedence.POWER:
+        # `**` is right-associative, and `-a ** b` means `-(a ** b)`, so its left operand takes no unary
+        return SlotConstraints(Precedence.AWAIT if is_left else Precedence.UNARY)
+    return SlotConstraints(precedence if is_left else precedence + 1)
+
+
+def _omits_parentheses(node) -> bool:
+    return node is not None and any(isinstance(m, OmitParentheses) for m in node.markers.markers)
+
+
+def _is_dot_adjacent_number(expression: J) -> bool:
+    """Whether a following `.` lexes into the number: `1.bit_length()` fails, `1.5`/`0x10` do not."""
+    if not isinstance(expression, j.Literal) or expression.value_source is None:
+        return False
+    source = expression.value_source
+    return source[0].isdigit() and source.replace('_', '').isdigit()
+
+
+def _id_of(node) -> Optional[UUID]:
+    return node.id if node is not None else None

--- a/rewrite-python/rewrite/src/rewrite/python/template/replacement.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/replacement.py
@@ -16,132 +16,15 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Dict, List, Union
 
-from rewrite.utils import random_id
-from rewrite.java import J, Expression
+from rewrite.java import J
 from rewrite.java import tree as j
 from rewrite.java.support_types import JContainer, JRightPadded
 from rewrite.python import tree as py
 from rewrite.python.visitor import PythonVisitor
 from .placeholder import from_placeholder
-
-if TYPE_CHECKING:
-    from rewrite.visitor import Cursor
-
-
-# Operator precedence for Python binary operators (higher number = higher precedence).
-# Only operators relevant for precedence-sensitive substitution are listed.
-_BINARY_PRECEDENCE: Dict[object, int] = {
-    j.Binary.Type.Or: 1,
-    j.Binary.Type.And: 2,
-    # Comparisons (all same precedence)
-    j.Binary.Type.Equal: 4,
-    j.Binary.Type.NotEqual: 4,
-    j.Binary.Type.LessThan: 4,
-    j.Binary.Type.GreaterThan: 4,
-    j.Binary.Type.LessThanOrEqual: 4,
-    j.Binary.Type.GreaterThanOrEqual: 4,
-    # Python-specific comparisons
-    py.Binary.Type.In: 4,
-    py.Binary.Type.NotIn: 4,
-    py.Binary.Type.Is: 4,
-    py.Binary.Type.IsNot: 4,
-    # Bitwise
-    j.Binary.Type.BitOr: 5,
-    j.Binary.Type.BitXor: 6,
-    j.Binary.Type.BitAnd: 7,
-    # Shifts
-    j.Binary.Type.LeftShift: 8,
-    j.Binary.Type.RightShift: 8,
-    # Arithmetic
-    j.Binary.Type.Addition: 9,
-    j.Binary.Type.Subtraction: 9,
-    j.Binary.Type.Multiplication: 10,
-    j.Binary.Type.Division: 10,
-    j.Binary.Type.Modulo: 10,
-    py.Binary.Type.FloorDivision: 10,
-    py.Binary.Type.MatrixMultiplication: 10,
-    py.Binary.Type.Power: 11,
-}
-
-
-def _get_precedence(expr: J) -> Optional[int]:
-    """Return the precedence of an expression, or None if not an operator node."""
-    if isinstance(expr, j.Binary):
-        return _BINARY_PRECEDENCE.get(expr.operator)
-    if isinstance(expr, py.Binary):
-        return _BINARY_PRECEDENCE.get(expr.operator)
-    if isinstance(expr, j.Unary) and expr.operator == j.Unary.Type.Not:
-        return 3  # `not` sits between `and` (2) and comparisons (4)
-    return None
-
-
-def _wrap_in_parens(expr: Expression) -> j.Parentheses:
-    """Wrap an expression in parentheses, preserving its prefix on the outer node."""
-    return j.Parentheses(
-        _id=random_id(),
-        _prefix=expr.prefix,
-        _markers=j.Markers.EMPTY,
-        _tree=JRightPadded(
-            expr.replace(_prefix=j.Space([], '')),
-            j.Space([], ''),
-            j.Markers.EMPTY,
-        ),
-    )
-
-
-def _needs_parens_in_binary(child: J, parent_op_prec: int) -> bool:
-    """Check if a child expression needs parentheses inside a binary with the given precedence."""
-    child_prec = _get_precedence(child)
-    if child_prec is None:
-        return False
-    return child_prec < parent_op_prec
-
-
-def _needs_parens_under_not(child: J) -> bool:
-    """Check if a child expression needs parentheses when placed under `not`."""
-    # `not` binds tighter than `and` and `or`, so both need parens
-    child_prec = _get_precedence(child)
-    if child_prec is None:
-        return False
-    # `not` has precedence 3 (between `and` at 2 and comparisons at 4)
-    return child_prec < 3
-
-
-def maybe_parenthesize(result: J, cursor: 'Cursor') -> J:
-    """Wrap *result* in parentheses when its precedence is lower than the
-    surrounding context (the cursor's parent tree node).
-
-    This handles the *outer* boundary: whether the template result as a whole
-    needs parentheses relative to where it is being inserted in the tree.
-    The *inner* operand parenthesization (within the template result itself)
-    is handled by ``PlaceholderReplacementVisitor.visit_binary`` / ``visit_unary``.
-
-    This mirrors ``ParenthesizeVisitor.maybeParenthesize`` in the Java
-    ``JavaTemplate`` implementation.
-    """
-    if not isinstance(result, (j.Binary, py.Binary, j.Unary)):
-        return result
-
-    parent_cursor = cursor.parent_tree_cursor()
-    parent = parent_cursor.value
-    if not isinstance(parent, J):
-        return result
-
-    # Parent is a binary operator — check precedence
-    if isinstance(parent, (j.Binary, py.Binary)):
-        parent_prec = _get_precedence(parent)
-        result_prec = _get_precedence(result)
-        if parent_prec is not None and result_prec is not None and result_prec < parent_prec:
-            return _wrap_in_parens(result)
-
-    # Parent is `not` — or/and need parens underneath
-    if isinstance(parent, j.Unary) and parent.operator == j.Unary.Type.Not:
-        if _needs_parens_under_not(result):
-            return _wrap_in_parens(result)
-
-    return result
+from .precedence import enclosing_tree, maybe_parenthesize
 
 
 class PlaceholderReplacementVisitor(PythonVisitor[None]):
@@ -152,9 +35,8 @@ class PlaceholderReplacementVisitor(PythonVisitor[None]):
     that match the placeholder pattern (__plh_name__) with
     the corresponding captured values.
 
-    When a substituted value has lower operator precedence than the
-    surrounding context, it is automatically wrapped in parentheses
-    to preserve semantics.
+    When a substituted value binds more loosely than the slot it lands
+    in demands, it is wrapped in parentheses to preserve semantics.
     """
 
     def __init__(self, values: Dict[str, Union[J, List[J]]]):
@@ -189,7 +71,9 @@ class PlaceholderReplacementVisitor(PythonVisitor[None]):
             if hasattr(replacement, 'prefix'):
                 replacement = replacement.replace(prefix=ident.prefix)
 
-            return replacement
+            # The cursor is still on the placeholder, so its parent owns the slot the value lands in
+            parent = enclosing_tree(self.cursor.parent) if self.cursor is not None else None
+            return maybe_parenthesize(parent, ident.id, replacement)
 
         # Not a placeholder or no value provided, continue normally
         return super().visit_identifier(ident, p)
@@ -229,53 +113,6 @@ class PlaceholderReplacementVisitor(PythonVisitor[None]):
             block = block.padding.replace(statements=new_stmts)
 
         return super().visit_block(block, p)
-
-    def visit_binary(self, binary: j.Binary, p: None) -> J:
-        """Visit a Java Binary and auto-parenthesize substituted operands if needed."""
-        binary = super().visit_binary(binary, p)
-        parent_prec = _BINARY_PRECEDENCE.get(binary.operator)
-        if parent_prec is None:
-            return binary
-
-        left = binary.left
-        right = binary.right
-
-        if _needs_parens_in_binary(left, parent_prec):
-            left = _wrap_in_parens(left)
-        if _needs_parens_in_binary(right, parent_prec):
-            right = _wrap_in_parens(right)
-
-        if left is not binary.left or right is not binary.right:
-            binary = binary.replace(_left=left, _right=right)
-        return binary
-
-    def visit_python_binary(self, binary: py.Binary, p: None) -> J:
-        """Visit a Python Binary and auto-parenthesize substituted operands if needed."""
-        binary = super().visit_python_binary(binary, p)
-        parent_prec = _BINARY_PRECEDENCE.get(binary.operator)
-        if parent_prec is None:
-            return binary
-
-        left = binary.left
-        right = binary.right
-
-        if _needs_parens_in_binary(left, parent_prec):
-            left = _wrap_in_parens(left)
-        if _needs_parens_in_binary(right, parent_prec):
-            right = _wrap_in_parens(right)
-
-        if left is not binary.left or right is not binary.right:
-            binary = binary.replace(_left=left, _right=right)
-        return binary
-
-    def visit_unary(self, unary: j.Unary, p: None) -> J:
-        """Visit a Unary and auto-parenthesize substituted operand under `not` if needed."""
-        unary = super().visit_unary(unary, p)
-        if unary.operator == j.Unary.Type.Not:
-            expr = unary.expression
-            if _needs_parens_under_not(expr):
-                unary = unary.replace(_expression=_wrap_in_parens(expr))
-        return unary
 
     def visit_method_invocation(self, method: j.MethodInvocation, p: None) -> J:
         """

--- a/rewrite-python/rewrite/src/rewrite/python/template/template.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/template.py
@@ -112,6 +112,7 @@ class Template:
         *,
         values: Optional[Union['MatchResult', Dict[str, Any]]] = None,
         coordinates: Optional[PythonCoordinates] = None,
+        format: bool = True,
     ) -> Optional[J]:
         """
         Apply this template, returning the generated AST node.
@@ -120,6 +121,9 @@ class Template:
             cursor: Current position in the AST.
             values: Captured values from a pattern match, or a dict of values.
             coordinates: Where/how to insert (default: replace current).
+            format: Whether the result is fitted to where it lands. Pass False to assemble
+                several results into one subtree and format that subtree once, rather than
+                once per application. The anchor supplies the result's prefix either way.
 
         Returns:
             The generated AST node.
@@ -172,7 +176,7 @@ class Template:
                 effective_coords = PythonCoordinates.replace(tree)
 
         if effective_coords is not None and result is not None:
-            result = TemplateEngine.apply_coordinates(result, cursor, effective_coords)
+            result = TemplateEngine.apply_coordinates(result, cursor, effective_coords, format)
 
         return result
 

--- a/rewrite-python/rewrite/src/rewrite/python/template/template.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/template.py
@@ -155,13 +155,14 @@ class Template:
         else:
             result = template_tree
 
-        # Phase 2: parenthesize the result if it has lower precedence than
-        # the surrounding context, mirroring JavaTemplate.doApply().
+        # Phase 2: parenthesize the result for the slot it replaces, mirroring JavaTemplate.doApply().
         # This must happen before coordinates are applied, because
         # apply_coordinates may wrap the expression in ExpressionStatement.
         if result is not None and cursor is not None:
-            from .replacement import maybe_parenthesize
-            result = maybe_parenthesize(result, cursor)
+            from .precedence import enclosing_tree, maybe_parenthesize
+            target = cursor.value
+            if isinstance(target, J):
+                result = maybe_parenthesize(enclosing_tree(cursor.parent), target.id, result)
 
         # Phase 3: apply coordinates (prefix preservation, statement wrapping, auto-format)
         effective_coords = coordinates

--- a/rewrite-python/rewrite/tests/python/template/test_precedence.py
+++ b/rewrite-python/rewrite/tests/python/template/test_precedence.py
@@ -1,0 +1,142 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parenthesization of a value spliced into a slot that would otherwise reparse it."""
+
+from rewrite import ExecutionContext, Recipe
+from rewrite.python.template import capture, pattern, template
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
+
+
+def _rule(before: str, after: str) -> Recipe:
+    """A recipe rewriting `before` to `after`, so one test drives one slot from source to source."""
+    x = capture('x')
+    pat = pattern(before, x=x)
+    tmpl = template(after, x=x)
+
+    class Rule(Recipe):
+        @property
+        def name(self) -> str:
+            return "test.Splice"
+
+        @property
+        def display_name(self) -> str:
+            return "Splice"
+
+        @property
+        def description(self) -> str:
+            return "Splices a captured expression into a template slot."
+
+        def editor(self):
+            class Visitor(PythonVisitor[ExecutionContext]):
+                def visit_method_invocation(self, method, p):
+                    method = super().visit_method_invocation(method, p)
+                    match = pat.match(method, self.cursor)
+                    return tmpl.apply(self.cursor, values=match) if match else method
+
+                def visit_array_access(self, array_access, p):
+                    array_access = super().visit_array_access(array_access, p)
+                    match = pat.match(array_access, self.cursor)
+                    return tmpl.apply(self.cursor, values=match) if match else array_access
+
+            return Visitor()
+
+    return Rule()
+
+
+def test_a_binary_operator_binds_its_right_operand_more_tightly():
+    RecipeSpec(recipe=_rule("below({x})", "10 - {x}")).rewrite_run(python(
+        "a = below(n - 1)\n"
+        "b = below(n * 2)\n",
+        "a = 10 - (n - 1)\n"
+        "b = 10 - n * 2\n",
+    ))
+
+
+def test_power_is_right_associative_and_takes_no_unary_on_its_left():
+    RecipeSpec(recipe=_rule("squared({x})", "{x} ** 2")).rewrite_run(python(
+        "a = squared(n ** 3)\n"
+        "b = squared(-n)\n"
+        "c = squared(await n)\n",
+        "a = (n ** 3) ** 2\n"
+        "b = (-n) ** 2\n"
+        "c = await n ** 2\n",
+    ))
+    RecipeSpec(recipe=_rule("exp({x})", "2 ** {x}")).rewrite_run(python(
+        "a = exp(n ** 3)\n"
+        "b = exp(-n)\n",
+        "a = 2 ** n ** 3\n"
+        "b = 2 ** -n\n",
+    ))
+
+
+def test_comparisons_chain_rather_than_associate():
+    RecipeSpec(recipe=_rule("under({x})", "{x} < 10")).rewrite_run(python(
+        "a = under(n < m)\n"
+        "b = under(n | m)\n",
+        "a = (n < m) < 10\n"
+        "b = n | m < 10\n",
+    ))
+
+
+def test_an_expression_that_is_not_an_operator_still_has_a_precedence():
+    RecipeSpec(recipe=_rule("twice({x})", "2 * {x}")).rewrite_run(python(
+        "a = twice(p if q else r)\n"
+        "b = twice(lambda: q)\n"
+        "c = twice(n := q)\n",
+        "a = 2 * (p if q else r)\n"
+        "b = 2 * (lambda: q)\n"
+        "c = 2 * (n := q)\n",
+    ))
+
+
+def test_an_attribute_target_takes_a_call_or_tighter():
+    RecipeSpec(recipe=_rule("length({x})", "{x}.bit_length()")).rewrite_run(python(
+        "a = length(n + 1)\n"
+        "b = length(n.d)\n",
+        "a = (n + 1).bit_length()\n"
+        "b = n.d.bit_length()\n",
+    ))
+
+
+def test_an_integer_literal_before_a_dot_is_parenthesized():
+    RecipeSpec(recipe=_rule("length({x})", "{x}.bit_length()")).rewrite_run(python(
+        "a = length(1)\n"
+        "b = length(1.5)\n",
+        "a = (1).bit_length()\n"
+        "b = 1.5.bit_length()\n",
+    ))
+
+
+def test_a_bare_tuple_survives_a_subscript_but_not_a_call():
+    RecipeSpec(recipe=_rule("d[{x}]", "f({x})")).rewrite_run(python(
+        "a = d[p, q]\n",
+        "a = f((p, q))\n",
+    ))
+    RecipeSpec(recipe=_rule("d[{x}]", "e[{x}]")).rewrite_run(python(
+        "a = d[p, q]\n",
+        "a = e[p, q]\n",
+    ))
+
+
+def test_a_bare_generator_survives_only_as_a_call_s_sole_argument():
+    RecipeSpec(recipe=_rule("collect({x})", "list({x})")).rewrite_run(python(
+        "a = collect(v for v in vs)\n",
+        "a = list(v for v in vs)\n",
+    ))
+    RecipeSpec(recipe=_rule("collect({x})", "sorted({x}, reverse=True)")).rewrite_run(python(
+        "a = collect(v for v in vs)\n",
+        "a = sorted((v for v in vs), reverse=True)\n",
+    ))

--- a/rewrite-python/rewrite/tests/python/template/test_precedence.py
+++ b/rewrite-python/rewrite/tests/python/template/test_precedence.py
@@ -140,3 +140,32 @@ def test_a_bare_generator_survives_only_as_a_call_s_sole_argument():
         "a = collect(v for v in vs)\n",
         "a = sorted((v for v in vs), reverse=True)\n",
     ))
+
+
+def test_a_slot_that_takes_a_plain_expression_rejects_a_walrus():
+    RecipeSpec(recipe=_rule("kw({x})", "f(k={x})")).rewrite_run(python(
+        "a = kw(n := 1)\n",
+        "a = f(k=(n := 1))\n",
+    ))
+    RecipeSpec(recipe=_rule("entry({x})", "{1: {x}}")).rewrite_run(python(
+        "a = entry(n := 1)\n",
+        "a = {1: (n := 1)}\n",
+    ))
+
+
+def test_a_comprehension_clause_takes_an_or_test():
+    RecipeSpec(recipe=_rule("over({x})", "[v for v in {x}]")).rewrite_run(python(
+        "a = over(p if c else q)\n",
+        "a = [v for v in (p if c else q)]\n",
+    ))
+    RecipeSpec(recipe=_rule("keep({x})", "[v for v in vs if {x}]")).rewrite_run(python(
+        "a = keep(p if c else q)\n",
+        "a = [v for v in vs if (p if c else q)]\n",
+    ))
+
+
+def test_a_comprehension_result_takes_an_expression():
+    RecipeSpec(recipe=_rule("d[{x}]", "[{x} for v in vs]")).rewrite_run(python(
+        "a = d[p, q]\n",
+        "a = [(p, q) for v in vs]\n",
+    ))

--- a/rewrite-python/rewrite/tests/python/template/test_replacement.py
+++ b/rewrite-python/rewrite/tests/python/template/test_replacement.py
@@ -193,8 +193,8 @@ class TestAutoParenthesization:
         assert isinstance(inner, j.Binary)
         assert inner.operator == j.Binary.Type.Or
 
-    def test_and_operand_in_and_no_parens(self):
-        """{a} and {b} with b=(x and y) should NOT add parens (same precedence)."""
+    def test_equal_precedence_right_operand_gets_parens(self):
+        """{a} and {b} with b=(x and y) parenthesizes, as every left-associative operator does."""
         tree = TemplateEngine.get_template_tree(
             "{a} and {b}", {'a': capture('a'), 'b': capture('b')}
         )
@@ -206,8 +206,7 @@ class TestAutoParenthesization:
         result = visitor.visit(tree, None)
 
         assert isinstance(result, j.Binary)
-        # Right operand should NOT be wrapped (same precedence)
-        assert isinstance(result.right, j.Binary)
+        assert isinstance(result.right, j.Parentheses)
 
     def test_or_operand_in_left_of_and_gets_parens(self):
         """{a} and {b} with a=(p or q) should produce (p or q) and b."""

--- a/rewrite-python/rewrite/tests/python/template/test_template.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template.py
@@ -335,6 +335,41 @@ class TestTemplateApplyRecipe:
 class TestTemplateApply:
     """Tests for Template.apply()."""
 
+    def test_format_false_anchors_the_template_without_fitting_it(self):
+        """The template's own layout survives, while the anchor still supplies the prefix."""
+        def recipe(fmt: bool) -> Recipe:
+            v = capture('v')
+            pat = pattern("old({v})", v=v)
+            tmpl = template("wrapper(\n    new({v})\n)", v=v)
+
+            class Rule(Recipe):
+                @property
+                def name(self) -> str:
+                    return "test.Wrap"
+
+                @property
+                def display_name(self) -> str:
+                    return "Wrap"
+
+                @property
+                def description(self) -> str:
+                    return "Wraps a call in a template spanning several lines."
+
+                def editor(self):
+                    class Visitor(PythonVisitor[ExecutionContext]):
+                        def visit_method_invocation(self, method, p):
+                            method = super().visit_method_invocation(method, p)
+                            match = pat.match(method, self.cursor)
+                            return tmpl.apply(self.cursor, values=match, format=fmt) if match else method
+                    return Visitor()
+            return Rule()
+
+        before = "with lock:\n    old(v)\n"
+        RecipeSpec(recipe=recipe(True)).rewrite_run(python(
+            before, "with lock:\n    wrapper(\n        new(v)\n    )\n"))
+        RecipeSpec(recipe=recipe(False)).rewrite_run(python(
+            before, "with lock:\n    wrapper(\n    new(v)\n)\n"))
+
     def test_apply_no_captures_returns_tree(self):
         """Test that apply with no captures returns a tree."""
         tmpl = template("x + 1")

--- a/rewrite-python/rewrite/tests/python/template/test_template.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template.py
@@ -26,7 +26,7 @@ from rewrite.java.support_types import Space, JRightPadded
 from rewrite.markers import Markers
 from rewrite.python.template import template, capture, pattern, Template, TemplateBuilder
 from rewrite.python.template.engine import TemplateEngine
-from rewrite.python.template.replacement import maybe_parenthesize
+from rewrite.python.template.precedence import enclosing_tree, maybe_parenthesize
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
 from rewrite.visitor import Cursor
@@ -394,6 +394,11 @@ class TestMaybeParenthesize:
         )
 
     @staticmethod
+    def _at_slot(result, cursor: Cursor):
+        """Applies the outer boundary as Template.apply does, from the cursor on the node replaced."""
+        return maybe_parenthesize(enclosing_tree(cursor.parent), cursor.value.id, result)
+
+    @staticmethod
     def _cursor_chain(*nodes) -> Cursor:
         """Build a cursor chain from root → … → leaf."""
         cur = Cursor(None, Cursor.ROOT_VALUE)
@@ -407,7 +412,7 @@ class TestMaybeParenthesize:
         and_parent = self._binary(or_expr, j.Binary.Type.And, self._ident('z'))
         cursor = self._cursor_chain(and_parent, or_expr)
 
-        result = maybe_parenthesize(or_expr, cursor)
+        result = self._at_slot(or_expr, cursor)
         assert isinstance(result, j.Parentheses)
 
     def test_and_result_in_or_parent(self):
@@ -416,7 +421,7 @@ class TestMaybeParenthesize:
         or_parent = self._binary(and_expr, j.Binary.Type.Or, self._ident('z'))
         cursor = self._cursor_chain(or_parent, and_expr)
 
-        result = maybe_parenthesize(and_expr, cursor)
+        result = self._at_slot(and_expr, cursor)
         assert not isinstance(result, j.Parentheses)
 
     def test_or_result_under_not(self):
@@ -429,7 +434,7 @@ class TestMaybeParenthesize:
         )
         cursor = self._cursor_chain(not_parent, or_expr)
 
-        result = maybe_parenthesize(or_expr, cursor)
+        result = self._at_slot(or_expr, cursor)
         assert isinstance(result, j.Parentheses)
 
     def test_identifier_result_unchanged(self):
@@ -438,7 +443,7 @@ class TestMaybeParenthesize:
         and_parent = self._binary(ident, j.Binary.Type.And, self._ident('z'))
         cursor = self._cursor_chain(and_parent, ident)
 
-        result = maybe_parenthesize(ident, cursor)
+        result = self._at_slot(ident, cursor)
         assert result is ident
 
     def test_same_precedence_no_parens(self):
@@ -447,7 +452,7 @@ class TestMaybeParenthesize:
         outer = self._binary(inner, j.Binary.Type.And, self._ident('c'))
         cursor = self._cursor_chain(outer, inner)
 
-        result = maybe_parenthesize(inner, cursor)
+        result = self._at_slot(inner, cursor)
         assert not isinstance(result, j.Parentheses)
 
     def test_template_apply_parenthesizes_in_binary_context(self):


### PR DESCRIPTION
Splicing a captured expression into a `rewrite-python` template could produce code that means something else, or does not parse at all:

```python
# template `10 - {x}`, x captured from `n - 1`
10 - n - 1                  # wanted: 10 - (n - 1)

# template `2 * {x}`, x captured from `p if q else r`
2 * p if q else r           # wanted: 2 * (p if q else r)
```

Two holes in `template/replacement.py`, both in the precedence model behind it:

- `_needs_parens_in_binary` compared a child against the parent *operator's* precedence with one threshold for both operands, so an equally binding right operand kept no parentheses. Same for `/`, `//`, `%` and the shifts; `**` had it backwards, being right-associative.
- `_get_precedence` answered only for `J.Binary`, `Py.Binary` and `not`. Every other kind returned `None`, which both callers read as "no parentheses needed", so a conditional, lambda, walrus, `await`, generator or bare tuple spliced in bare.

## The model

`template/precedence.py` replaces it with the shape `rewrite-javascript` uses, which the second bug is an argument for:

- `precedence_of` covers every expression kind and falls back to `PRIMARY`, so a kind it does not model is left alone rather than silently admitted.
- `slot_constraints(parent, child_id)` answers for **the slot** rather than the parent operator. That is how left and right operands come out different — the first bug.
- `SlotConstraints` carries the rules precedence cannot state: a bare generator is legal as a call's sole argument, and an integer literal before `.` lexes as a decimal point.

The table is Python's grammar, not a port of the ECMAScript one. Twenty-one levels, generator/yield/tuple/walrus at the loose end; comparisons chain rather than associate, so both operands demand `+1`; `**` takes no unary on its left, so `-a` splices as `(-a) ** 2`.

Substitution now parenthesizes at the placeholder's slot in `visit_identifier`, which reaches call arguments, subscripts, dict entries, keyword arguments and comprehension clauses — none of which `visit_binary`/`visit_python_binary`/`visit_unary` ever saw. All three overrides are deleted.

## Applying without fitting

`Template.apply(..., format=False)` returns once coordinates are applied, before `maybe_auto_format`, so a recipe assembling several applications into one subtree formats it once at the end. The anchor supplies the prefix either way. This is `ApplyOptions.format` in `rewrite-javascript` and the `autoFormat` argument to `JavaTemplate#doApply`.

## What this deliberately leaves alone

Starred expressions and slices. `(*x)` and `(a:b)` are both syntax errors, so parentheses are no remedy in those positions; they fall through to `PRIMARY`.

`Py.Binary.Type.StringConcatenation` stays at `PRIMARY`. Adjacent string literals form an atom, so the concatenation binds tighter than `.` and `[]`:

```pycon
>>> "p" "q".upper()
'PQ'
>>> "a" "bc"[0]
'a'
```

## Tests

`tests/python/template/test_precedence.py` adds 11 source-to-source tests, one per branch of the model; each was confirmed failing before the change.

One pre-existing test asserted the defect. `test_and_operand_in_and_no_parens` claimed `a and (x and y)` should keep no parentheses at equal precedence — harmless for `and` specifically, but it pins the symmetric threshold that is the bug for `-` and `/`. It is now `test_equal_precedence_right_operand_gets_parens`.

Full Python suite: 1966 passed, 65 skipped (RPC excluded). `ty` diagnostics in the template package go 14 → 7, the remainder pre-existing.
