### PR TITLE
UpgradeDependencyVersion: do not write dependencies into settings.gradle

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -584,6 +584,12 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             if (gradleProject == null) {
                 return sourceFile;
             }
+            // Plugin-provided dependencies are project configurations (e.g. runtimeClasspath); they are not valid
+            // top-level DSL in a settings script, so restrict synthesis to build scripts.
+            String path = sourceFile.getSourcePath().toString();
+            if (!path.endsWith("build.gradle") && !path.endsWith("build.gradle.kts")) {
+                return sourceFile;
+            }
 
             DependencyVersionSelector versionSelector = new DependencyVersionSelector(metadataFailures, gradleProject, null);
 

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionTest.java
@@ -2867,6 +2867,60 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     /**
+     * Reproduces a case where the runtime environment (e.g. the Moderne CLI) has attached a
+     * {@link GradleProject} marker to the settings script. The plugin-provided dependency
+     * insertion path must not synthesize a top-level {@code dependencies { }} block there — it
+     * would be invalid Gradle DSL for a settings script.
+     */
+    @Test
+    void doesNotAddPluginProvidedDirectDependencyToSettingsGradle() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.jetbrains.kotlin", "kotlin-stdlib-jdk8", "1.9.0", null))
+            .beforeRecipe(sourceFiles -> {
+                GradleProject buildProjectMarker = sourceFiles.stream()
+                  .filter(sf -> sf.getSourcePath().toString().endsWith("build.gradle"))
+                  .findFirst()
+                  .flatMap(sf -> sf.getMarkers().findFirst(GradleProject.class))
+                  .orElse(null);
+                if (buildProjectMarker != null) {
+                    for (int i = 0; i < sourceFiles.size(); i++) {
+                        SourceFile sf = sourceFiles.get(i);
+                        if (sf.getSourcePath().toString().endsWith("settings.gradle")) {
+                            sourceFiles.set(i, sf.withMarkers(sf.getMarkers().setByType(buildProjectMarker)));
+                        }
+                    }
+                }
+            }),
+          buildGradle(
+            //language=groovy
+            """
+              plugins {
+                  id 'org.jetbrains.kotlin.jvm' version '1.7.21'
+              }
+              repositories { mavenCentral() }
+              """,
+            //language=groovy
+            """
+              plugins {
+                  id 'org.jetbrains.kotlin.jvm' version '1.7.21'
+              }
+              repositories { mavenCentral() }
+
+              dependencies {
+                  api "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.0"
+              }
+              """
+          ),
+          settingsGradle(
+            //language=groovy
+            """
+              rootProject.name = "sample"
+              """
+          )
+        );
+    }
+
+    /**
      * Transitive dependencies from plugins should not be upgraded by this recipe.
      * kotlin-stdlib is a transitive dependency of kotlin-stdlib-jdk8 which is added by the Kotlin plugin.
      */


### PR DESCRIPTION
## What

`UpgradeDependencyVersion`'s `applyPluginProvidedDependencies` code path synthesizes an explicit direct dependency declaration when the target G:A appears only in the resolved dependency graph (i.e. contributed by a plugin such as Spring Boot's dependency management plugin or the Kotlin plugin). Its `AddDependencyVisitor` insert predicate accepts any `JavaSourceFile`, and in some runtimes a `settings.gradle(.kts)` file carries a `GradleProject` marker too, so the visitor could land the synthesized `dependencies { ... }` block in the settings script. A top-level `dependencies { }` block is not valid Gradle DSL for a settings script.

Restrict the plugin-provided synthesis to `build.gradle` / `build.gradle.kts` files. The mainline update paths — including existing `buildscript { dependencies { classpath ... } }` entries in `settings.gradle` — are unaffected.

## Why the existing tests didn't catch this

The OSS `withToolingApi()` test helper (`rewrite-gradle-tooling-model/model/.../toolingapi/Assertions.java:150-155`) only attaches `GradleSettings` to `settings.gradle(.kts)`, never `GradleProject`. So no unit test in this repo could exercise `applyPluginProvidedDependencies` against a settings script — the `gradleProject != null` guard would short-circuit before the write.

The new regression test reproduces the runtime condition by copying the sibling `build.gradle`'s `GradleProject` marker onto the `settings.gradle` in a `beforeRecipe` hook. Without the fix in this PR, the test fails with a synthesized `dependencies { api "..." }` block written to `settings.gradle`.

## Test plan

- [x] Added `UpgradeDependencyVersionTest#doesNotAddPluginProvidedDirectDependencyToSettingsGradle` — fails on `main`, passes with the fix
- [x] Neighbouring plugin-provided tests continue to pass: `groovyDslUpgradesPluginProvidedDirectDependency`, `kotlinDslUpgradesPluginProvidedDirectDependency`, `doesNotUpgradePluginProvidedTransitiveDependency`
- [x] Full `UpgradeDependencyVersionTest` suite passes locally