### PR TITLE
Override a Spring BOM property rather than pinning the version it governs

### DIFF
--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -89,12 +89,8 @@ public final class GradleProjectBuilder {
                 springDependencyManagementPlugin(project));
     }
 
-    /**
-     * The state of the {@code io.spring.dependency-management} plugin, which cannot be read from the build script:
-     * the Spring Boot plugin imports {@code spring-boot-dependencies} programmatically. Reflective throughout, as
-     * OpenRewrite must not depend on either plugin, and null whenever anything is unavailable so that recipes fall
-     * back to what the scripts say.
-     */
+    // Reflective because OpenRewrite depends on neither plugin, and null when anything is unavailable so that
+    // recipes fall back to what the scripts say.
     private static @Nullable SpringDependencyManagementPlugin springDependencyManagementPlugin(Project project) {
         try {
             Object extension = project.getExtensions().findByName("dependencyManagement");

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/marker/GradleProjectBuilder.java
@@ -38,6 +38,7 @@ import org.openrewrite.maven.tree.GroupArtifactVersion;
 import org.openrewrite.maven.tree.MavenRepository;
 import org.openrewrite.maven.tree.ResolvedGroupArtifactVersion;
 
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.*;
@@ -84,7 +85,81 @@ public final class GradleProjectBuilder {
                         randomId(),
                         new ArrayList<>(pluginRepositories),
                         GradleProjectBuilder.dependencyConfigurations(project.getBuildscript().getConfigurations())
-                ));
+                ),
+                springDependencyManagementPlugin(project));
+    }
+
+    /**
+     * The state of the {@code io.spring.dependency-management} plugin, which cannot be read from the build script:
+     * the Spring Boot plugin imports {@code spring-boot-dependencies} programmatically. Reflective throughout, as
+     * OpenRewrite must not depend on either plugin, and null whenever anything is unavailable so that recipes fall
+     * back to what the scripts say.
+     */
+    private static @Nullable SpringDependencyManagementPlugin springDependencyManagementPlugin(Project project) {
+        try {
+            Object extension = project.getExtensions().findByName("dependencyManagement");
+            if (extension == null) {
+                return null;
+            }
+            //noinspection unchecked
+            Map<String, String> importedProperties = (Map<String, String>) extension.getClass()
+                    .getMethod("getImportedProperties").invoke(extension);
+            //noinspection unchecked
+            Map<String, String> managedVersions = (Map<String, String>) extension.getClass()
+                    .getMethod("getManagedVersions").invoke(extension);
+            return new SpringDependencyManagementPlugin(
+                    importedBoms(project, extension),
+                    importedProperties == null ? emptyMap() : new LinkedHashMap<>(importedProperties),
+                    managedVersions == null ? emptyMap() : new LinkedHashMap<>(managedVersions));
+        } catch (Exception | LinkageError ignored) {
+            return null;
+        }
+    }
+
+    private static List<GroupArtifactVersion> importedBoms(Project project, Object extension) {
+        List<GroupArtifactVersion> boms = new ArrayList<>();
+        // The Boot plugin publishes the coordinates it imports, so prefer that over the other plugin's internals
+        Object bootPlugin = project.getPlugins().findPlugin("org.springframework.boot");
+        if (bootPlugin != null) {
+            try {
+                Object coordinates = bootPlugin.getClass().getField("BOM_COORDINATES").get(null);
+                GroupArtifactVersion gav = parseCoordinates(String.valueOf(coordinates));
+                if (gav != null) {
+                    boms.add(gav);
+                }
+            } catch (Exception | LinkageError ignored) {
+                // Fall through to the dependency management plugin's own view of what it imported
+            }
+        }
+        try {
+            Field containerField = extension.getClass().getDeclaredField("dependencyManagementContainer");
+            containerField.setAccessible(true);
+            Object container = containerField.get(extension);
+            Object globalDependencyManagement = container.getClass().getMethod("getGlobalDependencyManagement").invoke(container);
+            Method getImportedBomReferences = globalDependencyManagement.getClass().getDeclaredMethod("getImportedBomReferences");
+            getImportedBomReferences.setAccessible(true);
+            Object references = getImportedBomReferences.invoke(globalDependencyManagement);
+            if (references instanceof Iterable) {
+                for (Object reference : (Iterable<?>) references) {
+                    Object coordinates = reference.getClass().getMethod("getCoordinates").invoke(reference);
+                    GroupArtifactVersion gav = coordinates == null ? null : new GroupArtifactVersion(
+                            (String) coordinates.getClass().getMethod("getGroupId").invoke(coordinates),
+                            (String) coordinates.getClass().getMethod("getArtifactId").invoke(coordinates),
+                            (String) coordinates.getClass().getMethod("getVersion").invoke(coordinates));
+                    if (gav != null && gav.getArtifactId() != null && !boms.contains(gav)) {
+                        boms.add(gav);
+                    }
+                }
+            }
+        } catch (Exception | LinkageError ignored) {
+            // Plugin internals differ across versions; what the Boot plugin reported, if anything, still stands
+        }
+        return boms;
+    }
+
+    private static @Nullable GroupArtifactVersion parseCoordinates(String coordinates) {
+        String[] gav = coordinates.split(":");
+        return gav.length == 3 ? new GroupArtifactVersion(gav[0], gav[1], gav[2]) : null;
     }
 
     static List<MavenRepository> mapRepositories(List<ArtifactRepository> repositories) {

--- a/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
+++ b/rewrite-gradle-tooling-model/model/src/main/java/org/openrewrite/gradle/toolingapi/Assertions.java
@@ -182,7 +182,7 @@ public class Assertions {
                         // Construct a synthetic marker to apply to freestanding Gradle scripts to aid recipes in resolving dependencies
                         GradleProject freestandingScriptMarker = new GradleProject(
                                 randomId(), "", "", "", "", emptyList(), new ArrayList<>(allRepositories),
-                                emptyList(), emptyMap(), new GradleBuildscript(randomId(), new ArrayList<>(allBuildscriptRepositories), emptyMap()));
+                                emptyList(), emptyMap(), new GradleBuildscript(randomId(), new ArrayList<>(allBuildscriptRepositories), emptyMap()), null);
                         for (int i = 0; i < sourceFiles.size(); i++) {
                             SourceFile sourceFile = sourceFiles.get(i);
                             if ((sourceFile.getSourcePath().toString().endsWith(".gradle") || sourceFile.getSourcePath().toString().endsWith(".gradle.kts")) &&

--- a/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -406,13 +406,9 @@ class GradleProjectTest {
         }
     }
 
-    /**
-     * The Spring Boot plugin imports its BOM programmatically, so nothing in the build script says which BOM manages
-     * these dependencies. The dependency management plugin's own state is the only place that is observable.
-     */
     @Nested
     @DisabledIf("org.openrewrite.gradle.marker.GradleProjectTest#gradleOlderThan8")
-    class springDependencyManagement {
+    class SpringDependencyManagement {
         @TempDir
         static Path dir;
 

--- a/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
+++ b/rewrite-gradle-tooling-model/model/src/test/java/org/openrewrite/gradle/marker/GradleProjectTest.java
@@ -405,4 +405,76 @@ class GradleProjectTest {
               .anyMatch(dep -> dep.findAttribute(ProjectAttribute.class).isPresent() && "a".equals(dep.getGav().getArtifactId()));
         }
     }
+
+    /**
+     * The Spring Boot plugin imports its BOM programmatically, so nothing in the build script says which BOM manages
+     * these dependencies. The dependency management plugin's own state is the only place that is observable.
+     */
+    @Nested
+    @DisabledIf("org.openrewrite.gradle.marker.GradleProjectTest#gradleOlderThan8")
+    class springDependencyManagement {
+        @TempDir
+        static Path dir;
+
+        static GradleProject gradleProject;
+
+        //language=groovy
+        static String buildGradle = """
+          plugins{
+              id 'java'
+              id 'org.springframework.boot' version '3.3.5'
+              id 'io.spring.dependency-management' version '1.1.7'
+          }
+
+          repositories{
+              mavenCentral()
+          }
+
+          dependencies{
+              implementation 'org.yaml:snakeyaml'
+          }
+          """;
+
+        //language=groovy
+        static String settingsGradle = """
+          rootProject.name = "sample"
+          """;
+
+        @BeforeAll
+        static void gradleProject() throws IOException {
+            try (InputStream is = new ByteArrayInputStream(buildGradle.getBytes(StandardCharsets.UTF_8))) {
+                Files.write(dir.resolve("build.gradle"), readAllBytes(is));
+            }
+
+            try (InputStream is = new ByteArrayInputStream(settingsGradle.getBytes(StandardCharsets.UTF_8))) {
+                Files.write(dir.resolve("settings.gradle"), readAllBytes(is));
+            }
+
+            OpenRewriteModel model = OpenRewriteModelBuilder.forProjectDirectory(dir.toFile(), dir.resolve("build.gradle").toFile());
+            gradleProject = model.getGradleProject();
+        }
+
+        @Test
+        void capturesBomImportedByBootPlugin() {
+            SpringDependencyManagementPlugin dependencyManagement = requireNonNull(gradleProject.getSpringDependencyManagementPlugin());
+            assertThat(dependencyManagement.getImportedBoms())
+              .anyMatch(bom -> "org.springframework.boot".equals(bom.getGroupId()) &&
+                               "spring-boot-dependencies".equals(bom.getArtifactId()) &&
+                               "3.3.5".equals(bom.getVersion()));
+            assertThat(dependencyManagement.getImportedProperties())
+              .containsKey("snakeyaml.version");
+            assertThat(dependencyManagement.getManagedVersions())
+              .containsEntry("org.yaml:snakeyaml", dependencyManagement.getImportedProperties().get("snakeyaml.version"));
+        }
+
+        @Test
+        void serializable() throws Exception {
+            ObjectMapper m = new RecipeSerializer().getMapper();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            m.writeValue(baos, gradleProject);
+            ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+            GradleProject roundTripped = m.readValue(bais, GradleProject.class);
+            assertThat(roundTripped).isEqualTo(gradleProject);
+        }
+    }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -352,11 +352,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 }
             }
 
-            /**
-             * A versionless dependency in a project using the Spring dependency management plugin may be governed by
-             * a BOM property. Which BOMs are imported is not known until every script has been scanned, so only note
-             * the candidate here.
-             */
+            // Which BOMs the build imports isn't known until every script has been scanned.
             private void recordBomCandidate(GradleDependency gradleDependency, GroupArtifact ga, String configName) {
                 if (gradleProject != null && SpringBomProperty.isPluginApplied(gradleProject) &&
                         gradleDependency.getDeclaredVersion() == null && !gradleDependency.isPlatform()) {
@@ -530,11 +526,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
         }
     }
 
-    /**
-     * Matches each candidate against the BOMs the build imports, which is only knowable once every script has been
-     * scanned. A property that governs a candidate is recorded like a version variable, so the existing
-     * shared-variable guard vets every other artifact the property governs before anything is written.
-     */
+    // Recorded like a version variable so the shared-variable guard vets the other artifacts the property governs.
     private void resolveBomCandidates(DependencyVersionState acc, ExecutionContext ctx) {
         if (!acc.bomCandidatesResolved.compareAndSet(false, true)) {
             return;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -21,6 +21,7 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.internal.AddDependencyVisitor;
+import org.openrewrite.gradle.internal.SpringBomProperty;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.trait.ExtraProperty;
@@ -50,10 +51,10 @@ import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
 
-import static java.util.Collections.emptyMap;
-import static java.util.Collections.singletonList;
+import static java.util.Collections.*;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
@@ -140,6 +141,46 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
          * means the variable cannot be safely bumped; absence means the verdict is not yet known.
          */
         Map<String, @Nullable String> safeVariableVerdict = new HashMap<>();
+
+        /**
+         * Per module, the properties of BOMs imported through the Spring dependency management plugin that govern
+         * a targeted dependency. Overriding such a property is how the version is upgraded.
+         */
+        Map<String, Set<String>> bomPropertiesPerModule = new HashMap<>();
+
+        Set<String> gradlePropertiesKeys = new HashSet<>();
+
+        /**
+         * BOMs imported by any script in the build, since {@code apply from:} scripts and a root {@code subprojects}
+         * block import on behalf of a project whose own script says nothing.
+         */
+        List<GroupArtifactVersion> scriptImportedBoms = new ArrayList<>();
+
+        /**
+         * Extra properties any script declares, so an override is not written twice when the existing declaration
+         * lives in another script.
+         */
+        Set<String> declaredExtProperties = new HashSet<>();
+
+        /**
+         * Dependencies possibly governed by a BOM property, resolved once the whole build has been scanned and the
+         * imported BOMs of every script are known.
+         */
+        List<BomCandidate> bomCandidates = new ArrayList<>();
+
+        AtomicBoolean bomCandidatesResolved = new AtomicBoolean();
+    }
+
+    @Value
+    static class BomCandidate {
+        GradleProject gradleProject;
+        GroupArtifact ga;
+        String configurationName;
+
+        /**
+         * The version Gradle resolved, which the BOM governs and this recipe may improve on.
+         */
+        String resolvedVersion;
     }
 
     @Override
@@ -151,7 +192,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
     public TreeVisitor<?, ExecutionContext> getScanner(DependencyVersionState acc) {
 
         //noinspection BooleanMethodIsAlwaysInverted
-        return new JavaVisitor<ExecutionContext>() {
+        JavaVisitor<ExecutionContext> scanGradle = new JavaVisitor<ExecutionContext>() {
             @Nullable
             GradleProject gradleProject;
 
@@ -165,6 +206,12 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
             public @Nullable J visit(@Nullable Tree tree, ExecutionContext ctx) {
                 if (tree instanceof JavaSourceFile) {
                     gradleProject = tree.getMarkers().findFirst(GradleProject.class).orElse(null);
+                    for (GroupArtifactVersion bom : SpringBomProperty.importedBoms((JavaSourceFile) tree)) {
+                        if (!acc.scriptImportedBoms.contains(bom)) {
+                            acc.scriptImportedBoms.add(bom);
+                        }
+                    }
+                    acc.declaredExtProperties.addAll(SpringBomProperty.declaredProperties((JavaSourceFile) tree));
                 }
                 return super.visit(tree, ctx);
             }
@@ -278,12 +325,19 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             .add(configName);
                 }
 
-                if (!acc.gaToNewVersion.containsKey(ga) && shouldResolveVersion(groupId, artifactId)) {
+                if (!shouldResolveVersion(groupId, artifactId)) {
+                    return;
+                }
+
+                // Recorded per module, since each module needs its own override written
+                recordBomCandidate(gradleDependency, ga, configName);
+
+                if (!acc.gaToNewVersion.containsKey(ga)) {
                     try {
+                        String versionVar = gradleDependency.getVersionVariable();
                         String newVersion = new DependencyVersionSelector(metadataFailures, gradleProject, null)
                                 .select(ga, configName, UpgradeDependencyVersion.this.newVersion, versionPattern, ctx);
 
-                        String versionVar = gradleDependency.getVersionVariable();
                         if (versionVar != null) {
                             acc.versionPropNameToGA
                                     .computeIfAbsent(versionVar, k -> new HashMap<>())
@@ -298,6 +352,18 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 }
             }
 
+            /**
+             * A versionless dependency in a project using the Spring dependency management plugin may be governed by
+             * a BOM property. Which BOMs are imported is not known until every script has been scanned, so only note
+             * the candidate here.
+             */
+            private void recordBomCandidate(GradleDependency gradleDependency, GroupArtifact ga, String configName) {
+                if (gradleProject != null && SpringBomProperty.isPluginApplied(gradleProject) &&
+                        gradleDependency.getDeclaredVersion() == null && !gradleDependency.isPlatform()) {
+                    acc.bomCandidates.add(new BomCandidate(gradleProject, ga, configName, gradleDependency.getVersion()));
+                }
+            }
+
             // Some recipes make use of UpgradeDependencyVersion as an implementation detail.
             // Those other recipes might not know up-front which dependency needs upgrading
             // So they use the UpgradeDependencyVersion recipe with null groupId and artifactId to pre-populate all data they could possibly need
@@ -308,6 +374,28 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                         new DependencyMatcher(groupId, artifactId, null).matches(declaredGroupId, declaredArtifactId);
             }
 
+        };
+
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return scanGradle.isAcceptable(sourceFile, ctx) ||
+                        (sourceFile instanceof Properties.File && sourceFile.getSourcePath().endsWith(GRADLE_PROPERTIES_FILE_NAME));
+            }
+
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof Properties.File) {
+                    // Only the keys matter: a BOM property defined here is updated in place rather than declared in the script
+                    for (Properties.Content content : ((Properties.File) tree).getContent()) {
+                        if (content instanceof Properties.Entry) {
+                            acc.gradlePropertiesKeys.add(((Properties.Entry) content).getKey());
+                        }
+                    }
+                    return tree;
+                }
+                return scanGradle.visit(tree, ctx);
+            }
         };
     }
 
@@ -327,6 +415,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 stopAfterPreVisit();
                 Tree t = tree;
                 if (t instanceof SourceFile) {
+                    resolveBomCandidates(acc, ctx);
                     SourceFile sf = (SourceFile) t;
                     if (updateProperties.isAcceptable(sf, ctx)) {
                         t = updateProperties.visitNonNull(t, ctx);
@@ -360,8 +449,8 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                                 }
                             }
 
-                            gradleProject = gradleProject.upgradeDirectDependencyVersions(upgrades, ctx)
-                                    .upgradeBuildscriptDirectDependencyVersions(upgrades, ctx);
+                            gradleProject = constrainBomGoverned(gradleProject.upgradeDirectDependencyVersions(upgrades, ctx)
+                                    .upgradeBuildscriptDirectDependencyVersions(upgrades, ctx), ctx);
                             if (projectMarker.get() != gradleProject) {
                                 t = t.withMarkers(t.getMarkers().setByType(gradleProject));
                             }
@@ -384,6 +473,29 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 return t;
             }
 
+            /**
+             * A BOM property override also moves every other artifact the property governs; the model reflects
+             * that as a constraint on each configuration resolving one of them.
+             */
+            private GradleProject constrainBomGoverned(GradleProject gradleProject, ExecutionContext ctx) {
+                Map<String, Set<GroupArtifactVersion>> constraints = new HashMap<>();
+                for (String property : acc.bomPropertiesPerModule.getOrDefault(getGradleProjectKey(gradleProject), emptySet())) {
+                    String version = safeUpdatedVersion(property, updateGradle.dependencyMatcher, acc, gradleProject, ctx);
+                    if (version == null) {
+                        continue;
+                    }
+                    for (Map.Entry<GroupArtifact, Set<String>> usage : acc.variableNames.get(property).entrySet()) {
+                        GroupArtifact ga = usage.getKey();
+                        if (!acc.gaToNewVersion.containsKey(ga)) {
+                            for (String configuration : usage.getValue()) {
+                                constraints.computeIfAbsent(configuration, k -> new HashSet<>())
+                                        .add(new GroupArtifactVersion(ga.getGroupId(), ga.getArtifactId(), version));
+                            }
+                        }
+                    }
+                }
+                return constraints.isEmpty() ? gradleProject : gradleProject.addOrUpdateConstraints(constraints, ctx);
+            }
         };
     }
 
@@ -415,6 +527,45 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 return finalVersion.map(v -> entry.withValue(entry.getValue().withText(v))).orElse(entry);
             }
             return entry;
+        }
+    }
+
+    /**
+     * Matches each candidate against the BOMs the build imports, which is only knowable once every script has been
+     * scanned. A property that governs a candidate is recorded like a version variable, so the existing
+     * shared-variable guard vets every other artifact the property governs before anything is written.
+     */
+    private void resolveBomCandidates(DependencyVersionState acc, ExecutionContext ctx) {
+        if (!acc.bomCandidatesResolved.compareAndSet(false, true)) {
+            return;
+        }
+        for (BomCandidate candidate : acc.bomCandidates) {
+            GradleProject gradleProject = candidate.getGradleProject();
+            GroupArtifact ga = candidate.getGa();
+            SpringBomProperty property = SpringBomProperty.find(gradleProject, acc.scriptImportedBoms, ga, ctx);
+            if (property == null) {
+                continue;
+            }
+            String selected;
+            try {
+                GroupArtifactVersion gav = new GroupArtifactVersion(ga.getGroupId(), ga.getArtifactId(), candidate.getResolvedVersion());
+                selected = new DependencyVersionSelector(metadataFailures, gradleProject, null)
+                        .select(gav, candidate.getConfigurationName(), newVersion, versionPattern, ctx);
+            } catch (MavenDownloadingException e) {
+                continue;
+            }
+            if (selected == null || selected.equals(candidate.getResolvedVersion())) {
+                continue;
+            }
+            acc.gaToNewVersion.put(ga, selected);
+            acc.bomPropertiesPerModule.computeIfAbsent(getGradleProjectKey(gradleProject), k -> new HashSet<>()).add(property.getName());
+            acc.versionPropNameToGA.computeIfAbsent(property.getName(), k -> new HashMap<>())
+                    .computeIfAbsent(ga, k -> new HashSet<>())
+                    .add(candidate.getConfigurationName());
+            Map<GroupArtifact, Set<String>> usages = acc.variableNames.computeIfAbsent(property.getName(), k -> new HashMap<>());
+            usages.computeIfAbsent(ga, k -> new HashSet<>()).add(candidate.getConfigurationName());
+            property.governedOnClasspath(gradleProject, ga).forEach((governed, configurations) ->
+                    usages.computeIfAbsent(governed, k -> new HashSet<>()).addAll(configurations));
         }
     }
 
@@ -566,7 +717,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 gradleProject = original.getMarkers().findFirst(GradleProject.class)
                         .orElse(null);
                 JavaSourceFile sourceFile = applyPluginProvidedDependencies(original, ctx);
-                JavaSourceFile result = (JavaSourceFile) super.visit(sourceFile, ctx);
+                JavaSourceFile result = declareBomProperties((JavaSourceFile) super.visit(sourceFile, ctx), ctx);
                 if (result != original && gradleProject != null) {
                     JavaSourceSet.markDirty(ctx, gradleProject.getProjectName());
                 }
@@ -671,6 +822,26 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 }
             }
             return sourceFile;
+        }
+
+        /**
+         * Declares each BOM property override the script does not set yet. Properties the script already sets are
+         * updated in {@code postVisit}, and those defined in gradle.properties by {@code UpdateProperties}.
+         */
+        private JavaSourceFile declareBomProperties(JavaSourceFile cu, ExecutionContext ctx) {
+            if (gradleProject == null) {
+                return cu;
+            }
+            for (String property : acc.bomPropertiesPerModule.getOrDefault(getGradleProjectKey(gradleProject), emptySet())) {
+                if (acc.gradlePropertiesKeys.contains(property) || acc.declaredExtProperties.contains(property)) {
+                    continue;
+                }
+                String version = safeUpdatedVersion(property, dependencyMatcher, acc, gradleProject, ctx);
+                if (version != null) {
+                    cu = SpringBomProperty.addDeclaration(cu, property, version, ctx);
+                }
+            }
+            return cu;
         }
 
         /**

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -546,11 +546,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
         };
     }
 
-    /**
-     * A transitive dependency whose version a BOM derives from a property is upgraded by overriding that property
-     * rather than by a resolution rule, as long as every other artifact the property governs exists at the selected
-     * version. Which BOMs the build imports is only knowable once every script has been scanned.
-     */
+    // Which BOMs the build imports isn't known until every script has been scanned.
     private void resolveBomProperties(DependencyVersionState acc, DependencyMatcher dependencyMatcher, ExecutionContext ctx) {
         if (acc.bomPropertiesResolved) {
             return;
@@ -639,9 +635,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
             return super.visit(tree, ctx);
         }
 
-        /**
-         * Overrides each BOM property in the script, unless gradle.properties defines it and UpdateProperties updates it.
-         */
+        // Skips properties gradle.properties defines, which UpdateProperties handles instead.
         private JavaSourceFile overrideBomProperties(JavaSourceFile cu, Map<String, GroupArtifact> bomProperties, ExecutionContext ctx) {
             for (Map.Entry<String, GroupArtifact> bomProperty : bomProperties.entrySet()) {
                 String name = bomProperty.getKey();

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -21,8 +21,11 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.internal.ChangeStringLiteral;
+import org.openrewrite.gradle.internal.GradleParseUtils;
+import org.openrewrite.gradle.internal.SpringBomProperty;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.gradle.trait.ExtraProperty;
 import org.openrewrite.groovy.GroovyIsoVisitor;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -50,9 +53,6 @@ import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.DependencyMatcher;
 import org.openrewrite.semver.Semver;
 
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -119,35 +119,8 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
     @Nullable
     List<String> onlyForConfigurations;
 
-    /**
-     * This recipe needs to generate LST elements representing "constraints" and "because" method invocations.
-     * Aside from their parameterization with different arguments they are otherwise identical.
-     * GradleParser isn't particularly fast, so in a recipe run which involves more than one UpgradeTransitiveDependencyVersion
-     * it is much faster to produce these LST elements only once then manipulate their arguments.
-     * This largely mimics how caching works in JavaTemplate. If we create a Gradle/GroovyTemplate this could be refactored.
-     */
-    private static Map<String, Optional<JavaSourceFile>> snippetCache(ExecutionContext ctx) {
-        //noinspection unchecked
-        return (Map<String, Optional<JavaSourceFile>>) ctx.getMessages()
-                .computeIfAbsent(UpgradeTransitiveDependencyVersion.class.getName() + ".snippetCache", k -> new HashMap<String, Optional<G.CompilationUnit>>());
-    }
-
     private static Optional<JavaSourceFile> parseAsGradle(String snippet, boolean isKotlinDsl, ExecutionContext ctx) {
-        return snippetCache(ctx)
-                .computeIfAbsent(snippet, s -> GradleParser.builder().build().parseInputs(singleton(
-                                new Parser.Input(
-                                        Paths.get("build.gradle" + (isKotlinDsl ? ".kts" : "")),
-                                        () -> new ByteArrayInputStream(snippet.getBytes(StandardCharsets.UTF_8))
-                                )), null, ctx)
-                        .findFirst()
-                        .map(maybeCu -> {
-                            maybeCu.getMarkers()
-                                    .findFirst(ParseExceptionResult.class)
-                                    .ifPresent(per -> {
-                                        throw new IllegalStateException("Encountered exception " + per.getExceptionType() + " with message " + per.getMessage() + " on snippet:\n" + snippet);
-                                    });
-                            return (JavaSourceFile) maybeCu;
-                        }));
+        return GradleParseUtils.parseSnippet(snippet, isKotlinDsl, ctx);
     }
 
     String displayName = "Upgrade transitive Gradle dependencies";
@@ -169,6 +142,35 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
     public static class DependencyVersionState {
         Map<String, Map<GroupArtifact, Map<GradleDependencyConfiguration, String>>> updatesPerProject = new LinkedHashMap<>();
         Map<String, GroupArtifact> versionPropNameToGA = new HashMap<>();
+
+        /**
+         * Per project, the properties of BOMs imported through the Spring dependency management plugin that govern
+         * a transitive dependency to upgrade, mapped to the artifact each governs. Overriding the property replaces
+         * the resolution rule the plugin would otherwise require.
+         */
+        Map<String, Map<String, GroupArtifact>> bomPropertiesPerProject = new HashMap<>();
+
+        Set<String> gradlePropertiesKeys = new HashSet<>();
+
+        /**
+         * BOMs imported by any script in the build, since {@code apply from:} scripts and a root {@code subprojects}
+         * block import on behalf of a project whose own script says nothing.
+         */
+        List<GroupArtifactVersion> scriptImportedBoms = new ArrayList<>();
+
+        /**
+         * Extra properties any script declares, so an override is not written twice when the existing declaration
+         * lives in another script.
+         */
+        Set<String> declaredExtProperties = new HashSet<>();
+
+        /**
+         * Projects using the Spring dependency management plugin, whose updates are matched against the imported
+         * BOMs once the whole build has been scanned.
+         */
+        Map<String, GradleProject> projectsUsingDependencyManagement = new LinkedHashMap<>();
+
+        boolean bomPropertiesResolved;
         private boolean dependenciesToUpdateCalculated = false;
         private final Map<GroupArtifact, String> dependenciesToUpdate = new HashMap<>();
 
@@ -205,7 +207,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
 
     @Override
     public TreeVisitor<?, ExecutionContext> getScanner(DependencyVersionState acc) {
-        return Preconditions.check(new IsBuildGradle<>(), new JavaVisitor<ExecutionContext>() {
+        TreeVisitor<?, ExecutionContext> scanGradle = Preconditions.check(new IsBuildGradle<>(), new JavaVisitor<ExecutionContext>() {
             @SuppressWarnings("NotNullFieldNotInitialized")
             GradleProject gradleProject;
 
@@ -296,6 +298,16 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                             }
                         }
                     }
+
+                    if (SpringBomProperty.isPluginApplied(gradleProject)) {
+                        acc.projectsUsingDependencyManagement.put(getGradleProjectKey(gradleProject), gradleProject);
+                    }
+                    for (GroupArtifactVersion bom : SpringBomProperty.importedBoms((JavaSourceFile) tree)) {
+                        if (!acc.scriptImportedBoms.contains(bom)) {
+                            acc.scriptImportedBoms.add(bom);
+                        }
+                    }
+                    acc.declaredExtProperties.addAll(SpringBomProperty.declaredProperties((JavaSourceFile) tree));
                 }
                 return super.visit(tree, ctx);
             }
@@ -457,6 +469,28 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                 return null;
             }
         });
+
+        return new TreeVisitor<Tree, ExecutionContext>() {
+            @Override
+            public boolean isAcceptable(SourceFile sourceFile, ExecutionContext ctx) {
+                return scanGradle.isAcceptable(sourceFile, ctx) ||
+                        (sourceFile instanceof Properties.File && sourceFile.getSourcePath().endsWith("gradle.properties"));
+            }
+
+            @Override
+            public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
+                if (tree instanceof Properties.File) {
+                    // Only the keys matter: a BOM property defined here is updated in place rather than declared in the script
+                    for (Properties.Content content : ((Properties.File) tree).getContent()) {
+                        if (content instanceof Properties.Entry) {
+                            acc.gradlePropertiesKeys.add(((Properties.Entry) content).getKey());
+                        }
+                    }
+                    return tree;
+                }
+                return scanGradle.visit(tree, ctx);
+            }
+        };
     }
 
     @Override
@@ -475,6 +509,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
             public @Nullable Tree visit(@Nullable Tree tree, ExecutionContext ctx) {
                 Tree t = tree;
                 if (t instanceof SourceFile) {
+                    resolveBomProperties(acc, dependencyMatcher, ctx);
                     SourceFile sf = (SourceFile) t;
                     if (updateProperties.isAcceptable(sf, ctx)) {
                         t = updateProperties.visitNonNull(t, ctx);
@@ -511,6 +546,39 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
         };
     }
 
+    /**
+     * A transitive dependency whose version a BOM derives from a property is upgraded by overriding that property
+     * rather than by a resolution rule, as long as every other artifact the property governs exists at the selected
+     * version. Which BOMs the build imports is only knowable once every script has been scanned.
+     */
+    private void resolveBomProperties(DependencyVersionState acc, DependencyMatcher dependencyMatcher, ExecutionContext ctx) {
+        if (acc.bomPropertiesResolved) {
+            return;
+        }
+        acc.bomPropertiesResolved = true;
+        for (Map.Entry<String, GradleProject> project : acc.projectsUsingDependencyManagement.entrySet()) {
+            GradleProject gradleProject = project.getValue();
+            for (Map.Entry<GroupArtifact, Map<GradleDependencyConfiguration, String>> update :
+                    acc.updatesPerProject.getOrDefault(project.getKey(), emptyMap()).entrySet()) {
+                GroupArtifact ga = update.getKey();
+                if (!dependencyMatcher.matches(ga.getGroupId(), ga.getArtifactId())) {
+                    continue;
+                }
+                // One property cannot carry a different version per configuration
+                Set<String> versions = new HashSet<>(update.getValue().values());
+                if (versions.size() != 1) {
+                    continue;
+                }
+                SpringBomProperty property = SpringBomProperty.find(gradleProject, acc.scriptImportedBoms, ga, ctx);
+                if (property != null && SpringBomProperty.isPublished(versions.iterator().next(),
+                        property.governedOnClasspath(gradleProject, ga).keySet(), gradleProject.getMavenRepositories(), ctx)) {
+                    acc.bomPropertiesPerProject.computeIfAbsent(project.getKey(), k -> new HashMap<>()).put(property.getName(), ga);
+                    acc.versionPropNameToGA.put(property.getName(), ga);
+                }
+            }
+        }
+    }
+
     @RequiredArgsConstructor
     private class UpdateGradle extends JavaVisitor<ExecutionContext> {
         final DependencyVersionState acc;
@@ -522,7 +590,8 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                 JavaSourceFile cu = (JavaSourceFile) tree;
                 GradleProject gradleProject = cu.getMarkers().findFirst(GradleProject.class).orElse(null);
                 Map<GroupArtifact, Map<GradleDependencyConfiguration, String>> projectRequiredUpdates = gradleProject != null ? acc.updatesPerProject.getOrDefault(getGradleProjectKey(gradleProject), emptyMap()) : emptyMap();
-                if (projectRequiredUpdates.keySet().stream().anyMatch(ga -> dependencyMatcher.matches(ga.getGroupId(), ga.getArtifactId()))) {
+                Map<String, GroupArtifact> bomProperties = gradleProject != null ? acc.bomPropertiesPerProject.getOrDefault(getGradleProjectKey(gradleProject), emptyMap()) : emptyMap();
+                if (projectRequiredUpdates.keySet().stream().anyMatch(ga -> dependencyMatcher.matches(ga.getGroupId(), ga.getArtifactId()) && !bomProperties.containsValue(ga))) {
                     cu = (JavaSourceFile) Preconditions.check(
                             not(new JavaIsoVisitor<ExecutionContext>() {
                                 @Override
@@ -547,7 +616,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                     ).visitNonNull(cu, ctx);
 
                     for (Map.Entry<GroupArtifact, Map<GradleDependencyConfiguration, String>> update : projectRequiredUpdates.entrySet()) {
-                        if (!dependencyMatcher.matches(update.getKey().getGroupId(), update.getKey().getArtifactId())) {
+                        if (!dependencyMatcher.matches(update.getKey().getGroupId(), update.getKey().getArtifactId()) || bomProperties.containsValue(update.getKey())) {
                             continue;
                         }
                         Map<GradleDependencyConfiguration, String> configs = update.getValue();
@@ -558,15 +627,37 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                     }
 
                     // Spring dependency management plugin stomps on constraints. Use an alternative mechanism it does not override
-                    if (gradleProject.getPlugins().stream().anyMatch(plugin -> "io.spring.dependency-management".equals(plugin.getId()))) {
+                    if (SpringBomProperty.isPluginApplied(gradleProject)) {
                         cu = (JavaSourceFile) new DependencyConstraintToRule().getVisitor().visitNonNull(cu, ctx);
                     }
                 }
+                cu = overrideBomProperties(cu, bomProperties, ctx);
                 if (cu != tree) {
                     return cu;
                 }
             }
             return super.visit(tree, ctx);
+        }
+
+        /**
+         * Overrides each BOM property in the script, unless gradle.properties defines it and UpdateProperties updates it.
+         */
+        private JavaSourceFile overrideBomProperties(JavaSourceFile cu, Map<String, GroupArtifact> bomProperties, ExecutionContext ctx) {
+            for (Map.Entry<String, GroupArtifact> bomProperty : bomProperties.entrySet()) {
+                String name = bomProperty.getKey();
+                String version = acc.dependenciesToUpdate(dependencyMatcher).get(bomProperty.getValue());
+                if (version == null || acc.gradlePropertiesKeys.contains(name)) {
+                    continue;
+                }
+                if (acc.declaredExtProperties.contains(name)) {
+                    cu = (JavaSourceFile) new ExtraProperty.Matcher().propertyName(name).matchVariableDeclarations(false)
+                            .<ExecutionContext>asVisitor((property, c) -> property.withValue(version).getTree())
+                            .visitNonNull(cu, ctx);
+                } else {
+                    cu = SpringBomProperty.addDeclaration(cu, name, version, ctx);
+                }
+            }
+            return cu;
         }
 
         @Override

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleParseUtils.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleParseUtils.java
@@ -41,8 +41,10 @@ public final class GradleParseUtils {
     }
 
     /**
-     * Parse a constant Gradle snippet as a build script, caching the result on the execution context. GradleParser
-     * isn't particularly fast, so a recipe run that generates the same snippet repeatedly parses it only once.
+     * Parse a constant Gradle snippet as a build script, so that a recipe adding code gets a tree the parser
+     * produced rather than one it assembled by hand, which is how printing and formatting stay correct.
+     * The result is cached on the execution context, as GradleParser is slow enough that reparsing the same
+     * snippet for every source file is noticeable.
      */
     public static Optional<JavaSourceFile> parseSnippet(String snippet, boolean isKotlinDsl, ExecutionContext ctx) {
         //noinspection unchecked

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleParseUtils.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/GradleParseUtils.java
@@ -16,17 +16,52 @@
 package org.openrewrite.gradle.internal;
 
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.ParseExceptionResult;
+import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
 import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Statement;
 import org.openrewrite.tree.ParseError;
 
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
+
+import static java.util.Collections.singleton;
 
 public final class GradleParseUtils {
     private GradleParseUtils() {
+    }
+
+    /**
+     * Parse a constant Gradle snippet as a build script, caching the result on the execution context. GradleParser
+     * isn't particularly fast, so a recipe run that generates the same snippet repeatedly parses it only once.
+     */
+    public static Optional<JavaSourceFile> parseSnippet(String snippet, boolean isKotlinDsl, ExecutionContext ctx) {
+        //noinspection unchecked
+        Map<String, Optional<JavaSourceFile>> cache = (Map<String, Optional<JavaSourceFile>>) ctx.getMessages()
+                .computeIfAbsent(GradleParseUtils.class.getName() + ".snippetCache", k -> new HashMap<String, Optional<JavaSourceFile>>());
+        return cache.computeIfAbsent(snippet, s -> GradleParser.builder().build().parseInputs(singleton(
+                        new Parser.Input(
+                                Paths.get("build.gradle" + (isKotlinDsl ? ".kts" : "")),
+                                () -> new ByteArrayInputStream(snippet.getBytes(StandardCharsets.UTF_8))
+                        )), null, ctx)
+                .findFirst()
+                .map(maybeCu -> {
+                    maybeCu.getMarkers()
+                            .findFirst(ParseExceptionResult.class)
+                            .ifPresent(per -> {
+                                throw new IllegalStateException("Encountered exception " + per.getExceptionType() + " with message " + per.getMessage() + " on snippet:\n" + snippet);
+                            });
+                    return (JavaSourceFile) maybeCu;
+                }));
     }
 
     /**

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/SpringBomProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/SpringBomProperty.java
@@ -119,10 +119,7 @@ public class SpringBomProperty {
         return null;
     }
 
-    /**
-     * The plugin substitutes a project property for an imported BOM property only for properties it imported, so
-     * where the plugin's own view is available it decides.
-     */
+    // An empty view means the plugin's state wasn't captured, not that it imported nothing.
     private static boolean honorsOverrideOf(@Nullable SpringDependencyManagementPlugin plugin, String name) {
         return plugin == null || plugin.getImportedProperties().isEmpty() || plugin.getImportedProperties().containsKey(name);
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/SpringBomProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/SpringBomProperty.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.internal;
+
+import lombok.Value;
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Tree;
+import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
+import org.openrewrite.gradle.marker.GradleProject;
+import org.openrewrite.gradle.marker.SpringDependencyManagementPlugin;
+import org.openrewrite.gradle.trait.ExtraProperty;
+import org.openrewrite.gradle.trait.SpringDependencyManagementPluginEntry;
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.tree.K;
+import org.openrewrite.maven.MavenDownloadingException;
+import org.openrewrite.maven.internal.MavenPomDownloader;
+import org.openrewrite.maven.tree.*;
+
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.openrewrite.gradle.internal.GradleParseUtils.parseSnippet;
+import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
+
+/**
+ * The Maven property through which a BOM imported by the {@code io.spring.dependency-management} plugin governs a
+ * dependency's version. The plugin resolves BOM properties against the project's properties, so Spring documents
+ * {@code ext['snakeyaml.version'] = '1.33'} as the way to deviate from a BOM without a constraint or resolution rule.
+ */
+@Value
+public class SpringBomProperty {
+    public static final String PLUGIN_ID = "io.spring.dependency-management";
+    private static final Pattern PLACEHOLDER = Pattern.compile("\\$\\{([^}]+)}");
+
+    String name;
+
+    /**
+     * Every artifact whose version the BOM derives from this property, directly or through a nested BOM import.
+     */
+    Set<GroupArtifact> governed;
+
+    public static boolean isPluginApplied(GradleProject gradleProject) {
+        return gradleProject.getPlugins().stream().anyMatch(plugin -> PLUGIN_ID.equals(plugin.getId()));
+    }
+
+    /**
+     * The BOMs a script imports through {@code dependencyManagement { imports { mavenBom ... } }}, in declaration
+     * order. A version given as a script property is resolved; one that cannot be determined is skipped.
+     */
+    public static List<GroupArtifactVersion> importedBoms(JavaSourceFile cu) {
+        Map<String, String> properties = new HashMap<>();
+        new ExtraProperty.Matcher().<Integer>asVisitor((property, p) -> {
+            properties.put(property.getName(), property.getValue());
+            return property.getTree();
+        }).visit(cu, 0);
+        List<GroupArtifactVersion> boms = new ArrayList<>();
+        new SpringDependencyManagementPluginEntry.Matcher().<Integer>asVisitor((entry, p) -> {
+            if ("mavenBom".equals(entry.getTree().getSimpleName())) {
+                String version = entry.getVersion();
+                String property = placeholder(version);
+                if (property != null) {
+                    version = properties.get(property);
+                }
+                if (version != null) {
+                    for (String artifact : entry.getArtifacts()) {
+                        boms.add(new GroupArtifactVersion(entry.getGroup(), artifact, version));
+                    }
+                }
+            }
+            return entry.getTree();
+        }).visit(cu, 0);
+        return boms;
+    }
+
+    /**
+     * @return the property governing {@code ga} in the first BOM that manages it, or null when no BOM manages it or
+     * its managed version is not a single overridable {@code ${property}} placeholder. The BOMs the plugin actually
+     * imported are preferred over {@code scriptBoms}, which are only what the scripts happen to say.
+     */
+    public static @Nullable SpringBomProperty find(GradleProject gradleProject, List<GroupArtifactVersion> scriptBoms,
+                                                   GroupArtifact ga, ExecutionContext ctx) {
+        SpringDependencyManagementPlugin plugin = gradleProject.getSpringDependencyManagementPlugin();
+        List<GroupArtifactVersion> boms = plugin == null || plugin.getImportedBoms().isEmpty() ?
+                scriptBoms : plugin.getImportedBoms();
+        List<MavenRepository> repositories = gradleProject.getMavenRepositories();
+        MavenPomDownloader downloader = new MavenPomDownloader(ctx);
+        for (GroupArtifactVersion bomGav : boms) {
+            try {
+                Pom bom = downloader.download(bomGav, null, null, repositories);
+                String name = governingProperty(bom, ga, downloader, repositories);
+                if (name != null && honorsOverrideOf(plugin, name)) {
+                    return new SpringBomProperty(name, governedBy(bom, name, downloader, repositories));
+                }
+            } catch (MavenDownloadingException ignored) {
+                // A BOM we cannot read cannot be overridden through its properties either
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The plugin substitutes a project property for an imported BOM property only for properties it imported, so
+     * where the plugin's own view is available it decides.
+     */
+    private static boolean honorsOverrideOf(@Nullable SpringDependencyManagementPlugin plugin, String name) {
+        return plugin == null || plugin.getImportedProperties().isEmpty() || plugin.getImportedProperties().containsKey(name);
+    }
+
+    private static @Nullable String governingProperty(Pom bom, GroupArtifact ga, MavenPomDownloader downloader,
+                                                      List<MavenRepository> repositories) throws MavenDownloadingException {
+        for (ManagedDependency managed : bom.getDependencyManagement()) {
+            // The BOM's own entry wins over anything it imports, and a literal version cannot be overridden
+            if (managed instanceof ManagedDependency.Defined && manages(managed, ga)) {
+                return overridable(placeholder(managed.getVersion()));
+            }
+        }
+        for (ManagedDependency managed : bom.getDependencyManagement()) {
+            if (managed instanceof ManagedDependency.Imported) {
+                String property = overridable(placeholder(managed.getVersion()));
+                Pom nested = property == null ? null : downloadImported(bom, managed, downloader, repositories);
+                if (nested != null && nested.getDependencyManagement().stream().anyMatch(md -> md instanceof ManagedDependency.Defined && manages(md, ga))) {
+                    return property;
+                }
+            }
+        }
+        return null;
+    }
+
+    private static Set<GroupArtifact> governedBy(Pom bom, String name, MavenPomDownloader downloader,
+                                                 List<MavenRepository> repositories) throws MavenDownloadingException {
+        Set<GroupArtifact> governed = new LinkedHashSet<>();
+        for (ManagedDependency managed : bom.getDependencyManagement()) {
+            if (!name.equals(placeholder(managed.getVersion()))) {
+                continue;
+            }
+            if (managed instanceof ManagedDependency.Defined) {
+                governed.add(new GroupArtifact(managed.getGroupId(), managed.getArtifactId()));
+            } else {
+                Pom nested = downloadImported(bom, managed, downloader, repositories);
+                if (nested != null) {
+                    for (ManagedDependency md : nested.getDependencyManagement()) {
+                        if (md instanceof ManagedDependency.Defined) {
+                            governed.add(new GroupArtifact(md.getGroupId(), md.getArtifactId()));
+                        }
+                    }
+                }
+            }
+        }
+        return governed;
+    }
+
+    private static @Nullable Pom downloadImported(Pom bom, ManagedDependency imported, MavenPomDownloader downloader,
+                                                  List<MavenRepository> repositories) throws MavenDownloadingException {
+        String version = bom.getValue(imported.getVersion());
+        if (version == null || version.contains("${")) {
+            return null;
+        }
+        return downloader.download(new GroupArtifactVersion(imported.getGroupId(), imported.getArtifactId(), version), null, null, repositories);
+    }
+
+    /**
+     * The other governed artifacts some configuration resolves, keyed to the configurations resolving them.
+     */
+    public Map<GroupArtifact, Set<String>> governedOnClasspath(GradleProject gradleProject, GroupArtifact except) {
+        Map<GroupArtifact, Set<String>> onClasspath = new LinkedHashMap<>();
+        for (GradleDependencyConfiguration configuration : gradleProject.getConfigurations()) {
+            for (ResolvedDependency resolved : configuration.getResolved()) {
+                GroupArtifact ga = resolved.getGav().asGroupArtifact();
+                if (!ga.equals(except) && governed.contains(ga)) {
+                    onClasspath.computeIfAbsent(ga, k -> new HashSet<>()).add(configuration.getName());
+                }
+            }
+        }
+        return onClasspath;
+    }
+
+    /**
+     * Whether every artifact is published at {@code version}, so that moving them all through one property
+     * override does not leave the build unresolvable.
+     */
+    public static boolean isPublished(String version, Collection<GroupArtifact> gas, List<MavenRepository> repositories, ExecutionContext ctx) {
+        MavenPomDownloader downloader = new MavenPomDownloader(ctx);
+        for (GroupArtifact ga : gas) {
+            try {
+                if (!downloader.downloadMetadata(ga, null, repositories).getVersioning().getVersions().contains(version)) {
+                    return false;
+                }
+            } catch (MavenDownloadingException e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean manages(ManagedDependency managed, GroupArtifact ga) {
+        return managed.getGroupId().equals(ga.getGroupId()) && managed.getArtifactId().equals(ga.getArtifactId());
+    }
+
+    private static @Nullable String placeholder(@Nullable String version) {
+        Matcher matcher = version == null ? null : PLACEHOLDER.matcher(version);
+        return matcher != null && matcher.matches() ? matcher.group(1) : null;
+    }
+
+    private static @Nullable String overridable(@Nullable String property) {
+        // project.* placeholders resolve against the BOM's own coordinates, not the importing project's properties
+        return property == null || property.startsWith("project.") ? null : property;
+    }
+
+    /**
+     * The properties the script assigns through any {@code ext}/{@code extra} form, whatever the value's shape.
+     */
+    public static Set<String> declaredProperties(JavaSourceFile cu) {
+        Set<String> declared = new LinkedHashSet<>();
+        new JavaIsoVisitor<Integer>() {
+            @Override
+            public J preVisit(J tree, Integer p) {
+                String name = ExtraProperty.Matcher.assignedProperty(getCursor());
+                if (name != null) {
+                    declared.add(name);
+                }
+                return tree;
+            }
+        }.visit(cu, 0);
+        return declared;
+    }
+
+    /**
+     * Inserts {@code ext['name'] = 'value'} (or {@code extra["name"] = "value"} for the Kotlin DSL) after the
+     * {@code plugins} block, where the dependency management plugin reads it lazily when the BOM is resolved.
+     */
+    public static JavaSourceFile addDeclaration(JavaSourceFile cu, String name, String value, ExecutionContext ctx) {
+        if (cu instanceof K.CompilationUnit) {
+            K.CompilationUnit k = (K.CompilationUnit) cu;
+            Statement declaration = parseSnippet("extra[\"" + name + "\"] = \"" + value + "\"", true, ctx)
+                    .map(requireParsed(K.CompilationUnit.class))
+                    .map(parsed -> ((J.Block) parsed.getStatements().get(0)).getStatements().get(0))
+                    .orElseThrow(() -> new IllegalStateException("Unable to parse extra property declaration"));
+            return k.withStatements(ListUtils.mapFirst(k.getStatements(), statement -> {
+                if (!(statement instanceof J.Block)) {
+                    return statement;
+                }
+                J.Block block = (J.Block) statement;
+                return block.withStatements(insertAfterPlugins(block.getStatements(), declaration));
+            }));
+        }
+        G.CompilationUnit g = (G.CompilationUnit) cu;
+        Statement declaration = parseSnippet("ext['" + name + "'] = '" + value + "'", false, ctx)
+                .map(requireParsed(G.CompilationUnit.class))
+                .map(parsed -> parsed.getStatements().get(0))
+                .orElseThrow(() -> new IllegalStateException("Unable to parse ext property declaration"));
+        return g.withStatements(insertAfterPlugins(g.getStatements(), declaration));
+    }
+
+    private static List<Statement> insertAfterPlugins(List<Statement> statements, Statement declaration) {
+        declaration = declaration.withId(Tree.randomId());
+        int index = 0;
+        for (int i = 0; i < statements.size(); i++) {
+            if (statements.get(i) instanceof J.MethodInvocation) {
+                String name = ((J.MethodInvocation) statements.get(i)).getSimpleName();
+                if ("plugins".equals(name) || "buildscript".equals(name)) {
+                    index = i + 1;
+                }
+            }
+        }
+        if (index > 0) {
+            return ListUtils.insert(statements, declaration.withPrefix(Space.format("\n\n")), index);
+        }
+        // Take over the leading whitespace and comments so a license header stays first
+        Space first = Space.firstPrefix(statements);
+        return ListUtils.insert(Space.formatFirstPrefix(statements, Space.format("\n\n")), declaration.withPrefix(first), 0);
+    }
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleProject.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleProject.java
@@ -100,6 +100,14 @@ public class GradleProject implements ProjectIdentity, Serializable {
     @With
     GradleBuildscript buildscript = new GradleBuildscript(randomId(), emptyList(), emptyMap());
 
+    /**
+     * State of the {@code io.spring.dependency-management} plugin, or null when it is not applied or when the LST
+     * predates this field.
+     */
+    @With
+    @Nullable
+    SpringDependencyManagementPlugin springDependencyManagementPlugin;
+
     public GradleBuildscript getBuildscript() {
         // Temporary workaround for better compatibility with old LSTs that don't have a buildscript field yet.
         //noinspection ConstantValue
@@ -214,7 +222,8 @@ public class GradleProject implements ProjectIdentity, Serializable {
                 mavenRepositories,
                 mavenPluginRepositories,
                 configurations,
-                buildscript
+                buildscript,
+                springDependencyManagementPlugin
         );
     }
 
@@ -319,7 +328,8 @@ public class GradleProject implements ProjectIdentity, Serializable {
                 mavenRepositories,
                 mavenPluginRepositories,
                 updateExtendsFrom(updatedConfigurations, untouchedConfigurations),
-                buildscript
+                buildscript,
+                springDependencyManagementPlugin
         );
 
         // All configurations extending from a mutated configuration must be marked as requiring re-resolution to propagate heritable changes

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleProject.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/GradleProject.java
@@ -101,8 +101,7 @@ public class GradleProject implements ProjectIdentity, Serializable {
     GradleBuildscript buildscript = new GradleBuildscript(randomId(), emptyList(), emptyMap());
 
     /**
-     * State of the {@code io.spring.dependency-management} plugin, or null when it is not applied or when the LST
-     * predates this field.
+     * State of the {@code io.spring.dependency-management} plugin, or null when it is not applied.
      */
     @With
     @Nullable

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/SpringDependencyManagementPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/SpringDependencyManagementPlugin.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.gradle.marker;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Value;
+import lombok.With;
+import org.openrewrite.maven.tree.GroupArtifactVersion;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+
+/**
+ * The effective state of the {@code io.spring.dependency-management} plugin, which is not a Gradle concept: it is
+ * that plugin's own dependency management, layered on top of Gradle's. Recorded because a BOM can be imported
+ * without appearing in any build script — the Spring Boot plugin imports {@code spring-boot-dependencies}
+ * programmatically — and because the plugin honors a project property override of an imported BOM property.
+ */
+@Value
+@With
+@Builder
+@AllArgsConstructor
+public class SpringDependencyManagementPlugin implements Serializable {
+
+    /**
+     * The BOMs imported into this project, whether by a {@code mavenBom} entry in a script or programmatically.
+     */
+    @Builder.Default
+    List<GroupArtifactVersion> importedBoms = emptyList();
+
+    /**
+     * The properties the imported BOMs define. A project property of the same name overrides the BOM's value.
+     */
+    @Builder.Default
+    Map<String, String> importedProperties = emptyMap();
+
+    /**
+     * The versions the imported BOMs manage, keyed by {@code "group:artifact"}. Placeholders are already resolved,
+     * so these do not say which property governed which artifact.
+     */
+    @Builder.Default
+    Map<String, String> managedVersions = emptyMap();
+}

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/SpringDependencyManagementPlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/marker/SpringDependencyManagementPlugin.java
@@ -29,10 +29,9 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 /**
- * The effective state of the {@code io.spring.dependency-management} plugin, which is not a Gradle concept: it is
- * that plugin's own dependency management, layered on top of Gradle's. Recorded because a BOM can be imported
- * without appearing in any build script — the Spring Boot plugin imports {@code spring-boot-dependencies}
- * programmatically — and because the plugin honors a project property override of an imported BOM property.
+ * Dependency management that the {@code io.spring.dependency-management} plugin layers on top of Gradle's own.
+ * A BOM can be imported without appearing in any build script, as the Spring Boot plugin imports
+ * {@code spring-boot-dependencies} programmatically, so the plugin's own state is the only place to read it from.
  */
 @Value
 @With

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/ExtraProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/ExtraProperty.java
@@ -21,7 +21,9 @@ import org.openrewrite.Cursor;
 import org.openrewrite.gradle.internal.ChangeStringLiteral;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.kotlin.marker.IndexedAccess;
 import org.openrewrite.trait.Trait;
 
 /**
@@ -37,7 +39,7 @@ import org.openrewrite.trait.Trait;
  *   <li>ext block assignments: {@code ext { propertyName = 'value' }}</li>
  *   <li>ext field access: {@code ext.propertyName = 'value'}</li>
  *   <li>ext.set() method: {@code ext.set("propertyName", "value")}</li>
- *   <li>ext subscript access: {@code ext['propertyName'] = 'value'}</li>
+ *   <li>ext subscript access: {@code ext['propertyName'] = 'value'} or Kotlin {@code extra["propertyName"] = "value"}</li>
  *   <li>set() in ext block: {@code ext { set('propertyName', 'value') }}</li>
  * </ul>
  */
@@ -184,123 +186,111 @@ public class ExtraProperty implements Trait<J> {
         @Override
         protected @Nullable ExtraProperty test(Cursor cursor) {
             Object node = cursor.getValue();
-
-            // Check for variable declaration: def foo = "bar" or val foo = "bar"
-            if (matchVariableDeclarations && node instanceof J.VariableDeclarations.NamedVariable) {
-                J.VariableDeclarations.NamedVariable var = (J.VariableDeclarations.NamedVariable) node;
-                if (var.getInitializer() instanceof J.Literal) {
-                    J.Literal literal = (J.Literal) var.getInitializer();
-                    if (literal.getValue() instanceof String) {
-                        String name = var.getSimpleName();
-                        if (propertyName == null || propertyName.equals(name)) {
-                            return new ExtraProperty(
-                                    cursor,
-                                    name,
-                                    (String) literal.getValue(),
-                                    PropertySyntax.VARIABLE_DECLARATION
-                            );
-                        }
-                    }
+            String name;
+            Expression value;
+            PropertySyntax syntax;
+            if (node instanceof J.VariableDeclarations.NamedVariable) {
+                if (!matchVariableDeclarations) {
+                    return null;
                 }
+                J.VariableDeclarations.NamedVariable var = (J.VariableDeclarations.NamedVariable) node;
+                name = var.getSimpleName();
+                value = var.getInitializer();
+                syntax = PropertySyntax.VARIABLE_DECLARATION;
+            } else if (node instanceof J.Assignment) {
+                J.Assignment assignment = (J.Assignment) node;
+                syntax = assignmentSyntax(assignment.getVariable(), cursor);
+                name = assignedName(assignment.getVariable());
+                value = assignment.getAssignment();
+            } else if (node instanceof J.MethodInvocation) {
+                J.MethodInvocation method = (J.MethodInvocation) node;
+                syntax = setSyntax(method, cursor);
+                name = syntax == null ? null : stringLiteral(method.getArguments().get(0));
+                value = syntax == null ? null : method.getArguments().get(1);
+            } else {
+                return null;
             }
+            String literal = stringLiteral(value);
+            if (syntax == null || name == null || literal == null || (propertyName != null && !propertyName.equals(name))) {
+                return null;
+            }
+            return new ExtraProperty(cursor, name, literal, syntax);
+        }
 
-            // Check for assignment: ext { foo = "bar" } or ext.foo = "bar" or ext['foo'] = "bar"
+        /**
+         * The property assigned at the cursor through any {@code ext}/{@code extra} form, whatever the value's shape.
+         */
+        public static @Nullable String assignedProperty(Cursor cursor) {
+            Object node = cursor.getValue();
             if (node instanceof J.Assignment) {
                 J.Assignment assignment = (J.Assignment) node;
-                if (!(assignment.getAssignment() instanceof J.Literal)) {
-                    return null;
-                }
-                J.Literal literal = (J.Literal) assignment.getAssignment();
-                if (!(literal.getValue() instanceof String)) {
-                    return null;
-                }
-
-                String name = null;
-                PropertySyntax syntax = null;
-
-                // Check for ext { foo = "bar" }
-                if (assignment.getVariable() instanceof J.Identifier) {
-                    name = ((J.Identifier) assignment.getVariable()).getSimpleName();
-                    J.MethodInvocation enclosingMethod = cursor.firstEnclosing(J.MethodInvocation.class);
-                    if (enclosingMethod != null && "ext".equals(enclosingMethod.getSimpleName())) {
-                        syntax = PropertySyntax.EXT_BLOCK_ASSIGNMENT;
-                    }
-                }
-                // Check for ext.foo = "bar"
-                else if (assignment.getVariable() instanceof J.FieldAccess) {
-                    J.FieldAccess fieldAccess = (J.FieldAccess) assignment.getVariable();
-                    name = fieldAccess.getSimpleName();
-                    if ((fieldAccess.getTarget() instanceof J.Identifier &&
-                            "ext".equals(((J.Identifier) fieldAccess.getTarget()).getSimpleName())) ||
-                            (fieldAccess.getTarget() instanceof J.FieldAccess &&
-                                    "ext".equals(((J.FieldAccess) fieldAccess.getTarget()).getSimpleName()))) {
-                        syntax = PropertySyntax.EXT_FIELD_ACCESS;
-                    }
-                }
-                // Check for ext['foo'] = "bar" (subscript/indexed access)
-                else if (assignment.getVariable() instanceof G.Binary) {
-                    G.Binary binary = (G.Binary) assignment.getVariable();
-                    if (binary.getOperator() == G.Binary.Type.Access &&
-                            binary.getLeft() instanceof J.Identifier &&
-                            "ext".equals(((J.Identifier) binary.getLeft()).getSimpleName()) &&
-                            binary.getRight() instanceof J.Literal) {
-                        J.Literal keyLiteral = (J.Literal) binary.getRight();
-                        if (keyLiteral.getValue() instanceof String) {
-                            name = (String) keyLiteral.getValue();
-                            syntax = PropertySyntax.EXT_SUBSCRIPT_ACCESS;
-                        }
-                    }
-                }
-
-                if (name != null && syntax != null && (propertyName == null || propertyName.equals(name))) {
-                    return new ExtraProperty(cursor, name, (String) literal.getValue(), syntax);
-                }
+                return assignmentSyntax(assignment.getVariable(), cursor) == null ? null : assignedName(assignment.getVariable());
             }
-
-            // Check for ext.set("foo", "bar") or ext { set("foo", "bar") }
             if (node instanceof J.MethodInvocation) {
                 J.MethodInvocation method = (J.MethodInvocation) node;
-                if ("set".equals(method.getSimpleName()) && method.getArguments().size() == 2) {
-                    // Determine if this is ext.set() or set() inside ext block
-                    PropertySyntax setSyntax = null;
-                    if (method.getSelect() instanceof J.Identifier &&
-                            "ext".equals(((J.Identifier) method.getSelect()).getSimpleName())) {
-                        setSyntax = PropertySyntax.EXT_SET_METHOD;
-                    } else if (withinBlock(cursor, "ext")) {
-                        setSyntax = PropertySyntax.EXT_BLOCK_SET_METHOD;
-                    }
-
-                    if (setSyntax != null) {
-                        if (!(method.getArguments().get(0) instanceof J.Literal)) {
-                            return null;
-                        }
-                        J.Literal keyLiteral = (J.Literal) method.getArguments().get(0);
-                        if (!(keyLiteral.getValue() instanceof String)) {
-                            return null;
-                        }
-                        String name = (String) keyLiteral.getValue();
-
-                        if (!(method.getArguments().get(1) instanceof J.Literal)) {
-                            return null;
-                        }
-                        J.Literal valueLiteral = (J.Literal) method.getArguments().get(1);
-                        if (!(valueLiteral.getValue() instanceof String)) {
-                            return null;
-                        }
-
-                        if (propertyName == null || propertyName.equals(name)) {
-                            return new ExtraProperty(
-                                    cursor,
-                                    name,
-                                    (String) valueLiteral.getValue(),
-                                    setSyntax
-                            );
-                        }
-                    }
-                }
+                return setSyntax(method, cursor) == null ? null : stringLiteral(method.getArguments().get(0));
             }
-
             return null;
+        }
+
+        private static @Nullable PropertySyntax assignmentSyntax(Expression variable, Cursor cursor) {
+            if (variable instanceof J.Identifier) {
+                J.MethodInvocation enclosingMethod = cursor.firstEnclosing(J.MethodInvocation.class);
+                return enclosingMethod != null && "ext".equals(enclosingMethod.getSimpleName()) ? PropertySyntax.EXT_BLOCK_ASSIGNMENT : null;
+            }
+            if (variable instanceof J.FieldAccess) {
+                return isExt(((J.FieldAccess) variable).getTarget()) ? PropertySyntax.EXT_FIELD_ACCESS : null;
+            }
+            if (variable instanceof G.Binary) {
+                G.Binary binary = (G.Binary) variable;
+                return binary.getOperator() == G.Binary.Type.Access && isExt(binary.getLeft()) && stringLiteral(binary.getRight()) != null ?
+                        PropertySyntax.EXT_SUBSCRIPT_ACCESS : null;
+            }
+            if (variable instanceof J.MethodInvocation) {
+                // Kotlin extra["foo"] parses as an indexed <get> invocation
+                J.MethodInvocation get = (J.MethodInvocation) variable;
+                return get.getMarkers().findFirst(IndexedAccess.class).isPresent() && isExt(get.getSelect()) &&
+                        get.getArguments().size() == 1 && stringLiteral(get.getArguments().get(0)) != null ?
+                        PropertySyntax.EXT_SUBSCRIPT_ACCESS : null;
+            }
+            return null;
+        }
+
+        private static @Nullable String assignedName(Expression variable) {
+            if (variable instanceof J.Identifier) {
+                return ((J.Identifier) variable).getSimpleName();
+            }
+            if (variable instanceof J.FieldAccess) {
+                return ((J.FieldAccess) variable).getSimpleName();
+            }
+            if (variable instanceof G.Binary) {
+                return stringLiteral(((G.Binary) variable).getRight());
+            }
+            if (variable instanceof J.MethodInvocation) {
+                return stringLiteral(((J.MethodInvocation) variable).getArguments().get(0));
+            }
+            return null;
+        }
+
+        private static @Nullable PropertySyntax setSyntax(J.MethodInvocation method, Cursor cursor) {
+            if (!"set".equals(method.getSimpleName()) || method.getArguments().size() != 2) {
+                return null;
+            }
+            if (isExt(method.getSelect())) {
+                return PropertySyntax.EXT_SET_METHOD;
+            }
+            return withinBlock(cursor, "ext") ? PropertySyntax.EXT_BLOCK_SET_METHOD : null;
+        }
+
+        private static boolean isExt(@Nullable Expression expression) {
+            String name = expression instanceof J.Identifier ? ((J.Identifier) expression).getSimpleName() :
+                    expression instanceof J.FieldAccess ? ((J.FieldAccess) expression).getSimpleName() : null;
+            return "ext".equals(name) || "extra".equals(name);
+        }
+
+        private static @Nullable String stringLiteral(@Nullable Expression expression) {
+            return expression instanceof J.Literal && ((J.Literal) expression).getValue() instanceof String ?
+                    (String) ((J.Literal) expression).getValue() : null;
         }
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleTraitMatcher.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/trait/GradleTraitMatcher.java
@@ -36,7 +36,7 @@ public abstract class GradleTraitMatcher<U extends Trait<?>> extends SimpleTrait
         return maybeGp.orElse(null);
     }
 
-    protected boolean withinBlock(Cursor cursor, String name) {
+    protected static boolean withinBlock(Cursor cursor, String name) {
         Cursor parentCursor = cursor.getParent();
         while (parentCursor != null) {
             if (parentCursor.getValue() instanceof J.MethodInvocation) {

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionBomTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeDependencyVersionBomTest.java
@@ -20,7 +20,10 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.buildGradleKts;
+import static org.openrewrite.gradle.Assertions.settingsGradle;
 import static org.openrewrite.gradle.toolingapi.Assertions.withToolingApi;
+import static org.openrewrite.properties.Assertions.properties;
 
 /**
  * Test cases for UpgradeDependencyVersion with Spring Dependency Management plugin BOM imports.
@@ -365,6 +368,414 @@ class UpgradeDependencyVersionBomTest implements RewriteTest {
                   testImplementation 'org.springframework.boot:spring-boot-starter-test'
               }
               """
+          )
+        );
+    }
+
+    /**
+     * A versionless dependency whose version a BOM derives from a property is upgraded by overriding that property,
+     * which the dependency management plugin resolves against the project's properties.
+     */
+    @Test
+    void overridesBomPropertyOfManagedDependency() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.yaml", "snakeyaml", "1.33", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              ext['snakeyaml.version'] = '1.33'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void updatesExistingBomPropertyOverride() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.yaml", "snakeyaml", "1.33", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              ext['snakeyaml.version'] = '1.28'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              ext['snakeyaml.version'] = '1.33'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void updatesBomPropertyOverrideInGradleProperties() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.yaml", "snakeyaml", "1.33", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """
+          ),
+          properties(
+            """
+              snakeyaml.version=1.28
+              """,
+            """
+              snakeyaml.version=1.33
+              """,
+            spec -> spec.path("gradle.properties")
+          )
+        );
+    }
+
+    @Test
+    void overridesBomPropertyInKotlinDsl() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.yaml", "snakeyaml", "1.33", null)),
+          buildGradleKts(
+            """
+              plugins {
+                  java
+                  id("io.spring.dependency-management") version "1.1.7"
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom("org.springframework.boot:spring-boot-dependencies:2.5.7")
+                  }
+              }
+
+              dependencies {
+                  implementation("org.yaml:snakeyaml")
+              }
+              """,
+            """
+              plugins {
+                  java
+                  id("io.spring.dependency-management") version "1.1.7"
+              }
+
+              extra["snakeyaml.version"] = "1.33"
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom("org.springframework.boot:spring-boot-dependencies:2.5.7")
+                  }
+              }
+
+              dependencies {
+                  implementation("org.yaml:snakeyaml")
+              }
+              """
+          )
+        );
+    }
+
+    /**
+     * log4j-core is managed by the log4j BOM that spring-boot-dependencies imports at {@code ${log4j2.version}},
+     * so that property governs it and every other log4j artifact on the classpath.
+     */
+    @Test
+    void overridesPropertyOfNestedBomImport() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.apache.logging.log4j", "log4j-core", "2.17.1", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.apache.logging.log4j:log4j-core'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              ext['log4j2.version'] = '2.17.1'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.apache.logging.log4j:log4j-core'
+              }
+              """
+          )
+        );
+    }
+
+    /**
+     * The Boot plugin imports spring-boot-dependencies programmatically, so no `mavenBom` line exists to find. The
+     * import is discovered from the dependency management plugin's state on the GradleProject marker instead.
+     */
+    @Test
+    void overridesBomPropertyOfBomImportedByBootPlugin() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.yaml", "snakeyaml", "2.3", null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'org.springframework.boot' version '3.3.5'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+                  id 'org.springframework.boot' version '3.3.5'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              ext['snakeyaml.version'] = '2.3'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """
+          )
+        );
+    }
+
+    /**
+     * A project property is honored no matter which script imported the BOM, so the override is written into the
+     * build.gradle that owns the project rather than into the applied script.
+     */
+    @Test
+    void overridesBomPropertyWhenBomIsImportedByAppliedScript() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.yaml", "snakeyaml", "1.33", null)),
+          buildGradle(
+            """
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+              """,
+            spec -> spec.path("dependencyManagement.gradle")
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              apply from: 'dependencyManagement.gradle'
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              ext['snakeyaml.version'] = '1.33'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              apply from: 'dependencyManagement.gradle'
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """
+          )
+        );
+    }
+
+    /**
+     * The root project's `subprojects` block imports the BOM on the subproject's behalf. Writing the override into
+     * the subproject's own script shadows the root for that project only.
+     */
+    @Test
+    void overridesBomPropertyImportedByRootSubprojectsBlock() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("org.yaml", "snakeyaml", "1.33", null)),
+          settingsGradle(
+            """
+              rootProject.name = 'sample'
+              include 'sub'
+              """
+          ),
+          buildGradle(
+            """
+              plugins {
+                  id 'io.spring.dependency-management' version '1.1.7' apply false
+              }
+
+              subprojects {
+                  apply plugin: 'java'
+                  apply plugin: 'io.spring.dependency-management'
+
+                  repositories {
+                      mavenCentral()
+                  }
+
+                  dependencyManagement {
+                      imports {
+                          mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                      }
+                  }
+              }
+              """
+          ),
+          buildGradle(
+            """
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """,
+            """
+              ext['snakeyaml.version'] = '1.33'
+
+              dependencies {
+                  implementation 'org.yaml:snakeyaml'
+              }
+              """,
+            spec -> spec.path("sub/build.gradle")
           )
         );
     }

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1033,6 +1033,62 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
         );
     }
 
+    /**
+     * spring-boot-dependencies imports the log4j BOM at {@code ${log4j2.version}}, so overriding that project
+     * property is how Spring documents moving every log4j artifact, and no resolution rule is needed.
+     */
+    @Test
+    void overrideBomPropertyWhenSpringDependencyManagementPluginImportsBom() {
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeTransitiveDependencyVersion(
+            "org.apache.logging.log4j", "log4j-core", "2.17.1", null, null, null)),
+          buildGradle(
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+                  id 'io.spring.dependency-management' version '1.1.7'
+              }
+
+              ext['log4j2.version'] = '2.17.1'
+
+              repositories {
+                  mavenCentral()
+              }
+
+              dependencyManagement {
+                  imports {
+                      mavenBom 'org.springframework.boot:spring-boot-dependencies:2.5.7'
+                  }
+              }
+
+              dependencies {
+                  implementation 'org.springframework.boot:spring-boot-starter-log4j2'
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void useResolutionStrategyWithApplyFromWhenSpringDependencyManagementPluginIsPresent() {
         rewriteRun(

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/ExtraPropertyTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/trait/ExtraPropertyTest.java
@@ -22,6 +22,7 @@ import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 
 import static org.openrewrite.gradle.Assertions.buildGradle;
+import static org.openrewrite.gradle.Assertions.buildGradleKts;
 
 class ExtraPropertyTest implements RewriteTest {
 
@@ -247,6 +248,27 @@ class ExtraPropertyTest implements RewriteTest {
             """
               /*~~>*/ext['jackson.version'] = "2.13.3"
               ext['guava.version'] = "30.0-jre"
+              """
+          )
+        );
+    }
+
+    @Test
+    void updatesKotlinExtraSubscriptAccess() {
+        rewriteRun(
+          spec -> spec.recipe(RewriteTest.toRecipe(() -> new ExtraProperty.Matcher()
+            .propertyName("jackson.version")
+            .asVisitor((prop, ctx) -> prop.withValue("2.15.0").getTree()))),
+          buildGradleKts(
+            """
+              extra["jackson.version"] = "2.13.3"
+              extra["guava.version"] = "30.0-jre"
+              extra.set("guava.version", "30.0-jre")
+              """,
+            """
+              extra["jackson.version"] = "2.15.0"
+              extra["guava.version"] = "30.0-jre"
+              extra.set("guava.version", "30.0-jre")
               """
           )
         );


### PR DESCRIPTION
## What's changed

When the `io.spring.dependency-management` plugin governs a version through a property of an imported BOM, neither upgrade recipe produced the fix Spring documents.

- `UpgradeDependencyVersion` made no change at all for a versionless declaration, because there is no version in the script to rewrite.
- `UpgradeTransitiveDependencyVersion` emitted a `configurations.all { resolutionStrategy.eachDependency { ... } }` rule. That branch is taken purely because the plugin id is present, on the grounds that the plugin overrides constraints.

The plugin resolves its dependency management lazily and consults project properties while doing so, so a project property of the same name overrides the BOM's value. Both recipes now write that override:

```groovy
ext['snakeyaml.version'] = '2.3'
```

```kotlin
extra["snakeyaml.version"] = "2.3"
```

An existing declaration is updated in place, whether it lives in a build script or in `gradle.properties`. Where no property governs the version the previous behavior stands, so a Gradle-native `platform()` still gets a constraint and `useResolutionStrategyWhenSpringDependencyManagementPluginIsPresent` passes unchanged.

## Finding the BOM

A BOM need not appear in any build script to govern a version: the Spring Boot plugin imports `spring-boot-dependencies` programmatically. `GradleProjectBuilder` therefore records the plugin's effective state — imported BOMs, imported properties, managed versions — on a new `SpringDependencyManagementPlugin` marker.

Capture is reflective throughout, since OpenRewrite depends on neither plugin, and yields `null` whenever anything is unavailable, so an LST produced without it falls back to reading the scripts. Coordinates come from the Boot plugin's own `BOM_COORDINATES` constant where that plugin is applied, and otherwise from the dependency management plugin's internals; the internal shape is identical in 1.0.15 and 1.1.7. The marker field is nullable and appended last, so old LSTs deserialize with `null` and older readers ignore it.

Script-based discovery now spans the whole build rather than a single file, so an import in an `apply from:` script or a root `subprojects` block is found even without the new marker data. Because a dependency can be scanned before the script that imports its BOM, property matching happens once the scan completes. The override is written into the script carrying the project's marker, since a project property is honored wherever the import happened.

`ExtraProperty` gained the Kotlin `extra["x"]` and `extra.set(...)` forms, which it did not match before.

## Tests

All green against this branch's base.

| Class | Tests | Failures |
|---|---|---|
| `UpgradeDependencyVersionBomTest` | 14 | 0 |
| `UpgradeDependencyVersionTest` | 110 | 0 |
| `UpgradeTransitiveDependencyVersionTest` | 48 | 0 |
| `trait.ExtraPropertyTest` | 12 | 0 |
| `GradleProjectTest`, all nested classes | 14 | 0 |

The two skips are pre-existing `@Disabled` cases. New coverage: the plain BOM property override, updating an existing override, the `gradle.properties` route, Kotlin DSL, a property of a nested BOM import, a BOM imported only by the Boot plugin, an `apply from:` script, a root `subprojects` block, the transitive case, and a marker round-trip.

## Known limitations

- Only a single `${property}` placeholder qualifies. Composite and `project.*` expressions are treated as not overridable.
- Nested BOM imports are followed one level.
- A property may govern a family of artifacts, so before writing an override each governed artifact present in the resolved graph is checked to exist at the target version. If any is missing, the recipe leaves the build alone rather than making it unresolvable, and the transitive recipe falls back to the resolution rule.
- Declared-property tracking is build-wide, so in a multi-module build where a sibling module already declares the property, insertion is suppressed for the others. This was chosen over inserting a duplicate; scoping it per project would be a reasonable follow-up.
- `val x by extra(...)` delegates and `project.extra["x"]` are not matched.
- Per-configuration dependency management, `dependencyManagement { implementation { ... } }`, is not captured.
- `:rewrite-gradle-tooling-model:model:testGradle4` reports `NO-SOURCE` locally, so the Gradle 4.10 path was not exercised. The capture is fully guarded and returns `null` when the extension is absent, but that is reasoning rather than a test result.
