### PR TITLE
Python: a recipe test fails on an Expression in a Statement slot

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
+++ b/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
@@ -35,6 +35,7 @@ from rewrite.parser import ParseError
 from rewrite.markers import ParseExceptionResult
 
 from .spec import SourceSpec, AfterRecipeText, dedent
+from .well_formed import assert_well_formed
 
 if TYPE_CHECKING:
     from rewrite.tree import SourceFile
@@ -391,6 +392,8 @@ class RecipeSpec:
 
             # Get the result (may be None if no change, or the changed file)
             after_sf = result_map.get(source_file.id)
+            if after_sf is not None:
+                assert_well_formed(after_sf)
 
             if spec.after is None:
                 # No change expected

--- a/rewrite-python/rewrite/src/rewrite/test/well_formed.py
+++ b/rewrite-python/rewrite/src/rewrite/test/well_formed.py
@@ -1,0 +1,75 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Structural check that every slot of an LST holds the node kind its field declares.
+
+The printer renders a mis-slotted node (an `Expression` where a `Statement` is declared)
+identically to a correct one, so this is the only test-time signal for a tree that the Java
+receiver would reject on deserialization.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections import deque
+from typing import Any, List, Optional, Tuple, Type, Union, get_args, get_origin, get_type_hints
+
+from rewrite import Tree
+from rewrite.java.support_types import JContainer, JLeftPadded, JRightPadded
+
+_HINTS_CACHE: dict = {}
+
+
+def assert_well_formed(tree: Tree) -> None:
+    """Raise `AssertionError` naming every slot whose value is not an instance of its declared type."""
+    offenders: List[str] = []
+    pending: deque[Tuple[Any, Any, str]] = deque([(tree, type(tree), type(tree).__name__)])
+    while pending:
+        value, hint, path = pending.popleft()
+        hint = _strip_optional(hint)
+        if isinstance(value, list):
+            elem_hint = get_args(hint)[0] if get_origin(hint) is list else None
+            pending.extend((v, elem_hint, f"{path}[{i}]") for i, v in enumerate(value))
+        elif isinstance(value, (JRightPadded, JLeftPadded)):
+            pending.append((value.element, _type_arg(hint), path))
+        elif isinstance(value, JContainer):
+            pending.extend((p.element, _type_arg(hint), f"{path}[{i}]") for i, p in enumerate(value.padding.elements))
+        elif isinstance(value, Tree):
+            if isinstance(hint, type) and issubclass(hint, Tree) and not isinstance(value, hint):
+                offenders.append(f"{path} holds {type(value).__name__}, expected {hint.__name__}")
+            for name, field_hint in _slot_hints(type(value)):
+                pending.append((getattr(value, name), field_hint, f"{type(value).__name__}.{name.lstrip('_')}"))
+    assert not offenders, "Malformed tree:\n  " + "\n  ".join(offenders)
+
+
+def _slot_hints(cls: Type[Tree]) -> List[Tuple[str, Any]]:
+    hints = _HINTS_CACHE.get(cls)
+    if hints is None:
+        resolved = get_type_hints(cls)
+        hints = [(f.name, resolved.get(f.name)) for f in dataclasses.fields(cls)]
+        _HINTS_CACHE[cls] = hints
+    return hints
+
+
+def _strip_optional(hint: Any) -> Any:
+    if get_origin(hint) is Union:
+        args = [a for a in get_args(hint) if a is not type(None)]
+        return args[0] if len(args) == 1 else None
+    return hint
+
+
+def _type_arg(hint: Any) -> Optional[Any]:
+    args = get_args(hint)
+    return args[0] if args else None

--- a/rewrite-python/rewrite/src/rewrite/test/well_formed.py
+++ b/rewrite-python/rewrite/src/rewrite/test/well_formed.py
@@ -16,60 +16,117 @@
 """Structural check that every slot of an LST holds the node kind its field declares.
 
 The printer renders a mis-slotted node (an `Expression` where a `Statement` is declared)
-identically to a correct one, so this is the only test-time signal for a tree that the Java
-receiver would reject on deserialization.
+identically to a correct one, so this is the only test-time signal for a tree the Java side
+rejects: at receive time for single-node slots, on first typed access for padded lists.
 """
 
 from __future__ import annotations
 
 import dataclasses
+import types
 from collections import deque
-from typing import Any, List, Optional, Tuple, Type, Union, get_args, get_origin, get_type_hints
+from typing import Any, Dict, List, Optional, Tuple, Type, Union, get_args, get_origin, get_type_hints
 
 from rewrite import Tree
 from rewrite.java.support_types import JContainer, JLeftPadded, JRightPadded
 
-_HINTS_CACHE: dict = {}
+# A slot spec is ("tree", cls): an instance of the Tree subclass cls; ("list", elem): a list whose
+# elements satisfy elem; ("padded", wrapper, elem): a JRightPadded/JLeftPadded whose element
+# satisfies elem; ("container", elem): a JContainer whose elements satisfy elem; or ("any",):
+# unconstrained, though trees found inside are still walked.
+_Spec = Tuple[Any, ...]
+_ANY: _Spec = ("any",)
+_SLOTS_CACHE: Dict[type, List[Tuple[str, str, _Spec]]] = {}
 
 
 def assert_well_formed(tree: Tree) -> None:
     """Raise `AssertionError` naming every slot whose value is not an instance of its declared type."""
     offenders: List[str] = []
-    pending: deque[Tuple[Any, Any, str]] = deque([(tree, type(tree), type(tree).__name__)])
+    # Each pending item is (value, spec, path, owner); `path` is a linked list of segments
+    # rendered only for an offender, `owner` the "Type.field" that declares the slot.
+    pending = deque([(tree, ("tree", type(tree)), (None, type(tree).__name__), None)])
     while pending:
-        value, hint, path = pending.popleft()
-        hint = _strip_optional(hint)
-        if isinstance(value, list):
-            elem_hint = get_args(hint)[0] if get_origin(hint) is list else None
-            pending.extend((v, elem_hint, f"{path}[{i}]") for i, v in enumerate(value))
-        elif isinstance(value, (JRightPadded, JLeftPadded)):
-            pending.append((value.element, _type_arg(hint), path))
-        elif isinstance(value, JContainer):
-            pending.extend((p.element, _type_arg(hint), f"{path}[{i}]") for i, p in enumerate(value.padding.elements))
+        value, spec, path, owner = pending.popleft()
+        if value is None:
+            continue
+        kind = spec[0]
+        if kind == "tree":
+            if not isinstance(value, spec[1]):
+                offenders.append(_offence(path, value, spec[1].__name__, owner))
+            else:
+                _push_fields(pending, value, path)
+        elif kind == "list":
+            if not isinstance(value, list):
+                offenders.append(_offence(path, value, "list", owner))
+            else:
+                pending.extend((v, spec[1], (path, f"[{i}]"), owner) for i, v in enumerate(value))
+        elif kind == "padded":
+            if not isinstance(value, spec[1]):
+                offenders.append(_offence(path, value, spec[1].__name__, owner))
+            else:
+                pending.append((value.element, spec[2], path, owner))
+        elif kind == "container":
+            if not isinstance(value, JContainer):
+                offenders.append(_offence(path, value, "JContainer", owner))
+            else:
+                pending.extend((p.element, spec[1], (path, f"[{i}]"), owner)
+                               for i, p in enumerate(value.padding.elements))
         elif isinstance(value, Tree):
-            if isinstance(hint, type) and issubclass(hint, Tree) and not isinstance(value, hint):
-                offenders.append(f"{path} holds {type(value).__name__}, expected {hint.__name__}")
-            for name, field_hint in _slot_hints(type(value)):
-                pending.append((getattr(value, name), field_hint, f"{type(value).__name__}.{name.lstrip('_')}"))
+            _push_fields(pending, value, path)
+        elif isinstance(value, list):
+            pending.extend((v, _ANY, (path, f"[{i}]"), owner) for i, v in enumerate(value))
+        elif isinstance(value, (JRightPadded, JLeftPadded)):
+            pending.append((value.element, _ANY, path, owner))
+        elif isinstance(value, JContainer):
+            pending.extend((p.element, _ANY, (path, f"[{i}]"), owner) for i, p in enumerate(value.padding.elements))
     assert not offenders, "Malformed tree:\n  " + "\n  ".join(offenders)
 
 
-def _slot_hints(cls: Type[Tree]) -> List[Tuple[str, Any]]:
-    hints = _HINTS_CACHE.get(cls)
-    if hints is None:
-        resolved = get_type_hints(cls)
-        hints = [(f.name, resolved.get(f.name)) for f in dataclasses.fields(cls)]
-        _HINTS_CACHE[cls] = hints
-    return hints
+def _push_fields(pending: deque, node: Tree, path: Tuple) -> None:
+    cls = type(node)
+    for attr, name, spec in _slot_specs(cls):
+        pending.append((getattr(node, attr), spec, (path, "." + name), f"{cls.__name__}.{name}"))
 
 
-def _strip_optional(hint: Any) -> Any:
-    if get_origin(hint) is Union:
+def _offence(path: Tuple, value: Any, expected: str, owner: Optional[str]) -> str:
+    segments: List[str] = []
+    while path is not None:
+        path, segment = path
+        segments.append(segment)
+    where = "".join(reversed(segments))
+    declared = f" ({owner})" if owner else ""
+    return f"{where} holds {type(value).__name__}, expected {expected}{declared}"
+
+
+def _slot_specs(cls: Type[Tree]) -> List[Tuple[str, str, _Spec]]:
+    """(attribute, display name, spec) for each field of `cls` whose annotation can hold a tree."""
+    specs = _SLOTS_CACHE.get(cls)
+    if specs is None:
+        hints = get_type_hints(cls)
+        specs = []
+        for f in dataclasses.fields(cls):
+            spec = _compile(hints.get(f.name))
+            if spec is not None:
+                specs.append((f.name, f.name.lstrip("_"), spec))
+        _SLOTS_CACHE[cls] = specs
+    return specs
+
+
+def _compile(hint: Any) -> Optional[_Spec]:
+    """Compile a field annotation into a slot spec, or None for a field that never holds a tree."""
+    origin = get_origin(hint)
+    if origin in (Union, types.UnionType):
         args = [a for a in get_args(hint) if a is not type(None)]
-        return args[0] if len(args) == 1 else None
-    return hint
-
-
-def _type_arg(hint: Any) -> Optional[Any]:
-    args = get_args(hint)
-    return args[0] if args else None
+        return _compile(args[0]) if len(args) == 1 else _ANY
+    if origin is list:
+        elem = _compile(get_args(hint)[0])
+        return None if elem is None else ("list", elem)
+    if origin in (JRightPadded, JLeftPadded):
+        return ("padded", origin, _compile(get_args(hint)[0]) or _ANY)
+    if origin is JContainer:
+        return ("container", _compile(get_args(hint)[0]) or _ANY)
+    if isinstance(hint, type):
+        return ("tree", hint) if issubclass(hint, Tree) else None
+    if origin is not None and isinstance(origin, type):
+        return None  # a parameterised non-LST type such as a weakref
+    return _ANY

--- a/rewrite-python/rewrite/tests/test_rewrite_test.py
+++ b/rewrite-python/rewrite/tests/test_rewrite_test.py
@@ -15,15 +15,18 @@
 """Tests for the Python test harness."""
 
 from pathlib import Path
+from uuid import uuid4
 
 import pytest
 
 from rewrite import ExecutionContext, Recipe, TreeVisitor
+from rewrite.markers import Markers
 from rewrite.test import RecipeSpec, python, pyproject, uv, from_visitor, dedent
 from rewrite.test.spec import SourceSpec
 from rewrite.python.visitor import PythonVisitor
-from rewrite.python.tree import CompilationUnit
-from rewrite.java import J, JavaType
+from rewrite.java.tree import MethodInvocation, Yield
+from rewrite.python.tree import Await, CompilationUnit
+from rewrite.java import J, JavaType, Space
 
 
 class TestDedent:
@@ -495,3 +498,40 @@ class TestUvHelper:
                 ),
             )
         )
+
+
+def _await(node: J) -> Await:
+    return Await(uuid4(), node.prefix, Markers.EMPTY, node.replace(prefix=Space([], ' ')), None)
+
+
+class TestWellFormedness:
+    """The harness rejects an `after` tree whose slots hold the wrong node kind."""
+
+    def test_expression_in_statement_list_slot(self):
+        class AwaitEveryCall(PythonVisitor[ExecutionContext]):
+            def visit_method_invocation(self, mi: MethodInvocation, ctx: ExecutionContext) -> J:
+                return _await(mi)
+
+        spec = RecipeSpec(recipe=from_visitor(AwaitEveryCall()))
+        with pytest.raises(AssertionError, match=r"CompilationUnit\.statements\[0\] holds Await, expected Statement"):
+            spec.rewrite_run(python("foo()", "await foo()"))
+
+    def test_expression_in_single_statement_slot(self):
+        class AwaitEveryYield(PythonVisitor[ExecutionContext]):
+            def visit_yield(self, y: Yield, ctx: ExecutionContext) -> J:
+                return _await(y)
+
+        spec = RecipeSpec(recipe=from_visitor(AwaitEveryYield()))
+        with pytest.raises(AssertionError, match=r"StatementExpression\.statement holds Await, expected Statement"):
+            spec.rewrite_run(
+                python(
+                    """
+                    def f():
+                        yield 1
+                    """,
+                    """
+                    def f():
+                        await yield 1
+                    """,
+                )
+            )

--- a/rewrite-python/rewrite/tests/test_rewrite_test.py
+++ b/rewrite-python/rewrite/tests/test_rewrite_test.py
@@ -514,7 +514,7 @@ class TestWellFormedness:
 
         spec = RecipeSpec(recipe=from_visitor(AwaitEveryCall()))
         with pytest.raises(AssertionError, match=r"CompilationUnit\.statements\[0\] holds Await, expected Statement"):
-            spec.rewrite_run(python("foo()", "await foo()"))
+            spec.rewrite_run(python("foo()"))
 
     def test_expression_in_single_statement_slot(self):
         class AwaitEveryYield(PythonVisitor[ExecutionContext]):
@@ -522,16 +522,12 @@ class TestWellFormedness:
                 return _await(y)
 
         spec = RecipeSpec(recipe=from_visitor(AwaitEveryYield()))
-        with pytest.raises(AssertionError, match=r"StatementExpression\.statement holds Await, expected Statement"):
+        with pytest.raises(AssertionError, match=r"holds Await, expected Statement \(StatementExpression\.statement\)"):
             spec.rewrite_run(
                 python(
                     """
                     def f():
                         yield 1
-                    """,
                     """
-                    def f():
-                        await yield 1
-                    """,
                 )
             )


### PR DESCRIPTION
Two recipes in rewrite-migrate-python passed every unit test while returning trees the Java side cannot read. `ReplaceStrFormatWithFString` left a `Py.FormattedString` directly in `Block.statements`, where the `MethodInvocation` it replaced had been its own statement, and `MigrateAsyncioCoroutine` left `StatementExpression.statement = Py.Await`. Both aborted a whole `mod run` once #8768 removed the RPC desync that had masked them:

```
InvalidTypeIdException: Could not resolve type id 'Py$FormattedString' as a subtype of Statement
ClassCastException: Py$Await cannot be cast to Statement   (PythonReceiver.visitStatementExpression)
```

The printer renders the malformed and the correct tree identically, so a before/after text comparison cannot see the difference. `RecipeSpec.rewrite_run` now walks every `after` tree and asserts that each slot holds what its dataclass field declares, failing with the path to the node, the offending type and the slot's declaration:

```
Malformed tree:
  CompilationUnit.statements[1].body.statements[0].assignment.statement holds Await, expected Statement (StatementExpression.statement)
```

The check compiles each class's field annotations (`List[JRightPadded[Statement]]`, `JLeftPadded[Expression]`, …) into slot specs once, rather than keeping a hand-written list of slots, so it covers every cast `JavaReceiver` and `PythonReceiver` make, including `TypeTree`, `NameTree`, `Identifier` and `Block` slots, and also a bare node where a `JRightPadded` is declared or the reverse. `None` is accepted in any slot: several fields the Java model marks `@Nullable` are not `Optional` in the Python annotations, and tightening those is separate work. Walking the 3.7k-line `_parser_visitor.py` costs 26 ms against 421 ms to parse it.

Only recipe output is checked. Running the same check on parsed input is a two-line addition and passes the whole suite except `decorator_test.py::test_subscript_decorator`, because the parser puts an `ArrayAccess` into `Annotation.annotation_type` (declared `NameTree`) for `@x[0]`. That parser bug is fixed separately, and the parsed-input check goes in with it.

Verification:

- `TestWellFormedness` in `test_rewrite_test.py` reproduces both shapes, an `Await` in `CompilationUnit.statements` and in `StatementExpression.statement`. Both failed with a plain "expected no change" assertion before the check existed.
- The rewrite-python suite is unchanged at 2070 passed, and the parser output of the 270 Python files in this module trips nothing.
- rewrite-migrate-python's suite against this harness: on `main` only the three `MigrateAsyncioCoroutine` tests fail (`main` has no test with a bare `.format()` statement, so the f-string recipe is not exercised there); the branch fixing both recipes passes clean.
