### PR TITLE
Python: a recipe test's sources parse as one project

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
@@ -29,7 +29,7 @@ to fall through to the next layer.
 
 import re
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 # `# -*- python: 2 -*-` / `# -*- python: 2.7 -*-` — mirrors PEP-263's encoding
 # declaration style. Must appear on line 1 or 2 of the source.
@@ -44,6 +44,24 @@ _SHEBANG_RE = re.compile(r"^#!.*\bpython(?P<ver>\d+(?:\.\d+)?)\b")
 _CLASSIFIER_RE = re.compile(
     r"Programming Language\s*::\s*Python\s*::\s*(?P<ver>\d+(?:\.\d+)?)"
 )
+
+
+def requested_python_version(value: Any) -> Optional[str]:
+    """The value if it looks like a Python minor version ("3.12"), else None."""
+    return value if isinstance(value, str) and re.fullmatch(r"\d+\.\d+", value) else None
+
+
+def ty_python_version(*levels: Optional[str]) -> Optional[str]:
+    """The first language level precise enough to name a stdlib surface to ty.
+
+    One ty session serves a whole batch, so callers pass only levels holding
+    for all of it — never a per-file shebang or magic comment.
+    """
+    for level in levels:
+        version = requested_python_version(level)
+        if version:
+            return version
+    return None
 
 
 def detect_from_source(source: str) -> Optional[str]:

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -26,7 +26,6 @@ import csv
 import json
 import logging
 import os
-import re
 import select
 import sys
 import tempfile
@@ -45,6 +44,8 @@ except ImportError:  # not available on Windows
     resource = None
 
 from rewrite.discovery import RecipeAttribution, RecipeName, _normalize_package_name
+from rewrite.python._version_detect import (
+    detect_from_project, detect_from_source, requested_python_version, ty_python_version)
 from rewrite.rpc.reference import ReferenceMap
 
 # Deeply nested LST nodes (e.g., 256 implicitly concatenated strings) can
@@ -338,7 +339,6 @@ def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optio
     Values starting with "2" select the parso-based Py2ParserVisitor; anything
     else uses the ast-based Python 3 parser.
     """
-    from rewrite.python._version_detect import detect_from_source
 
     effective_version = (
         language_level
@@ -526,9 +526,8 @@ def handle_parse(params: dict) -> List[str]:
     # Resolve project-level language version once per request; per-file
     # detection (shebang / magic comment) can still override this inside
     # parse_python_source.
-    from rewrite.python._version_detect import detect_from_project
     project_language_level = detect_from_project(relative_to) if relative_to else None
-    ty_python_version = _ty_python_version(language_level, project_language_level)
+    ty_version = ty_python_version(language_level, project_language_level)
 
     # Create a ty-types client for this parse batch
     ty_client = None
@@ -538,7 +537,7 @@ def handle_parse(params: dict) -> List[str]:
         # Point ty-types at the caller-provisioned dependency environment (if any)
         # so supertypes reaching into third-party packages resolve.
         ty_client = TyTypesClient(virtual_env=dependency_path,
-                                  python_version=ty_python_version)
+                                  python_version=ty_version)
         if relative_to:
             ty_client.initialize(relative_to)
         else:
@@ -637,9 +636,8 @@ def handle_parse_project(params: dict) -> List[dict]:
 
     # Resolve project-level language version once for the whole walk; each
     # file may still override it via in-source signals inside parse_python_source.
-    from rewrite.python._version_detect import detect_from_project
     project_language_level = detect_from_project(project_path)
-    ty_python_version = _ty_python_version(language_level, project_language_level)
+    ty_version = ty_python_version(language_level, project_language_level)
 
     results = []
 
@@ -649,7 +647,7 @@ def handle_parse_project(params: dict) -> List[dict]:
         # Point ty-types at the caller-provisioned dependency environment (if any)
         # so supertypes reaching into third-party packages resolve.
         ty_client = TyTypesClient(virtual_env=dependency_path,
-                                  python_version=ty_python_version)
+                                  python_version=ty_version)
         ty_client.initialize(project_path)
     except (ImportError, RuntimeError):
         pass
@@ -828,28 +826,10 @@ def _typeshed_stdlib_dir() -> Path:
     raise ValueError(f"no typeshed stdlib/VERSIONS under {env}")
 
 
-def _requested_python_version(value: Any) -> Optional[str]:
-    """The value if it looks like a Python minor version ("3.12"), else None."""
-    return value if isinstance(value, str) and re.fullmatch(r'\d+\.\d+', value) else None
-
-
-def _ty_python_version(*levels: Optional[str]) -> Optional[str]:
-    """The first language level precise enough to name a stdlib surface to ty.
-
-    One ty session serves a whole batch, so callers pass only levels holding
-    for all of it — never a per-file shebang or magic comment.
-    """
-    for level in levels:
-        version = _requested_python_version(level)
-        if version:
-            return version
-    return None
-
-
 def _write_stdlib_ty_config(stdlib: Path, python_version: Optional[str]) -> str:
     """Throwaway ty.toml dir pointing ty's typeshed at the checkout so it resolves as the
     stdlib and names modules os, not stdlib.os — matching the parser's stdlib attribution."""
-    version = _requested_python_version(python_version) \
+    version = requested_python_version(python_version) \
               or '%d.%d' % (sys.version_info.major, sys.version_info.minor)
     ty_config_dir = tempfile.mkdtemp(prefix='ty-stdlib-')
     with open(os.path.join(ty_config_dir, 'ty.toml'), 'w') as f:
@@ -967,7 +947,7 @@ def handle_dependency_types(params: dict) -> List[dict]:
     name = params.get('name')
     version = params.get('version')
     # Stdlib stubs are version-conditioned; a malformed value falls back to the interpreter minor.
-    python_version = _requested_python_version(params.get('pythonVersion'))
+    python_version = requested_python_version(params.get('pythonVersion'))
     if not name:
         raise ValueError("DependencyTypes requires a dependency name")
 

--- a/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
+++ b/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
@@ -17,7 +17,8 @@
 from __future__ import annotations
 
 import ast
-from dataclasses import dataclass, field
+from contextlib import contextmanager
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 from uuid import uuid4
@@ -101,6 +102,22 @@ def from_visitor(visitor: TreeVisitor[Any, ExecutionContext]) -> Recipe:
 
 
 @dataclass
+class _Workspace:
+    """Where a run's sources sit on disk while they parse."""
+
+    paths: Dict[int, Path]
+    written: Dict[int, str]
+    ty_client: Optional[Any]
+
+    def source_path(self, spec: SourceSpec) -> Path:
+        return self.paths[id(spec)]
+
+    def file_path(self, spec: SourceSpec) -> Optional[str]:
+        # Only a ty session reads this path; an untyped parse has no use for it.
+        return self.written.get(id(spec)) if self.ty_client is not None else None
+
+
+@dataclass
 class RecipeSpec:
     """
     Configuration for running recipe tests.
@@ -139,16 +156,10 @@ class RecipeSpec:
     type_attribution: bool = True
 
     def with_recipe(self, recipe: Recipe) -> "RecipeSpec":
-        return RecipeSpec(recipe=recipe, execution_context=self.execution_context,
-                          check_parse_print_idempotence=self.check_parse_print_idempotence,
-                          allow_empty_diff=self.allow_empty_diff,
-                          type_attribution=self.type_attribution)
+        return replace(self, recipe=recipe)
 
     def with_allow_empty_diff(self, value: bool) -> "RecipeSpec":
-        return RecipeSpec(recipe=self.recipe, execution_context=self.execution_context,
-                          check_parse_print_idempotence=self.check_parse_print_idempotence,
-                          allow_empty_diff=value,
-                          type_attribution=self.type_attribution)
+        return replace(self, allow_empty_diff=value)
 
     def with_recipes(self, *recipes: Recipe) -> "RecipeSpec":
         if len(recipes) == 1:
@@ -172,17 +183,18 @@ class RecipeSpec:
         Raises:
             AssertionError: If any validation fails
         """
-        # Group specs by kind
-        specs_by_kind = self._group_by_kind(list(source_specs))
+        specs = list(source_specs)
+        specs_by_kind = self._group_by_kind(specs)
 
         # Parse and validate all source files
         all_parsed: List[Tuple[SourceSpec, SourceFile]] = []
-        for kind, specs in specs_by_kind.items():
-            parsed = self._parse(specs)
-            self._expect_no_parse_failures(parsed)
-            if self.check_parse_print_idempotence:
-                self._expect_parse_print_idempotence(parsed)
-            all_parsed.extend(parsed)
+        with self._workspace(specs) as workspace:
+            for kind, kind_specs in specs_by_kind.items():
+                parsed = self._parse(kind_specs, workspace)
+                self._expect_no_parse_failures(parsed)
+                if self.check_parse_print_idempotence:
+                    self._expect_parse_print_idempotence(parsed)
+                all_parsed.extend(parsed)
 
         # Apply before_recipe hooks (after idempotence check, before recipe execution)
         all_parsed = [
@@ -217,7 +229,9 @@ class RecipeSpec:
             groups[spec.kind].append(spec)
         return groups
 
-    def _parse(self, specs: List[SourceSpec]) -> List[Tuple[SourceSpec, SourceFile]]:
+    def _parse(
+        self, specs: List[SourceSpec], workspace: "_Workspace"
+    ) -> List[Tuple[SourceSpec, SourceFile]]:
         """Parse all specs using the appropriate parser."""
         result: List[Tuple[SourceSpec, SourceFile]] = []
 
@@ -227,77 +241,112 @@ class RecipeSpec:
                 continue
 
             if spec.kind != "python":
-                # Only Python specs are parsed (e.g., toml specs from pyproject()
-                # are consumed by uv() and don't need parsing)
+                # Non-Python specs shape the workspace rather than being parsed:
+                # a pyproject() is there to declare the project.
                 continue
 
-            # Determine source path
-            source_path = spec.path or Path(f"_{uuid4().hex}.{spec.ext}")
-
-            # Parse the source
-            source = dedent(spec.before)
-            parsed = self._parse_python(source, source_path, spec.project_root)
+            parsed = self._parse_python(
+                dedent(spec.before),
+                workspace.source_path(spec),
+                workspace.file_path(spec),
+                workspace.ty_client,
+            )
 
             result.append((spec, parsed))
 
         return result
 
+    @contextmanager
+    def _workspace(self, specs: List[SourceSpec]):
+        """Hold every source in the run in one directory while it parses.
+
+        ty reads the sources and the project metadata from there, so a declared
+        Python version picks the typeshed and the sources resolve against each
+        other. ``uv()`` supplies its dependency workspace through the specs;
+        otherwise the run owns one.
+        """
+        import shutil
+        import tempfile
+        from rewrite.python._version_detect import detect_from_project, ty_python_version
+
+        paths = {id(spec): spec.path or Path(f"_{uuid4().hex}.{spec.ext}") for spec in specs}
+
+        if not self.type_attribution:
+            yield _Workspace(paths, {}, None)
+            return
+
+        root = next((spec.project_root for spec in specs if spec.project_root), None)
+        owns_root = root is None
+        if owns_root:
+            root = tempfile.mkdtemp()
+
+        written: Dict[int, str] = {}
+        created: List[Path] = []
+        ty_client = None
+        try:
+            for spec in specs:
+                if spec.before is None:
+                    continue
+                logical = paths[id(spec)]
+                if logical.is_absolute() or ".." in logical.parts:
+                    # The run removes what it writes, so a path leading out of the
+                    # workspace would write and delete on the caller's tree.
+                    raise ValueError(f"a source path stays inside the workspace: {logical}")
+                destination = Path(root) / logical
+                created.extend(p for p in reversed(destination.parents) if not p.exists())
+                if not destination.exists():
+                    created.append(destination)
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                destination.write_text(dedent(spec.before))
+                written[id(spec)] = str(destination)
+
+            try:
+                from rewrite.python.ty_client import TyTypesClient
+                # handle_parse resolves this same version for a real parse.
+                ty_client = TyTypesClient(python_version=ty_python_version(detect_from_project(root)))
+                ty_client.initialize(root)
+            except (ImportError, RuntimeError):
+                ty_client = None
+
+            yield _Workspace(paths, written, ty_client)
+        finally:
+            if ty_client is not None:
+                ty_client.shutdown()
+            if owns_root:
+                shutil.rmtree(root, ignore_errors=True)
+            else:
+                # A uv() workspace is cached across runs and holds the project's own
+                # files — among them the pyproject.toml it was built from — so give
+                # back what this run added and nothing else.
+                for path in reversed(created):
+                    try:
+                        if path.is_dir():
+                            path.rmdir()
+                        else:
+                            path.unlink()
+                    except OSError:
+                        pass
+
     def _parse_python(
         self,
         source: str,
         source_path: Path,
-        project_root: Optional[str] = None,
+        file_path: Optional[str],
+        ty_client: Optional[Any],
     ) -> CompilationUnit:
         """Parse Python source code into a CompilationUnit.
 
-        Args:
-            source: Python source code.
-            source_path: Logical path for the source file.
-            project_root: Optional workspace directory for type attribution
-                (e.g., from ``uv()``).  When ``None`` a temporary directory is
-                created and cleaned up after parsing.
+        ``source_path`` is the logical path the tree carries; ``file_path`` is where
+        the source sits in the workspace, and is None for an untyped parse.
         """
-        import tempfile
-        import os
         from rewrite.python._parser_visitor import ParserVisitor
 
-        ty_client = None
-        workspace = project_root
-        owns_workspace = workspace is None
-        file_path = None
-
-        if self.type_attribution:
-            try:
-                from rewrite.python.ty_client import TyTypesClient
-                if owns_workspace:
-                    workspace = tempfile.mkdtemp()
-                file_name = source_path.name if source_path.name else 'test.py'
-                file_path = os.path.join(workspace, file_name)
-                with open(file_path, 'w') as f:
-                    f.write(source)
-                ty_client = TyTypesClient()
-                ty_client.initialize(workspace)
-            except (ImportError, RuntimeError):
-                file_path = None
-
-        try:
-            visitor = ParserVisitor(source, file_path, ty_client)
-            # Strip BOM before passing to ast.parse (ParserVisitor does this internally)
-            source_for_ast = source[1:] if source.startswith('\ufeff') else source
-            tree = ast.parse(source_for_ast)
-            cu = visitor.visit_Module(tree)
-            return cu.replace(source_path=source_path)
-        finally:
-            if ty_client is not None:
-                ty_client.shutdown()
-            if owns_workspace and workspace is not None:
-                import shutil
-                shutil.rmtree(workspace, ignore_errors=True)
-            elif file_path is not None:
-                try:
-                    os.unlink(file_path)
-                except OSError:
-                    pass
+        visitor = ParserVisitor(source, file_path, ty_client)
+        # Strip BOM before passing to ast.parse (ParserVisitor does this internally)
+        source_for_ast = source[1:] if source.startswith('\ufeff') else source
+        tree = ast.parse(source_for_ast)
+        cu = visitor.visit_Module(tree)
+        return cu.replace(source_path=source_path)
 
     def _expect_no_parse_failures(
         self, parsed: List[Tuple[SourceSpec, SourceFile]]

--- a/rewrite-python/rewrite/tests/python/test_declared_version_typeshed.py
+++ b/rewrite-python/rewrite/tests/python/test_declared_version_typeshed.py
@@ -24,7 +24,9 @@ import shutil
 
 import pytest
 
+from rewrite.java import JavaType
 from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, pyproject, python
 from rewrite.rpc import server
 
 
@@ -106,3 +108,42 @@ def test_version_outside_ty_support_keeps_the_rest_of_attribution(tmp_path):
     # ty declines a version it ships no stubs for by failing initialization,
     # which takes every type down with it unless the version is given up.
     assert found["getdefaultlocale"] == "locale"
+
+
+def _return_types_through_harness(classifier_version):
+    """Map each call to its method type's return type, reaching the parser the way a
+    recipe author does — ``rewrite_run`` rather than the RPC handler.
+    """
+    found = {}
+
+    class Collect(PythonVisitor):
+        def visit_method_invocation(self, mi, p):
+            found[mi.name.simple_name] = mi.method_type.return_type if mi.method_type else None
+            return super().visit_method_invocation(mi, p)
+
+    def collect(cu):
+        Collect().visit(cu, None)
+
+    RecipeSpec().rewrite_run(
+        pyproject(
+            '[project]\nname = "demo"\nversion = "0.1.0"\n'
+            'classifiers = ["Programming Language :: Python :: %s"]\n' % classifier_version
+        ),
+        python(SOURCE, before_recipe=collect),
+    )
+    return found
+
+
+@requires_ty_types_cli
+def test_rewrite_run_parses_under_the_declared_version():
+    on_310 = _return_types_through_harness("3.10")
+    on_313 = _return_types_through_harness("3.13")
+
+    # gettext.lgettext is in 3.10's typeshed and gone from 3.11's, so only the
+    # declared version can give it a signature.
+    assert on_310["lgettext"] == JavaType.Primitive.String
+    assert isinstance(on_313["lgettext"], JavaType.Unknown)
+
+    # Resolves under both, so the lgettext split is typeshed content, not a failed parse.
+    for found in (on_310, on_313):
+        assert not isinstance(found["getdefaultlocale"], JavaType.Unknown)

--- a/rewrite-python/rewrite/tests/test_rewrite_test.py
+++ b/rewrite-python/rewrite/tests/test_rewrite_test.py
@@ -14,6 +14,8 @@
 
 """Tests for the Python test harness."""
 
+from pathlib import Path
+
 import pytest
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor
@@ -21,7 +23,7 @@ from rewrite.test import RecipeSpec, python, pyproject, uv, from_visitor, dedent
 from rewrite.test.spec import SourceSpec
 from rewrite.python.visitor import PythonVisitor
 from rewrite.python.tree import CompilationUnit
-from rewrite.java import J
+from rewrite.java import J, JavaType
 
 
 class TestDedent:
@@ -340,6 +342,65 @@ def _uv_available() -> bool:
     """Check if uv is installed."""
     import shutil
     return shutil.which("uv") is not None
+
+
+def _ty_types_available() -> bool:
+    """Check if the ty-types CLI is installed."""
+    import shutil
+    try:
+        from ty_types.__main__ import find_ty_types_bin  # noqa: F401
+        return True
+    except Exception:
+        return shutil.which("ty-types") is not None
+
+
+class TestWorkspace:
+    """Tests for the directory a run parses its sources under."""
+
+    @pytest.mark.skipif(not _ty_types_available(), reason="ty-types not installed")
+    def test_sources_in_a_run_resolve_against_each_other(self):
+        returns = {}
+
+        class Collect(PythonVisitor):
+            def visit_method_invocation(self, mi, p):
+                returns[mi.name.simple_name] = (
+                    mi.method_type.return_type if mi.method_type else None
+                )
+                return super().visit_method_invocation(mi, p)
+
+        def collect(cu):
+            Collect().visit(cu, None)
+
+        RecipeSpec().rewrite_run(
+            python("def answer() -> int:\n    return 42\n", path=Path("helper.py")),
+            python("import helper\n\nvalue = helper.answer()\n", before_recipe=collect),
+        )
+
+        # Resolved through the import, which names a module of the same directory.
+        assert returns["answer"] == JavaType.Primitive.Int
+
+    def test_a_source_path_leading_out_of_the_workspace_is_rejected(self):
+        with pytest.raises(ValueError, match="inside the workspace"):
+            RecipeSpec().rewrite_run(python("x = 1\n", path=Path("../escaped.py")))
+
+    @pytest.mark.skipif(not _uv_available(), reason="uv not installed")
+    def test_a_borrowed_workspace_keeps_its_own_files(self):
+        specs = uv(
+            pyproject(
+                """
+                [project]
+                name = "test"
+                version = "0.0.0"
+                requires-python = ">=3.10"
+                """
+            ),
+            python("x = 1\n"),
+        )
+        root = Path(specs[0].project_root)
+
+        RecipeSpec().rewrite_run(*specs)
+
+        assert (root / "pyproject.toml").is_file()
 
 
 class TestPyprojectHelper:


### PR DESCRIPTION
`RecipeSpec` had no way to put a parse under a project root, so #8759's version selection was reachable only through the Parse RPC handler. Measured on `main`, `from gettext import lgettext; lgettext('Hi')`, parameter types:

| project declares | `main` | this PR |
|---|---|---|
| `requires-python = ">=3.10"` | `String` | `String` |
| `classifiers = ["... :: 3.10"]` | **`Unknown`** | `String` |

The first row is ty reading `pyproject.toml` itself; it resolves with #8759's code deleted. The classifier row isolates the feature, and it was unreachable: `_parse_python` built its client as `TyTypesClient()` with no `python_version` argument, so nothing on the harness path ever called `detect_from_project`.

## One directory per run

`rewrite_run` now holds every source in the run in one directory while it parses, the way `mavenProject`/`srcMainJava` lay out a Java test. ty reads the sources and the project metadata from there, so a `pyproject()` declared inline picks the typeshed:

```python
RecipeSpec().rewrite_run(
    pyproject('[project]\nname = "demo"\nversion = "0.1.0"\n'
              'classifiers = ["Programming Language :: Python :: 3.10"]\n'),
    python("from gettext import lgettext\nmsg = lgettext('Hi')\n"),
)
```

The sources are siblings in that directory, so they resolve against each other too — `import helper` finds a `python(..., path=Path("helper.py"))` from the same run.

I first gave `RecipeSpec` a `project_root` string for the caller to point at a directory it had built. That is a knob for something the harness already knows — the run *is* the project — and the only test that wanted it was assembling a `tmp_path` to hold a `pyproject.toml` the run could write itself.

Three things fall out:

- `detect_from_project` now reads the directory the sources actually parse under, not a caller-supplied root that was `None` in the common case.
- One ty-types session serves a whole run. A three-source test previously spawned three subprocesses, one per source.
- `_requested_python_version` and `_ty_python_version` move from `rpc/server.py` to `_version_detect.py`: `rpc.server` runs as `__main__`, so a name-import of it from the harness binds a second copy of the module with empty globals.

## Giving back a borrowed workspace

`uv()` supplies its own root, and that workspace is cached across runs, keyed on the `pyproject.toml` it was built from. So cleanup removes what the run *created*, not what it wrote: the pyproject a `uv()` run materializes is the workspace's own file and stays. Removing everything written leaves a workspace that `_is_valid` still accepts — it checks only `.venv` and `version.txt` — with no project metadata, degrading every later run against it:

```
ae82c7d9f0733d59  .venv pyproject.toml uv.lock version.txt
7dfa0252c5d25c44  .venv               uv.lock version.txt
```

A source path that is absolute or contains `..` is rejected, since the run both writes and deletes that path.

## Tests

`test_rewrite_run_parses_under_the_declared_version` reaches the parser through `rewrite_run` and asserts the return type `lgettext` gets under a 3.10 project versus a 3.13 one. It asserts on the *signature*, not the declaring type: #8758 makes a symbol no typeshed declares be named by the import that binds it, so `gettext` reads as the owner under both versions and only the signature moves.

`test_sources_in_a_run_resolve_against_each_other` pins the layout, and `test_a_borrowed_workspace_keeps_its_own_files` the cleanup contract. All three are mutation-checked — forcing `version = None`, nesting each source under its own subdirectory, and reverting cleanup to the written paths each fail exactly one.

2219 passed, 94 skipped. Five `TestDescriptorFqnContract` / `test_type_interning` failures are pre-existing: they go through `handle_parse_project`, and fail identically with this diff reverted.

## Not in this PR

A shared root plus a long-lived ty session would drop the temp dir entirely for runs with no project metadata, but the two are coupled — `initialize` on a different root restarts the process — and a shared root makes one test's modules importable from another. That wants its own change, with a measurement behind it.

## Merge order

Conflicts with #8758 in one place: that PR rewrites the last line of `test_declared_version_typeshed.py`, while this one replaces the block after it. Take theirs, then mine.
