### PR TITLE
Make external types visible to JS test parser and templates

### DIFF
--- a/rewrite-javascript/rewrite/src/javascript/assertions.ts
+++ b/rewrite-javascript/rewrite/src/javascript/assertions.ts
@@ -37,20 +37,49 @@ export const sourceFileCache: Map<string, ts.SourceFile> = new Map();
 // Pooled so a spec reuses the program the previous spec left behind; see `JavaScriptParser.parse`.
 const parserPool: Map<string, JavaScriptParser> = new Map();
 
-function pooledParser(relativeTo?: string): JavaScriptParser {
-    const key = relativeTo ?? "";
+function pooledParser(relativeTo?: string, types?: string[]): JavaScriptParser {
+    // Two parsers over one directory differ by the declarations they load, so `types` keys the pool too.
+    const key = `${relativeTo ?? ""}\u0000${types?.join(",") ?? ""}`;
     let parser = parserPool.get(key);
     if (!parser) {
-        parser = new JavaScriptParser({sourceFileCache, relativeTo});
+        parser = new JavaScriptParser({sourceFileCache, relativeTo, types});
         parserPool.set(key, parser);
     }
     return parser;
+}
+
+/** Packages the manifest declares whose declarations are ambient, which the default `"*"` misses. */
+function declaredTypePackages(relativeTo: string, packageJsonContent: string): string[] {
+    let manifest: {dependencies?: Record<string, string>, devDependencies?: Record<string, string>};
+    try {
+        manifest = JSON.parse(packageJsonContent);
+    } catch {
+        return [];
+    }
+    return Object.keys({...manifest.dependencies, ...manifest.devDependencies})
+        .filter(name => !name.startsWith("@types/"))
+        .filter(name => {
+            // A directive naming a package without declarations is an error, not a no-op.
+            const manifestPath = path.join(relativeTo, "node_modules", name, "package.json");
+            if (!fs.existsSync(manifestPath)) {
+                return false;
+            }
+            try {
+                const installed = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+                return typeof (installed.types ?? installed.typings) === "string";
+            } catch {
+                return false;
+            }
+        });
 }
 
 // Automatically enable sourceFileCache for template parsing in tests
 setTemplateSourceFileCache(sourceFileCache);
 
 export async function* npm(relativeTo: string, ...sourceSpecs: SourceSpec<any>[]): AsyncGenerator<SourceSpec<any>, void, unknown> {
+    // Set once the install has run; left unset otherwise, which keeps the parser's default.
+    let types: string[] | undefined;
+
     // Ensure the target directory exists
     if (!fs.existsSync(relativeTo)) {
         fs.mkdirSync(relativeTo, { recursive: true });
@@ -139,6 +168,15 @@ export async function* npm(relativeTo: string, ...sourceSpecs: SourceSpec<any>[]
             packageJsonSpec.before!
         );
 
+        // A fixture carrying a config decides its own type packages; the manifest names them only where none does.
+        const statesConfig = fs.existsSync(path.join(relativeTo, "tsconfig.json")) ||
+            fs.existsSync(path.join(relativeTo, "jsconfig.json"));
+        // `"*"` keeps `node_modules/@types`, which naming anything at all would otherwise replace.
+        const declared = statesConfig ? [] : declaredTypePackages(relativeTo, packageJsonSpec.before!);
+        if (declared.length > 0) {
+            types = ["*", ...declared];
+        }
+
         // Use PackageJsonParser to parse and attach NodeResolutionResult marker
         yield {
             ...packageJsonSpec,
@@ -186,7 +224,7 @@ export async function* npm(relativeTo: string, ...sourceSpecs: SourceSpec<any>[]
         // Prettier is NOT available: auto-detect styles from the source files
         // Pre-parse all JS specs to sample them
         const detector = Autodetect.detector();
-        const tempParser = new JavaScriptParser({sourceFileCache, relativeTo});
+        const tempParser = new JavaScriptParser({sourceFileCache, relativeTo, types});
 
         for (const spec of jsSpecs) {
             if (spec.before) {
@@ -224,7 +262,7 @@ export async function* npm(relativeTo: string, ...sourceSpecs: SourceSpec<any>[]
 
                 yield {
                     ...spec,
-                    parser: () => pooledParser(relativeTo),
+                    parser: () => pooledParser(relativeTo, types),
                     // Add style marker before recipe runs if available
                     // Compose with existing beforeRecipe if present
                     beforeRecipe: styleMarker ? (sf: JS.CompilationUnit) => {

--- a/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
+++ b/rewrite-javascript/rewrite/src/javascript/templating/engine.ts
@@ -105,7 +105,11 @@ function templateParser(workspaceDir?: string, types?: string[]): JavaScriptPars
     const key = `${workspaceDir ?? ""}::${JSON.stringify(types ?? null)}`;
     let parser = templateParsers.get(key);
     if (!parser) {
-        parser = new JavaScriptParser({relativeTo: workspaceDir, sourceFileCache: templateSourceFileCache, types});
+        // An empty list names nothing, which is the one way to load nothing.
+        const named = types === undefined || types.length === 0 ? types : ["*", ...types];
+        parser = new JavaScriptParser({
+            relativeTo: workspaceDir, sourceFileCache: templateSourceFileCache, types: named
+        });
         templateParsers.set(key, parser);
     }
     return parser;

--- a/rewrite-javascript/rewrite/test/javascript/templating/dependencies.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/templating/dependencies.test.ts
@@ -34,6 +34,39 @@ import {fromVisitor, RecipeSpec} from "../../../src/test";
 import * as path from "path";
 import * as os from "os";
 
+/** Where `process.cwd()` declares for a template with these options; `process` is reachable only through automatic type inclusion. */
+async function processDeclaringType(
+    dependencies: Record<string, string>,
+    types: string[]
+): Promise<string | undefined> {
+    const tmpl = template`process.cwd()`.configure({dependencies, types});
+
+    const parser = new JavaScriptParser();
+    const parseGen = parser.parse({text: `const x = 1;`, sourcePath: 'test.ts'});
+    const cu = (await parseGen.next()).value;
+
+    let applied: J | undefined;
+    await (new class extends JavaScriptVisitor<any> {
+        override async visitVariable(variable: any, _p: any): Promise<any> {
+            applied ??= await tmpl.apply(variable, this.cursor, {values: new Map()});
+            return variable;
+        }
+    }).visit(cu, undefined);
+
+    let methodType: Type.Method | undefined;
+    await (new class extends JavaScriptVisitor<any> {
+        override async visitMethodInvocation(method: J.MethodInvocation, _p: any): Promise<J | undefined> {
+            if (method.name.simpleName === 'cwd') {
+                methodType ??= method.methodType;
+            }
+            return method;
+        }
+    }).visit(applied!, undefined);
+    // The declaring type, not the name, is what says the declarations were loaded.
+    const declaring = methodType?.declaringType;
+    return declaring && Type.isClass(declaring) ? (declaring as Type.Class).fullyQualifiedName : undefined;
+}
+
 describe('template dependencies integration', () => {
 
     test('pattern with dependencies has proper type attribution in AST', async () => {
@@ -108,48 +141,16 @@ describe('template dependencies integration', () => {
     }, 120000);
 
     test('`types` decides which declarations the template parse loads', async () => {
-        // `process` is a global `@types/node` declares, reachable only through automatic type
-        // inclusion — unlike a module specifier, which resolves by path whatever this option says.
-        // An explicit list replaces the default rather than extending it, so `[]` loads nothing.
-        const processDeclaringTypeWith = async (types: string[]) => {
-            const tmpl = template`process.cwd()`.configure({
-                dependencies: {'@types/node': '^20.0.0'},
-                types
-            });
+        expect(await processDeclaringType({'@types/node': '^20.0.0'}, ['node'])).toBe('global.NodeJS.Process');
 
-            const parser = new JavaScriptParser();
-            const parseGen = parser.parse({text: `const x = 1;`, sourcePath: 'test.ts'});
-            const cu = (await parseGen.next()).value;
-
-            let applied: J | undefined;
-            await (new class extends JavaScriptVisitor<any> {
-                override async visitVariable(variable: any, _p: any): Promise<any> {
-                    applied ??= await tmpl.apply(variable, this.cursor, {values: new Map()});
-                    return variable;
-                }
-            }).visit(cu, undefined);
-
-            let methodType: Type.Method | undefined;
-            await (new class extends JavaScriptVisitor<any> {
-                override async visitMethodInvocation(method: J.MethodInvocation, _p: any): Promise<J | undefined> {
-                    if (method.name.simpleName === 'cwd') {
-                        methodType ??= method.methodType;
-                    }
-                    return method;
-                }
-            }).visit(applied!, undefined);
-            // `name` is the callee's own spelling whether or not anything resolved, so the
-            // declaring type is what says the declarations were loaded.
-            const declaring = methodType?.declaringType;
-            return declaring && Type.isClass(declaring)
-                ? (declaring as Type.Class).fullyQualifiedName
-                : undefined;
-        };
-
-        expect(await processDeclaringTypeWith(['node'])).toBe('global.NodeJS.Process');
-
-        expect(await processDeclaringTypeWith([])).toBeUndefined();
+        expect(await processDeclaringType({'@types/node': '^20.0.0'}, [])).toBeUndefined();
     }, 120000);
+
+    test('a named package is loaded alongside the type roots rather than in place of them', async () => {
+        expect(await processDeclaringType(
+            {'@openui5/types': '1.136.0', '@types/node': '^20.0.0'}, ['@openui5/types']))
+            .toBe('global.NodeJS.Process');
+    }, 180000);
 
     test('template with dependencies generates AST with type attribution', async () => {
         // Create a template with dependencies

--- a/rewrite-javascript/rewrite/test/javascript/type-mapping-ambient-modules.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/type-mapping-ambient-modules.test.ts
@@ -1,0 +1,159 @@
+// noinspection JSUnusedLocalSymbols
+
+/*
+ * Copyright 2025 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../src/test";
+import {JavaScriptVisitor, npm, packageJson, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+import {withDir} from "tmp-promise";
+import * as fs from "fs";
+import * as path from "path";
+
+/** UI5 declares its modules ambiently: `declare module "sap/m/Button"`, with no such path on disk. */
+function captureTypes(identifiers: string[], methods: string[]): {
+    recipe: Recipe,
+    identifierTypes: Map<string, string>,
+    declaringTypes: Map<string, string>
+} {
+    const identifierTypes = new Map<string, string>();
+    const declaringTypes = new Map<string, string>();
+
+    class CaptureRecipe extends Recipe {
+        name = "org.openrewrite.javascript.test.CaptureAmbientTypes";
+        displayName = "Capture ambient module types";
+        description = "Records the resolved type of selected identifiers and method receivers.";
+
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                async visitIdentifier(ident: J.Identifier, p: ExecutionContext): Promise<J.Identifier> {
+                    const visited = await super.visitIdentifier(ident, p) as J.Identifier;
+                    if (identifiers.includes(visited.simpleName) && !identifierTypes.has(visited.simpleName)) {
+                        const type = visited.type;
+                        identifierTypes.set(visited.simpleName,
+                            Type.isClass(type) ? type.fullyQualifiedName : Type.signature(type));
+                    }
+                    return visited;
+                }
+
+                protected async visitMethodInvocation(
+                    method: J.MethodInvocation,
+                    p: ExecutionContext
+                ): Promise<J | undefined> {
+                    const visited = await super.visitMethodInvocation(method, p) as J.MethodInvocation;
+                    const name = visited.name.simpleName;
+                    if (methods.includes(name) && !declaringTypes.has(name)) {
+                        const declaring = (visited.methodType as Type.Method | undefined)?.declaringType;
+                        declaringTypes.set(name,
+                            Type.isClass(declaring) ? declaring.fullyQualifiedName : Type.signature(declaring));
+                    }
+                    return visited;
+                }
+            };
+        }
+    }
+
+    return {recipe: new CaptureRecipe(), identifierTypes, declaringTypes};
+}
+
+const UI5_PACKAGE_JSON = `{
+  "name": "ui5-ambient-fixture",
+  "version": "1.0.0",
+  "devDependencies": { "@openui5/types": "1.136.0" }
+}`;
+
+describe("ambient module declarations from an external dependency", () => {
+    // Declaring the dependency is the whole setup here: no reference directive, no `types`.
+    test("a declared ambient package is in scope for the files that import it", async () => {
+        const {recipe, identifierTypes, declaringTypes} = captureTypes(["button"], ["attachPress"]);
+        const spec = new RecipeSpec();
+        spec.recipe = recipe;
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(`
+                        import Button from "sap/m/Button";
+
+                        const button = new Button({text: "Go"});
+                        button.attachPress(() => {});
+                    `),
+                    //language=json
+                    packageJson(UI5_PACKAGE_JSON)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(identifierTypes.get("button")).toBe("sap/m/Button.Button");
+        expect(declaringTypes.get("attachPress")).toBe("sap/m/Button.Button");
+    }, 180000);
+
+    test("a fixture stating its own compiler options is not given its manifest's packages", async () => {
+        const {recipe, identifierTypes} = captureTypes(["button"], []);
+        const spec = new RecipeSpec();
+        spec.recipe = recipe;
+
+        await withDir(async (repo) => {
+            fs.mkdirSync(repo.path, {recursive: true});
+            fs.writeFileSync(path.join(repo.path, "tsconfig.json"), `{"compilerOptions": {}}`);
+
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(`
+                        import Button from "sap/m/Button";
+
+                        const button = new Button({text: "Go"});
+                    `),
+                    //language=json
+                    packageJson(UI5_PACKAGE_JSON)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(identifierTypes.get("button")).toBe("<unknown>");
+    }, 180000);
+
+    // The same file reached through a directive instead, which no real UI5 source carries.
+    test("the same file resolves when a reference directive pulls the declarations in", async () => {
+        const {recipe, identifierTypes, declaringTypes} = captureTypes(["button"], ["attachPress"]);
+        const spec = new RecipeSpec();
+        spec.recipe = recipe;
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(`/// <reference types="@openui5/types" />
+                        import Button from "sap/m/Button";
+
+                        const button = new Button({text: "Go"});
+                        button.attachPress(() => {});
+                    `),
+                    //language=json
+                    packageJson(UI5_PACKAGE_JSON)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(identifierTypes.get("button")).toBe("sap/m/Button.Button");
+        expect(declaringTypes.get("attachPress")).toBe("sap/m/Button.Button");
+    }, 180000);
+});

--- a/rewrite-javascript/rewrite/test/javascript/ui5-setup.test.ts
+++ b/rewrite-javascript/rewrite/test/javascript/ui5-setup.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {RecipeSpec} from "../../src/test";
+import {JavaScriptVisitor, MethodMatcher, npm, packageJson, typescript} from "../../src/javascript";
+import {J, Type} from "../../src/java";
+import {ExecutionContext, Recipe} from "../../src";
+import {withDir} from "tmp-promise";
+
+// Verbatim from type-mapping-ambient-modules.test.ts, so both suites reuse one cached install.
+const UI5_PACKAGE_JSON = `{
+  "name": "ui5-ambient-fixture",
+  "version": "1.0.0",
+  "devDependencies": { "@openui5/types": "1.136.0" }
+}`;
+
+/** Records which of `patterns` match a named call, stating what a recipe could select. */
+function matchesOf(methodName: string, patterns: string[], sink: Map<string, boolean>): Recipe {
+    class MatchesRecipe extends Recipe {
+        name = 'org.openrewrite.javascript.test.UI5Matches';
+        displayName = 'Record matching method patterns';
+        description = 'Records which method patterns match a named call.';
+
+        async editor(): Promise<JavaScriptVisitor<ExecutionContext>> {
+            return new class extends JavaScriptVisitor<ExecutionContext> {
+                override async visitMethodInvocation(method: J.MethodInvocation, p: ExecutionContext): Promise<J.MethodInvocation> {
+                    if (method.name.simpleName === methodName) {
+                        for (const pattern of patterns) {
+                            sink.set(pattern, new MethodMatcher(pattern).matches(method.methodType));
+                        }
+                    }
+                    return method;
+                }
+            };
+        }
+    }
+
+    return new MatchesRecipe();
+}
+
+describe('SAP UI5 method patterns', () => {
+    // A UI5 FQN is module path plus exported name, so its type segment carries slashes, not dots.
+    test('a matcher selects a call on an imported UI5 control', async () => {
+        const matches = new Map<string, boolean>();
+        const spec = new RecipeSpec();
+        spec.recipe = matchesOf('attachPress', [
+            'sap/m/Button.Button attachPress(..)',
+            'sap/m/Button.* attach*(..)',
+            '*..* attachPress(..)',
+            'sap/m/* attachPress(..)',
+            'sap/ui/core/Control.Control attachPress(..)',
+        ], matches);
+
+        await withDir(async (repo) => {
+            await spec.rewriteRun(
+                npm(
+                    repo.path,
+                    //language=typescript
+                    typescript(`
+                        import Button from "sap/m/Button";
+
+                        const button = new Button({text: "Go"});
+                        button.attachPress(() => {});
+                    `),
+                    //language=json
+                    packageJson(UI5_PACKAGE_JSON)
+                )
+            );
+        }, {unsafeCleanup: true});
+
+        expect(matches.get('sap/m/Button.Button attachPress(..)')).toBe(true);
+        expect(matches.get('sap/m/Button.* attach*(..)')).toBe(true);
+        expect(matches.get('*..* attachPress(..)')).toBe(true);
+
+        // A module path is not a package, so it does not glob.
+        expect(matches.get('sap/m/* attachPress(..)')).toBe(false);
+
+        // Matching follows the receiver's own type, not the type declaring the member.
+        expect(matches.get('sap/ui/core/Control.Control attachPress(..)')).toBe(false);
+    }, 180000);
+});


### PR DESCRIPTION
### Problem
The used JS parser in JS tests does load external dependencies but only includes `node_modules/@types` in the parser context.
External dependencies often place their types in their own hierarchy; for example, OpenUI5 uses `@openui5/types`.
The result is the `button` in the below test has no type information, and the templating engine were also not able to create LSTs with external types properly.

### Solution
Test that carries a `tsconfig.json` or `jsconfig.json` now add the defined external types to the parser's context.
`JavaScriptTemplate`s parser gets this types now as well.

### Outcome
The test can now attribute types from external dependencies available at development. 
The variable `button` in the above example is now properly typed as `sap/m/Button` and matchable with matchers.
Also, templates created for LSTs now have external type information.

### Alternative
Define test parser dependencies like we do for Java recipe setup into type tables and load similarly.
As the dependencies were available before, I chose the short path. 
TypeTables might be something to adopt here in the future.

### Test snippet
```js
npm(repo.path,
  typescript(`
    import Button from "sap/m/Button";
    const button = new Button();
  `),
  packageJson(`
    {
      "name": "ui5-ambient-fixture",
      "version": "1.0.0",
      "devDependencies": { "@openui5/types": "1.136.0" }
    }
  `)
)
```
