### PR TITLE
Python: search preconditions walk the LST with the generated visitor

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
@@ -36,12 +36,21 @@ that :class:`Check` interprets as the gate matching.
 from __future__ import annotations
 
 import fnmatch
-from typing import Any, Optional
+import logging
+from typing import Any, Optional, cast
 
+from rewrite.java.support_types import J
+from rewrite.java.tree import Import, MethodInvocation
 from rewrite.markers import SearchResult
+from rewrite.python.import_utils import get_name_string, get_qualid_name
 from rewrite.python.method_matcher import MethodMatcher
+from rewrite.python.support_types import Py
+from rewrite.python.tree import MultiImport
+from rewrite.python.visitor import PythonVisitor
 from rewrite.tree import SourceFile, Tree
 from rewrite.visitor import Cursor, TreeVisitor
+
+logger = logging.getLogger(__name__)
 
 
 class IsSourceFile(TreeVisitor[Tree, Any]):
@@ -91,11 +100,11 @@ class UsesType(TreeVisitor[Tree, Any]):
     ) -> Optional[Tree]:
         if not isinstance(tree, SourceFile):
             return tree
-        if self._tree_uses_type(tree):
+        if self._tree_uses_type(tree, p):
             return SearchResult.found(tree)
         return tree
 
-    def _tree_uses_type(self, tree: Tree) -> bool:
+    def _tree_uses_type(self, tree: Tree, p: Any) -> bool:
         # Prefer TypesInUse on the source file when present (cheap O(N))
         types_in_use = getattr(tree, "types_in_use", None)
         if types_in_use is not None:
@@ -108,24 +117,7 @@ class UsesType(TreeVisitor[Tree, Any]):
                     if fqn and fnmatch.fnmatch(fqn, self._pattern):
                         return True
                 return False
-        return self._walk_for_type(tree)
-
-    def _walk_for_type(self, tree: Tree) -> bool:
-        """Fall back to walking every node looking for a typed reference
-        whose fully-qualified name matches ``self._pattern``."""
-        found = [False]
-
-        def check(node: Any) -> None:
-            if found[0]:
-                return
-            t = getattr(node, "type", None)
-            if t is not None:
-                fqn = _fully_qualified_name(t)
-                if fqn and fnmatch.fnmatch(fqn, self._pattern):
-                    found[0] = True
-
-        _walk(tree, check)
-        return found[0]
+        return _TypeSearch(self._pattern).search(tree, p)
 
 
 class UsesMethod(TreeVisitor[Tree, Any]):
@@ -147,23 +139,9 @@ class UsesMethod(TreeVisitor[Tree, Any]):
     ) -> Optional[Tree]:
         if not isinstance(tree, SourceFile):
             return tree
-        if self._tree_uses_method(tree):
+        if _MethodSearch(self._matcher).search(tree, p):
             return SearchResult.found(tree)
         return tree
-
-    def _tree_uses_method(self, tree: Tree) -> bool:
-        from rewrite.java.tree import MethodInvocation
-
-        found = [False]
-
-        def check(node: Any) -> None:
-            if found[0]:
-                return
-            if isinstance(node, MethodInvocation) and self._matcher.matches(node):
-                found[0] = True
-
-        _walk(tree, check)
-        return found[0]
 
 
 class UsesImport(TreeVisitor[Tree, Any]):
@@ -198,50 +176,9 @@ class UsesImport(TreeVisitor[Tree, Any]):
     ) -> Optional[Tree]:
         if not isinstance(tree, SourceFile):
             return tree
-        if self._tree_uses_import(tree):
+        if _ImportSearch(self._module).search(tree, p):
             return SearchResult.found(tree)
         return tree
-
-    def _tree_uses_import(self, tree: Tree) -> bool:
-        from rewrite.java.tree import Import
-        from rewrite.python.tree import MultiImport
-        from rewrite.python.import_utils import get_name_string, get_qualid_name
-
-        multi_imports: list = []
-        standalone_imports: list = []
-        child_ids: set = set()
-
-        def collect(node: Any) -> None:
-            if isinstance(node, MultiImport):
-                multi_imports.append(node)
-                for imp in node.names:
-                    child_ids.add(id(imp))
-            elif isinstance(node, Import):
-                standalone_imports.append(node)
-
-        _walk(tree, collect)
-
-        for multi in multi_imports:
-            if multi.from_ is not None:
-                # `from <module> import ...` — the module is the `from` clause.
-                if _import_path_matches(get_name_string(multi.from_), self._module):
-                    return True
-            else:
-                # `import <a>, <b>` — each name's qualid is itself a module.
-                for imp in multi.names:
-                    if _import_path_matches(get_qualid_name(imp.qualid), self._module):
-                        return True
-
-        # A truly standalone J.Import (not a MultiImport child) is an
-        # `import <module>` whose qualid is the module. Children of a `from`
-        # MultiImport are imported *names*, not modules, so they are excluded.
-        for imp in standalone_imports:
-            if id(imp) in child_ids:
-                continue
-            if _import_path_matches(get_qualid_name(imp.qualid), self._module):
-                return True
-
-        return False
 
 
 def _import_path_matches(imported: str, query: str) -> bool:
@@ -276,39 +213,110 @@ def _fully_qualified_name(type_obj: Any) -> Optional[str]:
     return None
 
 
-def _walk(node: Any, visit_fn) -> None:
-    """Iterative DFS over a tree, calling ``visit_fn`` on each node.
+class _FindFirst(PythonVisitor[Any]):
+    """Traversal that stops at the first node :meth:`matches` accepts.
 
-    Cheap reflection over public attributes — sufficient for matching
-    against type / method-invocation attributes which are publicly
-    exposed on LST nodes.
+    Dispatches straight to ``accept`` because a search reads nodes and never
+    rewrites them, so nothing consumes the cursor the base ``visit`` builds.
     """
-    stack = [node]
-    seen: set = set()
-    while stack:
-        cur = stack.pop()
-        if cur is None:
-            continue
-        cur_id = id(cur)
-        if cur_id in seen:
-            continue
-        seen.add(cur_id)
-        visit_fn(cur)
-        # Walk public attribute values that look tree-shaped
-        for attr in dir(cur):
-            if attr.startswith("_"):
-                continue
-            try:
-                val = getattr(cur, attr)
-            except Exception:
-                continue
-            if isinstance(val, (list, tuple)):
-                for item in val:
-                    if hasattr(item, "id") or hasattr(item, "markers"):
-                        stack.append(item)
-            elif hasattr(val, "id") or hasattr(val, "markers"):
-                if val is not cur:
-                    stack.append(val)
+
+    def __init__(self) -> None:
+        self.found = False
+
+    def matches(self, tree: Tree) -> bool:
+        raise NotImplementedError
+
+    def visit(
+        self,
+        tree: Optional[Tree],
+        p: Any,
+        parent: Optional[Cursor] = None,
+    ) -> Optional[J]:
+        if tree is None or self.found:
+            return cast(Optional[J], tree)
+        if self.matches(tree):
+            self.found = True
+            return cast(J, tree)
+        return tree.accept(self, p)
+
+    def search(self, tree: Tree, p: Any) -> bool:
+        """Whether ``tree`` or any node under it matches.
+
+        Only the Python model is searchable: a source file of another language
+        reaching a Python precondition is a file its recipe cannot edit anyway.
+        """
+        if not isinstance(tree, Py):
+            return False
+        try:
+            self.visit(tree, p)
+        except RecursionError:
+            # A tree deeper than the interpreter stack (generated data files
+            # nest thousands of implicit string concatenations) is one the gated
+            # visitor cannot edit either. Answering "no match" leaves no other
+            # trace of the file, hence the log line.
+            logger.warning(
+                "%s nests too deeply to search; treating it as no match",
+                getattr(tree, "source_path", tree),
+            )
+            return False
+        return self.found
+
+
+class _TypeSearch(_FindFirst):
+    def __init__(self, pattern: str) -> None:
+        super().__init__()
+        self._pattern = pattern
+
+    def matches(self, tree: Tree) -> bool:
+        # Read the attribution off any node that carries it: `Expression`
+        # declares its own `type` alongside `TypedTree` rather than under it,
+        # so a class check on either one alone misses the other's nodes.
+        fqn = _fully_qualified_name(getattr(tree, "type", None))
+        return fqn is not None and fnmatch.fnmatch(fqn, self._pattern)
+
+
+class _MethodSearch(_FindFirst):
+    def __init__(self, matcher: MethodMatcher) -> None:
+        super().__init__()
+        self._matcher = matcher
+
+    def matches(self, tree: Tree) -> bool:
+        return isinstance(tree, MethodInvocation) and self._matcher.matches(tree)
+
+
+class _ImportSearch(_FindFirst):
+    def __init__(self, module: str) -> None:
+        super().__init__()
+        self._module = module
+
+    def visit(
+        self,
+        tree: Optional[Tree],
+        p: Any,
+        parent: Optional[Cursor] = None,
+    ) -> Optional[J]:
+        if isinstance(tree, MultiImport):
+            # A MultiImport decides the whole statement: under
+            # `from <module> import a, b` its children are names, not modules.
+            self.found = self.found or self._multi_import_matches(tree)
+            return tree
+        return super().visit(tree, p, parent)
+
+    def _multi_import_matches(self, multi: MultiImport) -> bool:
+        if multi.from_ is not None:
+            # `from <module> import ...` — the module is the `from` clause.
+            return _import_path_matches(get_name_string(multi.from_), self._module)
+        # `import <a>, <b>` — each name's qualid is itself a module.
+        return any(
+            _import_path_matches(get_qualid_name(imp.qualid), self._module)
+            for imp in multi.names
+        )
+
+    def matches(self, tree: Tree) -> bool:
+        # A J.Import outside a MultiImport is `import <module>`.
+        return isinstance(tree, Import) and _import_path_matches(
+            get_qualid_name(tree.qualid), self._module
+        )
 
 
 __all__ = ["IsSourceFile", "UsesType", "UsesMethod", "UsesImport"]

--- a/rewrite-python/rewrite/tests/recipes/test_search_traversal.py
+++ b/rewrite-python/rewrite/tests/recipes/test_search_traversal.py
@@ -1,0 +1,120 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Reachability tests for the search preconditions.
+
+Every match sits below a decorated function, a nested class and a method, and
+then below an f-string comprehension, a ``with`` or an ``except`` block. A
+traversal that stops short of any of those answers "skip the file" for a file
+the gated recipe has to change.
+"""
+
+import ast
+import logging
+import os
+import shutil
+import tempfile
+
+import pytest
+
+from rewrite import InMemoryExecutionContext
+from rewrite.python._parser_visitor import ParserVisitor
+from rewrite.python.search import UsesImport, UsesMethod, UsesType
+
+NESTED_SOURCE = '''\
+import functools
+from contextlib import suppress
+
+
+@functools.cache
+def outer(items):
+    class Inner:
+        @property
+        def label(self) -> str:
+            return f"{[v.strip() for v in items]!r}"
+
+        def scan(self, values):
+            with suppress(ValueError):
+                try:
+                    return values.pop()
+                except KeyError:
+                    from calendar import isleap
+
+                    return isleap(2026)
+            return None
+
+    return Inner()
+'''
+
+
+@pytest.fixture(scope="module")
+def cu():
+    """The fixture parsed with type attribution, as UsesType needs types."""
+    workspace = tempfile.mkdtemp()
+    try:
+        file_path = os.path.join(workspace, "nested.py")
+        with open(file_path, "w") as f:
+            f.write(NESTED_SOURCE)
+        from rewrite.python.ty_client import TyTypesClient
+
+        client = TyTypesClient()
+        if not client.initialize(workspace):
+            pytest.skip("ty-types is unavailable, so there is no attribution to search")
+        try:
+            return ParserVisitor(NESTED_SOURCE, file_path, client).visit(
+                ast.parse(NESTED_SOURCE)
+            )
+        finally:
+            client.shutdown()
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def _matches(visitor, cu) -> bool:
+    # A precondition matches by returning a SearchResult-marked (new) tree,
+    # which is what Preconditions.Check keys off of.
+    return visitor.visit(cu, InMemoryExecutionContext()) is not cu
+
+
+def test_uses_type_reaches_nested_type(cu):
+    assert _matches(UsesType("contextlib.suppress"), cu)
+    assert not _matches(UsesType("datetime.datetime"), cu)
+
+
+def test_uses_method_reaches_call_in_fstring_comprehension(cu):
+    assert _matches(UsesMethod("*..* strip(..)"), cu)
+    assert not _matches(UsesMethod("*..* unused(..)"), cu)
+
+
+def test_uses_import_reaches_import_in_except_block(cu):
+    assert _matches(UsesImport("calendar"), cu)
+    assert not _matches(UsesImport("datetime"), cu)
+
+
+def test_tree_too_deep_to_visit_answers_no_match(caplog):
+    # One Py.Binary per concatenated fragment, so this nests deeper than the
+    # interpreter stack.
+    src = "x = " + " ".join(f'"s{i}"' for i in range(3000)) + "\n"
+    deep = ParserVisitor(src, "deep.py", None).visit(ast.parse(src))
+
+    with caplog.at_level(logging.WARNING, logger="rewrite.python.search"):
+        assert not _matches(UsesImport("os"), deep)
+
+    assert "nests too deeply" in caplog.text
+
+
+def test_uses_type_reads_attribution_off_expression_only_nodes(cu):
+    # `list` is attributed to the comprehension itself, a `Py` node that is an
+    # `Expression` without being a `TypedTree`.
+    assert _matches(UsesType("list"), cu)


### PR DESCRIPTION
Three of the four Python search preconditions walked the LST by reflection — `dir(cur)` plus a `getattr` on each of ~70 public attributes, per node — where every other language uses its own visitor. On `psf/requests` `tests/test_requests.py` (3094 lines, 15044 LST nodes), per-node cost against a `PythonVisitor` traversal of the same tree:

```
                                  before    after
UsesImport (module not present)  35.9 us   6.6 us/node
UsesMethod (method not present)  35.9 us   6.0 us/node
UsesType   (type not present)    35.8 us   5.7 us/node
```

Those are the miss cases, which is what a gate mostly does. A hit is far cheaper still, because the visitor stops at the first matching node where the walk collected the whole tree first: `UsesImport("pytest")` on the same file goes from 549 ms to 0.36 ms.

A file is gated once per sub-recipe, so 25 `ChangeImport` sub-recipes over that one file — the shape of `org.openrewrite.python.migrate.ReplaceCollectionsAbcImports` — go from **17.95s to 3.20s**. None of that is the recipe's own work: the gate never matches, so the run is precondition time end to end.

`_FindFirst` is a `PythonVisitor` that stops at the first node its `matches` accepts, and the three preconditions each supply one. It dispatches straight to `accept`, since a search never rewrites and nothing reads the cursor the base `visit` builds. The `seen` set and the `try`/`except` around `getattr` go with the walk; `IsSourceFile` never used it.

## Do both traversals reach the same nodes

Reflection's rule — any attribute holding something with `id` or `markers` — is not the visitor's, so I compared the two node sets over 1499 stdlib files (1.38M visited nodes):

```
reached only by reflection: Clause 1330, Condition 275, Pattern 3
reached only by visitor   : Kind 3790
```

Comprehension clauses, conditions and match-case patterns are reached through `visit_comprehension_clause` and friends rather than through `visit`, so their children are traversed either way, and none of the three is a `TypedTree`, a `J.MethodInvocation` or an import node. `J.ClassDeclaration.Kind` is exposed only on `.padding`, which is why reflection missed it.

Answers agreed on all 1881 (query, file) pairs checked: 33 queries × 37 files parsed without attribution, and 33 × 20 with ty-types attached. `UsesType` gets a sharper check, per FQN rather than per file, because a per-file comparison hides a node class whose type is also reachable from a sibling: every one of the 300 distinct fully-qualified names the old walk could match on across 14 ty-attributed files still matches. That check is why `_TypeSearch` reads `getattr(tree, "type", None)` — `Expression` declares its own `type` alongside `TypedTree` rather than under it, so an `isinstance` against either alone silently narrows the gate.

## The one behaviour change: depth

The visitor recurses ~5 Python frames per LST level against an interpreter limit of 2000, so it gives out around 350-400 levels of nesting where the iterative walk did not. That is lower than it sounds reachable — a 400-term `or` chain does it, as does `pydoc_data/topics.py` at 2295 levels. `search` catches `RecursionError`, logs the path at WARNING and answers "no match".

No file loses an edit to this, because every editor in the SDK is an equally recursive `PythonVisitor` and gives out at the same depth:

```
400-term `or` chain + `import os`     old gate   new gate   editor
  import first                          match      match     RecursionError
  import last                           match      no match  RecursionError
```

So the gate's answer changes only for a file the editor was going to fail on anyway, and only when the deep expression precedes the match. What changes is the diagnostic: an error naming a file no recipe could have changed becomes a WARNING naming a file that was skipped. Letting the `RecursionError` propagate instead would restore the error, on every sweep that touches such a file; the log line is the compromise, so the skip still leaves a trace.

## Tests

`tests/recipes/test_search_traversal.py` parses one fixture that buries each match below a decorated function, a nested class and method, and then below an f-string comprehension, a `with`, or an `except` block. It asserts the answer for a present and an absent type, method and import; replacing the descent with `return tree` fails all three. A fourth test pins that `list`, attributed to the comprehension node itself, is found — it fails against an `isinstance(tree, TypedTree)` gate. A fifth builds a 3000-fragment concatenation — deterministic, not dependent on a stdlib version — and fails if either the `RecursionError` catch or the warning goes.

Full Python SDK suite: 2194 passed, 11 skipped, including the Java-peer RPC tests.
