### PR TITLE
Python: a spliced template's context reaches the file it lands in

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -202,7 +202,8 @@ class AddImport(PythonVisitor):
 
     def _is_referenced(self, cu: CompilationUnit) -> bool:
         """Check if the identifier we're importing is actually used."""
-        target_name = self.alias or self.name or self.module.split('.')[-1]
+        # `import a.b.c` binds only `a`, so that is the name a use of it reads through.
+        target_name = self.alias or self.name or self.module.split('.')[0]
 
         class ReferenceChecker(PythonVisitor):
             def __init__(self):

--- a/rewrite-python/rewrite/src/rewrite/python/template/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/__init__.py
@@ -36,7 +36,7 @@ Examples:
         def visit_method_invocation(self, method, ctx):
             match = pat.match(method, self.cursor)
             if match:
-                return tmpl.apply(self.cursor, values=match)
+                return tmpl.apply(self, values=match)
             return super().visit_method_invocation(method, ctx)
 """
 

--- a/rewrite-python/rewrite/src/rewrite/python/template/__init__.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/__init__.py
@@ -36,7 +36,7 @@ Examples:
         def visit_method_invocation(self, method, ctx):
             match = pat.match(method, self.cursor)
             if match:
-                return tmpl.apply(self, values=match)
+                return tmpl.apply(self.cursor, visitor=self, values=match)
             return super().visit_method_invocation(method, ctx)
 """
 

--- a/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
@@ -1,0 +1,102 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The modules a template's context binds, and how they reach the file it is spliced into."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence, Tuple
+
+from rewrite.java import J
+from rewrite.java.tree import Identifier
+from rewrite.python.add_import import AddImportOptions, maybe_add_import
+from rewrite.python.binding_utils import import_bindings, is_reference
+from rewrite.python.visitor import PythonVisitor
+
+
+@dataclass(frozen=True)
+class ContextBinding:
+    """One name a template's context binds."""
+
+    name: str
+    """The local name the template's code uses: the alias where the context gives one, else the
+    member of a ``from`` import and the root package of ``import a.b.c``."""
+
+    module: str
+    """The module as written, keeping a relative import's leading dots."""
+
+    member: Optional[str]
+    """The member of ``from <module> import <member>``, None for ``import <module>``."""
+
+    alias: Optional[str]
+    """The name the context imports under, when it renames it."""
+
+
+def context_bindings(context: Sequence[str]) -> Tuple[ContextBinding, ...]:
+    """The modules ``context`` binds. Context that binds nothing importable — a type alias, a
+    stub definition — yields nothing, and neither does context that does not parse, which the
+    template's own parse reports."""
+    try:
+        parsed = ast.parse('\n'.join(context))
+    except SyntaxError:
+        return ()
+
+    bindings = []
+    for node in parsed.body:
+        if isinstance(node, ast.Import):
+            for name in node.names:
+                bindings.append(ContextBinding(name.asname or name.name.split('.')[0],
+                                               name.name, None, name.asname))
+        elif isinstance(node, ast.ImportFrom):
+            module = '.' * node.level + (node.module or '')
+            for name in node.names:
+                # A wildcard's names are a property of the module, so there is nothing here to
+                # recognise in the target file or to add to it.
+                if name.name != '*':
+                    bindings.append(ContextBinding(name.asname or name.name,
+                                                   module, name.name, name.asname))
+    return tuple(bindings)
+
+
+def bind_context(visitor: PythonVisitor, bindings: Sequence[ContextBinding]) -> Dict[str, str]:
+    """Binds each of ``bindings`` in the file ``visitor`` is visiting, and returns the names to
+    rename the template's references to where the file already binds a module under another name.
+    A conditional import binds nothing a spliced reference reaches, so it counts as unbound."""
+    existing = import_bindings(visitor)
+    renames: Dict[str, str] = {}
+    for binding in bindings:
+        bound = next((b.name for b in existing if b.module == binding.module
+                      and b.member == binding.member and not b.guarded), None)
+        if bound is None:
+            maybe_add_import(visitor, AddImportOptions(
+                module=binding.module, name=binding.member, alias=binding.alias))
+        elif bound != binding.name:
+            renames[binding.name] = bound
+    return renames
+
+
+class RenameBindings(PythonVisitor[None]):
+    """Renames a template's references to a context binding to the name the target file uses."""
+
+    def __init__(self, renames: Dict[str, str]) -> None:
+        super().__init__()
+        self._renames = renames
+
+    def visit_identifier(self, ident: Identifier, p: None) -> J:
+        renamed = self._renames.get(ident.simple_name)
+        if renamed is not None and is_reference(self.cursor, ident):
+            return ident.replace(simple_name=renamed)
+        return super().visit_identifier(ident, p)

--- a/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
@@ -18,13 +18,15 @@ from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
-from typing import Dict, Optional, Sequence, Tuple
+from typing import Dict, FrozenSet, Optional, Sequence, Set, Tuple
 
 from rewrite.java import J
 from rewrite.java.tree import Identifier
 from rewrite.python.add_import import AddImportOptions, maybe_add_import
-from rewrite.python.binding_utils import import_bindings, is_reference
+from rewrite.python.binding_utils import Binding, ImportBindings, import_bindings, is_reference
+from rewrite.python.scope_utils import LocalBindings, scope_of
 from rewrite.python.visitor import PythonVisitor
+from rewrite.visitor import Cursor, TreeVisitor
 
 
 @dataclass(frozen=True)
@@ -71,21 +73,69 @@ def context_bindings(context: Sequence[str]) -> Tuple[ContextBinding, ...]:
     return tuple(bindings)
 
 
-def bind_context(visitor: PythonVisitor, bindings: Sequence[ContextBinding]) -> Dict[str, str]:
+def reads_context_name(cursor: Cursor, ident: Identifier) -> bool:
+    """Whether ``ident`` reads a name the context binds. A name the template binds for itself is
+    its own, whatever the context calls the same spelling."""
+    return is_reference(cursor, ident) and not LocalBindings().is_bound(cursor, ident.simple_name)
+
+
+def names_read(tree: J) -> FrozenSet[str]:
+    """The context names ``tree`` reads, which are the ones the target file has to bind."""
+    names: Set[str] = set()
+
+    class Scan(PythonVisitor[None]):
+        def visit_identifier(self, ident: Identifier, p: None) -> J:
+            if reads_context_name(self.cursor, ident):
+                names.add(ident.simple_name)
+            return ident
+
+    Scan().visit(tree, None)
+    return frozenset(names)
+
+
+def bind_context(visitor: TreeVisitor, bindings: Sequence[ContextBinding]) -> Dict[str, str]:
     """Binds each of ``bindings`` in the file ``visitor`` is visiting, and returns the names to
     rename the template's references to where the file already binds a module under another name.
-    A conditional import binds nothing a spliced reference reaches, so it counts as unbound."""
+    A conditional import binds nothing a spliced reference reaches, so it counts as unbound, and
+    a name held by something else raises, no import being able to make it read the module."""
     existing = import_bindings(visitor)
+    cursor = visitor.cursor
     renames: Dict[str, str] = {}
     for binding in bindings:
         bound = next((b.name for b in existing if b.module == binding.module
                       and b.member == binding.member and not b.guarded), None)
+        name = bound or binding.name
+        if LocalBindings().is_bound(cursor, name):
+            raise ValueError(
+                f"The scope at the splice site binds '{name}' to something other than "
+                f"'{binding.module}', so the spliced code would read that instead. No import "
+                f"reaches a shadowed name; apply the template where '{name}' is free.")
         if bound is None:
+            if _taken(existing, cursor, binding):
+                raise ValueError(
+                    f"The file binds '{name}' to something other than '{binding.module}', so "
+                    f"importing the module under that name would rebind it. Import it under an "
+                    f"alias the file leaves free — context=[\"import {binding.module} as ...\"].")
             maybe_add_import(visitor, AddImportOptions(
                 module=binding.module, name=binding.member, alias=binding.alias))
         elif bound != binding.name:
             renames[binding.name] = bound
     return renames
+
+
+def _taken(existing: ImportBindings, cursor: Cursor, binding: ContextBinding) -> bool:
+    """Whether the file's module scope already reads ``binding.name`` as something else."""
+    if scope_of(cursor).declaring_scope(binding.name) is None:
+        return False
+    return not _same_package(existing.for_name(binding.name), binding)
+
+
+def _same_package(held: Optional[Binding], binding: ContextBinding) -> bool:
+    """Whether an import already holding the name binds the same package: ``import a.b`` and
+    ``import a.c`` both bind ``a`` to it."""
+    return (held is not None and held.member is None and binding.member is None
+            and binding.alias is None and held.name == binding.name
+            and held.module.split('.')[0] == binding.module.split('.')[0])
 
 
 class RenameBindings(PythonVisitor[None]):
@@ -97,6 +147,6 @@ class RenameBindings(PythonVisitor[None]):
 
     def visit_identifier(self, ident: Identifier, p: None) -> J:
         renamed = self._renames.get(ident.simple_name)
-        if renamed is not None and is_reference(self.cursor, ident):
+        if renamed is not None and reads_context_name(self.cursor, ident):
             return ident.replace(simple_name=renamed)
         return super().visit_identifier(ident, p)

--- a/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
@@ -21,10 +21,11 @@ from dataclasses import dataclass
 from typing import Dict, FrozenSet, Optional, Sequence, Set, Tuple
 
 from rewrite.java import J
-from rewrite.java.tree import Identifier
+from rewrite.java.tree import Block, Identifier
 from rewrite.python.add_import import AddImportOptions, maybe_add_import
 from rewrite.python.binding_utils import Binding, ImportBindings, import_bindings, is_reference
-from rewrite.python.scope_utils import LocalBindings, scope_of
+from rewrite.python.scope_utils import scope_of
+from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
 from rewrite.visitor import Cursor, TreeVisitor
 
@@ -76,7 +77,7 @@ def context_bindings(context: Sequence[str]) -> Tuple[ContextBinding, ...]:
 def reads_context_name(cursor: Cursor, ident: Identifier) -> bool:
     """Whether ``ident`` reads a name the context binds. A name the template binds for itself is
     its own, whatever the context calls the same spelling."""
-    return is_reference(cursor, ident) and not LocalBindings().is_bound(cursor, ident.simple_name)
+    return is_reference(cursor, ident) and _shadowing_scope(cursor, ident.simple_name) is None
 
 
 def names_read(tree: J) -> FrozenSet[str]:
@@ -102,25 +103,68 @@ def bind_context(visitor: TreeVisitor, bindings: Sequence[ContextBinding]) -> Di
     cursor = visitor.cursor
     renames: Dict[str, str] = {}
     for binding in bindings:
+        if _imported_locally(cursor, binding):
+            continue
+        _refuse_if_shadowed(cursor, binding.name, binding)
         bound = next((b.name for b in existing if b.module == binding.module
                       and b.member == binding.member and not b.guarded), None)
-        name = bound or binding.name
-        if LocalBindings().is_bound(cursor, name):
-            raise ValueError(
-                f"The scope at the splice site binds '{name}' to something other than "
-                f"'{binding.module}', so the spliced code would read that instead. No import "
-                f"reaches a shadowed name; apply the template where '{name}' is free.")
         if bound is None:
             if _taken(existing, cursor, binding):
                 raise ValueError(
-                    f"The file binds '{name}' to something other than '{binding.module}', so "
-                    f"importing the module under that name would rebind it. Import it under an "
-                    f"alias the file leaves free — context=[\"import {binding.module} as ...\"].")
+                    f"The file binds '{binding.name}' to something other than {_describe(binding)}, "
+                    f"so importing it under that name would rebind what the file already reads. "
+                    f"Import it under an alias the file leaves free — "
+                    f"context=[\"{_as_alias(binding)}\"].")
             maybe_add_import(visitor, AddImportOptions(
                 module=binding.module, name=binding.member, alias=binding.alias))
         elif bound != binding.name:
+            _refuse_if_shadowed(cursor, bound, binding)
             renames[binding.name] = bound
     return renames
+
+
+def _imported_locally(cursor: Cursor, binding: ContextBinding) -> bool:
+    """Whether a scope between the splice and the module already imports what ``binding`` names,
+    as a function importing lazily does. The name is bound where the splice lands, so the file's
+    module scope needs nothing."""
+    scope = _shadowing_scope(cursor, binding.name)
+    return scope is not None and _binds(_scope_imports(scope).for_name(binding.name), binding)
+
+
+def _refuse_if_shadowed(cursor: Cursor, name: str, binding: ContextBinding) -> None:
+    if _shadowing_scope(cursor, name) is not None:
+        raise ValueError(
+            f"A scope at the splice site binds '{name}', so the spliced code would read that "
+            f"rather than {_describe(binding)}. No import reaches a shadowed name; apply the "
+            f"template where '{name}' is free.")
+
+
+def _describe(binding: ContextBinding) -> str:
+    return (f"'{binding.member}' from '{binding.module}'" if binding.member is not None
+            else f"the module '{binding.module}'")
+
+
+def _as_alias(binding: ContextBinding) -> str:
+    return (f"from {binding.module} import {binding.member} as ..." if binding.member is not None
+            else f"import {binding.module} as ...")
+
+
+def _shadowing_scope(cursor: Cursor, name: str) -> Optional[J]:
+    """The innermost scope binding ``name`` between the splice and the module, None where the
+    module scope is what decides the name."""
+    scope = scope_of(cursor).declaring_scope(name)
+    return None if scope is None or isinstance(scope, CompilationUnit) else scope
+
+
+def _scope_imports(scope: J) -> ImportBindings:
+    """What the imports directly in ``scope``'s body bind. An import nested deeper — under a
+    ``with``, in a loop — is not reported, so the splice is refused rather than accepted."""
+    body = getattr(scope, 'body', None)
+    return import_bindings(body.statements if isinstance(body, Block) else ())
+
+
+def _binds(held: Optional[Binding], binding: ContextBinding) -> bool:
+    return held is not None and held.module == binding.module and held.member == binding.member
 
 
 def _taken(existing: ImportBindings, cursor: Cursor, binding: ContextBinding) -> bool:

--- a/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/bindings.py
@@ -94,13 +94,14 @@ def names_read(tree: J) -> FrozenSet[str]:
     return frozenset(names)
 
 
-def bind_context(visitor: TreeVisitor, bindings: Sequence[ContextBinding]) -> Dict[str, str]:
-    """Binds each of ``bindings`` in the file ``visitor`` is visiting, and returns the names to
-    rename the template's references to where the file already binds a module under another name.
+def bind_context(visitor: TreeVisitor, cursor: Cursor,
+                 bindings: Sequence[ContextBinding]) -> Dict[str, str]:
+    """Binds each of ``bindings`` in the file ``visitor`` is visiting, as read from ``cursor``,
+    and returns the names to rename the template's references to where the file already binds a
+    module under another name.
     A conditional import binds nothing a spliced reference reaches, so it counts as unbound, and
     a name held by something else raises, no import being able to make it read the module."""
     existing = import_bindings(visitor)
-    cursor = visitor.cursor
     renames: Dict[str, str] = {}
     for binding in bindings:
         if _imported_locally(cursor, binding):

--- a/rewrite-python/rewrite/src/rewrite/python/template/template.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/template.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 from rewrite.java import J
-from rewrite.python.visitor import PythonVisitor
+from rewrite.visitor import TreeVisitor
 from .capture import Capture
 from .coordinates import PythonCoordinates
 from .engine import TemplateEngine, TemplateOptions
@@ -110,16 +110,20 @@ class Template:
         return self._cached_tree
 
     def context_bindings(self) -> Tuple['ContextBinding', ...]:
-        """The modules this template's context binds, which the file it is spliced into has to
-        bind too for its code to run there."""
+        """The modules this template's code reads through its context, which the file it is
+        spliced into has to bind too for that code to run there. Context that only types a
+        capture is read by nothing the template splices, so it binds nothing here."""
         if self._context_bindings is None:
-            from .bindings import context_bindings
-            self._context_bindings = context_bindings(self._options.imports + self._options.context)
+            from .bindings import context_bindings, names_read
+            read = names_read(self.get_tree())
+            self._context_bindings = tuple(
+                b for b in context_bindings(self._options.imports + self._options.context)
+                if b.name in read)
         return self._context_bindings
 
     def apply(
         self,
-        cursor: Union['Cursor', PythonVisitor],
+        cursor: Union['Cursor', TreeVisitor],
         *,
         values: Optional[Union['MatchResult', Dict[str, Any]]] = None,
         coordinates: Optional[PythonCoordinates] = None,
@@ -150,8 +154,8 @@ class Template:
             # With explicit coordinates
             result = tmpl.apply(self, coordinates=PythonCoordinates.after(node))
         """
-        if isinstance(cursor, PythonVisitor):
-            visitor: Optional[PythonVisitor] = cursor
+        if isinstance(cursor, TreeVisitor):
+            visitor: Optional[TreeVisitor] = cursor
             at: Optional['Cursor'] = cursor.cursor
         else:
             visitor, at = None, cursor

--- a/rewrite-python/rewrite/src/rewrite/python/template/template.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/template.py
@@ -40,12 +40,12 @@ class Template:
     Examples:
         # Simple template
         tmpl = template("x + 1")
-        result = tmpl.apply(self)
+        result = tmpl.apply(self.cursor)
 
         # Template with capture from pattern match
         expr = capture('expr')
         tmpl = template(f"print({expr})")
-        result = tmpl.apply(self, values=match_result)
+        result = tmpl.apply(self.cursor, values=match_result)
 
         # Template whose context types it and is imported into the file it lands in
         tmpl = template(
@@ -123,7 +123,7 @@ class Template:
 
     def apply(
         self,
-        cursor: Union['Cursor', TreeVisitor],
+        cursor: Optional['Cursor'],
         *,
         visitor: Optional[TreeVisitor] = None,
         values: Optional[Union['MatchResult', Dict[str, Any]]] = None,
@@ -134,11 +134,10 @@ class Template:
         Apply this template, returning the generated AST node.
 
         Args:
-            cursor: Where the result lands — a visitor stands for its own cursor, which is
-                where a recipe splices what it is visiting.
-            visitor: The visitor doing the edit, for a splice landing somewhere other than where
-                it stands. A template whose context imports a module needs one either way: the
-                module reaches the file through it.
+            cursor: Where the result lands, which for a recipe rewriting what it is visiting
+                is ``self.cursor``.
+            visitor: The visitor doing the edit. A template whose context imports a module needs
+                it: the module reaches the file through the visitor, not through the cursor.
             values: Captured values from a pattern match, or a dict of values.
             coordinates: Where/how to insert (default: replace current).
             format: Whether the result is fitted to where it lands. Pass False to assemble
@@ -150,29 +149,25 @@ class Template:
 
         Examples:
             # Simple application
-            result = tmpl.apply(self)
+            result = tmpl.apply(self.cursor)
 
             # With values from pattern match
-            result = tmpl.apply(self, values=match)
+            result = tmpl.apply(self.cursor, visitor=self, values=match)
 
             # With explicit coordinates
-            result = tmpl.apply(self, coordinates=PythonCoordinates.after(node))
+            result = tmpl.apply(self.cursor, coordinates=PythonCoordinates.after(node))
         """
-        at: Optional['Cursor'] = cursor.cursor if isinstance(cursor, TreeVisitor) else cursor
-        if visitor is None and isinstance(cursor, TreeVisitor):
-            visitor = cursor
-
         renames: Dict[str, str] = {}
         if self.context_bindings():
             if visitor is None:
                 raise ValueError(
                     f"Template imports {', '.join(sorted({b.module for b in self.context_bindings()}))} "
                     "in its context, so applying it has to bind those modules in the file it is "
-                    "spliced into. Pass the visitor — apply(self, ...) — rather than its cursor.")
+                    "spliced into. Name the visitor — apply(self.cursor, visitor=self, ...).")
             from .bindings import bind_context
-            # The splice site decides which names are in scope, and it is where the visitor
-            # stands only for a recipe rewriting what it is visiting.
-            renames = bind_context(visitor, at or visitor.cursor, self.context_bindings())
+            # The splice site decides which names are in scope, which is where the visitor stands
+            # only for a recipe rewriting what it is visiting.
+            renames = bind_context(visitor, cursor or visitor.cursor, self.context_bindings())
 
         # Get the template tree
         template_tree = self.get_tree()
@@ -204,21 +199,21 @@ class Template:
         # Phase 2: parenthesize the result for the slot it replaces, mirroring JavaTemplate.doApply().
         # This must happen before coordinates are applied, because
         # apply_coordinates may wrap the expression in ExpressionStatement.
-        if result is not None and at is not None:
+        if result is not None and cursor is not None:
             from .precedence import enclosing_tree, maybe_parenthesize
-            target = at.value
+            target = cursor.value
             if isinstance(target, J):
-                result = maybe_parenthesize(enclosing_tree(at.parent), target.id, result)
+                result = maybe_parenthesize(enclosing_tree(cursor.parent), target.id, result)
 
         # Phase 3: apply coordinates (prefix preservation, statement wrapping, auto-format)
         effective_coords = coordinates
-        if effective_coords is None and at is not None:
-            tree = at.value
+        if effective_coords is None and cursor is not None:
+            tree = cursor.value
             if tree is not None:
                 effective_coords = PythonCoordinates.replace(tree)
 
         if effective_coords is not None and result is not None:
-            result = TemplateEngine.apply_coordinates(result, at, effective_coords, format)
+            result = TemplateEngine.apply_coordinates(result, cursor, effective_coords, format)
 
         return result
 

--- a/rewrite-python/rewrite/src/rewrite/python/template/template.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/template.py
@@ -16,15 +16,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Dict, List, Optional, Tuple, Union, TYPE_CHECKING
 
 from rewrite.java import J
+from rewrite.python.visitor import PythonVisitor
 from .capture import Capture
 from .coordinates import PythonCoordinates
 from .engine import TemplateEngine, TemplateOptions
 
 if TYPE_CHECKING:
     from rewrite.visitor import Cursor
+    from .bindings import ContextBinding
     from .pattern import MatchResult
 
 
@@ -38,17 +40,17 @@ class Template:
     Examples:
         # Simple template
         tmpl = template("x + 1")
-        result = tmpl.apply(cursor)
+        result = tmpl.apply(self)
 
         # Template with capture from pattern match
         expr = capture('expr')
         tmpl = template(f"print({expr})")
-        result = tmpl.apply(cursor, values=match_result)
+        result = tmpl.apply(self, values=match_result)
 
-        # Template with imports
+        # Template whose context types it and is imported into the file it lands in
         tmpl = template(
             "datetime.now()",
-            imports=["from datetime import datetime"]
+            context=["from datetime import datetime"]
         )
     """
 
@@ -80,6 +82,7 @@ class Template:
             dependencies=tuple(sorted(dependencies.items())) if dependencies else (),
         )
         self._cached_tree: Optional[J] = None
+        self._context_bindings: Optional[Tuple['ContextBinding', ...]] = None
 
     @property
     def code(self) -> str:
@@ -106,9 +109,17 @@ class Template:
             )
         return self._cached_tree
 
+    def context_bindings(self) -> Tuple['ContextBinding', ...]:
+        """The modules this template's context binds, which the file it is spliced into has to
+        bind too for its code to run there."""
+        if self._context_bindings is None:
+            from .bindings import context_bindings
+            self._context_bindings = context_bindings(self._options.imports + self._options.context)
+        return self._context_bindings
+
     def apply(
         self,
-        cursor: 'Cursor',
+        cursor: Union['Cursor', PythonVisitor],
         *,
         values: Optional[Union['MatchResult', Dict[str, Any]]] = None,
         coordinates: Optional[PythonCoordinates] = None,
@@ -118,7 +129,8 @@ class Template:
         Apply this template, returning the generated AST node.
 
         Args:
-            cursor: Current position in the AST.
+            cursor: The visitor doing the edit, or its cursor. A template whose context imports
+                a module needs the visitor: the module reaches the file through it.
             values: Captured values from a pattern match, or a dict of values.
             coordinates: Where/how to insert (default: replace current).
             format: Whether the result is fitted to where it lands. Pass False to assemble
@@ -130,16 +142,38 @@ class Template:
 
         Examples:
             # Simple application
-            result = tmpl.apply(cursor)
+            result = tmpl.apply(self)
 
             # With values from pattern match
-            result = tmpl.apply(cursor, values=match)
+            result = tmpl.apply(self, values=match)
 
             # With explicit coordinates
-            result = tmpl.apply(cursor, coordinates=PythonCoordinates.after(node))
+            result = tmpl.apply(self, coordinates=PythonCoordinates.after(node))
         """
+        if isinstance(cursor, PythonVisitor):
+            visitor: Optional[PythonVisitor] = cursor
+            at: Optional['Cursor'] = cursor.cursor
+        else:
+            visitor, at = None, cursor
+
+        renames: Dict[str, str] = {}
+        if self.context_bindings():
+            if visitor is None:
+                raise ValueError(
+                    f"Template imports {', '.join(sorted({b.module for b in self.context_bindings()}))} "
+                    "in its context, so applying it has to bind those modules in the file it is "
+                    "spliced into. Pass the visitor — apply(self, ...) — rather than its cursor.")
+            from .bindings import bind_context
+            renames = bind_context(visitor, self.context_bindings())
+
         # Get the template tree
         template_tree = self.get_tree()
+
+        # A name the file already binds is the one the spliced code has to use, and renaming ahead
+        # of substitution keeps the rename off the values, which are the target file's own code.
+        if renames:
+            from .bindings import RenameBindings
+            template_tree = RenameBindings(renames).visit(template_tree, None)
 
         # Convert MatchResult to dict if needed
         values_dict: Dict[str, Union[J, List[J]]] = {}
@@ -162,21 +196,21 @@ class Template:
         # Phase 2: parenthesize the result for the slot it replaces, mirroring JavaTemplate.doApply().
         # This must happen before coordinates are applied, because
         # apply_coordinates may wrap the expression in ExpressionStatement.
-        if result is not None and cursor is not None:
+        if result is not None and at is not None:
             from .precedence import enclosing_tree, maybe_parenthesize
-            target = cursor.value
+            target = at.value
             if isinstance(target, J):
-                result = maybe_parenthesize(enclosing_tree(cursor.parent), target.id, result)
+                result = maybe_parenthesize(enclosing_tree(at.parent), target.id, result)
 
         # Phase 3: apply coordinates (prefix preservation, statement wrapping, auto-format)
         effective_coords = coordinates
-        if effective_coords is None and cursor is not None:
-            tree = cursor.value
+        if effective_coords is None and at is not None:
+            tree = at.value
             if tree is not None:
                 effective_coords = PythonCoordinates.replace(tree)
 
         if effective_coords is not None and result is not None:
-            result = TemplateEngine.apply_coordinates(result, cursor, effective_coords, format)
+            result = TemplateEngine.apply_coordinates(result, at, effective_coords, format)
 
         return result
 

--- a/rewrite-python/rewrite/src/rewrite/python/template/template.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/template.py
@@ -125,6 +125,7 @@ class Template:
         self,
         cursor: Union['Cursor', TreeVisitor],
         *,
+        visitor: Optional[TreeVisitor] = None,
         values: Optional[Union['MatchResult', Dict[str, Any]]] = None,
         coordinates: Optional[PythonCoordinates] = None,
         format: bool = True,
@@ -133,8 +134,11 @@ class Template:
         Apply this template, returning the generated AST node.
 
         Args:
-            cursor: The visitor doing the edit, or its cursor. A template whose context imports
-                a module needs the visitor: the module reaches the file through it.
+            cursor: Where the result lands — a visitor stands for its own cursor, which is
+                where a recipe splices what it is visiting.
+            visitor: The visitor doing the edit, for a splice landing somewhere other than where
+                it stands. A template whose context imports a module needs one either way: the
+                module reaches the file through it.
             values: Captured values from a pattern match, or a dict of values.
             coordinates: Where/how to insert (default: replace current).
             format: Whether the result is fitted to where it lands. Pass False to assemble
@@ -154,11 +158,9 @@ class Template:
             # With explicit coordinates
             result = tmpl.apply(self, coordinates=PythonCoordinates.after(node))
         """
-        if isinstance(cursor, TreeVisitor):
-            visitor: Optional[TreeVisitor] = cursor
-            at: Optional['Cursor'] = cursor.cursor
-        else:
-            visitor, at = None, cursor
+        at: Optional['Cursor'] = cursor.cursor if isinstance(cursor, TreeVisitor) else cursor
+        if visitor is None and isinstance(cursor, TreeVisitor):
+            visitor = cursor
 
         renames: Dict[str, str] = {}
         if self.context_bindings():
@@ -168,7 +170,9 @@ class Template:
                     "in its context, so applying it has to bind those modules in the file it is "
                     "spliced into. Pass the visitor — apply(self, ...) — rather than its cursor.")
             from .bindings import bind_context
-            renames = bind_context(visitor, self.context_bindings())
+            # The splice site decides which names are in scope, and it is where the visitor
+            # stands only for a recipe rewriting what it is visiting.
+            renames = bind_context(visitor, at or visitor.cursor, self.context_bindings())
 
         # Get the template tree
         template_tree = self.get_tree()

--- a/rewrite-python/rewrite/tests/python/template/test_template_imports.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template_imports.py
@@ -269,7 +269,7 @@ def test_a_scope_binding_the_name_to_something_else_refuses():
                 """,
             )
         )
-    assert "binds 'subprocess' to something other than" in str(refusal.value.cause)
+    assert "rather than the module 'subprocess'" in str(refusal.value.cause)
 
 
 def test_a_file_binding_the_name_to_another_module_refuses():
@@ -288,7 +288,7 @@ def test_a_file_binding_the_name_to_another_module_refuses():
                 """,
             )
         )
-    assert "other than 'subprocess'" in str(refusal.value.cause)
+    assert "other than 'run' from 'subprocess'" in str(refusal.value.cause)
 
 
 def test_an_aliased_member_merges_into_the_file_s_import_of_that_module():
@@ -308,6 +308,55 @@ def test_an_aliased_member_merges_into_the_file_s_import_of_that_module():
             import os
             from subprocess import Popen, run as r
             out = r('ls')
+            """,
+        )
+    )
+
+
+def test_a_local_import_covering_the_context_is_left_to_do_the_binding():
+    """A function importing lazily binds the name where the splice lands."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)", context=["import subprocess"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+
+
+            def listing():
+                import subprocess
+                return os.popen('ls')
+            """,
+            """
+            import os
+
+
+            def listing():
+                import subprocess
+                return subprocess.run('ls', shell=True)
+            """,
+        )
+    )
+
+
+def test_a_relative_context_import_stays_relative():
+    """``from . import util`` names a sibling module, never the standard library's."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"util.run({arg})", context=["from . import util"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            from . import util
+            out = util.run('ls')
             """,
         )
     )

--- a/rewrite-python/rewrite/tests/python/template/test_template_imports.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template_imports.py
@@ -46,7 +46,7 @@ def _recipe(pat, tmpl) -> Recipe:
                     method = super().visit_method_invocation(method, p)
                     match = pat.match(method, self.cursor)
                     if match:
-                        return tmpl.apply(self, values=match)
+                        return tmpl.apply(self.cursor, visitor=self, values=match)
                     return method
 
             return Visitor()
@@ -206,7 +206,7 @@ def test_import_lands_at_module_scope_for_a_splice_inside_a_function():
 def test_applying_to_a_cursor_cannot_bind_and_says_so():
     tmpl = template("subprocess.run('ls')", context=["import subprocess"])
 
-    with pytest.raises(ValueError, match="Pass the visitor"):
+    with pytest.raises(ValueError, match="Name the visitor"):
         tmpl.apply(cursor=None)
 
 

--- a/rewrite-python/rewrite/tests/python/template/test_template_imports.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template_imports.py
@@ -17,6 +17,7 @@
 import pytest
 
 from rewrite import ExecutionContext, Recipe
+from rewrite.execution import RecipeRunException
 from rewrite.python.template import capture, pattern, template
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
@@ -149,7 +150,8 @@ def test_conditional_import_does_not_bind_at_runtime():
 
 
 def test_context_the_template_does_not_reference_is_not_imported():
-    """Context typing a capture is not code the template splices, so it imports nothing."""
+    """Context typing a capture is not code the template splices, so it imports nothing —
+    not even into a file that spells the same name for its own purposes."""
     arg = capture('arg')
     pat = pattern(f"os.popen({arg})", context=["import os"])
     tmpl = template(f"subprocess.run({arg}, shell=True)",
@@ -159,11 +161,15 @@ def test_context_the_template_does_not_reference_is_not_imported():
         python(
             """
             import os
+            Any = 3
+            print(Any)
             out = os.popen('ls')
             """,
             """
             import os
             import subprocess
+            Any = 3
+            print(Any)
             out = subprocess.run('ls', shell=True)
             """,
         )
@@ -222,3 +228,64 @@ def test_dotted_module_binds_its_root():
             """,
         )
     )
+
+
+def test_a_name_the_template_binds_itself_is_not_a_context_reference():
+    """The comprehension's ``run`` is the template's own, whatever the context calls the same name."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"[run(i) for run in {arg}]", context=["from subprocess import run"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            from subprocess import run as r
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            from subprocess import run as r
+            out = [run(i) for run in 'ls']
+            """,
+        )
+    )
+
+
+def test_a_scope_binding_the_name_to_something_else_refuses():
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)", context=["import subprocess"])
+
+    with pytest.raises(RecipeRunException) as refusal:
+        RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+            python(
+                """
+                import os
+                import subprocess
+
+                def listing(subprocess):
+                    return os.popen('ls')
+                """,
+            )
+        )
+    assert "binds 'subprocess' to something other than" in str(refusal.value.cause)
+
+
+def test_a_file_binding_the_name_to_another_module_refuses():
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"run({arg}, shell=True)", context=["from subprocess import run"])
+
+    with pytest.raises(RecipeRunException) as refusal:
+        RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+            python(
+                """
+                import os
+                from mylib import run
+                print(run)
+                out = os.popen('ls')
+                """,
+            )
+        )
+    assert "other than 'subprocess'" in str(refusal.value.cause)

--- a/rewrite-python/rewrite/tests/python/template/test_template_imports.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template_imports.py
@@ -21,6 +21,7 @@ from rewrite.execution import RecipeRunException
 from rewrite.python.template import capture, pattern, template
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
+from rewrite.visitor import Cursor
 
 
 def _recipe(pat, tmpl) -> Recipe:
@@ -357,6 +358,62 @@ def test_a_relative_context_import_stays_relative():
             import os
             from . import util
             out = util.run('ls')
+            """,
+        )
+    )
+
+
+def test_a_splice_reads_the_scope_it_lands_in_not_the_one_the_visitor_stands_in():
+    """A recipe naming both splices where it is not standing, and the local import there — not
+    the file's module scope — is what decides the binding."""
+    tmpl = template("return subprocess.run('ls', shell=True)", context=["import subprocess"])
+
+    class Rewrite(Recipe):
+        @property
+        def name(self):
+            return "test.Rewrite"
+
+        @property
+        def display_name(self):
+            return "Rewrite"
+
+        @property
+        def description(self):
+            return "Rewrite."
+
+        def editor(self):
+            class Visitor(PythonVisitor[ExecutionContext]):
+                def visit_compilation_unit(self, cu, p):
+                    method = cu.statements[-1]
+                    body = method.body
+                    padded = list(body.padding.statements)
+                    last = padded[-1]
+                    at = Cursor(Cursor(Cursor(self.cursor, method), body), last.element)
+                    padded[-1] = last.replace(element=tmpl.apply(at, visitor=self))
+                    outer = list(cu.padding.statements)
+                    outer[-1] = outer[-1].replace(
+                        element=method.replace(body=body.padding.replace(_statements=padded)))
+                    return cu.padding.replace(_statements=outer)
+
+            return Visitor()
+
+    RecipeSpec(recipe=Rewrite()).rewrite_run(
+        python(
+            """
+            import os
+
+
+            def listing():
+                import subprocess
+                return os.popen('ls')
+            """,
+            """
+            import os
+
+
+            def listing():
+                import subprocess
+                return subprocess.run('ls', shell=True)
             """,
         )
     )

--- a/rewrite-python/rewrite/tests/python/template/test_template_imports.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template_imports.py
@@ -1,0 +1,224 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the imports a spliced template brings into the file it lands in."""
+
+import pytest
+
+from rewrite import ExecutionContext, Recipe
+from rewrite.python.template import capture, pattern, template
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, python
+
+
+def _recipe(pat, tmpl) -> Recipe:
+    """A recipe replacing every match of ``pat`` with ``tmpl``."""
+
+    class Replace(Recipe):
+        @property
+        def name(self):
+            return "test.Replace"
+
+        @property
+        def display_name(self):
+            return "Replace"
+
+        @property
+        def description(self):
+            return "Replace."
+
+        def editor(self):
+            class Visitor(PythonVisitor[ExecutionContext]):
+                def visit_method_invocation(self, method, p):
+                    method = super().visit_method_invocation(method, p)
+                    match = pat.match(method, self.cursor)
+                    if match:
+                        return tmpl.apply(self, values=match)
+                    return method
+
+            return Visitor()
+
+    return Replace()
+
+
+def test_context_import_reaches_the_target_file():
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)", context=["import subprocess"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            import subprocess
+            out = subprocess.run('ls', shell=True)
+            """,
+        )
+    )
+
+
+def test_reference_uses_the_name_the_file_already_binds():
+    """A file importing the module under an alias binds it once, under that alias."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)", context=["import subprocess"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            import subprocess as sp
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            import subprocess as sp
+            out = sp.run('ls', shell=True)
+            """,
+        )
+    )
+
+
+def test_member_import_does_not_bind_the_module():
+    """``from subprocess import run`` binds ``run``, so ``subprocess.run`` still needs the module."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)", context=["import subprocess"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            from subprocess import run
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            from subprocess import run
+            import subprocess
+            out = subprocess.run('ls', shell=True)
+            """,
+        )
+    )
+
+
+def test_conditional_import_does_not_bind_at_runtime():
+    """An ``if TYPE_CHECKING`` import binds nothing the spliced call could reach."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)", context=["import subprocess"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            from typing import TYPE_CHECKING
+
+            if TYPE_CHECKING:
+                import subprocess
+
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            from typing import TYPE_CHECKING
+            import subprocess
+
+            if TYPE_CHECKING:
+                import subprocess
+
+            out = subprocess.run('ls', shell=True)
+            """,
+        )
+    )
+
+
+def test_context_the_template_does_not_reference_is_not_imported():
+    """Context typing a capture is not code the template splices, so it imports nothing."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)",
+                    context=["import subprocess", "from typing import Any"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            import subprocess
+            out = subprocess.run('ls', shell=True)
+            """,
+        )
+    )
+
+
+def test_import_lands_at_module_scope_for_a_splice_inside_a_function():
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"subprocess.run({arg}, shell=True)", context=["import subprocess"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+
+
+            def listing():
+                return os.popen('ls')
+            """,
+            """
+            import os
+            import subprocess
+
+
+            def listing():
+                return subprocess.run('ls', shell=True)
+            """,
+        )
+    )
+
+
+def test_applying_to_a_cursor_cannot_bind_and_says_so():
+    tmpl = template("subprocess.run('ls')", context=["import subprocess"])
+
+    with pytest.raises(ValueError, match="Pass the visitor"):
+        tmpl.apply(cursor=None)
+
+
+def test_dotted_module_binds_its_root():
+    """``import os.path`` binds ``os``, which is the name the spliced code reads through."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"os.path.basename({arg})", context=["import os.path"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            import os.path
+            out = os.path.basename('ls')
+            """,
+        )
+    )

--- a/rewrite-python/rewrite/tests/python/template/test_template_imports.py
+++ b/rewrite-python/rewrite/tests/python/template/test_template_imports.py
@@ -289,3 +289,25 @@ def test_a_file_binding_the_name_to_another_module_refuses():
             )
         )
     assert "other than 'subprocess'" in str(refusal.value.cause)
+
+
+def test_an_aliased_member_merges_into_the_file_s_import_of_that_module():
+    """The context's alias is the name imported, and the module's existing import carries it."""
+    arg = capture('arg')
+    pat = pattern(f"os.popen({arg})", context=["import os"])
+    tmpl = template(f"r({arg})", context=["from subprocess import run as r"])
+
+    RecipeSpec(recipe=_recipe(pat, tmpl)).rewrite_run(
+        python(
+            """
+            import os
+            from subprocess import Popen
+            out = os.popen('ls')
+            """,
+            """
+            import os
+            from subprocess import Popen, run as r
+            out = r('ls')
+            """,
+        )
+    )

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
@@ -136,8 +136,9 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
     }
 
     private boolean isReferenced(Py.CompilationUnit cu) {
+        // `import a.b.c` binds only `a`, so that is the name a use of it reads through.
         String target = alias != null ? alias :
-                name != null ? name : module.substring(module.lastIndexOf('.') + 1);
+                name != null ? name : module.split("\\.", 2)[0];
         Pattern spelledIn = Pattern.compile("\\b" + Pattern.quote(target) + "\\b");
         AtomicBoolean found = new AtomicBoolean();
         new PythonVisitor<AtomicBoolean>() {

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonAddImportVisitorTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonAddImportVisitorTest.java
@@ -89,6 +89,11 @@ class PythonAddImportVisitorTest {
     }
 
     @Test
+    void countsAUseOfTheRootPackageAsAReferenceToADottedModule() {
+        assertThat(mightChange("os.path", null, null, true, cu(use("os.getcwd")))).isTrue();
+    }
+
+    @Test
     void doesNotCountAnIdentifierBoundByAnImportAsAReference() {
         assertThat(mightChange("pathlib", null, null, true,
           cu(directImport(member("pathlib", "o", null))))).isFalse();

--- a/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImports.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/service/PythonImports.java
@@ -80,6 +80,11 @@ final class PythonImports {
     }
 
     /** A dotted name as the parser models it outside an import qualid: no empty target. */
+    /** A statement reading {@code dotted}, as against an import binding it. */
+    static Statement use(String dotted) {
+        return new Py.ExpressionStatement(randomId(), name(dotted));
+    }
+
     private static Expression name(String dotted) {
         String[] parts = dotted.split("\\.");
         Expression result = identifier(parts[0]);


### PR DESCRIPTION
A Python template's `context` parsed the template and nothing else, so a recipe splicing a name the target file did not import emitted code that raises `NameError` when it runs. It parses, it prints, and it reads as correct in a diff: two recipes in a downstream package shipped that way, their docstrings showing an import the code never emitted and their tests asserting the broken output as expected. Both were found by reading.

A template's `context` is now also what it needs bound where it lands:

```python
_arg = capture('arg')
_tmpl = template(f"subprocess.run({_arg}, shell=True)", context=["import subprocess"])

class Visitor(PythonVisitor[ExecutionContext]):
    def visit_method_invocation(self, method, p):
        match = _pat.match(method, self.cursor)
        return _tmpl.apply(self.cursor, visitor=self, values=match) if match else method
```

Applied to `out = os.popen('ls')`, what the file already binds decides what it gets:

| the file binds | the splice reads | imports added |
|---|---|---|
| nothing | `subprocess.run('ls', shell=True)` | `import subprocess` |
| `import subprocess as sp` | `sp.run('ls', shell=True)` | none |
| `from subprocess import run` | `subprocess.run('ls', shell=True)` | `import subprocess` — a member import does not bind the module |
| `if TYPE_CHECKING: import subprocess` | `subprocess.run('ls', shell=True)` | `import subprocess` — a conditional import binds nothing at runtime |
| `import subprocess` in the enclosing function | `subprocess.run('ls', shell=True)` | none — the local import binds it |
| `subprocess` in an enclosing scope, bound to anything else | — | refused: no import reaches a shadowed name |

A context binding counts only where the template's own code reads it, judged per occurrence, so a name the template binds for itself (a comprehension variable, a parameter) is neither renamed nor imported, and context that exists only to type a capture stays out of the file entirely. What does get imported joins the file's existing import of the same module — `from subprocess import Popen` becomes `Popen, run as r` — under whichever name the context or the file aliases it to, and a relative context import stays relative, `from . import util` naming a sibling module rather than the standard library's.

`visitor=` is what reaches the file's imports; the cursor is where the result lands, and the two differ for a recipe splicing somewhere other than where it stands — the scope questions are asked at the cursor. Omitting the visitor still works for a template whose context binds no module — `context=["MyType = int"]`, or no context at all — and raises otherwise, naming the modules and the call to make.

## Why automatic

TypeScript already treats this as the template's job. `Template.resolveBindings(visitor)` binds each module the context declares and returns the local name it actually bound; `apply({bindings})` renames the template's references to those names; and `rewrite(...).tryOn(cursor, node, {visitor: this})` does the whole thing once a pattern matches, throwing if it was given neither a visitor nor bindings (`templating/rewrite.ts:65`). Python has no `tryOn` — `apply()` is the splice path — so the wiring and the refusal both land there.

## Where it refuses rather than deconflicts

TS's `maybeBind` picks another name when the one it wants is taken. This has no such machinery, so it raises in the two cases where emitting the reference would read the wrong object: a scope at the splice site binding the name, and a module-scope import binding it to another module — the second would otherwise rebind a name the file already reads. `from subprocess import run as _run` in the context is the way out of the latter.

Reconciling the two import styles — collapsing a spliced `subprocess.run(...)` to `run(...)` where the file already imports the member — is #8791. It belongs to a normalizer that sees the whole file, not to the splice: binding is per member, so a template reading two members of a partly-imported module can be collapsed for neither use or for one.

## Tests

`tests/python/template/test_template_imports.py`, one per decision — the table's five rows, the module-scope import that a taken name refuses, context the template never references, a name the template binds for itself, a splice inside a function whose import still lands at module scope, and the cursor-only call that raises.

The dotted-module row turned up a second bug, in both halves of one predicate: `AddImport._is_referenced` and `PythonAddImportVisitor.isReferenced` looked for the *last* segment of a dotted module, so `import os.path` was only ever added to a file already using a name `path`. `import a.b.c` binds `a`.





