### PR TITLE
JavaScript: a non-optional list slot reads as empty when a peer sends none

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/rpc.ts
+++ b/rewrite-javascript/rewrite/src/javascript/rpc.ts
@@ -817,7 +817,7 @@ class JavaScriptReceiver extends JavaScriptVisitor<RpcReceiveQueue> {
 
     override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, q: RpcReceiveQueue): Promise<J | undefined> {
         const updates = {
-            modifiers: await q.receiveList(propertyAssignment.modifiers, el => this.visitDefined<J.Modifier>(el, q)),
+            modifiers: await q.receiveListDefined(propertyAssignment.modifiers, el => this.visitDefined<J.Modifier>(el, q)),
             name: await q.receive(propertyAssignment.name, el => this.visitRightPadded(el, q)),
             assigmentToken: await q.receive(propertyAssignment.assigmentToken),
             initializer: await q.receive(propertyAssignment.initializer, el => this.visitDefined<Expression>(el, q))

--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -551,7 +551,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
         const updates: any = {
             prefix: await this.visitSpace(propertyAssignment.prefix, p),
             markers: await this.visitMarkers(propertyAssignment.markers, p),
-            modifiers: await mapAsync(propertyAssignment.modifiers ?? [], m => this.visitDefined<J.Modifier>(m, p)),
+            modifiers: await mapAsync(propertyAssignment.modifiers, m => this.visitDefined<J.Modifier>(m, p)),
             name: await this.visitRightPadded(propertyAssignment.name, p),
             initializer: propertyAssignment.initializer && await this.visitDefined<Expression>(propertyAssignment.initializer, p)
         };

--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -401,11 +401,15 @@ export class RpcReceiveQueue {
         });
     }
 
+    /**
+     * Receives a list slot the model declares non-optional, reading an absent list as empty. A peer
+     * holds null for such a slot in an LST deserialized before the slot existed.
+     */
     async receiveListDefined<T>(
         before: T[] | undefined,
         onChange?: (before: T) => T | Promise<T | undefined> | undefined
     ): Promise<T[]> {
-        return (await this.receiveList(before, onChange))!;
+        return (await this.receiveList(before, onChange)) ?? [];
     }
 
     receiveList<T>(

--- a/rewrite-javascript/rewrite/test/javascript/absent-list-slot.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/absent-list-slot.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {JavaScriptParser, JavaScriptVisitor, JS, sourceFileCache} from "../../src/javascript";
+import {J} from "../../src/java";
+import {ReferenceMap, RpcReceiveQueue, RpcSendQueue} from "../../src/rpc";
+import {TreePrinters} from "../../src/print";
+import {create as produce} from "mutative";
+
+const SOURCE = "const o = {a: 1};";
+
+const parser = new JavaScriptParser({sourceFileCache});
+
+class DropModifiers extends JavaScriptVisitor<undefined> {
+    protected override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, p: undefined): Promise<J | undefined> {
+        const visited = await super.visitPropertyAssignment(propertyAssignment, p) as JS.PropertyAssignment;
+        return produce(visited, draft => {
+            (draft as { modifiers?: J.Modifier[] }).modifiers = undefined;
+        });
+    }
+}
+
+test("a peer holding no modifiers list round-trips to an empty one", async () => {
+    const parsed = (await parser.parse({text: SOURCE, sourcePath: "t.ts"}).next()).value as JS.CompilationUnit;
+    const stale = await new DropModifiers().visit(parsed, undefined) as JS.CompilationUnit;
+
+    const batch = await new RpcSendQueue(new ReferenceMap(), JS.Kind.CompilationUnit, false).generate(stale, undefined);
+    const received = await new RpcReceiveQueue(new Map(), JS.Kind.CompilationUnit, async () => batch, undefined, false)
+        .receive<JS.CompilationUnit>(undefined);
+
+    const modifiers: (J.Modifier[] | undefined)[] = [];
+    await new class extends JavaScriptVisitor<undefined> {
+        protected override async visitPropertyAssignment(pa: JS.PropertyAssignment, p: undefined): Promise<J | undefined> {
+            modifiers.push(pa.modifiers);
+            return super.visitPropertyAssignment(pa, p);
+        }
+    }().visit(received, undefined);
+
+    expect(modifiers).toEqual([[]]);
+    expect(await TreePrinters.print(received)).toBe(SOURCE);
+});

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -735,35 +735,7 @@ const x = 1;`
         await prettier.rewriteRun(typescript(before, after));
     });
 
-    test('autoFormat tolerates a property assignment whose modifiers list is absent', () => {
-        const spec = new RecipeSpec();
-        spec.recipe = fromVisitor(new DropModifiersAndFormat());
-        return spec.rewriteRun(
-            // @formatter:off
-            //language=typescript
-            typescript(
-                `const x = new Foo({a: 1, b: 2});\nconst b = ! true;`,
-                `const x = new Foo({a: 1, b: 2});\nconst b = !true;`,
-            )
-            // @formatter:on
-        );
-    });
-
 });
-
-class DropModifiersAndFormat extends JavaScriptVisitor<ExecutionContext> {
-    protected override async visitJsCompilationUnit(cu: JS.CompilationUnit, ctx: ExecutionContext): Promise<J | undefined> {
-        const edited = await super.visitJsCompilationUnit(cu, ctx) as JS.CompilationUnit;
-        return autoFormat(edited, ctx);
-    }
-
-    protected override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, ctx: ExecutionContext): Promise<J | undefined> {
-        const visited = await super.visitPropertyAssignment(propertyAssignment, ctx) as JS.PropertyAssignment;
-        return produce(visited, draft => {
-            (draft as { modifiers?: J.Modifier[] }).modifiers = undefined;
-        });
-    }
-}
 
 /** The edit `eslint-plugin-import-x`'s `consistent-type-specifier-style` makes, plus a layout pass. */
 class HoistInlineTypeAndFormat extends JavaScriptVisitor<ExecutionContext> {


### PR DESCRIPTION
Printing a JavaScript or TypeScript source file whose LST predates #8720 fails with a `TypeError` from the printer. Observed while running recipes over a corpus of open-source repositories: 879 failed prints across 293 files in 7 repositories, reproduced on two consecutive days and on two different bundled `@openrewrite/rewrite` versions (8.91.3 and 8.91.5).

```
TypeError: propertyAssignment.modifiers is not iterable
    at JavaScriptPrinter.visitPropertyAssignment (.../src/javascript/print.ts:1423:44)
    at async JavaScriptPrinter.visitBlock (.../src/javascript/print.ts:556:9)
    at async JavaScriptPrinter.visitNewClass (.../src/javascript/print.ts:1311:26)
  org.openrewrite.rpc.RewriteRpc.print(RewriteRpc.java:689),
  org.openrewrite.SourceFile.printAll(SourceFile.java:123),
  org.openrewrite.text.PlainTextParser.convert(PlainTextParser.java:58),
  org.openrewrite.text.FindAndReplace$1.visit(FindAndReplace.java:118)
```

Per repository: Netflix/pollyjs 411, spring-guides/tut-spring-security-and-angular-js 339, Netflix/conductor 69, spring-projects/spring-security 33, Netflix/metaflow 21, spring-projects/spring-restdocs 3, spring-projects/spring-session 3. The failure does not mark the source file as errored, so it is easy to miss. #8799 hit the same absent slot from the auto-formatter.

## Mechanism

`JS.PropertyAssignment.modifiers` was added in #8720, so an LST serialized before it deserializes into the current Java type with `modifiers == null`. `RpcSendQueue.sendList` sends nothing for a null list against a null before-value, and the receiver leaves the slot at its `undefined` default. A freshly parsed tree is unaffected — the TypeScript parser populates the slot, so both peers hold `[]`.

## Fix

The receiver already has a helper for this. Non-optional list slots take `receiveListDefined`, optional ones take `receiveList` — 19 slots against 1 in `javascript/rpc.ts`, and in `java/rpc.ts` the bare calls end in `|| []`. #8720 added the one slot that reads a non-optional list with the un-coerced call (`JSX.Tag.children`, the only other bare call, is genuinely optional: its self-closing union branch declares `children?: undefined`).

But `receiveListDefined` was `(await this.receiveList(...))!` — a non-null assertion the compiler erases, so it promised the type checker something it never enforced at runtime. It now coerces with `?? []`, which makes its name true and closes the same gap for all 53 of its call sites. `modifiers` then uses it.

This deliberately leaves `JS.PropertyAssignment` alone. A null list is already harmless on the Java side — `ListUtils.map(null, …)` returns null and the wither is a no-op — so the model needs no nullable-slot accommodation.

## Superseding #8799

#8799 guarded one consumer, `JavaScriptVisitor.visitPropertyAssignment`, with `?? []`. That did not cover this crash, because `JavaScriptPrinter` overrides that method — `print.ts` has 15 more `for (… of x.modifiers)` loops, and every other one is safe only because its slot is received through `receiveListDefined`. Guarding the receiver instead is what keeps all 16 safe, so the guard is reverted here and `visitor.ts` is back to treating all 10 of its `modifiers` slots alike.

Its test goes with it. It cast past the model's own `readonly modifiers: J.Modifier[]` to build a tree the type forbids, then asserted a consumer tolerated it — so it passed on `main` while the crash above still shipped. The replacement asserts the state cannot reach a consumer in the first place.

## Tests

`absent-list-slot.test.ts` round-trips a parsed compilation unit whose `modifiers` slot is absent through `RpcSendQueue`/`RpcReceiveQueue`, then asserts the received tree holds `[]` and prints back to its source. Both halves are load-bearing under mutation: restoring the `!` in `receiveListDefined` fails it, and so does putting `modifiers` back on the bare `receiveList`.
