### PR TITLE
Python: a scope model matching rewrite-javascript's scope.ts

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/__init__.py
@@ -90,6 +90,7 @@ from rewrite.python.format import (
 from rewrite.python.add_import import AddImport, AddImportOptions, maybe_add_import
 from rewrite.python.remove_import import RemoveImport, RemoveImportOptions, maybe_remove_import
 from rewrite.python.method_matcher import MethodMatcher
+from rewrite.python.scope_utils import Scope, scope_of
 
 # Type-comparison helpers
 from rewrite.python.type_utils import (
@@ -196,6 +197,9 @@ __all__ = [
     "maybe_remove_import",
     # Method matching
     "MethodMatcher",
+    # Scoping
+    "Scope",
+    "scope_of",
     # Type-comparison helpers
     "is_assignable_to",
     "is_of_type",

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
@@ -149,7 +149,7 @@ class ChangeImport(Recipe):
             module_alias: Optional[str] = None
             rewrote_qualified_refs: bool = False
             new_module_type: Optional[JavaType.Class] = None
-            local_bindings: LocalBindings  # a fresh instance per compilation unit
+            local_bindings = LocalBindings()
             old_import_at_module_level: bool = False
             direct_module_import_at_module_level: bool = False
 
@@ -160,7 +160,6 @@ class ChangeImport(Recipe):
                 self.module_alias = None
                 self.rewrote_qualified_refs = False
                 self.new_module_type = None
-                self.local_bindings = LocalBindings()
 
                 for stmt in cu.statements:
                     self._detect(stmt)

--- a/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Which names a Python scope binds, for telling a local apart from an import reference."""
+"""Which names a Python scope binds, and which scope binds a name at a given cursor."""
 
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, FrozenSet, List, Optional, Set
 
 from rewrite import Cursor
 from rewrite.java import J
@@ -22,54 +22,113 @@ from rewrite.java.tree import (Assignment, AssignmentOperation, ClassDeclaration
                                Identifier, Import, Lambda, MethodDeclaration, Parentheses,
                                VariableDeclarations)
 from rewrite.python.import_utils import get_alias_name, get_qualid_name
-from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ComprehensionExpression,
-                                 ExpressionStatement, MultiImport, Star, TypeHintedExpression,
-                                 VariableScope)
+from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, CompilationUnit,
+                                 ComprehensionExpression, ExpressionStatement, MultiImport, Star,
+                                 TypeHintedExpression, VariableScope)
 from rewrite.python.visitor import PythonVisitor
 
-# The module scope is excluded so that module-level references stay attributable
-# to the import that binds them.
-_SCOPES = (MethodDeclaration, Lambda, ClassDeclaration, ComprehensionExpression)
+_NO_NAMES: FrozenSet[str] = frozenset()
+
+# The nodes _BindingScan answers for; everything else binds nothing and is not a scope.
+_SCOPES = (MethodDeclaration, Lambda, ClassDeclaration, ComprehensionExpression, CompilationUnit)
+
+_SCOPE_NAMES = 'org.openrewrite.python.scopeNames'
+
+
+class Scope:
+    """One scope: the names it binds itself, the scopes around it, and what they answer
+    together. Reached through :func:`scope_of`."""
+
+    __slots__ = ('_chain', '_index', '_cache')
+
+    def __init__(self, chain: List[J], index: int, cache: Dict[J, FrozenSet[str]]) -> None:
+        self._chain = chain
+        self._index = index
+        self._cache = cache
+
+    def names(self) -> FrozenSet[str]:
+        """The names this scope binds itself, which is not what it reaches: for that, ask
+        :meth:`declares`."""
+        return (_names(self._chain[self._index], self._cache)
+                if self._index < len(self._chain) else _NO_NAMES)
+
+    def walk(self, visit: Callable[['Scope'], bool]) -> None:
+        """Visit this scope and then each one enclosing it, innermost first, stopping where
+        ``visit`` returns False."""
+        for index in range(self._index, len(self._chain)):
+            if not visit(Scope(self._chain, index, self._cache)):
+                return
+
+    def declares(self, name: str) -> bool:
+        """Whether this scope or one enclosing it binds ``name``."""
+        return self.declaring_scope(name) is not None
+
+    def declaring_scope(self, name: str) -> Optional[J]:
+        """The node owning the innermost scope that binds ``name`` — the compilation unit for
+        a module-level binding, otherwise the ``def``, ``class``, ``lambda`` or comprehension
+        holding it — or None where nothing in scope does. A caller holding a declaration asks
+        whether this is the node it came from: anything nearer shadows it."""
+        for scope in self._chain[self._index:]:
+            if name in _names(scope, self._cache):
+                return scope
+        return None
+
+
+def scope_of(cursor: Cursor) -> Scope:
+    """The innermost scope holding ``cursor``, which a visitor's own cursor rarely is: it
+    stands on whatever node it is visiting.
+
+    Syntactic, because ``field_type`` cannot decide it: it is unset for every identifier
+    when type attribution is unavailable.
+    """
+    return Scope(_enclosing_scopes(cursor), 0, _names_cache(cursor))
 
 
 class LocalBindings:
-    """Whether an identifier is a local of some enclosing scope rather than a
-    reference to a module-level import.
-
-    Syntactic, because ``field_type`` cannot decide it: it is unset for every
-    identifier when type attribution is unavailable. Caches per scope, so one
-    instance serves a whole compilation unit.
-    """
-
-    def __init__(self) -> None:
-        self._by_scope: Dict[Any, Set[str]] = {}
+    """Whether an identifier is a local of some enclosing scope rather than a reference to a
+    module-level import — :func:`scope_of` narrowed to that one question."""
 
     def is_bound(self, cursor: Cursor, name: str) -> bool:
-        return any(name in self._names(scope) for scope in _enclosing_scopes(cursor))
+        scope = scope_of(cursor).declaring_scope(name)
+        return scope is not None and not isinstance(scope, CompilationUnit)
 
-    def _names(self, scope: J) -> Set[str]:
-        names = self._by_scope.get(scope.id)
-        if names is None:
-            names = _BindingScan(scope).run()
-            self._by_scope[scope.id] = names
-        return names
+
+def _names_cache(cursor: Cursor) -> Dict[J, FrozenSet[str]]:
+    """Where a scan of one scope is kept, so a traversal scans each scope once. Hung on the
+    compilation unit's cursor, which lives exactly as long as the visit of that file; the
+    root cursor ``TreeVisitor`` starts from is a class attribute shared process-wide."""
+    for c in cursor.get_path_as_cursors():
+        if isinstance(c.value, CompilationUnit):
+            cache = c.get_message(_SCOPE_NAMES, None)
+            if cache is None:
+                cache = {}
+                c.put_message(_SCOPE_NAMES, cache)
+            return cache
+    return {}
+
+
+def _names(scope: J, cache: Dict[J, FrozenSet[str]]) -> FrozenSet[str]:
+    names = cache.get(scope)
+    if names is None:
+        names = frozenset(_BindingScan(scope).run())
+        cache[scope] = names
+    return names
 
 
 def _enclosing_scopes(cursor: Optional[Cursor]) -> List[J]:
     """The scopes a reference resolves through, innermost first.
 
-    A scope covers only the region Python evaluates inside it: a ``def``'s
-    decorators, annotations and parameter defaults belong to the scope enclosing
-    it. A class body is reachable only from directly within it, never from a
-    function nested in it.
+    A scope covers only the region Python evaluates inside it: a ``def``'s decorators,
+    annotations and parameter defaults belong to the scope enclosing it. A class body is
+    reachable only from directly within it, never from a function nested in it, nor from
+    a class nested in it.
     """
     path = _tree_path(cursor)
     scopes: List[J] = []
     for i, node in enumerate(path):
         if not isinstance(node, _SCOPES):
             continue
-        child = path[i - 1] if i else None
-        if not _governs(node, child, path[i - 2] if i > 1 else None, path):
+        if not _governs(node, i, path):
             continue
         if isinstance(node, ClassDeclaration) and scopes:
             continue
@@ -88,16 +147,24 @@ def _tree_path(cursor: Optional[Cursor]) -> List[Any]:
     return path
 
 
-def _governs(scope: J, child: Any, grandchild: Any, path: List[Any]) -> bool:
+def _governs(scope: J, index: int, path: List[Any]) -> bool:
+    """Whether ``scope``'s bindings reach ``path[:index]``, the nodes it holds on the path."""
+    if index == 0:
+        # The cursor stands on the scope node itself, which whatever encloses it evaluates —
+        # and a compilation unit is enclosed by nothing.
+        return isinstance(scope, CompilationUnit)
+    child = path[index - 1]
     if isinstance(scope, MethodDeclaration):
         return child is scope.body or (isinstance(child, VariableDeclarations) and _is_parameter_name(path))
     if isinstance(scope, Lambda):
         return child is scope.body or (child is scope.parameters and _is_parameter_name(path))
     if isinstance(scope, ClassDeclaration):
         return child is scope.body
-    # A comprehension's leading iterable is evaluated before its targets exist.
-    clauses = scope.clauses if isinstance(scope, ComprehensionExpression) else None
-    return not (clauses and child is clauses[0] and grandchild is clauses[0].iterated_list)
+    if isinstance(scope, ComprehensionExpression):
+        # A comprehension's leading iterable is evaluated before its targets exist.
+        leading = scope.clauses[0].iterated_list if scope.clauses else None
+        return leading is None or all(node is not leading for node in path[:index])
+    return True
 
 
 def _is_parameter_name(path: List[Any]) -> bool:

--- a/rewrite-python/rewrite/tests/python/test_scope.py
+++ b/rewrite-python/rewrite/tests/python/test_scope.py
@@ -1,0 +1,232 @@
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the scope model: scope_of, Scope, binding_names, LocalBindings."""
+
+from typing import List
+
+from rewrite import Cursor
+from rewrite.java.tree import Identifier, MethodDeclaration, MethodInvocation
+from rewrite.python.scope_utils import LocalBindings, Scope, scope_of
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
+
+
+def _cursor_at_anchor(source: str) -> Cursor:
+    """The cursor at the source's single ``anchor()`` call."""
+    found: List[Cursor] = []
+
+    class Finder(PythonVisitor):
+        def visit_method_invocation(self, method: MethodInvocation, p):
+            if isinstance(method.name, Identifier) and method.name.simple_name == 'anchor':
+                found.append(self.cursor)
+            return super().visit_method_invocation(method, p)
+
+    RecipeSpec(type_attribution=False).rewrite_run(
+        python(source, after_recipe=lambda sf: Finder().visit(sf, None)))
+    assert len(found) == 1
+    return found[0]
+
+
+def _scope_at_anchor(source: str) -> Scope:
+    return scope_of(_cursor_at_anchor(source))
+
+
+def _names_at_anchor(source: str) -> List[List[str]]:
+    """What each scope out from the anchor binds, innermost first."""
+    bound: List[List[str]] = []
+    _scope_at_anchor(source).walk(lambda scope: (bound.append(sorted(scope.names())), True)[1])
+    return bound
+
+
+def test_declaring_scope_names_the_innermost_scope_binding_a_name():
+    shadowed = _scope_at_anchor("""
+        import json
+        def f():
+            json = 1
+            anchor()
+        """)
+    assert isinstance(shadowed.declaring_scope('json'), MethodDeclaration)
+    assert shadowed.declaring_scope('absent') is None
+    assert shadowed.declares('absent') is False
+
+    reachable = _scope_at_anchor("""
+        import json
+        def f():
+            anchor()
+        """)
+    assert isinstance(reachable.declaring_scope('json'), CompilationUnit)
+    assert reachable.declares('json') is True
+
+
+def test_is_bound_answers_for_a_local_alone_so_a_module_import_stays_attributable():
+    bindings = LocalBindings()
+    shadowed = _cursor_at_anchor("""
+        import json
+        def f():
+            json = 1
+            anchor()
+        """)
+    # RemoveImport reads this to keep a local shadowing an import from counting as a use of it.
+    assert bindings.is_bound(shadowed, 'json') is True
+
+    reachable = _cursor_at_anchor("""
+        import json
+        def f():
+            anchor()
+        """)
+    assert bindings.is_bound(reachable, 'json') is False
+
+
+def test_a_defs_decorators_and_parameter_defaults_belong_to_the_enclosing_scope():
+    default = _scope_at_anchor("""
+        def outer():
+            def f(p=anchor()):
+                pass
+        """)
+    assert default.declares('f') is True
+    assert default.declares('p') is False
+
+    decorator = _scope_at_anchor("""
+        def outer():
+            @deco(anchor())
+            def f(p):
+                pass
+        """)
+    assert decorator.declares('p') is False
+
+
+def test_a_class_body_is_reachable_from_directly_within_it_and_nowhere_else():
+    assert _scope_at_anchor("""
+        class A:
+            a = 1
+            anchor()
+        """).declares('a') is True
+
+    # A method's own scope chains past the class body straight to the module.
+    assert _scope_at_anchor("""
+        class A:
+            a = 1
+            def m(self):
+                anchor()
+        """).declares('a') is False
+
+    # Class bodies do not nest either: `class B: y = a` inside `A` raises NameError.
+    assert _scope_at_anchor("""
+        class A:
+            a = 1
+            class B:
+                anchor()
+        """).declares('a') is False
+
+
+def test_a_comprehensions_leading_iterable_is_evaluated_before_its_targets_exist():
+    assert _scope_at_anchor("[x for x in anchor()]").declares('x') is False
+    assert _scope_at_anchor("[anchor() for x in ys]").declares('x') is True
+
+
+def test_global_hands_a_name_back_to_the_module_scope():
+    scope = _scope_at_anchor("""
+        import json
+        def f():
+            global json
+            json = 1
+            anchor()
+        """)
+    assert isinstance(scope.declaring_scope('json'), CompilationUnit)
+
+
+def test_an_except_alias_binds_for_the_whole_function():
+    scope = _scope_at_anchor("""
+        import json
+        def f():
+            try:
+                pass
+            except ValueError as json:
+                pass
+            anchor()
+        """)
+    # CPython puts the alias in `co_varnames`; the end-of-block `del` clears its value, so
+    # the later reference raises UnboundLocalError instead of resolving to the import.
+    assert isinstance(scope.declaring_scope('json'), MethodDeclaration)
+
+
+def test_walk_visits_each_scope_outwards_and_stops_where_the_caller_says():
+    source = """
+        top = 1
+        def fn(param):
+            local = 2
+            anchor()
+        """
+    assert _names_at_anchor(source) == [['local', 'param'], ['fn', 'top']]
+
+    visited: List[List[str]] = []
+    _scope_at_anchor(source).walk(
+        lambda scope: (visited.append(sorted(scope.names())), len(visited) < 1)[1])
+    assert visited == [['local', 'param']]
+
+
+def test_a_target_that_assigns_through_an_object_binds_no_name():
+    # `self.x` and `d[k]` mutate an object rather than binding a name in the scope.
+    assert _names_at_anchor("""
+        def f(self, d, k):
+            a, (b, *rest) = pair
+            self.x = 1
+            d[k] = 2
+            anchor()
+        """)[0] == ['a', 'b', 'd', 'k', 'rest', 'self']
+
+
+def test_a_cursor_outside_any_compilation_unit_has_no_scope():
+    found: List[Cursor] = []
+
+    class Finder(PythonVisitor):
+        def visit_method_invocation(self, method: MethodInvocation, p):
+            found.append(self.cursor)
+            return method
+
+    def visit_statement_alone(sf):
+        Finder().visit(sf.statements[0], None)
+
+    RecipeSpec(type_attribution=False).rewrite_run(
+        python("anchor()", after_recipe=visit_statement_alone))
+    scope = scope_of(found[0])
+    assert scope.names() == frozenset()
+    assert scope.declares('anchor') is False
+
+
+def test_a_cursor_on_a_scope_node_sits_outside_it_except_the_module():
+    answers = {}
+
+    class Peek(PythonVisitor):
+        def visit_comprehension_expression(self, comp, p):
+            answers['comprehension'] = scope_of(self.cursor).declares('zz')
+            return comp
+
+        def visit_lambda(self, lambda_, p):
+            answers['lambda'] = scope_of(self.cursor).declares('aa')
+            return lambda_
+
+        def visit_compilation_unit(self, cu, p):
+            answers['module'] = scope_of(self.cursor).declares('ys')
+            return super().visit_compilation_unit(cu, p)
+
+    RecipeSpec(type_attribution=False).rewrite_run(python("""
+        ys = [1]
+        q = [zz for zz in ys]
+        g = lambda aa: aa
+        """, after_recipe=lambda sf: Peek().visit(sf, None)))
+
+    assert answers == {'comprehension': False, 'lambda': False, 'module': True}


### PR DESCRIPTION
`scope_utils.py` documents that "a comprehension's leading iterable is evaluated before its targets exist", but the rule never fired. It keyed on `ComprehensionExpression.Clause` appearing on the cursor path, and `PythonVisitor.visit_comprehension_clause` is called directly rather than through `visit`, so no cursor ever holds a Clause:

```python
[x for x in x]   # the leading `x` resolved to the comprehension target
```

That went unnoticed because `LocalBindings` had no tests at all — nothing under `tests/` imported it, and its behaviour was covered only incidentally through remove-import and change-import.

## The model

Python's whole scope surface was one predicate, and not a public one: `scope_utils` is absent from `rewrite/python/__init__.py`, so both consumers (`remove_import.py:148`, `recipes/change_import.py:317`) reach it by internal module path. `rewrite-javascript/rewrite/src/javascript/scope.ts` has had a general model for a while; this is the same shape in Python:

```python
scope = scope_of(cursor)
scope.names()                 # what this scope binds itself
scope.walk(visit)             # this scope then each enclosing one, innermost first
scope.declares(name)
scope.declaring_scope(name)   # the NODE owning the innermost scope binding name
```

`CompilationUnit` joins `_SCOPES`, so module scope is representable and `declaring_scope` returns the compilation unit for a module-level binding. `LocalBindings.is_bound` becomes a shim over it, exactly rather than approximately: it was "some non-module scope binds it", and that is `declaring_scope` minus the compilation-unit case.

## Why the module scope is in it, when LocalBindings excluded it

`maybe_add_import` does no deconfliction — it checks `_import_exists` and `_is_referenced` and nothing else. It will add an import a local shadows:

```python
from locale import resetlocale, setlocale   # added by a recipe

def setlocale(*a):
    return 'mine'
```

Every `setlocale(...)` the recipe emits reaches the local. Valid Python, no exception. The guard is one line against this API, and it needs the module scope:

```python
if 'setlocale' not in scope_of(self.cursor).names():
    maybe_add_import(self, AddImportOptions(module='locale', name='setlocale'))
```

`namesDeclaredIn(cu)`, the JavaScript shape, would be wrong for this: it returns every name the file declares anywhere, so it would decline on a name bound inside an unrelated function, which does not shadow a module-level import.

## Scope

Purely additive apart from the comprehension fix. Deliberately not ported: `namesUsedIn`, `namesDeclaredIn`, `deconflict`, `isValueReference`, `bindingNames` — each exists in JavaScript because a JavaScript consumer calls it, and none has a Python consumer.

The parser keeps its own `ast`-level `_import_bindings()` index. `type_mapping.py` runs during parse, before any LST or `Cursor` exists, so nothing keyed on a cursor can serve that layer, and that index is deliberately blunter — whole-file and unscoped, for the reason its docstring gives.

## Tests

`tests/python/test_scope.py`, 11 tests where there were none. They pin the rules that until now lived only in a comment:

- `except E as e` is function-scoped — CPython puts the alias in `co_varnames`, and the end-of-block `del` clears the value rather than the binding, so a later read raises `UnboundLocalError`. JavaScript's `TryCatch` scope kind deliberately does not carry over.
- Nested class bodies do not chain, and a comprehension inside a class body does not see class scope. Both raise `NameError` in CPython.
- A `def`'s decorators and parameter defaults belong to the enclosing scope.
- A cursor standing on a scope node sits outside it, except a compilation unit, which nothing encloses — the case the `maybe_add_import` guard above depends on.

