### PR TITLE
Python: names inside a string annotation are references

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -24,7 +24,8 @@ from rewrite.java import J
 from rewrite.java.support_types import JContainer, JLeftPadded, JRightPadded
 from rewrite.java.tree import Empty, FieldAccess, Identifier, Import, Literal, Space
 from rewrite.markers import Markers
-from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name, get_canonical_fqn, pad_right
+from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
+                                         get_canonical_fqn, pad_right, referenced_names)
 from rewrite.python.tree import CompilationUnit, ExpressionStatement, MultiImport
 from rewrite.python.visitor import PythonVisitor
 
@@ -224,7 +225,7 @@ class AddImport(PythonVisitor):
                     self.in_import = False
 
             def visit_identifier(self, ident: Identifier, p) -> J:
-                if not self.in_import and ident.simple_name == target_name:
+                if not self.in_import and target_name in referenced_names(ident):
                     self.found = True
                 return ident
 

--- a/rewrite-python/rewrite/src/rewrite/python/import_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/import_utils.py
@@ -14,12 +14,13 @@
 
 """Shared utility functions for Python import handling."""
 
-from typing import Optional
+import ast
+from typing import Optional, Tuple
 
 from rewrite.java.support_types import JavaType, JRightPadded, Space
 from rewrite.java.tree import Empty, FieldAccess, Identifier, Import
 from rewrite.markers import Markers
-from rewrite.python.markers import CanonicalName
+from rewrite.python.markers import CanonicalName, Quoted
 
 
 def get_qualid_name(qualid) -> str:
@@ -80,6 +81,19 @@ def get_canonical_fqn(imp: Import) -> Optional[str]:
     if isinstance(t, JavaType.FullyQualified) and not isinstance(t, JavaType.Unknown):
         return getattr(t, 'fully_qualified_name', None) or None
     return None
+
+
+def referenced_names(ident: Identifier) -> Tuple[str, ...]:
+    """The names ``ident`` looks up. A quoted identifier is a forward reference
+    holding a whole expression, so its names come from parsing it; a string that
+    is not an expression names nothing."""
+    if ident.markers.find_first(Quoted) is None:
+        return (ident.simple_name,)
+    try:
+        reference = ast.parse(ident.simple_name.strip(), mode='eval')
+    except (SyntaxError, ValueError):
+        return ()
+    return tuple(node.id for node in ast.walk(reference) if isinstance(node, ast.Name))
 
 
 def pad_right(elem) -> JRightPadded:

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -20,7 +20,8 @@ from typing import Optional, Set
 from rewrite.java import J
 from rewrite.java.support_types import JContainer, JRightPadded
 from rewrite.java.tree import Identifier, Import, Space
-from rewrite.python.import_utils import get_qualid_name, get_name_string, get_alias_name, get_canonical_fqn
+from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
+                                         get_canonical_fqn, referenced_names)
 from rewrite.python.scope_utils import LocalBindings
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
@@ -167,8 +168,9 @@ class RemoveImport(PythonVisitor):
                     self.in_import = False
 
             def visit_identifier(self, ident: Identifier, p) -> J:
-                if not self.in_import and not bindings.is_bound(self.cursor, ident.simple_name):
-                    used.add(ident.simple_name)
+                if not self.in_import:
+                    used.update(name for name in referenced_names(ident)
+                                if not bindings.is_bound(self.cursor, name))
                 return ident
 
         collector = UsageCollector()
@@ -250,13 +252,12 @@ class RemoveImport(PythonVisitor):
             return self._remove_name_from_import(multi)
 
     def _remove_module_import(self, multi: MultiImport) -> Optional[MultiImport]:
-        """Remove an entire module import (import X or from X import ...)."""
+        """Remove the import that binds the module itself."""
         if multi.from_ is not None:
             # This is a "from X import Y" statement
-            syntactic = get_name_string(multi.from_) == self.module
             new_padded = [
                 padded_imp for padded_imp in multi.padding.names.padding.elements
-                if not (syntactic or self._canonical_module_matches(padded_imp.element))
+                if not self._canonical_module_matches(padded_imp.element)
                 or not self._is_removable(padded_imp.element,
                                           get_qualid_name(padded_imp.element.qualid))
             ]
@@ -273,10 +274,9 @@ class RemoveImport(PythonVisitor):
 
     def _canonical_module_matches(self, imp: Import) -> bool:
         """True when ``imp`` binds the requested module itself (``from os import
-        path`` for ``os.path``). Membership is deliberately not enough: a module
-        is the canonical home of every symbol re-exported through it, so
-        matching members would sweep up imports written against other modules.
-        """
+        path`` for ``os.path``). Membership is deliberately not enough, written
+        (``from typing import Any``) or canonical (``typing`` is the home of every
+        symbol re-exported through it): a member binds the member, not the module."""
         return get_canonical_fqn(imp) == self.module
 
     def _remove_name_from_import(self, multi: MultiImport) -> Optional[MultiImport]:
@@ -312,11 +312,12 @@ class RemoveImport(PythonVisitor):
         if len(new_padded) == len(existing_padded):
             return multi
 
-        # Fix up the first element's prefix to not have a leading space
-        # (only relevant if the removed element was the first one)
+        # Whatever separated the statement from its first name — nothing, or the line break
+        # and indent of a parenthesized import — belongs to whichever name is first now.
         first = new_padded[0]
-        if first.element.prefix != Space.EMPTY:
-            new_padded[0] = first.replace(_element=first.element.replace(prefix=Space.EMPTY))
+        leading = existing_padded[0].element.prefix
+        if first.element.prefix != leading:
+            new_padded[0] = first.replace(_element=first.element.replace(prefix=leading))
 
         return MultiImport(
             multi.id,

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -164,6 +164,22 @@ class TestMaybeAddImport:
             )
         )
 
+    def test_only_if_referenced_finds_a_reference_inside_a_string_annotation(self, arm):
+        """A compound forward reference names the symbol, so it is a reference."""
+        spec = RecipeSpec(recipe=from_visitor(
+            _add_import_visitor(arm, 'typing', 'Any', only_if_referenced=True)))
+        spec.rewrite_run(
+            python(
+                """
+                m: "Dict[Any, Any]" = {}
+                """,
+                """
+                from typing import Any
+                m: "Dict[Any, Any]" = {}
+                """,
+            )
+        )
+
     def test_only_if_referenced_finds_a_reference_in_a_comprehension(self, arm):
         """The only reference is inside a comprehension, a Python-specific node."""
         spec = RecipeSpec(recipe=from_visitor(

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -116,6 +116,45 @@ class TestMaybeRemoveImport:
             )
         )
 
+    def test_parenthesized_import_keeps_its_layout(self, arm):
+        """Every remaining name keeps the line break and indent it was written with,
+        whether or not the removed name was the first one."""
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'typing', 'Any', only_if_unused=False))).rewrite_run(
+            python(
+                """\
+                from typing import (
+                    TYPE_CHECKING,
+                    Any,
+                    Dict,
+                )
+                """,
+                """\
+                from typing import (
+                    TYPE_CHECKING,
+                    Dict,
+                )
+                """,
+            )
+        )
+
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'typing', 'TYPE_CHECKING', only_if_unused=False))).rewrite_run(
+            python(
+                """\
+                from typing import (
+                    TYPE_CHECKING,
+                    Any,
+                )
+                """,
+                """\
+                from typing import (
+                    Any,
+                )
+                """,
+            )
+        )
+
     def test_keep_import_when_used(self, arm):
         """Don't remove an import when the name is still used and only_if_unused=True."""
         spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'os.path', 'join')))
@@ -417,6 +456,19 @@ class TestCanonicalRemoveImport:
             )
         )
 
+    def test_whole_module_removal_spares_members_written_against_that_module(self, arm):
+        """`Optional` binds `Optional`, not the `typing` module, so a request for
+        the module leaves it alone however unused it is."""
+        RecipeSpec(recipe=from_visitor(
+            _remove_import_visitor(arm, 'typing', only_if_unused=False))).rewrite_run(
+            python(
+                """
+                from typing import Optional
+                x = 1
+                """,
+            )
+        )
+
 
 class TestRemoveImportUsageScoping:
     """``only_if_unused`` counts every reference the enclosing scopes do not
@@ -568,4 +620,63 @@ class TestRemoveImportScopeRules:
                 clock = 1
                 return clock, x
             """
+        )
+
+
+class TestRemoveImportStringAnnotations:
+    """A string annotation is a forward reference, so the names inside it are
+    load-bearing: whatever resolves the annotation later needs their imports."""
+
+    @staticmethod
+    def _assert_type_hints_resolve(source_file):
+        """The output is only correct if the annotations it kept still resolve, which
+        a text assertion cannot show: dropping an import leaves valid Python."""
+        import types
+        import typing
+
+        module = types.ModuleType('after_recipe')
+        exec(source_file.print_all(), module.__dict__)
+        typing.get_type_hints(module)
+
+    def test_names_inside_a_compound_reference_keep_their_imports(self, arm):
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing')))
+        spec.rewrite_run(
+            python(
+                """\
+                import typing
+                from typing import Any
+
+                m: "typing.Dict[Any, Any]" = {}
+                """,
+                after_recipe=self._assert_type_hints_resolve,
+            )
+        )
+
+    def test_bare_reference_keeps_its_import(self, arm):
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'Any')))
+        spec.rewrite_run(
+            python(
+                """\
+                from typing import Any
+
+                m: "Any" = None
+                """,
+            )
+        )
+
+    def test_name_absent_from_the_reference_is_still_removed(self, arm):
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'Optional')))
+        spec.rewrite_run(
+            python(
+                """\
+                from typing import Any, Optional
+
+                m: "Dict[Any, Any]" = {}
+                """,
+                """\
+                from typing import Any
+
+                m: "Dict[Any, Any]" = {}
+                """,
+            )
         )

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
@@ -24,12 +24,14 @@ import org.openrewrite.java.tree.NameTree;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.python.PythonVisitor;
 import org.openrewrite.python.internal.PythonBuiltins;
+import org.openrewrite.python.marker.Quoted;
 import org.openrewrite.python.tree.Py;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 import static org.openrewrite.python.internal.PythonImportNames.aliasName;
 import static org.openrewrite.python.internal.PythonImportNames.canonicalFqn;
@@ -136,6 +138,7 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
     private boolean isReferenced(Py.CompilationUnit cu) {
         String target = alias != null ? alias :
                 name != null ? name : module.substring(module.lastIndexOf('.') + 1);
+        Pattern spelledIn = Pattern.compile("\\b" + Pattern.quote(target) + "\\b");
         AtomicBoolean found = new AtomicBoolean();
         new PythonVisitor<AtomicBoolean>() {
             // Identifiers inside an import are bindings rather than uses, so neither kind of
@@ -150,9 +153,15 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
                 return multi;
             }
 
+            // A quoted identifier is a forward reference holding a whole expression, so the
+            // target can be one name within it. Spelling it is enough: the Python side parses
+            // the reference, and this predicate may only over-approximate.
             @Override
             public J visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
-                if (target.equals(identifier.getSimpleName())) {
+                String simpleName = identifier.getSimpleName();
+                if (target.equals(simpleName) ||
+                        identifier.getMarkers().findFirst(Quoted.class).isPresent() &&
+                                spelledIn.matcher(simpleName).find()) {
                     found.set(true);
                 }
                 return identifier;

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonRemoveImportVisitor.java
@@ -102,9 +102,6 @@ public class PythonRemoveImportVisitor<P> extends RpcImportVisitor<P> {
                 }
                 return false;
             }
-            if (module.equals(nameString(from))) {
-                return true;
-            }
             for (J.Import member : multi.getNames()) {
                 if (module.equals(canonicalFqn(member))) {
                     return true;

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonRemoveImportVisitorTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonRemoveImportVisitorTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.python.service;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.python.tree.Py;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,8 +77,14 @@ class PythonRemoveImportVisitorTest {
     }
 
     @Test
-    void dispatchesForAWholeModuleRequestAgainstAFromImport() {
-        assertThat(mightChange("typing", null, cu(fromImport("typing", member("List"))))).isTrue();
+    void dispatchesForAWholeModuleRequestAgainstAModuleBinding() {
+        assertThat(mightChange("os.path", null,
+                cu(fromImport("os", member("path", null, JavaType.ShallowClass.build("os.path")))))).isTrue();
+    }
+
+    @Test
+    void skipsAWholeModuleRequestAgainstAMemberOfThatModule() {
+        assertThat(mightChange("typing", null, cu(fromImport("typing", member("List"))))).isFalse();
     }
 
     @Test


### PR DESCRIPTION
`RemoveImport` drops imports that a string annotation still needs. Running any import-removing recipe (reproduced with `ReplaceTypingListWithList`) over a compound forward reference:

```diff
-import typing
-from typing import Any, Optional
+from typing import Optional

 M: "typing.Dict[Any, Any]" = {}
-x: typing.List[int] = []
+x: list[int] = []
```

```
before  get_type_hints -> {'M': typing.Dict[typing.Any, typing.Any], ...}
after   get_type_hints -> NameError: name 'typing' is not defined
```

The output is valid Python, so `ast.parse` and the printer round-trip say nothing is wrong; it fails only when something resolves the annotation — `typing.get_type_hints`, a pydantic model build, a dataclass under `from __future__ import annotations`.

## Mechanism

The parser gives a *simple* forward reference a quoted `J.Identifier` whose simple name is the name, and a *compound* one a single identifier whose simple name is the entire string:

```
Identifier simple_name = 'Any'
Identifier simple_name = 'typing.Dict[Any, Any]'   <- one opaque node
```

Both identifier scans read `simple_name` directly, so the compound string entered the used-set whole and none of `typing`, `Dict` or `Any` was ever marked used. `AddImport` mirrors it: `only_if_referenced=True` declined to add an import referenced only from such an annotation.

`referenced_names` parses a quoted identifier as an expression and walks it for `ast.Name`. Parsing, rather than a substring scan, is also what tells a reference apart from prose that merely spells the name out.

## Why not type attribution

ty types the string *literal*, not the annotation, and emits no `Alias` node, so there is no `CanonicalName` marker to lean on:

```
'typing.Dict[Any, Any]' | quoted=True | type=Primitive.String | canonical=None
'Optional[Undefined]'   | quoted=True | type=Primitive.String | canonical=None
```

Two further reasons it is the wrong lever even with better attribution: a resolved type names the *canonical* symbol (`typing.Dict`) while what must stay importable is the *written* name (`Dict`); and the second line shows an annotation can be unresolvable while its imports are still load-bearing. Which bindings a forward reference looks up is a syntactic question.

The Java dispatch predicate `PythonAddImportVisitor.isReferenced` has the same blind spot and gets a word-boundary check on quoted identifiers — it may only over-approximate, and the Python side does the exact test.

## Two adjacent fixes

**Whole-module removal matched members.** `RemoveImport(module='typing')` deleted every unused name from a `from typing import ...` statement. That contradicts the rule `_canonical_module_matches` already states for the canonical path: a member binds the member, not the module. The written path now follows it too, and `PythonRemoveImportVisitor.hasCandidate` stops dispatching for a member-only match. This is what let `Any` vanish from a *separate* statement when the recipe asked about `typing`.

**Parenthesized imports collapsed.** Removing any name blanked the first remaining name's prefix, so the layout `black` produces broke on every such file (three `pydantic` v1 files in the sample):

```diff
 from typing import (
-    TYPE_CHECKING,
+from typing import (TYPE_CHECKING,
     Dict,
```

The first remaining name now keeps whatever separated the statement from its first name.

## Tests

`test_names_inside_a_compound_reference_keep_their_imports` runs the recipe and then `exec`s the output into a module and calls `typing.get_type_hints` on it, so the assertion is that the annotations still resolve rather than that a particular import line survived. Alongside it: a bare `"Any"` reference (already correct, must not regress through the new parse path), and a compound reference naming a symbol that is genuinely unused elsewhere — the case that fails if the implementation degrades to a substring scan. Each new test was confirmed to fail against the unfixed code, and all of them run against both the native and the Java-RPC arm.

Pre-existing and unrelated: `RequirementsTxtParserTest.markerContainsDependenciesFromFreeze` fails locally (a live `uv` resolve of `requests` against PyPI now returns 5 flattened dependencies where the test expects 1). Verified pre-existing by re-running it with this PR's Java changes reverted.
