### PR TITLE
Go: fix how Switch statements are parsed, now with ControlParentheses

### DIFF
--- a/rewrite-go/pkg/format/minimum_spacing.go
+++ b/rewrite-go/pkg/format/minimum_spacing.go
@@ -314,16 +314,19 @@ func (v *MinimumViableSpacingVisitor) VisitIf(ifStmt *java.If, p any) java.J {
 
 func (v *MinimumViableSpacingVisitor) VisitSwitch(sw *java.Switch, p any) java.J {
 	out := v.GoVisitor.VisitSwitch(sw, p).(*java.Switch)
-	if out.Tag == nil {
+	if out.Selector == nil {
+		return out
+	}
+	if _, isEmpty := out.Selector.Tree.Element.(*java.Empty); isEmpty {
 		return out
 	}
 	if v.followsAnInit() {
 		return out
 	}
 	copied := *out
-	tag := *out.Tag
-	tag.Element = separateFrom("switch", tag.Element)
-	copied.Tag = &tag
+	selector := *out.Selector
+	selector.Tree.Element = separateFrom("switch", selector.Tree.Element, selector.Prefix)
+	copied.Selector = &selector
 	return &copied
 }
 

--- a/rewrite-go/pkg/parser/go_parser.go
+++ b/rewrite-go/pkg/parser/go_parser.go
@@ -1659,6 +1659,20 @@ func controlParentheses(inner java.Expression) *java.ControlParentheses {
 	}
 }
 
+// switchSelector wraps a switch selector in a ControlParentheses (matching
+// J.Switch). The selector's leading space is hoisted onto the wrapper so it
+// lives on the outermost element (the selector's own prefix), matching Java's
+// `switch (x)` model; the printer emits only the inner element (Go has no parens).
+func switchSelector(inner java.Expression) *java.ControlParentheses {
+	prefix, hoisted := hoistLeftPrefix(inner)
+	return &java.ControlParentheses{
+		ID:      uuid.New(),
+		Prefix:  prefix,
+		Markers: java.Markers{ID: uuid.New()},
+		Tree:    java.RightPadded[java.Expression]{Element: hoisted},
+	}
+}
+
 // wrapWithInit wraps an inner if/switch in a golang.StatementWithInit when an
 // init clause is present, moving the keyword prefix onto the wrapper and
 // leaving the inner statement prefix-less. With no init it returns inner as-is.
@@ -1702,11 +1716,9 @@ func (ctx *parseContext) mapSwitchStmt(stmt *ast.SwitchStmt) java.Statement {
 
 	init := ctx.mapInitClause(stmt.Init, stmt.Body.Lbrace)
 
-	var tag *java.RightPadded[java.Expression]
+	var selectorExpr java.Expression = &java.Empty{ID: uuid.New(), Markers: java.Markers{ID: uuid.New()}}
 	if stmt.Tag != nil {
-		tagExpr := ctx.mapExpr(stmt.Tag)
-		rp := java.RightPadded[java.Expression]{Element: tagExpr}
-		tag = &rp
+		selectorExpr = ctx.mapExpr(stmt.Tag)
 	}
 
 	body := ctx.mapBlockStmt(stmt.Body)
@@ -1716,10 +1728,10 @@ func (ctx *parseContext) mapSwitchStmt(stmt *ast.SwitchStmt) java.Statement {
 		innerPrefix = java.EmptySpace
 	}
 	return wrapWithInit(prefix, init, &java.Switch{
-		ID:     uuid.New(),
-		Prefix: innerPrefix,
-		Tag:    tag,
-		Body:   body,
+		ID:       uuid.New(),
+		Prefix:   innerPrefix,
+		Selector: switchSelector(selectorExpr),
+		Body:     body,
 	})
 }
 
@@ -1860,22 +1872,19 @@ func (ctx *parseContext) mapTypeSwitchStmt(stmt *ast.TypeSwitchStmt) java.Statem
 	init := ctx.mapInitClause(stmt.Init, stmt.Assign.Pos())
 
 	// The assign is `x.(type)` (ExprStmt) or `v := x.(type)` (AssignStmt)
-	var tag *java.RightPadded[java.Expression]
+	var selectorExpr java.Expression
 	switch a := stmt.Assign.(type) {
 	case *ast.ExprStmt:
 		// `x.(type)` — map the inner expression directly
-		expr := ctx.mapExpr(a.X)
-		if expr != nil {
-			rp := java.RightPadded[java.Expression]{Element: expr}
-			tag = &rp
-		}
+		selectorExpr = ctx.mapExpr(a.X)
 	case *ast.AssignStmt:
 		// `v := x.(type)` — map as assignment (which is also an Expression-like construct here)
-		assignStmt := ctx.mapAssignStmt(a)
-		if expr, ok := assignStmt.(java.Expression); ok {
-			rp := java.RightPadded[java.Expression]{Element: expr}
-			tag = &rp
+		if expr, ok := ctx.mapAssignStmt(a).(java.Expression); ok {
+			selectorExpr = expr
 		}
+	}
+	if selectorExpr == nil {
+		selectorExpr = &java.Empty{ID: uuid.New(), Markers: java.Markers{ID: uuid.New()}}
 	}
 
 	body := ctx.mapBlockStmt(stmt.Body)
@@ -1891,8 +1900,8 @@ func (ctx *parseContext) mapTypeSwitchStmt(stmt *ast.TypeSwitchStmt) java.Statem
 			ID:      uuid.New(),
 			Entries: []java.Marker{golang.TypeSwitchGuard{Ident: uuid.New()}},
 		},
-		Tag:  tag,
-		Body: body,
+		Selector: switchSelector(selectorExpr),
+		Body:     body,
 	})
 }
 

--- a/rewrite-go/pkg/printer/go_printer.go
+++ b/rewrite-go/pkg/printer/go_printer.go
@@ -607,9 +607,12 @@ func (p *GoPrinter) VisitSwitch(sw *java.Switch, param any) java.J {
 			out.Append(";")
 		}
 	}
-	if sw.Tag != nil {
-		p.Visit(sw.Tag.Element, out)
-		p.visitSpace(sw.Tag.After, out)
+	// The selector is a ControlParentheses (matching J.Switch), but Go has no
+	// parens, so emit only its inner element (an Empty for a tagless `switch {}`).
+	if sw.Selector != nil {
+		p.visitSpace(sw.Selector.Prefix, out)
+		p.Visit(sw.Selector.Tree.Element, out)
+		p.visitSpace(sw.Selector.Tree.After, out)
 	}
 	p.Visit(sw.Body, out)
 	p.afterSyntax(sw.Markers, out)

--- a/rewrite-go/pkg/rpc/java_receiver.go
+++ b/rewrite-go/pkg/rpc/java_receiver.go
@@ -529,22 +529,10 @@ func (r *JavaReceiver) VisitSwitch(sw *java.Switch, p any) java.J {
 	q := p.(*ReceiveQueue)
 	c := *sw // shallow copy to avoid mutating remoteObjects baseline
 	sw = &c
-	// selector - Java sends ControlParentheses, extract inner Expression for Tag
-	var selBefore any
-	if sw.Tag != nil {
-		selBefore = &java.ControlParentheses{
-			Tree: java.RightPadded[java.Expression]{Element: sw.Tag.Element, After: sw.Tag.After, Markers: sw.Tag.Markers},
-		}
-	}
-	if cpResult := q.Receive(selBefore, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
-		if cp, ok := cpResult.(*java.ControlParentheses); ok {
-			if _, isEmpty := cp.Tree.Element.(*java.Empty); !isEmpty {
-				sw.Tag = &java.RightPadded[java.Expression]{
-					Element: cp.Tree.Element,
-					After:   cp.Tree.After,
-				}
-			}
-		}
+	// selector - a ControlParentheses matching J.Switch; pass the existing one as
+	// the baseline so a changed selector keeps its unchanged children (mirroring VisitIf).
+	if cpResult := q.Receive(sw.Selector, func(v any) any { return r.Visit(v.(java.Tree), q) }); cpResult != nil {
+		sw.Selector = cpResult.(*java.ControlParentheses)
 	}
 	sw.Body = receiveValue(q, sw.Body, func(e *java.Block) any { return r.Visit(e, q) })
 	return sw

--- a/rewrite-go/pkg/rpc/java_sender.go
+++ b/rewrite-go/pkg/rpc/java_sender.go
@@ -19,7 +19,6 @@ package rpc
 import (
 	"strconv"
 
-	"github.com/google/uuid"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
 )
@@ -397,22 +396,9 @@ func (s *JavaSender) VisitForEachControl(fc *java.ForEachControl, p any) java.J 
 
 func (s *JavaSender) VisitSwitch(sw *java.Switch, p any) java.J {
 	q := p.(*SendQueue)
-	// selector - wrap tag in ControlParentheses for Java's J.Switch model
-	q.GetAndSend(sw, func(v any) any {
-		tag := v.(*java.Switch).Tag
-		var inner java.Expression
-		if tag != nil {
-			inner = tag.Element
-		} else {
-			// Tagless switch: use Empty as the expression
-			inner = &java.Empty{ID: uuid.New()}
-		}
-		return &java.ControlParentheses{
-			ID:      uuid.New(),
-			Markers: java.Markers{ID: uuid.New()},
-			Tree:    java.RightPadded[java.Expression]{Element: inner, After: java.EmptySpace},
-		}
-	}, func(v any) { s.Visit(v.(java.Tree), q) })
+	// selector - already a ControlParentheses, matching J.Switch
+	q.GetAndSend(sw, func(v any) any { return v.(*java.Switch).Selector },
+		func(v any) { s.Visit(v.(java.Tree), q) })
 	// cases (Block)
 	q.GetAndSend(sw, func(v any) any { return v.(*java.Switch).Body },
 		func(v any) { s.Visit(v.(java.Tree), q) })

--- a/rewrite-go/pkg/rpc/receive_queue.go
+++ b/rewrite-go/pkg/rpc/receive_queue.go
@@ -334,6 +334,16 @@ func receiveTypedList[T any](q *ReceiveQueue, before []T, onChange func(any) any
 				after[i] = before[pos]
 				continue
 			}
+			if !hasBefore && q.peek().State == NoChange {
+				// The sender diffed the edited tree against a baseline it believes
+				// this side holds and shipped this element as NO_CHANGE — but our
+				// baseline has nothing at this position, so its content never came
+				// over the wire and cannot be reconstructed. Fail with the cause
+				// named rather than letting the zero element nil-deref downstream in
+				// coerceToStatementRP/coerceToExpressionRP (openrewrite/rewrite#8424).
+				q.Take()
+				panic(fmt.Sprintf("RPC baseline desync: NO_CHANGE list element at position %d has no baseline (before holds %d element(s)); the sender diffed against a tree this receiver never received", pos, len(before)))
+			}
 			var beforeItem any
 			if hasBefore {
 				beforeItem = before[pos]

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -928,8 +928,8 @@ type Switch struct {
 	ID      uuid.UUID
 	Prefix  Space
 	Markers Markers
-	Tag     *RightPadded[Expression] // optional tag expression; After = space before {
-	Body    *Block                   // contains Case statements
+	Selector *ControlParentheses // selector expression (matching J.Switch); Go has no parens, so the wrapper carries no whitespace and the inner element holds the tag. Tree.Element is an Empty for a tagless `switch {}`. Tree.After = space before {
+	Body     *Block              // contains Case statements
 }
 
 func (*Switch) IsTree()      {}

--- a/rewrite-go/pkg/visitor/go_visitor.go
+++ b/rewrite-go/pkg/visitor/go_visitor.go
@@ -962,26 +962,19 @@ func (v *GoVisitor) VisitAssignmentOperation(ao *java.AssignmentOperation, p any
 func (v *GoVisitor) VisitSwitch(sw *java.Switch, p any) java.J {
 	prefix := v.self().VisitSpace(sw.Prefix, p)
 	markers := v.visitMarkers(sw.Markers, p)
-	tag := sw.Tag
-	if tag != nil {
-		elem := visitExpression(v, tag.Element, p)
-		after := v.self().VisitSpace(tag.After, p)
-		if elem != tag.Element || !java.SpaceEqual(after, tag.After) {
-			c := *tag
-			c.Element = elem
-			c.After = after
-			tag = &c
-		}
+	var selector *java.ControlParentheses
+	if sw.Selector != nil {
+		selector = visitAndCast[*java.ControlParentheses](v, sw.Selector, p)
 	}
 	body := visitAndCast[*java.Block](v, sw.Body, p)
 	if java.SpaceEqual(prefix, sw.Prefix) && java.MarkersEqual(markers, sw.Markers) &&
-		tag == sw.Tag && body == sw.Body {
+		selector == sw.Selector && body == sw.Body {
 		return sw
 	}
 	c := *sw
 	c.Prefix = prefix
 	c.Markers = markers
-	c.Tag = tag
+	c.Selector = selector
 	c.Body = body
 	return &c
 }


### PR DESCRIPTION
## What's changed?

Changing how `switch` statements are parsed in Go.
Adding the `ControlParenthesis` node.

## What's your motivation?

- This is what the LST structure on the Java side expects, even if Go syntax doesn't use parens.
- Partly fixes #8424.

