### PR TITLE
Python: a MethodMatcher pattern can name a call's argument types

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -853,7 +853,9 @@ class ParserVisitor(ast.NodeVisitor):
                 Markers.EMPTY,
                 self.__convert_name(node.arg),
                 self.__pad_left(self.__source_before('='), self.__convert(node.value)),
-                self._type_mapping.type(node)
+                # A keyword argument is an expression whose type is its value's;
+                # ty attributes the value, not the `ast.keyword` wrapping it.
+                self._type_mapping.type(node.value)
             )
         prefix = self.__whitespace()
         if self.__skip('**'):

--- a/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_py2_parser_visitor.py
@@ -2763,7 +2763,7 @@ class Py2ParserVisitor:
                 random_id(), Space.EMPTY, Markers.EMPTY,
                 name_ident,
                 JLeftPadded(self._parse_space(children[1].prefix), value, Markers.EMPTY),
-                None,
+                getattr(value, 'type', None),
             )
         # Generator-expression argument: ``test (sync_)comp_for ...``.
         if (len(children) >= 2 and

--- a/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
+++ b/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
@@ -38,7 +38,8 @@ from dataclasses import dataclass
 from typing import Optional, List
 
 from rewrite.java.support_types import JavaType
-from rewrite.java.tree import Identifier, MethodInvocation
+from rewrite.java.tree import Empty, Identifier, MethodInvocation
+from rewrite.python.type_mapping import PRIMITIVE_TO_PYTHON
 from rewrite.python.type_utils import is_of_type_with_name
 
 
@@ -167,6 +168,10 @@ class MethodMatcher:
     def _matches_arguments(self, method: MethodInvocation, allow_unknown: bool = False) -> bool:
         """Check if method arguments match the expected pattern."""
         args = method.arguments
+        if len(args) == 1 and isinstance(args[0], Empty):
+            # A call with no arguments holds one Empty placeholder, which
+            # no pattern names.
+            args = []
         arg_count = len(args)
 
         def accepts(matcher: "ArgumentMatcher", arg_type) -> bool:
@@ -478,20 +483,22 @@ class TypedArgumentMatcher(ArgumentMatcher):
     """Matches arguments of a specific type pattern."""
 
     _type_pattern: str
+    _type_matcher: "TypeMatcher"
+
+    @classmethod
+    def create(cls, type_pattern: str) -> "TypedArgumentMatcher":
+        return cls(_type_pattern=type_pattern,
+                   _type_matcher=_type_matcher_for(type_pattern))
 
     def matches(self, arg_type) -> bool:
-        if arg_type is None:
-            return False
-
         fqn = _get_fqn(arg_type)
         if fqn is None:
             return False
 
-        # Simple matching for now - could be enhanced
-        if self._type_pattern == "*":
-            return True
-
-        return fqn == self._type_pattern or fqn.endswith("." + self._type_pattern)
+        # An unqualified pattern also names the trailing component of a qualified
+        # type, so `datetime` reaches `datetime.datetime`.
+        return self._type_matcher.matches_name(fqn) or \
+            fqn.endswith("." + self._type_pattern)
 
     def matches_unknown(self, arg_type) -> bool:
         if arg_type is None or isinstance(arg_type, JavaType.Unknown):
@@ -500,14 +507,24 @@ class TypedArgumentMatcher(ArgumentMatcher):
 
 
 def _get_fqn(type_obj) -> Optional[str]:
-    """Extract the fully qualified name from a type object."""
+    """The name a pattern spells this type by."""
     if type_obj is None:
         return None
+
+    if isinstance(type_obj, JavaType.Primitive):
+        return PRIMITIVE_TO_PYTHON.get(type_obj)
 
     if hasattr(type_obj, "fully_qualified_name"):
         return type_obj.fully_qualified_name
 
     return None
+
+
+def _type_matcher_for(pattern: str) -> TypeMatcher:
+    # Universal wildcards that match everything
+    if pattern in ("*", "..*", "*..", "*..*", "*.."):
+        return WildcardTypeMatcher()
+    return PatternTypeMatcher.create(pattern)
 
 
 class _Parser:
@@ -556,7 +573,7 @@ class _Parser:
                 f"Invalid method pattern: '{self.pattern}'. "
                 f"Empty type pattern"
             )
-        self.type_matcher = self._parse_type_matcher(type_pattern)
+        self.type_matcher = _type_matcher_for(type_pattern)
 
         # Parse method name
         method_name = before_paren[separator + 1:].strip()
@@ -570,12 +587,6 @@ class _Parser:
         # Parse arguments
         args_str = pattern[open_paren + 1:close_paren].strip()
         self._parse_arguments(args_str)
-
-    def _parse_type_matcher(self, pattern: str) -> TypeMatcher:
-        # Universal wildcards that match everything
-        if pattern in ("*", "..*", "*..", "*..*", "*.."):
-            return WildcardTypeMatcher()
-        return PatternTypeMatcher.create(pattern)
 
     def _parse_method_matcher(self, name: str) -> MethodNameMatcher:
         if name == "*":
@@ -611,4 +622,4 @@ class _Parser:
             elif arg == "*":
                 self.argument_matchers.append(WildcardArgumentMatcher())
             else:
-                self.argument_matchers.append(TypedArgumentMatcher(arg))
+                self.argument_matchers.append(TypedArgumentMatcher.create(arg))

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -91,7 +91,7 @@ _PYTHON_PRIMITIVES: Dict[str, JavaType.Primitive] = {
 }
 
 # Reverse mapping from JavaType.Primitive to Python type name
-_PRIMITIVE_TO_PYTHON: Dict[JavaType.Primitive, str] = {
+PRIMITIVE_TO_PYTHON: Dict[JavaType.Primitive, str] = {
     JavaType.Primitive.String: 'str',
     JavaType.Primitive.Int: 'int',
     JavaType.Primitive.Double: 'float',
@@ -1727,7 +1727,7 @@ class PythonTypeMapping:
                 return java_type._type if isinstance(java_type._type, JavaType.FullyQualified) else java_type
             if isinstance(java_type, JavaType.Primitive):
                 return self._create_class_type(
-                    _PRIMITIVE_TO_PYTHON.get(java_type, java_type.name.lower())
+                    PRIMITIVE_TO_PYTHON.get(java_type, java_type.name.lower())
                 )
         return None
 

--- a/rewrite-python/rewrite/tests/python/py27/remaining_test.py
+++ b/rewrite-python/rewrite/tests/python/py27/remaining_test.py
@@ -19,6 +19,7 @@ comprehensions, chained assignment, two-token comparison operators."""
 import pytest
 
 from rewrite.java import tree as j
+from rewrite.java.support_types import JavaType
 from rewrite.python import tree as py
 from rewrite.python._py2_parser_visitor import Py2ParserVisitor
 from rewrite.python.markers import TupleExceptClause
@@ -231,6 +232,7 @@ class TestCallArgs:
         e = _expr("x = f(a=1)\n")
         assert isinstance(e, j.MethodInvocation)
         assert isinstance(e.arguments[0], py.NamedArgument)
+        assert e.arguments[0].type == JavaType.Primitive.Int
 
     def test_mixed_args(self):
         e = _expr("x = f(a, b=2)\n")

--- a/rewrite-python/rewrite/tests/python/test_method_matcher.py
+++ b/rewrite-python/rewrite/tests/python/test_method_matcher.py
@@ -14,12 +14,11 @@
 
 """Tests for the MethodMatcher utility."""
 
+from typing import List
+
 import pytest
 
-from typing import List
 from rewrite.java.tree import MethodInvocation
-from rewrite.python.visitor import PythonVisitor
-from rewrite.test import RecipeSpec, python
 from rewrite.python import MethodMatcher
 from rewrite.python.method_matcher import (
     PatternTypeMatcher,
@@ -28,6 +27,8 @@ from rewrite.python.method_matcher import (
     PatternMethodNameMatcher,
     WildcardMethodNameMatcher,
 )
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
 
 
 class TestMethodMatcherPatternParsing:
@@ -281,8 +282,8 @@ class TestMatchOverrides:
         assert selects(find_methods(pattern, match_overrides=True))
 
 
-def _invocation(source: str, name: str) -> MethodInvocation:
-    """The single call named ``name`` in ``source``, parsed without type attribution."""
+def _invocation(source: str, name: str, type_attribution: bool = False) -> MethodInvocation:
+    """The single call named ``name`` in ``source``."""
     found: List[MethodInvocation] = []
 
     class Finder(PythonVisitor):
@@ -291,7 +292,7 @@ def _invocation(source: str, name: str) -> MethodInvocation:
                 found.append(method)
             return super().visit_method_invocation(method, p)
 
-    RecipeSpec(type_attribution=False).rewrite_run(
+    RecipeSpec(type_attribution=type_attribution).rewrite_run(
         python(source, after_recipe=lambda sf: Finder().visit(sf, None)))
     assert len(found) == 1
     return found[0]
@@ -348,3 +349,41 @@ class TestMatchUnknownTypes:
         mi = _invocation("Assert.assertTrue(foo.bar())", "assertTrue")
         assert MethodMatcher.create("org.junit.Assert assertTrue(bool)").matches(
             mi, match_unknown_types=True)
+
+    def test_a_known_argument_type_is_still_checked(self):
+        mi = _invocation("Assert.assertTrue(foo.bar(), 'message')", "assertTrue")
+        assert MethodMatcher.create("org.junit.Assert assertTrue(*, str)").matches(
+            mi, match_unknown_types=True)
+
+        assert not MethodMatcher.create("org.junit.Assert assertTrue(*, int)").matches(
+            mi, match_unknown_types=True)
+
+class TestArgumentTypeMatching:
+    """Argument matching against a parsed call."""
+
+    def test_a_zero_argument_call_matches_an_empty_argument_pattern(self):
+        mi = _invocation("import m\nm.g()\n", "g")
+        assert MethodMatcher.create("m g()").matches(mi)
+        assert not MethodMatcher.create("m g(*)").matches(mi)
+        # The Java host matches the same call through JavaType.Method, counting
+        # parameter types; both peers have to see zero for one pattern to serve both.
+        assert not mi.method_type.parameter_types
+
+    def test_a_primitive_argument_matches_its_python_spelling(self):
+        mi = _invocation("import m\nm.f('s', 1, 1.5, True, None)\n", "f")
+        assert MethodMatcher.create("m f(str, int, float, bool, None)").matches(mi)
+        assert not MethodMatcher.create("m f(str, int, float, bool, str)").matches(mi)
+
+    def test_a_wildcard_argument_accepts_an_argument_with_no_type(self):
+        mi = _invocation("import m\nm.f(g(), 'message')\n", "f")
+        assert MethodMatcher.create("m f(*, str)").matches(mi)
+
+    def test_a_typed_pattern_matches_a_keyword_argument(self):
+        mi = _invocation("import m\nm.f(x=1)\n", "f")
+        assert MethodMatcher.create("m f(int)").matches(mi)
+
+    def test_an_argument_type_pattern_may_contain_wildcards(self):
+        mi = _invocation("import datetime\nimport m\nm.f(datetime.datetime.now())\n",
+                         "f", type_attribution=True)
+        assert MethodMatcher.create("m f(datetime.*)").matches(mi)
+        assert not MethodMatcher.create("m f(json.*)").matches(mi)


### PR DESCRIPTION
No `MethodMatcher` pattern that named an argument could match a Python call. Both an empty argument list and a named argument type failed, on fully import-resolved calls, with or without a type checker:

```
array.array('b')     array array(str)   -> False
array.array()        array array()      -> False
socket.getfqdn()     socket getfqdn()   -> False
m.f(x=1)             m f(int)           -> False
```

Three independent causes:

- A zero-argument call's `JContainer` holds one `J.Empty` placeholder, so `len(method.arguments)` was 1 where the pattern expected 0.
- `_get_fqn` read only `fully_qualified_name`, which `JavaType.Primitive` does not have, so every literal argument failed.
- `Py.NamedArgument._type` was `None` even under full attribution, because `visit_keyword` asked ty about the `ast.keyword` node instead of its value. `_get_parameter_types` already read `kw.value`, so the type mapper and the LST disagreed.

## Why the count stays on call-site arguments

Java counts `JavaType.Method.getParameterTypes()`, which is genuinely empty for a zero-argument method. Python's `parameter_types` is a different thing:

| call | `arguments` | `parameter_types` |
|---|---|---|
| `json.dumps({}, indent=2)` (ty) | 2 | 10 — `obj, skipkeys, …, **kwds` |
| `array.array('b')` (no ty) | 1 | 1 — call-site types, names `arg0` |
| `socket.getfqdn()` | 1 (`J.Empty`) | `None` |

Switching to it would make a pattern mean one thing with attribution and another without, and break every `(*, *)`-shaped pattern. So a lone `J.Empty` counts as zero instead.

That also settles a disagreement between the two implementations: `getParameterTypes()` returns `emptyList()` for a null array, so `matches(JavaType.Method)` already answered `true` for `socket getfqdn()` while this side answered `false`.

## Spelling

A pattern names primitives the way the source does — `str`, `int`, `float`, `bool`, `None` — from the map `type_mapping` already owned, now public as `PRIMITIVE_TO_PYTHON`. Builtin class FQNs are unqualified everywhere else in the module (`list`, `dict`, `bytes`), and Java's `boolean`/`java.lang.String` have no footing here.

Argument type patterns also route through the same `TypeMatcher` the receiver uses, so `f(datetime.*)` resolves.

## Tests

Five cases in `TestArgumentTypeMatching` cover the empty pattern (including that `(*)` still rejects a zero-argument call), the five spellings, a wildcard beside an untyped argument, an argument-position wildcard, and the keyword argument.

One case in `TestMatchUnknownTypes` pins `matches_unknown`'s fall-through for a *known* argument type — mutating that method to `return True` left the suite green before it. The Python 2 parser had the same keyword defect; since it builds no `JavaType.Method`, that one is pinned directly in `py27/remaining_test.py`.

- I hand-translated the argument cases from Java's `MethodMatcherTest.UnknownTypes` and confirmed all seven pass; five are the receiver cases `#8783` already covers with a different argument list, so only the distinct one is committed.

## Not fixed here

A `bytes` literal carries `Primitive.String`, so `f(str)` matches it and `f(bytes)` does not. `J.Literal.type` is declared `JavaType.Primitive` and the enum has no `Bytes` member, so there is nowhere else for it to go.
