### PR TITLE
Python: keep dependency workspaces out of $TMPDIR

### DIFF
--- a/rewrite-python/src/main/java/org/openrewrite/python/DependencyWorkspace.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/DependencyWorkspace.java
@@ -17,6 +17,7 @@ package org.openrewrite.python;
 
 import lombok.experimental.UtilityClass;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.python.internal.InstalledEnvParser;
 import org.openrewrite.python.internal.PackageManagerExecutor;
 
 import java.io.IOException;
@@ -396,7 +397,7 @@ public class DependencyWorkspace {
 
     private static boolean isRequirementsWorkspaceValid(Path workspaceDir) {
         return Files.exists(workspaceDir) &&
-                Files.isDirectory(workspaceDir.resolve(".venv")) &&
+                InstalledEnvParser.isIntact(workspaceDir.resolve(".venv")) &&
                 Files.exists(workspaceDir.resolve("freeze.txt")) &&
                 hasCurrentVersion(workspaceDir);
     }
@@ -441,7 +442,7 @@ public class DependencyWorkspace {
 
     private static boolean isWorkspaceValid(Path workspaceDir) {
         return Files.exists(workspaceDir) &&
-                Files.isDirectory(workspaceDir.resolve(".venv")) &&
+                InstalledEnvParser.isIntact(workspaceDir.resolve(".venv")) &&
                 Files.exists(workspaceDir.resolve("pyproject.toml")) &&
                 hasCurrentVersion(workspaceDir);
     }

--- a/rewrite-python/src/main/java/org/openrewrite/python/DependencyWorkspace.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/DependencyWorkspace.java
@@ -44,9 +44,16 @@ import static java.util.Collections.synchronizedMap;
  */
 @UtilityClass
 public class DependencyWorkspace {
+    /**
+     * Installed venvs are expensive to rebuild and are meant to outlive a single run, so they live
+     * beside the other {@code ~/.rewrite} caches. A {@code $TMPDIR} reaper evicts by access time,
+     * which uv's installed files inherit from their wheel rather than from the install, and would
+     * empty a workspace the same night it was created. Bounded by {@link #MAX_CACHE_SIZE}.
+     */
     private static final Path WORKSPACE_BASE = Paths.get(
-            System.getProperty("java.io.tmpdir"),
-            "openrewrite-python-workspaces"
+            System.getProperty("user.home"),
+            ".rewrite",
+            "python-workspaces"
     );
     /**
      * Bump this when the workspace layout changes (e.g. new files expected)
@@ -108,8 +115,7 @@ public class DependencyWorkspace {
             cache.put(hash, workspaceDir);
             return workspaceDir;
         }
-        // An invalid leftover at the target path (e.g. gutted by macOS periodic tmp
-        // cleanup, which deletes old files but keeps the directory skeleton) would
+        // An invalid leftover at the target path (e.g. from an interrupted run) would
         // block the final Files.move into place; remove it before rebuilding.
         cleanupDirectory(workspaceDir);
 
@@ -211,8 +217,7 @@ public class DependencyWorkspace {
             cache.put(hash, workspaceDir);
             return workspaceDir;
         }
-        // An invalid leftover at the target path (e.g. gutted by macOS periodic tmp
-        // cleanup, which deletes old files but keeps the directory skeleton) would
+        // An invalid leftover at the target path (e.g. from an interrupted run) would
         // block the final Files.move into place; remove it before rebuilding.
         cleanupDirectory(workspaceDir);
 
@@ -325,8 +330,7 @@ public class DependencyWorkspace {
             cache.put(hash, workspaceDir);
             return workspaceDir;
         }
-        // An invalid leftover at the target path (e.g. gutted by macOS periodic tmp
-        // cleanup, which deletes old files but keeps the directory skeleton) would
+        // An invalid leftover at the target path (e.g. from an interrupted run) would
         // block the final Files.move into place; remove it before rebuilding.
         cleanupDirectory(workspaceDir);
 

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
@@ -99,9 +99,8 @@ public final class InstalledEnvParser {
     /**
      * Whether {@code env} still holds the packages it was installed with: site-packages carries at
      * least one {@code *.dist-info}, and each has the METADATA every wheel is required to write.
-     * A {@code $TMPDIR} reaper evicts by access time, and uv's installed files carry their wheel's
-     * timestamps rather than the install's, so it strips package contents out of an env whose
-     * directory skeleton and freshly written marker files both survive.
+     * A {@code $TMPDIR} reaper evicts by access time, which uv's installed files inherit from their
+     * wheel rather than from the install, so it empties an env whose skeleton and markers survive.
      */
     public static boolean isIntact(Path env) {
         Path sitePackages = findSitePackages(env);

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
@@ -99,8 +99,7 @@ public final class InstalledEnvParser {
     /**
      * Whether {@code env} still holds the packages it was installed with: site-packages carries at
      * least one {@code *.dist-info}, and each has the METADATA every wheel is required to write.
-     * A {@code $TMPDIR} reaper evicts by access time, which uv's installed files inherit from their
-     * wheel rather than from the install, so it empties an env whose skeleton and markers survive.
+     * An env emptied out from under a cache still presents the directory skeleton it was built with.
      */
     public static boolean isIntact(Path env) {
         Path sitePackages = findSitePackages(env);

--- a/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/internal/InstalledEnvParser.java
@@ -97,6 +97,32 @@ public final class InstalledEnvParser {
     }
 
     /**
+     * Whether {@code env} still holds the packages it was installed with: site-packages carries at
+     * least one {@code *.dist-info}, and each has the METADATA every wheel is required to write.
+     * A {@code $TMPDIR} reaper evicts by access time, and uv's installed files carry their wheel's
+     * timestamps rather than the install's, so it strips package contents out of an env whose
+     * directory skeleton and freshly written marker files both survive.
+     */
+    public static boolean isIntact(Path env) {
+        Path sitePackages = findSitePackages(env);
+        if (sitePackages == null) {
+            return false;
+        }
+        boolean any = false;
+        try (DirectoryStream<Path> ds = Files.newDirectoryStream(sitePackages, "*.dist-info")) {
+            for (Path distInfo : ds) {
+                if (!Files.isRegularFile(distInfo.resolve("METADATA"))) {
+                    return false;
+                }
+                any = true;
+            }
+        } catch (IOException e) {
+            return false;
+        }
+        return any;
+    }
+
+    /**
      * Link transitive dependencies by reading each package's {@code dist-info/METADATA}
      * ({@code Requires-Dist} entries) from {@code sitePackages}, building the graph via
      * {@link PythonResolutionLinker#buildGraph}. Packages are matched to dist-info

--- a/rewrite-python/src/test/java/org/openrewrite/python/DependencyWorkspaceTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/DependencyWorkspaceTest.java
@@ -16,12 +16,14 @@
 package org.openrewrite.python;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.python.internal.InstalledEnvParser;
 import org.openrewrite.python.internal.PackageManagerExecutor;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -35,9 +37,8 @@ class DependencyWorkspaceTest {
         Path workspace = DependencyWorkspace.getOrCreateRequirementsWorkspace(requirements, null);
         assumeTrue(workspace != null, "could not create workspace (uv install failed?)");
 
-        // Simulate macOS periodic tmp cleanup, which deletes files older than three
-        // days from $TMPDIR but leaves the directory skeleton (including .venv) in
-        // place. The leftover directory occupies the path the rebuild moves into.
+        // Deleting the marker files invalidates the workspace without removing the
+        // directory the rebuild has to move into.
         Files.deleteIfExists(workspace.resolve("freeze.txt"));
         Files.deleteIfExists(workspace.resolve("version.txt"));
         // A fresh JVM would not have the (now invalid) workspace in the in-memory cache.
@@ -47,5 +48,24 @@ class DependencyWorkspaceTest {
         assertThat(rebuilt).isNotNull();
         assertThat(rebuilt.resolve("freeze.txt")).exists();
         assertThat(rebuilt.resolve("version.txt")).exists();
+    }
+
+    @Test
+    void rebuildsWorkspaceWhoseInstalledPackagesWereReaped() throws IOException {
+        assumeTrue(PackageManagerExecutor.UV.find() != null, "uv is not installed");
+
+        String requirements = "six==1.16.0\n";
+        Path workspace = DependencyWorkspace.getOrCreateRequirementsWorkspace(requirements, null);
+        assumeTrue(workspace != null, "could not create workspace (uv install failed?)");
+
+        // Gut the venv the way a $TMPDIR reaper does: package files go, marker files stay.
+        Path sitePackages = requireNonNull(InstalledEnvParser.findSitePackages(workspace.resolve(".venv")));
+        Files.delete(sitePackages.resolve("six-1.16.0.dist-info").resolve("METADATA"));
+        DependencyWorkspace.clearCache();
+
+        Path rebuilt = DependencyWorkspace.getOrCreateRequirementsWorkspace(requirements, null);
+        assertThat(rebuilt).isNotNull();
+        assertThat(requireNonNull(InstalledEnvParser.findSitePackages(rebuilt.resolve(".venv")))
+                .resolve("six-1.16.0.dist-info").resolve("METADATA")).exists();
     }
 }

--- a/rewrite-python/src/test/java/org/openrewrite/python/DependencyWorkspaceTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/DependencyWorkspaceTest.java
@@ -51,14 +51,14 @@ class DependencyWorkspaceTest {
     }
 
     @Test
-    void rebuildsWorkspaceWhoseInstalledPackagesWereReaped() throws IOException {
+    void rebuildsWorkspaceWhoseInstalledPackagesWentMissing() throws IOException {
         assumeTrue(PackageManagerExecutor.UV.find() != null, "uv is not installed");
 
         String requirements = "six==1.16.0\n";
         Path workspace = DependencyWorkspace.getOrCreateRequirementsWorkspace(requirements, null);
         assumeTrue(workspace != null, "could not create workspace (uv install failed?)");
 
-        // Gut the venv the way a $TMPDIR reaper does: package files go, marker files stay.
+        // A venv emptied from outside the cache: package files go, marker files stay.
         Path sitePackages = requireNonNull(InstalledEnvParser.findSitePackages(workspace.resolve(".venv")));
         Files.delete(sitePackages.resolve("six-1.16.0.dist-info").resolve("METADATA"));
         DependencyWorkspace.clearCache();

--- a/rewrite-python/src/test/java/org/openrewrite/python/internal/InstalledEnvParserTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/internal/InstalledEnvParserTest.java
@@ -36,6 +36,24 @@ class InstalledEnvParserTest {
     }
 
     @Test
+    void envIsIntactOnlyWhileItsPackagesAreOnDisk(@TempDir Path env) throws IOException {
+        Path sitePackages = env.resolve("lib/python3.12/site-packages");
+        writeDistInfo(sitePackages, "a", "1.0.0", """
+          Metadata-Version: 2.4
+          Name: a
+          Version: 1.0.0
+          """);
+        assertThat(InstalledEnvParser.isIntact(env)).isTrue();
+
+        Path distInfo = sitePackages.resolve("a-1.0.0.dist-info");
+        Files.delete(distInfo.resolve("METADATA"));
+        assertThat(InstalledEnvParser.isIntact(env)).isFalse();
+
+        Files.delete(distInfo);
+        assertThat(InstalledEnvParser.isIntact(env)).isFalse();
+    }
+
+    @Test
     void linksTransitiveDependenciesDeeply(@TempDir Path env) throws IOException {
         Path sitePackages = env.resolve("lib/python3.12/site-packages");
         writeDistInfo(sitePackages, "a", "1.0.0", """


### PR DESCRIPTION
On macOS, `DependencyWorkspace` has been handing out Python workspaces that the `$TMPDIR` reaper had already emptied, while still reporting them valid. The package directories under site-packages are left holding none of the `.py` files ty reads for external types, so third-party type attribution degrades with a green suite either way. It surfaced as a dependency-count assertion: `RequirementsTxtParserTest > markerContainsDependenciesFromFreeze` fails for anyone running `:rewrite-python:test` locally with `uv` installed, and has for far longer than the branch it was spotted on.

```
assertThat(marker.getDependencies()).hasSize(1);
    Expected size: 1 but was: 5
    certifi, charset-normalizer, idna, requests, urllib3
```

Five roots instead of one means `linkDependenciesFromMetadata` found no `dist-info/METADATA` to read, so every package fell through the unlinked fallback in `dependenciesFromResolved`.

## What happened

`uv` installs by cloning from its own cache and preserves the wheel's timestamps. A workspace created minutes ago already holds files stamped months back:

```
atime                | mtime                | file
May 30 18:28:07 2026 | May 30 18:28:07 2026 | requests-2.34.2.dist-info/METADATA
May 30 18:28:07 2026 | May 30 18:28:07 2026 | requests/__init__.py
May 30 18:28:08 2026 | Sep  3 11:16:17 2026 | requests-2.34.2.dist-info/RECORD
```

macOS reaps the per-user `$TMPDIR` by access time on a three-day threshold, and `WORKSPACE_BASE` sat under `java.io.tmpdir`. The nightly run therefore takes every file uv cloned in and leaves the ones written fresh at install time — so a workspace is gutted the night it is created, however recently it was used.

In the workspace behind this failure, `requests/` was an empty directory and five of six `dist-info` dirs had no METADATA. Only `ty`'s survived — that wheel was genuinely a day old. Across the whole cache on that machine, 82 of 249 `dist-info` dirs still had a METADATA: two thirds of the cached workspaces were being served gutted.

## The fix

Installed venvs are expensive to rebuild and are meant to outlive a single run, so they move to `~/.rewrite/python-workspaces`, beside the existing `~/.rewrite` caches. Nothing reaps that, which removes the eviction rather than racing it. The `MAX_CACHE_SIZE` LRU already bounds the directory; at ~27 MB per workspace that is ~2.7 GB at the 100-workspace ceiling.

`InstalledEnvParser.isIntact` stays as a guard against a workspace emptied some other way: site-packages must still hold packages, each with the METADATA every wheel is required to write. Both validators consult it, so such a workspace is rebuilt instead of trusted.

## Why detection alone was not enough

Validating on METADATA is sound for the dependency graph and only partial for attribution, which is why the location had to change. `linkDependenciesFromMetadata` reads every package's METADATA on each parse, refreshing its access time, while ty reads only the bodies of modules a source actually imports. Measured over one parse of an intact workspace:

```
METADATA         atime 1767222000 -> 1788428736   (moved)
certifi/core.py  atime 1767222000                 (unchanged)
```

A regularly parsed workspace would therefore hold every METADATA fresh while unread package bodies aged out and were reaped — the check passing at exactly the moment attribution had nothing left to read. Because the reaper works file by file, no cheap presence check fixes this: a package keeps whatever ty happened to read and loses its siblings.

## Why CI stayed green

The test is gated on `assumeTrue(PackageManagerExecutor.UV.find() != null)` and CI has no `uv`. `DependencyWorkspaceTest` did already claim to simulate this reaper — but by deleting `freeze.txt` and `version.txt`, the two files it demonstrably leaves alone. A test that asserts the scenario is covered while modelling the wrong half of it is worse than no test, so its comment is corrected here. The new `InstalledEnvParserTest` case needs no `uv` and runs everywhere.

## Tests

`envIsIntactOnlyWhileItsPackagesAreOnDisk` pins the contract against a hand-built venv. `rebuildsWorkspaceWhoseInstalledPackagesWentMissing` pins the wiring: delete one METADATA from a real workspace and the next call rebuilds it. Both were mutation-checked — stubbing `isIntact` to `return true` fails both while the pre-existing tests stay green.

`:rewrite-python:test` is 1965 tests, 0 failures, 9 skipped (all pre-existing live/network tests).

## Scope

`rewrite-javascript`'s `DependencyWorkspace` still uses `java.io.tmpdir`, but does not inherit the timestamps that make the Python case fire on the first night: npm writes files at extraction time, so a JS workspace does not arrive already past the reaper's threshold. Left alone here.

That is the whole of the measured difference. All 41 JS workspaces on this machine are under a day old with no file past the threshold, so the data says nothing about how one ages — and the reaper works per file there too, so it would be unread modules that age out rather than whole workspaces.

Any before/after measurement of *third-party* symbol resolution taken on macOS before this PR may have been reading a gutted workspace.

