### PR TITLE
Python: a subscript or nested-call decorator is a NameTree

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -2334,13 +2334,11 @@ class ParserVisitor(ast.NodeVisitor):
                     self.__pad_right(wrapped, suffix)
                 )
 
-            # Wrap in ExpressionTypeTree to satisfy NameTree type requirement
-            name = py.ExpressionTypeTree(
-                random_id(),
-                Space.EMPTY,
-                Markers.EMPTY,
-                wrapped
-            )
+            name = wrapped
+
+        # PEP 614 allows any expression here, but Annotation.annotation_type is a NameTree
+        if not isinstance(name, NameTree):
+            name = py.ExpressionTypeTree(random_id(), Space.EMPTY, Markers.EMPTY, name)
 
         return j.Annotation(
             random_id(),

--- a/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
+++ b/rewrite-python/rewrite/src/rewrite/test/rewrite_test.py
@@ -193,6 +193,8 @@ class RecipeSpec:
             for kind, kind_specs in specs_by_kind.items():
                 parsed = self._parse(kind_specs, workspace)
                 self._expect_no_parse_failures(parsed)
+                for _, sf in parsed:
+                    assert_well_formed(sf)
                 if self.check_parse_print_idempotence:
                     self._expect_parse_print_idempotence(parsed)
                 all_parsed.extend(parsed)

--- a/rewrite-python/rewrite/tests/python/all/tree/decorator_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/decorator_test.py
@@ -110,6 +110,20 @@ def test_subscript_decorator():
     ))
 
 
+def test_call_of_call_decorator():
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        """\
+        def factory():
+            return lambda n: lambda f: f
+
+        @factory()(1)
+        def f():
+            pass
+        """
+    ))
+
+
 def test_parenthesized_decorator():
     # language=python
     RecipeSpec().rewrite_run(python(


### PR DESCRIPTION
A PEP 614 decorator whose expression is a subscript (`@x[0]`) or a call of a call (`@x()(1)`) parsed into a `J.ArrayAccess` or `J.MethodInvocation` sitting directly in `Annotation.annotation_type`, a slot declared `NameTree`. The Python printer renders that fine, but `JavaReceiver.visitAnnotation` casts the slot to `NameTree` on the Java side, so any Java-hosted recipe run over such a file failed.

```
Annotation.annotation_type holds ArrayAccess, expected NameTree
Annotation.annotation_type holds MethodInvocation, expected NameTree
```

`__map_decorator` already wrapped a parenthesized decorator in `Py.ExpressionTypeTree`, but the subscript branch and the `ast.Call` branch converting `decorator.func` did not. The fix moves that wrapping to a single spot that applies to any decorator expression that is not already a `NameTree`, which also covers the parentheses path unchanged. Printed output is identical.

`RecipeSpec.rewrite_run` now also asserts every parsed tree is well-formed, not only recipe output, so a parser mis-slot fails its own parse/print test. With that check in place the existing `@[property][0]` test and the new `test_call_of_call_decorator` both fail against the old parser with the messages above and pass with the fix. The full non-RPC suite is green with the harness check.

Builds on the `assert_well_formed` harness check from #8769.


