### PR TITLE
Python: upgrade ty-types to 0.0.78

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.71",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.78",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -499,8 +499,8 @@ class PythonTypeMapping:
         if qualified:
             return (qualified[len('builtins.'):]
                     if qualified.startswith('builtins.') else qualified)
-        # TODO drop this fallback once the floor is ty-types 0.0.72+, where every
-        # class-bearing descriptor carries `qualifiedName`.
+        # Not every descriptor kind carries `qualifiedName`: `function`, `boundMethod`
+        # and `knownInstance` never do, and a few instances and TypedDicts lack it too.
         name = descriptor.get(name_key) or ''
         if not name:
             return ''
@@ -1777,7 +1777,6 @@ class PythonTypeMapping:
         by its FQN. An unqualified name is scoped to this file so the same name in
         two modules stays apart; a ``qualifiedName`` is already unique, and scoping
         it would keep two files from sharing one interned type."""
-        # TODO drop with the `_class_fqn` fallback once the floor is ty-types 0.0.72+.
         return None if descriptor.get('qualifiedName') else f"{self._file_path}#{name}"
 
     def _create_class_type(self, fqn: str, shallow: bool = True,

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3816,14 +3816,13 @@ class FqnCase:
     """One row of the descriptor→FQN contract. ``source``'s last statement is a
     bare expression; the type attributed to it must be keyed by ``expected``.
     ``type_parameters``, when set, additionally pins the resolved generic
-    arguments. ``xfail`` names the reason the mapping does not yet honour the row.
+    arguments.
     """
     id: str
     kind: str
     source: str
     expected: str
     type_parameters: Optional[Tuple[object, ...]] = None
-    xfail: Optional[str] = None
 
 
 # The fully-qualified name each ty descriptor kind must map to. `test.py` is the
@@ -3939,7 +3938,6 @@ _FQN_CASES = (
             m
         ''',
         expected='test.Movie',
-        xfail='ty emits no module on typedDict, so the value maps to bare `Movie`',
     ),
     FqnCase(
         id='new_type',
@@ -3952,7 +3950,6 @@ _FQN_CASES = (
             u
         ''',
         expected='test.UserId',
-        xfail='ty emits no module on newType, so the value maps to bare `UserId`',
     ),
     FqnCase(
         id='nested_class_instance',
@@ -3966,7 +3963,6 @@ _FQN_CASES = (
             o
         ''',
         expected='test.Outer.Inner',
-        xfail='the FQN is built as moduleName + className, which drops the enclosing class',
     ),
 )
 
@@ -3981,8 +3977,7 @@ def _fqn(java_type) -> Optional[str]:
 
 
 def _fqn_params(case: FqnCase):
-    marks = [pytest.mark.xfail(reason=case.xfail, strict=True)] if case.xfail else []
-    return pytest.param(case, id=case.id, marks=marks)
+    return pytest.param(case, id=case.id)
 
 
 @requires_ty_types_cli
@@ -3991,8 +3986,6 @@ class TestDescriptorFqnContract:
     type table resolves only when its entries carry the FQNs attribution mints at
     parse time: an unqualified name fails to resolve and collides with its
     namesakes.
-
-    TODO drop every `xfail` in this class once the floor is ty-types 0.0.72+.
     """
 
     @pytest.mark.parametrize('case', [_fqn_params(c) for c in _FQN_CASES])
@@ -4008,9 +4001,6 @@ class TestDescriptorFqnContract:
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason='ty emits no module on typedDict, so both map to bare `Movie`')
     def test_same_named_typed_dicts_in_different_modules_stay_distinct(self):
         source = '''
             from typing import TypedDict
@@ -4044,9 +4034,9 @@ class TestDescriptorFqnContract:
 
 
 class TestQualifiedNameForwardCompatibility:
-    """The xfailed rows of the FQN contract, driven from descriptors that carry
-    ``qualifiedName``. Hand-built, since the pinned ty-types CLI does not emit the
-    field yet — these pin the behaviour the first release carrying it will trigger.
+    """Descriptor-level coverage of ``_class_fqn`` and the declaring-type path,
+    driven from hand-built descriptors so each shape is pinned independently of
+    what a given ty-types build emits.
     """
 
     @staticmethod
@@ -4062,7 +4052,6 @@ class TestQualifiedNameForwardCompatibility:
         })
         assert _fqn(result) == 'a.b.Outer.Inner'
 
-    # TODO drop with the `_class_fqn` fallback once the floor is ty-types 0.0.72+.
     def test_class_literal_falls_back_to_module_name(self):
         _, result = self._resolve({
             'kind': 'classLiteral', 'className': 'Inner', 'moduleName': 'a.b',

--- a/rewrite-python/rewrite/tests/python/test_type_interning.py
+++ b/rewrite-python/rewrite/tests/python/test_type_interning.py
@@ -159,11 +159,12 @@ def test_same_named_typed_dicts_in_two_modules_keep_their_own_fields(tmp_path):
     fields = {}
     for result in results:
         for java_type in _java_types(server.local_objects[result['id']]).values():
-            if getattr(java_type, 'fully_qualified_name', None) == 'Movie':
-                fields[result['sourcePath']] = sorted(
+            fqn = getattr(java_type, 'fully_qualified_name', None)
+            if fqn in ('a_mod.Movie', 'b_mod.Movie'):
+                fields[fqn] = sorted(
                     m.name for m in (getattr(java_type, '_members', None) or []))
 
-    assert fields == {'a_mod.py': ['name'], 'b_mod.py': ['director', 'year']}
+    assert fields == {'a_mod.Movie': ['name'], 'b_mod.Movie': ['director', 'year']}
 
 
 @requires_ty_types_cli


### PR DESCRIPTION
`ty-types` 0.0.78 emits `qualifiedName` on class-bearing descriptors, so `_class_fqn` stops composing `moduleName` + `className` and starts keying a class by its full path. Four `xfail(strict=True)` marks recording the composed form now XPASS, and `test_same_named_typed_dicts_in_two_modules_keep_their_own_fields` looks up a bare `Movie` that no longer exists — the suite goes red on a release, with no change to this repo. `pyproject.toml` said `ty-types>=0.0.71` with no upper bound and the Gradle build does `pip install -e ".[dev]"` into a fresh venv with no lockfile, so dependency resolution alone was enough to land it.

The FQN is what moved, measured over rewrite-python's own sources:

```
OLD rewrite.recipe._AccumulatorEditor
NEW rewrite.recipe.ScanningRecipe.<locals of function 'editor'>._AccumulatorEditor

OLD rewrite.java.tree.PaddingHelper
NEW rewrite.java.tree.ForLoop.Control.PaddingHelper
```

## Why this and not the fallback removal

`_class_fqn` carried `TODO drop this fallback once the floor is ty-types 0.0.72+, where every class-bearing descriptor carries qualifiedName`. Raising the floor past 0.0.72 appears to make that due; it does not. Descriptor counts over `pydantic` under 0.0.78:

| kind | descriptors | with `qualifiedName` |
|---|---|---|
| `classLiteral` | 846 | 846 |
| `instance` | 1704 | 1677 |
| `function` | 3504 | 0 |
| `boundMethod` | 634 | 0 |
| `knownInstance` | 68 | 0 |

So the fallback is load-bearing and stays. The three TODOs pointing at a 0.0.72 that never shipped are replaced by one note at `_class_fqn` saying which kinds reach it.

## Attribution

Every typed LST slot, old release against new, over two real projects:

| corpus | typed nodes | requalified | `Unknown` → resolved | resolved → `Unknown` |
|---|---|---|---|---|
| `rewrite-python/rewrite/src/rewrite` | 161,389 | 14,024 | 197 | 8 |
| `pydantic` | 122,581 | 89 | 11,812 | 49 |

The 8 losses are seven nodes of `cached.__class__ = JavaType.Class` and one `yield from`. No node lost a type slot. `UsesType`, `TypeNameMatcher` and the FQN trie all match the `<locals of function 'f'>` spelling; a recipe keyed on the old unqualified FQN silently stops matching, which is the change worth knowing about.

## Tests

No new tests. Four marks removed, and the interning assertion keyed by `a_mod.Movie` / `b_mod.Movie` rather than by source path, which pins the per-module field lists against the FQN a type table actually uses. The now-unused `FqnCase.xfail` field and its `_fqn_params` branch go with them.

`pytest tests/`: 2303 passed, 11 skipped, 0 xfailed. `./gradlew :rewrite-python:test`: green. Against 0.0.71 this branch is red with 4 failures — the interning test passes either way, since qualification is pinned by the table rows and by `test_same_named_typed_dicts_in_different_modules_stay_distinct`.

## Not in scope

`PythonTypeMappingFqnContractTest` in moderne-cli mirrors `TestDescriptorFqnContract` row for row and carries the same three stale rows as `isNotEqualTo` assertions, on the unmerged `sync-java-pythontypemapping-to-qualified-fqns` branch. It will fail the same way once that branch meets 0.0.78.

- ty-types side: openrewrite/ty-types#23 (submodule bump and per-file panic isolation) and #25 (binding fix, `qualifiedName` doc correction).
