### PR TITLE
Let a template insert at the top level of a script

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeDependencyVersion.java
@@ -830,7 +830,7 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 }
                 String version = safeUpdatedVersion(property, dependencyMatcher, acc, gradleProject, ctx);
                 if (version != null) {
-                    cu = SpringBomProperty.addDeclaration(cu, property, version, ctx);
+                    cu = SpringBomProperty.addDeclaration(new Cursor(getCursor(), cu), property, version);
                 }
             }
             return cu;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -648,7 +648,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                             .<ExecutionContext>asVisitor((property, c) -> property.withValue(version).getTree())
                             .visitNonNull(cu, ctx);
                 } else {
-                    cu = SpringBomProperty.addDeclaration(cu, name, version, ctx);
+                    cu = SpringBomProperty.addDeclaration(new Cursor(getCursor(), cu), name, version);
                 }
             }
             return cu;

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/RewriteSpreadAllInConfigurationsBlock.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/RewriteSpreadAllInConfigurationsBlock.java
@@ -22,8 +22,8 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.marker.StarDot;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -77,28 +77,19 @@ public class RewriteSpreadAllInConfigurationsBlock extends Recipe {
                 }
                 List<Statement> stripped = ListUtils.map(statements, RewriteSpreadAllInConfigurationsBlock::stripSpread);
 
-                J.MethodInvocation template = parseConfigurationsAllTemplate(ctx);
-                J.Lambda templateLambda = (J.Lambda) template.getArguments().get(0);
-                J.Block templateBody = (J.Block) templateLambda.getBody();
+                J.MethodInvocation shell = GroovyTemplate.builder("configurations.all {\n}")
+                        .build()
+                        .apply(getCursor(), m.getCoordinates().replace());
+                J.Lambda shellLambda = (J.Lambda) shell.getArguments().get(0);
+                J.Block shellBody = (J.Block) shellLambda.getBody();
 
-                return autoFormat(template
-                        .withPrefix(m.getPrefix())
-                        .withArguments(singletonList(templateLambda.withBody(templateBody.withStatements(stripped)))),
+                // The shell arrives placed and formatted; only the statements poured into it are still indented for
+                // where they used to live.
+                return autoIndent(shell
+                        .withArguments(singletonList(shellLambda.withBody(shellBody.withStatements(stripped)))),
                         ctx, getCursor().getParentOrThrow());
             }
         });
-    }
-
-    private static J.MethodInvocation parseConfigurationsAllTemplate(ExecutionContext ctx) {
-        G.CompilationUnit parsed = (G.CompilationUnit) GradleParser.builder().build()
-                .parse(ctx, "configurations.all {\n}\n")
-                .findFirst()
-                .orElseThrow(() -> new IllegalStateException("Unable to parse `configurations.all { }` template"));
-        Statement first = parsed.getStatements().get(0);
-        if (!(first instanceof J.MethodInvocation)) {
-            throw new IllegalStateException("Expected a method invocation, got " + first.getClass().getName());
-        }
-        return (J.MethodInvocation) first;
     }
 
     private static boolean isConfigurationsClosure(J.MethodInvocation m) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/SpringBomProperty.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/internal/SpringBomProperty.java
@@ -17,20 +17,23 @@ package org.openrewrite.gradle.internal;
 
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
-import org.openrewrite.Tree;
 import org.openrewrite.gradle.marker.GradleDependencyConfiguration;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.marker.SpringDependencyManagementPlugin;
 import org.openrewrite.gradle.trait.ExtraProperty;
 import org.openrewrite.gradle.trait.SpringDependencyManagementPluginEntry;
+import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaSourceFile;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
+import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.internal.MavenPomDownloader;
@@ -40,8 +43,7 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static org.openrewrite.gradle.internal.GradleParseUtils.parseSnippet;
-import static org.openrewrite.gradle.internal.GradleParseUtils.requireParsed;
+import static java.util.Collections.emptyList;
 
 /**
  * The Maven property through which a BOM imported by the {@code io.spring.dependency-management} plugin governs a
@@ -246,45 +248,58 @@ public class SpringBomProperty {
      * Inserts {@code ext['name'] = 'value'} (or {@code extra["name"] = "value"} for the Kotlin DSL) after the
      * {@code plugins} block, where the dependency management plugin reads it lazily when the BOM is resolved.
      */
-    public static JavaSourceFile addDeclaration(JavaSourceFile cu, String name, String value, ExecutionContext ctx) {
-        if (cu instanceof K.CompilationUnit) {
-            K.CompilationUnit k = (K.CompilationUnit) cu;
-            Statement declaration = parseSnippet("extra[\"" + name + "\"] = \"" + value + "\"", true, ctx)
-                    .map(requireParsed(K.CompilationUnit.class))
-                    .map(parsed -> ((J.Block) parsed.getStatements().get(0)).getStatements().get(0))
-                    .orElseThrow(() -> new IllegalStateException("Unable to parse extra property declaration"));
-            return k.withStatements(ListUtils.mapFirst(k.getStatements(), statement -> {
-                if (!(statement instanceof J.Block)) {
-                    return statement;
-                }
-                J.Block block = (J.Block) statement;
-                return block.withStatements(insertAfterPlugins(block.getStatements(), declaration));
-            }));
+    public static JavaSourceFile addDeclaration(Cursor scope, String name, String value) {
+        JavaSourceFile cu = scope.getValue();
+        JavaTemplate declaration = cu instanceof K.CompilationUnit ?
+                KotlinTemplate.builder("extra[\"" + name + "\"] = \"" + value + "\"").build() :
+                GroovyTemplate.builder("ext['" + name + "'] = '" + value + "'").build();
+
+        List<Statement> statements = topLevelStatements(cu);
+        int plugins = lastPluginsBlock(statements);
+        // A coordinate places the declaration but says nothing about spacing, and Gradle scripts set their
+        // top-level blocks apart with a blank line
+        if (plugins < 0) {
+            // Nothing to sit under, so lead the file and push what was first down past a blank line
+            return blankLineBefore(declaration.apply(scope, statements.get(0).getCoordinates().before()), 1);
         }
-        G.CompilationUnit g = (G.CompilationUnit) cu;
-        Statement declaration = parseSnippet("ext['" + name + "'] = '" + value + "'", false, ctx)
-                .map(requireParsed(G.CompilationUnit.class))
-                .map(parsed -> parsed.getStatements().get(0))
-                .orElseThrow(() -> new IllegalStateException("Unable to parse ext property declaration"));
-        return g.withStatements(insertAfterPlugins(g.getStatements(), declaration));
+        return blankLineBefore(declaration.apply(scope, statements.get(plugins).getCoordinates().after()), plugins + 1);
     }
 
-    private static List<Statement> insertAfterPlugins(List<Statement> statements, Statement declaration) {
-        declaration = declaration.withId(Tree.randomId());
-        int index = 0;
+    private static int lastPluginsBlock(List<Statement> statements) {
+        int index = -1;
         for (int i = 0; i < statements.size(); i++) {
             if (statements.get(i) instanceof J.MethodInvocation) {
                 String name = ((J.MethodInvocation) statements.get(i)).getSimpleName();
                 if ("plugins".equals(name) || "buildscript".equals(name)) {
-                    index = i + 1;
+                    index = i;
                 }
             }
         }
-        if (index > 0) {
-            return ListUtils.insert(statements, declaration.withPrefix(Space.format("\n\n")), index);
+        return index;
+    }
+
+    private static JavaSourceFile blankLineBefore(JavaSourceFile cu, int index) {
+        return withTopLevelStatements(cu, ListUtils.map(topLevelStatements(cu),
+                (i, statement) -> i == index ? statement.withPrefix(Space.format("\n\n")) : statement));
+    }
+
+    /**
+     * A Kotlin script wraps its statements in a block; a Groovy script holds them directly.
+     */
+    private static List<Statement> topLevelStatements(JavaSourceFile cu) {
+        if (cu instanceof K.CompilationUnit) {
+            Statement first = ((K.CompilationUnit) cu).getStatements().get(0);
+            return first instanceof J.Block ? ((J.Block) first).getStatements() : emptyList();
         }
-        // Take over the leading whitespace and comments so a license header stays first
-        Space first = Space.firstPrefix(statements);
-        return ListUtils.insert(Space.formatFirstPrefix(statements, Space.format("\n\n")), declaration.withPrefix(first), 0);
+        return ((G.CompilationUnit) cu).getStatements();
+    }
+
+    private static JavaSourceFile withTopLevelStatements(JavaSourceFile cu, List<Statement> statements) {
+        if (cu instanceof K.CompilationUnit) {
+            K.CompilationUnit k = (K.CompilationUnit) cu;
+            return k.withStatements(ListUtils.mapFirst(k.getStatements(), first -> first instanceof J.Block ?
+                    ((J.Block) first).withStatements(statements) : first));
+        }
+        return ((G.CompilationUnit) cu).withStatements(statements);
     }
 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/SpacesVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/SpacesVisitor.java
@@ -18,6 +18,8 @@ package org.openrewrite.groovy.format;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.Tree;
 import org.openrewrite.groovy.marker.AsStyleTypeCast;
+import org.openrewrite.groovy.marker.LambdaStyle;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.internal.ToBeRemoved;
 import org.openrewrite.java.style.*;
 import org.openrewrite.java.tree.J;
@@ -51,6 +53,20 @@ public class SpacesVisitor<P> extends org.openrewrite.java.format.SpacesVisitor<
             return typeCast;
         }
         return super.visitTypeCast(typeCast, p);
+    }
+
+    @Override
+    public J.Lambda visitLambda(J.Lambda lambda, P p) {
+        J.Lambda l = super.visitLambda(lambda, p);
+        List<J> parameters = lambda.getParameters().getParameters();
+        if (parameters.isEmpty() || lambda.getParameters().isParenthesized() ||
+            lambda.getMarkers().findFirst(LambdaStyle.class).map(LambdaStyle::isJavaStyle).orElse(false)) {
+            return l;
+        }
+        // A closure's parameters follow `{`, so Java's rule of no padding after `(` must not eat the space there
+        Space beforeFirst = parameters.get(0).getPrefix();
+        return l.withParameters(l.getParameters().withParameters(ListUtils.mapFirst(l.getParameters().getParameters(),
+                param -> param.withPrefix(beforeFirst))));
     }
 
     @Override

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/service/GroovySourceFileStatementService.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/service/GroovySourceFileStatementService.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.service;
+
+import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.service.SourceFileStatementService;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.List;
+
+public class GroovySourceFileStatementService extends SourceFileStatementService {
+
+    @Override
+    public List<Statement> getStatements(JavaSourceFile cu) {
+        return cu instanceof G.CompilationUnit ? ((G.CompilationUnit) cu).getStatements() : super.getStatements(cu);
+    }
+
+    @Override
+    public JavaSourceFile withStatements(JavaSourceFile cu, List<Statement> statements) {
+        return cu instanceof G.CompilationUnit ?
+                ((G.CompilationUnit) cu).withStatements(statements) :
+                super.withStatements(cu, statements);
+    }
+}

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/tree/G.java
@@ -24,9 +24,11 @@ import org.openrewrite.groovy.GroovyPrinter;
 import org.openrewrite.groovy.GroovyVisitor;
 import org.openrewrite.groovy.internal.GroovyWhitespaceValidationService;
 import org.openrewrite.groovy.service.GroovyAutoFormatService;
+import org.openrewrite.groovy.service.GroovySourceFileStatementService;
 import org.openrewrite.internal.WhitespaceValidationService;
 import org.openrewrite.java.internal.TypesInUse;
 import org.openrewrite.java.service.AutoFormatService;
+import org.openrewrite.java.service.SourceFileStatementService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -156,6 +158,8 @@ public interface G extends J {
                     serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyAutoFormatService.class.getName());
                 } else if (WhitespaceValidationService.class.getName().equals(serviceName)) {
                     serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovyWhitespaceValidationService.class.getName());
+                } else if (SourceFileStatementService.class.getName().equals(serviceName)) {
+                    serviceClass = (Class<S>) service.getClassLoader().loadClass(GroovySourceFileStatementService.class.getName());
                 } else {
                     return JavaSourceFile.super.service(service);
                 }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
@@ -18,14 +18,51 @@ package org.openrewrite.groovy;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.groovy.tree.G;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.List;
 
 import static org.openrewrite.groovy.Assertions.groovy;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class GroovyTemplateTest implements RewriteTest {
+
+    // Replaces the invocation named `placeholder`, the shape Gradle DSL recipes need: a new statement in a script body
+    private static Recipe replacePlaceholder(String template) {
+        return toRecipe(() -> new GroovyVisitor<>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (!"placeholder".equals(method.getSimpleName())) {
+                    return super.visitMethodInvocation(method, ctx);
+                }
+                return GroovyTemplate.builder(template)
+                  .build()
+                  .apply(getCursor(), method.getCoordinates().replace());
+            }
+        });
+    }
+
+    // A Groovy script holds its statements directly, so a coordinate on one can only be reached from the file
+    private static Recipe insertAtTopLevel(boolean before) {
+        return toRecipe(() -> new GroovyVisitor<>() {
+            @Override
+            public J visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
+                G.CompilationUnit c = (G.CompilationUnit) super.visitCompilationUnit(cu, ctx);
+                if (c.getStatements().size() != 1) {
+                    return c;
+                }
+                Statement only = c.getStatements().get(0);
+                return GroovyTemplate.builder("ext['x'] = 'y'")
+                  .build()
+                  .apply(updateCursor(c), before ? only.getCoordinates().before() : only.getCoordinates().after());
+            }
+        });
+    }
 
     @DocumentExample
     @Test
@@ -90,6 +127,270 @@ class GroovyTemplateTest implements RewriteTest {
 
                   @SuppressWarnings("all")
                   def method() {}
+              }
+              """
+          ));
+    }
+
+    @Test
+    void statementWithEmptyClosure() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholder(
+            """
+              configurations.all {
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder()
+              """,
+            """
+              configurations.all {
+              }
+              """
+          ));
+    }
+
+    @Test
+    void nestedBlock() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholder(
+            """
+              java {
+                  sourceCompatibility = 11
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder()
+              """,
+            """
+              java {
+                  sourceCompatibility = 11
+              }
+              """
+          ));
+    }
+
+    @Test
+    void assignmentWithSubscript() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholder("ext['x'] = 'y'")),
+          groovy(
+            """
+              placeholder()
+              """,
+            """
+              ext['x'] = 'y'
+              """
+          ));
+    }
+
+    @Test
+    void methodInvocationWithTrailingClosureArgument() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholder(
+            """
+              tasks.named('test') {
+                  useJUnitPlatform()
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder()
+              """,
+            """
+              tasks.named('test') {
+                  useJUnitPlatform()
+              }
+              """
+          ));
+    }
+
+    @Test
+    void substituteExpressionIntoClosureBody() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new GroovyVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if (!"placeholder".equals(method.getSimpleName())) {
+                      return super.visitMethodInvocation(method, ctx);
+                  }
+                  return GroovyTemplate.builder(
+                      """
+                        configurations.all {
+                            #{any()}
+                        }
+                        """)
+                    .build()
+                    .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().get(0));
+              }
+          })),
+          groovy(
+            """
+              placeholder(exclude(group: 'commons-logging'))
+              """,
+            """
+              configurations.all {
+                  exclude(group: 'commons-logging')
+              }
+              """
+          ));
+    }
+
+    @Test
+    void statementWithClosureInsideMethod() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholder(
+            """
+              configurations.all {
+              }
+              """
+          )),
+          groovy(
+            """
+              class Test {
+                  def foo() {
+                      placeholder()
+                  }
+              }
+              """,
+            """
+              class Test {
+                  def foo() {
+                      configurations.all {
+                      }
+                  }
+              }
+              """
+          ));
+    }
+
+    @Test
+    void closureWithExplicitParameter() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholder(
+            """
+              configurations.all { config ->
+                  config.exclude group: 'log4j'
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder()
+              """,
+            """
+              configurations.all { config ->
+                  config.exclude group: 'log4j'
+              }
+              """
+          ));
+    }
+
+    @Test
+    void reindentStatementsPouredIntoATemplatedShell() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new GroovyVisitor<>() {
+              @Override
+              public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if (!"outer".equals(method.getSimpleName())) {
+                      return super.visitMethodInvocation(method, ctx);
+                  }
+                  J.Block outerBody = (J.Block) ((J.Lambda) method.getArguments().get(0)).getBody();
+                  // A closure's last statement is an implicit return
+                  J.MethodInvocation inner = (J.MethodInvocation) ((J.Return) outerBody.getStatements().get(0)).getExpression();
+                  List<Statement> poured = ((J.Block) ((J.Lambda) inner.getArguments().get(0)).getBody()).getStatements();
+
+                  J.MethodInvocation shell = GroovyTemplate.builder(
+                      """
+                        configurations.all {
+                        }
+                        """)
+                    .build()
+                    .apply(getCursor(), method.getCoordinates().replace());
+                  J.Lambda shellLambda = (J.Lambda) shell.getArguments().get(0);
+                  J.Block shellBody = (J.Block) shellLambda.getBody();
+                  return autoIndent(shell
+                      .withArguments(List.of(shellLambda.withBody(shellBody.withStatements(poured)))),
+                    ctx, getCursor().getParentOrThrow());
+              }
+          })),
+          groovy(
+            """
+              outer {
+                  inner {
+                      foo()
+                      bar()
+                  }
+              }
+              """,
+            """
+              configurations.all {
+                  foo()
+                  bar()
+              }
+              """
+          ));
+    }
+
+    @Test
+    void insertAfterTopLevelScriptStatement() {
+        rewriteRun(
+          spec -> spec.recipe(insertAtTopLevel(false)),
+          groovy(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+              }
+              ext['x'] = 'y'
+              """
+          ));
+    }
+
+    @Test
+    void insertBeforeTopLevelScriptStatement() {
+        rewriteRun(
+          spec -> spec.recipe(insertAtTopLevel(true)),
+          groovy(
+            """
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              ext['x'] = 'y'
+              plugins {
+                  id 'java'
+              }
+              """
+          ));
+    }
+
+    @Test
+    void insertBeforeTopLevelScriptStatementKeepsLicenseHeaderOnTop() {
+        rewriteRun(
+          spec -> spec.recipe(insertAtTopLevel(true)),
+          groovy(
+            """
+              // Copyright
+              plugins {
+                  id 'java'
+              }
+              """,
+            """
+              // Copyright
+              ext['x'] = 'y'
+              plugins {
+                  id 'java'
               }
               """
           ));

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
@@ -112,7 +112,7 @@ class AutoFormatVisitorTest implements RewriteTest {
               """,
             """
               if (convertTemplate == null)
-                  convertTemplate = inTypemap.find {key, value ->
+                  convertTemplate = inTypemap.find { key, value ->
                       (key instanceof Pattern && key.matcher(apiType).matches())
                   }?.value
               """

--- a/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/JavaVisitor.java
@@ -95,6 +95,24 @@ public class JavaVisitor<P> extends TreeVisitor<J, P> {
         return (J2) service.autoFormatVisitor(stopAfter).visit(j, p, parent);
     }
 
+    public <J2 extends J> J2 autoIndent(J2 j, P p, Cursor parent) {
+        return autoIndent(j, null, p, parent);
+    }
+
+    /**
+     * Re-indent {@code j} for where it now sits, leaving every other aspect of its formatting alone. Statements
+     * moved in from elsewhere in the tree arrive with the indentation of where they came from, which is all that
+     * needs fixing when the surrounding shell was itself parsed from well-formed source.
+     */
+    @SuppressWarnings({"ConstantConditions", "unchecked"})
+    public <J2 extends J> J2 autoIndent(J2 j, @Nullable J stopAfter, P p, Cursor parent) {
+        JavaSourceFile cu = (j instanceof JavaSourceFile) ?
+                (JavaSourceFile) j :
+                getCursor().firstEnclosingOrThrow(JavaSourceFile.class);
+        AutoFormatService service = cu.service(AutoFormatService.class);
+        return (J2) service.tabsAndIndentsVisitor(cu, stopAfter).visit(j, p, parent);
+    }
+
     /**
      * Targeted, low-blast-radius cleanup pass for the result of an LST edit.
      * Runs only the whitespace-normalisation steps of auto-format:

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -21,6 +21,7 @@ import org.openrewrite.TreeVisitor;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
+import org.openrewrite.java.service.SourceFileStatementService;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 
@@ -89,6 +90,75 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             }
 
             @Override
+            public @Nullable J preVisit(J tree, Integer p) {
+                if (loc == STATEMENT_PREFIX && mode != JavaCoordinates.Mode.REPLACEMENT && tree instanceof JavaSourceFile) {
+                    J spliced = insertIntoSourceFile((JavaSourceFile) tree, p);
+                    if (spliced != null) {
+                        stopAfterPreVisit();
+                        return spliced;
+                    }
+                }
+                return super.preVisit(tree, p);
+            }
+
+            /**
+             * A Groovy script has no block around its top-level statements, so the list the new statement joins can
+             * only be reached on the source file itself.
+             */
+            private @Nullable J insertIntoSourceFile(JavaSourceFile cu, Integer p) {
+                SourceFileStatementService statements = cu.service(SourceFileStatementService.class);
+                List<Statement> existing = statements.getStatements(cu);
+                if (existing.stream().noneMatch(s -> s.isScope(insertionPoint))) {
+                    return null;
+                }
+                return statements.withStatements(cu, ListUtils.flatMap(existing, statement -> {
+                    if (!isScope(statement)) {
+                        return statement;
+                    }
+                    return spliceAround(statement, unsubstitute(templateParser.parseBlockStatements(
+                            new Cursor(getCursor(), insertionPoint), Statement.class, substitutedTemplate,
+                            substitutions.getTypeVariables(), loc, mode)), p);
+                }));
+            }
+
+            /**
+             * Position generated statements around the one the coordinate anchors on. An anchor that does not begin
+             * its own line leads a script: it has no line break to hand over, and the block it may nominally sit in
+             * is not an indentation level, so its neighbours are placed rather than formatted.
+             */
+            private List<Statement> spliceAround(Statement anchor, List<Statement> gen, Integer p) {
+                boolean anchorBeginsLine = anchor.getPrefix().getWhitespace().contains("\n");
+                Cursor parent = getCursor();
+                for (int i = 0; i < gen.size(); i++) {
+                    Statement s = gen.get(i);
+                    if (anchorBeginsLine) {
+                        gen.set(i, autoFormat(i == 0 ?
+                                s.withPrefix(anchor.getPrefix().withComments(emptyList())) : s, p, parent));
+                    } else {
+                        gen.set(i, autoFormat(s, p, parent).withPrefix(leadingPrefix(anchor, i)));
+                    }
+                }
+                switch (mode) {
+                    case BEFORE:
+                        return ListUtils.concat(gen, anchorBeginsLine ? anchor :
+                                (Statement) anchor.withPrefix(Space.format("\n")));
+                    case AFTER:
+                        return ListUtils.concat(anchor, gen);
+                    default:
+                        return gen;
+                }
+            }
+
+            private Space leadingPrefix(Statement anchor, int i) {
+                if (i > 0 || mode == JavaCoordinates.Mode.AFTER) {
+                    return Space.format("\n");
+                }
+                // Displacing the leading statement takes over its comments too, so a license header stays on top
+                return mode == JavaCoordinates.Mode.BEFORE ? anchor.getPrefix() :
+                        anchor.getPrefix().withComments(emptyList());
+            }
+
+            @Override
             public J visitBlock(J.Block block, Integer p) {
                 switch (loc) {
                     case BLOCK_END: {
@@ -123,25 +193,9 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     case STATEMENT_PREFIX: {
                         return block.withStatements(ListUtils.flatMap(block.getStatements(), statement -> {
                             if (isScope(statement)) {
-                                List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(
+                                return spliceAround(statement, unsubstitute(templateParser.parseBlockStatements(
                                         new Cursor(getCursor(), insertionPoint), Statement.class, substitutedTemplate,
-                                        substitutions.getTypeVariables(), loc, mode));
-
-                                Cursor parent = getCursor();
-                                for (int i = 0; i < gen.size(); i++) {
-                                    Statement s = gen.get(i);
-                                    Statement formattedS = autoFormat(i == 0 ? s.withPrefix(statement.getPrefix().withComments(emptyList())) : s, p, parent);
-                                    gen.set(i, formattedS);
-                                }
-
-                                switch (mode) {
-                                    case REPLACEMENT:
-                                        return gen;
-                                    case BEFORE:
-                                        return ListUtils.concat(gen, statement);
-                                    case AFTER:
-                                        return ListUtils.concat(statement, gen);
-                                }
+                                        substitutions.getTypeVariables(), loc, mode)), p);
                             }
                             return statement;
                         }));

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/AutoFormatService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/AutoFormatService.java
@@ -23,6 +23,7 @@ import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.format.AutoFormatVisitor;
 import org.openrewrite.java.format.BlankLinesVisitor;
 import org.openrewrite.java.format.NormalizeFormatVisitor;
+import org.openrewrite.java.format.TabsAndIndentsVisitor;
 
 @Incubating(since = "8.2.0")
 public class AutoFormatService {
@@ -49,5 +50,12 @@ public class AutoFormatService {
      */
     public <P> JavaVisitor<P> blankLinesVisitor(SourceFile sourceFile, @Nullable Tree stopAfter) {
         return new BlankLinesVisitor<>(sourceFile, stopAfter);
+    }
+
+    /**
+     * Returns the language-appropriate {@link TabsAndIndentsVisitor}.
+     */
+    public <P> JavaVisitor<P> tabsAndIndentsVisitor(SourceFile sourceFile, @Nullable Tree stopAfter) {
+        return new TabsAndIndentsVisitor<>(sourceFile, stopAfter);
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/service/SourceFileStatementService.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/service/SourceFileStatementService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.java.service;
+
+import org.openrewrite.Incubating;
+import org.openrewrite.java.tree.JavaSourceFile;
+import org.openrewrite.java.tree.Statement;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+
+/**
+ * The statements a source file holds directly, for languages whose scripts have no enclosing {@link
+ * org.openrewrite.java.tree.J.Block}. Everything that edits a statement list otherwise works through the block that
+ * contains it, so this is the only way to reach a Groovy script's top-level statements from the Java layer.
+ */
+@Incubating(since = "8.92.0")
+public class SourceFileStatementService {
+
+    /**
+     * Empty when the file keeps its statements inside a block, which is the shape the rest of the Java family uses.
+     */
+    public List<Statement> getStatements(JavaSourceFile cu) {
+        return emptyList();
+    }
+
+    public JavaSourceFile withStatements(JavaSourceFile cu, List<Statement> statements) {
+        throw new UnsupportedOperationException(cu.getClass().getName() + " does not hold statements directly.");
+    }
+}

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaSourceFile.java
@@ -81,6 +81,8 @@ public interface JavaSourceFile extends J, SourceFile {
                 return (T) new JavaCommentService();
             } else if (SourcePositionService.class.getName().equals(service.getName())) {
                 return (T) service.getConstructor().newInstance();
+            } else if (SourceFileStatementService.class.getName().equals(service.getName())) {
+                return (T) service.getConstructor().newInstance();
             } else {
                 throw new UnsupportedOperationException("Service " + service + " not supported");
             }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/KotlinTemplateTest.java
@@ -21,6 +21,7 @@ import org.openrewrite.Cursor;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
+import org.openrewrite.Recipe;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
@@ -40,6 +41,7 @@ import java.util.Comparator;
 import java.util.List;
 
 import static org.openrewrite.kotlin.Assertions.kotlin;
+import static org.openrewrite.kotlin.Assertions.kotlinScript;
 import static org.openrewrite.test.RewriteTest.toRecipe;
 
 class KotlinTemplateTest implements RewriteTest {
@@ -1109,6 +1111,54 @@ class KotlinTemplateTest implements RewriteTest {
                   }
               }
               """
+          ));
+    }
+
+    // A Kotlin script wraps its statements in a block whose first statement starts at column 0
+    private static Recipe insertAtTopLevel(boolean before) {
+        return toRecipe(() -> new KotlinVisitor<>() {
+            @Override
+            public J visitCompilationUnit(K.CompilationUnit cu, ExecutionContext ctx) {
+                K.CompilationUnit c = (K.CompilationUnit) super.visitCompilationUnit(cu, ctx);
+                J.Block block = (J.Block) c.getStatements().get(0);
+                if (block.getStatements().size() != 1) {
+                    return c;
+                }
+                Statement only = block.getStatements().get(0);
+                return KotlinTemplate.builder("val y = 2")
+                  .build()
+                  .apply(updateCursor(c), before ? only.getCoordinates().before() : only.getCoordinates().after());
+            }
+        });
+    }
+
+    @Test
+    void insertAfterTopLevelScriptStatement() {
+        rewriteRun(
+          spec -> spec.recipe(insertAtTopLevel(false)).typeValidationOptions(TypeValidation.none()),
+          kotlinScript(
+            """
+              val x = 1
+              """,
+            spec -> spec.after(a -> """
+              val x = 1
+              val y = 2
+              """)
+          ));
+    }
+
+    @Test
+    void insertBeforeTopLevelScriptStatement() {
+        rewriteRun(
+          spec -> spec.recipe(insertAtTopLevel(true)).typeValidationOptions(TypeValidation.none()),
+          kotlinScript(
+            """
+              val x = 1
+              """,
+            spec -> spec.after(a -> """
+              val y = 2
+              val x = 1
+              """)
           ));
     }
 }


### PR DESCRIPTION
Stacked on #8803. Review that one first.

> Rewritten. An earlier version of this branch added a `JavaTemplate.parse` that returned a detached node. That was routing around the bug below rather than fixing it, and it is gone. Force-pushed, so the history is one commit.

## The bug

A template cannot insert a statement at the top level of a Gradle build script. That is why around ten places in rewrite-gradle parse a snippet with `GradleParser` and splice the node in by hand.

Both DSLs are affected, differently, and only one of them is loud about it.

**Groovy** throws `Cannot insert a new statement before an existing statement and return both to a visit method that returns one statement`. Insertion is implemented in `visitBlock`, and `G.CompilationUnit` holds its statements directly rather than in a `J.Block`. The traversal reaches the statement, but nothing along the way ever sees the statement *list*, so `visitStatement` is the only handler left and it cannot return two nodes.

**Kotlin script** does not throw, because a `.kts` file's statements do live in a `J.Block`. It silently produces `val x = 1val y = 2`. `visitBlock` hands the anchor's prefix to the generated statement, and a script block's first statement has prefix `""`. Fix that and it produces `    val y = 2`, because `TabsAndIndentsVisitor` treats the script's synthetic block as an indentation level when it is not.

Worth noting how easy the Kotlin half is to miss: a probe using `Assertions.kotlin(...)`, a regular `.kt` file, matches nothing at all, because top-level statements there sit directly on `K.CompilationUnit`. It takes `kotlinScript(...)` to see the real behaviour.

## The fix

**Reaching the list.** Where a language keeps its top-level statements is a language concern the Java layer cannot see, which is what services are for here. `SourceFileStatementService` is empty by default and implemented for Groovy, alongside `AutoFormatService` and `ImportService`.

I considered a `GroovyVisitor` mixin through `TreeVisitorAdapter`'s registry instead and rejected it: registered mixins are no-arg constructed and the proxy copies their fields, so a mixin cannot reach the template's state, and wiring one up would have meant a cursor-message protocol between delegate and mixin. The service keeps template logic in `JavaTemplateJavaExtension` where every other coordinate case already lives.

**Working within the contract.** Insertion hangs off `preVisit`, for `STATEMENT_PREFIX` in a non-replacement mode on a `JavaSourceFile`. That is the right seam twice over: the cursor is already the source file, so `autoFormat` gets the parent it needs, and `preVisit` runs before `accept`, so the traversal never descends to the statement whose `visitStatement` would throw. That error message stays. It still correctly rejects the real mistake, pointing `scope` at the statement instead of the file.

**Positioning.** `visitBlock` had this inline; it is now a shared `spliceAround` used by both paths, keyed on a single predicate: does the anchor begin its own line? Every Java and Groovy block statement does, so that path is byte-for-byte unchanged, which is why `rewrite-java-test`'s 2,207 tests do not move. An anchor that does not begin its own line leads a script. There is no line break to hand over, and the block it nominally sits in is not an indentation level, so its neighbours are placed rather than reformatted.

That one distinction fixes Kotlin's lost newline, Kotlin's spurious indent and Groovy's failure together. It also means a statement inserted before the first one inherits its comments, so a license header stays on top, which `SpringBomProperty` previously arranged by hand.

**`JavaVisitor.autoIndent`** re-indents just a spliced subtree instead of reformatting the file, which is what statements poured into a templated shell need, since they arrive carrying the indentation of wherever they came from. It dispatches through a new `AutoFormatService#tabsAndIndentsVisitor`, alongside `blankLinesVisitor`.

## Two call sites

**`RewriteSpreadAllInConfigurationsBlock` needed no new capability at all.** `apply(getCursor(), m.getCoordinates().replace())` hands back the `configurations.all` invocation already positioned and formatted, and the recipe pours the stripped statements into its closure body and returns it. The `withPrefix(m.getPrefix())` line is gone, because the coordinate did that. Nine tests pass unchanged. Saying where the node goes up front is strictly less code than parsing it loose and placing it afterwards.

**`SpringBomProperty`** is the case that needed the fix, and it comes with an honest wrinkle. It uses `after()` on the plugins block, falling back to `before()` on the first statement. The hand-built node and the list surgery are gone, but its expected output has a blank line either side of the declaration, and a coordinate says nothing about spacing, so the recipe now states that itself. Net +14 lines.

I deliberately did not teach the framework to leave a blank line beside a script's leading statement. It would have made these tests pass for free and also inserted a blank line between `val x = 1` and `val y = 2`, and nothing in the LST tells those apart. Blank-line policy belongs to the recipe.

## A bug found on the way

Groovy's `SpacesVisitor` dropped the space after a closure's opening brace whenever the closure declared parameters, turning `{ config ->` into `{config ->`. Java's `visitRightPadded` maps `LAMBDA_PARAM` onto `METHOD_DECLARATION_PARAMETERS`, so the first parameter gets the no-space-after-`(` rule, which is wrong when the position follows `{`. Reproducible with the plain `AutoFormat` recipe, nothing to do with templates.

**One existing expectation changed.** `AutoFormatVisitorTest.parenthesizedClosureReturnValue` fed in `find({ key, value ->` and asserted `find {key, value ->`, codifying the loss. It now asserts `find { key, value ->`, matching the input. Flagging it because it is a behaviour change beyond the two converted recipes; the visitor fix and the test edit revert together.

## Tests

| Suite / class | Tests | Failures |
|---|---|---|
| `:rewrite-groovy:test` | 704 | 0 |
| `:rewrite-java:test` | 716 | 0 |
| `:rewrite-java-test:test` | 2207 | 0 |
| `:rewrite-kotlin:test` | 1355 | 0 |
| `GroovyTemplateTest` | 13 | 0 |
| `KotlinTemplateTest` | 31 | 0 |
| `RewriteSpreadAllInConfigurationsBlockTest` and `$NoChange` | 9 | 0 |
| `UpgradeDependencyVersionBomTest` | 14 | 0 |
| `UpgradeTransitiveDependencyVersionTest` | 48 | 0 |
| `DependencyConstraintToRuleTest` | 6 | 0 |

New capability tests: `insertAfterTopLevelScriptStatement`, `insertBeforeTopLevelScriptStatement` and `insertBeforeTopLevelScriptStatementKeepsLicenseHeaderOnTop` in Groovy, and the first two in Kotlin `.kts`.

`GroovyTemplate` coverage went from 2 tests to 13 along the way. Before touching anything I checked it against the shapes these recipes need, and every one already worked: closures, nested blocks, subscript assignments, trailing-closure invocations, substitution into a closure body, and statement replacement inside an existing closure. Coverage was the weakness, not capability.

## Follow-ups

Now unblocked and mechanical: `UseVersionClosure`, `UseJavaExtensionBlock`, `EnableDevelocityBuildCache`, `UpdateJavaCompatibility`, `AddDevelocityGradlePlugin`, `MigrateGradleEnterpriseToDevelocity`, `UseProjectDependencyInsteadOfModuleCoordinates`, and `UseMainClassPropertyForApplication`, which is now a template choice plus a coordinate. `GradleParseUtils.parseMethodInvocation` is a hand-written node factory that coordinates make redundant. `AddPluginVisitor` is convertible, though its quote-style detection is the real content.

Still not mechanical:

- `DependencyConstraintToRule:209` — the snippet's leading `Object p = null` exists only so `p` resolves, and it then picks statement 1. The scaffolding needs somewhere to live.
- `DependencyConstraintToRule:304` — one snippet yielding a list of statements. `before()`/`after()` would insert them all, so this may be easier than it was, but it reshapes the surrounding code.
- `UseRepositoryHandlerActionOverloads:153` — I checked this one specifically. Dropping `indentOfEnclosingLine()` for `autoIndent` is easy, but the snippet body is assembled from `expression.printTrimmed(...)`, verbatim user source, and a fragment containing `#{` would be eaten by `Substitutions` before the parser saw it. Doing it properly means passing the expressions as `#{any()}` parameters, which is a real refactor.
- `AddSettingsPluginRepository` and `AddDependencyVisitor` parse whole files or hold a long-lived parser. They should stay as they are.
