### PR TITLE
Python: a MethodMatcher resolves a receiver the types lost

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -111,10 +111,11 @@ class ImportBindings:
         return None if declaring is not None and not isinstance(declaring, CompilationUnit) else binding
 
 
-def import_bindings(source: Union[TreeVisitor[Any, Any], CompilationUnit,
+def import_bindings(source: Union[TreeVisitor[Any, Any], Cursor, CompilationUnit,
                                   Iterable[Statement]]) -> ImportBindings:
-    """The bindings the imports of ``source`` introduce: a visitor answers for the file it is
-    visiting and scans it once, a compilation unit or statement list scans on every call.
+    """The bindings the imports of ``source`` introduce: a visitor or a cursor answers for the
+    file being visited and scans it once, a compilation unit or statement list scans on every
+    call.
 
     A scan descends into an ``if`` that has no ``else`` and into no ``try`` whatever it catches,
     so a fallback import's shim is never taken for the module — see :attr:`Binding.guarded`.
@@ -123,6 +124,8 @@ def import_bindings(source: Union[TreeVisitor[Any, Any], CompilationUnit,
         return ImportBindings(_scan(source.statements, guarded=False))
     if isinstance(source, TreeVisitor):
         return _cached(source.cursor)
+    if isinstance(source, Cursor):
+        return _cached(source)
     return ImportBindings(_scan(source, guarded=False))
 
 

--- a/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
+++ b/rewrite-python/rewrite/src/rewrite/python/method_matcher.py
@@ -37,10 +37,36 @@ Wildcards:
 from dataclasses import dataclass
 from typing import Optional, List
 
+from rewrite import Cursor
 from rewrite.java.support_types import JavaType
 from rewrite.java.tree import Empty, Identifier, MethodInvocation
+from rewrite.python.binding_utils import Binding, import_bindings
+from rewrite.python.import_utils import get_alias_name
 from rewrite.python.type_mapping import PRIMITIVE_TO_PYTHON
 from rewrite.python.type_utils import is_of_type_with_name
+
+
+def _argument_count(method: MethodInvocation) -> int:
+    """How many arguments the call passes. A call with none holds one ``Empty`` placeholder,
+    which no pattern names."""
+    args = method.arguments
+    return 0 if len(args) == 1 and isinstance(args[0], Empty) else len(args)
+
+
+def _has_usable_declaring_type(method: MethodInvocation) -> bool:
+    """Whether the call carries a declaring type that says what its receiver is."""
+    declaring = method.method_type.declaring_type if method.method_type else None
+    return declaring is not None and not isinstance(declaring, JavaType.Unknown)
+
+
+def _receiver_type(binding: Binding) -> Optional[str]:
+    """The type a receiver spelling ``binding``'s name has, or None where the name does not
+    stand for one on its own."""
+    if binding.member is not None:
+        # `from datetime import datetime` makes the receiver the member, not the module.
+        return f"{binding.module}.{binding.member}"
+    # `import os.path` binds `os`, which names the root package; an alias binds the whole path.
+    return binding.module if get_alias_name(binding.imp) else binding.name
 
 
 @dataclass
@@ -49,9 +75,10 @@ class MethodMatcher:
     Matches method invocations against an AspectJ-style pattern signature.
 
     Matching turns on the call's declaring type, which an import-resolved call
-    carries with no type check running; a pattern naming a concrete receiver fails
-    where that type is ``JavaType.Unknown``, though ``*..*`` still matches and
-    ``matches(method, match_unknown_types=True)`` falls back to the call as written.
+    carries with no type check running. Where that type is ``JavaType.Unknown`` a
+    pattern naming a concrete receiver needs another route: ``*..*`` matches anyway,
+    a ``cursor`` resolves the receiver against the file's imports, and
+    ``match_unknown_types=True`` reads the call as written.
     ``REWRITE_PYTHON_DUMP_TYPES=1`` in a test run prints what each call got.
     """
 
@@ -95,29 +122,43 @@ class MethodMatcher:
             _match_overrides=match_overrides,
         )
 
-    def matches(self, method: MethodInvocation, match_unknown_types: bool = False) -> bool:
+    def matches(self, method: MethodInvocation, match_unknown_types: bool = False,
+                *, cursor: Optional[Cursor] = None) -> bool:
         """
         Check if a method invocation matches this pattern.
 
         Args:
             method: The method invocation to check
-            match_unknown_types: when the attributed types don't match,
-                also match structurally, on the call's written receiver,
-                name and arguments. Reaches calls whose declaring type is
-                ``JavaType.Unknown``, at the risk of false positives on
-                unrelated calls, so it is off by default.
+            match_unknown_types: where the call has no declaring type to match,
+                also match structurally, on its written receiver, name and
+                arguments, at the risk of false positives on unrelated calls, so
+                it is off by default. Java reads the spelling against a resolved
+                declaring type too; this stops at the guard below.
+            cursor: standing on ``method``, which resolves the receiver against
+                the file's imports where its declaring type is ``Unknown``. One
+                binding of a name in any scope leaves every call in the file with
+                that type, so a pattern naming a module needs this to reach them.
 
         Returns:
             True if the method matches the pattern
         """
         if self._matches_typed(method):
             return True
+        if _has_usable_declaring_type(method):
+            # A declaring type names the receiver at this call site, which the imports and
+            # the spelling can only guess at, so where there is one it settles the question.
+            return False
+        if self._matches_resolved_receiver(method, cursor):
+            return True
         return match_unknown_types and self._matches_allowing_unknown_types(method)
 
     def _matches_typed(self, method: MethodInvocation) -> bool:
         """Check the pattern against the call's type attribution."""
-        # Check method name first (fast path)
+        # Name and arity are string and integer comparisons; the declaring type may walk a
+        # hierarchy and the argument types compare one by one, so they come after.
         if not self._matches_method_name(method):
+            return False
+        if not self._matches_parameter_count(method):
             return False
 
         # A parsed call's declaring type is JavaType.Unknown, never None, so this
@@ -126,11 +167,9 @@ class MethodMatcher:
         if method.method_type is None or method.method_type.declaring_type is None:
             return False
 
-        # Check declaring type
         if not self._matches_target_type(method.method_type.declaring_type):
             return False
 
-        # Check arguments
         return self._matches_arguments(method)
 
     def _matches_target_type(self, type_obj) -> bool:
@@ -141,9 +180,56 @@ class MethodMatcher:
             type_obj, True, self._type_matcher.matches_name
         )
 
+    def _matches_resolved_receiver(self, method: MethodInvocation,
+                                   cursor: Optional[Cursor]) -> bool:
+        """Check the pattern against a call with no declaring type, reading the receiver's
+        module off the import that binds it.
+
+        The name and argument checks stay the typed ones; only the declaring type comes from
+        the import.
+        """
+        if cursor is None or not self._matches_parameter_count(method):
+            return False
+
+        select = method.select
+        if select is None:
+            binding = self._binding_for(cursor, method.name)
+            if binding is None or binding.member is None:
+                return False
+            # A bare call reads the member the import bound, under whatever local name:
+            # `from socket import gethostname as getfqdn` calls `socket.gethostname`.
+            if not self._method_matcher.matches(binding.member):
+                return False
+            owner = binding.module
+        elif isinstance(select, Identifier):
+            if not self._matches_method_name(method):
+                return False
+            binding = self._binding_for(cursor, select)
+            owner = _receiver_type(binding) if binding is not None else None
+            if owner is None:
+                return False
+        else:
+            # A dotted receiver's root binds a prefix of the path, and the binding
+            # alone does not say how to recombine them.
+            return False
+
+        # `module` keeps a relative import's leading dot, so `.socket` is never `socket`.
+        if not self._type_matcher.matches_name(owner):
+            return False
+        return self._matches_arguments(method)
+
+    @staticmethod
+    def _binding_for(cursor: Cursor, name: Identifier) -> "Optional[Binding]":
+        binding = import_bindings(cursor).reference(cursor, name)
+        # An `if` decides whether a guarded binding happens at all, so the name it holds
+        # at this call site is not settled: `if TYPE_CHECKING:` binds nothing at runtime.
+        return None if binding is None or binding.guarded else binding
+
     def _matches_allowing_unknown_types(self, method: MethodInvocation) -> bool:
         """Check the pattern against the call as written, ignoring absent types."""
         if not self._method_matcher.matches(method.name.simple_name):
+            return False
+        if not self._matches_parameter_count(method):
             return False
 
         # Only a bare identifier receiver is compared; a qualified or computed
@@ -165,12 +251,18 @@ class MethodMatcher:
         return method.method_type is not None and \
             self._method_matcher.matches(method.method_type.name)
 
+    def _matches_parameter_count(self, method: MethodInvocation) -> bool:
+        """Whether the call passes as many arguments as the pattern names. Cheap, and
+        selective enough to run before resolving a receiver or walking a type hierarchy."""
+        count = _argument_count(method)
+        if self._varargs_position == -1:
+            return count == len(self._argument_matchers)
+        return count >= len(self._argument_matchers) - 1
+
     def _matches_arguments(self, method: MethodInvocation, allow_unknown: bool = False) -> bool:
         """Check if method arguments match the expected pattern."""
         args = method.arguments
         if len(args) == 1 and isinstance(args[0], Empty):
-            # A call with no arguments holds one Empty placeholder, which
-            # no pattern names.
             args = []
         arg_count = len(args)
 

--- a/rewrite-python/rewrite/tests/python/test_method_matcher_bindings.py
+++ b/rewrite-python/rewrite/tests/python/test_method_matcher_bindings.py
@@ -1,0 +1,176 @@
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""`MethodMatcher` resolving a receiver through import bindings.
+
+The parser synthesises a class per imported module, and a file where any scope also binds
+that name carries `JavaType.Unknown` on every call in it. Fixtures here therefore all hold a
+shadowing binding, since that is the state a cursor is needed for.
+"""
+
+import ast
+import dataclasses
+from typing import List, Optional
+
+from rewrite.java.support_types import JavaType
+from rewrite.java.tree import MethodInvocation
+from rewrite.python import MethodMatcher
+from rewrite.python._parser_visitor import ParserVisitor
+from rewrite.python.visitor import PythonVisitor
+
+# A binding of `socket` in some other scope, which costs the whole file its module type.
+SHADOW = 'def helper(socket):\n    return socket\n'
+
+
+def matches(source: str, pattern: str, *, with_cursor: bool = True,
+            match_unknown_types: bool = False,
+            stamp_declaring: Optional[str] = None) -> List[bool]:
+    """One entry per call in `source`, outermost first: whether `pattern` matched it.
+
+    `stamp_declaring` replaces each call's declaring type with a resolved class, which lets a
+    test disagree with what the imports say and see which of the two the matcher believed.
+    """
+    cu = ParserVisitor(source, None, None).visit(ast.parse(source))
+    matcher = MethodMatcher.create(pattern)
+    results: List[bool] = []
+
+    class Collect(PythonVisitor):
+        def visit_method_invocation(self, method: MethodInvocation, p) -> MethodInvocation:
+            probe = method
+            if stamp_declaring is not None and method.method_type is not None:
+                declaring = JavaType.ShallowClass()
+                declaring._flags_bit_map = 0
+                declaring._fully_qualified_name = stamp_declaring
+                declaring._kind = JavaType.FullyQualified.Kind.Class
+                probe = method.replace(_method_type=dataclasses.replace(
+                    method.method_type, _declaring_type=declaring))
+            results.append(matcher.matches(probe, match_unknown_types,
+                                           cursor=self.cursor if with_cursor else None))
+            return super().visit_method_invocation(method, p)
+
+    Collect().visit(cu, None)
+    return results
+
+
+def declaring_types(source: str) -> List[object]:
+    """The declaring type of each call, to tell a lost module type from a resolved one."""
+    cu = ParserVisitor(source, None, None).visit(ast.parse(source))
+    found: List[object] = []
+
+    class Collect(PythonVisitor):
+        def visit_method_invocation(self, method: MethodInvocation, p) -> MethodInvocation:
+            found.append(None if method.method_type is None else method.method_type.declaring_type)
+            return super().visit_method_invocation(method, p)
+
+    Collect().visit(cu, None)
+    return found
+
+
+def test_a_shadowing_binding_costs_the_file_its_module_type():
+    # The premise the rest of this file rests on, and the reason the fallback exists.
+    resolved = declaring_types('import socket\nsocket.getfqdn()\n')
+    assert [type(t).__name__ for t in resolved] == ['ShallowClass']
+
+    lost = declaring_types('import socket\nsocket.getfqdn()\n' + SHADOW)
+    assert [type(t).__name__ for t in lost] == ['Unknown']
+
+
+def test_module_receiver_resolves_through_its_import_and_alias():
+    assert matches('import socket\nsocket.getfqdn()\n' + SHADOW, 'socket getfqdn(..)') == [True]
+    assert matches('import socket as s\ns.getfqdn()\n' + SHADOW.replace('socket', 's'),
+                   'socket getfqdn(..)') == [True]
+
+
+def test_a_local_that_spells_the_module_is_not_the_module():
+    source = ('import socket\n'
+              'real = socket.getfqdn()\n'
+              'def helper(socket):\n'
+              '    return socket.getfqdn()\n')
+    assert matches(source, 'socket getfqdn(..)') == [True, False]
+
+
+def test_a_relative_import_is_never_the_module_of_the_same_name():
+    source = 'from .socket import getfqdn\ngetfqdn()\ndef helper(getfqdn):\n    return getfqdn\n'
+    assert matches(source, 'socket getfqdn(..)') == [False]
+
+
+def test_an_import_that_only_exists_for_type_checking_is_not_called_at_runtime():
+    source = ('from typing import TYPE_CHECKING\n'
+              'if TYPE_CHECKING:\n'
+              '    import socket\n'
+              'socket.getfqdn()\n' + SHADOW)
+    assert matches(source, 'socket getfqdn(..)') == [False]
+
+
+def test_without_a_cursor_the_receiver_is_not_resolved():
+    assert matches('import socket\nsocket.getfqdn()\n' + SHADOW, 'socket getfqdn(..)',
+                   with_cursor=False) == [False]
+
+
+def test_a_resolved_declaring_type_decides_it_against_the_imports_and_the_spelling():
+    # The imports say `socket` and the declaring type says `json`.
+    stamped = 'import socket\nsocket.getfqdn()\n'
+    assert matches(stamped, 'json getfqdn(..)', stamp_declaring='json') == [True]
+    assert matches(stamped, 'socket getfqdn(..)', stamp_declaring='json') == [False]
+
+    # `match_unknown_types` reads the spelling, which names `socket`. Java falls through
+    # to it here; a resolved declaring type decides instead.
+    aliased = 'import json as socket\nsocket.dumps(1)\n'
+    assert matches(aliased, 'socket dumps(..)', match_unknown_types=True) == [False]
+    assert matches(aliased, 'json dumps(..)') == [True]
+
+
+def test_a_from_imported_receiver_is_the_member_not_its_module():
+    source = ('from datetime import datetime\n'
+              'datetime.now()\n'
+              'def helper(datetime):\n'
+              '    return datetime\n')
+    assert matches(source, 'datetime.datetime now(..)') == [True]
+
+    assert matches(source, 'datetime now(..)') == [False]
+
+
+def test_a_bare_call_reads_the_member_the_import_bound_not_the_local_name():
+    plain = 'from socket import getfqdn\ngetfqdn()\ndef helper(getfqdn):\n    return getfqdn\n'
+    assert matches(plain, 'socket getfqdn(..)') == [True]
+
+    aliased = ('from socket import gethostname as getfqdn\n'
+               'getfqdn()\n'
+               'def helper(getfqdn):\n'
+               '    return getfqdn\n')
+    assert matches(aliased, 'socket gethostname(..)') == [True]
+    assert matches(aliased, 'socket getfqdn(..)') == [False]
+
+
+def test_a_dotted_import_binds_its_root_and_an_alias_binds_the_whole_path():
+    plain = 'import os.path\nos.getcwd()\ndef helper(os):\n    return os\n'
+    assert matches(plain, 'os getcwd(..)') == [True]
+    assert matches(plain, 'os.path getcwd(..)') == [False]
+
+    aliased = 'import os.path as p\np.join(1)\ndef helper(p):\n    return p\n'
+    assert matches(aliased, 'os.path join(..)') == [True]
+    assert matches(aliased, 'os join(..)') == [False]
+
+    # An alias spelled like the root package still binds the whole path.
+    shadowing_alias = 'import os.path as os\nos.join(1)\ndef helper(os):\n    return os\n'
+    assert matches(shadowing_alias, 'os.path join(..)') == [True]
+    assert matches(shadowing_alias, 'os join(..)') == [False]
+
+
+def test_arguments_are_still_checked_when_the_receiver_resolves():
+    source = 'import socket\nsocket.getfqdn(1)\n' + SHADOW
+    assert matches(source, 'socket getfqdn(int)') == [True]
+
+    assert matches(source, 'socket getfqdn(str)') == [False]
+


### PR DESCRIPTION
A `MethodMatcher` pattern naming a module stops matching a file the moment any scope in it binds that module's name — including at the call sites that genuinely do reference the module. The parser synthesises a class per imported module, so most calls match with no type checker running; one shadowing binding collapses the declaring type to `JavaType.Unknown` for every call in the file.

```
import socket
socket.getfqdn()                  declaring=ShallowClass 'socket'   matches -> True
socket.getfqdn()  + a def below   declaring=Unknown                 matches -> False
def helper(socket):               ^ the binding that costs the file its types
    return socket
```

Across 7,720 files of open-source Python (django, ansible, sqlalchemy, numpy, celery, scrapy, pytest, black, boto3, flask, httpx, requests), 575 of 11,420 module-qualified calls lose their declaring type this way. 567 of them name a receiver the file's own imports resolve.

## The fix

`matches` takes a cursor and reads the receiver's module off the import that binds it, where the call has no declaring type of its own:

```python
if self._matches_typed(method):
    return True
if _has_usable_declaring_type(method):
    return False                      # a resolved type already answered
if self._matches_resolved_receiver(method, cursor):
    return True
return match_unknown_types and self._matches_allowing_unknown_types(method)
```

Only the declaring type comes from the import; the name and argument checks stay the typed ones, so this accepts nothing the typed path rejected for another reason. The receiver's type follows the binding's shape — `from datetime import datetime` makes it `datetime.datetime`, a plain `import os.path` binds only the root `os`, and an alias binds the whole path. A relative `from .socket import` keeps its leading dot and so never matches the standard library's `socket`.

Measured over the same corpus: **450 calls recovered, 0 previously-matching calls lost, 0 false positives added.**

## match_unknown_types now needs the same condition

It read the call's spelling even against a fully resolved declaring type, so `socket dumps(..)` matched a file whose `import json as socket` says the receiver is `json`. Java deliberately falls through to the spelling there, citing types that survive deserialization with their hierarchies stripped; this stops instead. Nothing in the suite pinned the old behaviour, including the 24 hand-translated Java spec cases.

## Ordering

Name, then argument count, then receiver — Java's order, which the typed path had diverged from. On the resolving path an arity-mismatched pattern costs 0.17ms per 201 calls rather than 2.00ms, because the count check runs before the scope walk. Answers were identical across 197,952 checks. On the typed path the reorder is not measurable.

## Scope

`uses_method()` cannot reach the cursor: `_FindFirst.visit` dispatches straight to `accept` to skip cursor construction, so `_MethodSearch` has none to pass. This reaches visitors that pass their own cursor; making the precondition path benefit needs a follow-up. A declaring type present but stripped of its hierarchy — Java's stated reason for the fallthrough — is also left for later.
