### PR TITLE
Python: names inside a string return annotation are references

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -2228,13 +2228,11 @@ class ParserVisitor(ast.NodeVisitor):
             return_type = None
         else:
             arrow = self.__source_before('->')
-            with self.__type_context():
-                returns = self.__convert(node.returns)
             return_type = py.TypeHint(
                 random_id(),
                 arrow,
                 Markers.EMPTY,
-                returns,
+                self.__convert_type(node.returns),
                 self._type_mapping.type(node.returns)
             )
         body = self.__convert_block(node.body)
@@ -2953,6 +2951,7 @@ class ParserVisitor(ast.NodeVisitor):
                         Markers.EMPTY,
                         converted.replace(prefix=Space.EMPTY)
                     )
+                expression = converted
                 # Unwrap parenthesized literals to get to the Literal inside
                 while isinstance(converted, j.Parentheses):
                     converted = converted.tree
@@ -2968,6 +2967,16 @@ class ParserVisitor(ast.NodeVisitor):
                 quote_start = 0
                 while quote_start < len(source) and source[quote_start] not in ('"', "'"):
                     quote_start += 1
+
+                if 0 < quote_start < len(source):
+                    # The Quoted marker records only the quote style, so a string carrying a
+                    # prefix (r, b, u) stays a literal, where value_source holds the prefix.
+                    return py.ExpressionTypeTree(
+                        random_id(),
+                        expression.prefix,
+                        Markers.EMPTY,
+                        expression.replace(prefix=Space.EMPTY)
+                    )
 
                 if quote_start < len(source):
                     quote_char = source[quote_start]

--- a/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
@@ -156,6 +156,11 @@ def test_function_parameter_with_parenthesized_quoted_type_hint():
     ))
 
 
+def test_prefixed_string_type_hint_keeps_its_prefix():
+    # language=python
+    RecipeSpec().rewrite_run(python(r"""foo: r"List[\d]" = None"""))
+
+
 def test_variable_with_implicit_string_concat_type_hint():
     # language=python - type hint with implicit string concatenation
     RecipeSpec().rewrite_run(python('''X: """List[int]"""'☃' = []'''))

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -164,18 +164,24 @@ class TestMaybeAddImport:
             )
         )
 
-    def test_only_if_referenced_finds_a_reference_inside_a_string_annotation(self, arm):
+    @pytest.mark.parametrize('annotation_position, source', [
+        ('variable', 'm: "Dict[Any, Any]" = {}'),
+        ('parameter', 'def f(m: "Dict[Any, Any]") -> None: ...'),
+        ('return', 'def f() -> "Dict[Any, Any]": ...'),
+    ])
+    def test_only_if_referenced_finds_a_reference_inside_a_string_annotation(
+            self, arm, annotation_position, source):
         """A compound forward reference names the symbol, so it is a reference."""
         spec = RecipeSpec(recipe=from_visitor(
             _add_import_visitor(arm, 'typing', 'Any', only_if_referenced=True)))
         spec.rewrite_run(
             python(
-                """
-                m: "Dict[Any, Any]" = {}
+                f"""
+                {source}
                 """,
-                """
+                f"""
                 from typing import Any
-                m: "Dict[Any, Any]" = {}
+                {source}
                 """,
             )
         )

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -787,16 +787,24 @@ class TestRemoveImportStringAnnotations:
         module = types.ModuleType('after_recipe')
         exec(source_file.print_all(), module.__dict__)
         typing.get_type_hints(module)
+        for value in list(module.__dict__.values()):
+            if isinstance(value, types.FunctionType):
+                typing.get_type_hints(value)
 
-    def test_names_inside_a_compound_reference_keep_their_imports(self, arm):
+    @pytest.mark.parametrize('annotation_position, source', [
+        ('variable', 'm: "typing.Dict[Any, Any]" = {}'),
+        ('parameter', 'def f(m: "typing.Dict[Any, Any]") -> None: ...'),
+        ('return', 'def f() -> "typing.Dict[Any, Any]": ...'),
+    ])
+    def test_names_inside_a_compound_reference_keep_their_imports(self, arm, annotation_position, source):
         spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing')))
         spec.rewrite_run(
             python(
-                """\
+                f"""\
                 import typing
                 from typing import Any
 
-                m: "typing.Dict[Any, Any]" = {}
+                {source}
                 """,
                 after_recipe=self._assert_type_hints_resolve,
             )


### PR DESCRIPTION
`RemoveImport` drops an import that only a string return annotation still needs. #8750 fixed this for variable and parameter annotations; a return annotation reaches the LST as a different node, so the scans never see it.

```
=== variable annotation
  Identifier 'List[int]' quoted=True referenced_names=('List', 'int')
=== return annotation
  Literal value='List[int]' source='"List[int]"'
=== param annotation
  Identifier 'List[int]' quoted=True referenced_names=('List', 'int')
```

`referenced_names` takes a `J.Identifier` and is only reachable from the scans' `visit_identifier`, so `only_if_unused` judged `List` unused. The output is valid Python that raises the moment anything resolves the annotation — `typing.get_type_hints`, a pydantic model build, a dataclass under `from __future__ import annotations`. `AddImport` had the mirror-image gap.

## The fix

Three parser call sites feed annotations, and `visit_FunctionDef` was the one calling `__convert` rather than `__convert_type`; the other two already routed through the mapper that turns a string constant into a `Quoted` `J.Identifier`. Making the third match costs one line and needs nothing from the scans, which is why it beats teaching them to read `J.Literal`s in annotation position — leaving three positions modelled two ways is what let them drift.

That surfaced a second defect in the shared mapper. It rebuilds the string from `Quoted`, which records the quote style and nothing else, so the prefix is lost on the way out:

| source | printed, before |
|---|---|
| `x: r"List[\d]"` | `x: "List[\d]"` |
| `x: b"ab"` | `x: "ab"` |

The second row is not cosmetic — a bytes literal comes back as a `str`, so a no-op recipe changes what the annotation means. Variable and parameter annotations have always had this, and routing return annotations through the same mapper would have added a third corrupting position, so the mapper now leaves a prefixed string as a literal where `value_source` carries the prefix. All three positions round-trip. The cost is that such a string is not scanned as a forward reference, which is the right trade against retyping it.

## Tests

`test_names_inside_a_compound_reference_keep_their_imports` and its `AddImport` mirror now run over all three annotation positions. The remove-side assertion `exec`s the output and calls `typing.get_type_hints` on the module and on each function it defines, so a dropped import fails rather than producing plausible text. `test_prefixed_string_type_hint_keeps_its_prefix` pins the literal branch.

The Java port needs no change: `PythonAddImportVisitor`'s scan is `visitIdentifier`-based and `PythonRemoveImportVisitor` defers `only_if_unused` to the Python side. Both are exercised by the `java` arm of those tests, which replays the same cases over RPC.

`:rewrite-python:test` fails on `RequirementsTxtParserTest.markerContainsDependenciesFromFreeze` here, identically on this branch and on `main` — unrelated and pre-existing.
