### PR TITLE
JavaTemplate: diagnose method templates that don't generate one invocation

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
@@ -730,4 +730,61 @@ class JavaTemplateTest8Test implements RewriteTest {
           .hasMessageContaining("JavaTemplate coordinates were never matched")
           .hasMessageContaining(J.MethodInvocation.class.getName());
     }
+
+    @Test
+    void replaceMethodThatGeneratesSomethingElseFailsLoudly() {
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build()
+          .parse(
+            """
+              class Test {
+                  String test(String s) {
+                      return s.trim();
+                  }
+              }
+              """
+          )
+          .map(J.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        assertThatThrownBy(() -> new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                return JavaTemplate.apply("length", getCursor(), method.getCoordinates().replaceMethod());
+            }
+        }.visit(cu, 0))
+          .rootCause()
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("but generated 1")
+          .hasMessageContaining(J.FieldAccess.class.getName())
+          .hasMessageContaining("s.trim()");
+    }
+
+    @Test
+    void replaceArgumentsThatGenerateNothingFailsLoudly() {
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build()
+          .parse(
+            """
+              class Test {
+                  String test(String s) {
+                      return s.trim();
+                  }
+              }
+              """
+          )
+          .map(J.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        assertThatThrownBy(() -> new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
+                return JavaTemplate.apply(")", getCursor(), method.getCoordinates().replaceArguments());
+            }
+        }.visit(cu, 0))
+          .rootCause()
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("but generated 0")
+          .hasMessageContaining("s.trim()");
+    }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateParser.java
@@ -205,8 +205,7 @@ public class JavaTemplateParser {
         @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacedNameAndArgs, typeVariables, location, JavaCoordinates.Mode.REPLACEMENT);
         onBeforeParseTemplate.accept(stub);
         JavaSourceFile cu = compileTemplate(cursor, stub);
-        return (J.MethodInvocation) statementTemplateGenerator
-                .listTemplatedTrees(cu, Statement.class).get(0);
+        return onlyMethodInvocation(statementTemplateGenerator.listTemplatedTrees(cu, Statement.class), stub, method);
     }
 
     public J.MethodInvocation parseMethodArguments(Cursor cursor, String template, Collection<JavaType.GenericTypeVariable> typeVariables, Space.Location location) {
@@ -219,8 +218,17 @@ public class JavaTemplateParser {
         @Language("java") String stub = statementTemplateGenerator.template(cursor, methodWithReplacementArgs, typeVariables, location, JavaCoordinates.Mode.REPLACEMENT);
         onBeforeParseTemplate.accept(stub);
         JavaSourceFile cu = compileTemplate(cursor, stub);
-        return (J.MethodInvocation) statementTemplateGenerator
-                .listTemplatedTrees(cu, Statement.class).get(0);
+        return onlyMethodInvocation(statementTemplateGenerator.listTemplatedTrees(cu, Statement.class), stub, method);
+    }
+
+    private static J.MethodInvocation onlyMethodInvocation(List<Statement> generated, String stub, J.MethodInvocation method) {
+        if (generated.size() != 1 || !(generated.get(0) instanceof J.MethodInvocation)) {
+            throw new IllegalArgumentException("Expected a template that would generate exactly one " +
+                                               "method invocation to replace one method invocation, but generated " + generated.size() +
+                                               " " + generated.stream().map(g -> g.getClass().getName()).collect(toList()) +
+                                               ". Stub:\n" + stub + "\nMethod invocation:\n" + method);
+        }
+        return (J.MethodInvocation) generated.get(0);
     }
 
     private boolean isStatement(Cursor cursor) {


### PR DESCRIPTION
Replacing a method invocation's name or arguments ends in an unchecked cast of the first templated tree. When a template does not generate exactly one `J.MethodInvocation`, the failure surfaces as whichever accident is hit first: a `ClassCastException` from the cast, or an `IndexOutOfBoundsException` from `get(0)`.

```java
return (J.MethodInvocation) statementTemplateGenerator
        .listTemplatedTrees(cu, Statement.class).get(0);
```

Both were observed on the same recipe and the same source file while running recipes over a corpus of open-source repositories, so triage split one defect into two unrelated-looking signatures. Neither exception names the template: `class org.openrewrite.java.tree.J$FieldAccess cannot be cast to class org.openrewrite.java.tree.J$MethodInvocation` doesn't say which template produced a field access.

Both sites now check the contract before the cast, mirroring `JavaTemplateJavaExtension.maybeReplaceStatement`, which already guards the analogous "exactly one statement" case. The exception type is the same `IllegalArgumentException`, so callers that catch it are unaffected:

```
java.lang.IllegalArgumentException: Expected a template that would generate exactly one method invocation to replace one method invocation, but generated 1 [org.openrewrite.java.tree.J$FieldAccess]. Stub:
import org.openrewrite.java.internal.template.__M__;
import org.openrewrite.java.internal.template.__P__;
class Template {{
Object o =
/*__TEMPLATE__*/s.length/*__TEMPLATE_STOP__*/
;
}}
Method invocation:
s.trim()
```

There is no recovery: when a template doesn't produce the expected tree there is no correct value to return, so the goal is only to make the failure legible.

Two tests in `JavaTemplateTest8Test` pin the two halves of the guard, one per call site:

- `replaceMethodThatGeneratesSomethingElseFailsLoudly` — template `length` at `replaceMethod()` generates a `J.FieldAccess`, and reproduces the `ClassCastException` before the fix.
- `replaceArgumentsThatGenerateNothingFailsLoudly` — template `)` at `replaceArguments()` generates no trees, and reproduces the `IndexOutOfBoundsException`.

### Scope

The pattern dates to d6fcff3990 and 8cac6d7457 (October 2021), so it is long-standing, not a regression.

8cac6d7457 made JavaTemplate work across the Java family of languages, and recipes accordingly accept any `JavaSourceFile`, while this site still parses its stub as Java. A source file from another Java-family language can therefore reach it and yield a tree the cast doesn't expect. Closing that gap is out of scope here.
