### PR TITLE
JavaScript: fix autoformat of for loops with non-standard whitespace

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -3094,7 +3094,12 @@ export class JavaScriptParserVisitor {
                 prefix: this.prefix(this.findChildNode(node, ts.SyntaxKind.OpenParenToken)!),
                 markers: emptyMarkers,
                 init: [node.initializer ?
-                    (ts.isVariableDeclarationList(node.initializer) ? this.rightPadded(this.visit(node.initializer), this.suffix(node.initializer)) :
+                    (ts.isVariableDeclarationList(node.initializer) ? (() => {
+                            const initializerPrefix = this.prefix(node.initializer);
+                            return this.rightPadded(produce(this.visit(node.initializer), draft => {
+                                draft.prefix = initializerPrefix;
+                            }), this.suffix(node.initializer));
+                        })() :
                         this.rightPadded(ts.isStatement(node.initializer) ? this.visit(node.initializer) : {
                             kind: JS.Kind.ExpressionStatement,
                             id: randomId(),

--- a/rewrite-javascript/rewrite/test/javascript/whitespace-attachment.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/whitespace-attachment.test.ts
@@ -175,7 +175,12 @@ describe('whitespace should be attached to the outermost element', () => {
         "const userScores = new Map<string, number>()",
         "function* generateUsers() { yield { id: 1 } };",
         "type T = undefined extends undefined ? string : never;",
-        "const FirstEntity = class FirstEntityClass {};"
+        "const FirstEntity = class FirstEntityClass {};",
+        `
+        for (
+          let i = 0; i < numberOfConnections; i++
+        ) {}
+        `
     ])('%s', async (sourceCode) => {
         // given
         const parser = new JavaScriptParser({sourceFileCache});


### PR DESCRIPTION
## What's changed?

Fixing autoformat of `for` loops in JavaScript which have non-standard whitespace, e.g. multiline `for` header.

## What's your motivation?

- fixes #7951