### PR TITLE
JavaScript: handle propertyAssignment.modifiers being empty

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/visitor.ts
+++ b/rewrite-javascript/rewrite/src/javascript/visitor.ts
@@ -551,7 +551,7 @@ export class JavaScriptVisitor<P> extends JavaVisitor<P> {
         const updates: any = {
             prefix: await this.visitSpace(propertyAssignment.prefix, p),
             markers: await this.visitMarkers(propertyAssignment.markers, p),
-            modifiers: await mapAsync(propertyAssignment.modifiers, m => this.visitDefined<J.Modifier>(m, p)),
+            modifiers: await mapAsync(propertyAssignment.modifiers ?? [], m => this.visitDefined<J.Modifier>(m, p)),
             name: await this.visitRightPadded(propertyAssignment.name, p),
             initializer: propertyAssignment.initializer && await this.visitDefined<Expression>(propertyAssignment.initializer, p)
         };

--- a/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/format/format.test.ts
@@ -735,7 +735,35 @@ const x = 1;`
         await prettier.rewriteRun(typescript(before, after));
     });
 
+    test('autoFormat tolerates a property assignment whose modifiers list is absent', () => {
+        const spec = new RecipeSpec();
+        spec.recipe = fromVisitor(new DropModifiersAndFormat());
+        return spec.rewriteRun(
+            // @formatter:off
+            //language=typescript
+            typescript(
+                `const x = new Foo({a: 1, b: 2});\nconst b = ! true;`,
+                `const x = new Foo({a: 1, b: 2});\nconst b = !true;`,
+            )
+            // @formatter:on
+        );
+    });
+
 });
+
+class DropModifiersAndFormat extends JavaScriptVisitor<ExecutionContext> {
+    protected override async visitJsCompilationUnit(cu: JS.CompilationUnit, ctx: ExecutionContext): Promise<J | undefined> {
+        const edited = await super.visitJsCompilationUnit(cu, ctx) as JS.CompilationUnit;
+        return autoFormat(edited, ctx);
+    }
+
+    protected override async visitPropertyAssignment(propertyAssignment: JS.PropertyAssignment, ctx: ExecutionContext): Promise<J | undefined> {
+        const visited = await super.visitPropertyAssignment(propertyAssignment, ctx) as JS.PropertyAssignment;
+        return produce(visited, draft => {
+            (draft as { modifiers?: J.Modifier[] }).modifiers = undefined;
+        });
+    }
+}
 
 /** The edit `eslint-plugin-import-x`'s `consistent-type-specifier-style` makes, plus a layout pass. */
 class HoistInlineTypeAndFormat extends JavaScriptVisitor<ExecutionContext> {


### PR DESCRIPTION
## What's changed?

Adding a null-safety guard for `propertyAssignment.modifiers` in JavaScript's visitor logic.

## What's your motivation?

Otherwise this tends to be observed, for instance in the auto formatter:
```
java.util.concurrent.CompletionException: io.moderne.jsonrpc.JsonRpcException: {code=-32603, message='Request Visit failed with message: TypeError: Cannot read properties of undefined (reading 'length')
    at mapAsync (/opt/moderne/cli/recipes/npm/bundled/8.91.5/node_modules/@openrewrite/rewrite/src/util.ts:19:29)
    at NormalizeWhitespaceVisitor.visitPropertyAssignment (/opt/moderne/cli/recipes/npm/bundled/8.91.5/node_modules/@openrewrite/rewrite/src/javascript/visitor.ts:554:38)
```