### PR TITLE
Python: a construction the types lost still names a declaring type

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -1572,6 +1572,17 @@ class PythonTypeMapping:
                 resolved = self._get_call_return_type(receiver)
                 if resolved is not None:
                     return resolved
+                # ty types a call it matches to no overload `Unknown`, so a
+                # construction is known by the class it names. That is the receiver's
+                # own class, as for a `self` receiver, so an inherited member needs
+                # `match_overrides`.
+                constructed = self._constructed_class(receiver)
+                if constructed is not None:
+                    reference = self._class_reference(constructed)
+                    # `super()` builds a proxy, never the class declaring what is
+                    # called on it; `_declaring_class_of_callee` names that class.
+                    if reference.fully_qualified_name != 'super':
+                        return reference
 
             # Try to look up receiver type in ty-types index
             type_id = self._lookup_type_id(receiver)

--- a/rewrite-python/rewrite/tests/python/test_type_attribution.py
+++ b/rewrite-python/rewrite/tests/python/test_type_attribution.py
@@ -879,6 +879,29 @@ class TestDeclaringTypeWithTyTypes:
         finally:
             _cleanup_mapping(mapping, tmpdir, client)
 
+    def test_construction_receiver_declaring_type_when_ty_untypes_the_call(self):
+        """A construction ty leaves untyped still yields a declaring type."""
+        source = """
+            import array
+
+            class Subclass(array.array):
+                pass
+
+            Subclass().tobytes()
+        """
+        mapping, tree, tmpdir, client = _make_mapping(source)
+        try:
+            call = tree.body[2].value  # Subclass().tobytes()
+            result = mapping.method_invocation_type(call)
+            assert result is not None
+            # `array.array` has no zero-argument overload, so ty resolves no
+            # member on the construction.
+            declaring = result._declaring_type
+            assert declaring._fully_qualified_name == f'{_SOURCE_MODULE}.Subclass'
+            assert declaring._supertype._fully_qualified_name == 'array.array'
+        finally:
+            _cleanup_mapping(mapping, tmpdir, client)
+
     def test_user_defined_class_method(self):
         """Method call on a user-defined class instance."""
         source = '''


### PR DESCRIPTION
`MethodMatcher` and `uses_method` could not match a method inherited from `array.array` at all: the call's `declaring_type` was `JavaType.Unknown`, while `is_assignable_to("array.array", select.type)` on the same expression was `True`. `match_overrides=True` did not help, because there was no type to start the supertype walk from.

```python
import array
class S(array.array):
    pass
S().tostring()   # declaring_type: Unknown
```

## What ty reports

Nothing to do with `array` being a C extension. `array.array.__new__` has no zero-argument overload, so `S()` is a call error, and ty types an expression it matches to no overload `Unknown`:

```
reveal_type(S())           -> `Unknown`          # no-matching-overload
reveal_type(S('i'))        -> `array[int]`
reveal_type(SL())          -> `Unknown`          # class SL(slice)
reveal_type(R())           -> `R`                # class R(range), same error
reveal_type(array.array()) -> `array[_T@array]`
```

The discriminator is whether the base's `__new__` overloads return `Self`. `range` and `datetime.datetime` do, so ty recovers to the subclass even when the call errors; `array.array` and `slice` return concrete `array[int]` / `slice[Any, _T, Any]` and have nothing to recover to for a subclass callee. `slice` therefore behaves identically, and `dict`, `list`, `set`, `str`, `collections.OrderedDict`, `datetime.datetime` and `threading.Thread` never did.

## The fix

`_get_declaring_type` had only `_get_call_return_type` for a receiver that is itself a call, and that reads the `ExprCall` type ty dropped. The class the receiver constructs survives, so it is read instead.

That names the subclass rather than `array.array` — the convention a `self` receiver already uses, so an inherited member takes `match_overrides=True`.

Rejected: routing `_get_call_return_type` through `_get_return_type`, which prefers `callSignature.returnTypeId` and recovers the base directly. It regresses two things:

| receiver | declaring type |
|---|---|
| `super().__init__(...)` on a call ty flags | `Unknown` → `super` |
| `sys.stdin.buffer.read(n).decode(...)` | `bytes` → `str` |

38 sites across `_pytest`, `urllib3`, `requests` and `click` hit the first. The second is a latent bug this PR leaves alone: `_resolve_type` collapses `bytes` to `Primitive.String` while `_resolve_declaring_type` maps the same descriptor to `bytes`.

## Tests

`test_construction_receiver_declaring_type_when_ty_untypes_the_call` pins the declaring type as the constructed class and its supertype as `array.array`; the second assertion is what makes `match_overrides=True` reach the base. A/B over `_pytest`, `urllib3`, `requests` and `click` (11,694 calls) and this module's own sources (13,371): no declaring type changes.

## Not fixed

`s = S(); s.tobytes()` still has no declaring type — ty types the binding `s` as `Unknown`, and there is no signature at the use site to recover from. That needs binding inference, a separate mechanism.
