### PR TITLE
Python: an identifier that spells an import's name is not always a reference

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/__init__.py
@@ -90,6 +90,7 @@ from rewrite.python.format import (
 from rewrite.python.add_import import AddImport, AddImportOptions, maybe_add_import
 from rewrite.python.remove_import import RemoveImport, RemoveImportOptions, maybe_remove_import
 from rewrite.python.method_matcher import MethodMatcher
+from rewrite.python.binding_utils import Binding, ImportBindings, import_bindings, is_reference
 from rewrite.python.scope_utils import Scope, scope_of
 
 # Type-comparison helpers
@@ -200,6 +201,11 @@ __all__ = [
     # Scoping
     "Scope",
     "scope_of",
+    # Import bindings
+    "Binding",
+    "ImportBindings",
+    "import_bindings",
+    "is_reference",
     # Type-comparison helpers
     "is_assignable_to",
     "is_of_type",

--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -24,6 +24,7 @@ from rewrite.java import J
 from rewrite.java.support_types import JContainer, JLeftPadded, JRightPadded
 from rewrite.java.tree import Empty, FieldAccess, Identifier, Import, Literal, Space
 from rewrite.markers import Markers
+from rewrite.python.binding_utils import is_reference
 from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
                                          get_canonical_fqn, pad_right, referenced_names)
 from rewrite.python.tree import CompilationUnit, ExpressionStatement, MultiImport
@@ -207,25 +208,9 @@ class AddImport(PythonVisitor):
             def __init__(self):
                 super().__init__()
                 self.found = False
-                self.in_import = False
-
-            def visit_import(self, import_: Import, p) -> J:
-                # Identifiers in import statements are bindings, not references.
-                self.in_import = True
-                try:
-                    return super().visit_import(import_, p)
-                finally:
-                    self.in_import = False
-
-            def visit_multi_import(self, multi: MultiImport, p) -> J:
-                self.in_import = True
-                try:
-                    return super().visit_multi_import(multi, p)
-                finally:
-                    self.in_import = False
 
             def visit_identifier(self, ident: Identifier, p) -> J:
-                if not self.in_import and target_name in referenced_names(ident):
+                if is_reference(self.cursor, ident) and target_name in referenced_names(ident):
                     self.found = True
                 return ident
 

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -1,0 +1,206 @@
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Which names a file's imports bind, and whether an identifier references one.
+
+Structural throughout: a parse without a ``ty_client`` attributes no types, and a recipe
+gated on attribution then finds nothing while reporting success. Types widen matching;
+they never decide it.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
+
+from rewrite import Cursor
+from rewrite.java.support_types import J, Statement
+from rewrite.java.tree import FieldAccess, Identifier, Import, MethodInvocation
+from rewrite.python.import_utils import get_alias_name, module_scope_blocks
+from rewrite.python.scope_utils import scope_of
+from rewrite.python.tree import CompilationUnit, MultiImport, VariableScope
+from rewrite.visitor import TreeVisitor
+
+_IMPORT_BINDINGS = 'org.openrewrite.python.importBindings'
+
+
+@dataclass(frozen=True)
+class Binding:
+    """One name an import binds."""
+
+    name: str
+    """The local name: the alias where there is one, else the member of a ``from`` import and
+    the root package of ``import a.b.c``, which binds only ``a``."""
+
+    module: str
+    """The module as written, keeping a relative import's leading dots: ``.locale`` is a
+    sibling module and never the standard library's ``locale``."""
+
+    member: Optional[str]
+    """The member of ``from <module> import <member>``, None for ``import <module>``."""
+
+    imp: Import
+    """The node binding this one name; a ``MultiImport`` holds several."""
+
+    guarded: bool
+    """Whether an enclosing ``if`` decides the binding, as ``if TYPE_CHECKING:`` does. A
+    reference emitted at runtime may then find no name."""
+
+
+class ImportBindings:
+    """The names a file's imports bind, reached through :func:`import_bindings`."""
+
+    __slots__ = ('_bindings', '_by_name')
+
+    def __init__(self, bindings: Sequence[Binding]) -> None:
+        self._bindings = tuple(bindings)
+        # A second import of a name replaces the first, as running the statements would.
+        self._by_name: Dict[str, Binding] = {b.name: b for b in self._bindings}
+
+    def __iter__(self) -> Iterator[Binding]:
+        return iter(self._bindings)
+
+    def __len__(self) -> int:
+        return len(self._bindings)
+
+    def for_name(self, name: str) -> Optional[Binding]:
+        """The binding ``name`` holds, or None where no import binds it."""
+        return self._by_name.get(name)
+
+    def for_module(self, module: str, member: Optional[str] = None) -> Tuple[Binding, ...]:
+        """Every binding of ``module`` — of its ``member`` when one is given. A module can be
+        bound more than once, which a recipe removing the import has to reckon with: taking
+        the statement out takes every name it bound."""
+        return tuple(b for b in self._bindings
+                     if b.module == module and (member is None or b.member == member))
+
+    def reference(self, cursor: Cursor, ident: Identifier) -> Optional[Binding]:
+        """The binding ``ident`` reads, or None where it reads something else: a name in
+        member position, a name nothing imports, or one an enclosing scope rebinds."""
+        binding = self._by_name.get(ident.simple_name)
+        if binding is None or not is_reference(cursor, ident):
+            return None
+        declaring = scope_of(cursor).declaring_scope(ident.simple_name)
+        return None if declaring is not None and not isinstance(declaring, CompilationUnit) else binding
+
+
+def import_bindings(source: Union[TreeVisitor[Any, Any], CompilationUnit,
+                                  Iterable[Statement]]) -> ImportBindings:
+    """The bindings the imports of ``source`` introduce: a visitor answers for the file it is
+    visiting and scans it once, a compilation unit for its module scope, a statement list for
+    the block it belongs to, which is how a function's own imports are reached.
+
+    Module scope is the top-level statements plus the ``if`` bodies :func:`module_scope_blocks`
+    yields, so a ``try``/``except ImportError`` fallback never has its shim taken for the module.
+    """
+    if isinstance(source, CompilationUnit):
+        return ImportBindings(_module_scope_bindings(source))
+    if isinstance(source, TreeVisitor):
+        return _cached(source.cursor)
+    return ImportBindings(_scan(source, guarded=False))
+
+
+def is_reference(cursor: Cursor, ident: Identifier) -> bool:
+    """Whether ``ident`` reads a name, rather than filling a slot that names something.
+
+    Position is all this reads, so a name an enclosing scope rebinds still answers True;
+    :meth:`ImportBindings.reference` composes the two. ``cursor`` stands on ``ident`` or on
+    its parent, which lets a visitor ask about a node's own child from where it already is.
+    """
+    path = _path_from(cursor, ident)
+    index = 1
+    # A dotted name reads through its root, so where the chain sits decides for the root too.
+    while index < len(path):
+        enclosing = path[index]
+        if not isinstance(enclosing, FieldAccess) or enclosing.target is not path[index - 1]:
+            break
+        index += 1
+    node = path[index - 1]
+    parent = path[index] if index < len(path) else None
+
+    if isinstance(parent, (Import, MultiImport, VariableScope)):
+        # An import names the module or member it binds; `global x` names a binding elsewhere.
+        return False
+    if isinstance(parent, MethodInvocation):
+        # A call selecting nothing calls a name it read; with a receiver the name is a member.
+        return parent.name is not node or parent.select is None
+    # Every other node that names rather than reads keeps the name on `name`: an attribute, a
+    # keyword argument, a `def`, a `class`, a parameter, a type alias.
+    return getattr(parent, 'name', None) is not node
+
+
+def _path_from(cursor: Cursor, ident: Identifier) -> List[J]:
+    """``ident`` and the nodes enclosing it, padding wrappers left out."""
+    path: List[J] = [ident]
+    c: Optional[Cursor] = cursor
+    while c is not None:
+        value = c.value
+        if isinstance(value, J) and value is not ident:
+            path.append(value)
+        c = c.parent
+    return path
+
+
+def _cached(cursor: Cursor) -> ImportBindings:
+    """The scan of the file being visited, kept on its cursor as ``scope_utils`` keeps its own."""
+    for c in cursor.get_path_as_cursors():
+        if isinstance(c.value, CompilationUnit):
+            bindings = c.get_message(_IMPORT_BINDINGS, None)
+            if bindings is None:
+                bindings = ImportBindings(_module_scope_bindings(c.value))
+                c.put_message(_IMPORT_BINDINGS, bindings)
+            return bindings
+    return ImportBindings(())
+
+
+def _module_scope_bindings(cu: CompilationUnit) -> List[Binding]:
+    bindings = _scan(cu.statements, guarded=False)
+    for block in module_scope_blocks(cu.statements):
+        bindings.extend(_scan(block.statements, guarded=True))
+    return bindings
+
+
+def _scan(statements: Iterable[Statement], guarded: bool) -> List[Binding]:
+    bindings: List[Binding] = []
+    for stmt in statements:
+        if isinstance(stmt, MultiImport):
+            module = _dotted_path(stmt.from_) if stmt.from_ is not None else None
+            bindings.extend(_binding(imp, module, guarded) for imp in stmt.names)
+        elif isinstance(stmt, Import):
+            bindings.append(_binding(stmt, None, guarded))
+    return bindings
+
+
+def _binding(imp: Import, from_module: Optional[str], guarded: bool) -> Binding:
+    qualid = _dotted_path(imp.qualid)
+    alias = get_alias_name(imp)
+    if from_module is not None:
+        return Binding(alias or qualid, from_module, qualid, imp, guarded)
+    return Binding(alias or qualid.split('.')[0], qualid, None, imp, guarded)
+
+
+def _dotted_path(name: Optional[J]) -> str:
+    """A name tree as written, keeping the empty parts a relative import's leading dots parse to."""
+    parts: List[str] = []
+
+    def collect(node: Optional[J]) -> None:
+        if isinstance(node, FieldAccess):
+            collect(node.target)
+            parts.append(node.name.simple_name)
+        elif isinstance(node, Identifier):
+            parts.append(node.simple_name)
+
+    collect(name)
+    return '.'.join(parts)
+
+
+__all__ = ['Binding', 'ImportBindings', 'import_bindings', 'is_reference']

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -24,12 +24,12 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tupl
 
 from rewrite import Cursor
 from rewrite.java.support_types import J, Statement
-from rewrite.java.tree import (Assignment, FieldAccess, ForEachLoop, Identifier, If, Import,
-                               MethodInvocation, Parentheses)
+from rewrite.java.tree import (Assignment, Case, FieldAccess, ForEachLoop, Identifier, If,
+                               Import, MethodInvocation, Parentheses)
 from rewrite.python.import_utils import get_alias_name, unconditional_body
 from rewrite.python.scope_utils import scope_of
 from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ComprehensionExpression,
-                                 CompilationUnit, Del, ExpressionStatement, MultiImport, Star,
+                                 CompilationUnit, ExpressionStatement, MultiImport, Star,
                                  TypeHintedExpression, VariableScope)
 from rewrite.visitor import TreeVisitor
 
@@ -71,8 +71,13 @@ class ImportBindings:
 
     def __init__(self, bindings: Sequence[Binding]) -> None:
         self._bindings = tuple(bindings)
-        # A second import of a name replaces the first, as running the statements would.
-        self._by_name: Dict[str, Binding] = {b.name: b for b in self._bindings if b.member != '*'}
+        self._by_name: Dict[str, Binding] = {}
+        for binding in self._bindings:
+            held = self._by_name.get(binding.name)
+            # A later import of a name replaces an earlier one, as running the statements would,
+            # except that a guarded import binds nothing at runtime for an unguarded one to lose to.
+            if binding.member != '*' and (held is None or held.guarded or not binding.guarded):
+                self._by_name[binding.name] = binding
 
     def __iter__(self) -> Iterator[Binding]:
         return iter(self._bindings)
@@ -166,7 +171,9 @@ def _is_target(parent: Optional[J], node: J) -> bool:
     if isinstance(parent, ComprehensionExpression):
         # A clause holds its target directly, so the comprehension is the node above the name.
         return any(clause.iterator_variable is node for clause in parent.clauses)
-    return isinstance(parent, Del)
+    # An undotted case label is a capture pattern, which binds; `case json.Loads:` matches a
+    # value and so reads. A name nested in a class pattern's arguments is left as a read.
+    return isinstance(parent, Case) and any(label is node for label in parent.case_labels)
 
 
 def _enclosing_nodes(cursor: Cursor, ident: Identifier) -> Iterator[J]:

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -24,10 +24,17 @@ from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tupl
 
 from rewrite import Cursor
 from rewrite.java.support_types import J, Statement
-from rewrite.java.tree import FieldAccess, Identifier, Import, MethodInvocation
-from rewrite.python.import_utils import get_alias_name, module_scope_blocks
+from rewrite.java.tree import (Assignment, FieldAccess, ForEachLoop, Identifier, If, Import,
+                               MethodInvocation, Parentheses)
+from rewrite.python.import_utils import get_alias_name, unconditional_body
 from rewrite.python.scope_utils import scope_of
-from rewrite.python.tree import CompilationUnit, MultiImport, VariableScope
+from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ComprehensionExpression,
+                                 CompilationUnit, Del, ExpressionStatement, MultiImport, Star,
+                                 TypeHintedExpression, VariableScope)
+
+# The wrappers a target puts between a statement and the names it binds, as `scope_utils`
+# unwraps them to collect those names.
+_TARGET_WRAPPERS = (Parentheses, Star, CollectionLiteral, ExpressionStatement, TypeHintedExpression)
 from rewrite.visitor import TreeVisitor
 
 _IMPORT_BINDINGS = 'org.openrewrite.python.importBindings'
@@ -46,7 +53,8 @@ class Binding:
     sibling module and never the standard library's ``locale``."""
 
     member: Optional[str]
-    """The member of ``from <module> import <member>``, None for ``import <module>``."""
+    """The member of ``from <module> import <member>``, None for ``import <module>``, ``'*'``
+    for a wildcard."""
 
     imp: Import
     """The node binding this one name; a ``MultiImport`` holds several."""
@@ -64,7 +72,7 @@ class ImportBindings:
     def __init__(self, bindings: Sequence[Binding]) -> None:
         self._bindings = tuple(bindings)
         # A second import of a name replaces the first, as running the statements would.
-        self._by_name: Dict[str, Binding] = {b.name: b for b in self._bindings}
+        self._by_name: Dict[str, Binding] = {b.name: b for b in self._bindings if b.member != '*'}
 
     def __iter__(self) -> Iterator[Binding]:
         return iter(self._bindings)
@@ -73,7 +81,9 @@ class ImportBindings:
         return len(self._bindings)
 
     def for_name(self, name: str) -> Optional[Binding]:
-        """The binding ``name`` holds, or None where no import binds it."""
+        """The binding ``name`` holds, or None where no import binds it — which is weaker than
+        ``name`` being free, since a wildcard import and a ``try``/``except ImportError``
+        fallback both bind names no ``Binding`` records."""
         return self._by_name.get(name)
 
     def for_module(self, module: str, member: Optional[str] = None) -> Tuple[Binding, ...]:
@@ -85,7 +95,10 @@ class ImportBindings:
 
     def reference(self, cursor: Cursor, ident: Identifier) -> Optional[Binding]:
         """The binding ``ident`` reads, or None where it reads something else: a name in
-        member position, a name nothing imports, or one an enclosing scope rebinds."""
+        member position, a name nothing imports, or one an enclosing scope rebinds. A quoted
+        forward reference holds an expression rather than a name, so its names come from
+        :func:`referenced_names` instead. Check :attr:`Binding.guarded` before emitting a
+        reference that has to resolve at runtime."""
         binding = self._by_name.get(ident.simple_name)
         if binding is None or not is_reference(cursor, ident):
             return None
@@ -96,14 +109,13 @@ class ImportBindings:
 def import_bindings(source: Union[TreeVisitor[Any, Any], CompilationUnit,
                                   Iterable[Statement]]) -> ImportBindings:
     """The bindings the imports of ``source`` introduce: a visitor answers for the file it is
-    visiting and scans it once, a compilation unit for its module scope, a statement list for
-    the block it belongs to, which is how a function's own imports are reached.
+    visiting and scans it once, a compilation unit or statement list scans on every call.
 
-    Module scope is the top-level statements plus the ``if`` bodies :func:`module_scope_blocks`
-    yields, so a ``try``/``except ImportError`` fallback never has its shim taken for the module.
+    A scan descends into the body of an ``if`` that has no ``else``, so a ``try``/``except
+    ImportError`` fallback never has its shim taken for the module — see :attr:`Binding.guarded`.
     """
     if isinstance(source, CompilationUnit):
-        return ImportBindings(_module_scope_bindings(source))
+        return ImportBindings(_scan(source.statements, guarded=False))
     if isinstance(source, TreeVisitor):
         return _cached(source.cursor)
     return ImportBindings(_scan(source, guarded=False))
@@ -116,16 +128,19 @@ def is_reference(cursor: Cursor, ident: Identifier) -> bool:
     :meth:`ImportBindings.reference` composes the two. ``cursor`` stands on ``ident`` or on
     its parent, which lets a visitor ask about a node's own child from where it already is.
     """
-    path = _path_from(cursor, ident)
-    index = 1
-    # A dotted name reads through its root, so where the chain sits decides for the root too.
-    while index < len(path):
-        enclosing = path[index]
-        if not isinstance(enclosing, FieldAccess) or enclosing.target is not path[index - 1]:
+    node: J = ident
+    parent: Optional[J] = None
+    dotted = False
+    for enclosing in _enclosing_nodes(cursor, ident):
+        # A dotted name reads through its root, and a tuple or starred target spreads over the
+        # names under it, so in both the enclosing node decides for the one below.
+        if isinstance(enclosing, FieldAccess) and enclosing.target is node:
+            node, dotted = enclosing, True
+        elif isinstance(enclosing, _TARGET_WRAPPERS):
+            node = enclosing
+        else:
+            parent = enclosing
             break
-        index += 1
-    node = path[index - 1]
-    parent = path[index] if index < len(path) else None
 
     if isinstance(parent, (Import, MultiImport, VariableScope)):
         # An import names the module or member it binds; `global x` names a binding elsewhere.
@@ -133,21 +148,35 @@ def is_reference(cursor: Cursor, ident: Identifier) -> bool:
     if isinstance(parent, MethodInvocation):
         # A call selecting nothing calls a name it read; with a receiver the name is a member.
         return parent.name is not node or parent.select is None
+    if not dotted and _is_target(parent, node):
+        return False
     # Every other node that names rather than reads keeps the name on `name`: an attribute, a
     # keyword argument, a `def`, a `class`, a parameter, a type alias.
     return getattr(parent, 'name', None) is not node
 
 
-def _path_from(cursor: Cursor, ident: Identifier) -> List[J]:
-    """``ident`` and the nodes enclosing it, padding wrappers left out."""
-    path: List[J] = [ident]
+def _is_target(parent: Optional[J], node: J) -> bool:
+    """Whether ``node`` is a target ``parent`` binds. Only an undotted name asks: ``json.x = 1``
+    reads ``json`` to assign through it."""
+    if isinstance(parent, Assignment):
+        return parent.variable is node
+    if isinstance(parent, ChainedAssignment):
+        return any(variable is node for variable in parent.variables)
+    if isinstance(parent, ForEachLoop.Control):
+        return parent.variable is node
+    if isinstance(parent, ComprehensionExpression.Clause):
+        return parent.iterator_variable is node
+    return isinstance(parent, Del)
+
+
+def _enclosing_nodes(cursor: Cursor, ident: Identifier) -> Iterator[J]:
+    """The nodes enclosing ``ident``, innermost first, padding wrappers left out."""
     c: Optional[Cursor] = cursor
     while c is not None:
         value = c.value
         if isinstance(value, J) and value is not ident:
-            path.append(value)
+            yield value
         c = c.parent
-    return path
 
 
 def _cached(cursor: Cursor) -> ImportBindings:
@@ -156,20 +185,15 @@ def _cached(cursor: Cursor) -> ImportBindings:
         if isinstance(c.value, CompilationUnit):
             bindings = c.get_message(_IMPORT_BINDINGS, None)
             if bindings is None:
-                bindings = ImportBindings(_module_scope_bindings(c.value))
+                bindings = ImportBindings(_scan(c.value.statements, guarded=False))
                 c.put_message(_IMPORT_BINDINGS, bindings)
             return bindings
     return ImportBindings(())
 
 
-def _module_scope_bindings(cu: CompilationUnit) -> List[Binding]:
-    bindings = _scan(cu.statements, guarded=False)
-    for block in module_scope_blocks(cu.statements):
-        bindings.extend(_scan(block.statements, guarded=True))
-    return bindings
-
-
 def _scan(statements: Iterable[Statement], guarded: bool) -> List[Binding]:
+    """The bindings of ``statements`` in source order, which is the order that decides which
+    import of a name is the one in force."""
     bindings: List[Binding] = []
     for stmt in statements:
         if isinstance(stmt, MultiImport):
@@ -177,6 +201,10 @@ def _scan(statements: Iterable[Statement], guarded: bool) -> List[Binding]:
             bindings.extend(_binding(imp, module, guarded) for imp in stmt.names)
         elif isinstance(stmt, Import):
             bindings.append(_binding(stmt, None, guarded))
+        elif isinstance(stmt, If):
+            body = unconditional_body(stmt)
+            if body is not None:
+                bindings.extend(_scan(body.statements, guarded=True))
     return bindings
 
 

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -87,8 +87,8 @@ class ImportBindings:
 
     def for_name(self, name: str) -> Optional[Binding]:
         """The binding ``name`` holds, or None where no import binds it — which is weaker than
-        ``name`` being free, since a wildcard import and a ``try``/``except ImportError``
-        fallback both bind names no ``Binding`` records."""
+        ``name`` being free, since a wildcard import and an import under any ``try`` both bind
+        names no ``Binding`` records."""
         return self._by_name.get(name)
 
     def for_module(self, module: str, member: Optional[str] = None) -> Tuple[Binding, ...]:
@@ -116,8 +116,8 @@ def import_bindings(source: Union[TreeVisitor[Any, Any], CompilationUnit,
     """The bindings the imports of ``source`` introduce: a visitor answers for the file it is
     visiting and scans it once, a compilation unit or statement list scans on every call.
 
-    A scan descends into the body of an ``if`` that has no ``else``, so a ``try``/``except
-    ImportError`` fallback never has its shim taken for the module — see :attr:`Binding.guarded`.
+    A scan descends into an ``if`` that has no ``else`` and into no ``try`` whatever it catches,
+    so a fallback import's shim is never taken for the module — see :attr:`Binding.guarded`.
     """
     if isinstance(source, CompilationUnit):
         return ImportBindings(_scan(source.statements, guarded=False))

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -31,13 +31,13 @@ from rewrite.python.scope_utils import scope_of
 from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ComprehensionExpression,
                                  CompilationUnit, Del, ExpressionStatement, MultiImport, Star,
                                  TypeHintedExpression, VariableScope)
+from rewrite.visitor import TreeVisitor
+
+_IMPORT_BINDINGS = 'org.openrewrite.python.importBindings'
 
 # The wrappers a target puts between a statement and the names it binds, as `scope_utils`
 # unwraps them to collect those names.
 _TARGET_WRAPPERS = (Parentheses, Star, CollectionLiteral, ExpressionStatement, TypeHintedExpression)
-from rewrite.visitor import TreeVisitor
-
-_IMPORT_BINDINGS = 'org.openrewrite.python.importBindings'
 
 
 @dataclass(frozen=True)
@@ -156,16 +156,16 @@ def is_reference(cursor: Cursor, ident: Identifier) -> bool:
 
 
 def _is_target(parent: Optional[J], node: J) -> bool:
-    """Whether ``node`` is a target ``parent`` binds. Only an undotted name asks: ``json.x = 1``
-    reads ``json`` to assign through it."""
+    """Whether ``node`` is a target ``parent`` binds rather than an expression it evaluates."""
     if isinstance(parent, Assignment):
         return parent.variable is node
     if isinstance(parent, ChainedAssignment):
         return any(variable is node for variable in parent.variables)
     if isinstance(parent, ForEachLoop.Control):
         return parent.variable is node
-    if isinstance(parent, ComprehensionExpression.Clause):
-        return parent.iterator_variable is node
+    if isinstance(parent, ComprehensionExpression):
+        # A clause holds its target directly, so the comprehension is the node above the name.
+        return any(clause.iterator_variable is node for clause in parent.clauses)
     return isinstance(parent, Del)
 
 

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -100,10 +100,10 @@ class ImportBindings:
 
     def reference(self, cursor: Cursor, ident: Identifier) -> Optional[Binding]:
         """The binding ``ident`` reads, or None where it reads something else: a name in
-        member position, a name nothing imports, or one an enclosing scope rebinds. A quoted
-        forward reference holds an expression rather than a name, so its names come from
-        :func:`referenced_names` instead. Check :attr:`Binding.guarded` before emitting a
-        reference that has to resolve at runtime."""
+        member position, a name nothing imports, or one an enclosing scope rebinds. None is not
+        "unused": a quoted forward reference holds an expression, so a use census composes
+        :func:`is_reference` with :func:`referenced_names` rather than calling this. Check
+        :attr:`Binding.guarded` before emitting a runtime reference."""
         binding = self._by_name.get(ident.simple_name)
         if binding is None or not is_reference(cursor, ident):
             return None
@@ -171,8 +171,9 @@ def _is_target(parent: Optional[J], node: J) -> bool:
     if isinstance(parent, ComprehensionExpression):
         # A clause holds its target directly, so the comprehension is the node above the name.
         return any(clause.iterator_variable is node for clause in parent.clauses)
-    # An undotted case label is a capture pattern, which binds; `case json.Loads:` matches a
-    # value and so reads. A name nested in a class pattern's arguments is left as a read.
+    # A bare `case json:` label captures, and so binds. Every structured pattern is a
+    # `Py.MatchCase` instead, whose captures are left as reads: safe for a census, and a
+    # rename has to guard them itself.
     return isinstance(parent, Case) and any(label is node for label in parent.case_labels)
 
 

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Sequence, Set
 from rewrite.java import J
 from rewrite.java.support_types import JContainer, JRightPadded, Statement
 from rewrite.java.tree import Identifier, If, Import, Space
+from rewrite.python.binding_utils import is_reference
 from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
                                          get_canonical_fqn, referenced_names,
                                          unconditional_body)
@@ -143,39 +144,20 @@ class RemoveImport(PythonVisitor):
         return from_name != self.module or qualid != self.name
 
     def _collect_used_identifiers(self, cu: CompilationUnit) -> Set[str]:
-        """Collect all identifiers used in the code (excluding imports)."""
+        """The names the code reads. An identifier filling a slot that names a member —
+        `resp.json()`, `post(url, json=body)`, `item.payload.json` — spells the import
+        without reading it."""
         used: Set[str] = set()
         bindings = LocalBindings()
 
         class UsageCollector(PythonVisitor):
-            def __init__(self):
-                super().__init__()
-                self.in_import = False
-
-            def visit_import(self, import_: Import, p) -> J:
-                # Don't collect identifiers from standalone import statements
-                self.in_import = True
-                try:
-                    return super().visit_import(import_, p)
-                finally:
-                    self.in_import = False
-
-            def visit_multi_import(self, multi: MultiImport, p) -> J:
-                # Don't collect identifiers from import statements
-                self.in_import = True
-                try:
-                    return super().visit_multi_import(multi, p)
-                finally:
-                    self.in_import = False
-
             def visit_identifier(self, ident: Identifier, p) -> J:
-                if not self.in_import:
+                if is_reference(self.cursor, ident):
                     used.update(name for name in referenced_names(ident)
                                 if not bindings.is_bound(self.cursor, name))
                 return ident
 
-        collector = UsageCollector()
-        collector.visit(cu, None)
+        UsageCollector().visit(cu, None)
         return used
 
     def _remove_import(self, cu: CompilationUnit) -> CompilationUnit:

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -148,6 +148,21 @@ class TestMaybeAddImport:
             )
         )
 
+    def test_only_if_referenced_ignores_a_member_name_that_merely_matches(self, arm):
+        """``json`` occurs only in slots naming a member, never as a reference."""
+        spec = RecipeSpec(recipe=from_visitor(
+            _add_import_visitor(arm, 'json', only_if_referenced=True)))
+        spec.rewrite_run(
+            python(
+                """
+                def handle(resp, url, body, item):
+                    resp.json()
+                    post(url, json=body)
+                    return item.payload.json
+                """,
+            )
+        )
+
     def test_only_if_referenced_adds_when_referenced(self, arm):
         """The name is used, so the import is added."""
         spec = RecipeSpec(recipe=from_visitor(

--- a/rewrite-python/rewrite/tests/python/test_bindings.py
+++ b/rewrite-python/rewrite/tests/python/test_bindings.py
@@ -1,0 +1,160 @@
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the binding model: import_bindings, ImportBindings, is_reference."""
+
+from typing import Any, List, Optional, Tuple
+
+from rewrite.java.tree import Identifier, J, MethodDeclaration
+from rewrite.python.binding_utils import ImportBindings, import_bindings
+from rewrite.python.tree import CompilationUnit
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
+
+Reference = Tuple[str, str, Optional[str]]
+
+
+class _Census(PythonVisitor[Any]):
+    """Every identifier the file's module-scope imports resolve, as ``(spelling, module,
+    member)``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.found: List[Reference] = []
+
+    def visit_identifier(self, ident: Identifier, p: Any) -> J:
+        binding = import_bindings(self).reference(self.cursor, ident)
+        if binding is not None:
+            self.found.append((ident.simple_name, binding.module, binding.member))
+        return ident
+
+
+def _run(source: str, visitor: PythonVisitor[Any]) -> None:
+    RecipeSpec(type_attribution=False).rewrite_run(
+        python(source, after_recipe=lambda sf: visitor.visit(sf, None)))
+
+
+def _references(source: str) -> List[Reference]:
+    census = _Census()
+    _run(source, census)
+    return census.found
+
+
+def _bindings(source: str) -> ImportBindings:
+    captured: List[ImportBindings] = []
+
+    class Capture(PythonVisitor[Any]):
+        def visit_compilation_unit(self, cu: CompilationUnit, p: Any) -> J:
+            captured.append(import_bindings(cu))
+            return cu
+
+    _run(source, Capture())
+    return captured[0]
+
+
+def test_a_name_in_member_position_is_not_a_reference():
+    assert _references("""
+        import json
+        resp.json()
+        post(url, json=body)
+        item.payload.json
+        json.dumps(x)
+        """) == [('json', 'json', None)]
+
+
+def test_a_local_binding_shadows_the_import_it_matches():
+    assert _references("""
+        import json
+        def send(json):
+            return json.dumps(x)
+        """) == []
+
+
+def test_a_receiverless_call_names_the_member_it_was_imported_as():
+    assert _references("""
+        from json import dumps as encode
+        encode(x)
+        resp.encode()
+        """) == [('encode', 'json', 'dumps')]
+
+
+def test_an_import_statement_binds_its_names_rather_than_reading_them():
+    assert _references("""
+        import os.path
+        from os.path import join
+        os.path.join(a, b)
+        """) == [('os', 'os.path', None)]
+
+
+def test_bindings_record_the_local_name_module_and_member():
+    bindings = _bindings("""
+        import json
+        import os.path
+        import numpy as np
+        from datetime import datetime as dt
+        """)
+    assert [(b.name, b.module, b.member) for b in bindings] == [
+        ('json', 'json', None),
+        ('os', 'os.path', None),
+        ('np', 'numpy', None),
+        ('dt', 'datetime', 'datetime'),
+    ]
+
+
+def test_for_module_finds_every_name_bound_to_a_module():
+    bindings = _bindings("""
+        import json
+        import json as j
+        from json import dumps
+        """)
+    assert [b.name for b in bindings.for_module('json')] == ['json', 'j', 'dumps']
+    assert [b.name for b in bindings.for_module('json', 'dumps')] == ['dumps']
+
+
+def test_a_relative_import_is_not_the_module_of_the_same_name():
+    bindings = _bindings("""
+        from .locale import setlocale
+        from . import locale
+        """)
+    assert bindings.for_module('locale') == ()
+    assert [b.module for b in bindings] == ['.locale', '.']
+
+
+def test_only_the_imports_of_the_module_scope_bind():
+    bindings = _bindings("""
+        from typing import TYPE_CHECKING
+        try:
+            import ujson as json
+        except ImportError:
+            import json
+        if TYPE_CHECKING:
+            from decimal import Decimal
+        """)
+    assert [(b.name, b.guarded) for b in bindings] == [('TYPE_CHECKING', False), ('Decimal', True)]
+
+
+def test_a_statement_list_scans_the_imports_of_an_inner_block():
+    captured: List[List[str]] = []
+
+    class Capture(PythonVisitor[Any]):
+        def visit_method_declaration(self, method: MethodDeclaration, p: Any) -> J:
+            captured.append([b.name for b in import_bindings(method.body.statements)])
+            return method
+
+    _run("""
+        def f():
+            from json import dumps
+            return dumps(x)
+        """, Capture())
+    assert captured == [['dumps']]

--- a/rewrite-python/rewrite/tests/python/test_bindings.py
+++ b/rewrite-python/rewrite/tests/python/test_bindings.py
@@ -32,6 +32,11 @@ class _Census(PythonVisitor[Any]):
     def __init__(self) -> None:
         super().__init__()
         self.found: List[Reference] = []
+        self.bindings: List[Tuple[str, str, Optional[str], bool]] = []
+
+    def visit_compilation_unit(self, cu: CompilationUnit, p: Any) -> J:
+        self.bindings = [(b.name, b.module, b.member, b.guarded) for b in import_bindings(cu)]
+        return super().visit_compilation_unit(cu, p)
 
     def visit_identifier(self, ident: Identifier, p: Any) -> J:
         binding = import_bindings(self).reference(self.cursor, ident)
@@ -40,8 +45,8 @@ class _Census(PythonVisitor[Any]):
         return ident
 
 
-def _run(source: str, visitor: PythonVisitor[Any]) -> None:
-    RecipeSpec(type_attribution=False).rewrite_run(
+def _run(source: str, visitor: PythonVisitor[Any], attributed: bool = False) -> None:
+    RecipeSpec(type_attribution=attributed).rewrite_run(
         python(source, after_recipe=lambda sf: visitor.visit(sf, None)))
 
 
@@ -73,6 +78,33 @@ def test_a_name_in_member_position_is_not_a_reference():
         """) == [('json', 'json', None)]
 
 
+def test_a_global_statement_declares_a_binding_rather_than_reading_it():
+    assert _references("""
+        import json
+        def f():
+            global json
+            json = None
+        """) == []
+
+
+def test_attribution_changes_nothing_the_model_reports():
+    source = """
+        import json
+        from os.path import join as j
+        from . import sibling
+        resp.json()
+        json.dumps(j)
+        x: 'json.Foo' = None
+        """
+
+    def arm(attributed: bool):
+        census = _Census()
+        _run(source, census, attributed)
+        return census.found, census.bindings
+
+    assert arm(False) == arm(True)
+
+
 def test_a_local_binding_shadows_the_import_it_matches():
     assert _references("""
         import json
@@ -95,6 +127,41 @@ def test_an_import_statement_binds_its_names_rather_than_reading_them():
         from os.path import join
         os.path.join(a, b)
         """) == [('os', 'os.path', None)]
+
+
+def test_a_target_the_statement_binds_is_not_a_reference():
+    assert _references("""
+        import json
+        json = None
+        (a, json) = f()
+        for json in xs:
+            pass
+        del json
+        """) == []
+
+
+def test_a_dotted_target_reads_the_name_it_assigns_through():
+    assert _references("""
+        import json
+        json.cache = {}
+        json += 1
+        """) == [('json', 'json', None), ('json', 'json', None)]
+
+
+def test_the_last_import_of_a_name_in_source_order_is_the_one_in_force():
+    bindings = _bindings("""
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from a import Bar
+        from b import Bar
+        """)
+    assert bindings.for_name('Bar').module == 'b'
+
+
+def test_a_wildcard_import_binds_no_name_of_its_own():
+    bindings = _bindings("from json import *\n")
+    assert [(b.name, b.member) for b in bindings] == [('*', '*')]
+    assert bindings.for_name('*') is None
 
 
 def test_bindings_record_the_local_name_module_and_member():

--- a/rewrite-python/rewrite/tests/python/test_bindings.py
+++ b/rewrite-python/rewrite/tests/python/test_bindings.py
@@ -150,8 +150,25 @@ def test_a_target_the_statement_binds_is_not_a_reference():
         (a, json) = f()
         for json in xs:
             pass
-        del json
         """) == []
+
+
+def test_del_reads_the_name_it_unbinds():
+    # `del json` needs the name bound, so removing the import it names breaks the file.
+    assert _references("import json\ndel json\n") == [('json', 'json', None)]
+
+
+def test_an_undotted_case_label_captures_rather_than_matches():
+    assert _positions("""
+        match x:
+            case json:
+                pass
+        """) == [False]
+    assert _positions("""
+        match x:
+            case json.Loads():
+                pass
+        """) == [True]
 
 
 def test_a_comprehension_target_is_not_a_reference():
@@ -168,13 +185,20 @@ def test_a_dotted_target_reads_the_name_it_assigns_through():
 
 
 def test_the_last_import_of_a_name_in_source_order_is_the_one_in_force():
-    bindings = _bindings("""
+    assert _bindings("""
         from typing import TYPE_CHECKING
         if TYPE_CHECKING:
             from a import Bar
         from b import Bar
-        """)
-    assert bindings.for_name('Bar').module == 'b'
+        """).for_name('Bar').module == 'b'
+
+    # A guarded import binds no runtime name, so it does not displace one that does.
+    assert _bindings("""
+        from typing import TYPE_CHECKING
+        from a import Bar
+        if TYPE_CHECKING:
+            from b import Bar
+        """).for_name('Bar').module == 'a'
 
 
 def test_a_wildcard_import_binds_no_name_of_its_own():

--- a/rewrite-python/rewrite/tests/python/test_bindings.py
+++ b/rewrite-python/rewrite/tests/python/test_bindings.py
@@ -17,7 +17,7 @@
 from typing import Any, List, Optional, Tuple
 
 from rewrite.java.tree import Identifier, J, MethodDeclaration
-from rewrite.python.binding_utils import ImportBindings, import_bindings
+from rewrite.python.binding_utils import ImportBindings, import_bindings, is_reference
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
@@ -54,6 +54,20 @@ def _references(source: str) -> List[Reference]:
     census = _Census()
     _run(source, census)
     return census.found
+
+
+def _positions(source: str) -> List[bool]:
+    """What :func:`is_reference` answers for each ``json`` identifier, in source order."""
+    answers: List[bool] = []
+
+    class Positions(PythonVisitor[Any]):
+        def visit_identifier(self, ident: Identifier, p: Any) -> J:
+            if ident.simple_name == 'json':
+                answers.append(is_reference(self.cursor, ident))
+            return ident
+
+    _run(source, Positions())
+    return answers
 
 
 def _bindings(source: str) -> ImportBindings:
@@ -138,6 +152,11 @@ def test_a_target_the_statement_binds_is_not_a_reference():
             pass
         del json
         """) == []
+
+
+def test_a_comprehension_target_is_not_a_reference():
+    # `reference()` filters this by scope, so `is_reference` is asked on its own.
+    assert _positions("y = [json for json in xs]\n") == [True, False]
 
 
 def test_a_dotted_target_reads_the_name_it_assigns_through():

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -471,12 +471,37 @@ class TestCanonicalRemoveImport:
 
 
 class TestRemoveImportUsageScoping:
-    """``only_if_unused`` counts every reference the enclosing scopes do not
-    rebind, including references that appear only in annotations."""
+    """``only_if_unused`` counts the references the code reads: not a name an enclosing
+    scope rebinds, nor one filling a slot that names a member, and including references
+    that appear only in annotations."""
 
     @staticmethod
     def _remove(arm, module, name):
         return from_visitor(_remove_import_visitor(arm, module, name))
+
+    def test_remove_import_a_member_name_merely_matches(self, arm):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=self._remove(arm, 'json', None),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    import json
+
+
+                    def handle(resp, url, body, item):
+                        resp.json()
+                        post(url, json=body)
+                        return item.payload.json
+                    """,
+                    """\
+                    def handle(resp, url, body, item):
+                        resp.json()
+                        post(url, json=body)
+                        return item.payload.json
+                    """,
+                )
+            )
 
     def test_keep_import_referenced_in_function_annotations(self, arm):
         for type_attribution in (False, True):


### PR DESCRIPTION
Two import predicates in the Python SDK count every identifier that spells a name as a use of it. All four of these contain an `Identifier` whose `simple_name` is `json`, and none of them reference the module:

```python
resp.json()                 # MethodInvocation.name
post(url, json=body)        # NamedArgument.name
item.payload.json           # FieldAccess.name
def send(json): ...         # a parameter shadowing it
```

`RemoveImport._collect_used_identifiers` counted all of them, so `maybe_remove_import` under `only_if_unused=True` — the default — kept an import in any file spelling the name as an attribute or keyword argument anywhere.

`AddImport._is_referenced` is the same scan with the answer inverted: under `only_if_referenced=True`, also the default, it added an import the file never referenced. `scope_utils.LocalBindings` covered the shadowed parameter; nothing covered the other three.

## Why the tests were green

Different reasons on each side. `_add_import_visitor` defaults `only_if_referenced=False` against a production default of `True`, so 19 of 26 add-side tests never ran the predicate.

The remove side is the more instructive: `_remove_import_visitor` matches production and three test classes exercise the census, so it was well covered. No fixture put the name in member position — the failure mode you have to already know about to write a test for.

## The fix

`is_reference(cursor, ident)` decides the question from position alone, ported from rewrite-javascript's `scope.ts:isValueReference`. A dotted name reads through its root, so the walk ascends the `FieldAccess` chain and then asks one rule per parent:

- An import binds its names rather than reading them.
- A call with no receiver reads the name it calls.
- Otherwise a parent that names rather than reads keeps the name on `name` — covering attributes, keyword arguments, `def`, `class`, parameters and type aliases without enumerating them.

`import_bindings(source)` answers the other half, modelled on `binding.ts:moduleBindings`:

```python
bindings = import_bindings(self)          # visitor: scans the file once, cached on the CU cursor
bindings.for_module("json")               # -> tuple[Binding, ...]
bindings.reference(self.cursor, ident)    # -> Binding | None: position + shadowing + lookup

# Binding(name, module, member, imp, guarded)
#   import os.path           -> ('os', 'os.path', None)   # binds only `os`
#   import numpy as np       -> ('np', 'numpy',   None)
#   from .locale import x    -> module '.locale'          # never the stdlib `locale`
```

Both are structural: a parse without a `ty_client` attributes no types, and a recipe gated on attribution then finds nothing while reporting success. Types widen matching here, they never decide it.

Three shapes are handled by construction rather than by a predicate a caller can forget:

- `module` keeps the leading dots the parser already builds, so a relative import never matches the stdlib module of the same name.
- A scan descends into an `if` that has no `else` and into no `try` whatever it catches, so a fallback import's shim is never taken for the module it stands in for.
- An `if TYPE_CHECKING:` binding is marked `guarded`, because the name it binds does not exist at runtime.

## Tests

`test_bindings.py` covers the four member positions, the binding shapes, source order, relative imports, wildcards, `global`, `del`, and `match` capture patterns, and asserts that type attribution changes nothing the model reports. Each predicate gets a regression test for the file it used to judge wrong. Every test was mutation-checked: 23 mutants, each caught by exactly the intended test.

## Not in this change

`scope_utils._bound_import_name` and `remove_import._binds_other` still compute the bound-name rule independently; folding them in means moving it to `import_utils`, since `binding_utils` already imports `scope_utils`. The three agree on every shape tested.

The inverted `_add_import_visitor` default also stays: flipping it puts 19 tests through a predicate they were never written for.

`ChangeImport` has the same defect and is worse — it *renames* `resp.dumps()` and `post(url, dumps=body)`, corrupting source. It is not fixed here because `is_reference` alone breaks it: a rename has to follow the writes and `global` declarations that a read test excludes, so it needs the member-position half split out. Tracked separately.


