### PR TITLE
Missing types in AMD factory methods

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/parser.ts
+++ b/rewrite-javascript/rewrite/src/javascript/parser.ts
@@ -61,6 +61,8 @@ export interface JavaScriptParserOptions extends ParserOptions {
      * naming here for those declarations to be in scope.
      */
     types?: string[],
+    /** Types each AMD factory parameter from the dependency bound to it. On by default. */
+    amdFactoryTypes?: boolean,
 }
 
 function getScriptKindFromFileName(fileName: string): ts.ScriptKind {
@@ -89,12 +91,57 @@ type WithInvalidSyntaxSlots<T> = T & {
     modifiers?: ts.NodeArray<ts.ModifierLike>;
 };
 
+/** Overloads pairing each AMD dependency with the parameter bound to it, which nothing else declares. */
+function amdFactoryOverloads(sourceFile: ts.SourceFile): string | undefined {
+    // Keyed by declaration, so a file that repeats a dependency list declares one overload.
+    const overloads = new Set<string>();
+
+    const visit = (node: ts.Node): void => {
+        if (ts.isCallExpression(node) && node.arguments.length >= 2) {
+            const callee = ts.isPropertyAccessExpression(node.expression) ? node.expression.name.text :
+                ts.isIdentifier(node.expression) ? node.expression.text : undefined;
+            // `require` is declared globally by `@types/node`, so an overload there would overreach.
+            if (callee === "define" && ts.isArrayLiteralExpression(node.arguments[0])) {
+                const dependencies = node.arguments[0].elements;
+                if (dependencies.length > 0 && dependencies.every(ts.isStringLiteralLike)) {
+                    const modules = dependencies.map(d => (d as ts.StringLiteralLike).text);
+                    const tuple = modules.map(m => JSON.stringify(m)).join(", ");
+                    const parameters = modules
+                        .map((m, i) => `p${i}: typeof import(${JSON.stringify(m)}).default`)
+                        .join(", ");
+                    const signature = `function define(dependencies: [${tuple}], factory: (${parameters}) => any): void;`;
+                    // A qualified callee declares into its namespace; a bare one is global.
+                    const namespaceOf = ts.isPropertyAccessExpression(node.expression)
+                        ? node.expression.expression.getText(sourceFile)
+                        : undefined;
+                    overloads.add(namespaceOf !== undefined && /^[A-Za-z_$][\w$]*(\.[A-Za-z_$][\w$]*)*$/.test(namespaceOf)
+                        ? `declare namespace ${namespaceOf} {\n    ${signature}\n}`
+                        : `declare ${signature}`);
+                }
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(sourceFile);
+
+    return overloads.size === 0 ? undefined : [...overloads].join("\n");
+}
+
+/** References each named type package ahead of the overloads, or a loader's own `define` outranks them. */
+function withReferencesTo(types: string[] | undefined, declarations: string): string {
+    // `*` stands for the type roots rather than a package, so there is nothing to reference.
+    const references = (types ?? []).filter(name => name !== "*")
+        .map(name => `/// <reference types="${name}" />`);
+    return references.length === 0 ? declarations : `${references.join("\n")}\n${declarations}`;
+}
+
 export class JavaScriptParser extends Parser {
 
     private readonly tsConfig: TsConfigResolver;
     private readonly styles?: NamedStyles[];
     private readonly oldPrograms = new Map<string, ts.Program>();
     private readonly sourceFileCache?: Map<string, ts.SourceFile>;
+    private readonly amdFactoryTypes: boolean;
 
     constructor(
         {
@@ -103,9 +150,11 @@ export class JavaScriptParser extends Parser {
             styles,
             sourceFileCache,
             types,
+            amdFactoryTypes = true,
         }: JavaScriptParserOptions = {},
     ) {
         super({ctx, relativeTo});
+        this.amdFactoryTypes = amdFactoryTypes;
         const defaultCompilerOptions: ts.CompilerOptions = {
             target: ts.ScriptTarget.Latest,
             // Bundler matches `exports` conditions leniently, so packages that publish types only under
@@ -232,6 +281,26 @@ export class JavaScriptParser extends Parser {
             this.sourceFileCache && this.sourceFileCache.delete(normalizedSourcePath);
         }
 
+        // Declarations typing AMD factory parameters, each beside the source it belongs to.
+        const amdOverloadFiles = new Map<string, string>();
+        const amdOverloadOf = new Map<SourcePath, string>();
+        for (const [sourcePath, input] of this.amdFactoryTypes ? inputFiles : []) {
+            const text = parserInputRead(input);
+            // Cheap enough to skip the parse for the files that cannot contain an AMD block.
+            if (!text.includes("define")) {
+                continue;
+            }
+            const overloads = amdFactoryOverloads(ts.createSourceFile(
+                sourcePath, text, ts.ScriptTarget.Latest, true, getScriptKindFromFileName(sourcePath)));
+            if (overloads !== undefined) {
+                // Beside the source, so a relative dependency resolves as it does for the source.
+                const overloadPath = path.normalize(`${sourcePath}.__amd-types.d.ts`);
+                amdOverloadFiles.set(overloadPath, withReferencesTo(
+                    this.tsConfig.forFile(sourcePath).options.types, overloads));
+                amdOverloadOf.set(sourcePath, overloadPath);
+            }
+        }
+
         // Packages in a monorepo each configure their own module resolution.
         for (const normalizedSourcePath of inputFiles.keys()) {
             const {configFilePath, options} = this.tsConfig.forFile(normalizedSourcePath);
@@ -242,6 +311,10 @@ export class JavaScriptParser extends Parser {
                 projects.set(projectKey, project = {options, rootNames: []});
             }
             project.rootNames.push(normalizedSourcePath);
+            const overloadPath = amdOverloadOf.get(normalizedSourcePath);
+            if (overloadPath !== undefined) {
+                project.rootNames.push(overloadPath);
+            }
         }
 
         // Module resolution probes a directory before the files in it, so a directory holding
@@ -258,7 +331,8 @@ export class JavaScriptParser extends Parser {
             // TypeScript carries the previous program's bound files forward when the root paths match,
             // so a parser held across parses of one path costs a fraction of a freshly built one.
             const program = ts.createProgram(rootNames, options,
-                this.createCompilerHost(options, inputFiles, inputDirectories), this.oldPrograms.get(projectKey));
+                this.createCompilerHost(options, inputFiles, inputDirectories, amdOverloadFiles),
+                this.oldPrograms.get(projectKey));
             this.oldPrograms.set(projectKey, program);
 
             // A JavaScriptTypeMapping deduplicates by `ts.Type.id`, which is only unique within
@@ -303,7 +377,8 @@ export class JavaScriptParser extends Parser {
     }
 
     private createCompilerHost(compilerOptions: ts.CompilerOptions, inputFiles: Map<SourcePath, ParserInput>,
-                               inputDirectories: Set<string>): ts.CompilerHost {
+                               inputDirectories: Set<string>,
+                               amdOverloadFiles: Map<string, string>): ts.CompilerHost {
         const host = ts.createCompilerHost(compilerOptions);
 
         // Set the current directory for module resolution
@@ -333,6 +408,8 @@ export class JavaScriptParser extends Parser {
             const input = inputFiles.get(normalizedFileName);
             if (input) {
                 sourceText = parserInputRead(input);
+            } else if (amdOverloadFiles.has(normalizedFileName)) {
+                sourceText = amdOverloadFiles.get(normalizedFileName);
             } else {
                 // For dependency files
                 sourceText = ts.sys.readFile(normalizedFileName);
@@ -355,7 +432,7 @@ export class JavaScriptParser extends Parser {
 
                 sourceFile = ts.createSourceFile(normalizedFileName, sourceText, sourceFileOptions, true, scriptKind);
                 // Cache the SourceFile if it's a dependency
-                if (!input && this.sourceFileCache) {
+                if (!input && !amdOverloadFiles.has(normalizedFileName) && this.sourceFileCache) {
                     this.sourceFileCache.set(cacheKey, sourceFile);
                 }
                 return sourceFile;
@@ -368,7 +445,8 @@ export class JavaScriptParser extends Parser {
         // Override fileExists
         host.fileExists = (fileName) => {
             const normalizedFileName = path.normalize(fileName);
-            return inputFiles.has(normalizedFileName) || ts.sys.fileExists(normalizedFileName);
+            return inputFiles.has(normalizedFileName) || amdOverloadFiles.has(normalizedFileName) ||
+                ts.sys.fileExists(normalizedFileName);
         };
 
         host.directoryExists = (directoryName) => {
@@ -380,7 +458,8 @@ export class JavaScriptParser extends Parser {
         host.readFile = (fileName) => {
             const normalizedFileName = path.normalize(fileName);
             const input = inputFiles.get(normalizedFileName);
-            return input ? parserInputRead(input) : ts.sys.readFile(normalizedFileName);
+            return input ? parserInputRead(input) :
+                amdOverloadFiles.get(normalizedFileName) ?? ts.sys.readFile(normalizedFileName);
         };
 
         // Custom module resolution to handle in-memory imports

--- a/rewrite-javascript/rewrite/test/javascript/amd-factory-types.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/amd-factory-types.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import * as fs from "fs";
+import * as path from "path";
+import {withDir} from "tmp-promise";
+import {RecipeSpec, SourceSpec} from "../../src/test";
+import {JavaScriptParser, JavaScriptVisitor, npm, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+
+/**
+ * Records the type of selected identifiers and the declaring type of selected calls. A factory
+ * parameter typed from its dependency shows up on the variable it initialises and on the calls
+ * made through that variable, which is where a recipe reads it.
+ */
+function captureTypes(identifiers: string[], methods: string[]): {
+    recipe: Recipe,
+    identifierTypes: Map<string, string>,
+    declaringTypes: Map<string, string>
+} {
+    const identifierTypes = new Map<string, string>();
+    const declaringTypes = new Map<string, string>();
+
+    class CaptureRecipe extends Recipe {
+        name = "org.openrewrite.javascript.test.CaptureAmdTypes";
+        displayName = "Capture AMD factory types";
+        description = "Records the resolved type of selected identifiers and method receivers.";
+
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                async visitIdentifier(ident: J.Identifier, p: ExecutionContext): Promise<J.Identifier> {
+                    const visited = await super.visitIdentifier(ident, p) as J.Identifier;
+                    if (identifiers.includes(visited.simpleName) && !identifierTypes.has(visited.simpleName)) {
+                        const type = visited.type;
+                        identifierTypes.set(visited.simpleName,
+                            Type.isClass(type) ? type.fullyQualifiedName : Type.signature(type));
+                    }
+                    return visited;
+                }
+
+                protected async visitMethodInvocation(
+                    method: J.MethodInvocation,
+                    p: ExecutionContext
+                ): Promise<J | undefined> {
+                    const visited = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                    const name = visited.name.simpleName;
+                    if (methods.includes(name) && !declaringTypes.has(name)) {
+                        const declaring = visited.methodType?.declaringType;
+                        declaringTypes.set(name,
+                            Type.isClass(declaring) ? declaring.fullyQualifiedName : Type.signature(declaring));
+                    }
+                    return visited;
+                }
+            };
+        }
+    }
+
+    return {recipe: new CaptureRecipe(), identifierTypes, declaringTypes};
+}
+
+function write(repo: string, relativePath: string, content: string): void {
+    const file = path.join(repo, relativePath);
+    fs.mkdirSync(path.dirname(file), {recursive: true});
+    fs.writeFileSync(file, content);
+}
+
+/** The module an AMD block depends on, reached by a relative specifier as a project's own modules are. */
+function greeterModule(): SourceSpec<any> {
+    return {
+        //language=typescript
+        ...typescript(`
+            export default class Greeter {
+                greet(name: string): string {
+                    return name;
+                }
+            }
+        `),
+        path: "greeter.ts"
+    };
+}
+
+/**
+ * A loader declaring its own `define`, published outside `@types/` so it is only in scope where
+ * a project names it. Its `any[]` factory is what leaves every parameter untyped on its own.
+ */
+function writeLoaderTypes(repo: string): void {
+    write(repo, "node_modules/loader-types/package.json",
+        `{"name": "loader-types", "version": "1.0.0", "types": "index.d.ts"}`);
+    write(repo, "node_modules/loader-types/index.d.ts",
+        //language=typescript
+        `declare namespace my.loader {
+             function define(dependencies: string[], factory: (...args: any[]) => any): void;
+         }`);
+}
+
+describe("AMD factory parameters", () => {
+    // The loader binds the nth dependency to the nth parameter at runtime, so the parser declares it.
+    test("a factory parameter carries the type of the dependency bound to it", async () => {
+        const {recipe, identifierTypes, declaringTypes} = captureTypes(["greeter"], ["greet"]);
+        const spec = new RecipeSpec();
+        spec.recipe = recipe;
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(`
+                        define(["./greeter"], function (Greeter) {
+                            const greeter = new Greeter();
+                            greeter.greet("world");
+                        });
+                    `),
+                    greeterModule()
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(identifierTypes.get("greeter")).toBe("greeter.Greeter");
+        expect(declaringTypes.get("greet")).toBe("greeter.Greeter");
+    }, 120000);
+
+    // A loader named in `types` brings its own `define` along, which the generated overload has to outrank.
+    test("a loader's own declarations reached through `types` do not shadow the binding", async () => {
+        const {recipe, identifierTypes, declaringTypes} = captureTypes(["greeter"], ["define", "greet"]);
+        const spec = new RecipeSpec();
+        spec.recipe = recipe;
+
+        await withDir(async (repo) => {
+            writeLoaderTypes(repo.path);
+            write(repo.path, "tsconfig.json", `{"compilerOptions": {"types": ["loader-types"]}}`);
+
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(`
+                        my.loader.define(["./greeter"], function (Greeter) {
+                            const greeter = new Greeter();
+                            greeter.greet("world");
+                        });
+                    `),
+                    greeterModule()
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(declaringTypes.get("define")).toBe("my.loader");
+        expect(identifierTypes.get("greeter")).toBe("greeter.Greeter");
+        expect(declaringTypes.get("greet")).toBe("greeter.Greeter");
+    }, 120000);
+
+    test("a dependency list that is not literal declares nothing", async () => {
+        const {recipe, identifierTypes} = captureTypes(["greeter"], []);
+        const spec = new RecipeSpec();
+        spec.recipe = recipe;
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(`
+                        const dependencies = ["./greeter"];
+                        define(dependencies, function (Greeter) {
+                            const greeter = new Greeter();
+                        });
+                    `),
+                    greeterModule()
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(identifierTypes.get("greeter")).toBe("<unknown>");
+    }, 120000);
+
+    test("the binding is off when the parser is told so", async () => {
+        const {recipe, identifierTypes} = captureTypes(["greeter"], []);
+        const spec = new RecipeSpec();
+        spec.recipe = recipe;
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                {
+                    //language=typescript
+                    ...typescript(`
+                        define(["./greeter"], function (Greeter) {
+                            const greeter = new Greeter();
+                        });
+                    `),
+                    parser: () => new JavaScriptParser({relativeTo: repo.path, amdFactoryTypes: false})
+                },
+                greeterModule()
+            );
+        }, {unsafeCleanup: true});
+
+        expect(identifierTypes.get("greeter")).toBe("<unknown>");
+    }, 120000);
+});


### PR DESCRIPTION
Asynchronous Module Definition (AMD) is used by JavaScript libraries predating ES modules to handle dependencies. 

**Problem**: ORs current implementation misses the type information in the factory method because the JS parser does not know/care. This makes matchers unusable in these projects.

**Solution**: Defined dependencies to the parser's context in a synthetic `__amd-types.d.ts`. It can be deactivated in the parser configuration with `amdFactoryTypes: false`.

**Outcome**
AMD using JS sources now have type information that enables matcher usage, enabling JS `rewrite()` API usage.

```javascript
define(["./greeter"], function (Greeter) {
     const greeter = new Greeter(); // greeter now has typeinformation
     greeter.greet("world");
});
```

Works for external dependencies like [Open UI5](https://ui5.github.io/tutorials/walkthrough/steps/03/index.html#webappindextsjs) as well.
