### PR TITLE
Python: let a project's declared version pick the typeshed

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
@@ -88,10 +88,10 @@ def detect_from_project(project_path: Union[str, Path, None]) -> Optional[str]:
     * ``pyproject.toml`` ``[project].classifiers`` for
       ``Programming Language :: Python :: <ver>``.
     * ``pyproject.toml`` ``[project].requires-python`` when it pins a major
-      version (e.g. ``"<3"`` or ``">=2.7,<3"`` resolves to ``"2.7"``).
+      version (e.g. ``">=2.7,<3"`` resolves to ``"2.7"``).
     * ``setup.cfg`` ``[metadata].classifiers`` (same shape as pyproject).
 
-    The most specific version found wins; if multiple major versions are
+    A Python 3 span resolves to its floor; if multiple major versions are
     declared (e.g. both ``2.7`` and ``3.10``), returns ``None`` because the
     project supports both and per-file detection should decide.
     """
@@ -134,12 +134,22 @@ def _classifier_versions(text: str):
         yield ver
 
 
+# A clause that sets a floor. ``<`` and ``<=`` cap the range and ``!=`` punches
+# a hole in it; neither says what the lowest admitted version is.
+_LOWER_BOUND = re.compile(r"(?:^|,)\s*(?:>=?|~=|==)?\s*(?P<ver>\d+(?:\.\d+)?)")
+
+# An upper bound excluding every 3.x, which leaves only Python 2. ``<=3`` is
+# not one: it admits 3.0.
+_EXCLUDES_PY3 = re.compile(r"<\s*3(\.0)?\s*(,|$)")
+
+
 def _requires_python(pyproject_text: str) -> Optional[str]:
     """Best-effort parse of ``requires-python`` from a pyproject.toml.
 
     Avoids a TOML dependency; only looks for the ``requires-python = "..."``
-    line under any section. Returns the most restrictive major version
-    implied by the constraint, or None if it spans both 2 and 3.
+    line under any section. Returns the lowest version the constraint admits,
+    keeping its minor (``">=3.10"`` -> ``"3.10"``, matching how ty reads the
+    same field), or None where it names no floor or spans both 2 and 3.
     """
     m = re.search(
         r'(?m)^\s*requires-python\s*=\s*"([^"]+)"', pyproject_text
@@ -147,22 +157,22 @@ def _requires_python(pyproject_text: str) -> Optional[str]:
     if not m:
         return None
     spec = m.group(1)
-    allows_two = bool(re.search(r"(^|,)\s*[<>=!~]*\s*2(\.|\b)", spec))
-    allows_three = bool(re.search(r"(^|,)\s*[<>=!~]*\s*3(\.|\b)", spec))
-    upper_excludes_three = bool(re.search(r"<\s*3(\.|\b)", spec))
-    if allows_two and upper_excludes_three:
+    floors = _LOWER_BOUND.findall(spec)
+    py2 = [v for v in floors if v.split(".", 1)[0] == "2"]
+    py3 = [v for v in floors if v.split(".", 1)[0] == "3"]
+    if not py3 and _EXCLUDES_PY3.search(spec):
         return "2.7"
-    if allows_three and not allows_two:
-        return "3"
+    if py3 and not py2:
+        return _lowest(py3)
     return None
 
 
 def _resolve(versions) -> Optional[str]:
     """Reduce a set of version strings to a single effective version.
 
-    * Multiple major versions → ``None`` (project supports both; defer).
-    * Any Py2 entry → most specific Py2 version found.
-    * Otherwise → most specific Py3 version found.
+    Multiple major versions yield ``None`` — the project supports both, so
+    per-file detection has to decide. A Python 3 span resolves to its floor,
+    the one version every line of the project has to work on.
     """
     if not versions:
         return None
@@ -170,13 +180,17 @@ def _resolve(versions) -> Optional[str]:
     majors = {v.split(".", 1)[0] for v in versions}
     if "2" in majors and "3" in majors:
         return None
+    if "2" in majors:
+        # parso implements a single Python 2 grammar, so 2.7 is the only value
+        # the Py2 parser can act on.
+        return "2.7"
 
-    py2 = sorted(v for v in versions if v.startswith("2"))
-    if py2:
-        return py2[-1]
+    return _lowest(versions)
 
-    py3 = sorted(v for v in versions if v.startswith("3"))
-    if py3:
-        return py3[-1]
 
-    return None
+def _lowest(versions) -> str:
+    """The numerically lowest version, preferring those carrying a minor: a
+    bare ``"3"`` names no stdlib surface and would otherwise mask ``"3.10"``."""
+    with_minor = [v for v in versions if "." in v]
+    return min(with_minor or list(versions),
+               key=lambda v: tuple(int(part) for part in v.split(".")))

--- a/rewrite-python/rewrite/src/rewrite/python/ty_client.py
+++ b/rewrite-python/rewrite/src/rewrite/python/ty_client.py
@@ -27,8 +27,11 @@ import json
 import logging
 import os
 import queue
+import re
+import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from pathlib import Path
@@ -37,6 +40,23 @@ from typing import Any, Dict, Optional
 from .type_mapping import SessionTypeCache
 
 logger = logging.getLogger(__name__)
+
+# ty has only ever shipped Python 3 stubs.
+_TY_PYTHON_VERSION = re.compile(r'3\.\d+')
+
+
+def _ty_user_config_dir(python_version: str) -> str:
+    """A throwaway ``XDG_CONFIG_HOME`` holding a ty user config naming
+    ``python_version``. ty ranks a project's own ``ty.toml`` and
+    ``requires-python`` above it, so it only fills in versions ty cannot read
+    for itself, such as setuptools classifiers.
+    """
+    config_dir = tempfile.mkdtemp(prefix='ty-user-config-')
+    ty_dir = os.path.join(config_dir, 'ty')
+    os.mkdir(ty_dir)
+    with open(os.path.join(ty_dir, 'ty.toml'), 'w', encoding='utf-8') as f:
+        f.write('[environment]\npython-version = "%s"\n' % python_version)
+    return config_dir
 
 
 class TyTypesClient:
@@ -54,7 +74,8 @@ class TyTypesClient:
             result = client.get_types("/path/to/file.py")
     """
 
-    def __init__(self, virtual_env: Optional[str] = None):
+    def __init__(self, virtual_env: Optional[str] = None,
+                 python_version: Optional[str] = None):
         """Create a client and start the ``ty-types --serve`` subprocess.
 
         Args:
@@ -67,12 +88,20 @@ class TyTypesClient:
                 from the project's ``pyproject.toml`` so that supertypes reaching
                 into installed dependencies (e.g. ``class User(BaseModel)``)
                 resolve.
+            python_version: Optional Python version ("3.10") whose stdlib
+                surface ty resolves against, for projects declaring one
+                somewhere ty does not look. Non-3.x values are ignored.
         """
         self._process: Optional[subprocess.Popen] = None
         self._request_id: int = 0
         self._initialized = False
         self._project_root: Optional[str] = None
         self._virtual_env: Optional[str] = str(virtual_env) if virtual_env else None
+        self._python_version: Optional[str] = (
+            python_version if python_version and _TY_PYTHON_VERSION.fullmatch(python_version)
+            else None
+        )
+        self._ty_config_dir: Optional[str] = None
 
         # Cumulative type table for the lifetime of this ``--serve`` session.
         #
@@ -114,16 +143,22 @@ class TyTypesClient:
                 "ty-types is not installed. Ensure the ty-types binary is on PATH."
             )
 
+        if self._python_version is not None and self._ty_config_dir is None:
+            self._ty_config_dir = _ty_user_config_dir(self._python_version)
+
         try:
             self._process = subprocess.Popen(
                 [str(binary), '--serve'],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=self._subprocess_env(virtual_env=self._virtual_env),
+                env=self._subprocess_env(virtual_env=self._virtual_env,
+                                         ty_config_dir=self._ty_config_dir),
             )
         except FileNotFoundError:
             self._process = None
+            # No instance escapes the constructor to be shut down later.
+            self._discard_ty_config()
             raise RuntimeError(
                 "ty-types is not installed. Ensure the ty-types binary is on PATH."
             )
@@ -164,7 +199,8 @@ class TyTypesClient:
     def _subprocess_env(base_env: Optional[Dict[str, str]] = None,
                         prefix: Optional[str] = None,
                         base_prefix: Optional[str] = None,
-                        virtual_env: Optional[str] = None) -> Dict[str, str]:
+                        virtual_env: Optional[str] = None,
+                        ty_config_dir: Optional[str] = None) -> Dict[str, str]:
         """Build the environment for the ty-types subprocess.
 
         ty-types resolves a project's third-party packages by discovering the
@@ -189,6 +225,10 @@ class TyTypesClient:
         are injectable to keep this unit-testable.
         """
         env = dict(os.environ if base_env is None else base_env)
+
+        # Where ty looks for its user config, per platform.
+        if ty_config_dir:
+            env['APPDATA' if os.name == 'nt' else 'XDG_CONFIG_HOME'] = ty_config_dir
 
         def _point_at(venv: str) -> None:
             env['VIRTUAL_ENV'] = venv
@@ -302,6 +342,23 @@ class TyTypesClient:
             self.java_types.clear()
             self._start_process()
 
+        if self._try_initialize(project_root):
+            return True
+
+        # ty rejects a version outside the range it ships stubs for by failing
+        # initialization outright, which costs the batch every type rather than
+        # only the version-gated ones. The version is a fallback, so trade it
+        # away. A timeout is no verdict on it, and retrying would pay it twice.
+        if self._python_version is not None and self._consecutive_timeouts == 0:
+            logger.debug("ty-types rejected python-version %s; retrying without it",
+                         self._python_version)
+            self._python_version = None
+            self.shutdown()
+            self._start_process()
+            return self._try_initialize(project_root)
+        return False
+
+    def _try_initialize(self, project_root: str) -> bool:
         # Bounded so a wedged ty degrades to untyped instead of hanging; large
         # because ty indexes the whole project up front.
         result = self._send_request("initialize", {"projectRoot": project_root},
@@ -351,6 +408,7 @@ class TyTypesClient:
         # Local: the "shutdown" request can trip the breaker, whose ``_kill`` detaches ``self._process``.
         process = self._process
         if process is None:
+            self._discard_ty_config()
             return
 
         try:
@@ -362,6 +420,7 @@ class TyTypesClient:
             self._process = None
             self._initialized = False
             self._project_root = None
+            self._discard_ty_config()
 
     def _kill(self) -> None:
         """Forcibly terminate an unresponsive ty-types process."""
@@ -369,8 +428,16 @@ class TyTypesClient:
         self._process = None
         self._initialized = False
         self._project_root = None
+        self._discard_ty_config()
         if process is not None:
             try:
                 process.kill()
             except OSError:
                 pass
+
+    def _discard_ty_config(self) -> None:
+        """Remove the throwaway user-config dir; ``_start_process`` rebuilds it
+        while a version is still in play."""
+        if self._ty_config_dir is not None:
+            shutil.rmtree(self._ty_config_dir, ignore_errors=True)
+            self._ty_config_dir = None

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -528,6 +528,7 @@ def handle_parse(params: dict) -> List[str]:
     # parse_python_source.
     from rewrite.python._version_detect import detect_from_project
     project_language_level = detect_from_project(relative_to) if relative_to else None
+    ty_python_version = _ty_python_version(language_level, project_language_level)
 
     # Create a ty-types client for this parse batch
     ty_client = None
@@ -536,7 +537,8 @@ def handle_parse(params: dict) -> List[str]:
         from rewrite.python.ty_client import TyTypesClient
         # Point ty-types at the caller-provisioned dependency environment (if any)
         # so supertypes reaching into third-party packages resolve.
-        ty_client = TyTypesClient(virtual_env=dependency_path)
+        ty_client = TyTypesClient(virtual_env=dependency_path,
+                                  python_version=ty_python_version)
         if relative_to:
             ty_client.initialize(relative_to)
         else:
@@ -637,6 +639,7 @@ def handle_parse_project(params: dict) -> List[dict]:
     # file may still override it via in-source signals inside parse_python_source.
     from rewrite.python._version_detect import detect_from_project
     project_language_level = detect_from_project(project_path)
+    ty_python_version = _ty_python_version(language_level, project_language_level)
 
     results = []
 
@@ -645,7 +648,8 @@ def handle_parse_project(params: dict) -> List[dict]:
         from rewrite.python.ty_client import TyTypesClient
         # Point ty-types at the caller-provisioned dependency environment (if any)
         # so supertypes reaching into third-party packages resolve.
-        ty_client = TyTypesClient(virtual_env=dependency_path)
+        ty_client = TyTypesClient(virtual_env=dependency_path,
+                                  python_version=ty_python_version)
         ty_client.initialize(project_path)
     except (ImportError, RuntimeError):
         pass
@@ -827,6 +831,19 @@ def _typeshed_stdlib_dir() -> Path:
 def _requested_python_version(value: Any) -> Optional[str]:
     """The value if it looks like a Python minor version ("3.12"), else None."""
     return value if isinstance(value, str) and re.fullmatch(r'\d+\.\d+', value) else None
+
+
+def _ty_python_version(*levels: Optional[str]) -> Optional[str]:
+    """The first language level precise enough to name a stdlib surface to ty.
+
+    One ty session serves a whole batch, so callers pass only levels holding
+    for all of it — never a per-file shebang or magic comment.
+    """
+    for level in levels:
+        version = _requested_python_version(level)
+        if version:
+            return version
+    return None
 
 
 def _write_stdlib_ty_config(stdlib: Path, python_version: Optional[str]) -> str:

--- a/rewrite-python/rewrite/tests/python/test_declared_version_typeshed.py
+++ b/rewrite-python/rewrite/tests/python/test_declared_version_typeshed.py
@@ -1,0 +1,108 @@
+# Copyright 2026 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Type attribution resolves against the typeshed of the version the project
+declares, not that of whichever interpreter runs the parse.
+
+These projects declare via classifiers, the signal ty cannot read for itself;
+``requires-python`` it honors on its own, so a fixture using that would pass
+whether or not the version reached ty.
+"""
+
+import shutil
+
+import pytest
+
+from rewrite.python.visitor import PythonVisitor
+from rewrite.rpc import server
+
+
+def _ty_types_cli_available() -> bool:
+    try:
+        from ty_types.__main__ import find_ty_types_bin  # noqa: F401
+        return True
+    except Exception:
+        return shutil.which('ty-types') is not None
+
+
+requires_ty_types_cli = pytest.mark.skipif(
+    not _ty_types_cli_available(),
+    reason="ty-types CLI is not installed (ensure ty-types binary is on PATH)",
+)
+
+SOURCE = (
+    "from gettext import lgettext\n"
+    "from locale import getdefaultlocale\n"
+    "msg = lgettext('Hi')\n"
+    "loc = getdefaultlocale()\n"
+)
+
+
+def _project(root, classifier_version):
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "pyproject.toml").write_text(
+        '[project]\nname = "demo"\nversion = "0.1.0"\n'
+        'classifiers = ["Programming Language :: Python :: %s"]\n' % classifier_version
+    )
+    (root / "app.py").write_text(SOURCE)
+    return root
+
+
+def _declaring_types(root):
+    """Map each call in the project to its method type's declaring-type FQN.
+
+    ``JavaType.Unknown`` is truthy and carries no name, so an unresolved
+    declaring type reports as None rather than being mistaken for a hit.
+    """
+    found = {}
+
+    class Collect(PythonVisitor):
+        def visit_method_invocation(self, mi, p):
+            method_type = mi.method_type
+            declaring = getattr(method_type, 'declaring_type', None) if method_type else None
+            found[mi.name.simple_name] = (
+                declaring.fully_qualified_name
+                if declaring is not None and hasattr(declaring, '_fully_qualified_name')
+                else None
+            )
+            return super().visit_method_invocation(mi, p)
+
+    for item in server.handle_parse_project({'projectPath': str(root), 'relativeTo': str(root)}):
+        obj = server.local_objects.get(item['id'] if isinstance(item, dict) else item)
+        if obj is not None and obj.__class__.__name__ == 'CompilationUnit':
+            Collect().visit(obj, None)
+    return found
+
+
+@requires_ty_types_cli
+def test_declared_version_selects_typeshed(tmp_path):
+    on_310 = _declaring_types(_project(tmp_path / "p310", "3.10"))
+    on_313 = _declaring_types(_project(tmp_path / "p313", "3.13"))
+
+    # gettext.lgettext is in 3.10's typeshed and gone from 3.11's.
+    assert on_310["lgettext"] == "gettext"
+    assert on_313["lgettext"] is None
+
+    # In both, so the pair varies only by typeshed content, not by whether
+    # attribution ran at all.
+    assert on_310["getdefaultlocale"] == on_313["getdefaultlocale"] == "locale"
+
+
+@requires_ty_types_cli
+def test_version_outside_ty_support_keeps_the_rest_of_attribution(tmp_path):
+    found = _declaring_types(_project(tmp_path / "p399", "3.99"))
+
+    # ty declines a version it ships no stubs for by failing initialization,
+    # which takes every type down with it unless the version is given up.
+    assert found["getdefaultlocale"] == "locale"

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3132,7 +3132,7 @@ class TestDependencyPathForwarding:
     _captured: list = []
 
     class _StubTyClient:
-        def __init__(self, virtual_env=None):
+        def __init__(self, virtual_env=None, python_version=None):
             TestDependencyPathForwarding._captured.append(virtual_env)
 
         def initialize(self, project_root):

--- a/rewrite-python/rewrite/tests/python/version_detect_test.py
+++ b/rewrite-python/rewrite/tests/python/version_detect_test.py
@@ -125,7 +125,33 @@ class TestProjectDetection:
         (tmp_path / "pyproject.toml").write_text(
             '[project]\nrequires-python = ">=3.10"\n'
         )
-        assert detect_from_project(tmp_path) == "3"
+        assert detect_from_project(tmp_path) == "3.10"
+
+    def test_several_py3_versions_yield_the_lowest(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nclassifiers = ['
+            '"Programming Language :: Python :: 3.12", '
+            '"Programming Language :: Python :: 3.10"]\n'
+        )
+        assert detect_from_project(tmp_path) == "3.10"
+
+    def test_several_py2_versions_resolve_to_the_only_parso_grammar(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nclassifiers = ['
+            '"Programming Language :: Python :: 2.6", '
+            '"Programming Language :: Python :: 2.7"]\n'
+        )
+        # Any other 2.x turns every Py2-syntax file into a ParseError.
+        assert detect_from_project(tmp_path) == "2.7"
+
+    def test_requires_python_ignores_bounds_that_set_no_floor(self, tmp_path):
+        pyproject = tmp_path / "pyproject.toml"
+
+        pyproject.write_text('[project]\nrequires-python = "<3.13,>=3.9"\n')
+        assert detect_from_project(tmp_path) == "3.9"
+
+        pyproject.write_text('[project]\nrequires-python = "!=3.9.*,>=3.8"\n')
+        assert detect_from_project(tmp_path) == "3.8"
 
     def test_setup_cfg_classifier(self, tmp_path):
         (tmp_path / "setup.cfg").write_text(


### PR DESCRIPTION
A project declaring Python 3.10 only through setuptools classifiers is type-attributed against the typeshed of whichever interpreter happens to run the parse. Calls to APIs removed after that version come back as `JavaType.Unknown`, so the type-gated recipes for those APIs silently no-op — the workaround in moderneinc/rewrite-migrate-python#99 reads the file's own import statements as a fallback for five of them.

```python
from gettext import lgettext      # exists in 3.10's typeshed, gone from 3.11's
msg = lgettext("Hi")              # method_type.declaring_type -> Unknown
```

## What ty can and cannot see

ty derives the version from its own project `ty.toml`, then `pyproject.toml`'s `requires-python`, then the environment interpreter. `_version_detect` sees more than that — classifiers in `pyproject.toml` and `setup.cfg` — and none of it reached ty. Measured on the real parse path before this change:

| project declares | `detect_from_project` | `lgettext` |
|---|---|---|
| `requires-python = ">=3.10"` | `"3"` | resolves |
| pyproject `classifiers` 3.10 | `"3.10"` | **Unknown** |
| `setup.cfg` classifiers 3.10 | `"3.10"` | **Unknown** |

So `requires-python` was never the broken case — ty reads that itself, and it outranks `VIRTUAL_ENV`:

```
proj(requires-python>=3.10), VIRTUAL_ENV=py3.13 venv   lgettext resolves
bare (no pyproject),         VIRTUAL_ENV=py3.13 venv   Unknown
bare (no pyproject),         VIRTUAL_ENV=py3.10 venv   lgettext resolves
```

## The fix

The detected version reaches `TyTypesClient`, which materialises it as a ty *user* config in a throwaway `XDG_CONFIG_HOME` (`APPDATA` on Windows). ty ranks a project's own config above a user config, so this only ever fills a gap:

```
requires-python>=3.10  +  ours says 3.13   ->  3.10 wins
project ty.toml 3.10   +  ours says 3.13   ->  3.10 wins
no signal              +  ours says 3.10   ->  3.10 applies
```

Two alternatives don't work. `ty-types` has no `--python-version` — that flag is on the `ty` CLI, and this code drives a different binary (`ty-types <FILE>... [--project-root DIR] | --serve`). Pinning the workspace venv's interpreter doesn't help either, per the table above.

`_requires_python` kept only the major, so `">=3.10"` gave `"3"` — too coarse to name a stdlib surface. It now takes the lowest version admitted by a lower-bound clause; upper bounds and exclusions set no floor:

```
>=3.10         '3'    -> '3.10'
<3.13,>=3.9    '3.13' -> '3.9'
!=3.9.*,>=3.8  '3.9'  -> '3.8'
<3.12          '3.12' -> None    names no floor
<3             '3'    -> '2.7'   was selecting the Py3 parser for a Py2-only project
```

A Python 3 span resolves to its floor, the one version every line of the project has to work on — the same reading ty gives `requires-python`. Python 2 resolves to `2.7` whatever it declares, because parso implements that grammar alone and `parso.parse(src, version="2.6")` raises `NotImplementedError`.

## Degrading instead of collapsing

ty refuses a version outside the range it ships stubs for by failing initialization outright:

```
{"error":{"code":-32000,"message":"Failed to initialize: Failed to apply configuration files"}}
```

That costs the batch *every* type, not just the version-gated ones. The accepted range (3.7–3.15 on ty-types 0.0.71) drifts with each ty release, so a hardcoded bound would rot. Since the detected version is only ever a fallback, `initialize` gives it up and retries once — gated on the failure not being a timeout, so a wedged ty is not waited out twice.

## Tests

`test_declared_version_selects_typeshed` parses one project declaring 3.10 and one declaring 3.13 and asserts `lgettext` resolves only in the first, with `locale.getdefaultlocale` (present in both) as the control. The contrast is the point: a test asserting only against the running interpreter passes for the wrong reason. `test_version_outside_ty_support_keeps_the_rest_of_attribution` pins the retry — it fails without it, with every type lost rather than one.

Both fixtures declare via classifiers, since a `requires-python` fixture would pass whether or not the version reached ty.

## Not verified

The Windows path (`APPDATA`) is unverified — this repo has no Windows CI job and I had no Windows machine. It is ty's documented user-config location there and inert elsewhere, but treat it as untested.

