### PR TITLE
Python: MethodMatcher honours match_overrides in-process

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/java/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.py
@@ -215,6 +215,14 @@ class JavaType(ABC):
             Annotation = 3
             Record = 4
 
+        @property
+        def supertype(self) -> Optional[JavaType.FullyQualified]:
+            return getattr(self, '_supertype', None)
+
+        @property
+        def interfaces(self) -> List[JavaType.FullyQualified]:
+            return getattr(self, '_interfaces', None) or []
+
     class Unknown(FullyQualified):
         pass
 
@@ -256,6 +264,16 @@ class JavaType(ABC):
                 return t.fully_qualified_name
             return ''
 
+        @property
+        def supertype(self) -> Optional[JavaType.FullyQualified]:
+            t = getattr(self, '_type', None)
+            return t.supertype if t is not None else None
+
+        @property
+        def interfaces(self) -> List[JavaType.FullyQualified]:
+            t = getattr(self, '_type', None)
+            return t.interfaces if t is not None else []
+
     class Annotation(FullyQualified):
         _type: JavaType.FullyQualified
         _values: Optional[List[JavaType.Annotation.ElementValue]]
@@ -274,6 +292,16 @@ class JavaType(ABC):
             if t is not None and hasattr(t, 'fully_qualified_name'):
                 return t.fully_qualified_name
             return ''
+
+        @property
+        def supertype(self) -> Optional[JavaType.FullyQualified]:
+            t = getattr(self, '_type', None)
+            return t.supertype if t is not None else None
+
+        @property
+        def interfaces(self) -> List[JavaType.FullyQualified]:
+            t = getattr(self, '_type', None)
+            return t.interfaces if t is not None else []
 
         class ElementValue(ABC):
             """Base class for annotation element values."""

--- a/rewrite-python/rewrite/src/rewrite/java/support_types.pyi
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.pyi
@@ -60,7 +60,10 @@ class JavaType(ABC):
             Annotation: Kind
             Record: Kind
 
-
+        @property
+        def supertype(self) -> Optional[JavaType.FullyQualified]: ...
+        @property
+        def interfaces(self) -> List[JavaType.FullyQualified]: ...
 
     class Unknown(FullyQualified):
         pass
@@ -93,6 +96,10 @@ class JavaType(ABC):
         def type_parameters(self) -> Optional[List[JavaType]]: ...
         @property
         def fully_qualified_name(self) -> str: ...
+        @property
+        def supertype(self) -> Optional[JavaType.FullyQualified]: ...
+        @property
+        def interfaces(self) -> List[JavaType.FullyQualified]: ...
 
     class Annotation(FullyQualified):
         class ElementValue(ABC):
@@ -138,6 +145,10 @@ class JavaType(ABC):
         def values(self) -> List[JavaType.Annotation.ElementValue]: ...
         @property
         def fully_qualified_name(self) -> str: ...
+        @property
+        def supertype(self) -> Optional[JavaType.FullyQualified]: ...
+        @property
+        def interfaces(self) -> List[JavaType.FullyQualified]: ...
 
     @dataclass(frozen=True)
     class GenericTypeVariable:

--- a/rewrite-python/rewrite/src/rewrite/python/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/__init__.py
@@ -109,6 +109,7 @@ from rewrite.python.type_report import (
 # Type-comparison helpers
 from rewrite.python.type_utils import (
     is_assignable_to,
+    is_of_type_with_name,
     is_of_type,
     is_of_class_type,
     is_string,
@@ -231,6 +232,7 @@ __all__ = [
     "is_reference",
     # Type-comparison helpers
     "is_assignable_to",
+    "is_of_type_with_name",
     "is_of_type",
     "is_of_class_type",
     "is_string",

--- a/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
+++ b/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
@@ -38,6 +38,7 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 from rewrite.java.tree import MethodInvocation
+from rewrite.python.type_utils import is_of_type_with_name
 
 
 @dataclass
@@ -57,9 +58,10 @@ class MethodMatcher:
     _argument_matchers: List["ArgumentMatcher"]
     _varargs_position: int  # -1 if no varargs
     _original_pattern: str
+    _match_overrides: bool = False
 
     @classmethod
-    def create(cls, pattern: str) -> "MethodMatcher":
+    def create(cls, pattern: str, match_overrides: bool = False) -> "MethodMatcher":
         """
         Create a MethodMatcher from a pattern string.
 
@@ -67,6 +69,8 @@ class MethodMatcher:
 
         Args:
             pattern: The method signature pattern
+            match_overrides: Also match calls whose declaring type is a subtype
+                of the pattern's type
 
         Returns:
             A configured MethodMatcher
@@ -75,6 +79,7 @@ class MethodMatcher:
             >>> m = MethodMatcher.create("datetime.datetime utcnow()")
             >>> m = MethodMatcher.create("datetime.datetime#now(..)")
             >>> m = MethodMatcher.create("datetime..* *(..)")
+            >>> m = MethodMatcher.create("threading.Thread getName()", match_overrides=True)
         """
         parser = _Parser(pattern)
         parser.parse()
@@ -85,6 +90,7 @@ class MethodMatcher:
             _argument_matchers=parser.argument_matchers,
             _varargs_position=parser.varargs_position,
             _original_pattern=pattern,
+            _match_overrides=match_overrides,
         )
 
     def matches(self, method: MethodInvocation) -> bool:
@@ -108,11 +114,19 @@ class MethodMatcher:
             return False
 
         # Check declaring type
-        if not self._type_matcher.matches(method.method_type.declaring_type):
+        if not self._matches_target_type(method.method_type.declaring_type):
             return False
 
         # Check arguments
         return self._matches_arguments(method)
+
+    def _matches_target_type(self, type_obj) -> bool:
+        """Check if the declaring type matches, optionally through supertypes."""
+        if self._type_matcher.matches(type_obj):
+            return True
+        return self._match_overrides and is_of_type_with_name(
+            type_obj, True, self._type_matcher.matches_name
+        )
 
     def _matches_method_name(self, method: MethodInvocation) -> bool:
         """Check if the method name matches.

--- a/rewrite-python/rewrite/src/rewrite/python/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/python/preconditions.py
@@ -64,6 +64,8 @@ def uses_method(method_pattern: str, match_overrides: bool = False) -> RecipeRef
         uses_method("*..* tostring(..)")
         uses_method("java.util.Collections emptyList()")
 
+    ``match_overrides`` widens the receiver to its subtypes.
+
     For a pattern that does not fire, ``REWRITE_PYTHON_DUMP_TYPES=1`` prints the
     declaring type each call got during the test run.
 
@@ -73,7 +75,7 @@ def uses_method(method_pattern: str, match_overrides: bool = False) -> RecipeRef
     return RecipeRef(
         "org.openrewrite.java.search.HasMethod",
         {"methodPattern": method_pattern, "matchOverrides": match_overrides},
-        UsesMethod(method_pattern),
+        UsesMethod(method_pattern, match_overrides),
     )
 
 
@@ -128,7 +130,7 @@ def find_methods(
     return RecipeRef(
         "org.openrewrite.java.search.FindMethods",
         {"methodPattern": method_pattern, "matchOverrides": match_overrides},
-        UsesMethod(method_pattern),
+        UsesMethod(method_pattern, match_overrides),
     )
 
 

--- a/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
@@ -126,10 +126,13 @@ class UsesMethod(TreeVisitor[Tree, Any]):
     Mirrors ``org.openrewrite.java.search.HasMethod``. The ``method_pattern``
     follows the OpenRewrite method-pattern syntax
     (``<receiver-type> <method-name>(<args>)``) — e.g. ``"*..* tostring(..)"``.
+
+    With ``match_overrides``, a call whose declaring type is a subtype of the
+    pattern's receiver matches too.
     """
 
-    def __init__(self, method_pattern: str) -> None:
-        self._matcher = MethodMatcher.create(method_pattern)
+    def __init__(self, method_pattern: str, match_overrides: bool = False) -> None:
+        self._matcher = MethodMatcher.create(method_pattern, match_overrides)
 
     def visit(
         self,

--- a/rewrite-python/rewrite/src/rewrite/python/type_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_utils.py
@@ -21,6 +21,8 @@ commonly need:
 * :func:`is_assignable_to` — is a value of ``from_`` assignable to ``to``
   (a fully-qualified name *or* a :class:`JavaType`), walking the supertype and
   interface hierarchy.
+* :func:`is_of_type_with_name` — the same hierarchy walk against a name
+  predicate, for callers matching by pattern rather than by exact name.
 * :func:`is_of_type` — exact structural type equality.
 * :func:`is_of_class_type` — does a type match a given fully-qualified name.
 
@@ -30,10 +32,13 @@ qualified name.
 """
 
 
+from collections.abc import Callable
+
 from rewrite.java.support_types import JavaType
 
 __all__ = [
     "is_assignable_to",
+    "is_of_type_with_name",
     "is_of_type",
     "is_of_class_type",
     "is_string",
@@ -163,6 +168,49 @@ def is_of_type(type1: JavaType | None, type2: JavaType | None) -> bool:
     return False
 
 
+def is_of_type_with_name(
+    type_: JavaType | None,
+    match_overrides: bool,
+    matcher: Callable[[str], bool],
+) -> bool:
+    """True if ``matcher`` accepts the name of ``type_``, or — when
+    ``match_overrides`` is set — the name of any of its supertypes.
+
+    Ports ``TypeUtils.isOfTypeWithName``; a pattern naming ``object`` matches
+    any type, as ty's mapped supertype chains stop short of the implicit root.
+    """
+    return _is_of_type_with_name(type_, match_overrides, matcher, set())
+
+
+def _is_of_type_with_name(
+    type_: JavaType | None,
+    match_overrides: bool,
+    matcher: Callable[[str], bool],
+    seen: set[int],
+) -> bool:
+    fq = as_fully_qualified(type_)
+    # The type mapping resolves recursive references through placeholders it
+    # back-fills, so a hierarchy can lead back to a type already on this walk.
+    if fq is None or id(fq) in seen:
+        return False
+    seen.add(id(fq))
+    if matcher(fq.fully_qualified_name):
+        return True
+    if match_overrides:
+        # Only ty's spelling of the root short-circuits. A glob can cover a
+        # root name incidentally — ``builtins.*`` matches ``builtins.object``
+        # — so accepting the other ``_OBJECT_NAMES`` spellings here would
+        # make such a pattern match every type.
+        if matcher("object"):
+            return True
+        if _is_of_type_with_name(fq.supertype, True, matcher, seen):
+            return True
+        for interface in fq.interfaces:
+            if _is_of_type_with_name(interface, True, matcher, seen):
+                return True
+    return False
+
+
 def is_assignable_to(to: str | JavaType, from_: JavaType | None) -> bool:
     """True if a value of type ``from_`` can be assigned to ``to``.
 
@@ -180,14 +228,10 @@ def is_assignable_to(to: str | JavaType, from_: JavaType | None) -> bool:
 
 def _is_assignable_to_fqn(to: str, from_: JavaType | None) -> bool:
     if isinstance(from_, JavaType.FullyQualified) and not isinstance(from_, JavaType.Unknown):
-        if fully_qualified_names_are_equal(to, _fqn(from_)):
+        if is_of_type_with_name(
+            from_, True, lambda name: fully_qualified_names_are_equal(to, name)
+        ):
             return True
-        if _is_assignable_to_fqn(to, getattr(from_, "_supertype", None)):
-            return True
-        for i in getattr(from_, "_interfaces", None) or []:
-            if _is_assignable_to_fqn(to, i):
-                return True
-        return False
     elif isinstance(from_, JavaType.GenericTypeVariable):
         for bound in from_.bounds:
             if _is_assignable_to_fqn(to, bound):

--- a/rewrite-python/rewrite/tests/python/test_method_matcher.py
+++ b/rewrite-python/rewrite/tests/python/test_method_matcher.py
@@ -181,3 +181,97 @@ class TestMethodMatcherRepr:
     def test_repr(self):
         m = MethodMatcher.create("datetime.datetime utcnow()")
         assert repr(m) == "MethodMatcher('datetime.datetime utcnow()')"
+
+
+WORKER_SOURCE = (
+    "import threading\n"
+    "\n"
+    "\n"
+    "class Worker(threading.Thread):\n"
+    "    def run(self):\n"
+    "        pass\n"
+    "\n"
+    "\n"
+    "w = Worker()\n"
+    "w.getName()\n"
+)
+
+
+@pytest.fixture(scope="module")
+def worker_cu():
+    """Parse a ``threading.Thread`` subclass with real type attribution."""
+    import ast
+    import os
+    import shutil
+    import tempfile
+
+    from rewrite.python._parser_visitor import ParserVisitor
+    from rewrite.python.ty_client import TyTypesClient
+
+    if shutil.which("ty-types") is None:
+        pytest.skip("ty-types CLI is not installed (ensure ty-types binary is on PATH)")
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        path = os.path.join(tmpdir, "m.py")
+        with open(path, "w") as f:
+            f.write(WORKER_SOURCE)
+        with TyTypesClient() as client:
+            if not client.initialize(tmpdir):
+                pytest.skip("ty-types did not initialize, so there is no attribution to match")
+            return ParserVisitor(WORKER_SOURCE, path, client).visit_Module(
+                ast.parse(WORKER_SOURCE)
+            )
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _get_name_invocation(cu):
+    from rewrite.python.visitor import PythonVisitor
+
+    found = []
+
+    class _Collector(PythonVisitor):
+        def visit_method_invocation(self, mi, p):
+            if mi.name.simple_name == "getName":
+                found.append(mi)
+            return super().visit_method_invocation(mi, p)
+
+    _Collector().visit(cu, None)
+    assert len(found) == 1
+    return found[0]
+
+
+class TestMatchOverrides:
+    """Matching a method declared on a supertype of the call's declaring type."""
+
+    def test_base_type_pattern_matched_only_with_the_flag(self, worker_cu):
+        invocation = _get_name_invocation(worker_cu)
+
+        # The call is attributed to the subclass, so an exact base-type
+        # match cannot work.
+        assert invocation.method_type.declaring_type.fully_qualified_name == "m.Worker"
+
+        assert not MethodMatcher.create("threading.Thread getName(..)").matches(invocation)
+        assert MethodMatcher.create(
+            "threading.Thread getName(..)", match_overrides=True
+        ).matches(invocation)
+
+    def test_unrelated_supertype_still_rejected(self, worker_cu):
+        assert not MethodMatcher.create(
+            "queue.Queue getName(..)", match_overrides=True
+        ).matches(_get_name_invocation(worker_cu))
+
+    def test_preconditions_forward_the_flag(self, worker_cu):
+        from rewrite import InMemoryExecutionContext
+        from rewrite.markers import SearchResult
+        from rewrite.python.preconditions import find_methods, uses_method
+
+        def selects(recipe_ref) -> bool:
+            visited = recipe_ref.local_visitor.visit(worker_cu, InMemoryExecutionContext())
+            return visited.markers.find_first(SearchResult) is not None
+
+        pattern = "threading.Thread getName(..)"
+        assert not selects(uses_method(pattern))
+        assert selects(uses_method(pattern, match_overrides=True))
+        assert selects(find_methods(pattern, match_overrides=True))

--- a/rewrite-python/rewrite/tests/python/test_type_utils.py
+++ b/rewrite-python/rewrite/tests/python/test_type_utils.py
@@ -27,6 +27,7 @@ from rewrite.python.type_utils import (
     is_object,
     is_of_class_type,
     is_of_type,
+    is_of_type_with_name,
     is_string,
 )
 
@@ -291,8 +292,10 @@ class TestIsAssignableToFqn:
         assert not is_assignable_to("zoo.Cat", DOG)
 
     def test_object_fallback_when_no_supertype(self):
-        # A class with no _supertype attribute is still assignable to object
+        # A class with no _supertype attribute is still assignable to object,
+        # under any of the model's spellings of the root
         assert is_assignable_to("object", _cls("loose.Thing"))
+        assert is_assignable_to("java.lang.Object", _cls("loose.Thing"))
 
     def test_not_object_when_no_supertype(self):
         assert not is_assignable_to("other.Thing", _cls("loose.Thing"))
@@ -373,3 +376,33 @@ class TestIsAssignableToType:
 
     def test_none(self):
         assert not is_assignable_to(DOG, None)
+
+
+# ---------------------------------------------------------------------------
+# is_of_type_with_name
+# ---------------------------------------------------------------------------
+
+class TestIsOfTypeWithName:
+    def test_hierarchy_walked_only_with_overrides(self):
+        assert is_of_type_with_name(DOG, False, lambda n: n == "zoo.Dog")
+        assert not is_of_type_with_name(DOG, False, lambda n: n == "zoo.Animal")
+        assert is_of_type_with_name(DOG, True, lambda n: n == "zoo.Animal")
+        assert is_of_type_with_name(DOG, True, lambda n: n == "typing.Comparable")
+
+    def test_object_root_matches_any_type(self):
+        thing = _cls("loose.Thing")
+        assert is_of_type_with_name(thing, True, lambda n: n == "object")
+        assert not is_of_type_with_name(thing, True, lambda n: n == "java.lang.Object")
+
+    def test_parameterized_walks_the_wrapped_types_hierarchy(self):
+        assert is_of_type_with_name(_param(DOG, [ANIMAL]), True, lambda n: n == "zoo.Animal")
+
+    def test_cyclic_hierarchy_terminates(self):
+        a, b = _cls("m.A"), _cls("m.B")
+        a._supertype = b
+        b._supertype = a
+
+        assert not is_of_type_with_name(a, True, lambda n: n == "zoo.Cat")
+
+    def test_not_fully_qualified(self):
+        assert not is_of_type_with_name(JavaType.Unknown(), True, lambda n: True)


### PR DESCRIPTION
`uses_method("threading.Thread getName(..)", match_overrides=True)` sends `matchOverrides: true` to the Java host, which honours it, and bundles an in-process visitor that ignores it. The helpers have accepted the flag all along and dropped it one line later:

```python
RecipeRef(
    "org.openrewrite.java.search.HasMethod",
    {"methodPattern": method_pattern, "matchOverrides": match_overrides},
    UsesMethod(method_pattern),          # flag dropped here
)
```

`MethodMatcher.create(pattern)` had no parameter to forward it to, so `matches()` compared the declaring type by exact glob and stopped. In-process and host-side answers disagreed, and no unit test could distinguish the flag being set from it being ignored.

It matters because the declaring type at a call site is the receiver's class, not the class declaring the method:

```
class Worker(threading.Thread): ...
w = Worker()
w.getName()    ->  declaring_type = m.Worker,  chain: m.Worker -> threading.Thread
```

A gate written `uses_method("threading.Thread getName(..)")` therefore rejects the file before the visitor ever runs. The working alternative is the wildcard receiver `*..*`, which defeats host-side filtering and ships every file calling any `.getName()` over the wire.

The flag now threads through `MethodMatcher.create` -> `UsesMethod` -> both preconditions, backed by a new `type_utils.is_of_type_with_name(type_, match_overrides, matcher)`: a port of `TypeUtils.isOfTypeWithName` taking a name predicate, so a glob can be tested against each supertype. `is_assignable_to` routes through the same walk.

Three points where the port deliberately does not follow Java:

- **The root short-circuit accepts one spelling.** ty emits bare `object`, and its chains stop short of it (`m.B -> Exception -> BaseException`), so the short-circuit is the only way a root pattern can match at all. Accepting every `_OBJECT_NAMES` spelling would make `builtins.*` — which matches `builtins.object` — match every type.
- **`Parameterized` and `Annotation` gained `supertype`/`interfaces`.** Java overrides those getters to delegate to the wrapped type; Python had no accessor, so `getattr(t, "_supertype", None)` was `None` on any wrapper and a walk truncated there. `is_assignable_to("collections.abc.Sequence", <Parameterized list[int]>)` returned `False` where the raw `list` returned `True`.
- **A cycle guard.** `PythonTypeMapping` resolves recursive references through back-filled placeholders, so a hierarchy can lead back to a type already on the walk. Java carries no visited-set; without one, a self-referential supertype raises `RecursionError` out of `UsesMethod.visit` and aborts the run rather than not matching.

`TestMatchOverrides` parses a real `threading.Thread` subclass with ty attribution and pins the flag off and on, an unrelated base type still rejected, and both preconditions' bundled visitors reaching the same answer as the host. `TestIsOfTypeWithName` covers the flag guard, the interface branch, the single-spelling root, wrapper delegation, and cycle termination.
