### PR TITLE
Python: an associative operator lets its right operand regroup

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/template/precedence.py
+++ b/rewrite-python/rewrite/src/rewrite/python/template/precedence.py
@@ -114,6 +114,14 @@ _PY_BINARY_PRECEDENCE = {
     py.Binary.Type.StringConcatenation: Precedence.PRIMARY,
 }
 
+_ASSOCIATIVE = frozenset({j.Binary.Type.And, j.Binary.Type.Or})
+"""Operators whose right operand may stay unparenthesized at its own precedence.
+
+`and`/`or` are grammar, not the object protocol: both groupings call `__bool__`
+on the same operands in order and yield the same one. An overloadable operator
+is absent — `+` regroups differently on floats, `|`/`&`/`^` on `__ror__` dispatch.
+"""
+
 _UNARY_PRECEDENCE = {
     j.Unary.Type.Not: Precedence.NOT,
     j.Unary.Type.Negative: Precedence.UNARY,
@@ -309,6 +317,8 @@ def _binary_slot(parent, child_id: UUID) -> Optional[SlotConstraints]:
     if precedence == Precedence.POWER:
         # `**` is right-associative, and `-a ** b` means `-(a ** b)`, so its left operand takes no unary
         return SlotConstraints(Precedence.AWAIT if is_left else Precedence.UNARY)
+    if parent.operator in _ASSOCIATIVE:
+        return SlotConstraints(precedence)
     return SlotConstraints(precedence if is_left else precedence + 1)
 
 

--- a/rewrite-python/rewrite/tests/python/template/test_precedence.py
+++ b/rewrite-python/rewrite/tests/python/template/test_precedence.py
@@ -169,3 +169,25 @@ def test_a_comprehension_result_takes_an_expression():
         "a = d[p, q]\n",
         "a = [(p, q) for v in vs]\n",
     ))
+
+
+def test_an_associative_operator_lets_its_right_operand_regroup():
+    RecipeSpec(recipe=_rule("both({x})", "x and {x}")).rewrite_run(python(
+        "a = both(not p and not q)\n",
+        "a = x and not p and not q\n",
+    ))
+    RecipeSpec(recipe=_rule("either({x})", "x or {x}")).rewrite_run(python(
+        "a = either(p or q)\n",
+        "a = x or p or q\n",
+    ))
+
+
+def test_an_overloadable_operator_keeps_its_right_operand_parenthesized():
+    RecipeSpec(recipe=_rule("sum2({x})", "n + {x}")).rewrite_run(python(
+        "a = sum2(p + q)\n",
+        "a = n + (p + q)\n",
+    ))
+    RecipeSpec(recipe=_rule("union({x})", "s | {x}")).rewrite_run(python(
+        "a = union(p | q)\n",
+        "a = s | (p | q)\n",
+    ))

--- a/rewrite-python/rewrite/tests/python/template/test_replacement.py
+++ b/rewrite-python/rewrite/tests/python/template/test_replacement.py
@@ -193,21 +193,6 @@ class TestAutoParenthesization:
         assert isinstance(inner, j.Binary)
         assert inner.operator == j.Binary.Type.Or
 
-    def test_equal_precedence_right_operand_gets_parens(self):
-        """{a} and {b} with b=(x and y) parenthesizes, as every left-associative operator does."""
-        tree = TemplateEngine.get_template_tree(
-            "{a} and {b}", {'a': capture('a'), 'b': capture('b')}
-        )
-        and_expr = _make_binary(_ident('x'), j.Binary.Type.And, _ident('y'))
-        visitor = PlaceholderReplacementVisitor({
-            'a': _ident('a'),
-            'b': and_expr,
-        })
-        result = visitor.visit(tree, None)
-
-        assert isinstance(result, j.Binary)
-        assert isinstance(result.right, j.Parentheses)
-
     def test_or_operand_in_left_of_and_gets_parens(self):
         """{a} and {b} with a=(p or q) should produce (p or q) and b."""
         tree = TemplateEngine.get_template_tree(


### PR DESCRIPTION
A template splicing an associative binary into a like-precedence slot parenthesizes it. `x and {b}` with `b` bound to `not p and not q` prints `x and (not p and not q)`, where the parentheses change nothing — and recipe output is read by humans in diffs.

- #8747 introduced this while fixing the opposite bug: an equally binding right operand kept no parentheses, so `10 - {x}` with `x` bound to `n - 1` printed `10 - n - 1`. It applied `precedence + 1` to every right operand uniformly — correct for `-`, `/`, `//`, `%` and the shifts, noise for `and` and `or`. It also flipped the test that said so:

```diff
-    def test_and_operand_in_and_no_parens(self):
-        """{a} and {b} with b=(x and y) should NOT add parens (same precedence)."""
+    def test_equal_precedence_right_operand_gets_parens(self):
+        """{a} and {b} with b=(x and y) parenthesizes, as every left-associative operator does."""
```

`_binary_slot` now returns the operator's own precedence for a member of `_ASSOCIATIVE`, which holds `and` and `or` and nothing else.

## Why the set stops there

The splice point has no type information — `n + {x}` gives the model a bare identifier — so the set is bounded by what holds for every possible operand.

`and` and `or` are grammar rather than the object protocol. No dunder implements either; only `__bool__` runs, and both groupings call it on the same operands in the same order and yield the same operand object:

```
a and b and c and d       ->  c    __bool__ calls: ['a', 'b', 'c']
a and (b and (c and d))   ->  c    __bool__ calls: ['a', 'b', 'c']
```

Every overloadable operator stays out. `|`, `&` and `^` are associative on ints and sets, but regrouping changes which dunder fires, so one grouping can return where the other raises:

```
(L() | R()) | R()   ->  'R.__ror__'
L() | (R() | R())   ->  TypeError: R.__or__ refuses
```

`+` and `*` break on floats, where the result differs rather than the dispatch:

```
(1e100 + -1e100) + 1.0   ->  1.0
1e100 + (-1e100 + 1.0)   ->  0.0
```

`*` likewise: `(-6.900554583951795 * -8.669698086408202) * -1.9681797102985037` is `-117.74777784626677` and `-117.74777784626679` regrouped. A spare parenthesis costs a reader a glance; a regrouped float sum costs a wrong answer.

## Tests

`test_an_associative_operator_lets_its_right_operand_regroup` drives `and` and `or` from source to source, each assertion pinning one member of the set. `test_an_overloadable_operator_keeps_its_right_operand_parenthesized` pins `+` and `|` still parenthesizing; the existing `10 - (n - 1)` test cannot guard that boundary, since nobody would add `Subtraction` to an associativity set while `+` is the tempting one.

- Two tests go: the one #8747 flipped, and no source-level twin for `or` into `and` was added, because `test_or_operand_in_and_gets_parens` already covers it at the visitor level. 2151 passed, 85 skipped in the non-RPC suite.
