### PR TITLE
Groovy: print parentheses for a method invocation with no arguments

### DIFF
--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/GroovyPrinter.java
@@ -521,6 +521,11 @@ public class GroovyPrinter<P> extends GroovyVisitor<PrintOutputCapture<P>> {
 
             visitSpace(argContainer.getBefore(), Space.Location.METHOD_INVOCATION_ARGUMENTS, p);
             List<JRightPadded<Expression>> args = argContainer.getPadding().getElements();
+            // The parser gives a zero-argument call a J.Empty argument; an element-less container is
+            // recipe-built, and the loop below only emits parentheses alongside an argument.
+            if (args.isEmpty()) {
+                p.append("()");
+            }
             boolean argsAreAllClosures = args.stream().allMatch(it -> it.getElement() instanceof J.Lambda);
             boolean hasParentheses = true;
             boolean applyTrailingLambdaParenthese = true;

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
@@ -18,6 +18,7 @@ package org.openrewrite.groovy;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
@@ -89,6 +90,40 @@ class GroovyTemplateTest implements RewriteTest {
 
                   @SuppressWarnings("all")
                   def method() {}
+              }
+              """
+          ));
+    }
+
+    @Test
+    void replaceArgumentsOfExplicitConstructorInvocation() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new GroovyVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if ("super".equals(method.getSimpleName()) && method.getMethodType() != null && method.getArguments().size() == 1) {
+                      return JavaTemplate.builder("message, null")
+                        .build()
+                        .apply(getCursor(), method.getCoordinates().replaceArguments());
+                  }
+                  return method;
+              }
+          })),
+          groovy(
+            """
+              @groovy.transform.CompileStatic
+              class A extends RuntimeException {
+                  A(String message) {
+                      super(message)
+                  }
+              }
+              """,
+            """
+              @groovy.transform.CompileStatic
+              class A extends RuntimeException {
+                  A(String message) {
+                      super(message, null)
+                  }
               }
               """
           ));


### PR DESCRIPTION
A `J.MethodInvocation` whose argument container holds no elements prints as a bare name in Groovy — `super()` comes out as `super`, `foo()` as `foo`. Found while running a recipe over a corpus of open-source repositories, where it surfaced as:

```
java.lang.ClassCastException: class org.openrewrite.java.tree.J$FieldAccess cannot be cast to class org.openrewrite.java.tree.J$MethodInvocation
	at org.openrewrite.java.internal.template.JavaTemplateParser.parseMethodArguments(JavaTemplateParser.java:223)
```

## Mechanism

`GroovyPrinter.visitMethodInvocation` emits `(` and `)` from inside the loop over the container's elements — `(` when `i == 0`, `)` when `i == args.size() - 1`. With no elements the loop body never runs and both delimiters are lost. `JavaPrinter` has no equivalent problem: it delegates to `visitContainer("(", …, ")")`, which emits the delimiters whatever the container holds.

Parsing never yields such a container — `GroovyParserVisitor` gives a zero-argument call a `J.Empty` argument — so the only way in is an LST built by a recipe or by `JavaTemplate`. `JavaTemplateParser.parseMethodArguments` opens with exactly that:

```java
String methodWithReplacementArgs = method.withArguments(emptyList()).printTrimmed(cursor.getParentOrThrow())
        .replaceAll("\\)$", template + (isStatement(cursor) ? ");" : ")"));
```

With no trailing `)` the `replaceAll` matches nothing, the replacement arguments are silently dropped, and the stub reaches the Java parser as `Object o = /*__TEMPLATE__*/super/*__TEMPLATE_STOP__*/;`. A bare `super` parses to a `J.FieldAccess`, and the cast on the next line throws.

## Fix

Emit `()` when the element list is empty, ahead of the loop that decides the paren-less shapes. The loop is untouched, so command expressions (`println "x"`), trailing closures (`stage('Build') {}`), the multiple-closure case and the `EmptyArgumentListPrecedesArgument` marker keep their output, and a zero-argument call parsed from source still round-trips through its `J.Empty`.

`parseMethodArguments` gets no guard of its own. Its cast is unsound for any stub that does not parse to an invocation, but a guard could only trade one exception for another — the arguments are already lost by the time the string is spliced — and it would have to fire for shapes that are legitimately paren-less and unfixable by splicing.

## Tests

`GroovyTemplateTest.replaceArgumentsOfExplicitConstructorInvocation` applies a `JavaTemplate` with `replaceArguments` coordinates to a `super(..)` call in an `@CompileStatic` class — Groovy only attributes a method type to `super(..)` under `@CompileStatic`, which is what recipes check before templating. Without the printer change it fails with the `ClassCastException` above.
