### PR TITLE
Python: a rename follows more names than a read census

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/__init__.py
@@ -90,7 +90,8 @@ from rewrite.python.format import (
 from rewrite.python.add_import import AddImport, AddImportOptions, maybe_add_import
 from rewrite.python.remove_import import RemoveImport, RemoveImportOptions, maybe_remove_import
 from rewrite.python.method_matcher import MethodMatcher
-from rewrite.python.binding_utils import Binding, ImportBindings, import_bindings, is_reference
+from rewrite.python.binding_utils import (Binding, ImportBindings, import_bindings,
+                                          is_reference, resolves_in_scope)
 from rewrite.python.scope_utils import Scope, scope_of
 
 # Type-comparison helpers
@@ -206,6 +207,7 @@ __all__ = [
     "ImportBindings",
     "import_bindings",
     "is_reference",
+    "resolves_in_scope",
     # Type-comparison helpers
     "is_assignable_to",
     "is_of_type",

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -29,8 +29,8 @@ from rewrite.java.tree import (Assignment, Case, FieldAccess, ForEachLoop, Ident
 from rewrite.python.import_utils import get_alias_name, unconditional_body
 from rewrite.python.scope_utils import scope_of
 from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ComprehensionExpression,
-                                 CompilationUnit, ExpressionStatement, MultiImport, Star,
-                                 TypeHintedExpression, VariableScope)
+                                 CompilationUnit, ExpressionStatement, MultiImport,
+                                 NamedArgument, Star, TypeHintedExpression, VariableScope)
 from rewrite.visitor import TreeVisitor
 
 _IMPORT_BINDINGS = 'org.openrewrite.python.importBindings'
@@ -126,15 +126,33 @@ def import_bindings(source: Union[TreeVisitor[Any, Any], CompilationUnit,
     return ImportBindings(_scan(source, guarded=False))
 
 
-def is_reference(cursor: Cursor, ident: Identifier) -> bool:
-    """Whether ``ident`` reads a name, rather than filling a slot that names something.
-
-    Position is all this reads, so a name an enclosing scope rebinds still answers True;
-    :meth:`ImportBindings.reference` composes the two. ``cursor`` stands on ``ident`` or on
-    its parent, which lets a visitor ask about a node's own child from where it already is.
+def resolves_in_scope(cursor: Cursor, ident: Identifier) -> bool:
+    """Whether ``ident`` names something the enclosing scopes bind, rather than a member of
+    another namespace: an attribute, a keyword argument, or a name an import spells out.
+    Declarations and writes of a binding answer True, which is what a rename follows, and
+    position is all it reads, so pair it with a scope lookup. ``cursor`` stands on ``ident``
+    or on its parent, letting a visitor ask about a node's own child from where it is.
     """
+    node, parent, _ = _position(cursor, ident)
+    return _resolves(node, parent)
+
+
+def is_reference(cursor: Cursor, ident: Identifier) -> bool:
+    """Whether ``ident`` reads a name: :func:`resolves_in_scope` less the declarations, the
+    targets a statement binds and the names a ``global`` or ``nonlocal`` declares.
+    """
+    node, parent, dotted = _position(cursor, ident)
+    if not _resolves(node, parent) or _declares(node, parent):
+        return False
+    if isinstance(parent, VariableScope):
+        return False
+    return dotted or not _is_target(parent, node)
+
+
+def _position(cursor: Cursor, ident: Identifier) -> Tuple[J, Optional[J], bool]:
+    """The node standing for ``ident`` where it sits, the node above that, and whether a
+    dotted name carried it there."""
     node: J = ident
-    parent: Optional[J] = None
     dotted = False
     for enclosing in _enclosing_nodes(cursor, ident):
         # A dotted name reads through its root, and a tuple or starred target spreads over the
@@ -144,20 +162,28 @@ def is_reference(cursor: Cursor, ident: Identifier) -> bool:
         elif isinstance(enclosing, _TARGET_WRAPPERS):
             node = enclosing
         else:
-            parent = enclosing
-            break
+            return node, enclosing, dotted
+    return node, None, dotted
 
-    if isinstance(parent, (Import, MultiImport, VariableScope)):
-        # An import names the module or member it binds; `global x` names a binding elsewhere.
+
+def _resolves(node: J, parent: Optional[J]) -> bool:
+    """Whether the scopes decide what ``node`` names, rather than the node above it."""
+    if isinstance(parent, (Import, MultiImport)):
+        # An import names the module or member it binds, and holds it on `qualid`, not `name`.
         return False
     if isinstance(parent, MethodInvocation):
-        # A call selecting nothing calls a name it read; with a receiver the name is a member.
+        # A call selecting nothing calls a name it resolved; with a receiver it is a member.
         return parent.name is not node or parent.select is None
-    if not dotted and _is_target(parent, node):
-        return False
-    # Every other node that names rather than reads keeps the name on `name`: an attribute, a
-    # keyword argument, a `def`, a `class`, a parameter, a type alias.
-    return getattr(parent, 'name', None) is not node
+    if isinstance(parent, (FieldAccess, NamedArgument)):
+        # An attribute belongs to its target and a keyword argument to the callee's signature.
+        return parent.name is not node
+    return True
+
+
+def _declares(node: J, parent: Optional[J]) -> bool:
+    """Whether ``parent`` introduces ``node`` as a name of its own: a ``def``, a ``class``, a
+    parameter, a type alias. A receiverless call holds on ``name`` a name it resolved."""
+    return not isinstance(parent, MethodInvocation) and getattr(parent, 'name', None) is node
 
 
 def _is_target(parent: Optional[J], node: J) -> bool:
@@ -239,4 +265,5 @@ def _dotted_path(name: Optional[J]) -> str:
     return '.'.join(parts)
 
 
-__all__ = ['Binding', 'ImportBindings', 'import_bindings', 'is_reference']
+__all__ = ['Binding', 'ImportBindings', 'import_bindings', 'is_reference',
+           'resolves_in_scope']

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
@@ -28,6 +28,7 @@ from rewrite.java.tree import FieldAccess, Identifier, If, Import, MethodInvocat
 from rewrite.markers import Markers
 from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
                                          module_scope_blocks, unconditional_body)
+from rewrite.python.binding_utils import resolves_in_scope
 from rewrite.python.scope_utils import LocalBindings
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
@@ -295,6 +296,9 @@ class ChangeImport(Recipe):
                     return self._remove_module_from_import(multi, old_module)
 
             def visit_identifier(self, ident: Identifier, p: ExecutionContext) -> J:
+                # `resolves_in_scope` matches the cursor's nodes by identity, so it is asked
+                # of the identifier the cursor holds.
+                in_scope = resolves_in_scope(self.cursor, ident)
                 ident = super().visit_identifier(ident, p)  # ty: ignore[invalid-assignment]  # visitor covariance
                 if not isinstance(ident, Identifier):
                     return ident
@@ -306,13 +310,7 @@ class ChangeImport(Recipe):
                     return ident
                 if ident.simple_name != old_ref_name:
                     return ident
-                # Skip identifiers inside import statements
-                if self.cursor.first_enclosing(Import):
-                    return ident
-                # An attribute name resolves against its target object;
-                # visit_field_access handles the qualified references.
-                parent = self.cursor.parent_tree_cursor().value
-                if isinstance(parent, FieldAccess) and parent.name.id == ident.id:
+                if not in_scope:
                     return ident
                 if self.local_bindings.is_bound(self.cursor, old_ref_name):
                     return ident

--- a/rewrite-python/rewrite/tests/python/test_bindings.py
+++ b/rewrite-python/rewrite/tests/python/test_bindings.py
@@ -17,7 +17,8 @@
 from typing import Any, List, Optional, Tuple
 
 from rewrite.java.tree import Identifier, J, MethodDeclaration
-from rewrite.python.binding_utils import ImportBindings, import_bindings, is_reference
+from rewrite.python.binding_utils import (ImportBindings, import_bindings, is_reference,
+                                          resolves_in_scope)
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
@@ -56,14 +57,14 @@ def _references(source: str) -> List[Reference]:
     return census.found
 
 
-def _positions(source: str) -> List[bool]:
-    """What :func:`is_reference` answers for each ``json`` identifier, in source order."""
+def _positions(source: str, predicate: Any = is_reference) -> List[bool]:
+    """What ``predicate`` answers for each ``json`` identifier, in source order."""
     answers: List[bool] = []
 
     class Positions(PythonVisitor[Any]):
         def visit_identifier(self, ident: Identifier, p: Any) -> J:
             if ident.simple_name == 'json':
-                answers.append(is_reference(self.cursor, ident))
+                answers.append(predicate(self.cursor, ident))
             return ident
 
     _run(source, Positions())
@@ -169,6 +170,21 @@ def test_an_undotted_case_label_captures_rather_than_matches():
             case json.Loads():
                 pass
         """) == [True]
+
+
+def test_a_rename_follows_more_names_than_a_read_census():
+    # A write and a `global` declaration name the binding without reading it; member and
+    # keyword position name something else, which both predicates answer alike.
+    source = """
+        json = 1
+        def f(resp, url):
+            global json
+            resp.json()
+            post(url, json=1)
+            return json
+        """
+    assert _positions(source) == [False, False, False, False, True]
+    assert _positions(source, resolves_in_scope) == [True, True, False, False, True]
 
 
 def test_a_comprehension_target_is_not_a_reference():

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -901,6 +901,28 @@ class TestChangeImportPythonScopeRules:
             """,
         )
 
+    def test_member_and_keyword_positions_name_something_else(self):
+        self._run(
+            """\
+            from time import clock
+
+
+            def f(resp, item):
+                resp.clock()
+                poll(clock=1)
+                return item.payload.clock, clock()
+            """,
+            """\
+            from time import perf_counter
+
+
+            def f(resp, item):
+                resp.clock()
+                poll(clock=1)
+                return item.payload.clock, perf_counter()
+            """,
+        )
+
     def test_attribute_and_subscript_targets_do_not_bind(self):
         """``self.clock = 1`` and ``d[clock] = 1`` assign through an object."""
         self._run(
@@ -1005,6 +1027,52 @@ class TestChangeImportPythonScopeRules:
             def f(x=perf_counter):
                 clock = 1
                 return clock, x
+            """,
+        )
+
+    def test_a_module_level_def_moves_with_the_binding_it_rebinds(self):
+        """A `def` at module level rebinds the name the import bound, so the two move
+        together or the calls below it silently retarget the import."""
+        self._run(
+            """\
+            from time import clock
+
+
+            def clock():
+                return 1
+
+
+            print(clock())
+            """,
+            """\
+            from time import perf_counter
+
+
+            def perf_counter():
+                return 1
+
+
+            print(perf_counter())
+            """,
+        )
+
+    def test_a_quoted_annotation_renames_when_the_name_stands_alone(self):
+        """A quoted annotation parses to a single identifier, so only a name that is the
+        whole annotation is in reach."""
+        self._run(
+            """\
+            from time import clock
+
+
+            def f(x: 'clock', y: 'List[clock]'):
+                pass
+            """,
+            """\
+            from time import perf_counter
+
+
+            def f(x: 'perf_counter', y: 'List[clock]'):
+                pass
             """,
         )
 


### PR DESCRIPTION
`ChangeImport` renames every identifier that spells the imported name, including ones that name something else entirely. With `ChangeImport(old_module='json', old_name='dumps', new_module='simplejson', new_name='serialize')`:

```diff
-from json import dumps
+from simplejson import serialize
 
 
 def f(resp, url, body, item):
-    resp.dumps()
-    post(url, dumps=body)
+    resp.serialize()           # a method on `resp`
+    post(url, serialize=body)  # a parameter of `post`
     return item.payload.dumps
```

`visit_identifier` guarded two positions: `FieldAccess.name`, and anything under `cursor.first_enclosing(Import)`. The attribute chain survives on the first. The second never fires for `from x import y`, because `Py.MultiImport` extends `Py`, not `J.Import`. A call receiver and a keyword-argument label were guarded by neither.

## Why not `is_reference`

#8778's `is_reference` looks like the guard to reach for and is not: it is a *read* test, answering False for `global clock` and for `clock = 1`. But `test_global_declaration_is_not_a_local_binding` expects `global clock` to become `global perf_counter` — a rename follows every occurrence of a binding, writes and declarations included.

That predicate conflates two questions: whether the enclosing scopes decide what the identifier names, and whether it then reads or writes what they decide. This splits the first out as `resolves_in_scope` and leaves `is_reference` as that, less the declarations and writes.

```python
def is_reference(cursor: Cursor, ident: Identifier) -> bool:
    node, parent, dotted = _position(cursor, ident)
    if not _resolves(node, parent) or _declares(node, parent):
        return False
    if isinstance(parent, VariableScope):   # `global x`
        return False
    return dotted or not _is_target(parent, node)
```

A `writes=True` parameter on `is_reference` was the alternative, but it would have to answer True for a `global` declaration, which is not a reference under any reading. A local member-position guard in `ChangeImport` was the third, and copies back the knowledge #8778 centralised.

`is_reference`'s answers are unchanged — checked differentially against its previous body over a 79-identifier corpus, 0 divergences — so the `MethodMatcher` binding fallback stacked on #8778 is unaffected.

## Where the line falls

`resolves_in_scope` excludes member and keyword position only: `FieldAccess.name`, `MethodInvocation.name` under a receiver, `NamedArgument.name`, and the names an import spells out. Declaration names stay in, because `LocalBindings.is_bound` treats a module-level binding as the import's own — so excluding them would rename `print(clock())` while leaving `def clock()` alone, retargeting the call at the import. `test_a_module_level_def_moves_with_the_binding_it_rebinds` pins that.

## Tests

`test_a_rename_follows_more_names_than_a_read_census` runs both predicates over one file and pins where they diverge and where they agree. `test_member_and_keyword_positions_name_something_else` is the reproduction, carrying a genuine `clock()` read as a control.

Mutation-checked: defining `resolves_in_scope` as `is_reference` fails `test_global_declaration_is_not_a_local_binding`, which is the reason for the split; folding `_declares` into `_resolves` fails the module-level shadowing test; letting a call receiver through fails the reproduction and no other recipe test.

## Left open

- **Match patterns.** `case [clock]:` still renames, because `scope_utils` collects no match bindings and so the capture does not shadow the import; `case C(clock=x)` renames its keyword label, which is member position that `NamedVariable.name` shares with parameters and `except ... as`. Both behave as they did before this change. Doing either properly wants `MatchCase.Pattern` on the cursor path, which `visit_match_case_pattern` bypasses by calling itself rather than `self.visit`, plus a rule over sixteen pattern kinds of which several read: `case C(x)` and `case json.Foo()` name a class.
- **Compound quoted annotations.** A forward reference renames only where the name is the whole annotation, which is what `Identifier.simple_name` then holds, so `x: 'List[clock]'` is left behind once its import is gone. Reaching it wants a rewriter for the inside of a quoted expression; `referenced_names` finds the names but not their offsets.
