### PR TITLE
Python: an import in a module-scope `if` binds at module scope

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -29,7 +29,7 @@ import os
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Set, Tuple
 
 from ..java import JavaType
 
@@ -118,6 +118,19 @@ _KNOWN_INSTANCE_FQNS: Dict[str, str] = {
     'FunctoolsPartial': 'functools.partial',
     'FunctoolsPartialCall': 'functools.partial',
 }
+
+
+def _module_scope_statements(body: Sequence[ast.stmt]) -> Iterator[ast.stmt]:
+    """``body`` plus the statements an `if` with no `else` nests, since those bind into
+    the scope around it.
+
+    `import_utils.unconditional_body` is the same rule over the LST, for `RemoveImport`;
+    attribution runs during parse, where only `ast` exists. Keep the two in step.
+    """
+    for stmt in body:
+        yield stmt
+        if isinstance(stmt, ast.If) and not stmt.orelse:
+            yield from _module_scope_statements(stmt.body)
 
 
 def _module_all_names(tree: ast.Module) -> Optional[Set[str]]:
@@ -1050,10 +1063,11 @@ class PythonTypeMapping:
             tree = self._module_ast()
             bindings: Dict[str, str] = {}
             members: Dict[str, Tuple[str, str]] = {}
-            top_level = {id(alias) for stmt in (tree.body if tree else ())
-                         if isinstance(stmt, (ast.Import, ast.ImportFrom))
-                         for alias in stmt.names}
-            shadowed = self._rebound_names(tree, top_level)
+            module_scope = list(_module_scope_statements(tree.body if tree else ()))
+            module_level_aliases = {id(alias) for stmt in module_scope
+                                    if isinstance(stmt, (ast.Import, ast.ImportFrom))
+                                    for alias in stmt.names}
+            shadowed = self._rebound_names(tree, module_level_aliases)
 
             def bind(name: str, fqn: Optional[str]) -> None:
                 # `import a.b` after `import a` re-binds the root to the same FQN
@@ -1062,7 +1076,7 @@ class PythonTypeMapping:
                 else:
                     bindings[name] = fqn
 
-            for stmt in tree.body if tree else ():
+            for stmt in module_scope:
                 if isinstance(stmt, (ast.Import, ast.ImportFrom)):
                     # A relative import's written form is not a module path
                     relative = isinstance(stmt, ast.ImportFrom) and (stmt.level or not stmt.module)
@@ -1088,8 +1102,9 @@ class PythonTypeMapping:
                                               if name not in shadowed}
         return self._import_binding_index
 
-    def _rebound_names(self, tree: Optional[ast.Module], top_level: Set[int]) -> Set[str]:
-        """Every name this file binds somewhere other than one of its own top-level
+    def _rebound_names(self, tree: Optional[ast.Module],
+                       module_level_aliases: Set[int]) -> Set[str]:
+        """Every name this file binds somewhere other than one of its own module-level
         imports. Coarse on purpose: a name bound twice is one whose references cannot be
         read off an import, and declining to attribute costs less than attributing wrong.
         """
@@ -1107,7 +1122,7 @@ class PythonTypeMapping:
                     names.add(node.name)
                 elif isinstance(node, (ast.Global, ast.Nonlocal)):
                     names.update(node.names)
-                elif isinstance(node, ast.alias) and id(node) not in top_level:
+                elif isinstance(node, ast.alias) and id(node) not in module_level_aliases:
                     names.add(node.asname or node.name.split('.')[0])
             self._shadowed_names = names
         return set(self._shadowed_names)

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -3800,6 +3800,25 @@ class TestSymbolTheStubsDoNotDeclare:
         owner, _ = self._call_names('def g():\n    from lib import gone\ngone()\n')
         assert owner is None, 'a function-scope import binds only inside that function'
 
+    @pytest.mark.parametrize('source', [
+        'import sys\nif sys.version_info < (3, 11):\n    from lib import gone\ngone()\n',
+        'import sys\nif sys.platform == "linux":\n    if sys.version_info < (3, 11):\n'
+        '        from lib import gone\ngone()\n',
+    ], ids=['guarded', 'nested-guards'])
+    def test_an_import_under_an_unconditional_if_binds_at_module_scope(self, source):
+        assert self._call_names(source, -1) == ('lib', 'gone')
+
+    def test_an_import_with_an_else_branch_is_not_attributed(self):
+        owner, _ = self._call_names(
+            'import sys\nif sys.version_info < (3, 11):\n    from lib import gone\n'
+            'else:\n    from lib import present\ngone()\n', -1)
+        assert owner is None, 'the branches are alternatives, so neither one binds'
+
+    def test_an_import_in_a_try_is_not_attributed(self):
+        owner, _ = self._call_names(
+            'try:\n    from lib import gone\nexcept ImportError:\n    pass\ngone()\n', -1)
+        assert owner is None, 'a `try` body is not one of the scopes this reads'
+
     def test_a_receiver_names_the_module_its_import_binds(self):
         cu, tmpdir, client = _parse_with_types(
             {'m.py': 'import nosuchmod\nimport nosuch.pkg as np\n'


### PR DESCRIPTION
A call to a removed API gets no declaring type when the import binding it sits inside a module-scope `if` — the shape a codebase mid-migration actually writes:

```python
if sys.version_info < (3, 11):
    from gettext import lgettext
```

Measured on `gettext.lgettext`, which 3.14's typeshed does not declare. Position is not the problem: ty resolves a live symbol from every one of these.

| | live symbol | removed symbol |
|---|---|---|
| module scope | owner ✓ | owner ✓ |
| star import | owner ✓ | owner ✓ |
| aliased | owner ✓ | owner ✓ |
| if-guarded | owner ✓ | owner ✗ |
| function-local | owner ✓ | owner ✗ |
| try/except | owner ✓ | owner ✗ |

## The mechanism

A symbol ty cannot type is attributed from the file's own import bindings instead. `_import_bindings` indexed `tree.body` only, so a nested alias never entered the index; `_rebound_names` then added every alias outside that index to the shadowed set, so the name was actively excluded rather than merely absent. That exclusion is deliberate — a name bound twice cannot be read off an import — and right for a function-local or `else`-guarded import.

## The fix

`_module_scope_statements` walks a module body plus the bodies of `if`s with no `else` or `elif`: those bind into the enclosing scope, and nothing else binds them. Only that shape widens.

- The LST layer already encodes the same rule as `import_utils.unconditional_body` (#8739), which `RemoveImport` and `PythonRemoveImportVisitor` read. Attribution runs during parse, before any LST or `Cursor` exists, so the rule is now stated in two layers — over `ast` here, over `J.If` there. That is the parser-layer boundary #8758 ran into; the new helper's docstring points at its LST twin so the next person changing either finds the other.

The two other failing rows keep failing, and need no new predicate. A `try`'s handler can bind the name to a shim (`gone = None`), a genuine second binding `_rebound_names` already excludes on its own merits. A function-local import is scoped, and a module-level reference is not that binding.

## Tests

- The new rows go in `TestSymbolTheStubsDoNotDeclare`, which calls a symbol its fixture module does not define. A fixture using a symbol the typeshed still declares passes whether or not the binding path was reached — the confound behind the wrong conclusions on #8759.

`test_an_import_under_an_unconditional_if_binds_at_module_scope` covers one guard and nested guards; `..._with_an_else_branch_...` and `..._in_a_try_...` pin the declines. Each mutation-checked against the line it claims: dropping the `orelse` guard fails the `else` test, widening the helper to `ast.Try` fails the `try` test, and dropping its recursion fails the nested row.

## Downstream

In `moderneinc/rewrite-migrate-python` this is necessary but not sufficient. Run against the same guarded fixture per recipe, on this branch:

- `FindSslMatchHostname` and `FindLocaleGetdefaultlocale` act on it. The first gates on `_is_ssl_method(...)` before `member_called(...)`; the second is a bare `MethodMatcher.create("locale getdefaultlocale(..)")`. Both read the declaring type directly.
- `gettext lgettext`, `locale resetlocale` and `platform popen` still decline. They reach the receiver-less form only through `FromImports.member_called`, whose index is built from `cu.statements` — top-level only, exactly as this one was.

That helper's docstring gives the limit `try`/`except`'s reasoning, applied to the unconditional `if` too: the same conflation, one layer down. It widens separately, after this merges.

Full downstream suite on this branch: 668 passed, no test changed outcome in either direction.

