### PR TITLE
Python: a symbol ty cannot type is named by where it is bound

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/ty_client.py
+++ b/rewrite-python/rewrite/src/rewrite/python/ty_client.py
@@ -370,7 +370,8 @@ class TyTypesClient:
         return False
 
     def get_types(self, file_path: str, timeout: float = 30,
-                  include_display: bool = False) -> Optional[Dict[str, Any]]:
+                  include_display: bool = False,
+                  include_bindings: bool = False) -> Optional[Dict[str, Any]]:
         """Get all node types for a Python file.
 
         Args:
@@ -379,12 +380,16 @@ class TyTypesClient:
                      Some files with recursive types can cause ty to hang.
             include_display: Whether to include display strings in type
                            descriptors (default False — uses structured data).
+            include_bindings: Whether each name and attribute reference carries the
+                           module and qualified name binding it. Costs roughly 10%
+                           inference time and 17% payload.
         """
         if not self._initialized:
             return None
         result = self._send_request(
             "getTypes",
-            {"file": file_path, "includeDisplay": include_display},
+            {"file": file_path, "includeDisplay": include_display,
+             "includeBindings": include_bindings},
             timeout=timeout,
         )
         if result:

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -217,12 +217,14 @@ class PythonTypeMapping:
         self._module_ast_tree: Optional[ast.Module] = None
         self._import_binding_index: Optional[Dict[str, str]] = None
         self._from_import_member_index: Optional[Dict[str, Tuple[str, str]]] = None
+        self._shadowed_names: Optional[Set[str]] = None
 
         # ty-types data: populated by _build_index
         self._node_index: Dict[Tuple[int, int], Tuple[int, str]] = {}  # (start, end) -> (type_id, node_kind)
         self._node_index_by_start: Dict[int, List[Tuple[int, int, str]]] = {}  # start -> [(end, type_id, node_kind)]
         self._type_registry: Dict[int, Dict[str, Any]] = {}  # type_id -> TypeDescriptor
         self._call_signature_index: Dict[Tuple[int, int], Dict[str, Any]] = {}  # (start, end) -> callSignature
+        self._binding_index: Dict[Tuple[int, int], Dict[str, str]] = {}  # (start, end) -> BindingInfo
         session_java_types = getattr(ty_client, 'java_types', None) or SessionTypeCache()
         self._type_cache: Dict[str, JavaType] = session_java_types.by_fqn
         self._type_id_cache: Dict[int, JavaType] = session_java_types.by_type_id
@@ -267,7 +269,7 @@ class PythonTypeMapping:
             return
 
         # Fetch all types in one call
-        result = client.get_types(actual_file)
+        result = client.get_types(actual_file, include_bindings=True)
         if result:
             self._build_index(result)
 
@@ -338,6 +340,10 @@ class PythonTypeMapping:
             call_sig = node.get('callSignature')
             if call_sig is not None:
                 self._call_signature_index[(node['start'], node['end'])] = call_sig
+
+            binding = node.get('binding')
+            if binding is not None:
+                self._binding_index[(node['start'], node['end'])] = binding
 
         # Merge types into registry (keys are strings in JSON)
         for type_id_str, descriptor in result.get('types', {}).items():
@@ -965,7 +971,7 @@ class PythonTypeMapping:
         annotation: the decorating function or class itself, under the module defining
         it — not the type applying it returns.
 
-        An unshadowed import binding names a decorator ty cannot type at all.
+        A decorator no descriptor names is named by where it is bound.
         """
         type_id = self._lookup_type_id(node)
         descriptor = self._type_registry.get(type_id) if type_id is not None else None
@@ -979,10 +985,47 @@ class PythonTypeMapping:
                     and not descriptor.get('className'):
                 return self._create_class_type(
                     f"{_ALIASED_MODULES.get(module, module)}.{name}")
-        fqn = self._import_binding_fqn(node)
+        bound = self._binding_owner(node)
+        fqn = (f"{_ALIASED_MODULES.get(bound[0], bound[0])}.{bound[1]}" if bound
+               else self._import_binding_fqn(node))
         if fqn:
             return self._create_class_type(fqn)
         return self.type(node)
+
+    def _binding_owner(self, node: ast.expr) -> Optional[Tuple[str, str]]:
+        """The ``(module, symbol)`` ty binds a reference to, following re-export chains to
+        where the symbol is declared. ty reports a scope's first declaration, so a name
+        the file binds a second time is not read from one.
+        """
+        if self._writes_a_rebound_name(node):
+            return None
+        binding = self._lookup_binding(node)
+        if binding is None:
+            return None
+        module, qualified = binding.get('definedIn'), binding.get('qualifiedName')
+        if not module or not qualified or not qualified.startswith(f"{module}."):
+            return None
+        symbol = qualified[len(module) + 1:]
+        # Only what the module itself declares. A deeper path is a class member, owned by
+        # that class rather than the module — `"".join` binds `builtins.str.join` — or is
+        # under a scope `qualifiedName` spells as ty does (`<locals of function 'f'>`).
+        return (module, symbol) if '.' not in symbol else None
+
+    def _writes_a_rebound_name(self, node: ast.expr) -> bool:
+        """Whether the name ``node`` is written under is one the file binds a second time."""
+        while isinstance(node, ast.Attribute):
+            node = node.value
+        self._import_bindings()
+        return isinstance(node, ast.Name) and node.id in (self._shadowed_names or ())
+
+    def _lookup_binding(self, node: ast.expr) -> Optional[Dict[str, str]]:
+        """The BindingInfo ty attached to ``node``, by byte range."""
+        end_lineno = getattr(node, 'end_lineno', None)
+        end_col_offset = getattr(node, 'end_col_offset', None)
+        if getattr(node, 'lineno', None) is None or end_lineno is None or end_col_offset is None:
+            return None
+        return self._binding_index.get(
+            (self._decorated_start(node), self._pos_to_byte_offset(end_lineno, end_col_offset)))
 
     def _import_binding_fqn(self, node: ast.expr) -> Optional[str]:
         """The FQN an unshadowed module-level import gives ``node``'s written name."""
@@ -997,21 +1040,20 @@ class PythonTypeMapping:
 
     def _import_bindings(self) -> Dict[str, str]:
         """The FQN each of this file's absolute module-level imports names, keyed by the
-        name it binds, minus every name the file binds a second time. The same scan
+        name it binds, minus every name :meth:`_rebound_names` reports. The same scan
         yields the ``from M import f`` bindings that :meth:`_bound_from_import_member` reads.
 
         Python binds a name once per scope, so an import nothing else rebinds says what a
-        reference to that name means whether or not ty could type it. Anything that could
-        rebind — an assignment, a ``def``, a parameter, a second import — disqualifies the
-        name rather than being scoped precisely, since a decorator naming a shadowed
-        symbol is not worth a false attribution.
+        reference to that name means whether or not ty could type it.
         """
         if self._import_binding_index is None:
             tree = self._module_ast()
             bindings: Dict[str, str] = {}
             members: Dict[str, Tuple[str, str]] = {}
-            shadowed: Set[str] = set()
-            top_level = set()
+            top_level = {id(alias) for stmt in (tree.body if tree else ())
+                         if isinstance(stmt, (ast.Import, ast.ImportFrom))
+                         for alias in stmt.names}
+            shadowed = self._rebound_names(tree, top_level)
 
             def bind(name: str, fqn: Optional[str]) -> None:
                 # `import a.b` after `import a` re-binds the root to the same FQN
@@ -1022,7 +1064,6 @@ class PythonTypeMapping:
 
             for stmt in tree.body if tree else ():
                 if isinstance(stmt, (ast.Import, ast.ImportFrom)):
-                    top_level.update(id(alias) for alias in stmt.names)
                     # A relative import's written form is not a module path
                     relative = isinstance(stmt, ast.ImportFrom) and (stmt.level or not stmt.module)
                     for alias in stmt.names:
@@ -1041,26 +1082,35 @@ class PythonTypeMapping:
                             bind(alias.asname or alias.name, f"{stmt.module}.{alias.name}")
                             members[alias.asname or alias.name] = (stmt.module, alias.name)
 
-            for node in ast.walk(tree) if tree else ():
-                if isinstance(node, ast.Name):
-                    if isinstance(node.ctx, (ast.Store, ast.Del)):
-                        shadowed.add(node.id)
-                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-                    shadowed.add(node.name)
-                elif isinstance(node, ast.arg):
-                    shadowed.add(node.arg)
-                elif isinstance(node, ast.ExceptHandler) and node.name:
-                    shadowed.add(node.name)
-                elif isinstance(node, (ast.Global, ast.Nonlocal)):
-                    shadowed.update(node.names)
-                elif isinstance(node, ast.alias) and id(node) not in top_level:
-                    shadowed.add(node.asname or node.name.split('.')[0])
-
             self._import_binding_index = {name: fqn for name, fqn in bindings.items()
                                           if name not in shadowed}
             self._from_import_member_index = {name: member for name, member in members.items()
                                               if name not in shadowed}
         return self._import_binding_index
+
+    def _rebound_names(self, tree: Optional[ast.Module], top_level: Set[int]) -> Set[str]:
+        """Every name this file binds somewhere other than one of its own top-level
+        imports. Coarse on purpose: a name bound twice is one whose references cannot be
+        read off an import, and declining to attribute costs less than attributing wrong.
+        """
+        if self._shadowed_names is None:
+            names: Set[str] = set()
+            for node in ast.walk(tree) if tree else ():
+                if isinstance(node, ast.Name):
+                    if isinstance(node.ctx, (ast.Store, ast.Del)):
+                        names.add(node.id)
+                elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                    names.add(node.name)
+                elif isinstance(node, ast.arg):
+                    names.add(node.arg)
+                elif isinstance(node, ast.ExceptHandler) and node.name:
+                    names.add(node.name)
+                elif isinstance(node, (ast.Global, ast.Nonlocal)):
+                    names.update(node.names)
+                elif isinstance(node, ast.alias) and id(node) not in top_level:
+                    names.add(node.asname or node.name.split('.')[0])
+            self._shadowed_names = names
+        return set(self._shadowed_names)
 
     def _bound_from_import_member(self, node: ast.expr) -> Optional[Tuple[str, str]]:
         """The ``(module, member)`` an unshadowed module-level ``from M import f`` binds
@@ -1328,7 +1378,8 @@ class PythonTypeMapping:
         callee = self._type_registry.get(callee_id) if callee_id is not None else None
         if callee is not None and callee.get('kind') in _FUNCTION_KINDS:
             return callee.get('name') or None
-        return None
+        bound = self._binding_owner(node.func)
+        return bound[1] if bound else None
 
     def _extract_method_name(self, node: ast.Call) -> Optional[str]:
         """The name a Call node spells."""
@@ -1487,6 +1538,10 @@ class PythonTypeMapping:
                 module_name = callee.get('moduleName')
                 if module_name:
                     return self._module_class(module_name)
+
+        bound = self._binding_owner(node.func)
+        if bound:
+            return self._module_class(bound[0])
 
         if isinstance(node.func, ast.Attribute):
             receiver = node.func.value

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3745,12 +3745,20 @@ class TestSymbolIdentityAcrossImportForms:
     def test_a_platform_module_is_named_by_its_portable_alias(self):
         self._assert_names('from posixpath import join\njoin("a", "b")\n', 'os.path', 'join')
 
-    def test_an_attribute_of_a_reexporting_module_names_the_definition(self):
+    @pytest.mark.parametrize('member', [
+        'def bar():\n    return 1\n',
+        'def factory():\n    def d():\n        return 1\n    return d\n\n\nbar = factory()\n',
+    ], ids=['typed', 'untyped'])
+    @pytest.mark.parametrize('source', [
+        'import pkg.api\npkg.api.baz()\n',
+        'from pkg.api import baz\nbaz()\n',
+    ], ids=['as-attribute', 'through-facade'])
+    def test_a_reexported_module_member_names_the_definition(self, member, source):
         cu, tmpdir, client = _parse_with_types({
             'pkg/__init__.py': '',
-            'pkg/_impl.py': 'def bar():\n    return 1\n',
+            'pkg/_impl.py': member,
             'pkg/api.py': 'from pkg._impl import bar as baz\n',
-            'm.py': 'import pkg.api\npkg.api.baz()\n',
+            'm.py': source,
         })
         try:
             method_type = cu.statements[1].method_type
@@ -4351,9 +4359,11 @@ class TestDecoratorAttribution:
         self._assert_named_in_package(
             'from pkg.api import tag\n\n@tag\ndef f():\n    pass\n', 'pkg._impl.tag')
 
-    def test_a_package_and_its_submodule_bind_the_same_root(self):
-        """`import pkg` then `import pkg.api` binds `pkg` once, so the written path
-        still names a decorator ty cannot type."""
+    def test_an_untyped_decorator_names_the_module_defining_it(self):
         self._assert_named_in_package(
             'import pkg\nimport pkg.api\n\n@pkg.api.require\ndef f():\n    pass\n',
-            'pkg.api.require')
+            'pkg._impl.require')
+
+        # A star import spells no name at all, so only the binding can name what it binds.
+        self._assert_named_in_package(
+            'from pkg.api import *\n\n@require\ndef f():\n    pass\n', 'pkg._impl.require')


### PR DESCRIPTION
- #8756 gave every Python function the identity `(defining module, name)`, so one `MethodMatcher` pattern matches whatever import form a file wrote. It could only reach symbols ty types. Where ty has no type — anything an untyped decorator or factory produced — the descriptor carries no `moduleName`, and the owner fell back to the receiver's written path: the facade module, the candidate #8756 rejects by name as "computable, unstable".

`networkx` is the shape, since nearly every public function is `@nx._dispatchable`-decorated and ty types none of them:

| written | owner before | owner after |
|---|---|---|
| `nx.complete_graph(n)` | `networkx` | `networkx.generators.classic` |
| `nx.average_degree_connectivity(G)` | `networkx` | `networkx.algorithms.assortativity.connectivity` |
| `getattr(x, "y")` in pydantic | *unattributed* | `builtins` |
| `from pkg.api import baz; baz()` | `pkg.api` | `pkg._impl` |

512 of 107820 typed LST slots move across networkx, pydantic, _pytest, click and joblib. Nothing regresses: every changed slot is either an unattributed call gaining an owner or a facade becoming the defining module.

## Where the answer comes from

ty-types 0.0.78 added `includeBindings`: each `ExprName` and `ExprAttribute` carries `{"definedIn", "qualifiedName"}`, following re-export chains. A binding exists in cases a *type* does not, which is exactly the hole.

Two properties shape how it is read. `qualifiedName` cannot be split on `.` — a function-local binding reads `app.<locals of function 'f'>.x` — so `definedIn` says where the module part ends. And a binding names a scope's *first* declaration, not a flow-sensitive one:

```
from deco import wrap; wrap = None; @wrap   ->  deco.wrap   (the type there is NoneType)
import deco; deco = None; @deco.wrap        ->  deco.wrap
```

So a binding is read only for a name the file binds once. `_rebound_names` splits out of `_import_bindings` to answer that, which also stops a `*` import costing a file its shadow set.

## Why a module-level symbol only

A method belongs to its class, and its binding says so: `"".join` binds `builtins.str.join`. Taking only a single-segment symbol leaves every class member to the receiver, which already resolves it, and drops the scopes `qualifiedName` spells for itself.

## What the AST scan still does

`_import_bindings` stays for the other half. A symbol nothing declares has no definition site to point at, so `from lib import gone; gone()` gets no binding and `_bound_from_import_member` still names it from the import.

## Cost

`includeBindings` is on for every parse: +10.1% inference time and +21.5% payload over 40 pydantic files, matching ty-types' documented ~10%/17%.

## Tests

`test_a_reexported_module_member_names_the_definition` pins one identity across both spellings for a typed and an untyped re-export; the untyped rows fail without the binding. `test_an_untyped_decorator_names_the_module_defining_it` covers the decorator position and a `*` import. `test_rebound_name_is_not_attributed_from_its_import` fails without `_rebound_names`. All mutation-checked.

## One deliberate consequence

- `ctypes.POINTER` now reads `_ctypes POINTER(..)`, since `ctypes` re-exports it from the C extension. This is the `posixpath`/`os.path` trade #8756 already made and documented; `_ctypes` is stable across platforms, so unlike the `os.path` trio it earns no `_ALIASED_MODULES` entry.

moderne-cli's mirrored Java `PythonTypeMapping` needs the same handling to stay in sync.
