### PR TITLE
Python: a match-class keyword pattern names an attribute, not a binding

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -1419,24 +1419,22 @@ class ParserVisitor(ast.NodeVisitor):
                 children.append(converted)
             # Process keyword patterns
             for i, kwd in enumerate(node.kwd_attrs):
-                kwd_var = j.VariableDeclarations(
+                kwd_pattern = py.MatchCase.Pattern(
                     random_id(),
                     self.__whitespace(),
                     Markers.EMPTY,
-                    _EMPTY_LIST, _EMPTY_LIST, None, None, _EMPTY_LIST,
-                    [
-                        self.__pad_right(j.VariableDeclarations.NamedVariable(
-                            random_id(),
-                            Space.EMPTY,
-                            Markers.EMPTY,
-                            cast(j.Identifier, self.__convert_name(kwd)),
-                            _EMPTY_LIST,
-                            self.__pad_left(self.__source_before('='), self.__convert_match_pattern(node.kwd_patterns[i])),
-                            None
-                        ), Space.EMPTY)
-                    ]
+                    py.MatchCase.Pattern.Kind.KEYWORD,
+                    JContainer(
+                        Space.EMPTY,
+                        [
+                            self.__pad_right(self.__convert_name(kwd), self.__source_before('=')),
+                            self.__pad_right(self.__convert_match_pattern(node.kwd_patterns[i]), Space.EMPTY),
+                        ],
+                        Markers.EMPTY
+                    ),
+                    None
                 )
-                converted = self.__pad_list_element(kwd_var, last=i == len(node.kwd_attrs) - 1,
+                converted = self.__pad_list_element(kwd_pattern, last=i == len(node.kwd_attrs) - 1,
                                                     end_delim=')')
                 children.append(converted)
         else:

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -27,9 +27,9 @@ from rewrite.java.support_types import J, Statement
 from rewrite.java.tree import (Assignment, Case, FieldAccess, ForEachLoop, Identifier, If,
                                Import, MethodInvocation, Parentheses)
 from rewrite.python.import_utils import get_alias_name, unconditional_body
-from rewrite.python.scope_utils import scope_of
+from rewrite.python.scope_utils import captures, scope_of
 from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ComprehensionExpression,
-                                 CompilationUnit, ExpressionStatement, MultiImport,
+                                 CompilationUnit, ExpressionStatement, MatchCase, MultiImport,
                                  NamedArgument, Star, TypeHintedExpression, VariableScope)
 from rewrite.visitor import TreeVisitor
 
@@ -177,6 +177,9 @@ def _resolves(node: J, parent: Optional[J]) -> bool:
     if isinstance(parent, (FieldAccess, NamedArgument)):
         # An attribute belongs to its target and a keyword argument to the callee's signature.
         return parent.name is not node
+    if isinstance(parent, MatchCase.Pattern) and parent.kind is MatchCase.Pattern.Kind.KEYWORD:
+        # A class pattern's `attr=p` names an attribute of the class it matches.
+        return parent.children[0] is not node
     return True
 
 
@@ -197,10 +200,11 @@ def _is_target(parent: Optional[J], node: J) -> bool:
     if isinstance(parent, ComprehensionExpression):
         # A clause holds its target directly, so the comprehension is the node above the name.
         return any(clause.iterator_variable is node for clause in parent.clauses)
-    # A bare `case json:` label captures, and so binds. Every structured pattern is a
-    # `Py.MatchCase` instead, whose captures are left as reads: safe for a census, and a
-    # rename has to guard them itself.
-    return isinstance(parent, Case) and any(label is node for label in parent.case_labels)
+    if isinstance(parent, Case):
+        return any(capture is node for label in parent.case_labels for capture in captures(label))
+    # A pattern nested in another holds its own cursor, so the case above it is out of reach.
+    return (isinstance(parent, (MatchCase, MatchCase.Pattern))
+            and any(capture is node for capture in captures(parent)))
 
 
 def _enclosing_nodes(cursor: Cursor, ident: Identifier) -> Iterator[J]:

--- a/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/recipes/change_import.py
@@ -28,7 +28,7 @@ from rewrite.java.tree import FieldAccess, Identifier, If, Import, MethodInvocat
 from rewrite.markers import Markers
 from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
                                          module_scope_blocks, unconditional_body)
-from rewrite.python.binding_utils import resolves_in_scope
+from rewrite.python.binding_utils import is_reference, resolves_in_scope
 from rewrite.python.scope_utils import LocalBindings
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
@@ -296,9 +296,9 @@ class ChangeImport(Recipe):
                     return self._remove_module_from_import(multi, old_module)
 
             def visit_identifier(self, ident: Identifier, p: ExecutionContext) -> J:
-                # `resolves_in_scope` matches the cursor's nodes by identity, so it is asked
-                # of the identifier the cursor holds.
-                in_scope = resolves_in_scope(self.cursor, ident)
+                # The position predicates match the cursor's nodes by identity, so they are
+                # asked of the identifier the cursor holds.
+                at_cursor = ident
                 ident = super().visit_identifier(ident, p)  # ty: ignore[invalid-assignment]  # visitor covariance
                 if not isinstance(ident, Identifier):
                     return ident
@@ -310,9 +310,10 @@ class ChangeImport(Recipe):
                     return ident
                 if ident.simple_name != old_ref_name:
                     return ident
-                if not in_scope:
+                if not resolves_in_scope(self.cursor, at_cursor):
                     return ident
-                if self.local_bindings.is_bound(self.cursor, old_ref_name):
+                binding = not is_reference(self.cursor, at_cursor)
+                if self.local_bindings.is_bound(self.cursor, old_ref_name, binding=binding):
                     return ident
                 return ident.replace(_simple_name=new_ref_name)
 

--- a/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
@@ -14,17 +14,17 @@
 
 """Which names a Python scope binds, and which scope binds a name at a given cursor."""
 
-from typing import Any, Callable, Dict, FrozenSet, List, Optional, Set
+from typing import Any, Callable, Dict, FrozenSet, Iterator, List, Optional, Set, Tuple
 
 from rewrite import Cursor
 from rewrite.java import J
-from rewrite.java.tree import (Assignment, AssignmentOperation, ClassDeclaration, ForEachLoop,
-                               Identifier, Import, Lambda, MethodDeclaration, Parentheses,
-                               VariableDeclarations)
+from rewrite.java.tree import (Assignment, AssignmentOperation, Case, ClassDeclaration,
+                               ForEachLoop, Identifier, Import, Lambda, MethodDeclaration,
+                               Parentheses, VariableDeclarations)
 from rewrite.python.import_utils import get_alias_name, get_qualid_name
 from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, CompilationUnit,
-                                 ComprehensionExpression, ExpressionStatement, MultiImport, Star,
-                                 TypeHintedExpression, VariableScope)
+                                 ComprehensionExpression, ExpressionStatement, MatchCase,
+                                 MultiImport, Star, TypeHintedExpression, VariableScope)
 from rewrite.python.visitor import PythonVisitor
 
 _NO_NAMES: FrozenSet[str] = frozenset()
@@ -32,31 +32,58 @@ _NO_NAMES: FrozenSet[str] = frozenset()
 # The nodes _BindingScan answers for; everything else binds nothing and is not a scope.
 _SCOPES = (MethodDeclaration, Lambda, ClassDeclaration, ComprehensionExpression, CompilationUnit)
 
+# The names a pattern can stand on without capturing: `_` matches anything, and the parser
+# spells the singletons as identifiers.
+_NOT_CAPTURED = frozenset({'_', 'None', 'True', 'False'})
+
+# The pattern kinds whose first child names the class matched, the attribute or the mapping
+# key, leaving the rest of the children to capture.
+_HEADED_PATTERNS = (MatchCase.Pattern.Kind.CLASS, MatchCase.Pattern.Kind.KEYWORD,
+                    MatchCase.Pattern.Kind.KEY_VALUE)
+
 _SCOPE_NAMES = 'org.openrewrite.python.scopeNames'
+
+
+def captures(pattern: Optional[J]) -> Iterator[Identifier]:
+    """The identifiers a ``case`` pattern binds: every bare name standing where the pattern
+    matches a value."""
+    if isinstance(pattern, Identifier):
+        if pattern.simple_name not in _NOT_CAPTURED:
+            yield pattern
+    elif isinstance(pattern, MatchCase):
+        yield from captures(pattern.pattern)
+    elif isinstance(pattern, Star):
+        yield from captures(pattern.expression)
+    elif isinstance(pattern, MatchCase.Pattern):
+        children = pattern.children
+        for child in (children[1:] if pattern.kind in _HEADED_PATTERNS else children):
+            yield from captures(child)
 
 
 class Scope:
     """One scope: the names it binds itself, the scopes around it, and what they answer
     together. Reached through :func:`scope_of`."""
 
-    __slots__ = ('_chain', '_index', '_cache')
+    __slots__ = ('_chain', '_cuts', '_index', '_cache')
 
-    def __init__(self, chain: List[J], index: int, cache: Dict[J, FrozenSet[str]]) -> None:
+    def __init__(self, chain: List[J], cuts: List[Optional[J]], index: int,
+                 cache: Dict[Any, FrozenSet[str]]) -> None:
         self._chain = chain
+        self._cuts = cuts
         self._index = index
         self._cache = cache
 
     def names(self) -> FrozenSet[str]:
-        """The names this scope binds itself, which is not what it reaches: for that, ask
-        :meth:`declares`."""
-        return (_names(self._chain[self._index], self._cache)
+        """The names this scope binds itself where the cursor stands, which is not what it
+        reaches: for that, ask :meth:`declares`."""
+        return (_names(self._chain[self._index], self._cuts[self._index], self._cache)
                 if self._index < len(self._chain) else _NO_NAMES)
 
     def walk(self, visit: Callable[['Scope'], bool]) -> None:
         """Visit this scope and then each one enclosing it, innermost first, stopping where
         ``visit`` returns False."""
         for index in range(self._index, len(self._chain)):
-            if not visit(Scope(self._chain, index, self._cache)):
+            if not visit(Scope(self._chain, self._cuts, index, self._cache)):
                 return
 
     def declares(self, name: str) -> bool:
@@ -68,32 +95,34 @@ class Scope:
         a module-level binding, otherwise the ``def``, ``class``, ``lambda`` or comprehension
         holding it — or None where nothing in scope does. A caller holding a declaration asks
         whether this is the node it came from: anything nearer shadows it."""
-        for scope in self._chain[self._index:]:
-            if name in _names(scope, self._cache):
-                return scope
+        for index in range(self._index, len(self._chain)):
+            if name in _names(self._chain[index], self._cuts[index], self._cache):
+                return self._chain[index]
         return None
 
 
-def scope_of(cursor: Cursor) -> Scope:
+def scope_of(cursor: Cursor, binding: bool = False) -> Scope:
     """The innermost scope holding ``cursor``, which a visitor's own cursor rarely is: it
-    stands on whatever node it is visiting.
+    stands on whatever node it is visiting. ``binding`` marks a cursor on an identifier that
+    binds its name rather than reading it.
 
     Syntactic, because ``field_type`` cannot decide it: it is unset for every identifier
     when type attribution is unavailable.
     """
-    return Scope(_enclosing_scopes(cursor), 0, _names_cache(cursor))
+    scopes, cuts = _enclosing_scopes(cursor)
+    return Scope(scopes, [None] * len(cuts) if binding else cuts, 0, _names_cache(cursor))
 
 
 class LocalBindings:
     """Whether an identifier is a local of some enclosing scope rather than a reference to a
     module-level import — :func:`scope_of` narrowed to that one question."""
 
-    def is_bound(self, cursor: Cursor, name: str) -> bool:
-        scope = scope_of(cursor).declaring_scope(name)
+    def is_bound(self, cursor: Cursor, name: str, binding: bool = False) -> bool:
+        scope = scope_of(cursor, binding).declaring_scope(name)
         return scope is not None and not isinstance(scope, CompilationUnit)
 
 
-def _names_cache(cursor: Cursor) -> Dict[J, FrozenSet[str]]:
+def _names_cache(cursor: Cursor) -> Dict[Any, FrozenSet[str]]:
     """Where a scan of one scope is kept, so a traversal scans each scope once. Hung on the
     compilation unit's cursor, which lives exactly as long as the visit of that file; the
     root cursor ``TreeVisitor`` starts from is a class attribute shared process-wide."""
@@ -107,16 +136,26 @@ def _names_cache(cursor: Cursor) -> Dict[J, FrozenSet[str]]:
     return {}
 
 
-def _names(scope: J, cache: Dict[J, FrozenSet[str]]) -> FrozenSet[str]:
-    names = cache.get(scope)
-    if names is None:
-        names = frozenset(_BindingScan(scope).run())
-        cache[scope] = names
-    return names
+def _names(scope: J, cut: Optional[J], cache: Dict[Any, FrozenSet[str]]) -> FrozenSet[str]:
+    """The names ``scope`` binds — for a class body, the ones bound before ``cut``, the
+    statement of it the reference sits in. A class body looks a name up in the module until
+    its own binding runs, so ``json = json`` re-exports the import."""
+    names = cache.get((scope, cut))
+    if names is not None:
+        return names
+    scan = _BindingScan(scope)
+    if cut is None or not isinstance(scope, ClassDeclaration):
+        cache[(scope, None)] = names = frozenset(scan.run())
+        return names
+    for stmt in scope.body.statements:
+        cache[(scope, stmt)] = frozenset(scan.names())
+        scan.run(stmt)
+    return cache.get((scope, cut), frozenset(scan.names()))
 
 
-def _enclosing_scopes(cursor: Optional[Cursor]) -> List[J]:
-    """The scopes a reference resolves through, innermost first.
+def _enclosing_scopes(cursor: Optional[Cursor]) -> Tuple[List[J], List[Optional[J]]]:
+    """The scopes a reference resolves through, innermost first, each paired with the class
+    body statement holding the reference, None for every scope but a class body.
 
     A scope covers only the region Python evaluates inside it: a ``def``'s decorators,
     annotations and parameter defaults belong to the scope enclosing it. A class body is
@@ -125,6 +164,7 @@ def _enclosing_scopes(cursor: Optional[Cursor]) -> List[J]:
     """
     path = _tree_path(cursor)
     scopes: List[J] = []
+    cuts: List[Optional[J]] = []
     for i, node in enumerate(path):
         if not isinstance(node, _SCOPES):
             continue
@@ -133,7 +173,8 @@ def _enclosing_scopes(cursor: Optional[Cursor]) -> List[J]:
         if isinstance(node, ClassDeclaration) and scopes:
             continue
         scopes.append(node)
-    return scopes
+        cuts.append(path[i - 2] if isinstance(node, ClassDeclaration) and i >= 2 else None)
+    return scopes, cuts
 
 
 def _tree_path(cursor: Optional[Cursor]) -> List[Any]:
@@ -193,9 +234,14 @@ class _BindingScan(PythonVisitor[Any]):
         self._names: Set[str] = set()
         self._declared_elsewhere: Set[str] = set()
 
-    def run(self) -> Set[str]:
-        self.visit(self._scope, None)
+    def names(self) -> Set[str]:
         return self._names - self._declared_elsewhere
+
+    def run(self, node: Optional[J] = None) -> Set[str]:
+        """Scan ``node``, defaulting to the whole scope. Successive calls accumulate into one
+        set of names."""
+        self.visit(node if node is not None else self._scope, None)
+        return self.names()
 
     def _bind(self, target: Optional[J]) -> None:
         """Bind the names a target expression introduces. Attribute and subscript
@@ -261,6 +307,11 @@ class _BindingScan(PythonVisitor[Any]):
         for variable in var_decls.variables:
             self._bind(variable.name)
         return super().visit_variable_declarations(var_decls, p)
+
+    def visit_case(self, case: Case, p: Any) -> J:
+        for label in case.case_labels:
+            self._names.update(capture.simple_name for capture in captures(label))
+        return super().visit_case(case, p)
 
     def visit_assignment(self, assignment: Assignment, p: Any) -> J:
         self._bind(assignment.variable)

--- a/rewrite-python/rewrite/tests/python/test_bindings.py
+++ b/rewrite-python/rewrite/tests/python/test_bindings.py
@@ -159,17 +159,23 @@ def test_del_reads_the_name_it_unbinds():
     assert _references("import json\ndel json\n") == [('json', 'json', None)]
 
 
-def test_an_undotted_case_label_captures_rather_than_matches():
+def test_a_case_patterns_captures_bind_rather_than_read():
+    # Every capture position binds the name; a dotted value pattern reads it.
     assert _positions("""
         match x:
             case json:
                 pass
-        """) == [False]
-    assert _positions("""
-        match x:
+            case Point(json):
+                pass
+            case [json]:
+                pass
+            case {'k': json}:
+                pass
+            case Other() as json:
+                pass
             case json.Loads():
                 pass
-        """) == [True]
+        """) == [False, False, False, False, False, True]
 
 
 def test_a_rename_follows_more_names_than_a_read_census():

--- a/rewrite-python/rewrite/tests/python/test_scope.py
+++ b/rewrite-python/rewrite/tests/python/test_scope.py
@@ -17,7 +17,7 @@
 from typing import List
 
 from rewrite import Cursor
-from rewrite.java.tree import Identifier, MethodDeclaration, MethodInvocation
+from rewrite.java.tree import ClassDeclaration, Identifier, MethodDeclaration, MethodInvocation
 from rewrite.python.scope_utils import LocalBindings, Scope, scope_of
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
@@ -130,6 +130,47 @@ def test_a_class_body_is_reachable_from_directly_within_it_and_nowhere_else():
             class B:
                 anchor()
         """).declares('a') is False
+
+
+def test_a_match_case_binds_the_names_its_pattern_captures():
+    # The class matched, a keyword attribute and a dotted value pattern name something else.
+    assert _names_at_anchor("""
+        def f(p):
+            match p:
+                case Point(a, x=b):
+                    pass
+                case [c, *d]:
+                    pass
+                case {'k': e, **rest}:
+                    pass
+                case Other() as g:
+                    pass
+                case Color.RED:
+                    pass
+                case None | _:
+                    pass
+                case h:
+                    anchor()
+        """)[0] == ['a', 'b', 'c', 'd', 'e', 'g', 'h', 'p', 'rest']
+
+
+def test_a_class_bodys_bindings_reach_only_the_statements_after_them():
+    # A class body compiles a read to `LOAD_NAME`, which falls back to the module until the
+    # class-local name exists.
+    rebinding = _scope_at_anchor("""
+        import json
+        class C:
+            json = anchor()
+        """)
+    assert isinstance(rebinding.declaring_scope('json'), CompilationUnit)
+
+    rebound = _scope_at_anchor("""
+        import json
+        class C:
+            json = 1
+            alias = anchor()
+        """)
+    assert isinstance(rebound.declaring_scope('json'), ClassDeclaration)
 
 
 def test_a_comprehensions_leading_iterable_is_evaluated_before_its_targets_exist():

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -901,6 +901,25 @@ class TestChangeImportPythonScopeRules:
             """,
         )
 
+    def test_a_class_attribute_re_exporting_the_import_reads_it_on_the_right(self):
+        """`clock = clock` binds `C.clock` from the module's `clock`."""
+        self._run(
+            """\
+            from time import clock
+
+
+            class C:
+                clock = clock
+            """,
+            """\
+            from time import perf_counter
+
+
+            class C:
+                clock = perf_counter
+            """,
+        )
+
     def test_member_and_keyword_positions_name_something_else(self):
         self._run(
             """\
@@ -920,6 +939,29 @@ class TestChangeImportPythonScopeRules:
                 resp.clock()
                 poll(clock=1)
                 return item.payload.clock, perf_counter()
+            """,
+        )
+
+    def test_a_match_class_keyword_pattern_names_an_attribute(self):
+        """``Point(clock=v)`` matches ``Point``'s attribute and binds only ``v``."""
+        self._run(
+            """\
+            from time import clock
+
+
+            def f(p):
+                match p:
+                    case Point(clock=v):
+                        return clock(), v
+            """,
+            """\
+            from time import perf_counter
+
+
+            def f(p):
+                match p:
+                    case Point(clock=v):
+                        return perf_counter(), v
             """,
         )
 


### PR DESCRIPTION
`ChangeImport` rewrote the attribute name in a match-class keyword pattern, silently changing which attribute the pattern matches. `ChangeImport(old_module='time', old_name='clock', new_module='time', new_name='perf_counter')` over:

```python
from time import clock

match p:
    case Point(clock=v):
        pass
```

```python
from time import perf_counter

match p:
    case Point(perf_counter=v):   # Point's `clock` attribute, unrelated to the import
        pass
```

## The model, not the predicate

The parser mapped a class pattern's `attr=pattern` to a `j.VariableDeclarations` holding a `NamedVariable` whose `.name` was the *attribute*. That told the binding machinery two wrong things at once:

- `binding_utils._resolves` fell through to its "names something in scope" default, so a rename followed the attribute.
- `scope_utils._BindingScan` recorded the attribute as a local of the enclosing scope, so a real reference below it was skipped — and `RemoveImport` counted the shadow as a use.

`Py.MatchCase.Pattern.Kind.KEYWORD` already existed in both the Python and Java models, and the printer already emitted `<child>=<child>` for it; it was simply unused. The parser now builds it, which removes the false shadowing outright, and `_resolves` gains the member-position rule for `children[0]`.

## Two neighbours the same node exposed

**Captures bound nothing.** `_BindingScan` had no match handling, so a rename followed the capture in every pattern shape — `Point(x=clock)`, `Point(clock)`, `[clock]`, `Point() as clock`, `{'a': clock}`, `case clock:` — collapsing two distinct locals into one.

`scope_utils.captures()` now yields the identifiers a pattern binds. `_BindingScan` and `binding_utils._is_target` both consume it, so the scope model and the position predicates give one answer.

**Class-body bindings were position-independent.** `class C: clock = clock` kept the statement while the import renamed, leaving a `NameError`. A class body compiles a read to `LOAD_NAME`, which falls back to the module until the class-local exists, so `_names` scans only the statements above the reference.

The target itself is exempt, since `clock = 1` creates `C.clock` wherever it stands. `scope_of` and `LocalBindings.is_bound` take a `binding` flag for that, which `ChangeImport` fills from `is_reference`.

## Tests

Five: the keyword-pattern rename and the class-body re-export in `test_change_import.py`, the capture and class-body scope rules in `test_scope.py`, and a widened capture-position test in `test_bindings.py`. The `_NOT_CAPTURED` guard and the `_resolves` KEYWORD branch are mutation-checked — each has exactly one test that fails without it.

`PythonVisitorCompletenessTest` exercises the reshaped node through the Java `PythonVisitor` over RPC, but it is `@DisabledIfEnvironmentVariable(named = "CI")`, so it could not have caught this on main. Run locally against this branch, green.
