### PR TITLE
JavaScript: fix infinite recursion in add import

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -2090,7 +2090,8 @@ class MovedTypes extends TypeVisitor<undefined> {
     /**
      * A type reached while it is still being visited is a cycle — a class holds a method whose
      * declaring type is that class — and answers with itself, which is what ends the walk. Every
-     * reference to a binding shares one type, so a completed walk is remembered for the next.
+     * type visited is remembered by its answer, so a graph whose references fan out or rejoin is
+     * walked once rather than once per path that reaches into it.
      */
     override async visit<T extends Type>(type: T | undefined, p: undefined): Promise<T | undefined> {
         if (type === undefined || this.onPath.has(type)) {
@@ -2102,11 +2103,7 @@ class MovedTypes extends TypeVisitor<undefined> {
         this.onPath.add(type);
         try {
             const answer = await super.visit(type, p);
-            // Only the type a walk entered at is remembered: one reached inside it may have met
-            // a back edge, which answers with the type itself and so stands for the path it was on.
-            if (this.onPath.size === 1) {
-                this.answered.set(type, answer);
-            }
+            this.answered.set(type, answer);
             return answer;
         } finally {
             this.onPath.delete(type);

--- a/rewrite-javascript/rewrite/src/javascript/add-import.ts
+++ b/rewrite-javascript/rewrite/src/javascript/add-import.ts
@@ -2091,7 +2091,8 @@ class MovedTypes extends TypeVisitor<undefined> {
      * A type reached while it is still being visited is a cycle — a class holds a method whose
      * declaring type is that class — and answers with itself, which is what ends the walk. Every
      * type visited is remembered by its answer, so a graph whose references fan out or rejoin is
-     * walked once rather than once per path that reaches into it.
+     * walked once rather than once per path that reaches into it. An answer settled inside a cycle
+     * stands for the path it was on, so a walk reusing it can leave a rename unapplied.
      */
     override async visit<T extends Type>(type: T | undefined, p: undefined): Promise<T | undefined> {
         if (type === undefined || this.onPath.has(type)) {

--- a/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
@@ -648,6 +648,7 @@ describe("change-import", () => {
             oldMember: "documentToken",
             newModule: "./core-token"
         });
+        const referenced: { name?: string, members?: number } = {};
 
         await withDir(async (repo) => {
             await spec.rewriteRun(
@@ -657,8 +658,21 @@ describe("change-import", () => {
                         ...typescript(
                             `import { documentToken } from './token';\n\nconst d = documentToken;\nconsole.log(d);\n`,
                             `import { documentToken } from './core-token';\n\nconst d = documentToken;\nconsole.log(d);\n`),
-                        path: "main.ts"
-                    },
+                        path: "main.ts",
+                        afterRecipe: async (cu: any) => {
+                            await new class extends JavaScriptVisitor<any> {
+                                override async visitIdentifier(id: J.Identifier, p: any): Promise<J | undefined> {
+                                    const type = id.type;
+                                    if (id.simpleName === "documentToken" && referenced.name === undefined &&
+                                        type !== undefined && Type.isFullyQualified(type)) {
+                                        referenced.name = Type.FullyQualified.getFullyQualifiedName(type as any);
+                                        referenced.members = (type as Type.Class).members.length;
+                                    }
+                                    return id;
+                                }
+                            }().visit(cu, undefined);
+                        }
+                    } as any,
                     {
                         ...typescript(`export const documentToken: Document = document;`),
                         path: "token.ts"
@@ -667,5 +681,10 @@ describe("change-import", () => {
                 )
             );
         }, { unsafeCleanup: true });
+
+        // `Document` reaches some 50k types, which is the only reason this case is large enough to
+        // guard the walk; with a primitive here the recipe finishes instantly and pins nothing.
+        expect(referenced.name).toBe("Document");
+        expect(referenced.members).toBeGreaterThan(100);
     }, 30000);
 });

--- a/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/recipes/change-import.test.ts
@@ -640,4 +640,32 @@ describe("change-import", () => {
         // Printing does not show a method type's module, so this is what pins the sibling's.
         expect(attribution).toEqual(["lodash-es.assign", "lodash.flatten"]);
     });
+
+    test("moving a reference typed by a large graph terminates", async () => {
+        const spec = new RecipeSpec();
+        spec.recipe = new ChangeImport({
+            oldModule: "./token",
+            oldMember: "documentToken",
+            newModule: "./core-token"
+        });
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    {
+                        ...typescript(
+                            `import { documentToken } from './token';\n\nconst d = documentToken;\nconsole.log(d);\n`,
+                            `import { documentToken } from './core-token';\n\nconst d = documentToken;\nconsole.log(d);\n`),
+                        path: "main.ts"
+                    },
+                    {
+                        ...typescript(`export const documentToken: Document = document;`),
+                        path: "token.ts"
+                    },
+                    packageJson(`{"name": "test"}`)
+                )
+            );
+        }, { unsafeCleanup: true });
+    }, 30000);
 });


### PR DESCRIPTION
## What's changed?

A follow-up to #8708 I suppose. Changing the recursion guard in the new `MovedTypes` visitor of the Add Import in JavaScript.

## What's your motivation?

- Otherwise it would run into what seems like an infinite loop, but probably is an exponential explosion of traversed paths. It hangs for 1hr+ in one of the derived modules.