### PR TITLE
JS: prepareJavaRecipe returns a lazy delegatesTo placeholder, aligned with Python

### DIFF
--- a/rewrite-javascript/rewrite/fixtures/composite-with-java-delegate.ts
+++ b/rewrite-javascript/rewrite/fixtures/composite-with-java-delegate.ts
@@ -21,16 +21,10 @@ export async function activate(marketplace: RecipeMarketplace) {
 }
 
 /**
- * Mirrors the shape of Angular's `UpgradeToAngular19`: a JS composite whose
- * {@code recipeList()} contains a recipe that delegates entirely to a Java recipe
- * (here {@code org.openrewrite.javascript.UpgradeDependencyVersion}, via
- * {@link prepareJavaRecipe}).
- *
- * The host re-prepares each child of this composite by id while building
- * {@code RpcRecipe.getRecipeList()}. The Java-delegate child is an {@code RpcRecipe}
- * that {@code installSubRecipes} does not register in this server's marketplace, so the
- * re-prepare misses here and the server must answer with {@code delegatesTo} (rather than
- * throwing) so the host resolves it from its own marketplace as a local Java recipe.
+ * A JS composite whose {@code recipeList()} contains recipes that delegate entirely to Java
+ * recipes (via {@link prepareJavaRecipe}), the shape of a framework upgrade recipe. The server
+ * emits each such child as {@code delegatesTo} and the host builds it from its marketplace while
+ * building {@code RpcRecipe.getRecipeList()}.
  */
 class CompositeWithJavaDelegate extends Recipe {
     name = "org.openrewrite.example.npm.composite-with-java-delegate";
@@ -39,10 +33,8 @@ class CompositeWithJavaDelegate extends Recipe {
 
     async recipeList(): Promise<Recipe[]> {
         return [
-            await prepareJavaRecipe("org.openrewrite.javascript.UpgradeDependencyVersion", {
-                packagePattern: "@angular/*",
-                newVersion: "19.x"
-            })
+            await prepareJavaRecipe("org.openrewrite.example.host.replace-hello"),
+            await prepareJavaRecipe("org.openrewrite.text.FindAndReplace", {find: "goodbye", replace: "farewell"})
         ];
     }
 }

--- a/rewrite-javascript/rewrite/fixtures/java-delegate-precondition.ts
+++ b/rewrite-javascript/rewrite/fixtures/java-delegate-precondition.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {check, ExecutionContext, Recipe, RecipeMarketplace, TreeVisitor} from "@openrewrite/rewrite";
+import {prepareJavaRecipe} from "@openrewrite/rewrite/rpc";
+import {FindIdentifier} from "./search-recipe";
+
+export async function activate(marketplace: RecipeMarketplace) {
+    await marketplace.install(FindIdentifierGatedByJavaRecipe, []);
+}
+
+/**
+ * Gates a JS editor on a Java recipe, the shape of `check(usesType(...), editor)` when the
+ * gate is a recipe rather than a `RecipeRef`.
+ */
+class FindIdentifierGatedByJavaRecipe extends Recipe {
+    name = "org.openrewrite.example.npm.find-identifier-gated-by-java-recipe";
+    displayName = "Find identifier gated by a Java recipe";
+    description = "Find identifiers in files a Java search recipe matches.";
+
+    async editor(): Promise<TreeVisitor<any, ExecutionContext>> {
+        return check(
+            await prepareJavaRecipe("org.openrewrite.text.Find", {find: "gate"}),
+            new FindIdentifier({identifier: "x"}).editor()
+        );
+    }
+}

--- a/rewrite-javascript/rewrite/fixtures/recipe-with-rpc-sub-recipe.ts
+++ b/rewrite-javascript/rewrite/fixtures/recipe-with-rpc-sub-recipe.ts
@@ -18,10 +18,10 @@ import {RewriteRpc, RpcRecipe} from "@openrewrite/rewrite/rpc";
 import {ChangeText} from "./change-text";
 
 /**
- * Mirrors the shape of a real-world composite recipe (e.g. Angular's
- * `UpgradeToAngular21`) whose `recipeList()` mixes locally-defined recipes with
- * recipes that were prepared on a remote RPC peer (via `prepareJavaRecipe` /
- * `rpc.prepareRecipe`, which return {@link RpcRecipe} instances).
+ * Mirrors the shape of a real-world framework-upgrade composite whose
+ * `recipeList()` mixes locally-defined recipes with recipes that were prepared
+ * on a remote RPC peer (via `rpc.prepareRecipe`, which returns {@link RpcRecipe}
+ * instances).
  *
  * The remote sub-recipe must not be re-installed by its constructor during
  * `PrepareRecipe` — `RpcRecipe` is a proxy that cannot be constructed without

--- a/rewrite-javascript/rewrite/src/rpc/index.ts
+++ b/rewrite-javascript/rewrite/src/rpc/index.ts
@@ -33,7 +33,7 @@ export * from "./queue";
 export * from "../reference";
 export {RewriteRpc} from "./rewrite-rpc";
 export {RpcRecipe, RpcVisitor} from "./recipe";
-export {prepareJavaRecipe} from "./java-recipe";
+export {DelegatingRecipe, prepareJavaRecipe} from "./java-recipe";
 export {registerVisitor} from "./request/visitor-registry";
 
 RpcCodecs.registerCodec(TreeKind.Checksum, {

--- a/rewrite-javascript/rewrite/src/rpc/java-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/java-recipe.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 the original author or authors.
+ * Copyright 2026 the original author or authors.
  * <p>
  * Licensed under the Moderne Source Available License (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,23 +15,110 @@
  */
 import {RewriteRpc} from "./rewrite-rpc";
 import type {RpcRecipe} from "./recipe";
+import {Recipe, RecipeDescriptor, ScanningRecipe} from "../recipe";
+import {TreeVisitor} from "../visitor";
+import {ExecutionContext} from "../execution";
+import {SourceFile} from "../tree";
 
 /**
- * Prepare a Java recipe via the active {@link RewriteRpc} connection.
- *
- * Routes a `PrepareRecipe` request to whichever side hosts the Java
- * implementation:
- *  - in production, the Java host that spawned the TS server (`dist/rpc/server.js`);
- *  - in tests, the JVM spawned via `JavaRpcTestServer` (see
- *    `@openrewrite/rewrite/test/java-rpc`).
- *
- * The returned {@link RpcRecipe} extends `Recipe`, so it can be used directly
- * as a recipe — e.g. assigned to `RecipeSpec.recipe` — or composed inside a
- * larger TS recipe (as the editor of a `check(usesType(...), ...)`
- * precondition, or as a step in `recipeList()`).
- *
- * Top-level convenience functions for specific Java recipes (e.g.
- * `addDependency`, `changeType`) sit naturally on top of this primitive:
+ * A stand-in for a Java recipe, composable like any other recipe (a `recipeList()` entry, a
+ * `check(...)` gate, a `RecipeSpec.recipe`). The Java host resolves it by name: from `delegatesTo`
+ * when it prepares the enclosing recipe, or by class name when it gates a visitor, like a `RecipeRef`.
+ * Only when this process runs it itself (a test, a JS-hosted run) is it prepared over the active
+ * {@link RewriteRpc} connection, on first use.
+ */
+export class DelegatingRecipe extends ScanningRecipe<number> {
+    readonly name: string;
+    readonly displayName: string;
+    readonly description: string;
+    private delegate?: {rpc: RewriteRpc, recipe: Promise<RpcRecipe>};
+
+    constructor(readonly javaRecipeName: string,
+                readonly delegatesToOptions: Record<string, any>) {
+        super();
+        this.name = javaRecipeName;
+        this.displayName = javaRecipeName;
+        this.description = `Delegates to the Java recipe \`${javaRecipeName}\`.`;
+    }
+
+    // Local, with an empty recipe list: the host fills the subtree in, and recipeList() prepares the delegate.
+    async descriptor(): Promise<RecipeDescriptor> {
+        return {
+            name: this.name,
+            displayName: this.displayName,
+            instanceName: this.instanceName(),
+            description: this.description,
+            tags: this.tags,
+            estimatedEffortPerOccurrence: this.estimatedEffortPerOccurrence,
+            options: Object.entries(this.delegatesToOptions).map(([name, value]) => ({
+                name,
+                value,
+                displayName: name,
+                description: "",
+                required: false
+            })),
+            preconditions: [],
+            recipeList: [],
+            dataTables: this.dataTables,
+            maintainers: [],
+            contributors: [],
+            examples: []
+        };
+    }
+
+    async recipeList(): Promise<Recipe[]> {
+        return (await this.prepared()).recipeList();
+    }
+
+    initialValue(_ctx: ExecutionContext): number {
+        return 0;
+    }
+
+    async editorWithData(acc: number): Promise<TreeVisitor<any, ExecutionContext>> {
+        return (await this.prepared()).editorWithData(acc);
+    }
+
+    async scanner(acc: number): Promise<TreeVisitor<any, ExecutionContext>> {
+        return (await this.prepared()).scanner(acc);
+    }
+
+    async generate(acc: number, ctx: ExecutionContext): Promise<SourceFile[]> {
+        return (await this.prepared()).generate(acc, ctx);
+    }
+
+    async onComplete(ctx: ExecutionContext): Promise<void> {
+        if (this.delegate) {
+            await (await this.delegate.recipe).onComplete(ctx);
+        }
+    }
+
+    private prepared(): Promise<RpcRecipe> {
+        const rpc = RewriteRpc.get();
+        if (!rpc) {
+            throw new Error(
+                `Cannot run Java recipe "${this.javaRecipeName}": no active RewriteRpc connection.\n` +
+                "  • Tests: spawn one via JavaRpcTestServer.start() — see " +
+                "@openrewrite/rewrite/test/java-rpc.\n" +
+                "  • Production: the Java host provides one automatically when it " +
+                "loads the TS recipe artifact."
+            );
+        }
+        // Prepared once per connection; a failed prepare is dropped so the next use retries.
+        if (!this.delegate || this.delegate.rpc !== rpc) {
+            const recipe = rpc.prepareRecipe(this.javaRecipeName, this.delegatesToOptions);
+            this.delegate = {rpc, recipe};
+            recipe.catch(() => {
+                if (this.delegate?.recipe === recipe) {
+                    this.delegate = undefined;
+                }
+            });
+        }
+        return this.delegate.recipe;
+    }
+}
+
+/**
+ * Reference a Java recipe by name from a TS recipe:
  *
  * ```ts
  * export function addDependency(options: AddDependencyOptions): Promise<Recipe> {
@@ -39,26 +126,13 @@ import type {RpcRecipe} from "./recipe";
  * }
  * ```
  *
- * There is no in-process fallback by design: a Java recipe's editor is the
- * single source of truth — we don't reimplement editing recipes in TS. For
- * preconditions that need a graceful no-RPC fallback, use the {@link RecipeRef}
+ * There is no in-process fallback by design: a Java recipe's editor is the single source of
+ * truth. For preconditions that need a graceful no-RPC fallback, use the {@link RecipeRef}
  * pattern via `usesType` / `usesMethod`, which carries a `localVisitor`.
- *
- * @throws Error when no active {@link RewriteRpc} connection is registered.
  */
 export async function prepareJavaRecipe(
     id: string,
     options?: Record<string, any>,
-): Promise<RpcRecipe> {
-    const rpc = RewriteRpc.get();
-    if (!rpc) {
-        throw new Error(
-            `Cannot prepare Java recipe "${id}": no active RewriteRpc connection.\n` +
-            "  • Tests: spawn one via JavaRpcTestServer.start() — see " +
-            "@openrewrite/rewrite/test/java-rpc.\n" +
-            "  • Production: the Java host provides one automatically when it " +
-            "loads the TS recipe artifact."
-        );
-    }
-    return rpc.prepareRecipe(id, options);
+): Promise<DelegatingRecipe> {
+    return new DelegatingRecipe(id, options ?? {});
 }

--- a/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/prepare-recipe.ts
@@ -19,6 +19,7 @@ import {Recipe, RecipeDescriptor, ScanningRecipe} from "../../recipe";
 import {SnowflakeId} from "@akashrajpurohit/snowflake-id";
 import {Check, CheckArg, CompositePrecondition, RecipeRef} from "../../preconditions";
 import {RpcRecipe} from "../recipe";
+import {DelegatingRecipe} from "../java-recipe";
 import {TreeVisitor} from "../../visitor";
 import {ExecutionContext} from "../../execution";
 import {withMetrics} from "./metrics";
@@ -42,22 +43,10 @@ export class PrepareRecipe {
                     context.target = request.id;
                     const recipeCtor = marketplace.findRecipe(request.id);
                     if (!recipeCtor) {
-                        // A miss means the host owns this recipe (e.g. a sub-recipe that delegates to
-                        // a Java recipe, produced by prepareJavaRecipe — an RpcRecipe hosted on the peer
-                        // with no no-arg constructor to register here). Tell the host to resolve the id
-                        // locally via delegatesTo rather than failing with "Could not find recipe ...".
-                        const id = snowflake.generate();
-                        return {
-                            id: id,
-                            descriptor: PrepareRecipe.delegateDescriptor(request.id),
-                            editVisitor: `edit:${id}`,
-                            editPreconditions: [],
-                            scanPreconditions: [],
-                            delegatesTo: {
-                                recipeName: request.id,
-                                options: request.options ?? {}
-                            }
-                        };
+                        // A miss means the host owns this recipe (e.g. a Java-delegate child a host
+                        // re-prepares by name), so answer with a delegatesTo stand-in for it to resolve.
+                        return await PrepareRecipe.prepareInstance(new DelegatingRecipe(request.id, request.options ?? {}),
+                            snowflake, preparedRecipes, marketplace);
                     }
                     if (!recipeCtor[1]) {
                         throw new Error(`Recipe ${request.id} was installed without a constructor`);
@@ -70,44 +59,30 @@ export class PrepareRecipe {
     }
 
     /**
-     * Minimal stand-in descriptor for a recipe the host will resolve locally via
-     * {@link PrepareRecipeResponse.delegatesTo}. The host reads only `delegatesTo` for
-     * delegated recipes and ignores this descriptor, but the response type requires one.
-     */
-    private static delegateDescriptor(name: string): RecipeDescriptor {
-        return {
-            name: name,
-            displayName: name,
-            instanceName: name,
-            description: "",
-            tags: [],
-            estimatedEffortPerOccurrence: 5,
-            options: [],
-            preconditions: [],
-            recipeList: [],
-            dataTables: [],
-            maintainers: [],
-            contributors: [],
-            examples: []
-        };
-    }
-
-    /**
-     * Prepares a recipe instance and recursively its whole child tree, registering every node in
-     * {@code preparedRecipes} and returning the prepared response with {@code recipeList} populated,
-     * so the host builds the tree locally instead of a PrepareRecipe round-trip per child.
-     *
-     * Mirrors the C# server's PrepareInstance. Required options are validated as each node is
-     * prepared (covering the whole tree). A child hosted on the peer (an {@link RpcRecipe}, e.g. from
-     * prepareJavaRecipe) carries only {@code delegatesTo} for the host to resolve locally; every other
-     * child carries its own {@code recipeList}. Delegating recipes forward validation to the recipe
-     * they delegate to, so they are not validated here.
+     * Prepares a recipe and, recursively, its whole child tree, registering every node in
+     * {@code preparedRecipes}; the response carries {@code recipeList} so the host builds the tree
+     * without a PrepareRecipe round-trip per child (mirrors the C# server's PrepareInstance).
+     * Required options are validated per node. A stand-in for a host recipe (see {@link #delegatesTo})
+     * carries only {@code delegatesTo} and leaves validation to the host.
      */
     private static async prepareInstance(recipe: Recipe,
                                          snowflake: ReturnType<typeof SnowflakeId>,
                                          preparedRecipes: Map<String, Recipe>,
                                          marketplace: RecipeMarketplace): Promise<PrepareRecipeResponse> {
         const id = snowflake.generate();
+        const delegatesTo = PrepareRecipe.delegatesTo(recipe);
+        if (delegatesTo) {
+            // Registered so a peer that visits `edit:<id>` instead of honouring delegatesTo reaches it.
+            preparedRecipes.set(id, recipe);
+            return {
+                id: id,
+                descriptor: await recipe.descriptor(),
+                editVisitor: `edit:${id}`,
+                editPreconditions: [],
+                scanPreconditions: [],
+                delegatesTo
+            };
+        }
 
         const editPreconditions: Precondition[] = [];
         recipe = await PrepareRecipe.optimizePreconditions(recipe, "edit", editPreconditions);
@@ -117,13 +92,9 @@ export class PrepareRecipe {
         preparedRecipes.set(id, recipe);
 
         const descriptor = await recipe.descriptor();
-        const isDelegating = 'javaRecipeName' in recipe;
-
-        if (!isDelegating) {
-            for (const option of descriptor.options) {
-                if ((option.required ?? true) && option.value == null) {
-                    throw new Error(`Missing required option \`${option.name}\` for recipe \`${descriptor.name}\`.`);
-                }
+        for (const option of descriptor.options) {
+            if ((option.required ?? true) && option.value == null) {
+                throw new Error(`Missing required option \`${option.name}\` for recipe \`${descriptor.name}\`.`);
             }
         }
 
@@ -136,47 +107,41 @@ export class PrepareRecipe {
             scanPreconditions: scanPreconditions
         };
 
-        if (isDelegating) {
-            response.delegatesTo = {
-                recipeName: (recipe as any).javaRecipeName,
-                options: (recipe as any).delegatesToOptions ?? {}
-            };
-            return response;
-        }
-
         const childResponses: PrepareRecipeResponse[] = [];
         for (const child of await recipe.recipeList()) {
             if (child instanceof RpcRecipe) {
-                // Hosted on the peer: emit delegatesTo (its name + the options its parent set) so the
-                // host resolves it locally, matching how the by-name fallback used to resolve it.
-                const childId = snowflake.generate();
-                const childDescriptor = await child.descriptor();
+                // Already prepared on the host: hand it back by name with the options its parent set.
                 const options: Record<string, any> = {};
-                for (const option of childDescriptor.options) {
+                for (const option of (await child.descriptor()).options) {
                     if (option.value != null) {
                         options[option.name] = option.value;
                     }
                 }
-                childResponses.push({
-                    id: childId,
-                    descriptor: PrepareRecipe.delegateDescriptor(child.name),
-                    editVisitor: `edit:${childId}`,
-                    editPreconditions: [],
-                    scanPreconditions: [],
-                    delegatesTo: {recipeName: child.name, options}
-                });
-            } else {
-                // Register a child that was instantiated in recipeList() but never installed, so a peer
-                // that re-prepares children by name (rather than consuming recipeList) can still find it.
-                if (!marketplace.findRecipe(child.name)) {
-                    await marketplace.install(child.constructor as any, []);
-                }
-                childResponses.push(await PrepareRecipe.prepareInstance(child, snowflake, preparedRecipes, marketplace));
+                childResponses.push(await PrepareRecipe.prepareInstance(new DelegatingRecipe(child.name, options),
+                    snowflake, preparedRecipes, marketplace));
+                continue;
             }
+            // Register a child that was instantiated in recipeList() but never installed, so a peer
+            // that re-prepares children by name (rather than consuming recipeList) can still find it.
+            if (!PrepareRecipe.delegatesTo(child) && !marketplace.findRecipe(child.name)) {
+                await marketplace.install(child.constructor as any, []);
+            }
+            childResponses.push(await PrepareRecipe.prepareInstance(child, snowflake, preparedRecipes, marketplace));
         }
         response.recipeList = childResponses;
 
         return response;
+    }
+
+    /**
+     * The Java recipe {@code recipe} stands in for, or {@code undefined} for a recipe this process
+     * runs itself. Duck-typed on the fields {@link DelegatingRecipe} declares, so a recipe package
+     * that loaded its own copy of this module is recognised too.
+     */
+    private static delegatesTo(recipe: any): {recipeName: string, options: Record<string, any>} | undefined {
+        return recipe != null && typeof recipe.javaRecipeName === "string" ?
+            {recipeName: recipe.javaRecipeName, options: {...(recipe.delegatesToOptions ?? {})}} :
+            undefined;
     }
 
     /**
@@ -246,13 +211,13 @@ export class PrepareRecipe {
             }
             return {op: condition.op, operands};
         }
-        // Common case: helpers like usesMethod / usesType return a lightweight
-        // RecipeRef so the recipe author can declare a precondition without
-        // firing an RPC at editor() time. The Java host's
-        // PreparedRecipeCache.instantiateVisitor constructs the named recipe
-        // via Jackson and uses its visitor.
-        if (condition instanceof RecipeRef) {
-            return {visitorName: condition.recipeName, visitorOptions: {...condition.options}};
+        // Common case: usesMethod / usesType return a lightweight RecipeRef, and
+        // prepareJavaRecipe a DelegatingRecipe, so a precondition is declared without
+        // firing an RPC at editor() time. The Java host's PreparedRecipeCache
+        // .instantiateVisitor constructs the named recipe via Jackson and uses its visitor.
+        const ref = condition instanceof RecipeRef ? condition : PrepareRecipe.delegatesTo(condition);
+        if (ref) {
+            return {visitorName: ref.recipeName, visitorOptions: {...ref.options}};
         }
         if (condition instanceof RpcRecipe) {
             return {visitorName: phase === "edit" ? condition.editVisitor : condition.scanVisitor!};

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -50,18 +50,11 @@ import {GetLanguages} from "./request/get-languages";
 
 export class RewriteRpc {
     /**
-     * Key for the active {@link RewriteRpc} connection on {@link globalThis}.
-     *
-     * It deliberately lives on `globalThis` rather than as a `static` field:
-     * a recipe package that bundles `@openrewrite/rewrite` (or resolves it from
-     * its own `node_modules`) loads a *separate copy* of this module, with its
-     * own class object and therefore its own statics. A `static` field set by
-     * the host would be invisible to such a copy, so `RewriteRpc.get()` (e.g.
-     * via `prepareJavaRecipe`) would return `undefined` and throw "no active
-     * RewriteRpc connection" — surfacing during `InstallRecipes` as the
-     * misleading "Ensure the constructor can be called without any arguments".
-     * {@link Symbol.for} resolves to the same symbol across every module copy,
-     * so all copies share the one active connection. See gh-7968.
+     * Key for the active {@link RewriteRpc} connection on {@link globalThis}. A recipe package that
+     * bundles `@openrewrite/rewrite` or resolves it from its own `node_modules` loads a separate copy
+     * of this module with its own class object and statics, so a `static` field set by the host would
+     * be invisible to it; {@link Symbol.for} resolves to the same symbol across every module copy, so
+     * all copies share the one active connection. See gh-7968.
      */
     private static readonly GLOBAL_KEY: symbol = Symbol.for("org.openrewrite.rpc.RewriteRpc.global");
 

--- a/rewrite-javascript/rewrite/test/rpc/java-recipe-via-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/java-recipe-via-rpc.test.ts
@@ -46,4 +46,14 @@ describeJavaRpc("Java recipe via RPC", () => {
             },
         );
     });
+
+    testJavaRpc("prepareJavaRecipe exposes a Java composite's children for a run in this process", async ({javaRpc: _javaRpc}) => {
+        const recipe = await prepareJavaRecipe(
+            "org.openrewrite.maven.cleanup.AddProjectBuildOutputTimestamp",
+            {timestamp: "2024-01-01T00:00:00Z"},
+        );
+        expect((await recipe.descriptor()).recipeList).toEqual([]);
+        expect((await recipe.recipeList()).map(child => child.name))
+            .toEqual(["org.openrewrite.maven.AddProperty"]);
+    });
 });

--- a/rewrite-javascript/rewrite/test/rpc/java-recipe.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/java-recipe.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {prepareJavaRecipe} from "../../src/rpc";
+
+describe("prepareJavaRecipe", () => {
+    // Test files share a worker, so unset any connection a neighbour registered.
+    const GLOBAL_KEY = Symbol.for("org.openrewrite.rpc.RewriteRpc.global");
+    let saved: any;
+    beforeEach(() => {
+        saved = (globalThis as any)[GLOBAL_KEY];
+        delete (globalThis as any)[GLOBAL_KEY];
+    });
+    afterEach(() => {
+        (globalThis as any)[GLOBAL_KEY] = saved;
+    });
+
+    test("builds a placeholder carrying the options without an active connection", async () => {
+        const recipe = await prepareJavaRecipe("org.openrewrite.text.FindAndReplace", {find: "Hello", replace: "Goodbye"});
+        expect(recipe.name).toEqual("org.openrewrite.text.FindAndReplace");
+        const descriptor = await recipe.descriptor();
+        expect(descriptor.options.map(o => [o.name, o.value])).toEqual([["find", "Hello"], ["replace", "Goodbye"]]);
+        expect(descriptor.recipeList).toEqual([]);
+    });
+});

--- a/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/rewrite-rpc.test.ts
@@ -23,6 +23,8 @@ import {RecipeSpec} from "../../src/test";
 import {PassThrough} from "node:stream";
 import * as rpc from "vscode-jsonrpc/node";
 import {activate} from "../../fixtures/example-recipe";
+import {activate as activateCompositeWithJavaDelegate} from "../../fixtures/composite-with-java-delegate";
+import {activate as activateJavaDelegatePrecondition} from "../../fixtures/java-delegate-precondition";
 import {
     findNodeResolutionResult,
     javascript,
@@ -40,6 +42,7 @@ describe("Rewrite RPC", () => {
     const spec = new RecipeSpec();
 
     let server: RewriteRpc;
+    let serverMarketplace: RecipeMarketplace;
     let client: RewriteRpc;
 
     beforeEach(async () => {
@@ -59,10 +62,10 @@ describe("Rewrite RPC", () => {
             new rpc.StreamMessageReader(clientToServer),
             new rpc.StreamMessageWriter(serverToClient)
         );
-        const marketplace = new RecipeMarketplace();
-        await activate(marketplace);
+        serverMarketplace = new RecipeMarketplace();
+        await activate(serverMarketplace);
         server = new RewriteRpc(serverConnection, {
-            marketplace: marketplace
+            marketplace: serverMarketplace
         });
     });
 
@@ -269,10 +272,10 @@ describe("Rewrite RPC", () => {
 
     test("prepareRecipeWithRpcSubRecipeInRecipeList", async () => {
         // A composite recipe whose recipeList() mixes a local recipe with an
-        // already-prepared remote (RpcRecipe) sub-recipe — the shape of e.g.
-        // Angular's UpgradeToAngular21, which lists upgradeDependencyVersion()
-        // (a Java recipe prepared over RPC). Preparing it must not try to
-        // re-install the RpcRecipe by its (no-arg-incompatible) constructor.
+        // already-prepared remote (RpcRecipe) sub-recipe — the shape of a
+        // framework-upgrade composite listing a Java recipe prepared over RPC.
+        // Preparing it must not try to re-install the RpcRecipe by its
+        // (no-arg-incompatible) constructor.
         const recipe = await client.prepareRecipe("org.openrewrite.example.text.with-rpc-sub-recipe");
         const descriptor = await recipe.descriptor();
         expect(descriptor.recipeList.map(r => r.name)).toContain(
@@ -300,13 +303,6 @@ describe("Rewrite RPC", () => {
     });
 
     test("preparing an unknown recipe id delegates to the host instead of failing", async () => {
-        // When the host builds RpcRecipe.getRecipeList() it re-prepares every child by
-        // id over RPC. A child that delegates to a Java recipe (e.g. Angular's
-        // upgradeDependencyVersion() -> org.openrewrite.javascript.UpgradeDependencyVersion)
-        // is an RpcRecipe that installSubRecipes intentionally does NOT register in this
-        // marketplace, so findRecipe misses. Rather than throwing "Could not find recipe
-        // with id ...", the server must tell the host to resolve it locally via delegatesTo
-        // (the Java recipe is on the host's classpath).
         const response: PrepareRecipeResponse = await (client as any).connection.sendRequest(
             new rpc.RequestType<PrepareRecipe, PrepareRecipeResponse, Error>("PrepareRecipe"),
             new PrepareRecipe("org.openrewrite.javascript.UpgradeDependencyVersion", {newVersion: "19.x"})
@@ -315,6 +311,29 @@ describe("Rewrite RPC", () => {
             recipeName: "org.openrewrite.javascript.UpgradeDependencyVersion",
             options: {newVersion: "19.x"}
         });
+    });
+
+    test("a composite's Java-delegate children are emitted as delegatesTo with the options as passed", async () => {
+        await activateCompositeWithJavaDelegate(serverMarketplace);
+        const response: PrepareRecipeResponse = await (client as any).connection.sendRequest(
+            new rpc.RequestType<PrepareRecipe, PrepareRecipeResponse, Error>("PrepareRecipe"),
+            new PrepareRecipe("org.openrewrite.example.npm.composite-with-java-delegate")
+        );
+        expect(response.recipeList!.map(child => child.delegatesTo)).toEqual([
+            {recipeName: "org.openrewrite.example.host.replace-hello", options: {}},
+            {recipeName: "org.openrewrite.text.FindAndReplace", options: {find: "goodbye", replace: "farewell"}}
+        ]);
+    });
+
+    test("a Java-delegate precondition is sent as a named visitor for the host to gate on", async () => {
+        await activateJavaDelegatePrecondition(serverMarketplace);
+        const response: PrepareRecipeResponse = await (client as any).connection.sendRequest(
+            new rpc.RequestType<PrepareRecipe, PrepareRecipeResponse, Error>("PrepareRecipe"),
+            new PrepareRecipe("org.openrewrite.example.npm.find-identifier-gated-by-java-recipe")
+        );
+        expect(response.editPreconditions).toContainEqual(
+            {visitorName: "org.openrewrite.text.Find", visitorOptions: {find: "gate"}}
+        );
     });
 
     test("runRecipeWithCrossModuleRecipeList", async () => {

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRewriteRpcTest.java
@@ -23,8 +23,10 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.*;
+import org.openrewrite.config.DeclarativeRecipe;
 import org.openrewrite.config.Environment;
 import org.openrewrite.config.RecipeDescriptor;
+import org.openrewrite.config.YamlResourceLoader;
 import org.openrewrite.internal.RecipeLoader;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaVisitor;
@@ -32,7 +34,6 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.javascript.JavaScriptIsoVisitor;
 import org.openrewrite.javascript.JavaScriptParser;
-import org.openrewrite.javascript.UpgradeDependencyVersion;
 import org.openrewrite.javascript.style.Autodetect;
 import org.openrewrite.marker.Markup;
 import org.openrewrite.marketplace.RecipeBundle;
@@ -40,21 +41,25 @@ import org.openrewrite.marketplace.RecipeBundleReader;
 import org.openrewrite.marketplace.RecipeBundleResolver;
 import org.openrewrite.marketplace.RecipeListing;
 import org.openrewrite.marketplace.RecipeMarketplace;
-import org.openrewrite.rpc.RpcRecipe;
 import org.openrewrite.rpc.request.Print;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.tree.ParseError;
 import org.openrewrite.yaml.tree.Yaml;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.javascript.Assertions.*;
 import static org.openrewrite.json.Assertions.json;
@@ -657,48 +662,64 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
     }
 
     /**
-     * A JS composite whose {@code recipeList()} contains a recipe that delegates to a Java recipe
-     * (the shape of Angular's {@code UpgradeToAngular19}). The host re-prepares each child by id while
-     * building {@code RpcRecipe.getRecipeList()}; the Java-delegate child misses in the JS marketplace,
-     * so the JS server must answer {@code delegatesTo} (rather than throwing "Could not find recipe
-     * with id ...") and the host resolves it from its own marketplace as a LOCAL Java recipe.
-     * <p>
-     * The host (this JVM) is configured with a runtime-classpath marketplace + resolver that owns its
-     * bundled {@code org.openrewrite.javascript.*} recipes — mirroring the moderne-cli concession.
+     * A JS composite whose {@code recipeList()} delegates to a Java recipe: the JS peer sends that
+     * child as a {@code delegatesTo} stand-in, which the host resolves from its marketplace only
+     * when the composite runs.
      */
     @Test
     void jsCompositeWithJavaDelegateChild() {
-        Environment env = Environment.builder().scanRuntimeClasspath("org.openrewrite.javascript").build();
-        RecipeMarketplace marketplace = env.toMarketplace(RecipeBundle.runtimeClasspath());
+        File fixture = new File("rewrite/dist-fixtures/composite-with-java-delegate.js");
+        String composite = "org.openrewrite.example.npm.composite-with-java-delegate";
+        // Declarative on purpose: the host's inbound PrepareRecipe handler loads class names off the
+        // classpath, so only a marketplace-only delegate proves nothing was prepared before the run.
+        String delegate = "org.openrewrite.example.host.replace-hello";
+        String optionDelegate = "org.openrewrite.text.FindAndReplace";
+
+        // Builder defaults: no marketplace to resolve the delegate from, yet install and describe succeed.
+        assertThat(client().installRecipes(fixture).getRecipesInstalled()).isGreaterThan(0);
+        Recipe unwired = client().prepareRecipe(composite);
+        assertThat(unwired.getDescriptor().getRecipeList())
+          .extracting(RecipeDescriptor::getName)
+          .containsExactly(delegate, optionDelegate);
+        assertThatThrownBy(unwired::getRecipeList)
+          .hasMessageContaining("no recipe found in marketplace")
+          .hasMessageContaining(delegate);
+
+        JavaScriptRewriteRpc.shutdownCurrent();
+        Environment env = Environment.builder()
+          .scanRuntimeClasspath("org.openrewrite.text")
+          .load(new YamlResourceLoader(new ByteArrayInputStream("""
+            type: specs.openrewrite.org/v1beta/recipe
+            name: %s
+            displayName: Replace hello
+            description: Replaces hello with goodbye.
+            recipeList:
+              - org.openrewrite.text.FindAndReplace:
+                  find: hello
+                  replace: goodbye
+            """.formatted(delegate).getBytes(StandardCharsets.UTF_8)), URI.create("rewrite.yml"), new Properties()))
+          .build();
         JavaScriptRewriteRpc.setFactory(JavaScriptRewriteRpc.builder()
           .recipeInstallDir(tempDir)
-          .marketplace(marketplace)
-          .resolvers(List.of(new RuntimeClasspathResolver(marketplace)))
+          .marketplace(env.toMarketplace(RecipeBundle.runtimeClasspath()))
+          .resolvers(List.of(new RuntimeClasspathResolver(env)))
           .log(tempDir.resolve("rpc.log")));
-
-        assertThat(client().installRecipes(new File("rewrite/dist-fixtures/composite-with-java-delegate.js"))
-          .getRecipesInstalled()).isGreaterThan(0);
-
-        Recipe composite = client().prepareRecipe("org.openrewrite.example.npm.composite-with-java-delegate");
-
-        Recipe delegate = composite.getRecipeList().stream()
-          .filter(r -> "org.openrewrite.javascript.UpgradeDependencyVersion".equals(r.getName()))
-          .findFirst()
-          .orElseThrow(() -> new AssertionError("expected an org.openrewrite.javascript.UpgradeDependencyVersion child"));
-        assertThat(delegate)
-          .isInstanceOf(UpgradeDependencyVersion.class)
-          .isNotInstanceOf(RpcRecipe.class);
+        assertThat(client().installRecipes(fixture).getRecipesInstalled()).isGreaterThan(0);
+        rewriteRun(
+          spec -> spec.recipe(client().prepareRecipe(composite)),
+          text("hello world", "farewell world")
+        );
     }
 
     /**
-     * A runtime-classpath {@link RecipeBundleResolver} that materializes a bundled recipe by id straight
-     * off the JVM classpath, mirroring the moderne-cli {@code RuntimeClasspathRecipeBundleResolver}.
+     * A {@link RecipeBundleResolver} that materializes a listed recipe from an {@link Environment}
+     * scanned off the JVM classpath, the shape of a host's runtime-classpath resolver.
      */
     private static class RuntimeClasspathResolver implements RecipeBundleResolver {
-        private final RecipeMarketplace marketplace;
+        private final Environment env;
 
-        RuntimeClasspathResolver(RecipeMarketplace marketplace) {
-            this.marketplace = marketplace;
+        RuntimeClasspathResolver(Environment env) {
+            this.env = env;
         }
 
         @Override
@@ -716,17 +737,20 @@ class JavaScriptRewriteRpcTest implements RewriteTest {
 
                 @Override
                 public RecipeMarketplace read() {
-                    return marketplace;
+                    return env.toMarketplace(bundle);
                 }
 
                 @Override
                 public RecipeDescriptor describe(RecipeListing listing) {
-                    return new RecipeLoader(null).load(listing.getName(), Map.of()).getDescriptor();
+                    return prepare(listing, Map.of()).getDescriptor();
                 }
 
                 @Override
                 public Recipe prepare(RecipeListing listing, Map<String, Object> options) {
-                    return new RecipeLoader(null).load(listing.getName(), options);
+                    return env.listRecipes().stream()
+                      .filter(r -> r instanceof DeclarativeRecipe && r.getName().equals(listing.getName()))
+                      .findFirst()
+                      .orElseGet(() -> new RecipeLoader(null).load(listing.getName(), options));
                 }
             };
         }


### PR DESCRIPTION
A JS composite whose `recipeList()` contains `await prepareJavaRecipe(...)` fails to install and describe on a host whose `JavaScriptRewriteRpc` was built with the builder defaults, i.e. an empty marketplace and no resolvers:

```
Request InstallRecipes failed with message: Failed to install recipe 'CompositeWithJavaDelegate'.
Ensure the constructor can be called without any arguments.
Cause: Internal error: Could not resolve type id 'org.openrewrite.example.host.replace-hello'
as a subtype of `org.openrewrite.Recipe`: no such class found
```

`Recipe.descriptor()` awaits `recipeList()`, and `prepareJavaRecipe` sent `PrepareRecipe` to the host the moment it was called. `InstallRecipes` therefore made the host prepare every Java delegate of every recipe in the package, as nested JS-to-Java round trips, and failed on the first delegate the host could not load by class name.

A downstream host measured repeated describes of a composite with one delegate on the same released host jar; the difference is work no longer done, not work done faster:

| engine | describe |
|---|---|
| eager, on main | 194 to 203 ms |
| lazy, this PR | 5 to 8 ms |

- The other peers never do this. Python's `RpcRecipe` (#7956) stores the delegate's name and options and sends `PrepareRecipe` only from `editor()`; its server emits `delegatesTo` from those fields, on the wire contract #7038 introduced for every peer. C# (`IDelegatesTo`) and Go (`recipe.DelegatesTo`) are marker interfaces their servers read the same way.

`prepareJavaRecipe` now returns a `DelegatingRecipe` in that shape. It holds `javaRecipeName` and `delegatesToOptions`, builds its descriptor locally with the options as values, and prepares the delegate over the active connection only when this process runs it, on first use of its scanner or editor. The JS server emits it as a `delegatesTo` node wherever it appears:

- a `recipeList` child;
- a `check(...)` precondition, sent as a named visitor with its options like a `RecipeRef`;
- an unknown id a host re-prepares by name.

The function stays `async` for source compatibility. The wire contract and the host jar are unchanged, so no other peer and no Java code moves. With the released host this means:

- `InstallRecipes` needs no host, and no install order between the bundle owning the delegate and the npm package delegating into it.
- Describing the composite is one `PrepareRecipe`, and the delegate stays unresolved. That is correct for a host that only catalogues the package: listing its recipes, showing a composite's options and children, or counting them needs no runnable delegate, and a host serving one ecosystem may not have it at all.
- Details therefore show the delegate by name and options with an empty recipe list. The eager engine showed its full descriptor because the peer round-tripped it at install; a host-side follow-up will fill the subtree in where the delegate is available.
- A run resolves the delegate from the host marketplace in `getRecipeList()`, as before.
- A delegate's subtree is no longer in the peer's marketplace listing, so a `recipeCount` over that listing counts the delegate as one recipe. Details are unaffected.

Tests: `java-recipe.test.ts` builds the placeholder with no connection registered and checks its descriptor carries the options. `rewrite-rpc.test.ts` gains a composite whose two Java-delegate children are emitted as `delegatesTo` with their options, and a precondition sent as a named visitor.

`JavaScriptRewriteRpcTest.jsCompositeWithJavaDelegateChild` runs end to end against the released host: with the builder defaults, install and describe succeed and `getRecipeList()` fails naming the delegate; with a marketplace and resolver, the composite edits a file through both delegates, a declarative recipe and FindAndReplace with options. The first is declarative so the inbound handler's class-name fallback cannot mask an eager prepare. Restoring the eager `prepareJavaRecipe` fails the first phase with the error above.

