### PR TITLE
JavaScript: spacing owns the operators TypeScript adds to the Java model

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/format/format.ts
+++ b/rewrite-javascript/rewrite/src/javascript/format/format.ts
@@ -119,6 +119,9 @@ function tabsAndIndentsFrom(prettierStyle: PrettierStyle, fallback: TabsAndInden
     return {...fallback, useTabCharacter, tabSize: tabWidth, indentSize: tabWidth, continuationIndent: tabWidth};
 }
 
+/** A word operator carries its own separator, so no `aroundOperators` setting can take it away. */
+const WORD_OPERATOR_KEEPS_ITS_SEPARATOR = true;
+
 export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
     constructor(private style: SpacesStyle, private stopAfter?: Tree) {
         super();
@@ -156,6 +159,13 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                 draft.dimension.index.after.whitespace = this.style.within.arrayBrackets ? " " : "";
             }
         });
+    }
+
+    protected async visitAs(as_: JS.As, p: P): Promise<J | undefined> {
+        const ret = await super.visitAs(as_, p) as JS.As;
+        return produce(ret, draft => {
+            this.normalizeWordOperatorSeparator(draft.left, draft.right);
+        }) as JS.As;
     }
 
     protected async visitAssignment(assignment: J.Assignment, p: P): Promise<J | undefined> {
@@ -220,6 +230,37 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
                 draft.right.prefix.whitespace = property ? " " : "";
             }
         }) as J.Binary;
+    }
+
+    /** The operators TypeScript adds to the Java model; {@link SpacesVisitor#visitBinary} only sees a `J.Binary`. */
+    protected async visitBinaryExtensions(binary: JS.Binary, p: P): Promise<J | undefined> {
+        const ret = await super.visitBinaryExtensions(binary, p) as JS.Binary;
+        switch (ret.operator.element.valueOf()) {
+            case JS.Binary.Type.IdentityEquals:
+            case JS.Binary.Type.IdentityNotEquals:
+                return this.spaceAroundBinaryOperator(ret, this.style.aroundOperators.equality);
+            case JS.Binary.Type.QuestionQuestion:
+                return this.spaceAroundBinaryOperator(ret, this.style.aroundOperators.logical);
+            case JS.Binary.Type.In:
+            case JS.Binary.Type.As:
+                return this.spaceAroundBinaryOperator(ret, WORD_OPERATOR_KEEPS_ITS_SEPARATOR);
+            case JS.Binary.Type.Comma:
+                // The comma operator takes the comma rules, which are asymmetric.
+                return produce(ret, draft => {
+                    this.spaceBeforeLeftPaddedOperatorDraft(draft.operator, this.style.other.beforeComma);
+                    this.spaceBeforeDraft(draft.right, this.style.other.afterComma);
+                }) as JS.Binary;
+            default:
+                // Unknown operator: keep the author's spacing rather than throw mid-file.
+                return ret;
+        }
+    }
+
+    private spaceAroundBinaryOperator(binary: JS.Binary, space: boolean): JS.Binary {
+        return produce(binary, draft => {
+            this.spaceBeforeLeftPaddedOperatorDraft(draft.operator, space);
+            this.spaceBeforeDraft(draft.right, space);
+        }) as JS.Binary;
     }
 
     protected async visitCase(aCase: J.Case, p: P): Promise<J | undefined> {
@@ -417,6 +458,13 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
         });
     }
 
+    protected async visitInstanceOf(instanceOf: J.InstanceOf, p: P): Promise<J | undefined> {
+        const ret = await super.visitInstanceOf(instanceOf, p) as J.InstanceOf;
+        return produce(ret, draft => {
+            this.normalizeWordOperatorSeparator(draft.expression, draft.class);
+        }) as J.InstanceOf;
+    }
+
     protected async visitMethodDeclaration(methodDecl: J.MethodDeclaration, p: P): Promise<J | undefined> {
         const ret = await super.visitMethodDeclaration(methodDecl, p) as J.MethodDeclaration;
         return produceAsync(ret, async draft => {
@@ -479,6 +527,13 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
             });
         }
         return pa;
+    }
+
+    protected async visitSatisfiesExpression(satisfies: JS.SatisfiesExpression, p: P): Promise<J | undefined> {
+        const ret = await super.visitSatisfiesExpression(satisfies, p) as JS.SatisfiesExpression;
+        return produce(ret, draft => {
+            this.spaceBeforeLeftPaddedElementDraft(draft.satisfiesType, WORD_OPERATOR_KEEPS_ITS_SEPARATOR, WORD_OPERATOR_KEEPS_ITS_SEPARATOR);
+        }) as JS.SatisfiesExpression;
     }
 
     protected async visitSwitch(switchNode: J.Switch, p: P): Promise<J | undefined> {
@@ -661,6 +716,24 @@ export class SpacesVisitor<P> extends JavaScriptVisitor<P> {
             draft.after.whitespace = " ";
         } else if (!spaceAfter && SpacesVisitor.isOnlySpacesAndNotEmpty(draft.after.whitespace)) {
             draft.after.whitespace = "";
+        }
+    }
+
+    /** Normalizes to the one space a word operator needs; `xasany` and `"k"ino` would not parse. */
+    private normalizeWordOperatorSeparator<L extends J, R extends J>(left: Draft<J.RightPadded<L>>, right: Draft<R>): void {
+        this.spaceAfterRightPaddedDraft(left, WORD_OPERATOR_KEEPS_ITS_SEPARATOR);
+        this.spaceBeforeDraft(right, WORD_OPERATOR_KEEPS_ITS_SEPARATOR);
+    }
+
+    /** Modifies the before space of a LeftPadded draft whose element is not a tree, in place. */
+    private spaceBeforeLeftPaddedOperatorDraft<T extends J | J.Space | number | string | boolean>(draft: Draft<J.LeftPadded<T>>, spaceBefore: boolean): void {
+        if (draft.before.comments.length > 0) {
+            return;
+        }
+        if (spaceBefore && SpacesVisitor.isNotSingleSpace(draft.before.whitespace)) {
+            draft.before.whitespace = " ";
+        } else if (!spaceBefore && SpacesVisitor.isOnlySpacesAndNotEmpty(draft.before.whitespace)) {
+            draft.before.whitespace = "";
         }
     }
 

--- a/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/spaces-visitor.test.ts
@@ -266,6 +266,79 @@ describe('SpacesVisitor', () => {
             // @formatter:on
         )});
 
+    test('space around the operators TypeScript adds to the Java model', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `const a = x  ===  y;
+const b = x  !==  y;
+const c = x  ??  y;
+const d = "k"  in  o;
+const e = x  instanceof  Y;
+const f = x  as  any;
+const g = obj  satisfies  Shape;`,
+                `const a = x === y;
+const b = x !== y;
+const c = x ?? y;
+const d = "k" in o;
+const e = x instanceof Y;
+const f = x as any;
+const g = obj satisfies Shape;`)
+            // @formatter:on
+        )});
+
+    test('the aroundOperators settings reach those operators too', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces(draft => {
+            draft.aroundOperators.equality = false;
+            draft.aroundOperators.logical = false;
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `const a = x == y;
+const b = x === y;
+const c = x !== y;
+const d = x && y;
+const e = x ?? y;`,
+                `const a = x==y;
+const b = x===y;
+const c = x!==y;
+const d = x&&y;
+const e = x??y;`)
+            // @formatter:on
+        )});
+
+    test('a word operator keeps its space whatever the settings say', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces(draft => {
+            draft.aroundOperators.equality = false;
+            draft.aroundOperators.relational = false;
+            draft.aroundOperators.logical = false;
+        })));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `const a = "k" in o;
+const b = x instanceof Y;
+const c = x as any;
+const d = obj satisfies Shape;`)
+            // @formatter:on
+        )});
+
+    test('a line break around one of those operators is the author\'s', () => {
+        spec.recipe = fromVisitor(new SpacesVisitor(spaces()));
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `const a = someLongCondition
+    ?? someOtherValue;`)
+            // @formatter:on
+        )});
+
     test('assignment with newline after = should not collapse to single line', () => {
         spec.recipe = fromVisitor(new SpacesVisitor(spaces()));
         return spec.rewriteRun(


### PR DESCRIPTION
- `autoFormat` normalizes the spacing around every operator the Java model already had and leaves every operator TypeScript added alone. `x  ==  y` comes back as `x == y`; `x  ===  y` comes back untouched. The `aroundOperators` settings that name equality, relational and logical do nothing for those operators in either direction — with `equality: false`, `x == y` collapses to `x==y` while `x === y` is left as written. Measured on `main` at `ee6e1f0718`.

| Operator | LST | `x  ⋯  y` after `autoFormat` before this change |
|---|---|---|
| `===` `!==` | `JS.Binary` | `x  ===  y` |
| `in` | `JS.Binary` | `"k"  in  o` |
| `??` | `JS.Binary` | `x  ??  y` |
| `,` | `JS.Binary` | `x  ,  y` |
| `instanceof` | `J.InstanceOf` | `x  instanceof  Y` |
| `as` | `JS.As` | `x  as  any` |
| `satisfies` | `JS.SatisfiesExpression` | `obj  satisfies  Shape` |

## The mechanism

`SpacesVisitor` implements `visitBinary` and nothing dispatches on the four kinds beside it. The parser decides which one you get: `===`, `!==`, `in`, `??` and the comma operator are `JS.Binary`, while `instanceof`, `as` and `satisfies` have kinds of their own. `visitBinary`'s switch ends in `default: throw new Error("Unsupported operator type " + ...)`, so it was written to be reachable only from `J.Binary$Type` — the JS half was never a gap someone left open, it was never in scope.

Four overrides close it. The punctuators read the same style fields `visitBinary` already reads.

## Why the word operators take no setting

`in`, `instanceof`, `as` and `satisfies` normalize to exactly one space and consult nothing. `MinimumViableSpacingVisitor` sits at index 1 of the `AutoformatVisitor` pipeline and guarantees their separator, but its `ensureSpace` only fills whitespace that is empty — it never collapses `x  as  any`. `SpacesVisitor` sits at index 4, so a setting honoured here would undo that guarantee with nothing left to repair it, and print `"k"ino`. `SpacesVisitor` is also constructed directly by recipes that want spacing without a full autoformat, so it cannot assume the earlier visitor ran at all.

That leaves it one job on those operators, which is turning two spaces into one. `WORD_OPERATOR_KEEPS_ITS_SEPARATOR` names the constant so the next reader doesn't wire the setting in.

## One deliberate difference from `visitBinary`

The new switch's `default` arm returns the node unchanged where `visitBinary` throws. An operator kind added later should cost a line of unnormalized spacing, not an exception in the middle of formatting a file. Worth a second opinion if you'd rather the pair be identical.

## Derived styles reach this the same way they reach `==`

`spacesFrom` overrides `within.objectLiteralBraces` and `within.es6ImportExportBraces` from `bracketSpacing` and spreads the fallback for the rest, and `SpacesStatistics.getSpacesStyle` samples indentation and the three brace cases only. Neither derives `aroundOperators`, so `===` now resolves to the same value `==` already resolved to, from the same field. A project with a Prettier configuration reprints through `applyPrettierFormatting` and returns before any of this runs.

## Tests

Four in `spaces-visitor.test.ts`: the normalization above; the settings being consulted, with `equality` and `logical` off collapsing `==`, `===`, `!==`, `&&` and `??`; the word operators keeping their separator with `equality`, `relational` and `logical` all off; and a line break around `??` surviving. Each was confirmed to fail without the corresponding override.

## Scope

The keywords `MinimumViableSpacingVisitor` also protects — `typeof`, `void`, `delete`, `await`, `yield`, `keyof`, `is` — are prefix forms that no `aroundOperators` setting names, so normalizing their spacing is a separate question rather than part of this defect.

Typecheck, build and the whole of `test/javascript` are green: 156 files, 1916 passed, 21 skipped, nothing re-baselined. The diff adds 162 lines and changes none.
