### PR TITLE
A record component's annotations keep the type they were written with

### DIFF
--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -19,6 +19,7 @@ package org.openrewrite.java.isolated;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.tree.*;
 import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
@@ -27,6 +28,7 @@ import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.*;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Pair;
 import com.sun.tools.javac.util.Position;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.Nullable;
@@ -59,6 +61,7 @@ import java.util.stream.Stream;
 
 import static java.lang.Math.max;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.*;
 import static java.util.stream.StreamSupport.stream;
@@ -599,10 +602,65 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
 
     private List<JCAnnotation> extractRecordComponentAnnotations(Symbol.RecordComponent rc) {
         List<JCAnnotation> annotations = rc.getOriginalAnnos();
-        for (int i = 0; i < rc.getAnnotationMirrors().size(); i++) {
-            annotations.get(i).getAnnotationType().setType((Type) rc.getAnnotationMirrors().get(i).getAnnotationType());
+        if (annotations.isEmpty()) {
+            return annotations;
+        }
+
+        // javac types each header annotation only where it landed (JLS 9.7.4), leaving these originals untyped
+        Map<Integer, JCAnnotation> onAccessor = rc.accessorMeth == null ? emptyMap() :
+                mapAnnotations(rc.accessorMeth.getModifiers().getAnnotations(), new HashMap<>());
+        List<Type> componentApplicableTypes = null;
+        for (JCAnnotation annotation : annotations) {
+            JCTree annotationType = annotation.getAnnotationType();
+            JCAnnotation accessorAnnotation = onAccessor.get(annotation.pos);
+            if (accessorAnnotation != null && accessorAnnotation.getAnnotationType().type != null) {
+                annotationType.setType(accessorAnnotation.getAnnotationType().type);
+                continue;
+            }
+            if (componentApplicableTypes == null) {
+                componentApplicableTypes = componentApplicableTypes(rc.getAnnotationMirrors());
+            }
+            // by name, as the mirrors cover only the component-applicable annotations and so never line up by index
+            Type type = typeNamed(annotationType.toString(), componentApplicableTypes);
+            if (type != null) {
+                annotationType.setType(type);
+            }
         }
         return annotations;
+    }
+
+    private static List<Type> componentApplicableTypes(List<Attribute.Compound> mirrors) {
+        List<Type> types = new ArrayList<>(mirrors.size());
+        for (Attribute.Compound mirror : mirrors) {
+            types.add(mirror.type);
+            // repeated annotations are attributed as the one container annotation that holds them
+            for (Pair<Symbol.MethodSymbol, Attribute> value : mirror.values) {
+                if (value.snd instanceof Attribute.Array) {
+                    for (Attribute repeated : ((Attribute.Array) value.snd).values) {
+                        if (repeated instanceof Attribute.Compound) {
+                            types.add(repeated.type);
+                        }
+                    }
+                }
+            }
+        }
+        return types;
+    }
+
+    private static @Nullable Type typeNamed(String writtenName, List<Type> types) {
+        Type enclosingTypeOmitted = null;
+        for (Type type : types) {
+            if (type.tsym != null) {
+                String qualifiedName = type.tsym.getQualifiedName().toString();
+                if (qualifiedName.equals(writtenName)) {
+                    return type;
+                }
+                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
+                    enclosingTypeOmitted = type;
+                }
+            }
+        }
+        return enclosingTypeOmitted;
     }
 
     @Override

--- a/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
+++ b/rewrite-java-17/src/main/java/org/openrewrite/java/isolated/ReloadableJava17ParserVisitor.java
@@ -60,6 +60,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.lang.Math.max;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -610,7 +611,6 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         // javac types each header annotation only where it landed (JLS 9.7.4), leaving these originals untyped
         Map<Integer, JCAnnotation> onAccessor = rc.accessorMeth == null ? emptyMap() :
                 mapAnnotations(rc.accessorMeth.getModifiers().getAnnotations(), new HashMap<>());
-        List<Type> componentApplicableTypes = null;
         for (JCAnnotation annotation : annotations) {
             JCTree annotationType = annotation.getAnnotationType();
             JCAnnotation accessorAnnotation = onAccessor.get(annotation.pos);
@@ -618,11 +618,8 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
                 annotationType.setType(accessorAnnotation.getAnnotationType().type);
                 continue;
             }
-            if (componentApplicableTypes == null) {
-                componentApplicableTypes = componentApplicableTypes(rc.getAnnotationMirrors());
-            }
             // by name, as the mirrors cover only the component-applicable annotations and so never line up by index
-            Type type = typeNamed(annotationType.toString(), componentApplicableTypes);
+            Type type = typeNamed(annotationType.toString(), rc.getAnnotationMirrors());
             if (type != null) {
                 annotationType.setType(type);
             }
@@ -630,38 +627,38 @@ public class ReloadableJava17ParserVisitor extends TreePathScanner<J, Space> {
         return annotations;
     }
 
-    private static List<Type> componentApplicableTypes(List<Attribute.Compound> mirrors) {
-        List<Type> types = new ArrayList<>(mirrors.size());
-        for (Attribute.Compound mirror : mirrors) {
-            types.add(mirror.type);
-            // repeated annotations are attributed as the one container annotation that holds them
-            for (Pair<Symbol.MethodSymbol, Attribute> value : mirror.values) {
-                if (value.snd instanceof Attribute.Array) {
-                    for (Attribute repeated : ((Attribute.Array) value.snd).values) {
-                        if (repeated instanceof Attribute.Compound) {
-                            types.add(repeated.type);
+    private static @Nullable Type typeNamed(String writtenName, List<? extends Attribute> attributes) {
+        Type enclosingTypeOmitted = null;
+        for (Attribute attribute : attributes) {
+            Symbol.TypeSymbol tsym = attribute.type.tsym;
+            if (tsym != null) {
+                String qualifiedName = tsym.getQualifiedName().toString();
+                if (qualifiedName.equals(writtenName)) {
+                    return attribute.type;
+                }
+                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
+                    enclosingTypeOmitted = attribute.type;
+                }
+            }
+        }
+        return enclosingTypeOmitted != null ? enclosingTypeOmitted : repeatedTypeNamed(writtenName, attributes);
+    }
+
+    // repeated annotations are attributed as the one container annotation that holds them
+    private static @Nullable Type repeatedTypeNamed(String writtenName, List<? extends Attribute> attributes) {
+        for (Attribute attribute : attributes) {
+            if (attribute instanceof Attribute.Compound) {
+                for (Pair<Symbol.MethodSymbol, Attribute> value : ((Attribute.Compound) attribute).values) {
+                    if (value.snd instanceof Attribute.Array) {
+                        Type type = typeNamed(writtenName, asList(((Attribute.Array) value.snd).values));
+                        if (type != null) {
+                            return type;
                         }
                     }
                 }
             }
         }
-        return types;
-    }
-
-    private static @Nullable Type typeNamed(String writtenName, List<Type> types) {
-        Type enclosingTypeOmitted = null;
-        for (Type type : types) {
-            if (type.tsym != null) {
-                String qualifiedName = type.tsym.getQualifiedName().toString();
-                if (qualifiedName.equals(writtenName)) {
-                    return type;
-                }
-                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
-                    enclosingTypeOmitted = type;
-                }
-            }
-        }
-        return enclosingTypeOmitted;
+        return null;
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -62,6 +62,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.lang.Math.max;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -617,7 +618,6 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         // javac types each header annotation only where it landed (JLS 9.7.4), leaving these originals untyped
         Map<Integer, JCAnnotation> onAccessor = rc.accessorMeth == null ? emptyMap() :
                 mapAnnotations(rc.accessorMeth.getModifiers().getAnnotations(), new HashMap<>());
-        List<Type> componentApplicableTypes = null;
         for (JCAnnotation annotation : annotations) {
             JCTree annotationType = annotation.getAnnotationType();
             JCAnnotation accessorAnnotation = onAccessor.get(annotation.pos);
@@ -625,11 +625,8 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
                 annotationType.setType(accessorAnnotation.getAnnotationType().type);
                 continue;
             }
-            if (componentApplicableTypes == null) {
-                componentApplicableTypes = componentApplicableTypes(rc.getAnnotationMirrors());
-            }
             // by name, as the mirrors cover only the component-applicable annotations and so never line up by index
-            Type type = typeNamed(annotationType.toString(), componentApplicableTypes);
+            Type type = typeNamed(annotationType.toString(), rc.getAnnotationMirrors());
             if (type != null) {
                 annotationType.setType(type);
             }
@@ -637,38 +634,38 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
         return annotations;
     }
 
-    private static List<Type> componentApplicableTypes(List<Attribute.Compound> mirrors) {
-        List<Type> types = new ArrayList<>(mirrors.size());
-        for (Attribute.Compound mirror : mirrors) {
-            types.add(mirror.type);
-            // repeated annotations are attributed as the one container annotation that holds them
-            for (Pair<Symbol.MethodSymbol, Attribute> value : mirror.values) {
-                if (value.snd instanceof Attribute.Array) {
-                    for (Attribute repeated : ((Attribute.Array) value.snd).values) {
-                        if (repeated instanceof Attribute.Compound) {
-                            types.add(repeated.type);
+    private static @Nullable Type typeNamed(String writtenName, List<? extends Attribute> attributes) {
+        Type enclosingTypeOmitted = null;
+        for (Attribute attribute : attributes) {
+            Symbol.TypeSymbol tsym = attribute.type.tsym;
+            if (tsym != null) {
+                String qualifiedName = tsym.getQualifiedName().toString();
+                if (qualifiedName.equals(writtenName)) {
+                    return attribute.type;
+                }
+                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
+                    enclosingTypeOmitted = attribute.type;
+                }
+            }
+        }
+        return enclosingTypeOmitted != null ? enclosingTypeOmitted : repeatedTypeNamed(writtenName, attributes);
+    }
+
+    // repeated annotations are attributed as the one container annotation that holds them
+    private static @Nullable Type repeatedTypeNamed(String writtenName, List<? extends Attribute> attributes) {
+        for (Attribute attribute : attributes) {
+            if (attribute instanceof Attribute.Compound) {
+                for (Pair<Symbol.MethodSymbol, Attribute> value : ((Attribute.Compound) attribute).values) {
+                    if (value.snd instanceof Attribute.Array) {
+                        Type type = typeNamed(writtenName, asList(((Attribute.Array) value.snd).values));
+                        if (type != null) {
+                            return type;
                         }
                     }
                 }
             }
         }
-        return types;
-    }
-
-    private static @Nullable Type typeNamed(String writtenName, List<Type> types) {
-        Type enclosingTypeOmitted = null;
-        for (Type type : types) {
-            if (type.tsym != null) {
-                String qualifiedName = type.tsym.getQualifiedName().toString();
-                if (qualifiedName.equals(writtenName)) {
-                    return type;
-                }
-                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
-                    enclosingTypeOmitted = type;
-                }
-            }
-        }
-        return enclosingTypeOmitted;
+        return null;
     }
 
     @Override

--- a/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
+++ b/rewrite-java-21/src/main/java/org/openrewrite/java/isolated/ReloadableJava21ParserVisitor.java
@@ -19,6 +19,7 @@ package org.openrewrite.java.isolated;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.tree.*;
 import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Type;
@@ -27,6 +28,7 @@ import com.sun.tools.javac.tree.EndPosTable;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.*;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Pair;
 import com.sun.tools.javac.util.Position;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.Nullable;
@@ -61,6 +63,7 @@ import java.util.stream.Stream;
 
 import static java.lang.Math.max;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.*;
 import static java.util.stream.StreamSupport.stream;
@@ -606,10 +609,65 @@ public class ReloadableJava21ParserVisitor extends TreePathScanner<J, Space> {
 
     private List<JCAnnotation> extractRecordComponentAnnotations(Symbol.RecordComponent rc) {
         List<JCAnnotation> annotations = rc.getOriginalAnnos();
-        for (int i = 0; i < rc.getAnnotationMirrors().size(); i++) {
-            annotations.get(i).getAnnotationType().setType((Type) rc.getAnnotationMirrors().get(i).getAnnotationType());
+        if (annotations.isEmpty()) {
+            return annotations;
+        }
+
+        // javac types each header annotation only where it landed (JLS 9.7.4), leaving these originals untyped
+        Map<Integer, JCAnnotation> onAccessor = rc.accessorMeth == null ? emptyMap() :
+                mapAnnotations(rc.accessorMeth.getModifiers().getAnnotations(), new HashMap<>());
+        List<Type> componentApplicableTypes = null;
+        for (JCAnnotation annotation : annotations) {
+            JCTree annotationType = annotation.getAnnotationType();
+            JCAnnotation accessorAnnotation = onAccessor.get(annotation.pos);
+            if (accessorAnnotation != null && accessorAnnotation.getAnnotationType().type != null) {
+                annotationType.setType(accessorAnnotation.getAnnotationType().type);
+                continue;
+            }
+            if (componentApplicableTypes == null) {
+                componentApplicableTypes = componentApplicableTypes(rc.getAnnotationMirrors());
+            }
+            // by name, as the mirrors cover only the component-applicable annotations and so never line up by index
+            Type type = typeNamed(annotationType.toString(), componentApplicableTypes);
+            if (type != null) {
+                annotationType.setType(type);
+            }
         }
         return annotations;
+    }
+
+    private static List<Type> componentApplicableTypes(List<Attribute.Compound> mirrors) {
+        List<Type> types = new ArrayList<>(mirrors.size());
+        for (Attribute.Compound mirror : mirrors) {
+            types.add(mirror.type);
+            // repeated annotations are attributed as the one container annotation that holds them
+            for (Pair<Symbol.MethodSymbol, Attribute> value : mirror.values) {
+                if (value.snd instanceof Attribute.Array) {
+                    for (Attribute repeated : ((Attribute.Array) value.snd).values) {
+                        if (repeated instanceof Attribute.Compound) {
+                            types.add(repeated.type);
+                        }
+                    }
+                }
+            }
+        }
+        return types;
+    }
+
+    private static @Nullable Type typeNamed(String writtenName, List<Type> types) {
+        Type enclosingTypeOmitted = null;
+        for (Type type : types) {
+            if (type.tsym != null) {
+                String qualifiedName = type.tsym.getQualifiedName().toString();
+                if (qualifiedName.equals(writtenName)) {
+                    return type;
+                }
+                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
+                    enclosingTypeOmitted = type;
+                }
+            }
+        }
+        return enclosingTypeOmitted;
     }
 
     @Override

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -19,6 +19,7 @@ package org.openrewrite.java.isolated;
 import com.sun.source.doctree.DocCommentTree;
 import com.sun.source.tree.*;
 import com.sun.source.util.TreePathScanner;
+import com.sun.tools.javac.code.Attribute;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symtab;
@@ -30,6 +31,7 @@ import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.*;
 import com.sun.tools.javac.parser.Tokens;
 import com.sun.tools.javac.util.Context;
+import com.sun.tools.javac.util.Pair;
 import com.sun.tools.javac.util.Position;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.Nullable;
@@ -61,6 +63,7 @@ import java.util.stream.Stream;
 
 import static java.lang.Math.max;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.*;
 import static java.util.stream.StreamSupport.stream;
@@ -619,10 +622,65 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
 
     private List<JCAnnotation> extractRecordComponentAnnotations(Symbol.RecordComponent rc) {
         List<JCAnnotation> annotations = rc.getOriginalAnnos();
-        for (int i = 0; i < rc.getAnnotationMirrors().size(); i++) {
-            annotations.get(i).getAnnotationType().setType((Type) rc.getAnnotationMirrors().get(i).getAnnotationType());
+        if (annotations.isEmpty()) {
+            return annotations;
+        }
+
+        // javac types each header annotation only where it landed (JLS 9.7.4), leaving these originals untyped
+        Map<Integer, JCAnnotation> onAccessor = rc.accessorMeth == null ? emptyMap() :
+                mapAnnotations(rc.accessorMeth.getModifiers().getAnnotations(), new HashMap<>());
+        List<Type> componentApplicableTypes = null;
+        for (JCAnnotation annotation : annotations) {
+            JCTree annotationType = annotation.getAnnotationType();
+            JCAnnotation accessorAnnotation = onAccessor.get(annotation.pos);
+            if (accessorAnnotation != null && accessorAnnotation.getAnnotationType().type != null) {
+                annotationType.setType(accessorAnnotation.getAnnotationType().type);
+                continue;
+            }
+            if (componentApplicableTypes == null) {
+                componentApplicableTypes = componentApplicableTypes(rc.getAnnotationMirrors());
+            }
+            // by name, as the mirrors cover only the component-applicable annotations and so never line up by index
+            Type type = typeNamed(annotationType.toString(), componentApplicableTypes);
+            if (type != null) {
+                annotationType.setType(type);
+            }
         }
         return annotations;
+    }
+
+    private static List<Type> componentApplicableTypes(List<Attribute.Compound> mirrors) {
+        List<Type> types = new ArrayList<>(mirrors.size());
+        for (Attribute.Compound mirror : mirrors) {
+            types.add(mirror.type);
+            // repeated annotations are attributed as the one container annotation that holds them
+            for (Pair<Symbol.MethodSymbol, Attribute> value : mirror.values) {
+                if (value.snd instanceof Attribute.Array) {
+                    for (Attribute repeated : ((Attribute.Array) value.snd).values) {
+                        if (repeated instanceof Attribute.Compound) {
+                            types.add(repeated.type);
+                        }
+                    }
+                }
+            }
+        }
+        return types;
+    }
+
+    private static @Nullable Type typeNamed(String writtenName, List<Type> types) {
+        Type enclosingTypeOmitted = null;
+        for (Type type : types) {
+            if (type.tsym != null) {
+                String qualifiedName = type.tsym.getQualifiedName().toString();
+                if (qualifiedName.equals(writtenName)) {
+                    return type;
+                }
+                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
+                    enclosingTypeOmitted = type;
+                }
+            }
+        }
+        return enclosingTypeOmitted;
     }
 
     @Override

--- a/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
+++ b/rewrite-java-25/src/main/java/org/openrewrite/java/isolated/ReloadableJava25ParserVisitor.java
@@ -62,6 +62,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.lang.Math.max;
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonList;
@@ -630,7 +631,6 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         // javac types each header annotation only where it landed (JLS 9.7.4), leaving these originals untyped
         Map<Integer, JCAnnotation> onAccessor = rc.accessorMeth == null ? emptyMap() :
                 mapAnnotations(rc.accessorMeth.getModifiers().getAnnotations(), new HashMap<>());
-        List<Type> componentApplicableTypes = null;
         for (JCAnnotation annotation : annotations) {
             JCTree annotationType = annotation.getAnnotationType();
             JCAnnotation accessorAnnotation = onAccessor.get(annotation.pos);
@@ -638,11 +638,8 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
                 annotationType.setType(accessorAnnotation.getAnnotationType().type);
                 continue;
             }
-            if (componentApplicableTypes == null) {
-                componentApplicableTypes = componentApplicableTypes(rc.getAnnotationMirrors());
-            }
             // by name, as the mirrors cover only the component-applicable annotations and so never line up by index
-            Type type = typeNamed(annotationType.toString(), componentApplicableTypes);
+            Type type = typeNamed(annotationType.toString(), rc.getAnnotationMirrors());
             if (type != null) {
                 annotationType.setType(type);
             }
@@ -650,38 +647,38 @@ public class ReloadableJava25ParserVisitor extends TreePathScanner<J, Space> {
         return annotations;
     }
 
-    private static List<Type> componentApplicableTypes(List<Attribute.Compound> mirrors) {
-        List<Type> types = new ArrayList<>(mirrors.size());
-        for (Attribute.Compound mirror : mirrors) {
-            types.add(mirror.type);
-            // repeated annotations are attributed as the one container annotation that holds them
-            for (Pair<Symbol.MethodSymbol, Attribute> value : mirror.values) {
-                if (value.snd instanceof Attribute.Array) {
-                    for (Attribute repeated : ((Attribute.Array) value.snd).values) {
-                        if (repeated instanceof Attribute.Compound) {
-                            types.add(repeated.type);
+    private static @Nullable Type typeNamed(String writtenName, List<? extends Attribute> attributes) {
+        Type enclosingTypeOmitted = null;
+        for (Attribute attribute : attributes) {
+            Symbol.TypeSymbol tsym = attribute.type.tsym;
+            if (tsym != null) {
+                String qualifiedName = tsym.getQualifiedName().toString();
+                if (qualifiedName.equals(writtenName)) {
+                    return attribute.type;
+                }
+                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
+                    enclosingTypeOmitted = attribute.type;
+                }
+            }
+        }
+        return enclosingTypeOmitted != null ? enclosingTypeOmitted : repeatedTypeNamed(writtenName, attributes);
+    }
+
+    // repeated annotations are attributed as the one container annotation that holds them
+    private static @Nullable Type repeatedTypeNamed(String writtenName, List<? extends Attribute> attributes) {
+        for (Attribute attribute : attributes) {
+            if (attribute instanceof Attribute.Compound) {
+                for (Pair<Symbol.MethodSymbol, Attribute> value : ((Attribute.Compound) attribute).values) {
+                    if (value.snd instanceof Attribute.Array) {
+                        Type type = typeNamed(writtenName, asList(((Attribute.Array) value.snd).values));
+                        if (type != null) {
+                            return type;
                         }
                     }
                 }
             }
         }
-        return types;
-    }
-
-    private static @Nullable Type typeNamed(String writtenName, List<Type> types) {
-        Type enclosingTypeOmitted = null;
-        for (Type type : types) {
-            if (type.tsym != null) {
-                String qualifiedName = type.tsym.getQualifiedName().toString();
-                if (qualifiedName.equals(writtenName)) {
-                    return type;
-                }
-                if (enclosingTypeOmitted == null && qualifiedName.endsWith("." + writtenName)) {
-                    enclosingTypeOmitted = type;
-                }
-            }
-        }
-        return enclosingTypeOmitted;
+        return null;
     }
 
     @Override

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.tree;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.Issue;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MinimumJava17;
 import org.openrewrite.test.RewriteTest;
@@ -34,6 +35,7 @@ import static org.openrewrite.java.Assertions.java;
  * each one only where it landed. Whichever of those it was, the annotation keeps the type it was written
  * with.
  */
+@Issue("https://github.com/openrewrite/rewrite/pull/8751")
 @MinimumJava17
 class RecordComponentAnnotationTypeTest implements RewriteTest {
 
@@ -158,6 +160,20 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
           java(
             """
               record AccessorOnlyWithArgument(@OnMethod("full_name") String name) {
+              }
+              """,
+            annotationTypes("OnMethod -> OnMethod")
+          )
+        );
+    }
+
+    @Test
+    void accessorOnlyAnnotationWithAWrittenAttributeName() {
+        rewriteRun(
+          java(ANNOTATIONS),
+          java(
+            """
+              record AccessorOnlyWithNamedArgument(@OnMethod(value = "full_name") String name) {
               }
               """,
             annotationTypes("OnMethod -> OnMethod")

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
@@ -34,6 +34,9 @@ import static org.openrewrite.java.Assertions.java;
  * method and the constructor parameter the annotation is applicable to (JLS 9.7.4), and javac attributes
  * each one only where it landed. Whichever of those it was, the annotation keeps the type it was written
  * with.
+ * <p>
+ * These assert the type each annotation resolves to rather than leaning on type validation, which only
+ * sees whether a type is present: an annotation that took its neighbour's type is well formed and passes.
  */
 @Issue("https://github.com/openrewrite/rewrite/pull/8751")
 @MinimumJava17
@@ -55,6 +58,10 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
 
       @Target(ElementType.FIELD)
       @interface OnField {
+      }
+
+      @Target({ElementType.RECORD_COMPONENT, ElementType.FIELD})
+      @interface OnComponentAndField {
       }
 
       @Target(ElementType.RECORD_COMPONENT)
@@ -149,6 +156,20 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
               }
               """,
             annotationTypes("OnField -> OnField", "OnComponent -> OnComponent")
+          )
+        );
+    }
+
+    @Test
+    void accessorOnlyAnnotationBeforeOneThatAlsoReachesTheField() {
+        rewriteRun(
+          java(ANNOTATIONS),
+          java(
+            """
+              record AccessorOnlyBeforeComponentAndField(@OnMethod @OnComponentAndField String name) {
+              }
+              """,
+            annotationTypes("OnMethod -> OnMethod", "OnComponentAndField -> OnComponentAndField")
           )
         );
     }

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.tree;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.MinimumJava17;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.SourceSpec;
+import org.openrewrite.test.TypeValidation;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * A record component's annotations are propagated to whichever of the component, the field, the accessor
+ * method and the constructor parameter the annotation is applicable to (JLS 9.7.4). Only those applicable
+ * to the component itself appear in {@code Symbol.RecordComponent#getAnnotationMirrors()}, while
+ * {@code #getOriginalAnnos()} holds every annotation written in the record header. The two lists therefore
+ * do not line up, and the parser attributes one from the other by index.
+ */
+@MinimumJava17
+class RecordComponentAnnotationTypeTest implements RewriteTest {
+
+    private static final String ANNOTATIONS = """
+      import java.lang.annotation.ElementType;
+      import java.lang.annotation.Target;
+
+      @Target(ElementType.METHOD)
+      @interface OnMethod {
+      }
+
+      @Target(ElementType.RECORD_COMPONENT)
+      @interface OnComponent {
+      }
+
+      @Target(ElementType.FIELD)
+      @interface OnField {
+      }
+      """;
+
+    private static Consumer<SourceSpec<J.CompilationUnit>> annotationTypes(String... expected) {
+        return spec -> spec.afterRecipe(cu -> {
+            List<String> actual = new ArrayList<>();
+            new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.Annotation visitAnnotation(J.Annotation annotation, Integer p) {
+                    JavaType type = annotation.getAnnotationType().getType();
+                    actual.add(annotation.getSimpleName() + " -> " + (type == null ? "null" : TypeUtils.toString(type)));
+                    return super.visitAnnotation(annotation, p);
+                }
+            }.visit(cu, 0);
+            assertThat(actual).containsExactly(expected);
+        });
+    }
+
+    @Test
+    void componentApplicableAnnotation() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(ANNOTATIONS),
+          java(
+            """
+              record ComponentApplicable(@OnComponent String name) {
+              }
+              """,
+            annotationTypes("OnComponent -> OnComponent")
+          )
+        );
+    }
+
+    @Disabled("Resolves to Unknown: the annotation reaches only the accessor, so it has no mirror on the component")
+    @Test
+    void accessorOnlyAnnotation() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(ANNOTATIONS),
+          java(
+            """
+              record AccessorOnly(@OnMethod String name) {
+              }
+              """,
+            annotationTypes("OnMethod -> OnMethod")
+          )
+        );
+    }
+
+    @Disabled("OnMethod resolves to OnComponent: the mirror for the second annotation is attributed to the first")
+    @Test
+    void accessorOnlyAnnotationBeforeComponentApplicableOne() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(ANNOTATIONS),
+          java(
+            """
+              record AccessorOnlyFirst(@OnMethod @OnComponent String name) {
+              }
+              """,
+            annotationTypes("OnMethod -> OnMethod", "OnComponent -> OnComponent")
+          )
+        );
+    }
+
+    @Disabled("OnMethod resolves to Unknown: the mirror list is shorter, so the trailing annotation is never attributed")
+    @Test
+    void componentApplicableAnnotationBeforeAccessorOnlyOne() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(ANNOTATIONS),
+          java(
+            """
+              record AccessorOnlyLast(@OnComponent @OnMethod String name) {
+              }
+              """,
+            annotationTypes("OnComponent -> OnComponent", "OnMethod -> OnMethod")
+          )
+        );
+    }
+
+    @Disabled("OnComponent resolves to Unknown: a field-only annotation shifts the mirror off its annotation")
+    @Test
+    void fieldOnlyAnnotationBeforeComponentApplicableOne() {
+        rewriteRun(
+          spec -> spec.typeValidationOptions(TypeValidation.none()),
+          java(ANNOTATIONS),
+          java(
+            """
+              record FieldOnlyFirst(@OnField @OnComponent String name) {
+              }
+              """,
+            annotationTypes("OnField -> OnField", "OnComponent -> OnComponent")
+          )
+        );
+    }
+}

--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/RecordComponentAnnotationTypeTest.java
@@ -15,13 +15,11 @@
  */
 package org.openrewrite.java.tree;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MinimumJava17;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.SourceSpec;
-import org.openrewrite.test.TypeValidation;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,20 +30,21 @@ import static org.openrewrite.java.Assertions.java;
 
 /**
  * A record component's annotations are propagated to whichever of the component, the field, the accessor
- * method and the constructor parameter the annotation is applicable to (JLS 9.7.4). Only those applicable
- * to the component itself appear in {@code Symbol.RecordComponent#getAnnotationMirrors()}, while
- * {@code #getOriginalAnnos()} holds every annotation written in the record header. The two lists therefore
- * do not line up, and the parser attributes one from the other by index.
+ * method and the constructor parameter the annotation is applicable to (JLS 9.7.4), and javac attributes
+ * each one only where it landed. Whichever of those it was, the annotation keeps the type it was written
+ * with.
  */
 @MinimumJava17
 class RecordComponentAnnotationTypeTest implements RewriteTest {
 
     private static final String ANNOTATIONS = """
       import java.lang.annotation.ElementType;
+      import java.lang.annotation.Repeatable;
       import java.lang.annotation.Target;
 
       @Target(ElementType.METHOD)
       @interface OnMethod {
+          String value() default "";
       }
 
       @Target(ElementType.RECORD_COMPONENT)
@@ -54,6 +53,16 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
 
       @Target(ElementType.FIELD)
       @interface OnField {
+      }
+
+      @Target(ElementType.RECORD_COMPONENT)
+      @Repeatable(OnComponentRepeats.class)
+      @interface OnComponentRepeated {
+      }
+
+      @Target(ElementType.RECORD_COMPONENT)
+      @interface OnComponentRepeats {
+          OnComponentRepeated[] value();
       }
       """;
 
@@ -75,7 +84,6 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
     @Test
     void componentApplicableAnnotation() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(ANNOTATIONS),
           java(
             """
@@ -87,11 +95,9 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
         );
     }
 
-    @Disabled("Resolves to Unknown: the annotation reaches only the accessor, so it has no mirror on the component")
     @Test
     void accessorOnlyAnnotation() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(ANNOTATIONS),
           java(
             """
@@ -103,11 +109,9 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
         );
     }
 
-    @Disabled("OnMethod resolves to OnComponent: the mirror for the second annotation is attributed to the first")
     @Test
     void accessorOnlyAnnotationBeforeComponentApplicableOne() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(ANNOTATIONS),
           java(
             """
@@ -119,11 +123,9 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
         );
     }
 
-    @Disabled("OnMethod resolves to Unknown: the mirror list is shorter, so the trailing annotation is never attributed")
     @Test
     void componentApplicableAnnotationBeforeAccessorOnlyOne() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(ANNOTATIONS),
           java(
             """
@@ -135,11 +137,9 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
         );
     }
 
-    @Disabled("OnComponent resolves to Unknown: a field-only annotation shifts the mirror off its annotation")
     @Test
     void fieldOnlyAnnotationBeforeComponentApplicableOne() {
         rewriteRun(
-          spec -> spec.typeValidationOptions(TypeValidation.none()),
           java(ANNOTATIONS),
           java(
             """
@@ -147,6 +147,34 @@ class RecordComponentAnnotationTypeTest implements RewriteTest {
               }
               """,
             annotationTypes("OnField -> OnField", "OnComponent -> OnComponent")
+          )
+        );
+    }
+
+    @Test
+    void accessorOnlyAnnotationWithAnArgument() {
+        rewriteRun(
+          java(ANNOTATIONS),
+          java(
+            """
+              record AccessorOnlyWithArgument(@OnMethod("full_name") String name) {
+              }
+              """,
+            annotationTypes("OnMethod -> OnMethod")
+          )
+        );
+    }
+
+    @Test
+    void repeatedComponentApplicableAnnotations() {
+        rewriteRun(
+          java(ANNOTATIONS),
+          java(
+            """
+              record Repeated(@OnComponentRepeated @OnComponentRepeated String name) {
+              }
+              """,
+            annotationTypes("OnComponentRepeated -> OnComponentRepeated", "OnComponentRepeated -> OnComponentRepeated")
           )
         );
     }


### PR DESCRIPTION
### Problem
Annotated record components are around now. Jackson DTOs, Spring request bodies, validation constraints. Since v8.69.0 the parser has been giving those annotations the wrong type, or no type at all.
Two ways to hit:
1. recipe tests touching such a record fail with LST contains missing or invalid type information. lead to more `TypeValidation.none()` usage
2. when a component carries two annotations, the first can quietly take the second's type

### Solution
The parser now takes each annotation's type from wherever javac actually recorded it, instead of assuming the annotations written in the record header line up with the ones that reached the component. They are distributed by javac.


