### PR TITLE
JavaScript: RemoveImport keeps an import the file still references

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/index.ts
+++ b/rewrite-javascript/rewrite/src/javascript/index.ts
@@ -35,7 +35,7 @@ export type {Scope} from "./scope";
 // `cursorOf` is deliberately absent: a visitor of one's own reaches `this.cursor` directly, and
 // the free functions that have no visitor to reach it through are already in this list.
 export {
-    scopeOf, namesDeclaredIn, namesDeclaredWithin, namesUsedIn, bindingNames, deconflict,
+    scopeOf, namesDeclaredIn, namesDeclaredWithin, namesUsedIn, namesReferencedWithin, bindingNames, deconflict,
     isValueReference, declarationsOf, compilationUnitOf, walk
 } from "./scope";
 export type {QuoteChar, AddImportOptions} from "./add-import";

--- a/rewrite-javascript/rewrite/src/javascript/remove-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/remove-import.ts
@@ -1,6 +1,6 @@
 import {JavaScriptVisitor} from "./visitor";
 import {J} from "../java";
-import {bindingNames} from "./scope";
+import {bindingNames, namesReferencedWithin} from "./scope";
 import {JS, JSX} from "./tree";
 import {mapAsync, updateIfChanged} from "../util";
 import {ElementRemovalFormatter} from "../java";
@@ -101,14 +101,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
     }
 
     override async visitJsCompilationUnit(compilationUnit: JS.CompilationUnit, p: P): Promise<J | undefined> {
-        // First, collect all used identifiers in the file
-        const usedIdentifiers = new Set<string>();
-        const usedTypes = new Set<string>();
-
-        // Traverse the AST to collect used identifiers
-        await this.collectUsedIdentifiers(compilationUnit, usedIdentifiers, usedTypes);
-
-        // Now process imports with knowledge of what's used
+        const usedNames = collectUsedNames(compilationUnit);
         return this.produceJavaScript(compilationUnit, p, async draft => {
             const formatter = new ElementRemovalFormatter<J>(true); // Preserve file headers from first import
 
@@ -118,7 +111,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                 // Handle ES6 imports
                 if (statement?.kind === JS.Kind.Import) {
                     const jsImport = statement as JS.Import;
-                    const result = await this.processImport(jsImport, usedIdentifiers, usedTypes, p);
+                    const result = await this.processImport(jsImport, usedNames, p);
                     if (result === undefined) {
                         formatter.markRemoved(statement);
                         return undefined;
@@ -133,7 +126,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                 // Multi-variable declarations might come as JS.ScopedVariableDeclarations
                 if (statement?.kind === J.Kind.VariableDeclarations) {
                     const varDecl = statement as J.VariableDeclarations;
-                    const result = await this.processRequireFromVarDecls(varDecl, usedIdentifiers, p);
+                    const result = await this.processRequireFromVarDecls(varDecl, usedNames, p);
                     if (result === undefined) {
                         formatter.markRemoved(statement);
                         return undefined;
@@ -154,7 +147,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                     for (const v of scopedVarDecl.variables) {
                         const varDecl = v.element;
                         if (varDecl?.kind === J.Kind.VariableDeclarations) {
-                            const result = await this.processRequireFromVarDecls(varDecl as J.VariableDeclarations, usedIdentifiers, p);
+                            const result = await this.processRequireFromVarDecls(varDecl as J.VariableDeclarations, usedNames, p);
                             if (result === undefined) {
                                 hasChanges = true;
                                 varFormatter.markRemoved(varDecl);
@@ -197,13 +190,12 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
 
     private async processImport(
         jsImport: JS.Import,
-        usedIdentifiers: Set<string>,
-        usedTypes: Set<string>,
+        usedNames: Set<string>,
         p: P
     ): Promise<JS.Import | undefined> {
         // Handle import-equals-require syntax: import util = require("util");
         if (jsImport.initializer) {
-            return this.processImportEqualsRequire(jsImport, usedIdentifiers, usedTypes, p);
+            return this.processImportEqualsRequire(jsImport, usedNames, p);
         }
 
         // Check if this import is from the target module
@@ -231,10 +223,10 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                 let shouldRemove: boolean;
                 if (this.member === 'default') {
                     // Special case: member 'default' means remove any default import from the target module if unused
-                    shouldRemove = !usedIdentifiers.has(name) && !usedTypes.has(name);
+                    shouldRemove = !usedNames.has(name);
                 } else {
                     // Regular case: check if the import name matches the removal criteria
-                    shouldRemove = this.shouldRemoveImport(name, usedIdentifiers, usedTypes, name);
+                    shouldRemove = this.shouldRemoveImport(name, usedNames, name);
                 }
 
                 if (shouldRemove) {
@@ -281,7 +273,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                 if (this.member !== undefined) {
                     // We're trying to remove a specific member from this namespace
                     // Check if the namespace itself is used
-                    if (!usedIdentifiers.has(name) && !usedTypes.has(name)) {
+                    if (!usedNames.has(name)) {
                         // Namespace is not used, remove the entire import
                         if (!importClause.name) {
                             return undefined;
@@ -291,7 +283,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                         }, p);
                     }
                     // Namespace is used, we can't remove individual members from it
-                } else if (this.shouldRemoveImport(name, usedIdentifiers, usedTypes, name)) {
+                } else if (this.shouldRemoveImport(name, usedNames, name)) {
                     // If there's no default import, remove the entire import
                     if (!importClause.name) {
                         return undefined;
@@ -311,7 +303,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                 if (this.member !== undefined) {
                     // We're trying to remove a specific member from this namespace
                     // Check if the namespace itself is used
-                    if (!usedIdentifiers.has(aliasName) && !usedTypes.has(aliasName)) {
+                    if (!usedNames.has(aliasName)) {
                         // Namespace is not used, remove the entire import
                         if (!importClause.name) {
                             return undefined;
@@ -321,7 +313,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                         }, p);
                     }
                     // Namespace is used, we can't remove individual members from it
-                } else if (this.shouldRemoveImport(aliasName, usedIdentifiers, usedTypes, aliasName)) {
+                } else if (this.shouldRemoveImport(aliasName, usedNames, aliasName)) {
                     // If there's no default import, remove the entire import
                     if (!importClause.name) {
                         return undefined;
@@ -336,7 +328,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
             // Handle named imports: import { a, b } from 'module'
             if (namedBindings.kind === JS.Kind.NamedImports) {
                 const namedImports = namedBindings as JS.NamedImports;
-                const updatedImports = await this.processNamedImports(namedImports, usedIdentifiers, usedTypes, p);
+                const updatedImports = await this.processNamedImports(namedImports, usedNames, p);
 
                 if (updatedImports === undefined) {
                     // All named imports were removed
@@ -366,12 +358,11 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
      */
     private async processImportEqualsRequire(
         jsImport: JS.Import,
-        usedIdentifiers: Set<string>,
-        usedTypes: Set<string>,
+        usedNames: Set<string>,
         p: P
     ): Promise<JS.Import | undefined> {
         const initializer = jsImport.initializer?.element;
-        if (!initializer || !this.isRequireCall(initializer)) {
+        if (!initializer || !isRequireCall(initializer)) {
             return jsImport;
         }
 
@@ -392,23 +383,11 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
 
         // For import-equals-require, we can only remove the entire import since
         // it imports the whole module as a single identifier
-        if (this.shouldRemoveIdentifier(importedName, usedIdentifiers, usedTypes)) {
+        if (this.shouldRemoveIdentifier(importedName, usedNames)) {
             return undefined;
         }
 
         return jsImport;
-    }
-
-    /**
-     * Check if a node is a require() method invocation
-     */
-    private isRequireCall(node: J): boolean {
-        if (node.kind !== J.Kind.MethodInvocation) {
-            return false;
-        }
-        const methodInv = node as J.MethodInvocation;
-        return methodInv.name?.kind === J.Kind.Identifier &&
-               (methodInv.name as J.Identifier).simpleName === 'require';
     }
 
     /**
@@ -421,17 +400,16 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
     /**
      * Check if an identifier should be removed based on usage
      */
-    private shouldRemoveIdentifier(name: string, usedIdentifiers: Set<string>, usedTypes: Set<string>): boolean {
+    private shouldRemoveIdentifier(name: string, usedNames: Set<string>): boolean {
         // For CommonJS and import-equals-require, we're removing the entire import
         // if the identifier is not used (member is typically undefined for these cases,
         // or we're checking if a specific binding is used)
-        return !usedIdentifiers.has(name) && !usedTypes.has(name);
+        return !usedNames.has(name);
     }
 
     private async processNamedImports(
         namedImports: JS.NamedImports,
-        usedIdentifiers: Set<string>,
-        usedTypes: Set<string>,
+        usedNames: Set<string>,
         p: P
     ): Promise<JS.NamedImports | undefined> {
         const {filtered, allRemoved} = await this.filterElementsWithPrefixPreservation(
@@ -451,12 +429,12 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                         // We're removing a specific member - check if this matches
                         if (this.member === importName) {
                             // This is the member we want to remove - check if it's used
-                            return usedIdentifiers.has(nameToCheck) || usedTypes.has(nameToCheck);
+                            return usedNames.has(nameToCheck);
                         }
                         return true; // Keep imports that don't match the member
                     } else {
                         // We're removing based on the import name itself
-                        return !this.shouldRemoveImport(importName, usedIdentifiers, usedTypes, importName);
+                        return !this.shouldRemoveImport(importName, usedNames, importName);
                     }
                 }
                 return true; // Keep non-ImportSpecifier elements
@@ -493,7 +471,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
 
     private async processRequireFromVarDecls(
         varDecls: J.VariableDeclarations,
-        usedIdentifiers: Set<string>,
+        usedNames: Set<string>,
         p: P
     ): Promise<J.VariableDeclarations | undefined> {
         // Check if this is a require() call
@@ -507,7 +485,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
         }
 
         const initializer = namedVar.initializer?.element;
-        if (!initializer || !this.isRequireCall(initializer)) {
+        if (!initializer || !isRequireCall(initializer)) {
             return varDecls;
         }
 
@@ -525,7 +503,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
 
             // For require() statements, check the module name from the require call
             const moduleName = this.getModuleNameFromRequire(methodInv);
-            if (moduleName && this.matchesTargetModule(moduleName) && !usedIdentifiers.has(varName)) {
+            if (moduleName && this.matchesTargetModule(moduleName) && !usedNames.has(varName)) {
                 return undefined; // Remove the entire require statement
             }
         }
@@ -533,7 +511,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
         // Handle: const { readFile } = require('fs')
         if (pattern.kind === JS.Kind.ObjectBindingPattern && this.member !== undefined) {
             const objectPattern = pattern as JS.ObjectBindingPattern;
-            const updatedPattern = await this.processObjectBindingPattern(objectPattern, usedIdentifiers, p);
+            const updatedPattern = await this.processObjectBindingPattern(objectPattern, usedNames, p);
 
             if (updatedPattern === undefined) {
                 return undefined; // Remove entire require
@@ -572,7 +550,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
 
     private async processObjectBindingPattern(
         pattern: JS.ObjectBindingPattern,
-        usedIdentifiers: Set<string>,
+        usedNames: Set<string>,
         p: P
     ): Promise<JS.ObjectBindingPattern | undefined> {
         const {filtered, allRemoved} = await this.filterElementsWithPrefixPreservation(
@@ -581,7 +559,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
                 const bound = this.boundByPatternElement(elem);
                 // An element whose names cannot be read is left alone.
                 return bound.length === 0 ||
-                    bound.some(b => !this.shouldRemoveImport(b.name, usedIdentifiers, new Set(), b.member));
+                    bound.some(b => !this.shouldRemoveImport(b.name, usedNames, b.member));
             },
             async (elem: J, prefix: J.Space) => {
                 if (elem.kind === J.Kind.Identifier) {
@@ -659,8 +637,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
 
     private shouldRemoveImport(
         name: string,
-        usedIdentifiers: Set<string>,
-        usedTypes: Set<string>,
+        usedNames: Set<string>,
         member: string | undefined
     ): boolean {
         // If member is specified, we're removing a specific member from the module
@@ -675,7 +652,7 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
         // So we check if this particular import is unused
 
         // Check if it's used
-        return !(usedIdentifiers.has(name) || usedTypes.has(name));
+        return !usedNames.has(name);
     }
 
     private isTargetModule(jsImport: JS.Import): boolean {
@@ -692,379 +669,28 @@ export class RemoveImport<P> extends JavaScriptVisitor<P> {
         return moduleName === this.module;
     }
 
-    /**
-     * Helper to traverse parameters from various node types
-     */
-    private async traverseParameters(
-        params: any,
-        usedIdentifiers: Set<string>,
-        usedTypes: Set<string>
-    ): Promise<void> {
-        if (!params || typeof params !== 'object') return;
+}
 
-        if (Array.isArray(params)) {
-            for (const p of params) {
-                // Array elements might be RightPadded, so unwrap them
-                const elem = (p as any).element || p;
-                await this.collectUsedIdentifiers(elem, usedIdentifiers, usedTypes);
-            }
-        } else if (params.elements) {
-            for (const p of params.elements) {
-                if (p.element) {
-                    await this.collectUsedIdentifiers(p.element, usedIdentifiers, usedTypes);
-                }
-            }
-        } else if (params.parameters) {
-            for (const p of params.parameters) {
-                const elem = p.element || p;
-                await this.collectUsedIdentifiers(elem, usedIdentifiers, usedTypes);
-            }
+/**
+ * The names the file references, less its own imports: a specifier names what it binds, so counting
+ * one would read an import as a use of itself.
+ */
+function collectUsedNames(cu: JS.CompilationUnit): Set<string> {
+    const used = new Set<string>();
+    for (const statement of cu.statements) {
+        const element = statement.element;
+        if (!element || element.kind === JS.Kind.Import) {
+            continue;
         }
+        namesReferencedWithin(element).forEach(name => used.add(name));
     }
+    return used;
+}
 
-    /**
-     * Helper to traverse statements from various node types
-     */
-    private async traverseStatements(
-        statements: any,
-        usedIdentifiers: Set<string>,
-        usedTypes: Set<string>
-    ): Promise<void> {
-        if (!statements) return;
-
-        if (Array.isArray(statements)) {
-            for (const stmt of statements) {
-                const element = stmt.element || stmt;
-                if (element) {
-                    await this.collectUsedIdentifiers(element, usedIdentifiers, usedTypes);
-                }
-            }
-        }
+function isRequireCall(node: J): boolean {
+    if (node.kind !== J.Kind.MethodInvocation) {
+        return false;
     }
-
-    /**
-     * Helper to check for type expressions and collect type usage
-     */
-    private async checkTypeExpression(
-        node: any,
-        usedTypes: Set<string>
-    ): Promise<void> {
-        if (node.typeExpression) {
-            await this.collectTypeUsage(node.typeExpression, usedTypes);
-        }
-    }
-
-    private async collectUsedIdentifiers(
-        node: J,
-        usedIdentifiers: Set<string>,
-        usedTypes: Set<string>
-    ): Promise<void> {
-        // This is a simplified version - in a real implementation,
-        // we'd need to traverse the entire AST and collect all identifier usages
-        // For now, we'll implement a basic traversal
-
-        if (node.kind === J.Kind.Identifier) {
-            const identifier = node as J.Identifier;
-            usedIdentifiers.add(identifier.simpleName);
-        } else if (node.kind === J.Kind.VariableDeclarations) {
-            const varDecls = node as J.VariableDeclarations;
-            // Check the type expression on the VariableDeclarations itself
-            await this.checkTypeExpression(varDecls, usedTypes);
-            for (const v of varDecls.variables) {
-                // Check the initializer
-                if (v.element.initializer?.element) {
-                    await this.collectUsedIdentifiers(v.element.initializer.element, usedIdentifiers, usedTypes);
-                }
-            }
-        } else if (node.kind === J.Kind.MethodInvocation) {
-            const methodInv = node as J.MethodInvocation;
-
-            // Check if this is a member access pattern like fs.readFileSync
-            if (methodInv.select?.element?.kind === J.Kind.FieldAccess) {
-                const fieldAccess = methodInv.select.element as J.FieldAccess;
-                if (fieldAccess.target?.kind === J.Kind.Identifier) {
-                    usedIdentifiers.add((fieldAccess.target as J.Identifier).simpleName);
-                }
-            } else if (methodInv.select?.element?.kind === J.Kind.Identifier) {
-                // Direct identifier like fs in fs.method() - though this is rare
-                usedIdentifiers.add((methodInv.select.element as J.Identifier).simpleName);
-            } else if (!methodInv.select) {
-                // No select means this is a direct function call like isArray()
-                // Only in this case should we add the method name as a used identifier
-                if (methodInv.name && methodInv.name.kind === J.Kind.Identifier) {
-                    usedIdentifiers.add((methodInv.name as J.Identifier).simpleName);
-                }
-            }
-            // Note: We don't add method names for calls like Array.isArray() or obj.method()
-            // because those are methods on objects, not standalone imported functions
-            // Recursively check arguments
-            if (methodInv.arguments) {
-                for (const arg of methodInv.arguments.elements) {
-                    if (arg.element) {
-                        await this.collectUsedIdentifiers(arg.element, usedIdentifiers, usedTypes);
-                    }
-                }
-            }
-            // Check select (object being called on)
-            if (methodInv.select?.element) {
-                await this.collectUsedIdentifiers(methodInv.select.element, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === J.Kind.MemberReference) {
-            const memberRef = node as J.MemberReference;
-            if (memberRef.containing && memberRef.containing.element?.kind === J.Kind.Identifier) {
-                usedIdentifiers.add((memberRef.containing.element as J.Identifier).simpleName);
-            }
-        } else if (node.kind === J.Kind.FieldAccess) {
-            // Handle field access like fs.readFileSync
-            const fieldAccess = node as J.FieldAccess;
-            if (fieldAccess.target?.kind === J.Kind.Identifier) {
-                usedIdentifiers.add((fieldAccess.target as J.Identifier).simpleName);
-            }
-            // Recursively check the target
-            if (fieldAccess.target) {
-                await this.collectUsedIdentifiers(fieldAccess.target, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === JS.Kind.CompilationUnit) {
-            const cu = node as JS.CompilationUnit;
-            for (const stmt of cu.statements) {
-                if (stmt.element && stmt.element.kind !== JS.Kind.Import) {
-                    // Skip require() statements at the top level
-                    if (stmt.element.kind === J.Kind.VariableDeclarations) {
-                        const varDecls = stmt.element as J.VariableDeclarations;
-                        // Check if this is a require() statement
-                        let isRequire = false;
-                        for (const v of varDecls.variables) {
-                            const namedVar = v.element;
-                            if (namedVar?.initializer?.element?.kind === J.Kind.MethodInvocation) {
-                                const methodInv = namedVar.initializer.element as J.MethodInvocation;
-                                if (methodInv.name?.kind === J.Kind.Identifier &&
-                                    (methodInv.name as J.Identifier).simpleName === 'require') {
-                                    isRequire = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if (!isRequire) {
-                            // Not a require statement, process normally
-                            await this.collectUsedIdentifiers(stmt.element, usedIdentifiers, usedTypes);
-                        }
-                    } else if (stmt.element.kind !== JS.Kind.ScopedVariableDeclarations) {
-                        // Process other non-import, non-require statements normally
-                        await this.collectUsedIdentifiers(stmt.element, usedIdentifiers, usedTypes);
-                    }
-                }
-            }
-        } else if (node.kind === J.Kind.Return) {
-            // Handle return statements
-            const returnStmt = node as J.Return;
-            if (returnStmt.expression) {
-                await this.collectUsedIdentifiers(returnStmt.expression, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === J.Kind.Block) {
-            const block = node as J.Block;
-            for (const stmt of block.statements) {
-                if (stmt.element) {
-                    await this.collectUsedIdentifiers(stmt.element, usedIdentifiers, usedTypes);
-                }
-            }
-        } else if (node.kind === J.Kind.MethodDeclaration) {
-            const method = node as J.MethodDeclaration;
-            // Check parameters for type usage
-            if (method.parameters) {
-                for (const param of method.parameters.elements) {
-                    // Parameters can be various types, handle them recursively
-                    if (param.element) {
-                        await this.collectUsedIdentifiers(param.element, usedIdentifiers, usedTypes);
-                    }
-                }
-            }
-            // Check body
-            if (method.body) {
-                await this.collectUsedIdentifiers(method.body, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === JS.Kind.TypeOf) {
-            // Handle typeof expressions like: typeof util
-            const typeOf = node as JS.TypeOf;
-            if (typeOf.expression) {
-                await this.collectUsedIdentifiers(typeOf.expression, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === JS.Kind.TypeQuery) {
-            // Handle typeof type queries like: const x: typeof util
-            const typeQuery = node as JS.TypeQuery;
-            if (typeQuery.typeExpression) {
-                await this.collectUsedIdentifiers(typeQuery.typeExpression, usedIdentifiers, usedTypes);
-            }
-        } else if ((node as any).typeExpression) {
-            // Handle nodes with type expressions (parameters, variables, etc.)
-            await this.checkTypeExpression(node, usedTypes);
-            // Continue traversing other parts
-            if ((node as any).name) {
-                await this.collectUsedIdentifiers((node as any).name, usedIdentifiers, usedTypes);
-            }
-            if ((node as any).initializer) {
-                await this.collectUsedIdentifiers((node as any).initializer, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === JS.Kind.ArrowFunction || node.kind === J.Kind.Lambda) {
-            // Handle arrow functions and lambdas
-            const func = node as any;
-            if (func.parameters) {
-                await this.collectUsedIdentifiers(func.parameters, usedIdentifiers, usedTypes);
-            }
-            if (func.lambda) {
-                await this.collectUsedIdentifiers(func.lambda, usedIdentifiers, usedTypes);
-            }
-            if (func.body) {
-                await this.collectUsedIdentifiers(func.body, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === J.Kind.Lambda) {
-            const lambda = node as J.Lambda;
-            if (lambda.parameters?.parameters) {
-                for (const param of lambda.parameters.parameters) {
-                    if (param.element) {
-                        await this.collectUsedIdentifiers(param.element, usedIdentifiers, usedTypes);
-                    }
-                }
-            }
-            if (lambda.body) {
-                await this.collectUsedIdentifiers(lambda.body, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === JS.Kind.JsxTag) {
-            // Handle JSX tags like <div>content</div>
-            const jsxTag = node as JSX.Tag;
-            // Check attributes
-            if (jsxTag.attributes) {
-                for (const attr of jsxTag.attributes) {
-                    if (attr.element) {
-                        await this.collectUsedIdentifiers(attr.element, usedIdentifiers, usedTypes);
-                    }
-                }
-            }
-            // Check children
-            if (jsxTag.children) {
-                for (const child of jsxTag.children) {
-                    if (child) {
-                        await this.collectUsedIdentifiers(child, usedIdentifiers, usedTypes);
-                    }
-                }
-            }
-        } else if (node.kind === JS.Kind.JsxEmbeddedExpression) {
-            // Handle JSX embedded expressions like {React.version}
-            const embedded = node as JSX.EmbeddedExpression;
-            // The expression is wrapped in RightPadded, so unwrap it
-            const expr = embedded.expression?.element || embedded.expression;
-            if (expr) {
-                await this.collectUsedIdentifiers(expr, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === JS.Kind.JsxAttribute) {
-            // Handle JSX attributes like onClick={handler}
-            const jsxAttr = node as any;
-            if (jsxAttr.value) {
-                await this.collectUsedIdentifiers(jsxAttr.value, usedIdentifiers, usedTypes);
-            }
-        } else if (node.kind === JS.Kind.TypeDeclaration) {
-            // Handle type alias declarations like: type Props = { children: React.ReactNode }
-            const typeDecl = node as JS.TypeDeclaration;
-            // The initializer contains the type expression (the right side of the =)
-            if (typeDecl.initializer?.element) {
-                await this.collectTypeUsage(typeDecl.initializer.element, usedTypes);
-            }
-        } else if ((node as any).statements) {
-            // Generic handler for nodes with statements
-            await this.traverseStatements((node as any).statements, usedIdentifiers, usedTypes);
-        } else if ((node as any).body) {
-            // Generic handler for nodes with body
-            await this.collectUsedIdentifiers((node as any).body, usedIdentifiers, usedTypes);
-        } else if ((node as any).parameters) {
-            // Handle anything with parameters (functions, methods, etc.)
-            await this.traverseParameters((node as any).parameters, usedIdentifiers, usedTypes);
-            // Continue with the body if it exists
-            if ((node as any).body) {
-                await this.collectUsedIdentifiers((node as any).body, usedIdentifiers, usedTypes);
-            }
-        }
-    }
-
-    private async collectTypeUsage(typeExpr: J, usedTypes: Set<string>): Promise<void> {
-        if (typeExpr.kind === J.Kind.Identifier) {
-            usedTypes.add((typeExpr as J.Identifier).simpleName);
-        } else if (typeExpr.kind === J.Kind.ParameterizedType) {
-            const paramType = typeExpr as J.ParameterizedType;
-            // First, collect usage from the base type (e.g., React.Ref from React.Ref<T>)
-            if (paramType.class) {
-                await this.collectTypeUsage(paramType.class, usedTypes);
-            }
-            // Then collect usage from type parameters (e.g., HTMLButtonElement from React.Ref<HTMLButtonElement>)
-            if (paramType.typeParameters) {
-                for (const typeParam of paramType.typeParameters.elements) {
-                    if (typeParam.element) {
-                        await this.collectTypeUsage(typeParam.element, usedTypes);
-                    }
-                }
-            }
-        } else if (typeExpr.kind === J.Kind.FieldAccess) {
-            // Handle qualified names in type positions like React.Ref
-            const fieldAccess = typeExpr as J.FieldAccess;
-            if (fieldAccess.target?.kind === J.Kind.Identifier) {
-                usedTypes.add((fieldAccess.target as J.Identifier).simpleName);
-            } else if (fieldAccess.target) {
-                // Recursively handle nested field accesses
-                await this.collectTypeUsage(fieldAccess.target, usedTypes);
-            }
-        } else if (typeExpr.kind === JS.Kind.Intersection) {
-            // Handle intersection types like ButtonProps & { ref?: React.Ref<HTMLButtonElement> }
-            const intersection = typeExpr as JS.Intersection;
-            for (const typeElem of intersection.types) {
-                if (typeElem.element) {
-                    await this.collectTypeUsage(typeElem.element, usedTypes);
-                }
-            }
-        } else if (typeExpr.kind === JS.Kind.TypeLiteral) {
-            // Handle type literals like { ref?: React.Ref<HTMLButtonElement> }
-            const typeLiteral = typeExpr as JS.TypeLiteral;
-            // TypeLiteral members are in a Block, which contains statements
-            for (const stmt of typeLiteral.members.statements) {
-                if (stmt.element) {
-                    // Each statement is typically a VariableDeclarations representing a property
-                    await this.collectUsedIdentifiers(stmt.element, new Set(), usedTypes);
-                }
-            }
-        } else if (typeExpr.kind === JS.Kind.TypeQuery) {
-            // Handle typeof type queries like: const x: typeof util
-            const typeQuery = typeExpr as JS.TypeQuery;
-            if (typeQuery.typeExpression) {
-                await this.collectTypeUsage(typeQuery.typeExpression, usedTypes);
-            }
-        } else if (typeExpr.kind === JS.Kind.TypeOf) {
-            // Handle typeof expressions in types
-            const typeOf = typeExpr as JS.TypeOf;
-            if (typeOf.expression) {
-                // For typeof expressions, the expression contains the identifier
-                // Add it to usedTypes since it's used in a type context
-                if (typeOf.expression.kind === J.Kind.Identifier) {
-                    usedTypes.add((typeOf.expression as J.Identifier).simpleName);
-                } else {
-                    await this.collectTypeUsage(typeOf.expression, usedTypes);
-                }
-            }
-        } else if (typeExpr.kind === JS.Kind.TypeTreeExpression) {
-            // Handle TypeTreeExpression which wraps type identifiers
-            const typeTree = typeExpr as JS.TypeTreeExpression;
-            if (typeTree.expression) {
-                await this.collectTypeUsage(typeTree.expression, usedTypes);
-            }
-        } else if (typeExpr.kind === JS.Kind.TypeInfo) {
-            // Handle TypeInfo which contains type identifiers
-            const typeInfo = typeExpr as JS.TypeInfo;
-            if (typeInfo.typeIdentifier) {
-                await this.collectTypeUsage(typeInfo.typeIdentifier, usedTypes);
-            }
-        } else if ((typeExpr as any).expression) {
-            // Generic handler for nodes with expression property
-            await this.collectTypeUsage((typeExpr as any).expression, usedTypes);
-        } else if ((typeExpr as any).typeIdentifier) {
-            // Generic handler for nodes with typeIdentifier property
-            await this.collectTypeUsage((typeExpr as any).typeIdentifier, usedTypes);
-        }
-        // Add more type expression handlers as needed
-    }
+    const name = (node as J.MethodInvocation).name;
+    return name?.kind === J.Kind.Identifier && (name as J.Identifier).simpleName === 'require';
 }

--- a/rewrite-javascript/rewrite/src/javascript/scope.ts
+++ b/rewrite-javascript/rewrite/src/javascript/scope.ts
@@ -153,6 +153,69 @@ export function namesDeclaredWithin(node: unknown, cacheKey: object = node as ob
 }
 
 /**
+ * The names `node` reads and nothing within it binds, so each one reaches a binding further out.
+ * A name its parent introduces rather than reads is not one, nor is a name an inner scope rebinds:
+ * that reference reads the rebinding.
+ */
+export function namesReferencedWithin(node: unknown, cacheKey: object = node as object): ReadonlySet<string> {
+    if (cacheKey === null || typeof cacheKey !== 'object') {
+        return noNames;
+    }
+    const cached = referenced.get(cacheKey);
+    if (cached) {
+        return cached;
+    }
+    const names = new Set<string>();
+    collectReferences(node, undefined, undefined, names);
+    referenced.set(cacheKey, names);
+    return names;
+}
+
+/** The scopes enclosing a node, innermost first, each paired with what {@link frameBindings} reads. */
+interface Frames {
+    node: unknown;
+    parent: unknown;
+    outer?: Frames;
+}
+
+/** Whether a scope between the name and where the walk began binds it. */
+function shadowed(scopes: Frames | undefined, name: string): boolean {
+    for (let scope = scopes; scope; scope = scope.outer) {
+        if (frameBindings(scope.node, scope.parent).has(name)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function collectReferences(node: unknown, parent: unknown, scopes: Frames | undefined, names: Set<string>): void {
+    if (Array.isArray(node)) {
+        node.forEach(child => collectReferences(child, parent, scopes, names));
+        return;
+    }
+    const kind = (node as { kind?: string } | undefined)?.kind;
+    if (kind === J.Kind.RightPadded || kind === J.Kind.LeftPadded) {
+        // A naming position reads against the tree parent, so padding forwards the one it was handed.
+        collectReferences((node as J.RightPadded<any>).element, parent, scopes, names);
+        return;
+    }
+    if (kind === J.Kind.Container) {
+        collectReferences((node as J.Container<any>).elements, parent, scopes, names);
+        return;
+    }
+    if (!isTree(node)) {
+        return;
+    }
+    const name = kind === J.Kind.Identifier ? (node as J.Identifier).simpleName : undefined;
+    if (name && reads(node as J.Identifier, parent) && !shadowed(scopes, name)) {
+        names.add(name);
+    }
+    const within = scopeKinds.has(kind!) ? {node, parent, outer: scopes} : scopes;
+    Object.entries(node as object).forEach(([key, value]) =>
+        key !== 'markers' && collectReferences(value, node, within, names));
+}
+
+/**
  * Every name a binding pattern introduces. `member` is the property a name takes its value from,
  * which only a name an object pattern binds directly has: anything deeper reads a property of a
  * property, an array element is chosen by position, and a rest name gathers what nothing claimed.
@@ -213,8 +276,12 @@ function frameBindings(node: any, parent: any): ReadonlySet<string> {
     // A function expression is the only function whose own name its body reaches: a declaration's
     // name belongs to the enclosing block, a method's to an instance.
     if (node?.kind === J.Kind.MethodDeclaration && parent?.kind === JS.Kind.StatementExpression) {
-        const self = bindingNames((node as J.MethodDeclaration).name).map(bound => bound.name);
-        return new Set([...self, ...ownBindings(node)]);
+        let names = selfNamed.get(node);
+        if (!names) {
+            const self = bindingNames((node as J.MethodDeclaration).name).map(bound => bound.name);
+            selfNamed.set(node, names = new Set([...self, ...ownBindings(node)]));
+        }
+        return names;
     }
     return ownBindings(node);
 }
@@ -369,7 +436,9 @@ const blockScoped = new Set(['let', 'const', 'using']);
 const hoisted = new WeakMap<object, string[]>();
 const declared = new WeakMap<object, ReadonlySet<string>>();
 const used = new WeakMap<object, ReadonlySet<string>>();
+const referenced = new WeakMap<object, ReadonlySet<string>>();
 const frames = new WeakMap<object, ReadonlySet<string>>();
+const selfNamed = new WeakMap<object, ReadonlySet<string>>();
 
 /**
  * The names blocks under `scope` hoist out to it. A `var` or function declaration reaches the whole
@@ -496,19 +565,46 @@ export function isValueReference(cursor: Cursor, identifier: J.Identifier): bool
     while (c && isPadding(c.value)) {
         c = c.parent;
     }
-    const parent = c?.value as
-        { kind?: string; name?: unknown; key?: unknown; label?: unknown; select?: unknown } | undefined;
+    return references(identifier, c?.value);
+}
+
+/** The position half of {@link isValueReference}, against a parent already found. */
+function references(identifier: J.Identifier, parent: unknown): boolean {
+    const owner = parent as {
+        kind?: string; name?: unknown; key?: unknown; label?: unknown; select?: unknown;
+        propertyName?: unknown;
+    } | undefined;
 
     // A call names a member of whatever it selects from. With nothing selected there is no member,
     // and its `name` is a reference to the function being called.
-    if (parent?.kind === J.Kind.MethodInvocation && !parent.select) {
+    if (owner?.kind === J.Kind.MethodInvocation && !owner.select) {
         return true;
+    }
+
+    // A binding element names the property it destructures and binds under `name`, so both slots
+    // name rather than reference.
+    if (owner?.kind === JS.Kind.BindingElement && holds(owner.propertyName, identifier)) {
+        return false;
     }
 
     // A JSX attribute keeps its prop name on `key`; the three label-bearing nodes keep theirs on
     // `label`. Every other kind that names rather than references keeps it on `name`.
-    const named = parent?.kind === JS.Kind.JsxAttribute ? parent.key : (parent?.name ?? parent?.label);
-    return named !== identifier && (named as { element?: unknown } | undefined)?.element !== identifier;
+    return !holds(owner?.kind === JS.Kind.JsxAttribute ? owner.key : (owner?.name ?? owner?.label), identifier);
+}
+
+/** Whether a node slot, padded or not, is the identifier itself. */
+function holds(slot: unknown, identifier: J.Identifier): boolean {
+    return slot === identifier || (slot as { element?: unknown } | undefined)?.element === identifier;
+}
+
+/**
+ * As {@link references}, for a collector rather than a renamer: a shorthand property's name slot is
+ * also the value it reads, which a rename has to expand rather than follow.
+ */
+function reads(identifier: J.Identifier, parent: unknown): boolean {
+    const owner = parent as { kind?: string; initializer?: unknown } | undefined;
+    return (owner?.kind === JS.Kind.PropertyAssignment && owner.initializer === undefined) ||
+        references(identifier, parent);
 }
 
 function isPadding(value: unknown): boolean {

--- a/rewrite-javascript/rewrite/test/javascript/remove-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/remove-import.test.ts
@@ -1595,4 +1595,116 @@ describe('RemoveImport visitor', () => {
             }, {unsafeCleanup: true});
         });
     });
+
+    describe('reference positions', () => {
+        test('an identifier read anywhere in an expression keeps the import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        const handlers = {read: readFile};
+                        const first = [readFile][0] ?? readFile;
+                    `
+                )
+            );
+        });
+
+        test('a shorthand property is a use of the binding it names', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        export const handlers = {readFile};
+                    `
+                )
+            );
+        });
+
+        test('a reference inside a require call keeps the import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        const contents = require(readFile);
+                    `
+                )
+            );
+        });
+
+        test('a re-export keeps the import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        export {readFile};
+                    `
+                )
+            );
+        });
+    });
+
+    describe('shadowed names', () => {
+        test('a name an inner scope rebinds is not a use of the import', async () => {
+            const spec = new RecipeSpec();
+            spec.recipe = fromVisitor(new RemoveImport("fs", "readFile"));
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        function f() {
+                            const readFile = 1;
+                            return readFile;
+                        }
+                    `,
+                    `
+                        function f() {
+                            const readFile = 1;
+                            return readFile;
+                        }
+                    `
+                )
+            );
+
+            //language=typescript
+            await spec.rewriteRun(
+                typescript(
+                    `
+                        import {readFile} from 'fs';
+
+                        function g(readFile: number) {
+                            return readFile;
+                        }
+                    `,
+                    `
+                        function g(readFile: number) {
+                            return readFile;
+                        }
+                    `
+                )
+            );
+        });
+    });
 });


### PR DESCRIPTION
`RemoveImport` deletes imports the file still references. `new RemoveImport("moment")`, the shape `moment-to-temporal` calls, on a file that calls `moment()` twice:

```ts
import moment from 'moment';                          const range = {start: moment(), end: moment()};
                                                →     export const isStale = range.start < range.end;
const range = {start: moment(), end: moment()};
export const isStale = range.start < range.end;
```

19 of 24 ordinary reference positions failed this way, measured with `new RemoveImport("fs", "readFile")` over `import {readFile} from 'fs';` plus one line:

```
const x = readFile + 1;      REMOVED     const o = {a: readFile};      REMOVED
const x = `${readFile}`;     REMOVED     const a = [readFile];         REMOVED
if (readFile) { }            REMOVED     export {readFile};            REMOVED
const x = readFile ? 1 : 2;  REMOVED     throw readFile;               REMOVED
const x = new readFile();    REMOVED     switch (readFile) { }         REMOVED
```

## Mechanism

`collectUsedIdentifiers` was not a flat identifier scan. It was an `if`/`else` chain over 19 hardcoded node kinds plus three property-name fallbacks, and said so itself — *"This is a simplified version... For now, we'll implement a basic traversal."* The distinction matters for which way the error runs: a flat scan over-counts uses and errs toward leaving an unused import behind, while a partial one reads an unvisited position as zero uses. `J.Binary` carries `left`/`right`, matches no branch, and contributes nothing, so `const x = readFile + 1` collected no names at all.

## The fix

- `scope.ts` already models JS scope, and `remove-import.ts` imported only `bindingNames` from it. The chronology explains why rather than excusing it: `remove-import.ts` landed 2025-09-30 (#6095), `scope.ts` 2026-08-27 (#8686), and #8721 three days later was *"a recipe reaches the scope helpers it was reimplementing"* — this file was missed by that pass.

`scope.ts` gains `namesReferencedWithin(node)`: a walk collecting identifiers in reference positions, skipping any name an inner scope rebinds. `remove-import.ts` consults it and loses ~370 lines of traversal. `usedIdentifiers` and `usedTypes` collapse into one set because every call site already OR'd them; both are private, and the public surface of `RemoveImport`, `maybeUnbind` and `maybeRemoveImport` is unchanged. The one added export is `namesReferencedWithin` itself.

Two positions needed a rule rather than a wider walk. A shorthand `{readFile}` is both a property name and a read of the binding, and `isValueReference` answers false there deliberately — `add-import.ts` expands the shorthand rather than following it — so the read-side answer lives in a separate `reads()` and the renamer is untouched. A destructured `const {readFile: rf}` names a property, which `isValueReference` already claimed ("a name its parent introduces does not — a property, a method, a variable") but did not read, since `BindingElement` keeps the binding on `name` and the property on `propertyName`.

## Both directions move

Everything above makes removal less aggressive. One case goes the other way: a local shadowing an imported name previously kept that import alive, and now it is removed. That is correct — an import shadowed at every reference is genuinely unused — but it is the direction where an over-eager skip would delete something needed, and `a name an inner scope rebinds is not a use of the import` is the test holding that line.

## Tests

Five added, each pinning a different decision: an identifier read anywhere in an expression, a shorthand property, a reference inside a `require` call, a re-export, and the shadowing case (carrying both a `const` and a parameter). The existing `Array.isArray()` tests are what keep naming positions from counting as uses; they run through the new path, so a break fails them by name. Full JS suite green — 156 files, 1911 tests.
