### PR TITLE
Python: a method call is owned by the class declaring it

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -1533,12 +1533,11 @@ class PythonTypeMapping:
             # `module_type` leaves a class to its own FQN.
             return self._class_reference(constructed)
 
-        # A `super()` receiver names no class of its own: the attribute can resolve
-        # further up the MRO than the pivot, so only the callee's declaring class
-        # names the owner. Every other receiver keeps the receiver convention.
-        super_owner = self._super_call_declaring_type(node)
-        if super_owner is not None:
-            return super_owner
+        # A method is owned by the class that declares it, so `match_overrides` walks
+        # up from an override. Mirrors Java, where this is `MethodSymbol.owner`.
+        declared_by = self._declaring_class_of_callee(node)
+        if declared_by is not None:
+            return declared_by
 
         # The callee names what is called; a receiver names only the module a call was
         # reached through, which differs for a re-exported function. A value receiver
@@ -1591,13 +1590,18 @@ class PythonTypeMapping:
         inferred = self._infer_declaring_type_from_ast(node)
         return inferred if inferred is not None else _UNKNOWN
 
-    def _super_call_declaring_type(self, node: ast.Call) -> Optional[JavaType.FullyQualified]:
-        """The declaring class of a call whose receiver is a ``super`` object."""
+    def _declaring_class_of_callee(self, node: ast.Call) -> Optional[JavaType.FullyQualified]:
+        """The class ty resolved the callee to through the MRO.
+
+        None for a module-level function or a builtin bound method; the
+        receiver's own type names those.
+        """
         if not isinstance(node.func, ast.Attribute):
             return None
-        if self._descriptor_of(node.func.value).get('kind') != 'super':
+        callee = self._descriptor_of(node.func)
+        if callee.get('kind') != 'boundMethod':
             return None
-        declaring_id = self._descriptor_of(node.func).get('declaringClassId')
+        declaring_id = callee.get('declaringClassId')
         return None if declaring_id is None else self._resolve_declaring_type(declaring_id)
 
     def _descriptor_of(self, node: ast.expr) -> Dict[str, Any]:

--- a/rewrite-python/rewrite/tests/python/test_method_matcher.py
+++ b/rewrite-python/rewrite/tests/python/test_method_matcher.py
@@ -199,6 +199,7 @@ WORKER_SOURCE = (
     "\n"
     "w = Worker()\n"
     "w.getName()\n"
+    "w.run()\n"
 )
 
 
@@ -231,14 +232,14 @@ def worker_cu():
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-def _get_name_invocation(cu):
+def _worker_invocation(cu, name):
     from rewrite.python.visitor import PythonVisitor
 
     found = []
 
     class _Collector(PythonVisitor):
         def visit_method_invocation(self, mi, p):
-            if mi.name.simple_name == "getName":
+            if mi.name.simple_name == name:
                 found.append(mi)
             return super().visit_method_invocation(mi, p)
 
@@ -250,22 +251,22 @@ def _get_name_invocation(cu):
 class TestMatchOverrides:
     """Matching a method declared on a supertype of the call's declaring type."""
 
-    def test_base_type_pattern_matched_only_with_the_flag(self, worker_cu):
-        invocation = _get_name_invocation(worker_cu)
-
-        # The call is attributed to the subclass, so an exact base-type
-        # match cannot work.
-        assert invocation.method_type.declaring_type.fully_qualified_name == "m.Worker"
-
-        assert not MethodMatcher.create("threading.Thread getName(..)").matches(invocation)
+    def test_the_flag_is_needed_only_for_a_real_override(self, worker_cu):
+        overridden = _worker_invocation(worker_cu, "run")
+        assert overridden.method_type.declaring_type.fully_qualified_name == "m.Worker"
+        assert not MethodMatcher.create("threading.Thread run(..)").matches(overridden)
         assert MethodMatcher.create(
-            "threading.Thread getName(..)", match_overrides=True
-        ).matches(invocation)
+            "threading.Thread run(..)", match_overrides=True
+        ).matches(overridden)
+
+        # Inherited without an override, so the base type is already the declaring one.
+        inherited = _worker_invocation(worker_cu, "getName")
+        assert MethodMatcher.create("threading.Thread getName(..)").matches(inherited)
 
     def test_unrelated_supertype_still_rejected(self, worker_cu):
         assert not MethodMatcher.create(
-            "queue.Queue getName(..)", match_overrides=True
-        ).matches(_get_name_invocation(worker_cu))
+            "queue.Queue run(..)", match_overrides=True
+        ).matches(_worker_invocation(worker_cu, "run"))
 
     def test_preconditions_forward_the_flag(self, worker_cu):
         from rewrite import InMemoryExecutionContext
@@ -276,7 +277,7 @@ class TestMatchOverrides:
             visited = recipe_ref.local_visitor.visit(worker_cu, InMemoryExecutionContext())
             return visited.markers.find_first(SearchResult) is not None
 
-        pattern = "threading.Thread getName(..)"
+        pattern = "threading.Thread run(..)"
         assert not selects(uses_method(pattern))
         assert selects(uses_method(pattern, match_overrides=True))
         assert selects(find_methods(pattern, match_overrides=True))

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -2428,7 +2428,8 @@ class TestDeclaringTypeUnification:
             mt = mapping.method_invocation_type(call)
             assert mt is not None
             assert mt._declaring_type is not None
-            assert mt._declaring_type.fully_qualified_name == 'os.PathLike'
+            # `register` is declared on the metaclass.
+            assert mt._declaring_type.fully_qualified_name == 'abc.ABCMeta'
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
 
@@ -2670,12 +2671,40 @@ class TestSupertypeChainResolution:
 
 
 @requires_ty_types_cli
-class TestSelfReceiverDeclaringType:
-    """A call through ``self`` or ``cls`` is owned by the enclosing class.
+class TestInheritedCallDeclaringType:
+    """Attribution of a call to a method the receiver's class does not override."""
 
-    Anything else leaves ``MethodMatcher`` and ``UsesMethod`` blind to the
-    shape most calls inside a class body are written in.
-    """
+    SRC = '''
+        import threading
+
+        class Worker(threading.Thread):
+            def run(self):
+                pass
+
+        w = Worker()
+        w.getName()
+        w.run()
+    '''
+
+    def test_an_inherited_call_names_the_declaring_class(self):
+        cu, tmpdir, client = _parse_with_types({'m.py': self.SRC})
+        try:
+            declaring = {c.name.simple_name: c.method_type.declaring_type
+                         for c in _collect_method_invocations(cu)}
+
+            assert _fqn(declaring['getName']) == 'threading.Thread', \
+                f"inherited without override: got {declaring['getName']!r}"
+
+            assert _fqn(declaring['run']) == 'm.Worker', \
+                f"overridden, so the subclass declares it: got {declaring['run']!r}"
+        finally:
+            _cleanup_parse(tmpdir, client)
+
+
+@requires_ty_types_cli
+class TestSelfReceiverDeclaringType:
+    """A call through ``self`` or ``cls`` resolves to a class, not to ``Unknown``,
+    which ``MethodMatcher`` and ``UsesMethod`` cannot gate on."""
 
     SRC = '''
         class Base:
@@ -2695,16 +2724,16 @@ class TestSelfReceiverDeclaringType:
                 return cls.build()
     '''
 
-    def test_self_and_cls_receivers_are_owned_by_the_enclosing_class(self):
+    def test_self_and_cls_receivers_resolve_to_the_declaring_class(self):
         cu, tmpdir, client = _parse_with_types({'m.py': self.SRC})
         try:
             declaring = {c.name.simple_name: c.method_type.declaring_type
                          for c in _collect_method_invocations(cu)}
 
-            assert _fqn(declaring['greet']) == 'm.Child', \
+            assert _fqn(declaring['greet']) == 'm.Base', \
                 f"self-rooted call: got {declaring['greet']!r}"
 
-            assert _fqn(declaring['build']) == 'm.Child', \
+            assert _fqn(declaring['build']) == 'm.Base', \
                 f"cls-rooted call: got {declaring['build']!r}"
         finally:
             _cleanup_parse(tmpdir, client)

--- a/rewrite-python/rewrite/tests/python/test_type_report.py
+++ b/rewrite-python/rewrite/tests/python/test_type_report.py
@@ -211,18 +211,18 @@ class _NoOp(Recipe):
 
 
 @requires_ty_types_cli
-def test_supertypes_walks_past_the_receiver_class_to_the_builtin_base(tmp_path):
+def test_supertypes_reports_the_chain_above_the_declaring_class(tmp_path):
     path = _write(tmp_path, "class MyList(list):\n    pass\n\n\ndef f(items: MyList):\n    items.append(1)\n")
     cu = parse_for_types(path, with_types=True, project_root=str(tmp_path))
 
     call = next(e for e in build_type_report(cu, supertypes=True).entries
                 if e.kind == "MethodInvocation")
 
-    # The declaring type is the receiver's class, so `list append(..)` only
-    # matches via the chain — which is why the chain has to be reported.
-    assert call.type.startswith("sample.MyList append(..)")
+    # `append` is declared on `list`, so that is the pattern a MethodMatcher
+    # takes; the chain reports which broader patterns also match it.
+    assert call.type.startswith("list append(..)")
     assert call.supertypes is not None
-    assert call.supertypes.split(" <: ")[:2] == ["sample.MyList", "list"]
+    assert call.supertypes.split(" <: ")[0] == "list"
 
 
 @requires_ty_types_cli


### PR DESCRIPTION
`rewrite-python` attributed an ordinary method call to the **receiver's** class. A call to a method the receiver's class inherits without overriding named the subclass, not the class that declares it:

```
class Worker(threading.Thread):   # does not override getName
    def run(self): ...

w.getName()   declaring_type = m.Worker        # Java gives java.lang.Thread
```

Java reads `methodSymbol.owner.type` (`ReloadableJava21TypeMapping.java:444`) — the declaring class.

## Why it mattered

`MethodMatcher.matchesTargetType` walks **upward** from the declaring type, and `match_overrides` is documented as matching "overridden forms of the method on subclasses". Under the receiver convention the flag was doing the opposite job: it was required for a call that overrode nothing, purely to reach past an attribution that had parked the call on the subclass.

| pattern | before | after |
|---|---|---|
| `threading.Thread getName(..)` | needed `match_overrides` | matches |
| `m.Worker getName(..)` | matched | no match, as in Java |

## The fix

- Read ty's `declaringClassId`, which resolves the callee through the MRO. It subsumes the `super()` handling added in #8785 — that was the same question asked of one receiver shape — so two rules collapse into one. Receiver-based resolution stays as the fallback, since `declaringClassId` is absent for module-level functions and builtin bound methods.

Rejected a client-side walk of `supertypes`: it agrees with ty on 99.7% of call sites but is breadth-first rather than C3, so it picks the wrong base in every diamond (37 hits on one `sqlalchemy` method alone) and in one case turned a same into a shift.

## Measured

Over requests, click, flask, httpx, scrapy and sqlalchemy — 1,417 files, 223,559 invocations — **2,541 of 14,232** resolved instance-method calls change declaring type (17.9%). `declaringClassId` was present on every resolved bound-method call, so the fallback covers a defined gap rather than a long tail.

## Tests

`TestInheritedCallDeclaringType` pins both sides in one fixture: `getName` inherited names `threading.Thread`, `run` overridden stays `m.Worker`. Four existing tests asserted the receiver convention and were rewritten; `TestMatchOverrides` now uses the overridden `run`, where the flag earns its name, and asserts that the inherited call needs no flag.

## Scope

A method typeshed declares on a base rather than on the type you would name still needs that base in the pattern — `dict setdefault(..)` is `typing.MutableMapping setdefault(..)`, and `match_overrides` cannot bridge it, since it walks the other way. Java behaves the same. `rewrite-python-types --supertypes` prints the pattern that matches in its first column.
