### PR TITLE
Report a Java-compatible column type from Python data tables

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/data_table.py
+++ b/rewrite-python/rewrite/src/rewrite/data_table.py
@@ -21,7 +21,8 @@ import os
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, Dict, Generic, Iterator, List, Optional, Type, TypeVar, TYPE_CHECKING, cast
+from typing import (Any, Dict, Generic, Iterator, List, Optional, Type, TypeVar, TYPE_CHECKING,
+                    Union, cast, get_args, get_origin)
 
 if TYPE_CHECKING:
     from rewrite.execution import ExecutionContext
@@ -251,6 +252,63 @@ class CsvDataTableStore(DataTableStore):
         return s
 
 
+# Java derives a column's type from `field.getType().getSimpleName()` (see
+# RecipeIntrospectionUtils). `type` is one of only two non-nullable fields on
+# ColumnDescriptor, so a Python table that omits it produces a descriptor Java
+# consumers cannot render. Map the annotation onto the Java simple name that an
+# equivalent Java-authored table would report.
+_JAVA_TYPE_NAMES = {
+    "str": "String",
+    # Python integers are arbitrary-precision, so Long is the closer analogue.
+    "int": "Long",
+    "bool": "Boolean",
+    "float": "Double",
+}
+
+# Every value is displayable as text, so an unrecognized annotation degrades to
+# String rather than failing the descriptor.
+DEFAULT_COLUMN_TYPE = "String"
+
+_OPTIONAL = re.compile(r"(?:typing\.)?Optional\[(.+)\]")
+
+
+def _unwrap_optional(annotation: Any) -> Any:
+    """Strip Optional/Union-with-None, which describes nullability, not type.
+
+    Java names a nullable column by its underlying type, so `Optional[str]` and
+    `str` must both report String.
+    """
+    args = [a for a in get_args(annotation) if a is not type(None)]
+    if get_origin(annotation) is Union and len(args) == 1:
+        return args[0]
+    return annotation
+
+
+def _java_type_name(annotation: Any) -> str:
+    """Map a dataclass field annotation to its Java simple type name."""
+    if annotation is None:
+        return DEFAULT_COLUMN_TYPE
+
+    if not isinstance(annotation, str):
+        # A real annotation object: unwrap before reading its name, since
+        # `Optional[int].__name__` is "Optional" and loses the inner type.
+        annotation = _unwrap_optional(annotation)
+        name = getattr(annotation, "__name__", str(annotation))
+    else:
+        # Under `from __future__ import annotations` the annotation is source
+        # text, so unwrap the same two spellings textually.
+        name = annotation.strip()
+        optional = _OPTIONAL.fullmatch(name)
+        if optional:
+            name = optional.group(1)
+        else:
+            union = [part.strip() for part in name.split("|")]
+            if len(union) == 2 and "None" in union:
+                name = next(part for part in union if part != "None")
+
+    return _JAVA_TYPE_NAMES.get(name.strip(), DEFAULT_COLUMN_TYPE)
+
+
 Row = TypeVar("Row")
 
 
@@ -340,6 +398,7 @@ class DataTable(Generic[Row]):
                     columns.append(
                         {
                             "name": field_name,
+                            "type": _java_type_name(field.type),
                             "displayName": col_desc.display_name,
                             "description": col_desc.description,
                         }

--- a/rewrite-python/rewrite/tests/test_data_table_column_types.py
+++ b/rewrite-python/rewrite/tests/test_data_table_column_types.py
@@ -1,4 +1,4 @@
-# Copyright 2025 the original author or authors.
+# Copyright 2026 the original author or authors.
 # <p>
 # Licensed under the Moderne Source Available License (the "License");
 # you may not use this file except in compliance with the License.

--- a/rewrite-python/rewrite/tests/test_data_table_column_types.py
+++ b/rewrite-python/rewrite/tests/test_data_table_column_types.py
@@ -1,0 +1,166 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests that column descriptors report a Java-compatible ``type``.
+
+``ColumnDescriptor`` declares ``name`` and ``type`` non-nullable, so every
+column a Python recipe reports must carry a type for Java consumers to render
+the table.
+"""
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+import pytest
+
+from rewrite.data_table import (DEFAULT_COLUMN_TYPE, DataTable, _java_type_name,
+                                column)
+from rewrite.recipe import Recipe, RecipeDescriptor
+
+
+@dataclass
+class ScalarRow:
+    """Covers each annotation with a distinct Java analogue."""
+
+    text: str = field(metadata=column("Text", "A string column"))
+    count: int = field(metadata=column("Count", "An integer column"))
+    enabled: bool = field(metadata=column("Enabled", "A boolean column"))
+    ratio: float = field(metadata=column("Ratio", "A floating point column"))
+
+
+def columns_by_name(data_table: DataTable) -> dict:
+    return {c["name"]: c for c in data_table.descriptor()["columns"]}
+
+
+def test_every_column_reports_a_type():
+    table = DataTable[ScalarRow]("org.example.Scalars", "Scalars", "d", ScalarRow)
+
+    untyped = [c["name"] for c in table.descriptor()["columns"] if not c.get("type")]
+    assert untyped == []
+
+
+@pytest.mark.parametrize(
+    "field_name,expected",
+    [
+        ("text", "String"),
+        ("count", "Long"),
+        ("enabled", "Boolean"),
+        ("ratio", "Double"),
+    ],
+)
+def test_annotation_maps_to_java_type_name(field_name, expected):
+    table = DataTable[ScalarRow]("org.example.Scalars", "Scalars", "d", ScalarRow)
+
+    assert columns_by_name(table)[field_name]["type"] == expected
+
+
+@dataclass
+class OptionalRow:
+    maybe_text: Optional[str] = field(metadata=column("Maybe Text", "Nullable"))
+    maybe_count: Optional[int] = field(metadata=column("Maybe Count", "Nullable"))
+
+
+def test_optional_unwraps_to_the_underlying_type():
+    """Nullability is not a type; Java names a nullable column by its type."""
+    table = DataTable[OptionalRow]("org.example.Optionals", "Optionals", "d", OptionalRow)
+
+    columns = columns_by_name(table)
+    assert columns["maybe_text"]["type"] == "String"
+    assert columns["maybe_count"]["type"] == "Long"
+
+
+@dataclass
+class CustomTypeRow:
+    payload: complex = field(metadata=column("Payload", "No Java analogue"))
+
+
+def test_unrecognized_annotation_falls_back_to_the_default():
+    """An unmapped annotation must still yield a type, never a null."""
+    table = DataTable[CustomTypeRow]("org.example.Custom", "Custom", "d", CustomTypeRow)
+
+    assert columns_by_name(table)["payload"]["type"] == DEFAULT_COLUMN_TYPE
+
+
+def test_type_is_preserved_alongside_the_other_column_metadata():
+    table = DataTable[ScalarRow]("org.example.Scalars", "Scalars", "d", ScalarRow)
+
+    assert columns_by_name(table)["text"] == {
+        "name": "text",
+        "type": "String",
+        "displayName": "Text",
+        "description": "A string column",
+    }
+
+
+CHILD_TABLE = DataTable[ScalarRow]("org.example.Child", "Child", "d", ScalarRow)
+
+
+class ChildRecipe(Recipe):
+    @property
+    def name(self) -> str:
+        return "org.example.ChildRecipe"
+
+    @property
+    def display_name(self) -> str:
+        return "Child recipe"
+
+    @property
+    def description(self) -> str:
+        return "Produces a data table."
+
+    @property
+    def data_tables(self):
+        return [CHILD_TABLE]
+
+
+class CompositeRecipe(Recipe):
+    @property
+    def name(self) -> str:
+        return "org.example.CompositeRecipe"
+
+    @property
+    def display_name(self) -> str:
+        return "Composite recipe"
+
+    @property
+    def description(self) -> str:
+        return "Runs a child recipe."
+
+    def recipe_list(self):
+        return [ChildRecipe()]
+
+
+def test_types_survive_aggregation_onto_a_composite():
+    """A composite reports its children's tables; those columns keep their types."""
+    descriptor = RecipeDescriptor.from_recipe(CompositeRecipe())
+
+    aggregated = descriptor.data_tables[0]["columns"]
+    assert [c["type"] for c in aggregated] == ["String", "Long", "Boolean", "Double"]
+
+
+@pytest.mark.parametrize(
+    "annotation,expected",
+    [
+        ("str", "String"),
+        ("int", "Long"),
+        ("Optional[int]", "Long"),
+        ("typing.Optional[int]", "Long"),
+        ("str | None", "String"),
+        ("int | None", "Long"),
+        ("SomeUnmappedType", DEFAULT_COLUMN_TYPE),
+    ],
+)
+def test_string_annotations_are_mapped(annotation, expected):
+    """Under `from __future__ import annotations` the annotation is source text."""
+    assert _java_type_name(annotation) == expected


### PR DESCRIPTION
## Problem

`ColumnDescriptor` declares two non-nullable fields, `name` and `type`:

```java
@EqualsAndHashCode.Include String name;
@EqualsAndHashCode.Include String type;
@Nullable @NlsRewrite.DisplayName String displayName;
@Nullable @NlsRewrite.Description String description;
```

Java populates `type` by reflection in `RecipeIntrospectionUtils`:

```java
columns.add(new ColumnDescriptor(field.getName(),
        field.getType().getSimpleName(),
        column.displayName(),
        column.description()));
```

Python's `DataTable.descriptor()` had no equivalent — it emitted `name`,
`displayName` and `description` only. Every column of every Python-authored
data table therefore deserialized with `type == null`.

Nothing downstream catches this. `RpcRecipe#createRecipeDescriptor` returns the
descriptor received over RPC verbatim:

```java
return this.descriptor != null ? this.descriptor : super.createRecipeDescriptor();
```

so a Python descriptor never passes through `createRecipeDescriptor()` and is
never normalized. The null reaches consumers unchanged.

## Impact

A consumer that exposes `type` as non-nullable fails when it reads one. In the
case that prompted this, a GraphQL layer surfaced it as:

```
The field at path '.../columns[0]/type' was declared as a non null type,
but the code involved in retrieving data has wrongly returned a null value.
The non-nullable type is 'String' within parent type 'Column'
```

Because the field is non-nullable, the null propagates up through its ancestors
until it reaches a nullable one. A single untyped column can therefore blank an
entire response — including well-formed tables from Java recipes in the same
result — rather than degrading to one missing value.

## Change

`descriptor()` now maps each dataclass field annotation onto the Java simple
type name an equivalent Java table would report:

| Python | Java |
| --- | --- |
| `str` | `String` |
| `int` | `Long` |
| `bool` | `Boolean` |
| `float` | `Double` |
| anything else | `String` |

`int` maps to `Long` because Python integers are arbitrary-precision, so `Long`
is the closer analogue than `Integer`.

`Optional[X]` and `X | None` unwrap to `X`. Nullability is not a type — Java
names a nullable column by its underlying type. Both the real-annotation and
the string form are handled, since annotations arrive as source text under
`from __future__ import annotations`. This needs `get_origin`/`get_args` rather
than name inspection, as `Optional[int].__name__` is `"Optional"` and discards
the inner type.

Unrecognized annotations degrade to `String` rather than raising or emitting
null. Every value is displayable as text, and the failure mode above argues
strongly that a column should never report no type at all.

## Tests

`test_data_table_column_types.py` covers each scalar mapping, `Optional`
unwrapping in both spellings, the unmapped-annotation fallback, that `type` sits
alongside the existing metadata rather than replacing it, and that types survive
aggregation onto a composite recipe's descriptor.

Full suite: 2222 passed, 10 failed — the same 10 fail on an unmodified tree
(PEP 695 syntax requiring Python 3.12; run on 3.11).

## Scope and follow-ups

This fixes the missing value. It does not make the descriptor boundary
resilient, and the same class of defect can recur, because nothing validates
what a Python recipe reports. Verified against the current SDK, a recipe author
can pass `None` — or a non-string — for `DataTableDescriptor.name`,
`displayName` or `description`, all non-nullable in Java, and it will be
accepted silently. Overriding `descriptor()` bypasses any check made inside it.

Two follow-ups worth considering separately:

1. Validate in `RecipeDescriptor.from_recipe`, the collection point every
   descriptor flows through, so an overridden `descriptor()` is still caught.
2. Add a `@JsonCreator` to `ColumnDescriptor` (and extend the existing one on
   `DataTableDescriptor`) to default cosmetic fields and reject null identity
   fields. This protects every RPC binding rather than Python alone.

They are deliberately not in this PR: (2) touches shared core types and warrants
its own review, and the split keeps the correctness fix independently
reviewable.

- Root problem: https://github.com/moderneinc/customer-requests/issues/3051
