### PR TITLE
Add CODEGENOME secrets to npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -121,6 +121,9 @@ jobs:
           echo "dist_tag=next"  >> "$GITHUB_OUTPUT"
 
       - shell: bash
+        env:
+          CODEGENOME_USERNAME: ${{ secrets.CODEGENOME_USERNAME }}
+          CODEGENOME_TOKEN: ${{ secrets.CODEGENOME_TOKEN }}
         run: |
           ARGS=()
           if [[ -n '${{ steps.ver.outputs.version }}' ]]; then


### PR DESCRIPTION
**What**: Adding configuration of `CODEGENOME` secrets/variables to `npm-publish` GitHub Actions workflow

**Why**:
- npm publishing suddenly stopped working with no new versions showing up in https://www.npmjs.com/package/@openrewrite/rewrite?activeTab=versions
- npm-publish jobs fail with:
```
Caused by: java.lang.NullPointerException: Username must not be null!
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:920)
	at org.gradle.internal.resource.transport.http.ntlm.NTLMCredentials.<init>(NTLMCredentials.java:36)
```
- derived projects fail to start RPC server for JS properly as the versions are lacking 