### PR TITLE
Python: a `self`, `cls`, or `super()` receiver gets a declaring type

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.78",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.79",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -1533,6 +1533,13 @@ class PythonTypeMapping:
             # `module_type` leaves a class to its own FQN.
             return self._class_reference(constructed)
 
+        # A `super()` receiver names no class of its own: the attribute can resolve
+        # further up the MRO than the pivot, so only the callee's declaring class
+        # names the owner. Every other receiver keeps the receiver convention.
+        super_owner = self._super_call_declaring_type(node)
+        if super_owner is not None:
+            return super_owner
+
         # The callee names what is called; a receiver names only the module a call was
         # reached through, which differs for a re-exported function. A value receiver
         # owns its calls, so it is read below instead: `"x".upper()` is `str`'s.
@@ -1583,6 +1590,20 @@ class PythonTypeMapping:
 
         inferred = self._infer_declaring_type_from_ast(node)
         return inferred if inferred is not None else _UNKNOWN
+
+    def _super_call_declaring_type(self, node: ast.Call) -> Optional[JavaType.FullyQualified]:
+        """The declaring class of a call whose receiver is a ``super`` object."""
+        if not isinstance(node.func, ast.Attribute):
+            return None
+        if self._descriptor_of(node.func.value).get('kind') != 'super':
+            return None
+        declaring_id = self._descriptor_of(node.func).get('declaringClassId')
+        return None if declaring_id is None else self._resolve_declaring_type(declaring_id)
+
+    def _descriptor_of(self, node: ast.expr) -> Dict[str, Any]:
+        """The TypeDescriptor ty gave a node, empty when it typed the node as nothing."""
+        type_id = self._lookup_type_id(node)
+        return (self._type_registry.get(type_id) or {}) if type_id is not None else {}
 
     def _names_a_module(self, node: ast.expr) -> bool:
         type_id = self._lookup_type_id(node)

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -1708,6 +1708,13 @@ class PythonTypeMapping:
             if descriptor.get('className'):
                 return self._class_reference(descriptor)
 
+        elif kind == 'typeVar':
+            # `self` is a `Self` typevar bound to its class, `cls` a `type[Self]`
+            # arriving through `subclassOf`, so the bound is what owns the call.
+            upper_bound_id = descriptor.get('upperBound')
+            if upper_bound_id is not None:
+                return self._resolve_declaring_type(upper_bound_id)
+
         return None
 
     def _get_call_return_type(self, call_node: ast.Call) -> Optional[JavaType.FullyQualified]:

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2710,6 +2710,66 @@ class TestSelfReceiverDeclaringType:
             _cleanup_parse(tmpdir, client)
 
 
+@requires_ty_types_cli
+class TestSuperReceiverDeclaringType:
+    """A `super()`-rooted call is owned by the class declaring what it resolves to.
+
+    Ordinary calls keep naming the receiver, which is a different class for any
+    inherited method.
+    """
+
+    SRC = '''
+        class A:
+            def f(self) -> int:
+                return 1
+
+            def inherited(self) -> int:
+                return 2
+
+        class B(A):
+            pass
+
+        class C(B):
+            def f(self) -> str:
+                return "s"
+
+            def go(self):
+                self.f()
+                self.inherited()
+                super().f()
+    '''
+
+    def test_super_takes_the_declaring_class_and_self_keeps_the_receiver(self):
+        mapping, tree, tmpdir, client = _make_mapping(self.SRC)
+        try:
+            registry = mapping._type_registry
+            class_ids = {d.get('qualifiedName'): i for i, d in registry.items()
+                         if d.get('kind') == 'classLiteral'}
+            go = tree.body[2].body[1]
+            self_f, self_inherited, super_f = (stmt.value for stmt in go.body)
+
+            # ty-types >= 0.0.79 (openrewrite/ty-types#27) surfaces these; synthesize
+            # them so the contract is pinned against the wire shape, not the binary.
+            registry[mapping._lookup_type_id(super_f.func.value)] = {
+                'kind': 'super',
+                'pivotClassId': class_ids['test.C'],
+                'receiverId': mapping._lookup_type_id(go.args.args[0]),
+            }
+            for call, declaring in ((super_f, 'test.A'), (self_f, 'test.C'),
+                                    (self_inherited, 'test.A')):
+                registry[mapping._lookup_type_id(call.func)]['declaringClassId'] = \
+                    class_ids[declaring]
+
+            assert _fqn(mapping._get_declaring_type(super_f)) == 'test.A', \
+                "super() must name the declaring class, not the pivot"
+
+            # `inherited` carries declaringClassId test.A, but a non-super receiver
+            # must keep naming the receiver.
+            assert _fqn(mapping._get_declaring_type(self_inherited)) == 'test.C'
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
+
 class TestSubprocessEnvironment:
     """TyTypesClient must point ty-types at the running interpreter's
     environment so third-party imports (and their supertypes) resolve, rather

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2712,19 +2712,12 @@ class TestSelfReceiverDeclaringType:
 
 @requires_ty_types_cli
 class TestSuperReceiverDeclaringType:
-    """A `super()`-rooted call is owned by the class declaring what it resolves to.
-
-    Ordinary calls keep naming the receiver, which is a different class for any
-    inherited method.
-    """
+    """A `super()`-rooted call is owned by the class declaring what it resolves to."""
 
     SRC = '''
         class A:
             def f(self) -> int:
                 return 1
-
-            def inherited(self) -> int:
-                return 2
 
         class B(A):
             pass
@@ -2734,21 +2727,14 @@ class TestSuperReceiverDeclaringType:
                 return "s"
 
             def go(self):
-                self.inherited()
                 super().f()
     '''
 
-    def test_super_takes_the_declaring_class_and_self_keeps_the_receiver(self):
+    def test_super_takes_the_declaring_class_not_the_pivot(self):
         mapping, tree, tmpdir, client = _make_mapping(self.SRC)
         try:
-            self_inherited, super_f = (stmt.value for stmt in tree.body[2].body[1].body)
-
-            assert _fqn(mapping._get_declaring_type(super_f)) == 'test.A', \
-                "super() must name the declaring class, not the pivot"
-
-            # `inherited` carries declaringClassId test.A, but a non-super receiver
-            # must keep naming the receiver.
-            assert _fqn(mapping._get_declaring_type(self_inherited)) == 'test.C'
+            super_f = tree.body[2].body[1].body[0].value
+            assert _fqn(mapping._get_declaring_type(super_f)) == 'test.A'
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
 

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2748,17 +2748,18 @@ class TestSuperReceiverDeclaringType:
             go = tree.body[2].body[1]
             self_f, self_inherited, super_f = (stmt.value for stmt in go.body)
 
-            # ty-types >= 0.0.79 (openrewrite/ty-types#27) surfaces these; synthesize
-            # them so the contract is pinned against the wire shape, not the binary.
-            registry[mapping._lookup_type_id(super_f.func.value)] = {
-                'kind': 'super',
-                'pivotClassId': class_ids['test.C'],
-                'receiverId': mapping._lookup_type_id(go.args.args[0]),
-            }
+            # Below the pinned ty-types floor these are absent, so stand them up to
+            # the shape openrewrite/ty-types#27 emits; a binary that sends them wins,
+            # which is what makes a change to the contract fail here.
+            receiver = registry[mapping._lookup_type_id(super_f.func.value)]
+            if receiver.get('kind') != 'super':
+                receiver.clear()
+                receiver.update(kind='super', pivotClassId=class_ids['test.C'],
+                                receiverId=mapping._lookup_type_id(go.args.args[0]))
             for call, declaring in ((super_f, 'test.A'), (self_f, 'test.C'),
                                     (self_inherited, 'test.A')):
-                registry[mapping._lookup_type_id(call.func)]['declaringClassId'] = \
-                    class_ids[declaring]
+                registry[mapping._lookup_type_id(call.func)].setdefault(
+                    'declaringClassId', class_ids[declaring])
 
             assert _fqn(mapping._get_declaring_type(super_f)) == 'test.A', \
                 "super() must name the declaring class, not the pivot"

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2669,6 +2669,47 @@ class TestSupertypeChainResolution:
             _cleanup_parse(tmpdir, client)
 
 
+@requires_ty_types_cli
+class TestSelfReceiverDeclaringType:
+    """A call through ``self`` or ``cls`` is owned by the enclosing class.
+
+    Anything else leaves ``MethodMatcher`` and ``UsesMethod`` blind to the
+    shape most calls inside a class body are written in.
+    """
+
+    SRC = '''
+        class Base:
+            def greet(self):
+                return "hi"
+
+            @classmethod
+            def build(cls):
+                return cls()
+
+        class Child(Base):
+            def go(self):
+                self.greet()
+
+            @classmethod
+            def make(cls):
+                return cls.build()
+    '''
+
+    def test_self_and_cls_receivers_are_owned_by_the_enclosing_class(self):
+        cu, tmpdir, client = _parse_with_types({'m.py': self.SRC})
+        try:
+            declaring = {c.name.simple_name: c.method_type.declaring_type
+                         for c in _collect_method_invocations(cu)}
+
+            assert _fqn(declaring['greet']) == 'm.Child', \
+                f"self-rooted call: got {declaring['greet']!r}"
+
+            assert _fqn(declaring['build']) == 'm.Child', \
+                f"cls-rooted call: got {declaring['build']!r}"
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+
 class TestSubprocessEnvironment:
     """TyTypesClient must point ty-types at the running interpreter's
     environment so third-party imports (and their supertypes) resolve, rather
@@ -4061,7 +4102,8 @@ def _fqn(java_type) -> Optional[str]:
     if isinstance(java_type, JavaType.Parameterized):
         java_type = java_type._type
     return (java_type.fully_qualified_name
-            if isinstance(java_type, JavaType.FullyQualified) else None)
+            if isinstance(java_type, JavaType.FullyQualified)
+            and not isinstance(java_type, JavaType.Unknown) else None)
 
 
 def _fqn_params(case: FqnCase):

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2734,7 +2734,6 @@ class TestSuperReceiverDeclaringType:
                 return "s"
 
             def go(self):
-                self.f()
                 self.inherited()
                 super().f()
     '''
@@ -2742,24 +2741,7 @@ class TestSuperReceiverDeclaringType:
     def test_super_takes_the_declaring_class_and_self_keeps_the_receiver(self):
         mapping, tree, tmpdir, client = _make_mapping(self.SRC)
         try:
-            registry = mapping._type_registry
-            class_ids = {d.get('qualifiedName'): i for i, d in registry.items()
-                         if d.get('kind') == 'classLiteral'}
-            go = tree.body[2].body[1]
-            self_f, self_inherited, super_f = (stmt.value for stmt in go.body)
-
-            # Below the pinned ty-types floor these are absent, so stand them up to
-            # the shape openrewrite/ty-types#27 emits; a binary that sends them wins,
-            # which is what makes a change to the contract fail here.
-            receiver = registry[mapping._lookup_type_id(super_f.func.value)]
-            if receiver.get('kind') != 'super':
-                receiver.clear()
-                receiver.update(kind='super', pivotClassId=class_ids['test.C'],
-                                receiverId=mapping._lookup_type_id(go.args.args[0]))
-            for call, declaring in ((super_f, 'test.A'), (self_f, 'test.C'),
-                                    (self_inherited, 'test.A')):
-                registry[mapping._lookup_type_id(call.func)].setdefault(
-                    'declaringClassId', class_ids[declaring])
+            self_inherited, super_f = (stmt.value for stmt in tree.body[2].body[1].body)
 
             assert _fqn(mapping._get_declaring_type(super_f)) == 'test.A', \
                 "super() must name the declaring class, not the pivot"


### PR DESCRIPTION
A method call whose receiver is `self`, `cls`, or `super()` got `JavaType.Unknown` as its declaring type, while the same call through a variable receiver was attributed correctly. Every type-based gate — `MethodMatcher`, `UsesMethod`, `FindMethods` — was blind to the shape most calls inside a class body take.

```python
class Child(Base):
    def go(self):
        self.greet()        # JavaType.Unknown
        Child.greet(self)   # m.Child
        super().greet()     # JavaType.Unknown

c = Child()
c.greet()                   # m.Child
```

## Two causes

ty reported a type for `self` all along; the mapping had nowhere to put it. A `self` receiver is a `Self` typevar whose `upperBound` is the enclosing class, `cls` a `subclassOf` over it, and `_declaring_type_from_descriptor` had no `typeVar` arm. One arm recursing on the bound covers both, plus stdlib bases: `self.getName()` in `class Worker(threading.Thread)` gives `m.Worker -> threading.Thread`.

- `super()` was a real gap in ty-types, fixed upstream in openrewrite/ty-types#27 and released as v0.0.79, which this PR pins. That receiver had serialized as `{"kind": "other"}` — with `includeDisplay` off, as this consumer runs, the entire descriptor.

## Why the pivot is the wrong owner

- Structuring the receiver alone would not have sufficed, which is why #27 also added `declaringClassId` to `function` and `boundMethod`:

```python
class A:
    def f(self) -> int: ...
class B(A): pass
class C(B):
    def f(self) -> str: ...
    def go(self):
        super().f()        # resolves to A.f
```

The pivot is `C` and the next class in the MRO is `B`, while ty resolves the call to `A.f` — measured, the invocation's return type is `int`. Walking outward from the pivot lands on a class that does not declare the method, so the arm reads the callee's `declaringClassId`.

## Scope

The `super()` arm is scoped to a `super` receiver. ty puts `declaringClassId` on every method descriptor, so reading it unconditionally would change far more than this PR fixes. Deliberately left alone:

- Ordinary calls still name the receiver. `c.greet()` on a `c: Child` inheriting from `Base` reports `m.Child`, matching what the rest of the family assumes — rewrite-csharp's `MethodMatcherTests` assert `DeclaringType = DerivedClass`, with `matchOverrides` walking up to `BaseClass`. Flipping these wants its own migration measurement.
- A constrained type variable (`V = TypeVar("V", A, B)`) still yields `Unknown`, since only `upperBound` is read and such a receiver has none. Unchanged from before; picking one constraint is a semantic choice worth making separately.

## Tests

`TestSelfReceiverDeclaringType` pins the `typeVar` arm through a full parse, asserting both receiver spellings. `TestSuperReceiverDeclaringType` pins the `super()` arm against ty's own `super` kind and `declaringClassId`, with no synthesized descriptors. Both are mutation-checked: dropping either arm, and widening the `super()` one past a `super` receiver, each fail a test.
