### PR TITLE
Python, Go: fix concurrency issue around RPC binary

### DIFF
--- a/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
+++ b/rewrite-go/src/main/java/org/openrewrite/golang/rpc/GoRewriteRpc.java
@@ -397,8 +397,10 @@ public class GoRewriteRpc extends RewriteRpc {
         }
 
         /**
-         * Supplies the path to the Go RPC binary. The supplier is invoked at most
-         * once, when the RPC is first started. Returning {@code null} uses the built-in
+         * Supplies the path to the Go RPC binary. The supplier is invoked once per
+         * thread that starts an RPC, since {@link RewriteRpcProcessManager} holds one
+         * RPC per thread; invocations are serialized across threads (see
+         * {@link #resolveGoBinaryPath}). Returning {@code null} uses the built-in
          * fallback discovery (same as not configuring the path at all). Exceptions
          * thrown by the supplier propagate out of the RPC-start call.
          *
@@ -456,7 +458,7 @@ public class GoRewriteRpc extends RewriteRpc {
 
         @Override
         public GoRewriteRpc get() {
-            @Nullable Path goBinaryPath = goBinaryPathSupplier.get();
+            @Nullable Path goBinaryPath = resolveGoBinaryPath(goBinaryPathSupplier);
             String binaryPath;
             if (goBinaryPath != null) {
                 binaryPath = goBinaryPath.toString();
@@ -498,6 +500,14 @@ public class GoRewriteRpc extends RewriteRpc {
                         .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
+            }
+        }
+
+        private static final Object BINARY_PATH_LOCK = new Object();
+
+        static @Nullable Path resolveGoBinaryPath(Supplier<@Nullable Path> goBinaryPathSupplier) {
+            synchronized (BINARY_PATH_LOCK) {
+                return goBinaryPathSupplier.get();
             }
         }
     }

--- a/rewrite-go/src/test/java/org/openrewrite/golang/rpc/GoBinaryPathConcurrencyTest.java
+++ b/rewrite-go/src/test/java/org/openrewrite/golang/rpc/GoBinaryPathConcurrencyTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Moderne CLI's {@code goBinaryPathSupplier} takes a JVM-wide exclusive
+ * {@link FileLock} on the Go workspace while it rebuilds the RPC binary. Because
+ * {@link RewriteRpcProcessManager} holds one RPC per thread, several worker threads
+ * can start a Go RPC at once, each invoking the supplier concurrently. A {@code FileLock}
+ * is held per JVM, not per thread, so overlapping lock attempts from one JVM throw
+ * {@link OverlappingFileLockException} rather than blocking (openrewrite/rewrite#8527).
+ * {@link GoRewriteRpc.Builder#resolveGoBinaryPath} serializes the supplier so at most one
+ * thread holds the workspace lock at a time.
+ */
+class GoBinaryPathConcurrencyTest {
+
+    private static final int THREADS = 8;
+
+    @Test
+    void concurrentSupplierInvocationsAreSerialized(@TempDir Path tempDir) throws Exception {
+        // given
+        Path workspaceLock = tempDir.resolve("workspace.lock");
+        Path binary = tempDir.resolve("rewrite-go-rpc");
+
+        CountDownLatch ready = new CountDownLatch(THREADS);
+        CountDownLatch go = new CountDownLatch(1);
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        List<Path> resolved = new CopyOnWriteArrayList<>();
+
+        // A supplier that mimics the CLI: it takes the JVM-wide workspace file lock,
+        // holds it briefly (as a rebuild would), then releases and returns the binary path.
+        java.util.function.Supplier<Path> supplier = () -> {
+            try (FileChannel channel = FileChannel.open(workspaceLock, CREATE, WRITE);
+                 FileLock ignored = channel.lock()) {
+                Thread.sleep(25);
+                return binary;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        // when
+        Thread[] threads = new Thread[THREADS];
+        for (int i = 0; i < THREADS; i++) {
+            threads[i] = new Thread(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                    resolved.add(GoRewriteRpc.Builder.resolveGoBinaryPath(supplier));
+                } catch (Throwable t) {
+                    failures.add(t);
+                }
+            });
+            threads[i].start();
+        }
+        assertThat(ready.await(30, SECONDS)).as("threads failed to start").isTrue();
+        go.countDown();
+        for (Thread t : threads) {
+            t.join(SECONDS.toMillis(30));
+        }
+
+        // then
+        assertThat(failures)
+                .as("no thread may see an OverlappingFileLockException")
+                .noneMatch(OverlappingFileLockException.class::isInstance);
+        assertThat(failures).isEmpty();
+        assertThat(resolved).hasSize(THREADS).containsOnly(binary);
+    }
+}

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -505,8 +505,10 @@ public class PythonRewriteRpc extends RewriteRpc {
         }
 
         /**
-         * Supplies the path to the Python executable. The supplier is invoked at most
-         * once, when the RPC is first started. Returning {@code null} uses the built-in
+         * Supplies the path to the Python executable. The supplier is invoked once per
+         * thread that starts an RPC, since {@link RewriteRpcProcessManager} holds one RPC
+         * per thread; invocations are serialized across threads (see
+         * {@link #resolveUnderInstallLock}). Returning {@code null} uses the built-in
          * default (same as not configuring the path at all). Exceptions thrown by the
          * supplier propagate out of the RPC-start call.
          *
@@ -616,7 +618,8 @@ public class PythonRewriteRpc extends RewriteRpc {
         }
 
         /**
-         * Supplies the engine install directory, resolved at most once when the RPC first starts.
+         * Supplies the engine install directory, resolved once per thread that starts an RPC and
+         * serialized across threads (see {@link #resolveUnderInstallLock}).
          * Returning {@code null} means "no pre-provisioned engine" (fall back to normal detection).
          * Because it runs at start, the supplier is the right place to do lazy, on-demand work such
          * as installing the engine before returning its directory.
@@ -657,7 +660,7 @@ public class PythonRewriteRpc extends RewriteRpc {
 
         @Override
         public PythonRewriteRpc get() {
-            Path pythonPath = pythonPathSupplier.get();
+            Path pythonPath = resolveUnderInstallLock(pythonPathSupplier);
             if (pythonPath == null) {
                 pythonPath = findDefaultPythonPath();
             }
@@ -671,7 +674,7 @@ public class PythonRewriteRpc extends RewriteRpc {
             // already provisioned out-of-band. Resolved lazily here so any such work only happens
             // when the RPC actually starts; when present, use it directly and skip all
             // bootstrap/detection — no network, no interpreter probes. Null → normal path.
-            Path engineInstallDir = engineInstallDirSupplier.get();
+            Path engineInstallDir = resolveUnderInstallLock(engineInstallDirSupplier);
             if (engineInstallDir != null) {
                 resolvedPipPackagesPath = engineInstallDir;
             } else if (!isDevBuild) {
@@ -788,6 +791,14 @@ public class PythonRewriteRpc extends RewriteRpc {
                         .log(log == null ? null : new PrintStream(Files.newOutputStream(log, StandardOpenOption.APPEND, StandardOpenOption.CREATE)));
             } catch (IOException e) {
                 throw new UncheckedIOException(e);
+            }
+        }
+
+        private static final Object INSTALL_LOCK = new Object();
+
+        static @Nullable Path resolveUnderInstallLock(Supplier<@Nullable Path> supplier) {
+            synchronized (INSTALL_LOCK) {
+                return supplier.get();
             }
         }
 

--- a/rewrite-python/src/test/java/org/openrewrite/python/rpc/PythonInstallLockConcurrencyTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/rpc/PythonInstallLockConcurrencyTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+
+import static java.nio.file.StandardOpenOption.CREATE;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The Moderne CLI's {@code pythonPathSupplier} / {@code engineInstallDirSupplier} run a pip/uv
+ * install under a JVM-wide exclusive {@link FileLock}. Because {@link RewriteRpcProcessManager}
+ * holds one RPC per thread, several worker threads can start a Python RPC at once, each invoking
+ * a supplier concurrently. A {@code FileLock} is held per JVM, not per thread, so overlapping lock
+ * attempts from one JVM throw {@link OverlappingFileLockException} rather than blocking
+ * (openrewrite/rewrite#8527). {@link PythonRewriteRpc.Builder#resolveUnderInstallLock} serializes
+ * the supplier so at most one thread holds the install lock at a time.
+ */
+class PythonInstallLockConcurrencyTest {
+
+    private static final int THREADS = 8;
+
+    @Test
+    void concurrentSupplierInvocationsAreSerialized(@TempDir Path tempDir) throws Exception {
+        // given
+        Path installLock = tempDir.resolve("install.lock");
+        Path resolvedPath = tempDir.resolve("python");
+
+        CountDownLatch ready = new CountDownLatch(THREADS);
+        CountDownLatch go = new CountDownLatch(1);
+        List<Throwable> failures = new CopyOnWriteArrayList<>();
+        List<Path> resolved = new CopyOnWriteArrayList<>();
+
+        // A supplier that mimics the CLI: it takes the JVM-wide install file lock,
+        // holds it briefly (as a pip/uv install would), then releases and returns the path.
+        java.util.function.Supplier<Path> supplier = () -> {
+            try (FileChannel channel = FileChannel.open(installLock, CREATE, WRITE);
+                 FileLock ignored = channel.lock()) {
+                Thread.sleep(25);
+                return resolvedPath;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        // when
+        Thread[] threads = new Thread[THREADS];
+        for (int i = 0; i < THREADS; i++) {
+            threads[i] = new Thread(() -> {
+                ready.countDown();
+                try {
+                    go.await();
+                    resolved.add(PythonRewriteRpc.Builder.resolveUnderInstallLock(supplier));
+                } catch (Throwable t) {
+                    failures.add(t);
+                }
+            });
+            threads[i].start();
+        }
+        assertThat(ready.await(30, SECONDS)).as("threads failed to start").isTrue();
+        go.countDown();
+        for (Thread t : threads) {
+            t.join(SECONDS.toMillis(30));
+        }
+
+        // then
+        assertThat(failures)
+                .as("no thread may see an OverlappingFileLockException")
+                .noneMatch(OverlappingFileLockException.class::isInstance);
+        assertThat(failures).isEmpty();
+        assertThat(resolved).hasSize(THREADS).containsOnly(resolvedPath);
+    }
+}


### PR DESCRIPTION
## What's changed?

Adding synchronization around Go's and Python's logic to fetch RPC binary.

## What's your motivation?

- Fixes #8527