### PR TITLE
Cut allocation and round trips out of the RPC send and receive paths

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/DynamicDispatchRpcCodec.java
@@ -46,10 +46,21 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
         discoverFrom(DynamicDispatchRpcCodec.class.getClassLoader());
     }
 
+    /**
+     * Bumped whenever discovery registers a provider, so memoized lookups re-resolve.
+     * A memoized miss would otherwise outlive the arrival of the codec that answers it,
+     * leaving the sender to inline a value the remote expects property messages for.
+     */
+    private static volatile int generation;
+
+    /** The context classloader of the most recent lookup, to keep the scan off the hot path. */
+    private static volatile @Nullable ClassLoader lastScannedContext;
+
     private static synchronized void discoverFrom(@Nullable ClassLoader cl) {
         if (cl == null || !SCANNED_CLASSLOADERS.add(cl)) {
             return;
         }
+        boolean registered = false;
         @SuppressWarnings({"unchecked", "rawtypes"}) ServiceLoader<DynamicDispatchRpcCodec<?>> loader =
                 (ServiceLoader<DynamicDispatchRpcCodec<?>>) (ServiceLoader) ServiceLoader.load(DynamicDispatchRpcCodec.class, cl);
         for (DynamicDispatchRpcCodec<?> provider : loader) {
@@ -65,7 +76,11 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
             }
             if (!alreadyPresent) {
                 bucket.add(provider);
+                registered = true;
             }
+        }
+        if (registered) {
+            generation++;
         }
     }
 
@@ -88,11 +103,50 @@ public abstract class DynamicDispatchRpcCodec<T> implements RpcCodec<T> {
         }
     }
 
+    private static final class CodecEntry {
+        final int generation;
+        final @Nullable RpcCodec<?> codec;
+
+        CodecEntry(int generation, @Nullable RpcCodec<?> codec) {
+            this.generation = generation;
+            this.codec = codec;
+        }
+    }
+
+    private static final ClassValue<Map<String, CodecEntry>> CODEC_CACHE = new ClassValue<Map<String, CodecEntry>>() {
+        @Override
+        protected Map<String, CodecEntry> computeValue(Class<?> type) {
+            return new ConcurrentHashMap<>();
+        }
+    };
+
     @SuppressWarnings("unchecked")
     public static <T> @Nullable RpcCodec<T> getCodec(Object t, @Nullable String sourceFileType) {
         if (sourceFileType == null) {
             return null;
         }
+        // A context classloader this lookup has not seen may carry providers, and a
+        // memoized entry never reaches resolveCodec, which is the only other caller of
+        // discoverFrom. Scanning here is a reference comparison once the loader is known;
+        // registering a provider bumps the generation, which stales every memo.
+        ClassLoader context = Thread.currentThread().getContextClassLoader();
+        if (context != lastScannedContext) {
+            discoverFrom(context);
+            lastScannedContext = context;
+        }
+        Map<String, CodecEntry> bySourceFileType = CODEC_CACHE.get(t.getClass());
+        CodecEntry entry = bySourceFileType.get(sourceFileType);
+        if (entry == null || entry.generation != generation) {
+            // The generation is read before resolving, so a provider that resolution
+            // itself discovers stales this entry and it is resolved once more.
+            entry = new CodecEntry(generation, resolveCodec(t, sourceFileType));
+            bySourceFileType.put(sourceFileType, entry);
+        }
+        return (RpcCodec<T>) entry.codec;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> @Nullable RpcCodec<T> resolveCodec(Object t, String sourceFileType) {
         // Discover codecs from any classloader we haven't seen yet. Covers plugin/recipe
         // classloaders that weren't visible when this class's static initializer ran.
         discoverFrom(Thread.currentThread().getContextClassLoader());

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -45,6 +45,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
@@ -767,13 +768,18 @@ public class RewriteRpc {
             CompletableFuture<JsonRpcSuccess> future = jsonRpc.send(JsonRpcRequest.newRequest(method, body));
 
             // future.get(timeout) from a FJP worker triggers ManagedBlocker compensation,
-            // which spawns helper threads that can leak per-thread RewriteRpc state.
-            long pollIntervalMs = 1;
+            // which spawns helper threads that can leak per-thread RewriteRpc state. So the
+            // completion unparks this thread instead: a response arrives in a few hundred
+            // microseconds, while Thread.sleep cannot wait for less than about a millisecond
+            // before Java 21 -- long enough to dominate a request that is otherwise idle.
+            Thread waiter = Thread.currentThread();
+            boolean unparkRegistered = false;
+
             long livenessIntervalNanos = TimeUnit.MILLISECONDS.toNanos(500);
             long startNanos = System.nanoTime();
             long deadlineNanos = startNanos + TimeUnit.MILLISECONDS.toNanos(timeout.toMillis());
             long lastLivenessNanos = startNanos;
-            while (System.nanoTime() < deadlineNanos) {
+            while (true) {
                 JsonRpcSuccess result = future.getNow(null);
                 if (result != null) {
                     return result.getResult(responseType);
@@ -781,7 +787,23 @@ public class RewriteRpc {
                 if (future.isCompletedExceptionally()) {
                     return future.get().getResult(responseType);
                 }
-                Thread.sleep(pollIntervalMs);
+                if (!unparkRegistered) {
+                    // Registered only once the response is known not to be here yet: on an
+                    // already-completed future this runs inline, and the permit it grants
+                    // would outlive this call and release someone else's park.
+                    future.whenComplete((r, t) -> LockSupport.unpark(waiter));
+                    unparkRegistered = true;
+                }
+                long parkUntilNanos = System.nanoTime();
+                if (parkUntilNanos >= deadlineNanos) {
+                    break;
+                }
+                // Bounded so liveness is still checked on its own cadence, and because a
+                // park may return spuriously; the loop re-reads the future either way.
+                LockSupport.parkNanos(Math.min(livenessIntervalNanos, deadlineNanos - parkUntilNanos));
+                if (Thread.interrupted()) {
+                    throw new InterruptedException();
+                }
                 long nowNanos = System.nanoTime();
                 if (nowNanos - lastLivenessNanos >= livenessIntervalNanos) {
                     checkLiveness();

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpc.java
@@ -729,24 +729,51 @@ public class RewriteRpc {
         // (e.g., via a Java-side recipe) since the remote doesn't know about those changes.
         Object before = remoteObjects.get(id);
 
+        GetObject request = new GetObject(id, sourceFileType);
+        AtomicReference<CompletableFuture<JsonRpcSuccess>> nextPage = new AtomicReference<>();
         RpcReceiveQueue q = new RpcReceiveQueue(
                 remoteRefs,
-                () -> send("GetObject", new GetObject(id, sourceFileType), GetObjectResponse.class),
+                () -> {
+                    CompletableFuture<JsonRpcSuccess> pending = nextPage.getAndSet(null);
+                    GetObjectResponse page = await(pending == null ? request("GetObject", request) : pending,
+                            GetObjectResponse.class);
+                    // The following page is requested before this one is handed over, so the
+                    // remote serializes it while this one is being deserialized. A page ending
+                    // in END_OF_OBJECT has no successor, and asking for one would restart the
+                    // transfer rather than return nothing.
+                    if (!page.isEmpty() && page.get(page.size() - 1).getState() != END_OF_OBJECT) {
+                        nextPage.set(request("GetObject", request));
+                    }
+                    return page;
+                },
                 sourceFileType,
                 log.get()
         );
         Object remoteObject;
         try {
             remoteObject = q.receive(before, null);
+            // Inside the try so that a missing end marker unwinds the same way a failed
+            // receive does: a page is in flight here whenever the last one did not end in
+            // END_OF_OBJECT, which is the condition this rejects.
+            RpcObjectData endMarker = q.take();
+            if (endMarker.getState() != END_OF_OBJECT) {
+                throw new IllegalStateException("Expected END_OF_OBJECT but got: " + endMarker);
+            }
         } catch (Exception e) {
             // Reset our tracking of the remote state so the next interaction
             // forces a full object sync (ADD) instead of a delta (CHANGE).
             remoteObjects.remove(id);
+            CompletableFuture<JsonRpcSuccess> pending = nextPage.getAndSet(null);
+            if (pending != null) {
+                // Awaited rather than abandoned so the remote's serialization of it is
+                // finished before the next request; the response itself is correlated by
+                // id, so an unawaited one is dropped rather than misdelivered.
+                try {
+                    await(pending, GetObjectResponse.class);
+                } catch (Exception ignored) {
+                }
+            }
             throw e;
-        }
-        RpcObjectData endMarker = q.take();
-        if (endMarker.getState() != END_OF_OBJECT) {
-            throw new IllegalStateException("Expected END_OF_OBJECT but got: " + endMarker);
         }
 
         //noinspection ConstantValue
@@ -761,11 +788,22 @@ public class RewriteRpc {
     }
 
     protected <P> P send(String method, @Nullable RpcRequest body, Class<P> responseType) {
+        return await(request(method, body), responseType);
+    }
+
+    /**
+     * Puts a request on the wire without waiting for it, so a caller can have the next
+     * one in flight while it works through the current response. Requests carry distinct
+     * ids and their futures complete independently, so several may be outstanding.
+     */
+    private CompletableFuture<JsonRpcSuccess> request(String method, @Nullable RpcRequest body) {
+        checkLiveness();
+        return jsonRpc.send(JsonRpcRequest.newRequest(method, body));
+    }
+
+    private <P> P await(CompletableFuture<JsonRpcSuccess> future, Class<P> responseType) {
         checkLiveness();
         try {
-
-            // Send the request and get the future
-            CompletableFuture<JsonRpcSuccess> future = jsonRpc.send(JsonRpcRequest.newRequest(method, body));
 
             // future.get(timeout) from a FJP worker triggers ManagedBlocker compensation,
             // which spawns helper threads that can leak per-thread RewriteRpc state. So the

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RpcSendQueue.java
@@ -22,6 +22,8 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import static java.util.Collections.emptyList;
+import static java.util.Collections.nCopies;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.rpc.RpcObjectData.ADDED_LIST_ITEM;
 import static org.openrewrite.rpc.RpcObjectData.State.*;
@@ -151,15 +153,18 @@ public class RpcSendQueue {
         send(after, before, () -> {
             assert after != null : "A DELETE event should have been sent.";
 
-            Map<Object, Integer> beforeIdx = putListPositions(after, before, id);
+            int[] positions = putListPositions(after, before, id);
 
+            // Walked with an iterator rather than by index so a sequential-access list
+            // costs the same here as a random-access one; `positions` is already indexed.
+            int i = 0;
             for (T anAfter : after) {
-                Integer beforePos = beforeIdx.get(id.apply(anAfter));
+                int beforePos = positions == null ? ADDED_LIST_ITEM : positions[i++];
                 Runnable onChangeRun = onChange == null ? null : () -> onChange.accept(anAfter);
-                if (beforePos == null) {
+                if (beforePos == ADDED_LIST_ITEM) {
                     add(asRef ? Reference.asRef(anAfter) : anAfter, onChangeRun);
                 } else {
-                    T aBefore = before == null ? null : before.get(beforePos);
+                    T aBefore = requireNonNull(before).get(beforePos);
                     if (aBefore == anAfter) {
                         put(new RpcObjectData(NO_CHANGE, null, null, null, trace));
                     } else if (asRef || aBefore == null || anAfter.getClass() != aBefore.getClass()) {
@@ -174,20 +179,50 @@ public class RpcSendQueue {
         });
     }
 
-    private <T> Map<Object, Integer> putListPositions(List<T> after, @Nullable List<T> before, Function<? super T, ?> id) {
-        Map<Object, Integer> beforeIdx = new HashMap<>();
-        if (before != null) {
-            for (int i = 0; i < before.size(); i++) {
-                beforeIdx.put(id.apply(before.get(i)), i);
-            }
+    /**
+     * Emits the positions message and returns the same positions for the caller to walk,
+     * or null when every element is new.
+     */
+    private <T> int @Nullable [] putListPositions(List<T> after, @Nullable List<T> before, Function<? super T, ?> id) {
+        int afterSize = after.size();
+        if (before == null || before.isEmpty()) {
+            // Every element is an addition, so the positions are a constant that needs
+            // neither an index map nor a per-element array.
+            put(new RpcObjectData(CHANGE, null, afterSize == 0 ? emptyList() :
+                    nCopies(afterSize, ADDED_LIST_ITEM), null, trace));
+            return null;
         }
-        List<Integer> positions = new ArrayList<>();
-        for (T t : after) {
-            Integer beforePos = beforeIdx.get(id.apply(t));
-            positions.add(beforePos == null ? ADDED_LIST_ITEM : beforePos);
+
+        Map<Object, Integer> beforeIdx = new HashMap<>((int) (before.size() / 0.75f) + 1);
+        for (int i = 0; i < before.size(); i++) {
+            beforeIdx.put(id.apply(before.get(i)), i);
         }
-        put(new RpcObjectData(CHANGE, null, positions, null, trace));
-        return beforeIdx;
+        int[] positions = new int[afterSize];
+        for (int i = 0; i < afterSize; i++) {
+            Integer beforePos = beforeIdx.get(id.apply(after.get(i)));
+            positions[i] = beforePos == null ? ADDED_LIST_ITEM : beforePos;
+        }
+        put(new RpcObjectData(CHANGE, null, new BoxedIntList(positions), null, trace));
+        return positions;
+    }
+
+    /** Presents an {@code int[]} to the serializer without boxing it into a second collection. */
+    private static final class BoxedIntList extends AbstractList<Integer> implements RandomAccess {
+        private final int[] values;
+
+        BoxedIntList(int[] values) {
+            this.values = values;
+        }
+
+        @Override
+        public Integer get(int index) {
+            return values[index];
+        }
+
+        @Override
+        public int size() {
+            return values.length;
+        }
     }
 
     private void add(Object after, @Nullable Runnable onChange) {

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RpcSendQueueTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RpcSendQueueTest.java
@@ -188,6 +188,57 @@ class RpcSendQueueTest {
         assertThat(roundTripList(after, before)).isEqualTo(after);
     }
 
+    /**
+     * The positions array is what lets a reorder cost one integer per element instead of
+     * re-sending the elements themselves; an event stream without a move event cannot.
+     */
+    @Test
+    void reorderedElementsAreRepositionedNotResent() throws Exception {
+        List<String> before = List.of("A", "B", "C");
+        List<String> after = List.of("C", "A", "B");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        RpcSendQueue q = new RpcSendQueue(10, t -> {
+            assertThat(t).containsExactly(
+              new RpcObjectData(RpcObjectData.State.CHANGE, null, null, null, false),
+              new RpcObjectData(RpcObjectData.State.CHANGE, null, List.of(2, 0, 1), null, false),
+              new RpcObjectData(RpcObjectData.State.NO_CHANGE, null, null, null, false) /* C */,
+              new RpcObjectData(RpcObjectData.State.NO_CHANGE, null, null, null, false) /* A */,
+              new RpcObjectData(RpcObjectData.State.NO_CHANGE, null, null, null, false) /* B */
+            );
+            latch.countDown();
+        }, new IdentityHashMap<>(), null, false);
+
+        q.sendList(after, before, Function.identity(), null, false);
+        q.flush();
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(roundTripList(after, before)).isEqualTo(after);
+    }
+
+    @Test
+    void everyElementIsAddedWhenTheBeforeListIsEmpty() throws Exception {
+        List<String> before = List.of();
+        List<String> after = List.of("A", "B");
+
+        CountDownLatch latch = new CountDownLatch(1);
+        RpcSendQueue q = new RpcSendQueue(10, t -> {
+            assertThat(t).containsExactly(
+              new RpcObjectData(RpcObjectData.State.CHANGE, null, null, null, false),
+              new RpcObjectData(RpcObjectData.State.CHANGE, null, List.of(-1, -1), null, false),
+              new RpcObjectData(ADD, null, "A", null, false),
+              new RpcObjectData(ADD, null, "B", null, false)
+            );
+            latch.countDown();
+        }, new IdentityHashMap<>(), null, false);
+
+        q.sendList(after, before, Function.identity(), null, false);
+        q.flush();
+
+        assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+        assertThat(roundTripList(after, before)).isEqualTo(after);
+    }
+
     private List<String> roundTripList(List<String> after, List<String> before) {
         Deque<List<RpcObjectData>> batches = new ArrayDeque<>();
         RpcSendQueue sq = new RpcSendQueue(1, batches::addLast, new IdentityHashMap<>(), null, false);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JRightPadded.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JRightPadded.java
@@ -128,8 +128,6 @@ public class JRightPadded<T> {
     }
 
     public static <J2 extends J> List<JRightPadded<J2>> withElements(List<JRightPadded<J2>> before, List<J2> elements) {
-        Map<UUID, JRightPadded<J2>> beforeById = new HashMap<>((int) Math.ceil(elements.size() / 0.75));
-        List<JRightPadded<J2>> after = new ArrayList<>(elements.size());
         if (before != null) {
             // a cheaper check for the most common case when there are no changes
             if (elements.size() == before.size()) {
@@ -146,11 +144,23 @@ public class JRightPadded<T> {
             } else if (elements.isEmpty()) {
                 return emptyList();
             }
+        }
 
-            for (JRightPadded<J2> j : before) {
-                if (beforeById.put(j.getElement().getId(), j) != null) {
-                    throw new IllegalStateException("Duplicate key");
-                }
+        List<JRightPadded<J2>> after = new ArrayList<>(elements.size());
+        if (before == null || before.isEmpty()) {
+            // Nothing to carry padding over from, so every element is padded fresh and
+            // an index over `before` would answer every lookup with a miss.
+            for (J2 t : elements) {
+                after.add(new JRightPadded<>(t, Space.EMPTY, Markers.EMPTY));
+            }
+            return after;
+        }
+
+        // Sized from what it holds, which is one entry per before element.
+        Map<UUID, JRightPadded<J2>> beforeById = new HashMap<>((int) Math.ceil(before.size() / 0.75));
+        for (JRightPadded<J2> j : before) {
+            if (beforeById.put(j.getElement().getId(), j) != null) {
+                throw new IllegalStateException("Duplicate key");
             }
         }
 


### PR DESCRIPTION
Sending a tree the peer has never seen ran the list-diff id function over every element of every list, then ran it again in the emit loop, and discarded both results: with no `before` list the index map is empty, so every lookup was guaranteed to miss.

For `JavaType` lists that id function builds a type signature recursively. One send of a 120-file corpus spent ~19.7M signature builds on answers it could not use, and allocated 12.05 GB.

## What each change bought

Measured against the tree as it stood at that commit, so **these do not chain and do not sum**: several shorten the same loop.

| change | measured |
|---|---|
| Skip the list-diff keys that cannot match | send wall −24%; JVM allocation 12.05 GB → 4.09 GB (**−66%**) |
| Memoize codec lookup per class and source file type | print JVM CPU 2,090 → 1,416 ms (**−32%**) |
| Wait for a response instead of polling a 1 ms sleep | print 4,808 → 4,417 ms |
| Request the next page before draining the current one | parse **−20%**, JVM CPU unchanged |

The prefetch row is the one to read carefully: CPU is flat because the work is overlapped, not removed. The remote no longer sits idle while this side deserializes, and this side no longer sits idle while the remote serializes.

## The wire is unchanged, the behaviour is not

The positions-array format is untouched, and the 13,963,822 positions messages a 120-file send emits compare byte-for-byte against the previous algorithm.

One behavioural change the byte comparison does not catch: skipping the keys that cannot match also removes a call site. With no `before` list the id function is not applied at all, where it previously ran and its result was discarded.

That matters whenever the id function is not total, and it was. The `JavaType` signature builder threw on an annotation element value with neither array set — a state a C# peer produces legitimately — so this branch silently stopped a crash it does not fix. #8813 fixed it properly and is already on main.

## Coverage

`sendList` was close to untested. `RpcSendQueueTest` gains a reorder, an empty-but-present `before` list, a mix of additions and removals, and an unchanged list.

The reorder case is the one to keep deliberately: it pins the property that distinguishes a positions array from an event stream, namely that reordered elements are repositioned by index rather than re-sent.

## From review

Three fixes are folded into the commits that introduced them:

- codec discovery no longer sits behind the memo, so a provider arriving in a later classloader is still found
- `sendList` walks `after` with an iterator, so a sequential-access list is not quadratic
- `await` registers its unpark only after the response is known not to have arrived, so an already-complete future cannot leave a stale permit on the calling thread

Not changed: `getObject` holds its prefetched page in an `AtomicReference` where a plain holder would do. It is captured by a lambda so it needs one, and `getAndSet` reads and clears in a step.

## Scope

This PR is the Java half. The Go, JavaScript, C# and Python ports of the same ideas — each with its own throughput harness and its own numbers — are in separate PRs, because their findings and their measurements are independent of these.
