### PR TITLE
Python: a call names the member its import binds

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -216,6 +216,7 @@ class PythonTypeMapping:
         self._module_ast_parsed = False
         self._module_ast_tree: Optional[ast.Module] = None
         self._import_binding_index: Optional[Dict[str, str]] = None
+        self._from_import_member_index: Optional[Dict[str, Tuple[str, str]]] = None
 
         # ty-types data: populated by _build_index
         self._node_index: Dict[Tuple[int, int], Tuple[int, str]] = {}  # (start, end) -> (type_id, node_kind)
@@ -996,7 +997,8 @@ class PythonTypeMapping:
 
     def _import_bindings(self) -> Dict[str, str]:
         """The FQN each of this file's absolute module-level imports names, keyed by the
-        name it binds, minus every name the file binds a second time.
+        name it binds, minus every name the file binds a second time. The same scan
+        yields the ``from M import f`` bindings that :meth:`_bound_from_import_member` reads.
 
         Python binds a name once per scope, so an import nothing else rebinds says what a
         reference to that name means whether or not ty could type it. Anything that could
@@ -1007,6 +1009,7 @@ class PythonTypeMapping:
         if self._import_binding_index is None:
             tree = self._module_ast()
             bindings: Dict[str, str] = {}
+            members: Dict[str, Tuple[str, str]] = {}
             shadowed: Set[str] = set()
             top_level = set()
 
@@ -1030,11 +1033,13 @@ class PythonTypeMapping:
                         elif alias.name == '*':
                             # A star import can bind any name, so nothing here is decidable
                             self._import_binding_index = {}
+                            self._from_import_member_index = {}
                             return self._import_binding_index
                         elif relative:
                             bind(alias.asname or alias.name, None)
                         else:
                             bind(alias.asname or alias.name, f"{stmt.module}.{alias.name}")
+                            members[alias.asname or alias.name] = (stmt.module, alias.name)
 
             for node in ast.walk(tree) if tree else ():
                 if isinstance(node, ast.Name):
@@ -1053,7 +1058,19 @@ class PythonTypeMapping:
 
             self._import_binding_index = {name: fqn for name, fqn in bindings.items()
                                           if name not in shadowed}
+            self._from_import_member_index = {name: member for name, member in members.items()
+                                              if name not in shadowed}
         return self._import_binding_index
+
+    def _bound_from_import_member(self, node: ast.expr) -> Optional[Tuple[str, str]]:
+        """The ``(module, member)`` an unshadowed module-level ``from M import f`` binds
+        ``node``'s name to. A receiver-less call spells the binding's name, which an alias
+        makes different from the member's, so both halves come from the import.
+        """
+        if not isinstance(node, ast.Name):
+            return None
+        self._import_bindings()
+        return (self._from_import_member_index or {}).get(node.id)
 
     def import_alias_type(self, node: ast.alias) -> Optional[JavaType]:
         """The type of the symbol an import name binds, named under the module defining
@@ -1267,9 +1284,16 @@ class PythonTypeMapping:
             return None
         if self._constructed_class(node) is not None:
             method_name = '<constructor>'
+        else:
+            method_name = self._callee_declared_name(node) or method_name
 
         # Get declaring type
         declaring_type = self._get_declaring_type(node)
+        if isinstance(declaring_type, JavaType.Unknown):
+            # Nothing resolved the callee, so the import binding it is what names it.
+            bound = self._bound_from_import_member(node.func)
+            if bound:
+                declaring_type, method_name = self._module_class(bound[0]), bound[1]
 
         # Get parameter names and types from method signature
         param_names, param_types = self._get_method_signature(node)
@@ -1295,8 +1319,19 @@ class PythonTypeMapping:
             _declared_formal_type_names=type_param_names if type_param_names else None,
         )
 
+    def _callee_declared_name(self, node: ast.Call) -> Optional[str]:
+        """The name the callee carries where it is defined. Its owner is read off the
+        callee, so its name is too: a binding that renames a symbol renames neither
+        half — ``from platform import system as s`` calls ``platform system(..)``.
+        """
+        callee_id = self._lookup_func_type_id(node)
+        callee = self._type_registry.get(callee_id) if callee_id is not None else None
+        if callee is not None and callee.get('kind') in _FUNCTION_KINDS:
+            return callee.get('name') or None
+        return None
+
     def _extract_method_name(self, node: ast.Call) -> Optional[str]:
-        """Extract the method name from a Call node."""
+        """The name a Call node spells."""
         if isinstance(node.func, ast.Name):
             return node.func.id
         elif isinstance(node.func, ast.Attribute):
@@ -1468,6 +1503,13 @@ class PythonTypeMapping:
                 resolved = self._resolve_declaring_type(type_id)
                 if resolved is not None:
                     return resolved
+
+        if isinstance(node.func, ast.Attribute):
+            # A receiver whose root an unshadowed import binds is that module, spelled as
+            # the import names it. A written chain alone cannot tell a module from a value.
+            module = self._import_binding_fqn(node.func.value)
+            if module:
+                return self._module_class(module)
 
         inferred = self._infer_declaring_type_from_ast(node)
         return inferred if inferred is not None else _UNKNOWN

--- a/rewrite-python/rewrite/tests/python/test_declared_version_typeshed.py
+++ b/rewrite-python/rewrite/tests/python/test_declared_version_typeshed.py
@@ -24,6 +24,7 @@ import shutil
 
 import pytest
 
+from rewrite.java import JavaType
 from rewrite.python.visitor import PythonVisitor
 from rewrite.rpc import server
 
@@ -59,8 +60,9 @@ def _project(root, classifier_version):
     return root
 
 
-def _declaring_types(root):
-    """Map each call in the project to its method type's declaring-type FQN.
+def _call_facts(root):
+    """Map each call in the project to its declaring-type FQN and whether the typeshed
+    gave it a signature.
 
     ``JavaType.Unknown`` is truthy and carries no name, so an unresolved
     declaring type reports as None rather than being mistaken for a hit.
@@ -71,10 +73,12 @@ def _declaring_types(root):
         def visit_method_invocation(self, mi, p):
             method_type = mi.method_type
             declaring = getattr(method_type, 'declaring_type', None) if method_type else None
+            return_type = getattr(method_type, 'return_type', None) if method_type else None
             found[mi.name.simple_name] = (
                 declaring.fully_qualified_name
                 if declaring is not None and hasattr(declaring, '_fully_qualified_name')
-                else None
+                else None,
+                return_type is not None and not isinstance(return_type, JavaType.Unknown),
             )
             return super().visit_method_invocation(mi, p)
 
@@ -87,22 +91,23 @@ def _declaring_types(root):
 
 @requires_ty_types_cli
 def test_declared_version_selects_typeshed(tmp_path):
-    on_310 = _declaring_types(_project(tmp_path / "p310", "3.10"))
-    on_313 = _declaring_types(_project(tmp_path / "p313", "3.13"))
+    on_310 = _call_facts(_project(tmp_path / "p310", "3.10"))
+    on_313 = _call_facts(_project(tmp_path / "p313", "3.13"))
 
-    # gettext.lgettext is in 3.10's typeshed and gone from 3.11's.
-    assert on_310["lgettext"] == "gettext"
-    assert on_313["lgettext"] is None
+    # gettext.lgettext is in 3.10's typeshed and gone from 3.11's. Its owner is the
+    # module the import binds either way, so the signature is what the typeshed decides.
+    assert on_310["lgettext"] == ("gettext", True)
+    assert on_313["lgettext"] == ("gettext", False)
 
     # In both, so the pair varies only by typeshed content, not by whether
     # attribution ran at all.
-    assert on_310["getdefaultlocale"] == on_313["getdefaultlocale"] == "locale"
+    assert on_310["getdefaultlocale"] == on_313["getdefaultlocale"] == ("locale", True)
 
 
 @requires_ty_types_cli
 def test_version_outside_ty_support_keeps_the_rest_of_attribution(tmp_path):
-    found = _declaring_types(_project(tmp_path / "p399", "3.99"))
+    found = _call_facts(_project(tmp_path / "p399", "3.99"))
 
     # ty declines a version it ships no stubs for by failing initialization,
     # which takes every type down with it unless the version is given up.
-    assert found["getdefaultlocale"] == "locale"
+    assert found["getdefaultlocale"] == ("locale", True)

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3731,17 +3731,78 @@ class TestSymbolIdentityAcrossImportForms:
             _cleanup_parse(tmpdir, client)
 
     # `asyncio` re-exports the `sleep` that `asyncio.tasks` defines, written through
-    # the facade, through the defining module, and as an attribute of the package.
+    # the facade, through the defining module, as an attribute of the package, and
+    # under a name of the file's own choosing.
     @pytest.mark.parametrize('source', [
         'from asyncio import sleep\nsleep(1)\n',
         'from asyncio.tasks import sleep\nsleep(1)\n',
         'import asyncio\nasyncio.sleep(1)\n',
-    ], ids=['through-facade', 'through-definer', 'as-attribute'])
+        'from asyncio import sleep as nap\nnap(1)\n',
+    ], ids=['through-facade', 'through-definer', 'as-attribute', 'under-an-alias'])
     def test_a_reexported_function_has_one_identity(self, source):
         self._assert_names(source, 'asyncio.tasks', 'sleep')
 
     def test_a_platform_module_is_named_by_its_portable_alias(self):
         self._assert_names('from posixpath import join\njoin("a", "b")\n', 'os.path', 'join')
+
+    def test_an_attribute_of_a_reexporting_module_names_the_definition(self):
+        cu, tmpdir, client = _parse_with_types({
+            'pkg/__init__.py': '',
+            'pkg/_impl.py': 'def bar():\n    return 1\n',
+            'pkg/api.py': 'from pkg._impl import bar as baz\n',
+            'm.py': 'import pkg.api\npkg.api.baz()\n',
+        })
+        try:
+            method_type = cu.statements[1].method_type
+            assert (method_type.declaring_type.fully_qualified_name,
+                    method_type.name) == ('pkg._impl', 'bar')
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+
+@requires_ty_types_cli
+class TestSymbolTheStubsDoNotDeclare:
+    """A symbol no stub declares is named by the import that binds it — reached through
+    a from-import, or through a receiver whose own import names the module."""
+
+    LIB = 'def present():\n    return 1\n'
+
+    def _call_names(self, source, call_index=1):
+        cu, tmpdir, client = _parse_with_types({'lib.py': self.LIB, 'm.py': source})
+        try:
+            method_type = cu.statements[call_index].method_type
+            declaring_type = method_type.declaring_type
+            return (getattr(declaring_type, 'fully_qualified_name', None), method_type.name)
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+    @pytest.mark.parametrize('source', [
+        'import lib\nlib.gone()\n',
+        'from lib import gone\ngone()\n',
+        'from lib import gone as g\ng()\n',
+    ], ids=['as-attribute', 'through-from-import', 'under-an-alias'])
+    def test_an_undeclared_symbol_has_one_identity(self, source):
+        assert self._call_names(source) == ('lib', 'gone')
+
+    def test_a_rebound_name_is_not_attributed_from_its_import(self):
+        owner, _ = self._call_names('from lib import gone\ngone = None\ngone()\n', 2)
+        assert owner is None, 'a name the file rebinds no longer names what it imported'
+
+    def test_an_import_in_a_function_does_not_bind_at_module_scope(self):
+        owner, _ = self._call_names('def g():\n    from lib import gone\ngone()\n')
+        assert owner is None, 'a function-scope import binds only inside that function'
+
+    def test_a_receiver_names_the_module_its_import_binds(self):
+        cu, tmpdir, client = _parse_with_types(
+            {'m.py': 'import nosuchmod\nimport nosuch.pkg as np\n'
+                     'nosuchmod.gone()\nnp.sub.gone()\n'})
+        try:
+            owners = [c.method_type.declaring_type.fully_qualified_name
+                      for c in _collect_method_invocations(cu)]
+            assert owners == ['nosuchmod', 'nosuch.pkg.sub'], \
+                'a receiver names the module its import binds, not the chain it spells'
+        finally:
+            _cleanup_parse(tmpdir, client)
 
 
 @requires_ty_types_cli


### PR DESCRIPTION
`MethodMatcher("gettext lgettext(..)")` misses `from gettext import lgettext; lgettext('m')`, and `MethodMatcher("platform system(..)")` misses `from platform import system as s; s()`. Both spell a symbol the file plainly calls. Measured at `5905e9d581`:

| source | owner + name the call carries |
|---|---|
| `import gettext; gettext.lgettext('m')` | `gettext lgettext(..)` |
| `from gettext import lgettext; lgettext('m')` | `<Unknown> lgettext(..)` |
| `from platform import system as s; s()` | `platform s(..)` |
| `import pkg.api; pkg.api.baz()`, where `api` re-exports `_impl.bar` as `baz` | `pkg._impl baz(..)` |

Rows 3 and 4 name FQNs nothing declares: `platform` has no `s`, `pkg._impl` no `baz`.

## Two causes

**A call's name was spelled; its owner was declared.** `_get_declaring_type` reads the callee's descriptor, `_extract_method_name` read the identifier at the call site, and a renaming binding splits the pair. `import_alias_type` already read the descriptor, so `FindMethods("platform system(..)")` marked the import and missed the call — the half-marking #8737 fixed for the module half, left live for the alias half.

**A symbol the stubs do not declare has no owner at all.** ty resolves `lib.gone()` through `lib` whether or not `gone` exists, so only the from-import form has nothing to read. It arrives as `JavaType.Unknown`, not `null`, so the obvious guard misses it.

Which symbols those are tracks the typeshed in use: `locale.resetlocale` resolves under 3.12 and is `Unknown` under 3.14.

#8759 makes that follow the project's declared version rather than the parse interpreter, and does not close this for two reasons. It needs a project: `server.py` reads `detect_from_project(relative_to) if relative_to else None`, so a parse with no project root — every recipe unit test, and any loose file — has no declared version to apply.

Measured on `main` at `91f14a032e`, with #8759 present and this PR absent, all four resolve to `Unknown`; on this branch they name `platform`, `gettext`, `ssl` and `locale`:

```
from platform import popen; popen()
from gettext import lgettext; lgettext()
from ssl import match_hostname; match_hostname(c, h)
from locale import resetlocale; resetlocale()
```

The second reason survives even with a project: a migration declares the version it is moving *to*, so the removed API it exists to rewrite is `Unknown` by #8759's design.

## Why the parser

The name comes off the callee, as its owner already does. Where nothing resolved the callee, the import binding the name is what names it — through the `_import_bindings()` index this file already consults for **decorators**, where `test_decorator_an_untyped_factory_produced` pins an untyped `require` as `deco.require`. Calls get the same treatment: one shadowing policy, not two.

A receiver goes through that index too. `import nosuchmod; nosuchmod.gone()` was `Unknown` where the dotted `import nosuch.mod; nosuch.mod.gone()` already minted `nosuch.mod` from its written chain — a bare receiver alone cannot be told from a value, and the import binding is what tells them apart. `import a.b as ab; ab.c.gone()` now names `a.b.c` rather than the written `ab.c`.

A Python-side service — `resolve_binding(identifier, cursor)`, or a cursor-aware `MethodMatcher.matches` — cannot fix the reported symptom, which is `uses_method("*..* popen(..)")` gating a file out before any visitor runs. That gate is `UsesMethod` over `TypesInUse`, computed from the LST by the `MethodMatcher` implementation Java shares, and nothing Python-side reaches it.

`scope_utils.LocalBindings` is unavailable to the parser for a second reason: it answers from a `Cursor`, and `type_mapping.py` runs on `ast` before one exists.

## Not #8737's index, restored

#8737 keyed a from-import index on ty's **type id**, and said why: a rebound name "misses the index and keeps the owner ty gives it, with no scope analysis". That key is unavailable here, because a symbol no stub declares has no type id.

The key can only be the bound name, so the scope analysis #8737 declined is what has to replace it. `_import_bindings()` supplies it: an import counts only if it is module-level, absolute, and the file binds its name nowhere else. #8756's rule is untouched — this fires only where ty defines the symbol nowhere.

## What a type table now carries

An owner minted from an import is an FQN attribution did not derive from ty, which is the real cost here.

The receiver form already mints from the same two facts: `import gettext; gettext.lgettext('m')` is owned by ty's `gettext` module and named by the source's spelled `lgettext`, a pair in the table today for a symbol that does not exist. `from gettext import lgettext` has both facts, and was the one form discarding them.

## One test on `main` changes meaning

`test_declared_version_selects_typeshed` (#8759) proved the typeshed had swapped by asserting `gettext.lgettext` has no declaring type under 3.13 and `gettext` under 3.10. Its owner is now `gettext` under both, so that control stops discriminating.

It reads the signature instead: 3.10 gives `lgettext` a `str` return and one `str` parameter, 3.13 gives `Unknown` and placeholders taken from the call. That observes the typeshed's content rather than the presence of an owner, which is the stronger control of the two.

## Tests

`TestSymbolTheStubsDoNotDeclare` uses a workspace module declaring `present` and not `gone`, which reproduces the removed-API shape without depending on the interpreter's typeshed. Three import forms of `gone` must name `lib gone(..)`; a rebound name and a function-scope import must stay unresolved; and a module absent from the environment pins both receiver forms.

`TestSymbolIdentityAcrossImportForms` gains `from asyncio import sleep as nap` and the re-exported `pkg.api.baz()`, both of which fail on the spelled name before this change.

## Scope

A pattern spelling an alias stops matching: `*..* p(..)` no longer matches `from platform import popen as p; p('ls')`, since `p` is not the symbol's name.

An undeclared symbol's **import qualid** still carries no type, so `get_canonical_fqn` returns `None` for it and `FindMethods` marks the call but not the binding. A call site establishes by syntax that what it names is callable; an import binding establishes nothing, so minting a `JavaType.Method` there would fabricate a kind rather than a name.

`RemoveImport` matches module and name syntactically — verified on `from lib import gone` in plain and aliased form — so import removal is unaffected. For the same reason a construction of an undeclared class reads as a function call: without a type, nothing tells the two apart.

`rewrite-migrate-python`'s `_from_imports.py` helper is deleted separately, once this ships.
