### PR TITLE
Never read a tree the RPC peer lost as a deletion

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -58,6 +58,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static org.openrewrite.rpc.RpcObjectData.State.END_OF_OBJECT;
+import static org.openrewrite.rpc.RpcObjectData.State.NO_CHANGE;
 
 /**
  * Base class for RPC clients with thread-local context support.
@@ -736,6 +737,10 @@ public class RewriteRpc {
         );
         Object remoteObject;
         try {
+            if (before == null && q.peek().getState() == NO_CHANGE) {
+                // The remote believes this side already holds the object; a null here would read as a deletion.
+                throw new IllegalStateException("Remote reports no change to " + id + " but this side holds no copy of it");
+            }
             remoteObject = q.receive(before, null);
         } catch (Exception e) {
             // Reset our tracking of the remote state so the next interaction

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcReceiveQueue.java
@@ -53,6 +53,13 @@ public class RpcReceiveQueue {
         return batch.remove();
     }
 
+    public RpcObjectData peek() {
+        if (batch.isEmpty()) {
+            batch.addAll(pull.get());
+        }
+        return batch.element();
+    }
+
     /**
      * Receive a value from the queue and apply a function to it to convert it to the required
      * type.

--- a/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
+++ b/rewrite-core/src/main/java/org/openrewrite/scheduling/RecipeRunCycle.java
@@ -508,18 +508,7 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
         try {
             response = rpc.batchVisit(originalBefore, ctx, rootCursor, batch.items);
         } catch (Throwable t) {
-            if (!batch.recipeStacks.isEmpty()) {
-                SourceFile beforeError = source;
-                if (!(t instanceof RecipeRunException)) {
-                    source = Markup.error(source, t);
-                }
-                source = handleError(leaf(batch.recipeStacks.get(0)), originalBefore, source, t);
-                if (source != null && source != beforeError) {
-                    source = addRecipesThatMadeChanges(batch.recipeStacks.get(0), source);
-                }
-            }
-            batch.clear();
-            return source;
+            return batchFailed(batch, originalBefore, source, t);
         }
 
         // Build attribution map: SearchResult UUID → recipe name
@@ -556,12 +545,17 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
             return null;
         }
 
-        SourceFile fetched;
+        SourceFile fetched = source;
         if (anyModified) {
-            // Fetch final tree state from remote
-            fetched = rpc.getObject(originalBefore.getId().toString(), DynamicDispatchRpcCodec.canonicalSourceFileType(originalBefore.getClass()));
-        } else {
-            fetched = source;
+            try {
+                fetched = rpc.getObject(originalBefore.getId().toString(), DynamicDispatchRpcCodec.canonicalSourceFileType(originalBefore.getClass()));
+                if (fetched == null) {
+                    // A batch reports its deletions in its results, so a missing tree here is one the remote lost.
+                    throw new IllegalStateException("Remote reported " + originalBefore.getSourcePath() + " as modified but no longer holds it");
+                }
+            } catch (Throwable t) {
+                return batchFailed(batch, originalBefore, source, t);
+            }
         }
 
         if (anyModified) {
@@ -588,6 +582,21 @@ public class RecipeRunCycle<LSS extends LargeSourceSet> {
 
         batch.clear();
         return fetched;
+    }
+
+    private @Nullable SourceFile batchFailed(BatchState batch, SourceFile originalBefore, SourceFile source, Throwable t) {
+        if (!batch.recipeStacks.isEmpty()) {
+            SourceFile beforeError = source;
+            if (!(t instanceof RecipeRunException)) {
+                source = Markup.error(source, t);
+            }
+            source = handleError(leaf(batch.recipeStacks.get(0)), originalBefore, source, t);
+            if (source != null && source != beforeError) {
+                source = addRecipesThatMadeChanges(batch.recipeStacks.get(0), source);
+            }
+        }
+        batch.clear();
+        return source;
     }
 
     /**

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcTest.java
@@ -54,6 +54,7 @@ import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openrewrite.marketplace.RecipeBundle.runtimeClasspath;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 import static org.openrewrite.test.SourceSpecs.text;
@@ -198,6 +199,30 @@ class RewriteRpcTest implements RewriteTest {
         server.localObjects.put(id, fixed);
         PlainText result = client.getObject(id, sourceFileType);
         assertThat(result.getText()).isEqualTo("Fixed");
+    }
+
+    /**
+     * A NO_CHANGE answer for an object this side never received means the peers have drifted apart,
+     * not that the object was deleted: getObject() must fail rather than hand back null.
+     */
+    @Test
+    void getObjectRejectsNoChangeWithoutABaseline() {
+        PlainText original = PlainText.builder()
+          .sourcePath(Path.of("test.txt"))
+          .text("Hello")
+          .build();
+        String id = original.getId().toString();
+        String sourceFileType = PlainText.class.getName();
+
+        server.localObjects.put(id, original);
+        client.getObject(id, sourceFileType);
+
+        // The client loses its copy (a failed receive drops it) while the server still believes it was delivered.
+        client.remoteObjects.remove(id);
+
+        assertThatThrownBy(() -> client.getObject(id, sourceFileType))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("no change to " + id);
     }
 
     /**

--- a/rewrite-python/rewrite/src/rewrite/rpc/facade.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/facade.py
@@ -16,9 +16,10 @@ _LOCAL = object()  # stands in for a bundle when the facade runs a visitor itsel
 
 
 class Facade:
-    def __init__(self, children, hub_pull=None, local_visit=None, is_local_visitor=None):
+    def __init__(self, children, hub_pull=None, local_visit=None, is_local_visitor=None, hub_drop=None):
         self._children = children
         self._hub_pull = hub_pull
+        self._hub_drop = hub_drop
         # Built-in visitors (auto-format, add-import) belong to no recipe bundle, so the facade runs
         # them itself against the working tree it holds rather than failing to route them.
         self._local_visit = local_visit
@@ -96,7 +97,8 @@ class Facade:
         result = self._children.request(bundle, "Visit", params)
         tree_id = params.get("treeId")
         if self._hub_pull is not None and tree_id is not None and result.get("modified"):
-            self._hub_pull(self._children, bundle, tree_id, params.get("sourceFileType"))
+            # A single Visit reports only "modified", so a deletion is only visible on the pull.
+            self._hub_pull(self._children, bundle, tree_id, params.get("sourceFileType"), may_delete=True)
         return result
 
     def batch_visit(self, params: dict) -> dict:
@@ -124,11 +126,14 @@ class Facade:
             response = self._children.request(owner, "BatchVisit", {**params, "visitors": sub_visitors})
             sub_results = response.get("results", [])
             results.extend(sub_results)
+            if any(r.get("deleted") for r in sub_results):
+                # The result already says so; pulling would get DELETE, which a lost tree also answers.
+                if self._hub_drop is not None and tree_id is not None:
+                    self._hub_drop(tree_id)
+                break
             if (self._hub_pull is not None and tree_id is not None and
                     any(r.get("modified") for r in sub_results)):
                 self._hub_pull(self._children, owner, tree_id, source_file_type)
-            if any(r.get("deleted") for r in sub_results):
-                break
         return {"results": results}
 
     def evict(self, params: dict) -> bool:

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -2417,7 +2417,8 @@ def _hub_serve_child(bundle: str, obj_id: str, source_file_type: Optional[str]) 
     return data
 
 
-def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: Optional[str]) -> None:
+def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: Optional[str],
+                         may_delete: bool = False) -> None:
     """Pull a child's edit back as a diff against what it was served and apply it to the facade's
     tree, so the next bundle starts from this bundle's result."""
     from rewrite.rpc.receive_queue import RpcReceiveQueue
@@ -2437,6 +2438,8 @@ def _hub_pull_child_edit(children, bundle: str, obj_id: str, source_file_type: O
 
     edited = RpcReceiveQueue(refs, source_file_type, pull).receive(served, None)
     if edited is None:
+        if not may_delete:
+            raise RuntimeError(f"{bundle} reported {obj_id} as modified but no longer holds it")
         _hub_forget(obj_id)
     else:
         _hub_tree[obj_id] = edited
@@ -2563,6 +2566,7 @@ def _get_facade():
                                         upstream=_serve_child_object,
                                         on_child_replaced=_hub_drop_bundle),
                          hub_pull=_hub_pull_child_edit,
+                         hub_drop=_hub_forget,
                          local_visit=_hub_local_visit,
                          is_local_visitor=_hub_is_builtin_visitor)
     return _facade

--- a/rewrite-python/rewrite/tests/rpc/test_facade.py
+++ b/rewrite-python/rewrite/tests/rpc/test_facade.py
@@ -1,3 +1,5 @@
+import pytest
+
 from rewrite.rpc.facade import Facade
 
 
@@ -140,7 +142,7 @@ class _EditingChildren(_FakeChildren):
 def test_cross_bundle_batch_pulls_each_bundles_edit_into_the_hub_in_order():
     children = _EditingChildren()
     pulls = []
-    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft, **kw: pulls.append((b, tid, sft)))
     f._bundle_by_visitor.update({"edit:a": "A", "edit:b": "B"})
 
     f.batch_visit({"treeId": "T", "sourceFileType": "py",
@@ -156,7 +158,7 @@ def test_cross_bundle_batch_pulls_each_bundles_edit_into_the_hub_in_order():
 def test_single_visit_pulls_its_edit_into_the_hub():
     children = _EditingChildren()
     pulls = []
-    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft, **kw: pulls.append((b, tid, sft)))
     f._bundle_by_visitor["edit:a"] = "A"
 
     f.visit({"visitor": "edit:a", "treeId": "T", "sourceFileType": "py"})
@@ -167,7 +169,7 @@ def test_single_visit_pulls_its_edit_into_the_hub():
 def test_single_visit_does_not_pull_when_nothing_changed():
     children = _EditingChildren(modified=False)
     pulls = []
-    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft, **kw: pulls.append((b, tid, sft)))
     f._bundle_by_visitor["edit:a"] = "A"
 
     f.visit({"visitor": "edit:a", "treeId": "T", "sourceFileType": "py"})
@@ -178,7 +180,7 @@ def test_single_visit_does_not_pull_when_nothing_changed():
 def test_single_bundle_batch_still_pulls_its_edit_into_the_hub():
     children = _EditingChildren()
     pulls = []
-    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft, **kw: pulls.append((b, tid, sft)))
     f._bundle_by_visitor.update({"edit:a1": "A", "edit:a2": "A"})
 
     f.batch_visit({"treeId": "T", "sourceFileType": "py",
@@ -192,7 +194,7 @@ def test_single_bundle_batch_still_pulls_its_edit_into_the_hub():
 def test_unmodified_run_is_not_pulled():
     children = _EditingChildren(modified=False)
     pulls = []
-    f = Facade(children, hub_pull=lambda ch, b, tid, sft: pulls.append((b, tid, sft)))
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft, **kw: pulls.append((b, tid, sft)))
     f._bundle_by_visitor.update({"edit:a": "A"})
 
     f.batch_visit({"treeId": "T", "visitors": [{"visitor": "edit:a"}]})
@@ -686,9 +688,10 @@ def test_reset_drops_a_half_drained_dependency_types_page(monkeypatch):
 
 
 def test_a_childs_delete_is_forgotten_without_disturbing_ref_numbering(monkeypatch):
-    """A child that deletes the file answers the pull with DELETE. The facade has to let go of the
-    tree — otherwise it serves the next bundle a file that no longer exists — but must leave both
-    ref maps alone: no Evict has been broadcast, so the child still holds this file's refs."""
+    """A child that deletes the file in a single Visit can only say so by answering the pull with
+    DELETE. The facade has to let go of the tree — otherwise it serves the next bundle a file that
+    no longer exists — but must leave both ref maps alone: no Evict has been broadcast, so the child
+    still holds this file's refs."""
     import rewrite.rpc.server as server
     from rewrite.rpc.reference import ReferenceMap
 
@@ -705,7 +708,7 @@ def test_a_childs_delete_is_forgotten_without_disturbing_ref_numbering(monkeypat
     refs.create(object())
     server._hub_recv_refs[bundle] = {1: object()}
 
-    server._hub_pull_child_edit(_DeletingChild(), bundle, tree_id, sft)
+    server._hub_pull_child_edit(_DeletingChild(), bundle, tree_id, sft, may_delete=True)
 
     assert tree_id not in server._hub_tree
     assert (bundle, tree_id) not in server._hub_served
@@ -781,3 +784,62 @@ def test_replacing_a_bundles_child_drops_the_ref_tables_that_mirrored_it():
     assert not [k for k in server._hub_send_checkpoint if k[0] == "pkg"]
     assert not [k for k in server._hub_recv_checkpoint if k[0] == "pkg"]
     assert not [k for k in server._hub_served if k[0] == "pkg"]
+
+
+class _DeletingBatchChildren(_FakeChildren):
+    """Every BatchVisit reports that its visitors deleted the file."""
+    def request(self, bundle, method, params):
+        if method == "BatchVisit":
+            vs = [v["visitor"] for v in params.get("visitors", [])]
+            self.calls.append(("batch", bundle, vs))
+            return {"results": [{"visitor": v, "modified": True, "deleted": True} for v in vs]}
+        return super().request(bundle, method, params)
+
+
+def test_batch_visit_drops_a_deleted_file_instead_of_pulling_it():
+    children = _DeletingBatchChildren()
+    pulls, drops = [], []
+    f = Facade(children, hub_pull=lambda ch, b, tid, sft, **kw: pulls.append((b, tid, sft)),
+               hub_drop=lambda tid: drops.append(tid))
+    f._bundle_by_visitor.update({"edit:a": "A", "edit:b": "B"})
+
+    resp = f.batch_visit({"treeId": "T", "sourceFileType": "py",
+                          "visitors": [{"visitor": "edit:a"}, {"visitor": "edit:b"}]})
+
+    # The deletion is reported and ends the batch; nothing is pulled and B never runs.
+    assert [r["deleted"] for r in resp["results"]] == [True]
+    assert pulls == []
+    assert drops == ["T"]
+    assert [c for c in children.calls if c[0] == "batch"] == [("batch", "A", ["edit:a"])]
+
+
+class _LostTreeChild:
+    """A child that answers every GetObject with DELETE, as one does for an id it no longer holds."""
+    def request(self, bundle, method, params):
+        return [{"state": "DELETE"}, {"state": "END_OF_OBJECT"}]
+
+
+def test_hub_pull_refuses_a_child_that_lost_the_tree(monkeypatch):
+    """A batch reports its deletions in its results, so DELETE on the pull means the child lost the
+    tree. The facade must keep the file it holds and fail the pull rather than let the host read the
+    missing tree as a deletion."""
+    import rewrite.rpc.server as server
+
+    cu = _parse_python("x = 1\n")
+    tree_id, sft, bundle = str(cu.id), "org.openrewrite.python.tree.Py$CompilationUnit", "pkg"
+
+    _isolated_hub(monkeypatch, server)
+    monkeypatch.setattr(server, "get_object_from_java",
+                        lambda obj_id, source_file_type=None: cu if obj_id == tree_id else None)
+    server._hub_acquire(tree_id, sft)
+    server._hub_serve_child(bundle, tree_id, sft)
+
+    with pytest.raises(RuntimeError, match="no longer holds"):
+        server._hub_pull_child_edit(_LostTreeChild(), bundle, tree_id, sft)
+    assert server._hub_tree[tree_id] is cu
+    assert server.local_objects[tree_id] is cu
+
+    # A single Visit has no other way to report a deletion, so there the pull may let the file go.
+    server._hub_pull_child_edit(_LostTreeChild(), bundle, tree_id, sft, may_delete=True)
+    assert tree_id not in server._hub_tree
+    assert tree_id not in server.local_objects


### PR DESCRIPTION
## What happened

- Running a composite Python migration recipe over real repositories deleted ordinary source modules that no recipe in the composite targets (for example `tornado/template.py`, `src/textual/widget.py`, `xonsh/built_ins.py`). Running every leaf recipe of the composite directly over the same files returns a tree for each of them; none returns `None`. The run that deleted them was also full of ref-table drift between the peers ("Received a reference to an object that was not previously sent" on the Java side, "Received reference to unknown object" on the Python side), and re-running the same recipe over the same LST with the facade ref-table fix from #8768 produced no errors and no deletions.

## Why a lost tree became a deletion

Every way the transport can fail to hand a tree back looked, to the scheduler, like the recipe having deleted it:

- `RewriteRpc.getObject` answered `null` when the remote sent `NO_CHANGE` for an id this side holds no baseline for (a failed receive drops the baseline; the remote still records the object as delivered). `RecipeRunCycle.flushBatch` then returned that `null` as the file's new state, although no batch result had reported a deletion, and the file was removed.
- The Python facade's `_hub_pull_child_edit` forgot a file whenever the child answered its pull with `DELETE`. A child answers `DELETE` both for a file its visitor deleted and for an id it no longer holds, and once the facade forgets the file the host's next `GetObject` sees `DELETE` too.

## Fix

- `RewriteRpc.getObject`: `NO_CHANGE` without a baseline is an `IllegalStateException`, never `null` (`RpcReceiveQueue.peek` added to look at the head state).
- `RecipeRunCycle.flushBatch`: when a batch's results carry no deletion but the remote cannot produce the modified tree, the file is marked with the error through the same path a failed `BatchVisit` takes, instead of being dropped.
- Python facade: a batch result that reports a deletion is dropped from the hub without a pull (`hub_drop`); `_hub_pull_child_edit` refuses a `DELETE` answer unless the caller allows it, which only the single-`Visit` path does, since there the child has no other way to report a deletion.

## Tests

- `RewriteRpcTest.getObjectRejectsNoChangeWithoutABaseline`
- `test_facade.py`: `test_batch_visit_drops_a_deleted_file_instead_of_pulling_it`, `test_hub_pull_refuses_a_child_that_lost_the_tree`; the existing single-Visit deletion test now states that contract.
