### PR TITLE
Python: MethodMatcher gains an opt-in match_unknown_types fallback

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
+++ b/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
@@ -37,7 +37,8 @@ Wildcards:
 from dataclasses import dataclass
 from typing import Optional, List
 
-from rewrite.java.tree import MethodInvocation
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import Identifier, MethodInvocation
 from rewrite.python.type_utils import is_of_type_with_name
 
 
@@ -47,10 +48,10 @@ class MethodMatcher:
     Matches method invocations against an AspectJ-style pattern signature.
 
     Matching turns on the call's declaring type, which an import-resolved call
-    carries with no type check running; a pattern naming a concrete receiver
-    fails where that type is ``JavaType.Unknown``, though ``*..*`` still matches.
-    ``REWRITE_PYTHON_DUMP_TYPES=1`` during a test run, or ``rewrite-python-types
-    <file>``, prints what each call actually got.
+    carries with no type check running; a pattern naming a concrete receiver fails
+    where that type is ``JavaType.Unknown``, though ``*..*`` still matches and
+    ``matches(method, match_unknown_types=True)`` falls back to the call as written.
+    ``REWRITE_PYTHON_DUMP_TYPES=1`` in a test run prints what each call got.
     """
 
     _type_matcher: "TypeMatcher"
@@ -93,23 +94,34 @@ class MethodMatcher:
             _match_overrides=match_overrides,
         )
 
-    def matches(self, method: MethodInvocation) -> bool:
+    def matches(self, method: MethodInvocation, match_unknown_types: bool = False) -> bool:
         """
         Check if a method invocation matches this pattern.
 
-        Requires type attribution to be present on the method invocation.
-
         Args:
             method: The method invocation to check
+            match_unknown_types: when the attributed types don't match,
+                also match structurally, on the call's written receiver,
+                name and arguments. Reaches calls whose declaring type is
+                ``JavaType.Unknown``, at the risk of false positives on
+                unrelated calls, so it is off by default.
 
         Returns:
             True if the method matches the pattern
         """
+        if self._matches_typed(method):
+            return True
+        return match_unknown_types and self._matches_allowing_unknown_types(method)
+
+    def _matches_typed(self, method: MethodInvocation) -> bool:
+        """Check the pattern against the call's type attribution."""
         # Check method name first (fast path)
         if not self._matches_method_name(method):
             return False
 
-        # Require type info
+        # A parsed call's declaring type is JavaType.Unknown, never None, so this
+        # guard leaves Unknown to the target-type check below, where a wildcard
+        # receiver still matches it. Rejecting it here would diverge from Java.
         if method.method_type is None or method.method_type.declaring_type is None:
             return False
 
@@ -128,6 +140,20 @@ class MethodMatcher:
             type_obj, True, self._type_matcher.matches_name
         )
 
+    def _matches_allowing_unknown_types(self, method: MethodInvocation) -> bool:
+        """Check the pattern against the call as written, ignoring absent types."""
+        if not self._method_matcher.matches(method.name.simple_name):
+            return False
+
+        # Only a bare identifier receiver is compared; a qualified or computed
+        # one is left unchecked, as in Java.
+        select = method.select
+        if isinstance(select, Identifier) and \
+                not self._type_matcher.matches_simple_name(select.simple_name):
+            return False
+
+        return self._matches_arguments(method, allow_unknown=True)
+
     def _matches_method_name(self, method: MethodInvocation) -> bool:
         """Check if the method name matches.
 
@@ -138,10 +164,13 @@ class MethodMatcher:
         return method.method_type is not None and \
             self._method_matcher.matches(method.method_type.name)
 
-    def _matches_arguments(self, method: MethodInvocation) -> bool:
+    def _matches_arguments(self, method: MethodInvocation, allow_unknown: bool = False) -> bool:
         """Check if method arguments match the expected pattern."""
         args = method.arguments
         arg_count = len(args)
+
+        def accepts(matcher: "ArgumentMatcher", arg_type) -> bool:
+            return matcher.matches_unknown(arg_type) if allow_unknown else matcher.matches(arg_type)
 
         if self._varargs_position == -1:
             # No varargs - exact count required
@@ -149,7 +178,7 @@ class MethodMatcher:
                 return False
             for i, matcher in enumerate(self._argument_matchers):
                 arg_type = args[i].type if hasattr(args[i], 'type') else None
-                if not matcher.matches(arg_type):
+                if not accepts(matcher, arg_type):
                     return False
             return True
         else:
@@ -163,7 +192,7 @@ class MethodMatcher:
             # Match before varargs
             for i in range(before_count):
                 arg_type = args[i].type if hasattr(args[i], 'type') else None
-                if not self._argument_matchers[i].matches(arg_type):
+                if not accepts(self._argument_matchers[i], arg_type):
                     return False
 
             # Match after varargs
@@ -171,7 +200,7 @@ class MethodMatcher:
                 arg_idx = arg_count - after_count + i
                 matcher_idx = self._varargs_position + 1 + i
                 arg_type = args[arg_idx].type if hasattr(args[arg_idx], 'type') else None
-                if not self._argument_matchers[matcher_idx].matches(arg_type):
+                if not accepts(self._argument_matchers[matcher_idx], arg_type):
                     return False
 
             return True
@@ -189,6 +218,10 @@ class TypeMatcher:
     def matches_name(self, fqn: str) -> bool:
         raise NotImplementedError
 
+    def matches_simple_name(self, simple_name: str) -> bool:
+        """Whether the pattern's trailing component matches an unqualified name."""
+        raise NotImplementedError
+
 
 class WildcardTypeMatcher(TypeMatcher):
     """Matches any type."""
@@ -199,11 +232,15 @@ class WildcardTypeMatcher(TypeMatcher):
     def matches_name(self, fqn: str) -> bool:
         return True
 
+    def matches_simple_name(self, simple_name: str) -> bool:
+        return True
+
 
 @dataclass
 class PatternTypeMatcher(TypeMatcher):
     """Matches types against a pattern with wildcards."""
 
+    _pattern: str
     _segments: List[str]  # Pattern segments split by '.'
     _has_double_wildcard: bool  # Whether pattern contains '..'
 
@@ -215,7 +252,7 @@ class PatternTypeMatcher(TypeMatcher):
         if not has_double:
             # Simple case - no double wildcards
             segments = pattern.split(".")
-            return cls(_segments=segments, _has_double_wildcard=False)
+            return cls(_pattern=pattern, _segments=segments, _has_double_wildcard=False)
 
         # Handle patterns with .. by splitting on ".." first
         # Examples: "datetime..*" -> ["datetime", "*"]
@@ -239,7 +276,7 @@ class PatternTypeMatcher(TypeMatcher):
                 if part:
                     segments.extend(part.split("."))
 
-        return cls(_segments=segments, _has_double_wildcard=True)
+        return cls(_pattern=pattern, _segments=segments, _has_double_wildcard=True)
 
     def matches(self, type_obj) -> bool:
         fqn = _get_fqn(type_obj)
@@ -250,6 +287,19 @@ class PatternTypeMatcher(TypeMatcher):
     def matches_name(self, fqn: str) -> bool:
         fqn_parts = fqn.split(".")
         return self._match_segments(self._segments, fqn_parts)
+
+    def matches_simple_name(self, simple_name: str) -> bool:
+        last_dot = self._pattern.rfind(".")
+        if last_dot < 0:
+            # Java accepts a dotless pattern as a receiver name only when literal.
+            return "*" not in self._pattern and self._pattern == simple_name
+
+        tail = self._pattern[last_dot + 1:]
+        if not tail:
+            return False
+        if "*" in tail:
+            return self._matches_glob(tail, simple_name)
+        return tail == simple_name
 
     def _match_segments(self, pattern: List[str], parts: List[str]) -> bool:
         """Match pattern segments against FQN parts."""
@@ -398,6 +448,10 @@ class ArgumentMatcher:
     def matches(self, arg_type) -> bool:
         raise NotImplementedError
 
+    def matches_unknown(self, arg_type) -> bool:
+        """Whether the argument matches once absent type information is excused."""
+        raise NotImplementedError
+
 
 class WildcardArgumentMatcher(ArgumentMatcher):
     """Matches any single argument."""
@@ -405,11 +459,17 @@ class WildcardArgumentMatcher(ArgumentMatcher):
     def matches(self, arg_type) -> bool:
         return True
 
+    def matches_unknown(self, arg_type) -> bool:
+        return True
+
 
 class WildcardVarargsArgumentMatcher(ArgumentMatcher):
     """Matches zero or more arguments of any type (..)."""
 
     def matches(self, arg_type) -> bool:
+        return True
+
+    def matches_unknown(self, arg_type) -> bool:
         return True
 
 
@@ -432,6 +492,11 @@ class TypedArgumentMatcher(ArgumentMatcher):
             return True
 
         return fqn == self._type_pattern or fqn.endswith("." + self._type_pattern)
+
+    def matches_unknown(self, arg_type) -> bool:
+        if arg_type is None or isinstance(arg_type, JavaType.Unknown):
+            return True
+        return self.matches(arg_type)
 
 
 def _get_fqn(type_obj) -> Optional[str]:

--- a/rewrite-python/rewrite/src/rewrite/python/preconditions.py
+++ b/rewrite-python/rewrite/src/rewrite/python/preconditions.py
@@ -66,6 +66,11 @@ def uses_method(method_pattern: str, match_overrides: bool = False) -> RecipeRef
 
     ``match_overrides`` widens the receiver to its subtypes.
 
+    ``match_unknown_types`` is deliberately absent: ``HasMethod`` gates on the
+    file's used ``JavaType.Method`` set, with no call site to match structurally,
+    so the host would reject files the flag admits. Gate on it by passing
+    ``UsesMethod(pattern, match_unknown_types=True)`` to ``Preconditions.check``.
+
     For a pattern that does not fire, ``REWRITE_PYTHON_DUMP_TYPES=1`` prints the
     declaring type each call got during the test run.
 

--- a/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/search/__init__.py
@@ -129,10 +129,16 @@ class UsesMethod(TreeVisitor[Tree, Any]):
 
     With ``match_overrides``, a call whose declaring type is a subtype of the
     pattern's receiver matches too.
+
+    ``match_unknown_types`` widens a concrete receiver pattern to calls whose
+    declaring type is ``JavaType.Unknown``; see :meth:`MethodMatcher.matches`
+    for the false-positive trade-off.
     """
 
-    def __init__(self, method_pattern: str, match_overrides: bool = False) -> None:
+    def __init__(self, method_pattern: str, match_overrides: bool = False,
+                 match_unknown_types: bool = False) -> None:
         self._matcher = MethodMatcher.create(method_pattern, match_overrides)
+        self._match_unknown_types = match_unknown_types
 
     def visit(
         self,
@@ -142,7 +148,7 @@ class UsesMethod(TreeVisitor[Tree, Any]):
     ) -> Optional[Tree]:
         if not isinstance(tree, SourceFile):
             return tree
-        if _MethodSearch(self._matcher).search(tree, p):
+        if _MethodSearch(self._matcher, self._match_unknown_types).search(tree, p):
             return SearchResult.found(tree)
         return tree
 
@@ -279,12 +285,14 @@ class _TypeSearch(_FindFirst):
 
 
 class _MethodSearch(_FindFirst):
-    def __init__(self, matcher: MethodMatcher) -> None:
+    def __init__(self, matcher: MethodMatcher, match_unknown_types: bool = False) -> None:
         super().__init__()
         self._matcher = matcher
+        self._match_unknown_types = match_unknown_types
 
     def matches(self, tree: Tree) -> bool:
-        return isinstance(tree, MethodInvocation) and self._matcher.matches(tree)
+        return isinstance(tree, MethodInvocation) and self._matcher.matches(
+            tree, match_unknown_types=self._match_unknown_types)
 
 
 class _ImportSearch(_FindFirst):

--- a/rewrite-python/rewrite/tests/python/test_method_matcher.py
+++ b/rewrite-python/rewrite/tests/python/test_method_matcher.py
@@ -16,6 +16,10 @@
 
 import pytest
 
+from typing import List
+from rewrite.java.tree import MethodInvocation
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
 from rewrite.python import MethodMatcher
 from rewrite.python.method_matcher import (
     PatternTypeMatcher,
@@ -275,3 +279,72 @@ class TestMatchOverrides:
         assert not selects(uses_method(pattern))
         assert selects(uses_method(pattern, match_overrides=True))
         assert selects(find_methods(pattern, match_overrides=True))
+
+
+def _invocation(source: str, name: str) -> MethodInvocation:
+    """The single call named ``name`` in ``source``, parsed without type attribution."""
+    found: List[MethodInvocation] = []
+
+    class Finder(PythonVisitor):
+        def visit_method_invocation(self, method: MethodInvocation, p):
+            if method.name.simple_name == name:
+                found.append(method)
+            return super().visit_method_invocation(method, p)
+
+    RecipeSpec(type_attribution=False).rewrite_run(
+        python(source, after_recipe=lambda sf: Finder().visit(sf, None)))
+    assert len(found) == 1
+    return found[0]
+
+
+class TestMatchUnknownTypes:
+    """Structural fallback for calls whose declaring type is ``JavaType.Unknown``."""
+
+    def test_wildcard_receiver_matches_an_unknown_declaring_type_by_default(self):
+        mi = _invocation("Assert.assertTrue(foo.bar())", "assertTrue")
+        assert MethodMatcher.create("* *(..)").matches(mi)
+        assert MethodMatcher.create("*..* assertTrue(..)").matches(mi)
+
+    def test_concrete_receiver_needs_match_unknown_types(self):
+        mi = _invocation("Assert.assertTrue(foo.bar())", "assertTrue")
+        m = MethodMatcher.create("org.junit.Assert assertTrue(..)")
+        assert not m.matches(mi)
+        assert m.matches(mi, match_unknown_types=True)
+
+    def test_receiver_identifier_is_matched_against_the_pattern_tail(self):
+        mi = _invocation("MyHelper.do_something(True)", "do_something")
+
+        def matches(type_pattern: str) -> bool:
+            return MethodMatcher.create(f"{type_pattern} do_something(..)").matches(
+                mi, match_unknown_types=True)
+
+        assert matches("com.foo.MyHelper")
+        assert matches("com.foo.*")
+        assert matches("com..MyHelper")
+        assert matches("com.foo.My*Helper")
+        assert not matches("com.foo.OtherHelper")
+        assert not matches("com.foo.Your*Helper")
+
+    def test_a_receiver_that_is_not_an_identifier_is_not_checked(self):
+        mi = _invocation("array.array('b').tostring()", "tostring")
+        # Matching an unrelated receiver here is the false positive `matches`
+        # warns about; Java leaves a non-identifier receiver unchecked too.
+        assert MethodMatcher.create("nowhere.At.All tostring(..)").matches(
+            mi, match_unknown_types=True)
+
+    def test_a_mismatched_method_name_is_rejected(self):
+        mi = _invocation("Assert.assertTrue(foo.bar())", "assertTrue")
+        assert not MethodMatcher.create("org.junit.Assert assertFalse(..)").matches(
+            mi, match_unknown_types=True)
+
+    def test_argument_count_must_still_match(self):
+        mi = _invocation("Assert.assertTrue(foo.bar(), 'message')", "assertTrue")
+        assert not MethodMatcher.create("org.junit.Assert assertTrue(*)").matches(
+            mi, match_unknown_types=True)
+        assert not MethodMatcher.create("org.junit.Assert assertTrue(*, *, *)").matches(
+            mi, match_unknown_types=True)
+
+    def test_an_unattributed_argument_satisfies_a_typed_argument_matcher(self):
+        mi = _invocation("Assert.assertTrue(foo.bar())", "assertTrue")
+        assert MethodMatcher.create("org.junit.Assert assertTrue(bool)").matches(
+            mi, match_unknown_types=True)

--- a/rewrite-python/rewrite/tests/recipes/test_search_traversal.py
+++ b/rewrite-python/rewrite/tests/recipes/test_search_traversal.py
@@ -97,6 +97,14 @@ def test_uses_method_reaches_call_in_fstring_comprehension(cu):
     assert not _matches(UsesMethod("*..* unused(..)"), cu)
 
 
+def test_uses_method_can_widen_to_calls_that_have_no_declaring_type():
+    src = "MyHelper.do_something(1)\n"
+    unattributed = ParserVisitor(src, "unattributed.py", None).visit(ast.parse(src))
+    pattern = "com.foo.MyHelper do_something(..)"
+    assert not _matches(UsesMethod(pattern), unattributed)
+    assert _matches(UsesMethod(pattern, match_unknown_types=True), unattributed)
+
+
 def test_uses_import_reaches_import_in_except_block(cu):
     assert _matches(UsesImport("calendar"), cu)
     assert not _matches(UsesImport("datetime"), cu)


### PR DESCRIPTION
Python's `MethodMatcher` can only match a call whose declaring type resolved. A pattern naming a concrete receiver silently fails wherever attribution collapsed to `JavaType.Unknown`, and on a Python LST that is a common shape: the parser writes `JavaType.Unknown` into `declaring_type` rather than leaving it `None`, so Java's `methodType == null` branch is dead here and the live path is "the typed match failed".

Java has carried a fallback for exactly this — `MethodMatcher.matches(J.MethodInvocation, boolean matchUnknownTypes)`, which compares the call as written when the attributed types do not match. This ports it.

```python
# mi is `Assert.assertTrue(foo.bar())`, declaring type JavaType.Unknown
m = MethodMatcher.create("org.junit.Assert assertTrue(..)")
m.matches(mi)                            # False
m.matches(mi, match_unknown_types=True)  # True
```

It defaults off, mirroring Java's javadoc: the flag "increases the risk of false-positive matches on unrelated MethodInvocation instances". Only a bare identifier receiver is compared; a qualified or computed one is left unchecked, as in Java, and that is where the risk comes from.

## Structure

`matches()` becomes a two-arm dispatcher, with the typed check moved into a private `_matches_typed()` so the two paths are siblings as they are in Java:

```python
if self._matches_typed(method):
    return True
return match_unknown_types and self._matches_allowing_unknown_types(method)
```

`TypeMatcher` gains `matches_simple_name` and `ArgumentMatcher` gains `matches_unknown` — the two comparisons the structural path needs, ported from `TypeNameMatcher.matchesSimpleName` and the `matchesUnknown` implementations.

- The flag is a per-call argument while `match_overrides` (#8782) is a constructor field. That asymmetry mirrors Java, where `matchUnknownTypes` is a parameter on `matches` and `matchOverrides` is set at construction.

## Why `uses_method` does not take it

That helper returns a `RecipeRef` for `org.openrewrite.java.search.HasMethod`, which delegates to `UsesMethod<P>` and matches over `TypesInUse.getUsedMethods()` — a set of `JavaType.Method` with no call site to match structurally. Threading the flag into only the bundled local visitor would make the precondition looser in tests than under the host: green tests, then a silent no-op. It is on `UsesMethod` instead, which a recipe can pass to `Preconditions.check` directly.

## Tests

Seven in `TestMatchUnknownTypes`, one per branch, plus one for the `UsesMethod` wiring. The default is pinned explicitly — with an `Unknown` declaring type, `* *(..)` and `*..* foo(..)` still match *without* the flag, which is existing behaviour that must not regress.

I also hand-translated all 24 assertions from Java's `MethodMatcherTest.UnknownTypes`. Every receiver, method-name and argument-count case reproduces.

## Out of scope

Six of those 24 fail on two pre-existing defects that limit the typed path identically, both fixed separately:

- `TypedArgumentMatcher` resolves types through `fully_qualified_name` only, so a `JavaType.Primitive` argument never matches — `array array(str)` fails against a fully attributed `array.array('b')`.
- A zero-argument call's container holds a lone `J.Empty`, so no `()` pattern matches.
