### PR TITLE
Fix the Python RPC facade's ref-table asymmetries

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
@@ -12,10 +12,13 @@ from rewrite.rpc.child_connection import ChildConnection, child_command
 
 
 class BundleChildren:
-    def __init__(self, python_executable, venvs_root, upstream, *, spawn=None, venv_ops=None):
+    def __init__(self, python_executable, venvs_root, upstream, *, spawn=None, venv_ops=None,
+                 on_child_replaced=None):
         self._python = python_executable
         self._venvs_root = Path(venvs_root)
         self._upstream = upstream
+        # A fresh child starts with empty ref maps, so whatever mirrors the old one has to go.
+        self._on_child_replaced = on_child_replaced or (lambda bundle_dist: None)
         self._spawn = spawn or ChildConnection.spawn
         self._venv_ops = venv_ops or venv_manager
         self._children = {}     # bundle_dist -> child connection
@@ -67,6 +70,7 @@ class BundleChildren:
             stale = self._children.pop(bundle_dist, None)
             if stale is not None:
                 stale.close()
+            self._on_child_replaced(bundle_dist)
             self._venv_ops.create_venv(self._python, venv_dir, clear=venv_dir.exists())
         self._venv_ops.install_into_venv(venv_dir, spec, force=force)
         self._versions[bundle_dist] = self._venv_ops.installed_version(venv_dir, bundle_dist)

--- a/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/bundle_children.py
@@ -50,6 +50,10 @@ class BundleChildren:
         for child in self._children.values():
             child.request("Evict", params)
 
+    def broadcast_reset(self, params: dict) -> None:
+        for child in self._children.values():
+            child.request("Reset", params)
+
     def install(self, bundle_dist: str, spec: str, force: bool = False, attribution_name=None):
         """Create/reuse the bundle's venv, install ``spec``, spawn its child, cache its recipes.
 

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -127,6 +127,8 @@ class Facade:
             if (self._hub_pull is not None and tree_id is not None and
                     any(r.get("modified") for r in sub_results)):
                 self._hub_pull(self._children, owner, tree_id, source_file_type)
+            if any(r.get("deleted") for r in sub_results):
+                break
         return {"results": results}
 
     def evict(self, params: dict) -> bool:

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -133,6 +133,10 @@ class Facade:
         self._children.broadcast_evict(params)
         return True
 
+    def reset(self, params: dict) -> bool:
+        self._children.broadcast_reset(params)
+        return True
+
     def set_data_table_store(self, params: dict) -> bool:
         self._children.set_data_table_store(params)
         return True

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1136,6 +1136,8 @@ def handle_reset(params: dict) -> bool:
     _hub_recv_refs.clear()
     _hub_send_checkpoint.clear()
     _hub_recv_checkpoint.clear()
+    # A half-drained page would resume mid-list for a host that expects to start over.
+    _dependency_types_pending.clear()
 
     logger.info("Reset: cleared all cached state")
     return True

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -2436,7 +2436,9 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
         return [d for d in remaining.pop(0) if d.get('state') != 'END_OF_OBJECT']
 
     edited = RpcReceiveQueue(refs, source_file_type, pull).receive(served, None)
-    if edited is not None:
+    if edited is None:
+        _hub_forget(obj_id)
+    else:
         _hub_tree[obj_id] = edited
         _hub_served[(bundle, obj_id)] = edited
         local_objects[obj_id] = edited
@@ -2444,14 +2446,31 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
             local_objects[str(edited.id)] = edited
 
 
+def _hub_drop_bundle(bundle: str) -> None:
+    """Forget everything the hub holds on one bundle's behalf, for when its child is replaced."""
+    _hub_send_refs.pop(bundle, None)
+    _hub_recv_refs.pop(bundle, None)
+    for table in (_hub_served, _hub_send_checkpoint, _hub_recv_checkpoint):
+        for key in [k for k in table if k[0] == bundle]:
+            del table[key]
+
+
+def _hub_forget(obj_id: str) -> None:
+    """Let go of a file while leaving every child's ref numbering where it stands. This is the half
+    of _hub_release that is safe without an Evict: a child that has not been told to roll back still
+    holds this file's refs, and dropping ours would strand the ones it goes on to cite."""
+    _hub_tree.pop(obj_id, None)
+    local_objects.pop(obj_id, None)
+    for key in [k for k in _hub_served if k[1] == obj_id]:
+        del _hub_served[key]
+
+
 def _hub_release(obj_id: str) -> None:
     """The rollback must be symmetric with the child's own Evict, in both directions: the child drops
     this file's refs from both of its maps, so a ref kept here would name an id the child no longer
     holds ("Received reference to unknown object").
     """
-    _hub_tree.pop(obj_id, None)
-    for key in [k for k in _hub_served if k[1] == obj_id]:
-        del _hub_served[key]
+    _hub_forget(obj_id)
     for key in [k for k in _hub_send_checkpoint if k[1] == obj_id]:
         checkpoint = _hub_send_checkpoint.pop(key)
         refs = _hub_send_refs.get(key[0])
@@ -2495,7 +2514,7 @@ def _hub_local_visit(visitor_items: List[dict], params: dict) -> List[dict]:
             'searchResultIds': [],
         })
         if after is None:
-            _hub_release(tree_id)
+            _hub_forget(tree_id)
             tree = None
             break
         tree = after
@@ -2540,7 +2559,9 @@ def _get_facade():
         if removed:
             logger.info("Cleared %d pre-venv recipe artifact(s) from %s: %s",
                         len(removed), _recipe_install_dir, ", ".join(removed))
-        _facade = Facade(BundleChildren(sys.executable, _recipe_install_dir, upstream=_serve_child_object),
+        _facade = Facade(BundleChildren(sys.executable, _recipe_install_dir,
+                                        upstream=_serve_child_object,
+                                        on_child_replaced=_hub_drop_bundle),
                          hub_pull=_hub_pull_child_edit,
                          local_visit=_hub_local_visit,
                          is_local_visitor=_hub_is_builtin_visitor)

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -77,6 +77,14 @@ local_refs = ReferenceMap()
 _ref_checkpoints: Dict[str, int] = {}
 _local_ref_checkpoints: Dict[str, int] = {}
 
+
+def _checkpoint_refs(tree_id: str) -> None:
+    """Snapshot both directions' ref high-water before any of a file's data moves, so
+    handle_evict rolls back exactly what that file introduced (first sight of the file wins)."""
+    _ref_checkpoints.setdefault(tree_id, max(remote_refs.keys(), default=-1))
+    _local_ref_checkpoints.setdefault(tree_id, local_refs.snapshot())
+
+
 # Per-call metrics CSV (--metrics-csv), same schema as Go: cache-size ramp vs per-file-Evict sawtooth.
 _metrics_file = None
 _metrics_writer = None
@@ -2079,10 +2087,7 @@ def handle_visit(params: dict) -> dict:
 
     ctx = _context_for(p_id)
 
-    # Snapshot both directions' ref high-water for this file before fetching its tree
-    # (first visit wins).
-    _ref_checkpoints.setdefault(tree_id, max(remote_refs.keys(), default=-1))
-    _local_ref_checkpoints.setdefault(tree_id, local_refs.snapshot())
+    _checkpoint_refs(tree_id)
 
     # Always fetch the tree from Java to ensure we have the latest version.
     # Java may have modified the tree (e.g., via a Java-side recipe) since our last sync.
@@ -2139,9 +2144,7 @@ def handle_batch_visit(params: dict) -> dict:
 
     ctx = _context_for(p_id)
 
-    # Snapshot both directions' ref high-water for this file before fetching its tree.
-    _ref_checkpoints.setdefault(tree_id, max(remote_refs.keys(), default=-1))
-    _local_ref_checkpoints.setdefault(tree_id, local_refs.snapshot())
+    _checkpoint_refs(tree_id)
 
     # Fetch tree once from Java
     tree = get_object_from_java(tree_id, source_file_type)
@@ -2363,14 +2366,19 @@ def handle_generate(params: dict) -> dict:
 # child's stream directly to a sibling is unsafe.
 _hub_tree: Dict[str, Any] = {}              # obj_id -> the facade's authoritative tree
 _hub_send_refs: Dict[str, ReferenceMap] = {}  # bundle -> send ref map      (facade -> child)
+_hub_recv_refs: Dict[str, Dict[int, Any]] = {}  # bundle -> receive ref map (child -> facade)
 _hub_served: Dict[tuple, Any] = {}          # (bundle, obj_id) -> what that child was last served
 _hub_send_checkpoint: Dict[tuple, int] = {}  # (bundle, obj_id) -> send ref counter before this file
+_hub_recv_checkpoint: Dict[tuple, int] = {}  # (bundle, obj_id) -> highest received ref before this file
 
 def _hub_acquire(obj_id: str, source_file_type: Optional[str]):
     """The facade's copy of the in-flight tree, fetched from Java (over the facade<->Java table) the
     first time it is needed and owned by the facade from then on."""
     if obj_id is None:
         return None
+    # The facade routes Visit and BatchVisit past handle_visit, so this is the only place
+    # it sees a file early enough to checkpoint the facade<->Java tables.
+    _checkpoint_refs(obj_id)
     tree = _hub_tree.get(obj_id)
     if tree is None:
         tree = get_object_from_java(obj_id, source_file_type)
@@ -2407,6 +2415,10 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
     from rewrite.rpc.receive_queue import RpcReceiveQueue
 
     served = _hub_served.get((bundle, obj_id))
+    # The child's send map spans its connection, so a bundle pulled twice — a BatchVisit whose
+    # owners alternate, or a later file — cites on the second pull a ref it ADDed on the first.
+    refs = _hub_recv_refs.setdefault(bundle, {})
+    _hub_recv_checkpoint.setdefault((bundle, obj_id), max(refs, default=-1))
     remaining = [children.request(bundle, 'GetObject',
                                   {'id': obj_id, 'sourceFileType': source_file_type})]
 
@@ -2415,7 +2427,7 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
             return []
         return [d for d in remaining.pop(0) if d.get('state') != 'END_OF_OBJECT']
 
-    edited = RpcReceiveQueue({}, source_file_type, pull).receive(served, None)
+    edited = RpcReceiveQueue(refs, source_file_type, pull).receive(served, None)
     if edited is not None:
         _hub_tree[obj_id] = edited
         _hub_served[(bundle, obj_id)] = edited
@@ -2425,9 +2437,9 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
 
 
 def _hub_release(obj_id: str) -> None:
-    """The rollback must be symmetric with the child's own Evict: the child drops the refs this file
-    introduced from its receive map, so if the facade kept them in its send map it would emit a
-    GET_REF for a ref the child no longer has ("Received reference to unknown object").
+    """The rollback must be symmetric with the child's own Evict, in both directions: the child drops
+    this file's refs from both of its maps, so a ref kept here would name an id the child no longer
+    holds ("Received reference to unknown object").
     """
     _hub_tree.pop(obj_id, None)
     for key in [k for k in _hub_served if k[1] == obj_id]:
@@ -2437,6 +2449,12 @@ def _hub_release(obj_id: str) -> None:
         refs = _hub_send_refs.get(key[0])
         if refs is not None:
             refs.rollback_to(checkpoint)
+    for key in [k for k in _hub_recv_checkpoint if k[1] == obj_id]:
+        checkpoint = _hub_recv_checkpoint.pop(key)
+        refs = _hub_recv_refs.get(key[0])
+        if refs is not None:
+            for ref_id in [r for r in refs if r > checkpoint]:
+                del refs[ref_id]
 
 
 def _hub_is_builtin_visitor(visitor_name: Optional[str]) -> bool:

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -1130,6 +1130,12 @@ def handle_reset(params: dict) -> bool:
     _ref_checkpoints.clear()
     _local_ref_checkpoints.clear()
     local_refs.clear()
+    _hub_tree.clear()
+    _hub_served.clear()
+    _hub_send_refs.clear()
+    _hub_recv_refs.clear()
+    _hub_send_checkpoint.clear()
+    _hub_recv_checkpoint.clear()
 
     logger.info("Reset: cleared all cached state")
     return True
@@ -2548,6 +2554,9 @@ def handle_request(method: str, params: dict) -> Any:
             facade.evict(params)
             _hub_release(params.get('id'))
             return handle_evict(params)
+        if method == 'Reset':
+            facade.reset(params)
+            return handle_reset(params)
         facade_handlers = {
             'InstallRecipes': facade.install_recipes,
             'GetMarketplace': facade.get_marketplace,

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -413,7 +413,8 @@ def _print_python(cu) -> str:
 def _isolated_hub(monkeypatch, server):
     """Fresh hub state so this test neither sees nor leaves module-global tables."""
     for name in ("_hub_tree", "_hub_served", "_hub_send_refs", "_hub_recv_refs",
-                 "_hub_send_checkpoint", "_hub_recv_checkpoint", "local_objects"):
+                 "_hub_send_checkpoint", "_hub_recv_checkpoint", "local_objects",
+                 "_ref_checkpoints", "_local_ref_checkpoints"):
         monkeypatch.setattr(server, name, {})
 
 
@@ -601,11 +602,9 @@ def test_facade_visit_checkpoints_its_own_ref_tables_so_evict_rolls_them_back(mo
     monkeypatch.setattr(server, "_child_bundle", None)
     monkeypatch.setattr(server, "_facade", _RefGrowingFacade())
 
+    _isolated_hub(monkeypatch, server)
     monkeypatch.setattr(server, "local_refs", ReferenceMap())
     monkeypatch.setattr(server, "remote_refs", {})
-    monkeypatch.setattr(server, "_ref_checkpoints", {})
-    monkeypatch.setattr(server, "_local_ref_checkpoints", {})
-    monkeypatch.setattr(server, "_hub_tree", {})
 
     # an earlier file's refs, which this file's eviction must leave alone
     kept = object()

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -301,12 +301,15 @@ def test_hub_release_rolls_each_childs_ref_table_back_in_lockstep():
 
     server._hub_tree["T"] = object()
     server._hub_served[("A", "T")] = object()
-    # child A had 2 refs before this file, then the file introduced refs 3 and 4
+    # child A had 2 refs in each direction before this file, then the file introduced 3 and 4
     refs = server._hub_send_refs["A"] = ReferenceMap()
     survivors = [object(), object()]
     for obj in survivors + [object(), object()]:
         refs.create(obj)
     server._hub_send_checkpoint[("A", "T")] = 2
+    recv = server._hub_recv_refs["A"] = {i: object() for i in range(1, 5)}
+    kept = {i: recv[i] for i in (1, 2)}
+    server._hub_recv_checkpoint[("A", "T")] = 2
 
     server._hub_release("T")
 
@@ -314,9 +317,11 @@ def test_hub_release_rolls_each_childs_ref_table_back_in_lockstep():
     assert [refs.get(obj) for obj in survivors] == [1, 2]
     assert len(refs) == 2
     assert refs.snapshot() == 2                     # counter rewound so the next file re-ADDs
+    assert recv == kept
     assert "T" not in server._hub_tree
     assert ("A", "T") not in server._hub_served
     assert ("A", "T") not in server._hub_send_checkpoint
+    assert ("A", "T") not in server._hub_recv_checkpoint
 
 
 class _PreconditionChildren(_FakeChildren):
@@ -407,8 +412,8 @@ def _print_python(cu) -> str:
 
 def _isolated_hub(monkeypatch, server):
     """Fresh hub state so this test neither sees nor leaves module-global tables."""
-    for name in ("_hub_tree", "_hub_served", "_hub_send_refs",
-                 "_hub_send_checkpoint", "local_objects"):
+    for name in ("_hub_tree", "_hub_served", "_hub_send_refs", "_hub_recv_refs",
+                 "_hub_send_checkpoint", "_hub_recv_checkpoint", "local_objects"):
         monkeypatch.setattr(server, name, {})
 
 
@@ -528,3 +533,94 @@ def test_an_unknown_visitor_is_still_an_error():
         assert False, "expected a ValueError for a visitor no child owns"
     except ValueError as e:
         assert "No child owns visitor" in str(e)
+
+
+class _RefUsingChild:
+    """A child bundle as a real RPC peer: one persistent send ref map toward the hub, so the second
+    edit that reuses a type the first edit already sent cites it as a bare ref."""
+
+    def __init__(self, edits):
+        from rewrite.rpc.reference import ReferenceMap
+        self._edits = edits                 # obj_id -> the tree this child's visitors produced
+        self.refs = ReferenceMap()
+
+    def request(self, bundle, method, params):
+        import rewrite.rpc.server as server
+        from rewrite.rpc.send_queue import RpcSendQueue
+
+        obj_id = params["id"]
+        before = server._hub_served[(bundle, obj_id)]
+        return RpcSendQueue(params["sourceFileType"], self.refs).generate(self._edits[obj_id], before)
+
+
+def test_the_hub_resolves_a_back_reference_a_childs_earlier_edit_assigned(monkeypatch):
+    import rewrite.rpc.server as server
+
+    sft, bundle = "org.openrewrite.python.tree.Py$CompilationUnit", "pkg"
+    # Both edits add a statement whose literal carries the same primitive type, which is what the
+    # child sends once and cites thereafter.
+    files = {_parse_python("x = 1\n"): _parse_python("x = 1\ny = 2\n"),
+             _parse_python("q = 3\n"): _parse_python("q = 3\nr = 4\n")}
+    trees = {str(before.id): before for before in files}
+    edits = {str(before.id): after for before, after in files.items()}
+
+    _isolated_hub(monkeypatch, server)
+    monkeypatch.setattr(server, "get_object_from_java",
+                        lambda obj_id, source_file_type=None: trees.get(obj_id))
+
+    children = _RefUsingChild(edits)
+    for tree_id in trees:
+        server._hub_acquire(tree_id, sft)
+        server._hub_serve_child(bundle, tree_id, sft)
+        server._hub_pull_child_edit(children, bundle, tree_id, sft)
+
+    assert [_print_python(server._hub_tree[tree_id]) for tree_id in trees] == [
+        "x = 1\ny = 2\n", "q = 3\nr = 4\n"]
+
+
+def test_facade_visit_checkpoints_its_own_ref_tables_so_evict_rolls_them_back(monkeypatch, tmp_path):
+    import rewrite.rpc.server as server
+    from rewrite.rpc.reference import ReferenceMap
+
+    class _RefGrowingFacade:
+        def get_marketplace(self, params): ...
+        def install_recipes(self, params): ...
+        def prepare_recipe(self, params): ...
+        def set_data_table_store(self, params): ...
+        def batch_visit(self, params): ...
+        def generate(self, params): ...
+
+        def evict(self, params):
+            return True
+
+        def visit(self, params):
+            server.local_refs.create(object())  # what handle_get_object's response assigns
+            return {"modified": True}
+
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)  # facade mode on
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_facade", _RefGrowingFacade())
+
+    monkeypatch.setattr(server, "local_refs", ReferenceMap())
+    monkeypatch.setattr(server, "remote_refs", {})
+    monkeypatch.setattr(server, "_ref_checkpoints", {})
+    monkeypatch.setattr(server, "_local_ref_checkpoints", {})
+    monkeypatch.setattr(server, "_hub_tree", {})
+
+    # an earlier file's refs, which this file's eviction must leave alone
+    kept = object()
+    server.local_refs.create(kept)
+    server.remote_refs[1] = object()
+
+    def _fake_get_object_from_java(obj_id, source_file_type):
+        server.remote_refs[2] = object()  # the tree Java sends for this file
+        return object()
+
+    monkeypatch.setattr(server, "get_object_from_java", _fake_get_object_from_java)
+
+    server.handle_request("Visit", {"treeId": "T", "sourceFileType": "py", "visitor": "edit:1"})
+    server.handle_request("Evict", {"id": "T"})
+
+    assert server.local_refs.get(kept) == 1
+    assert server.local_refs.snapshot() == 1
+    assert sorted(server.remote_refs) == [1]

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -668,3 +668,19 @@ def test_reset_reaches_the_children(monkeypatch, tmp_path):
     # The hub's per-bundle ref maps and the child's own are two ends of one table: dropping only
     # the hub's would leave the child citing ids the hub can no longer resolve.
     assert broadcast == [{}]
+
+
+def test_reset_drops_a_half_drained_dependency_types_page(monkeypatch):
+    import rewrite.rpc.server as server
+
+    monkeypatch.setattr(server, "_dependency_types_pending", {("attrs", "23.1", (3, 12)): [{"a": 1}]})
+    # In-flight call bookkeeping is owned by send_request's finally, and Reset is served from
+    # inside that machinery, so clearing it here would strand an outer frame's response.
+    monkeypatch.setattr(server, "_awaiting_ids", {7})
+    monkeypatch.setattr(server, "_pending_responses", {7: {"id": 7}})
+
+    server.handle_reset({})
+
+    assert not server._dependency_types_pending
+    assert server._awaiting_ids == {7}
+    assert server._pending_responses == {7: {"id": 7}}

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -475,11 +475,11 @@ def test_local_visit_advances_the_hub_tree_and_the_next_serve_carries_it_to_the_
 
 
 def test_a_built_in_visitor_that_deletes_the_file_releases_it_from_the_hub(monkeypatch):
-    """A built-in visitor may delete the file outright. The facade has to let go of it the same way
-    a broadcast Evict would: drop the tree, forget what each child was served, and rewind that
-    child's send-ref numbering — otherwise the next file reuses ref numbers the child no longer
-    holds. Nothing after the delete may run, and the child must be told DELETE, not served a
-    resurrected tree."""
+    """A built-in visitor may delete the file outright. The facade drops the tree and forgets what
+    each child was served, but leaves ref numbering alone: no Evict was broadcast, so each child
+    still holds this file's refs and rewinding ours would strand the ones it goes on to cite.
+    Nothing after the delete may run, and the child must be told DELETE, not served a resurrected
+    tree."""
     import rewrite.rpc.server as server
     from rewrite.python.visitor import PythonVisitor
 
@@ -515,12 +515,11 @@ def test_a_built_in_visitor_that_deletes_the_file_releases_it_from_the_hub(monke
                         "hasNewMessages": False, "searchResultIds": []}]
     assert ran_after == []
 
-    # The facade no longer owns the file, and every per-child table it seeded is rolled back.
+    # The facade no longer owns the file, while the child's ref numbering stands until its Evict.
     assert tree_id not in server._hub_tree
     assert (bundle, tree_id) not in server._hub_served
-    assert (bundle, tree_id) not in server._hub_send_checkpoint
-    assert len(server._hub_send_refs[bundle]) == 0
-    assert server._hub_send_refs[bundle].snapshot() == 0
+    assert (bundle, tree_id) in server._hub_send_checkpoint
+    assert server._hub_send_refs[bundle].snapshot() > 0
 
     # So a child asking for it again is told the file is gone rather than served a stale tree.
     assert server._hub_serve_child(bundle, tree_id, sft) == [
@@ -684,3 +683,101 @@ def test_reset_drops_a_half_drained_dependency_types_page(monkeypatch):
     assert not server._dependency_types_pending
     assert server._awaiting_ids == {7}
     assert server._pending_responses == {7: {"id": 7}}
+
+
+def test_a_childs_delete_is_forgotten_without_disturbing_ref_numbering(monkeypatch):
+    """A child that deletes the file answers the pull with DELETE. The facade has to let go of the
+    tree — otherwise it serves the next bundle a file that no longer exists — but must leave both
+    ref maps alone: no Evict has been broadcast, so the child still holds this file's refs."""
+    import rewrite.rpc.server as server
+    from rewrite.rpc.reference import ReferenceMap
+
+    class _DeletingChild:
+        def request(self, bundle, method, params):
+            return [{"state": "DELETE"}, {"state": "END_OF_OBJECT"}]
+
+    tree_id, sft, bundle = "T", "py", "pkg"
+    _isolated_hub(monkeypatch, server)
+    server._hub_tree[tree_id] = object()
+    server._hub_served[(bundle, tree_id)] = object()
+    server.local_objects[tree_id] = object()
+    refs = server._hub_send_refs[bundle] = ReferenceMap()
+    refs.create(object())
+    server._hub_recv_refs[bundle] = {1: object()}
+
+    server._hub_pull_child_edit(_DeletingChild(), bundle, tree_id, sft)
+
+    assert tree_id not in server._hub_tree
+    assert (bundle, tree_id) not in server._hub_served
+    assert tree_id not in server.local_objects          # so GetObject answers DELETE
+    # The child was told nothing, so its refs and ours still agree.
+    assert len(refs) == 1 and server._hub_recv_refs[bundle] == {1: server._hub_recv_refs[bundle][1]}
+
+
+def test_a_batch_stops_after_a_child_deletes_the_file():
+    """Once a bundle deletes the file there is nothing left for a later bundle to visit, and
+    _hub_serve_child would answer it DELETE anyway."""
+    ran = []
+
+    class _DeletingChildren(_FakeChildren):
+        def request(self, bundle, method, params):
+            if method == "BatchVisit":
+                vs = [v["visitor"] for v in params.get("visitors", [])]
+                ran.append((bundle, vs))
+                deleted = any(v.startswith("del:") for v in vs)
+                return {"results": [{"visitor": v, "modified": True, "deleted": deleted} for v in vs]}
+            return super().request(bundle, method, params)
+
+    children = _DeletingChildren()
+    f = Facade(children)
+    f._bundle_by_visitor.update({"del:a": "A", "edit:b": "B"})
+
+    resp = f.batch_visit({"treeId": "T", "sourceFileType": "py",
+                          "visitors": [{"visitor": "del:a"}, {"visitor": "edit:b"}]})
+
+    assert [r.get("visitor") for r in resp["results"]] == ["del:a"]
+    assert ran == [("A", ["del:a"])]
+
+
+def test_replacing_a_bundles_child_drops_the_ref_tables_that_mirrored_it():
+    """A respawned child starts with empty ref maps. The hub tables are keyed by bundle name, not by
+    child process, so they have to go with the child they were mirroring."""
+    import rewrite.rpc.server as server
+    from rewrite.rpc.bundle_children import BundleChildren
+    from rewrite.rpc.reference import ReferenceMap
+
+    class _Venvs:
+        def __init__(self): self.usable = False
+        def is_usable_venv(self, d): return self.usable
+        def create_venv(self, *a, **k): ...
+        def install_into_venv(self, *a, **k): ...
+        def installed_version(self, *a, **k): return "1.0"
+        def purge_non_venv_entries(self, *a, **k): return []
+
+    class _Child:
+        def close(self): ...
+        def request(self, method, params): return []
+
+    dropped = []
+    children = BundleChildren("python", "/tmp/venvs", upstream=lambda *a: None,
+                              spawn=lambda *a, **k: _Child(), venv_ops=_Venvs(),
+                              on_child_replaced=dropped.append)
+    children.install("pkg", "pkg==1.0")
+    children.install("pkg", "pkg==1.1")   # venv unusable again -> stale child closed, fresh one spawned
+
+    assert dropped == ["pkg", "pkg"]
+
+    # and the server's hook is what clears the tables
+    server._hub_send_refs["pkg"] = ReferenceMap()
+    server._hub_recv_refs["pkg"] = {1: object()}
+    server._hub_send_checkpoint[("pkg", "T")] = 0
+    server._hub_recv_checkpoint[("pkg", "T")] = -1
+    server._hub_served[("pkg", "T")] = object()
+
+    server._hub_drop_bundle("pkg")
+
+    assert "pkg" not in server._hub_send_refs
+    assert "pkg" not in server._hub_recv_refs
+    assert not [k for k in server._hub_send_checkpoint if k[0] == "pkg"]
+    assert not [k for k in server._hub_recv_checkpoint if k[0] == "pkg"]
+    assert not [k for k in server._hub_served if k[0] == "pkg"]

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -623,3 +623,48 @@ def test_facade_visit_checkpoints_its_own_ref_tables_so_evict_rolls_them_back(mo
     assert server.local_refs.get(kept) == 1
     assert server.local_refs.snapshot() == 1
     assert sorted(server.remote_refs) == [1]
+
+
+def test_reset_clears_the_hub_tables_too(monkeypatch):
+    import rewrite.rpc.server as server
+    from rewrite.rpc.reference import ReferenceMap
+
+    _isolated_hub(monkeypatch, server)
+    tree = object()
+    server._hub_tree["T"] = tree
+    server._hub_served[("A", "T")] = tree
+    server._hub_send_refs["A"] = ReferenceMap()
+    server._hub_send_refs["A"].create(object())
+    server._hub_recv_refs["A"] = {1: object()}
+    server._hub_send_checkpoint[("A", "T")] = 0
+    server._hub_recv_checkpoint[("A", "T")] = -1
+
+    server.handle_reset({})
+
+    assert not server._hub_tree
+    assert not server._hub_served
+    assert not server._hub_send_refs
+    assert not server._hub_recv_refs
+    assert not server._hub_send_checkpoint
+    assert not server._hub_recv_checkpoint
+
+
+def test_reset_reaches_the_children(monkeypatch, tmp_path):
+    import rewrite.rpc.server as server
+
+    broadcast = []
+
+    class _FakeChildren(_EditingChildren):
+        def broadcast_reset(self, params):
+            broadcast.append(params)
+
+    monkeypatch.setattr(server, "_recipe_install_dir", tmp_path)  # facade mode on
+    monkeypatch.setattr(server, "_child_bundle", None)
+    monkeypatch.setattr(server, "_facade", Facade(_FakeChildren()))
+    _isolated_hub(monkeypatch, server)
+
+    assert server.handle_request("Reset", {}) is True
+
+    # The hub's per-bundle ref maps and the child's own are two ends of one table: dropping only
+    # the hub's would leave the child citing ids the hub can no longer resolve.
+    assert broadcast == [{}]


### PR DESCRIPTION
Type-aware Python recipes fail on a large fraction of the files in a real repository. `mod run --recipe=org.openrewrite.python.migrate.UpgradeToPython313` over four cloned repos (Fay, moviepy, wifiphisher, LearnPython) on Moderne CLI 4.7.4 lands 57 rows in `SourcesFileErrors`, concentrated in `RemoveFutureImports` (29) and `ReplaceThreadSetDaemon` (20):

```
java.lang.IllegalStateException: Received a reference to an object that was not previously sent: 1
  at org.openrewrite.java.internal.rpc.JavaReceiver.visitIdentifier
io.moderne.jsonrpc.JsonRpcException {code=-32603, message='Received reference to unknown object: 1'}
  facade.batch_visit -> _hub_pull_child_edit -> receive_queue.py:_do_change
```

Two ref-table asymmetries in facade mode (`--recipe-install-dir`, how the CLI runs a PyPI recipe bundle) account for them, one on each side of the hub.

## The hub's missing receive table

The facade keeps one RPC ref table per connection: its own facade↔Java pair, plus one per child bundle. The child direction had a send map only — `_hub_pull_child_edit` built its `RpcReceiveQueue` on a fresh `{}` every pull, while a child bundle is a full RPC peer whose *send* map spans its connection.

So the second time a bundle returns an edit touching an object it already sent, it emits `ref=N` instead of the object and an empty map cannot resolve it. A `BatchVisit` whose owners alternate (A, B, A) pulls A twice for one file and hits this with no eviction involved.

Now one `_hub_recv_refs` per bundle, checkpointed per `(bundle, obj_id)` and rolled back in `_hub_release` beside the send map already rolled back there. The rollback must be symmetric: `facade.evict` broadcasts Evict to every child, each drops the file's refs from both of its maps, so a ref kept on the hub would name an id the child has released.

## The facade's missing checkpoint

`handle_evict` mirrors `RewriteRpc.evict` only for a file it holds a checkpoint for, and the only writers were `handle_visit` and `handle_batch_visit`. In facade mode `handle_request` routes Visit and BatchVisit to the facade instead, so no checkpoint was recorded and neither `local_refs` nor `remote_refs` was rolled back.

The host dropped a file's refs while the facade kept them. `JavaType.Primitive` members are Python enum singletons reaching `_add_as_ref`, so the first file to send one owned its ref for the life of the connection and every later file cited it. `_hub_acquire` is the facade's single funnel for an unseen file, so the checkpoint is taken there. Both fixes are needed — with only the receive map, wifiphisher still reports 8 host-side rows.

## A deleted source file

Three holes around a file a recipe deletes, all reachable through a child bundle rather than only through the built-in visitors:

- `_hub_pull_child_edit` ignored a DELETE. The receive returns `None` and the guard skipped every update, so the facade kept the tree and served it to the next bundle.
- `facade.batch_visit` ran the groups after the deleting one, where `_hub_local_visit` has always stopped.
- A bundle's hub tables are keyed by name and outlived the child process they mirror, so a child respawned by `install` inherited a ref table it never populated. `BundleChildren` now reports a replacement and the hub drops that bundle's tables.

Letting go of a file is not the same as evicting it, and `_hub_release` conflated the two: it rolled both ref maps back on a local delete, but no Evict was broadcast, so each child still held that file's refs and would cite them on the next file — this PR's own bug from the other direction. `_hub_forget` now drops the tree state; `_hub_release` keeps the rollback, which only the Evict path performs.

## Reset

`handle_reset` cleared the facade↔Java tables while all six hub tables survived, so the facade kept trees whose ids Java had forgotten plus the previous run's per-file bookkeeping. It now clears them, and broadcasts Reset to the children as `Evict` already did — clearing the hub's ref maps alone would reintroduce the desync above.

Auditing the module's remaining caches against Reset turned up one more that outlived it: `handle_dependency_types` serves a dependency's exported types in batches, and a Reset mid-pagination left the remainder to be resumed from the middle. `_awaiting_ids` and `_pending_responses` deliberately stay — they are `send_request`'s in-flight bookkeeping, cleaned in its `finally`, and Reset is served from inside that machinery.

## Measured

Same working set, same LSTs, engine patched in place; each cell is one `mod run`.

| repo | `SourcesFileErrors` rows |
|---|---|
| Fay | 25 → 0 |
| moviepy | 14 → 0 |
| wifiphisher | 9 → 0 |
| LearnPython | 9 → 0 |

57 → 0, and the files each run edits rises with it — wifiphisher goes from 3 to 11.

## Tests

`test_the_hub_resolves_a_back_reference_a_childs_earlier_edit_assigned` drives a child that is a real *send* peer — one persistent `ReferenceMap` across two files, as a child process has — and on `main` reproduces `Received reference to unknown object: 1` verbatim.

The rest cover the release rollback in both directions, the checkpoint, both Reset behaviours, the two delete paths, and the child replacement. Each was mutation-checked by reverting its production line and confirming that test, and only that test, fails.

## Not in this PR

`RewriteRpc`'s own inbound Evict handler is the one peer of five that never rolled back (`// Inbound side has no per-file checkpoint`). It is latent — no non-Java host originates Evict today — and is left for a follow-up.



