### PR TITLE
RPC: a `delegatesTo` child loads from the host classpath on a marketplace miss

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -229,14 +229,7 @@ public class RewriteRpc {
                 }
             }
         });
-        jsonRpc.rpc("PrepareRecipe", new PrepareRecipe.Handler(preparedRecipes, (id, opts) -> {
-            RecipeListing listing = marketplace.findRecipe(id);
-            if (listing != null) {
-                return listing.prepare(RewriteRpc.this.resolvers, opts);
-            }
-            // Fall back to loading by class name if not found in marketplace
-            return new RecipeLoader(null).load(id, opts);
-        }));
+        jsonRpc.rpc("PrepareRecipe", new PrepareRecipe.Handler(preparedRecipes, this::loadRecipe));
         jsonRpc.rpc("Parse", new Parse.Handler(localObjects, () -> parsers));
         jsonRpc.rpc("Print", new Print.Handler(this::getObject));
         jsonRpc.rpc("SetDataTableStore", new SetDataTableStore.Handler(
@@ -515,17 +508,28 @@ public class RewriteRpc {
     Recipe recipeFromPrepareResponse(PrepareRecipeResponse r) {
         if (r.getDelegatesTo() != null) {
             PrepareRecipeResponse.DelegatesTo d = r.getDelegatesTo();
-            RecipeListing listing = marketplace.findRecipe(d.getRecipeName());
-            if (listing == null) {
-                throw new IllegalStateException(
-                        "Remote declared delegatesTo " + d.getRecipeName() +
-                        " but no recipe found in marketplace.");
-            }
-            return listing.prepare(resolvers, d.getOptions());
+            return loadRecipe(d.getRecipeName(), d.getOptions());
         }
         return new RpcRecipe(this, r.getId(), r.getDescriptor(), r.getEditVisitor(),
                 matchAll(r.getEditPreconditions()), r.getScanVisitor(), matchAll(r.getScanPreconditions()),
                 r.getRecipeList());
+    }
+
+    /**
+     * Marketplace first, then the class by name: a peer may name a recipe (inbound PrepareRecipe or
+     * an outbound delegatesTo) that this process has on its classpath without listing it.
+     */
+    private Recipe loadRecipe(String name, Map<String, Object> options) {
+        RecipeListing listing = marketplace.findRecipe(name);
+        if (listing != null) {
+            return listing.prepare(resolvers, options);
+        }
+        try {
+            return new RecipeLoader(null).load(name, options);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Recipe " + name +
+                                            " is neither in the marketplace nor loadable from the classpath", e);
+        }
     }
 
     private @Nullable TreeVisitor<?, ExecutionContext> matchAll(List<PrepareRecipeResponse.Precondition> preconditions) {

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -528,7 +528,8 @@ public class RewriteRpc {
             return new RecipeLoader(null).load(name, options);
         } catch (RuntimeException e) {
             throw new IllegalStateException("Recipe " + name +
-                                            " is neither in the marketplace nor loadable from the classpath", e);
+                                            " is not in the marketplace and could not be loaded from the classpath: " +
+                                            e.getMessage(), e);
         }
     }
 

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/request/PrepareRecipeResponse.java
@@ -41,8 +41,8 @@ public class PrepareRecipeResponse {
 
     /**
      * When non-null, the remote declares that this recipe delegates entirely
-     * to a Java recipe. The host should load the recipe locally via the
-     * marketplace instead of wrapping it in an RpcRecipe.
+     * to a Java recipe. The host instantiates it locally (marketplace, then
+     * classpath) instead of wrapping it in an RpcRecipe.
      */
     @Nullable
     DelegatesTo delegatesTo;

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -55,6 +55,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openrewrite.marketplace.RecipeBundle.runtimeClasspath;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.test.SourceSpecs.text;
@@ -319,6 +320,17 @@ class RewriteRpcTest implements RewriteTest {
           null);
 
         assertThat(client.recipeFromPrepareResponse(response)).isEqualTo(expected);
+    }
+
+    @Test
+    void delegatesToFailsWithLoaderCauseWhenNeitherMarketplaceNorClasspathHasIt() {
+        PrepareRecipeResponse response = new PrepareRecipeResponse("1", null, "", List.of(), null, List.of(),
+          new PrepareRecipeResponse.DelegatesTo("org.example.Missing", Map.of()), null);
+
+        assertThatThrownBy(() -> client.recipeFromPrepareResponse(response))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("org.example.Missing")
+          .hasCauseInstanceOf(RuntimeException.class);
     }
 
     @Test

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -38,6 +38,7 @@ import org.openrewrite.marketplace.*;
 import org.openrewrite.table.TextMatches;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.marker.RecipesThatMadeChanges;
+import org.openrewrite.rpc.request.PrepareRecipeResponse;
 import org.openrewrite.text.PlainText;
 import org.openrewrite.text.PlainTextVisitor;
 
@@ -304,6 +305,20 @@ class RewriteRpcTest implements RewriteTest {
         Recipe recipe = client.prepareRecipe("org.openrewrite.text.Find",
           Map.of("find", "hello"));
         assertThat(recipe.getDescriptor().getDisplayName()).isEqualTo("Find text");
+    }
+
+    @Test
+    void delegatesToLoadsFromClasspathWhenMarketplaceMisses() {
+        // FindSourceFiles is on the classpath but outside the org.openrewrite.text scan of `env`
+        FindSourceFiles expected = new FindSourceFiles("**/*.txt");
+        assertThat(marketplace.findRecipe(expected.getName())).isNull();
+
+        PrepareRecipeResponse response = new PrepareRecipeResponse("1", expected.getDescriptor(),
+          "", List.of(), null, List.of(),
+          new PrepareRecipeResponse.DelegatesTo(expected.getName(), Map.of("filePattern", "**/*.txt")),
+          null);
+
+        assertThat(client.recipeFromPrepareResponse(response)).isEqualTo(expected);
     }
 
     @Test

--- a/rewrite-go/cmd/rpc/cross_ecosystem_test.go
+++ b/rewrite-go/cmd/rpc/cross_ecosystem_test.go
@@ -29,8 +29,8 @@ import (
 )
 
 // goDelegatingRecipe delegates entirely to a Java host recipe. The Go server can't run it, so
-// PrepareRecipe answers with delegatesTo{recipeName, options} and the Java host resolves the
-// recipe from its own marketplace instead of wrapping the Go recipe in an RpcRecipe.
+// PrepareRecipe answers with delegatesTo{recipeName, options} and the Java host instantiates the
+// recipe locally (marketplace, then classpath) instead of wrapping the Go recipe in an RpcRecipe.
 type goDelegatingRecipe struct{ recipe.Base }
 
 func (*goDelegatingRecipe) Name() string           { return "org.openrewrite.go.test.Delegating" }

--- a/rewrite-javascript/rewrite/fixtures/composite-with-java-delegate.ts
+++ b/rewrite-javascript/rewrite/fixtures/composite-with-java-delegate.ts
@@ -30,7 +30,7 @@ export async function activate(marketplace: RecipeMarketplace) {
  * {@code RpcRecipe.getRecipeList()}. The Java-delegate child is an {@code RpcRecipe}
  * that {@code installSubRecipes} does not register in this server's marketplace, so the
  * re-prepare misses here and the server must answer with {@code delegatesTo} (rather than
- * throwing) so the host resolves it from its own marketplace as a local Java recipe.
+ * throwing) so the host instantiates it as a local Java recipe (marketplace, then classpath).
  */
 class CompositeWithJavaDelegate extends Recipe {
     name = "org.openrewrite.example.npm.composite-with-java-delegate";

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -661,7 +661,7 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
      * (the shape of Angular's {@code UpgradeToAngular19}). The host re-prepares each child by id while
      * building {@code RpcRecipe.getRecipeList()}; the Java-delegate child misses in the JS marketplace,
      * so the JS server must answer {@code delegatesTo} (rather than throwing "Could not find recipe
-     * with id ...") and the host resolves it from its own marketplace as a LOCAL Java recipe.
+     * with id ...") and the host instantiates it as a LOCAL Java recipe (marketplace, then classpath).
      * <p>
      * The host (this JVM) is configured with a runtime-classpath marketplace + resolver that owns its
      * bundled {@code org.openrewrite.javascript.*} recipes — mirroring the moderne-cli concession.

--- a/rewrite-python/src/integTest/java/org/openrewrite/python/RecipeListReferencingJavaRecipeIntegTest.java
+++ b/rewrite-python/src/integTest/java/org/openrewrite/python/RecipeListReferencingJavaRecipeIntegTest.java
@@ -64,10 +64,11 @@ import static org.openrewrite.test.SourceSpecs.text;
  * {@code existingFileStrategy}) and string-to-enum coercion ({@code "Continue"}).
  * <p>
  * The Python composite is supplied as a test-only fixture package installed into
- * the peer via the {@code InstallRecipes} RPC, and the delegated Java recipe is
- * made resolvable to the JVM's {@code delegatesTo} consumer by a marketplace
- * scanned from the runtime classpath (mirroring {@code RewriteRpcTest}). No
- * production code or shipped recipe is involved.
+ * the peer via the {@code InstallRecipes} RPC, and the JVM's {@code delegatesTo}
+ * consumer resolves the delegated Java recipe from a marketplace scanned from the
+ * runtime classpath (mirroring {@code RewriteRpcTest}), exercising the marketplace
+ * route rather than its classpath fallback. No production code or shipped recipe is
+ * involved.
  */
 class RecipeListReferencingJavaRecipeIntegTest implements RewriteTest {
 
@@ -188,9 +189,9 @@ class RecipeListReferencingJavaRecipeIntegTest implements RewriteTest {
 
     /**
      * Resolves recipes straight from the runtime-classpath marketplace, so the
-     * JVM's {@code delegatesTo} consumer (which does a marketplace lookup) can
-     * find and natively instantiate the delegated Java recipe. Mirrors the
-     * resolver in {@code RewriteRpcTest}.
+     * JVM's {@code delegatesTo} consumer (marketplace first, then classpath) finds
+     * the delegated Java recipe through the marketplace. Mirrors the resolver in
+     * {@code RewriteRpcTest}.
      */
     class TestRecipeBundleResolver implements RecipeBundleResolver {
         @Override


### PR DESCRIPTION
A customer JavaScript composite whose recipe list includes a Java recipe fails on the host with:

```
IllegalStateException: Remote declared delegatesTo org.openrewrite.javascript.UpgradeDependencyVersion but no recipe found in marketplace.
```

The composite calls `upgradeDependencyVersion(...)`. The JS server answers that child with `delegatesTo` on its own marketplace miss (#8050), and the host then has to instantiate the Java recipe itself.

`RewriteRpc` has two places that turn a recipe name from a peer into a local `Recipe`, and they disagree:

| path | marketplace hit | marketplace miss |
|---|---|---|
| inbound `PrepareRecipe` handler | `listing.prepare(resolvers, opts)` | `new RecipeLoader(null).load(id, opts)` |
| outbound `delegatesTo` in `recipeFromPrepareResponse` | `listing.prepare(resolvers, opts)` | throw |

A host built with the `JavaScriptRewriteRpc` builder defaults has an empty marketplace, so every Java delegate of a JavaScript composite failed there, even with the delegate's class on the classpath.

Both sites now share one `loadRecipe`: marketplace listing first, then `RecipeLoader` by class name. Only a double miss throws, an `IllegalStateException` carrying the loader's message and cause, so an option-value error on a loadable class is not reported as a missing class. Any host with the delegate's class on its classpath can now run it.

Rejected: configuring a populated marketplace on the affected host. It fixes one deployment and leaves every other host built with the builder defaults broken the same way.

- `RewriteRpcTest.delegatesToLoadsFromClasspathWhenMarketplaceMisses` feeds `recipeFromPrepareResponse` a `delegatesTo` naming a recipe that is on the classpath but outside the test marketplace's scan, and asserts the local instance comes back with its options. Before the change it fails with the exception above.
- `RewriteRpcTest.delegatesToFailsWithLoaderCauseWhenNeitherMarketplaceNorClasspathHasIt` pins the double-miss contract: an `IllegalStateException` naming the recipe, with the loader failure as its cause.

`./gradlew :rewrite-core:test` passes. `./gradlew :rewrite-javascript:integTest --tests JavaScriptRewriteRpcTest` passes 26 of 27, including `jsCompositeWithJavaDelegateChild`; the remaining `getRecipes` fails identically against main (it installs a local fixture and then asks for the `@openrewrite/recipes-npm` bundle) and CI does not run that suite.

## Behaviour change for hosts with a partial marketplace

The fallback loads the class through rewrite-core's own classloader. A host whose bundle marketplace lists only each bundle's own recipes now runs an unlisted delegate from the host's own copy, where it previously failed. The inbound `PrepareRecipe` handler has always done this. Listing the delegate in the marketplace remains the way to pin it to a bundle.

The `delegatesTo` comments in the Go, JavaScript, and Python test fixtures described the host consumer as marketplace-only; they now name the classpath fallback, which is why those modules appear in the diff.
