### PR TITLE
Keep single line Groovy closures on one line

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpdateJavaCompatibility.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.marker.SearchResult;
@@ -119,10 +120,10 @@ public class UpdateJavaCompatibility extends Recipe {
                 } else if (visited instanceof K.CompilationUnit) {
                     K.CompilationUnit c = (K.CompilationUnit) visited;
                     if (!sourceCompatibilityFound) {
-                        c = addKotlinCompatibilityType(c, "source", ctx);
+                        c = addKotlinCompatibilityType(c, "source", getCursor(), ctx);
                     }
                     if (!targetCompatibilityFound) {
-                        c = addKotlinCompatibilityType(c, "target", ctx);
+                        c = addKotlinCompatibilityType(c, "target", getCursor(), ctx);
                     }
                     return c;
                 }
@@ -201,21 +202,28 @@ public class UpdateJavaCompatibility extends Recipe {
         return c;
     }
 
-    // Parsed rather than templated: a template insertion into a Kotlin script comes back indented one level too
-    // far, since the block a script's statements sit in is not an indentation level
-    private K.CompilationUnit addKotlinCompatibilityType(K.CompilationUnit c, String targetCompatibilityType, ExecutionContext ctx) {
+    private K.CompilationUnit addKotlinCompatibilityType(K.CompilationUnit c, String targetCompatibilityType, Cursor scope, ExecutionContext ctx) {
         if ((compatibilityType == null || targetCompatibilityType.equals(compatibilityType.toString())) && TRUE.equals(addIfMissing)) {
             J withExistingJavaMethod = maybeAddToExistingJavaMethod(c, targetCompatibilityType, ctx);
             if (withExistingJavaMethod != c) {
                 return (K.CompilationUnit) withExistingJavaMethod;
             }
 
-            K.CompilationUnit sourceFile = (K.CompilationUnit) KotlinParser.builder()
-                    .isKotlinScript(true)
-                    .build().parse(ctx, "\n\njava {\n    " + targetCompatibilityType + "Compatibility = " + styleMissingCompatibilityVersion(DeclarationStyle.Enum) + "\n}")
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalStateException("Unable to parse compatibility type as a Gradle file"));
-            c = c.withStatements(ListUtils.concatAll(c.getStatements(), sourceFile.getStatements()));
+            List<Statement> statements = c.getStatements().get(0) instanceof J.Block ?
+                    ((J.Block) c.getStatements().get(0)).getStatements() : emptyList();
+            if (statements.isEmpty()) {
+                return c;
+            }
+            Statement last = statements.get(statements.size() - 1);
+            K.CompilationUnit updated = KotlinTemplate.builder("java {\n    " + targetCompatibilityType + "Compatibility = " + styleMissingCompatibilityVersion(DeclarationStyle.Enum) + "\n}")
+                    .build()
+                    .apply(new Cursor(scope, c), last.getCoordinates().after());
+            // Gradle scripts set their top-level blocks apart with a blank line, which a coordinate places but
+            // does not style
+            return updated.withStatements(ListUtils.mapFirst(updated.getStatements(), first -> first instanceof J.Block ?
+                    ((J.Block) first).withStatements(ListUtils.mapLast(((J.Block) first).getStatements(),
+                            s -> s.withPrefix(Space.format("\n\n")))) :
+                    first));
         }
         return c;
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseMainClassPropertyForApplication.java
@@ -18,18 +18,15 @@ package org.openrewrite.gradle.gradle9;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.openrewrite.*;
-import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
-import org.openrewrite.groovy.tree.G;
+import org.openrewrite.groovy.GroovyTemplate;
+import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.JavaVisitor;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 
-import java.nio.file.Paths;
 import java.util.List;
-
-import static java.util.Collections.singletonList;
-import static org.openrewrite.gradle.GradleParser.requireParsed;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -75,8 +72,7 @@ public class UseMainClassPropertyForApplication extends Recipe {
                 if (getCursor().firstEnclosing(J.Lambda.class) == null) {
                     Expression rhs = assignment.getAssignment();
                     if (rhs instanceof J.Literal && ((J.Literal) rhs).getValueSource() != null) {
-                        String valueSource = ((J.Literal) rhs).getValueSource();
-                        return parseApplicationBlock(ctx, valueSource, assignment.getPrefix());
+                        return applicationBlock(assignment, rhs);
                     }
                 }
                 return assignment;
@@ -100,35 +96,17 @@ public class UseMainClassPropertyForApplication extends Recipe {
                 if (!(initializer instanceof J.Literal) || ((J.Literal) initializer).getValueSource() == null) {
                     return super.visitVariableDeclarations(multiVariable, ctx);
                 }
-                String valueSource = ((J.Literal) initializer).getValueSource();
-                return parseApplicationBlock(ctx, valueSource, multiVariable.getPrefix());
+                return applicationBlock(multiVariable, initializer);
             }
 
-            // Parsed rather than templated: a template replacement of a Kotlin script statement comes back indented
-            // one level too far, since the block a script's statements sit in is not an indentation level
-            private J parseApplicationBlock(ExecutionContext ctx, String valueSource, Space prefix) {
-                String snippet = "application {\n    mainClass = " + valueSource + "\n}";
-                JavaSourceFile sourceFile = getCursor().firstEnclosing(JavaSourceFile.class);
-                boolean isKotlinDsl = sourceFile instanceof K.CompilationUnit;
-                if (isKotlinDsl) {
-                    Statement statement = GradleParser.builder().build()
-                            .parseInputs(singletonList(
-                                    Parser.Input.fromString(Paths.get("build.gradle.kts"), snippet)), null, ctx)
-                            .map(requireParsed(K.CompilationUnit.class))
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("Could not parse application block"))
-                            .getStatements()
-                            .get(0);
-                    return ((J) statement).withPrefix(prefix);
-                }
-                return ((J) GradleParser.builder().build()
-                        .parse(ctx, snippet)
-                        .map(requireParsed(G.CompilationUnit.class))
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("Could not parse application block"))
-                        .getStatements()
-                        .get(0))
-                        .withPrefix(prefix);
+            // The main class travels as a parameter rather than as text, so a `#{` inside the literal cannot be
+            // mistaken for a template placeholder
+            private J applicationBlock(Statement original, Expression mainClass) {
+                String snippet = "application {\n    mainClass = #{any()}\n}";
+                JavaTemplate template = getCursor().firstEnclosing(JavaSourceFile.class) instanceof K.CompilationUnit ?
+                        KotlinTemplate.builder(snippet).build() :
+                        GroovyTemplate.builder(snippet).build();
+                return template.apply(getCursor(), original.getCoordinates().replace(), mainClass);
             }
 
             private boolean isMainClassName(Tree variable) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseProjectDependencyInsteadOfModuleCoordinates.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseProjectDependencyInsteadOfModuleCoordinates.java
@@ -75,14 +75,13 @@ public class UseProjectDependencyInsteadOfModuleCoordinates extends Recipe {
                     return m;
                 }
 
-                // The `OmitParentheses` marker (Groovy command syntax, e.g. `implementation 'a:b:c'`) lives on
-                // the argument element itself, so carry the original coordinate's markers over to the replacement
-                // to preserve whether the enclosing call uses parentheses.
-                Expression projectNotation = GroovyTemplate.builder("project('" + projectPath(gp) + "')")
+                J.MethodInvocation withProjectNotation = GroovyTemplate.builder("project('" + projectPath(gp) + "')")
                         .build()
-                        .<Expression>apply(new Cursor(getCursor(), coordinate), coordinate.getCoordinates().replace())
-                        .withMarkers(coordinate.getMarkers());
-                return m.withArguments(ListUtils.mapFirst(m.getArguments(), arg -> projectNotation));
+                        .apply(getCursor(), coordinate.getCoordinates().replace());
+                // The `OmitParentheses` marker (Groovy command syntax, e.g. `implementation 'a:b:c'`) lives on the
+                // argument element itself, so it has to travel with the replacement
+                return withProjectNotation.withArguments(ListUtils.mapFirst(withProjectNotation.getArguments(),
+                        arg -> arg.withMarkers(coordinate.getMarkers())));
             }
         });
     }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/AddDevelocityGradlePlugin.java
@@ -20,22 +20,20 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.DependencyVersionSelector;
-import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
 import org.openrewrite.gradle.IsSettingsGradle;
 import org.openrewrite.gradle.marker.GradleProject;
 import org.openrewrite.gradle.marker.GradleSettings;
 import org.openrewrite.gradle.util.GradleWrapper;
+import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.tree.G;
-import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
-import org.openrewrite.java.style.IntelliJ;
-import org.openrewrite.java.style.TabsAndIndentsStyle;
-import org.openrewrite.java.tree.J;
-import org.openrewrite.java.tree.JavaSourceFile;
-import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.BuildTool;
+import org.openrewrite.marker.Markers;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.tree.GroupArtifact;
@@ -44,17 +42,17 @@ import org.openrewrite.properties.search.FindProperties;
 import org.openrewrite.properties.tree.Properties;
 import org.openrewrite.semver.Semver;
 import org.openrewrite.semver.VersionComparator;
-import org.openrewrite.style.Style;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static java.util.Collections.singletonList;
-import static org.openrewrite.gradle.GradleParser.requireParsed;
+import static org.openrewrite.Tree.randomId;
 import static org.openrewrite.gradle.util.GradleWrapper.WRAPPER_PROPERTIES_LOCATION_RELATIVE_PATH;
 
 @Value
@@ -361,12 +359,7 @@ public class AddDevelocityGradlePlugin extends ScanningRecipe<AddDevelocityGradl
                         .visitNonNull(cu, ctx, getCursor());
                 cu = (G.CompilationUnit) new UpgradePluginVersion(pluginId, newVersion, null).getVisitor()
                         .visitNonNull(cu, ctx, getCursor());
-                J.MethodInvocation gradleEnterpriseInvocation = groovyEnterpriseDsl(
-                        newVersion,
-                        versionComparator,
-                        getIndent(cu),
-                        ctx);
-                return cu.withStatements(ListUtils.concat(cu.getStatements(), gradleEnterpriseInvocation));
+                return (G.CompilationUnit) appendDevelocityDsl(cu, getCursor(), newVersion, versionComparator, false);
             }
 
             private K.CompilationUnit withPlugin(K.CompilationUnit cu, String pluginId, String newVersion, VersionComparator versionComparator, ExecutionContext ctx) {
@@ -374,12 +367,7 @@ public class AddDevelocityGradlePlugin extends ScanningRecipe<AddDevelocityGradl
                         .visitNonNull(cu, ctx, getCursor());
                 cu = (K.CompilationUnit) new UpgradePluginVersion(pluginId, newVersion, null).getVisitor()
                         .visitNonNull(cu, ctx, getCursor());
-                J.MethodInvocation gradleEnterpriseInvocation = kotlinEnterpriseDsl(
-                        newVersion,
-                        versionComparator,
-                        getIndent(cu),
-                        ctx);
-                return cu.withStatements(ListUtils.concat(cu.getStatements(), gradleEnterpriseInvocation));
+                return (K.CompilationUnit) appendDevelocityDsl(cu, getCursor(), newVersion, versionComparator, true);
             }
         });
     }
@@ -407,152 +395,86 @@ public class AddDevelocityGradlePlugin extends ScanningRecipe<AddDevelocityGradl
         return found.get();
     }
 
-    private J.@Nullable MethodInvocation groovyEnterpriseDsl(String newVersion, VersionComparator versionComparator, String indent, ExecutionContext ctx) {
+    /**
+     * Every option value travels as a parameter rather than as text, so nothing a user supplies can be mistaken
+     * for the template's own placeholder syntax.
+     */
+    private JavaSourceFile appendDevelocityDsl(JavaSourceFile cu, Cursor scope, String newVersion,
+                                               VersionComparator versionComparator, boolean kotlinDsl) {
         if (server == null && allowUntrustedServer == null && captureTaskInputFiles == null && uploadInBackground == null && publishCriteria == null) {
-            return null;
+            return cu;
         }
         boolean versionIsAtLeast3_2 = versionComparator.compare(null, newVersion, "3.2") >= 0;
         boolean versionIsAtLeast3_7 = versionComparator.compare(null, newVersion, "3.7") >= 0;
         boolean versionIsAtLeast3_17 = versionComparator.compare(null, newVersion, "3.17") >= 0;
-        StringBuilder ge;
-        if (versionIsAtLeast3_17) {
-            ge = new StringBuilder("develocity {\n");
-        } else {
-            ge = new StringBuilder("gradleEnterprise {\n");
-        }
+
+        List<Expression> values = new ArrayList<>();
+        StringBuilder ge = new StringBuilder(versionIsAtLeast3_17 ? "develocity {\n" : "gradleEnterprise {\n");
         if (server != null && !server.isEmpty()) {
-            ge.append(indent).append("server = '").append(server).append("'\n");
+            ge.append(kotlinDsl ? "    server.set(#{any()})\n" : "    server = #{any()}\n");
+            values.add(literal(server, kotlinDsl));
         }
         if (allowUntrustedServer != null && versionIsAtLeast3_2) {
-            ge.append(indent).append("allowUntrustedServer = ").append(allowUntrustedServer).append("\n");
+            ge.append(kotlinDsl ? "    allowUntrustedServer.set(#{any()})\n" : "    allowUntrustedServer = #{any()}\n");
+            values.add(literal(allowUntrustedServer));
         }
         if (captureTaskInputFiles != null || uploadInBackground != null || (allowUntrustedServer != null && !versionIsAtLeast3_2) || publishCriteria != null) {
-            ge.append(indent).append("buildScan {\n");
+            ge.append("    buildScan {\n");
             if (publishCriteria != null) {
                 if (publishCriteria == PublishCriteria.Always) {
-                    if (versionIsAtLeast3_17) {
-                        ge.append(indent).append(indent).append("publishing.onlyIf { true }\n");
-                    } else {
-                        ge.append(indent).append(indent).append("publishAlways()\n");
-                    }
+                    ge.append(versionIsAtLeast3_17 ? "        publishing.onlyIf { true }\n" : "        publishAlways()\n");
+                } else if (versionIsAtLeast3_17) {
+                    ge.append(kotlinDsl ?
+                            "        publishing.onlyIf { it.buildResult.failures.isNotEmpty() }\n" :
+                            "        publishing.onlyIf { !it.buildResult.failures.empty }\n");
                 } else {
-                    if (versionIsAtLeast3_17) {
-                        ge.append(indent).append(indent).append("publishing.onlyIf { !it.buildResult.failures.empty }\n");
-                    } else {
-                        ge.append(indent).append(indent).append("publishOnFailure()\n");
-                    }
+                    ge.append("        publishOnFailure()\n");
                 }
             }
             if (allowUntrustedServer != null && !versionIsAtLeast3_2) {
-                ge.append(indent).append(indent).append("allowUntrustedServer = ").append(allowUntrustedServer).append("\n");
+                ge.append(kotlinDsl ? "        allowUntrustedServer.set(#{any()})\n" : "        allowUntrustedServer = #{any()}\n");
+                values.add(literal(allowUntrustedServer));
             }
             if (uploadInBackground != null) {
-                ge.append(indent).append(indent).append("uploadInBackground = ").append(uploadInBackground).append("\n");
+                ge.append(kotlinDsl ? "        uploadInBackground.set(#{any()})\n" : "        uploadInBackground = #{any()}\n");
+                values.add(literal(uploadInBackground));
             }
             if (captureTaskInputFiles != null) {
                 if (versionIsAtLeast3_7) {
-                    ge.append(indent).append(indent).append("capture {\n");
-                    if (versionIsAtLeast3_17) {
-                        ge.append(indent).append(indent).append(indent).append("fileFingerprints = ").append(captureTaskInputFiles).append("\n");
-                    } else {
-                        ge.append(indent).append(indent).append(indent).append("taskInputFiles = ").append(captureTaskInputFiles).append("\n");
-                    }
-                    ge.append(indent).append(indent).append("}\n");
+                    ge.append("        capture {\n");
+                    String property = versionIsAtLeast3_17 ? "fileFingerprints" : "taskInputFiles";
+                    ge.append(kotlinDsl ? "            " + property + ".set(#{any()})\n" : "            " + property + " = #{any()}\n");
+                    values.add(literal(captureTaskInputFiles));
+                    ge.append("        }\n");
                 } else {
-                    ge.append(indent).append(indent).append("captureTaskInputFiles = ").append(captureTaskInputFiles).append("\n");
+                    ge.append(kotlinDsl ? "        captureTaskInputFiles.set(#{any()})\n" : "        captureTaskInputFiles = #{any()}\n");
+                    values.add(literal(captureTaskInputFiles));
                 }
             }
-            ge.append(indent).append("}\n");
+            ge.append("    }\n");
         }
-        ge.append("}\n");
-        G.CompilationUnit cu = GradleParser.builder().build()
-                .parseInputs(singletonList(
-                        Parser.Input.fromString(Paths.get("settings.gradle"), ge.toString())), null, ctx)
-                .map(requireParsed(G.CompilationUnit.class))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
+        ge.append("}");
 
-        return ((J.MethodInvocation) cu.getStatements().get(0)).withPrefix(Space.format("\n"));
+        List<Statement> statements = kotlinDsl ?
+                ((J.Block) ((K.CompilationUnit) cu).getStatements().get(0)).getStatements() :
+                ((G.CompilationUnit) cu).getStatements();
+        if (statements.isEmpty()) {
+            return cu;
+        }
+        Statement last = statements.get(statements.size() - 1);
+        JavaTemplate template = kotlinDsl ?
+                KotlinTemplate.builder(ge.toString()).build() :
+                GroovyTemplate.builder(ge.toString()).build();
+        return template.apply(new Cursor(scope, cu), last.getCoordinates().after(), values.toArray());
     }
 
-    private J.@Nullable MethodInvocation kotlinEnterpriseDsl(String newVersion, VersionComparator versionComparator, String indent, ExecutionContext ctx) {
-        if (server == null && allowUntrustedServer == null && captureTaskInputFiles == null && uploadInBackground == null && publishCriteria == null) {
-            return null;
-        }
-        boolean versionIsAtLeast3_2 = versionComparator.compare(null, newVersion, "3.2") >= 0;
-        boolean versionIsAtLeast3_7 = versionComparator.compare(null, newVersion, "3.7") >= 0;
-        boolean versionIsAtLeast3_17 = versionComparator.compare(null, newVersion, "3.17") >= 0;
-        StringBuilder ge;
-        if (versionIsAtLeast3_17) {
-            ge = new StringBuilder("\ndevelocity {\n");
-        } else {
-            ge = new StringBuilder("\ngradleEnterprise {\n");
-        }
-        if (server != null && !server.isEmpty()) {
-            ge.append(indent).append("server.set(\"").append(server).append("\")\n");
-        }
-        if (allowUntrustedServer != null && versionIsAtLeast3_2) {
-            ge.append(indent).append("allowUntrustedServer.set(").append(allowUntrustedServer).append(")\n");
-        }
-        if (captureTaskInputFiles != null || uploadInBackground != null || (allowUntrustedServer != null && !versionIsAtLeast3_2) || publishCriteria != null) {
-            ge.append(indent).append("buildScan {\n");
-            if (publishCriteria != null) {
-                if (publishCriteria == PublishCriteria.Always) {
-                    if (versionIsAtLeast3_17) {
-                        ge.append(indent).append(indent).append("publishing.onlyIf { true }\n");
-                    } else {
-                        ge.append(indent).append(indent).append("publishAlways()\n");
-                    }
-                } else {
-                    if (versionIsAtLeast3_17) {
-                        ge.append(indent).append(indent).append("publishing.onlyIf { it.buildResult.failures.isNotEmpty() }\n");
-                    } else {
-                        ge.append(indent).append(indent).append("publishOnFailure()\n");
-                    }
-                }
-            }
-            if (allowUntrustedServer != null && !versionIsAtLeast3_2) {
-                ge.append(indent).append(indent).append("allowUntrustedServer.set(").append(allowUntrustedServer).append(")\n");
-            }
-            if (uploadInBackground != null) {
-                ge.append(indent).append(indent).append("uploadInBackground.set(").append(uploadInBackground).append(")\n");
-            }
-            if (captureTaskInputFiles != null) {
-                if (versionIsAtLeast3_7) {
-                    ge.append(indent).append(indent).append("capture {\n");
-                    if (versionIsAtLeast3_17) {
-                        ge.append(indent).append(indent).append(indent).append("fileFingerprints.set(").append(captureTaskInputFiles).append(")\n");
-                    } else {
-                        ge.append(indent).append(indent).append(indent).append("taskInputFiles.set(").append(captureTaskInputFiles).append(")\n");
-                    }
-                    ge.append(indent).append(indent).append("}\n");
-                } else {
-                    ge.append(indent).append(indent).append("captureTaskInputFiles.set(").append(captureTaskInputFiles).append(")\n");
-                }
-            }
-            ge.append(indent).append("}\n");
-        }
-        ge.append("}\n");
-        K.CompilationUnit cu = GradleParser.builder().build()
-                .parseInputs(singletonList(
-                        Parser.Input.fromString(Paths.get("settings.gradle.kts"), ge.toString())), null, ctx)
-                .map(requireParsed(K.CompilationUnit.class))
-                .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
-
-        return (J.MethodInvocation) ((J.Block) cu.getStatements().get(0)).getStatements().get(0);
+    // A value, not a construct: the quoting is the recipe's own, so there is nothing for a parser to tell us
+    private static J.Literal literal(String value, boolean kotlinDsl) {
+        String quote = kotlinDsl ? "\"" : "'";
+        return new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, value, quote + value + quote, null, JavaType.Primitive.String);
     }
 
-    private static String getIndent(JavaSourceFile cu) {
-        TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents);
-        if (style.getUseTabCharacter()) {
-            return "\t";
-        } else {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 0; i < style.getIndentSize(); i++) {
-                sb.append(" ");
-            }
-            return sb.toString();
-        }
+    private static J.Literal literal(Boolean value) {
+        return new J.Literal(randomId(), Space.EMPTY, Markers.EMPTY, value, String.valueOf(value), null, JavaType.Primitive.Boolean);
     }
 }

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/plugins/MigrateGradleEnterpriseToDevelocity.java
@@ -20,28 +20,22 @@ import lombok.Value;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.gradle.DependencyVersionSelector;
-import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsSettingsGradle;
 import org.openrewrite.gradle.marker.GradleSettings;
 import org.openrewrite.groovy.GroovyIsoVisitor;
+import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
-import org.openrewrite.java.style.IntelliJ;
-import org.openrewrite.java.style.TabsAndIndentsStyle;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.maven.MavenDownloadingException;
 import org.openrewrite.maven.table.MavenMetadataFailures;
 import org.openrewrite.maven.tree.GroupArtifact;
-import org.openrewrite.style.Style;
 
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static java.util.Collections.singletonList;
-import static org.openrewrite.gradle.GradleParser.requireParsed;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -114,11 +108,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
                 }
 
                 if ("publishAlwaysIf".equals(m.getSimpleName())) {
-                    J.MethodInvocation publishingTemplate = develocityPublishAlwaysIfDsl(getIndent(getCursor().firstEnclosing(G.CompilationUnit.class)), ctx);
-                    if (publishingTemplate == null) {
-                        return m;
-                    }
-
+                    J.MethodInvocation publishingTemplate = publishingOnlyIf(m, "true");
                     return publishingTemplate.withArguments(ListUtils.mapFirst(publishingTemplate.getArguments(), arg -> {
                         if (arg instanceof J.Lambda) {
                             J.Lambda lambda = (J.Lambda) arg;
@@ -137,11 +127,7 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
             }
 
             if (m.getSimpleName().startsWith("publishOnFailure") && withinMethodInvocations(Arrays.asList("gradleEnterprise", "buildScan"))) {
-                J.MethodInvocation publishingTemplate = develocityPublishOnFailureIfDsl(getIndent(getCursor().firstEnclosing(G.CompilationUnit.class)), ctx);
-                if (publishingTemplate == null) {
-                    return m;
-                }
-
+                J.MethodInvocation publishingTemplate = publishingOnlyIf(m, "!it.buildResult.failures.empty");
                 if ("publishOnFailure".equals(m.getSimpleName()) && noArguments(m.getArguments())) {
                     return publishingTemplate;
                 }
@@ -236,55 +222,10 @@ public class MigrateGradleEnterpriseToDevelocity extends Recipe {
             return null;
         }
 
-        private J.@Nullable MethodInvocation develocityPublishAlwaysIfDsl(String indent, ExecutionContext ctx) {
-            StringBuilder ge = new StringBuilder("\ndevelocity {\n");
-            ge.append(indent).append("buildScan {\n");
-            ge.append(indent).append(indent).append("publishing.onlyIf { true }\n");
-            ge.append(indent).append("}\n");
-            ge.append("}\n");
-
-            G.CompilationUnit cu = GradleParser.builder().build()
-                    .parseInputs(singletonList(
-                            Parser.Input.fromString(Paths.get("settings.gradle"), ge.toString())), null, ctx)
-                    .map(requireParsed(G.CompilationUnit.class))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
-
-            J.MethodInvocation develocity = (J.MethodInvocation) cu.getStatements().get(0);
-            J.MethodInvocation buildScan = (J.MethodInvocation) ((J.Return) ((J.Block) ((J.Lambda) develocity.getArguments().get(0)).getBody()).getStatements().get(0)).getExpression();
-            return (J.MethodInvocation) ((J.Return) ((J.Block) ((J.Lambda) buildScan.getArguments().get(0)).getBody()).getStatements().get(0)).getExpression();
-        }
-
-        private J.@Nullable MethodInvocation develocityPublishOnFailureIfDsl(String indent, ExecutionContext ctx) {
-            StringBuilder ge = new StringBuilder("\ndevelocity {\n");
-            ge.append(indent).append("buildScan {\n");
-            ge.append(indent).append(indent).append("publishing.onlyIf { !it.buildResult.failures.empty }\n");
-            ge.append(indent).append("}\n");
-            ge.append("}\n");
-
-            G.CompilationUnit cu = GradleParser.builder().build()
-                    .parseInputs(singletonList(
-                            Parser.Input.fromString(Paths.get("settings.gradle"), ge.toString())), null, ctx)
-                    .map(requireParsed(G.CompilationUnit.class))
-                    .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("Could not parse as Gradle"));
-
-            J.MethodInvocation develocity = (J.MethodInvocation) cu.getStatements().get(0);
-            J.MethodInvocation buildScan = (J.MethodInvocation) ((J.Return) ((J.Block) ((J.Lambda) develocity.getArguments().get(0)).getBody()).getStatements().get(0)).getExpression();
-            return (J.MethodInvocation) ((J.Return) ((J.Block) ((J.Lambda) buildScan.getArguments().get(0)).getBody()).getStatements().get(0)).getExpression();
-        }
-
-        private String getIndent(G.CompilationUnit cu) {
-            TabsAndIndentsStyle style = Style.from(TabsAndIndentsStyle.class, cu, IntelliJ::tabsAndIndents);
-            if (style.getUseTabCharacter()) {
-                return "\t";
-            } else {
-                StringBuilder sb = new StringBuilder();
-                for (int i = 0; i < style.getIndentSize(); i++) {
-                    sb.append(" ");
-                }
-                return sb.toString();
-            }
+        private J.MethodInvocation publishingOnlyIf(J.MethodInvocation replacing, String condition) {
+            return GroovyTemplate.builder("publishing.onlyIf { " + condition + " }")
+                    .build()
+                    .apply(getCursor(), replacing.getCoordinates().replace());
         }
     }
 }

--- a/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/WrappingAndBracesVisitor.java
+++ b/rewrite-groovy/src/main/java/org/openrewrite/groovy/format/WrappingAndBracesVisitor.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.groovy.format;
+
+import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
+import org.openrewrite.Tree;
+import org.openrewrite.groovy.marker.LambdaStyle;
+import org.openrewrite.java.style.SpacesStyle;
+import org.openrewrite.java.style.WrappingAndBracesStyle;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JRightPadded;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.Statement;
+import org.openrewrite.style.NamedStyles;
+
+import java.util.List;
+
+public class WrappingAndBracesVisitor<P> extends org.openrewrite.java.format.WrappingAndBracesVisitor<P> {
+    public WrappingAndBracesVisitor(List<NamedStyles> styles, @Nullable Tree stopAfter) {
+        super(styles, stopAfter);
+    }
+
+    public WrappingAndBracesVisitor(SpacesStyle spacesStyle, WrappingAndBracesStyle wrappingAndBracesStyle, @Nullable Tree stopAfter) {
+        super(spacesStyle, wrappingAndBracesStyle, stopAfter);
+    }
+
+    @Override
+    public <T> @Nullable JRightPadded<T> visitRightPadded(@Nullable JRightPadded<T> right, JRightPadded.Location loc, P p) {
+        if (loc == JRightPadded.Location.BLOCK_STATEMENT && isSingleLineClosureBody(getCursor())) {
+            loc = JRightPadded.Location.LANGUAGE_EXTENSION;
+        }
+        return super.visitRightPadded(right, loc, p);
+    }
+
+    @Override
+    public Space visitSpace(@Nullable Space space, Space.Location loc, P p) {
+        // The base visitor gives every statement in a block, and every block's closing brace, a line of its own
+        if (loc == Space.Location.BLOCK_END ?
+                isSingleLineClosureBody(getCursor()) :
+                loc.name().endsWith("_PREFIX") && isSingleLineClosureBody(getCursor().getParentTreeCursor())) {
+            loc = Space.Location.LANGUAGE_EXTENSION;
+        }
+        return super.visitSpace(space, loc, p);
+    }
+
+    /**
+     * A closure written on one line, as `useJUnitPlatform { it.excludeTags 'slow' }` is throughout the Gradle DSL.
+     * Java has no such convention, so the base visitor puts every block statement on its own line.
+     */
+    private static boolean isSingleLineClosureBody(Cursor cursor) {
+        if (!(cursor.getValue() instanceof J.Block)) {
+            return false;
+        }
+        J.Block block = cursor.getValue();
+        // An empty block is already governed by the style's keep-in-one-line settings
+        if (block.getStatements().isEmpty() || block.getEnd().getWhitespace().contains("\n")) {
+            return false;
+        }
+        Object parent = cursor.getParentTreeCursor().getValue();
+        if (!(parent instanceof J.Lambda) ||
+            ((J.Lambda) parent).getMarkers().findFirst(LambdaStyle.class).map(LambdaStyle::isJavaStyle).orElse(false)) {
+            return false;
+        }
+        for (Statement statement : block.getStatements()) {
+            if (statement.getPrefix().getWhitespace().contains("\n")) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyVisitorTest.java
@@ -47,9 +47,7 @@ class GroovyVisitorTest implements RewriteTest {
               Test.test({ it })
               """,
             """
-              Test.test {
-                  it
-              }
+              Test.test { it }
               """
           )
         );

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/format/AutoFormatVisitorTest.java
@@ -112,9 +112,77 @@ class AutoFormatVisitorTest implements RewriteTest {
               """,
             """
               if (convertTemplate == null)
-                  convertTemplate = inTypemap.find { key, value ->
-                      (key instanceof Pattern && key.matcher(apiType).matches())
-                  }?.value
+                  convertTemplate = inTypemap.find { key, value -> (key instanceof Pattern && key.matcher(apiType).matches()) }?.value
+              """
+          )
+        );
+    }
+
+    @Test
+    void keepsSingleLineClosureOnOneLine() {
+        rewriteRun(
+          groovy(
+            """
+              develocity {
+              buildScan {
+              publishing.onlyIf { !it.buildResult.failures.empty }
+              }
+              }
+              """,
+            """
+              develocity {
+                  buildScan {
+                      publishing.onlyIf { !it.buildResult.failures.empty }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void stillWrapsAClosureTheAuthorWroteAcrossLines() {
+        rewriteRun(
+          groovy(
+            """
+              develocity {
+              buildScan {
+              publishing.onlyIf {
+              !it.buildResult.failures.empty
+              }
+              }
+              }
+              """,
+            """
+              develocity {
+                  buildScan {
+                      publishing.onlyIf {
+                          !it.buildResult.failures.empty
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void wrapsAClosureWhoseStatementsSpanLines() {
+        rewriteRun(
+          groovy(
+            """
+              develocity {
+                  buildScan { publishing.enabled = true
+                      publishing.onlyIf { true } }
+              }
+              """,
+            """
+              develocity {
+                  buildScan {
+                      publishing.enabled = true
+                      publishing.onlyIf { true }
+                  }
+              }
               """
           )
         );

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
@@ -22,9 +22,11 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Issue;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.NameTree;
+import org.openrewrite.java.tree.Statement;
 import org.openrewrite.marker.SearchResult;
 import org.openrewrite.test.RewriteTest;
 
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.test.RewriteTest.toRecipe;
@@ -706,6 +708,7 @@ class JavaTemplateTest8Test implements RewriteTest {
             """
               class Test {
                   void test() {
+                      int n = 1;
                       System.out.println(hashCode());
                   }
               }
@@ -715,12 +718,14 @@ class JavaTemplateTest8Test implements RewriteTest {
           .findFirst()
           .orElseThrow();
 
+        // The coordinate names a statement that is not inside `scope`, so nothing can ever match it
         assertThatThrownBy(() -> new JavaIsoVisitor<Integer>() {
             @Override
             public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, Integer p) {
                 if ("println".equals(method.getSimpleName())) {
-                    // The argument is nested inside `method`, which the template visitor never descends into
-                    return JavaTemplate.apply("0", getCursor(), method.getArguments().getFirst().getCoordinates().replace());
+                    J.MethodDeclaration enclosing = getCursor().firstEnclosingOrThrow(J.MethodDeclaration.class);
+                    Statement sibling = requireNonNull(enclosing.getBody()).getStatements().getFirst();
+                    return JavaTemplate.apply("0", getCursor(), sibling.getCoordinates().replace());
                 }
                 return super.visitMethodInvocation(method, p);
             }
@@ -728,6 +733,37 @@ class JavaTemplateTest8Test implements RewriteTest {
           .rootCause()
           .isInstanceOf(IllegalStateException.class)
           .hasMessageContaining("JavaTemplate coordinates were never matched")
-          .hasMessageContaining(J.MethodInvocation.class.getName());
+          .hasMessageContaining(J.VariableDeclarations.class.getName());
+    }
+
+    @Test
+    void coordinatesNestedInArgumentsAreReachable() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.MethodInvocation visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                  if ("println".equals(method.getSimpleName()) && method.getArguments().getFirst() instanceof J.MethodInvocation) {
+                      return JavaTemplate.apply("0", getCursor(), method.getArguments().getFirst().getCoordinates().replace());
+                  }
+                  return super.visitMethodInvocation(method, ctx);
+              }
+          })),
+          java(
+            """
+              class Test {
+                  void test() {
+                      System.out.println(hashCode());
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test() {
+                      System.out.println(0);
+                  }
+              }
+              """
+          )
+        );
     }
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -518,7 +518,11 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                                     loc))
                             .withPrefix(method.getPrefix()), integer);
                 }
-                return maybeReplaceStatement(method, J.class, 0);
+                if (isScope(method)) {
+                    return maybeReplaceStatement(method, J.class, 0);
+                }
+                // Descend, so that a coordinate on something nested in the arguments is still reachable
+                return super.visitMethodInvocation(method, integer);
             }
 
             @Override

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/format/TabsAndIndentsVisitor.java
@@ -98,6 +98,9 @@ public class TabsAndIndentsVisitor<P> extends KotlinIsoVisitor<P> {
             getCursor().putMessage("indentType", IndentType.ALIGN);
         } else if (tree instanceof J.Block && tree.getMarkers().findFirst(SingleExpressionBlock.class).isPresent()) {
             getCursor().putMessage("indentType", wrappingStyle.getExpressionBodyFunctions().getUseContinuationIndent() ? IndentType.CONTINUATION_INDENT : IndentType.INDENT);
+        } else if (tree instanceof J.Block && getCursor().getParentTreeCursor().getValue() instanceof JavaSourceFile) {
+            // A script's statements sit in a block that has no braces of its own, so it is not an indentation level
+            getCursor().putMessage("indentType", IndentType.ALIGN);
         } else if (tree instanceof J.Block ||
                 tree instanceof K.Property ||
                 tree instanceof K.AnnotatedExpression ||


### PR DESCRIPTION
- Stacked on #8810, itself on #8805 and #8803. Review those first.

## Read this part first: three existing expectations change

Two are Groovy auto-format behaviour, affecting everyone who runs `AutoFormat` on Groovy, not just these recipes. In both, the new output is what the author actually wrote.

**`AutoFormatVisitorTest.parenthesizedClosureReturnValue`** — input is one line.

```groovy
// before
convertTemplate = inTypemap.find { key, value ->
    (key instanceof Pattern && key.matcher(apiType).matches())
}?.value

// after
convertTemplate = inTypemap.find { key, value -> (key instanceof Pattern && key.matcher(apiType).matches()) }?.value
```

**`GroovyVisitorTest.autoFormatIncludesOmitParentheses`** — input is `Test.test({ it })`.

```groovy
// before
Test.test {
    it
}

// after
Test.test { it }
```

**`JavaTemplateTest8Test.unreachableCoordinatesFailLoudly`** is a change of test intent, not of output. Its own comment read "The argument is nested inside `method`, which the template visitor never descends into" — it existed to pin the shallowness that fix 3 removes. It now points at a genuinely unreachable coordinate, a sibling statement outside the scope subtree, so it still asserts the loud failure, and a new `coordinatesNestedInArgumentsAreReachable` covers what now works.

## Fix 1: Groovy auto-format expanded single line closures

`publishing.onlyIf { !it.buildResult.failures.empty }` is the idiomatic Gradle shape, and auto-format broke it onto three lines. That blocked three conversions across two earlier PRs, and it is a formatting bug independently of any of them.

The cause is a general rule at the end of `WrappingAndBracesVisitor.visitSpace`: a statement whose parent is a `J.Block` gets its own line. Correct for Java, wrong for a Groovy closure body. Worth noting the first two guesses were both wrong — `SpacesVisitor` only drops the space before `{`, which `MinimumViableSpacingVisitor` puts back, and the `BLOCK_STATEMENT` case in `visitRightPadded` matches but is not what emits the newline. It took printing each visitor's output in the chain to find it.

Groovy now shadows `WrappingAndBracesVisitor`, as it already does for `SpacesVisitor` and `MinimumViableSpacingVisitor`, and remaps the block locations to `LANGUAGE_EXTENSION` (the idiom already used in Groovy's `SpacesVisitor`) when the enclosing block is a single line closure body: non-empty, no line break in the block end or any statement prefix, parent a non-Java-style `J.Lambda`. A closure the author wrote across lines is untouched, and empty blocks still follow the existing `keepWhenFormatting` style.

**Build note.** Gradle's incremental compiler did not recompile `AutoFormatVisitor` when the new same-package class appeared, so the fix silently did nothing until a `--rerun-tasks` compile. A clean `rewrite-groovy` compile may be needed on first pull.

## Fix 2: Kotlin over-indented replacements, and it was not a template bug

- A template replacement of a top level `.kts` statement came back indented one level too far. The obvious route, reusing #8805's `spliceAround` line check in `maybeReplaceStatement`, does not apply: in the failing case the anchor's prefix is `"\n\n"`, so the guard never fires. Restoring the anchor's prefix unconditionally instead broke six Java tests.

The actual cause is one level down, in Kotlin's own `TabsAndIndentsVisitor`, which treats every `J.Block` as an indentation level. A `.kts` script's synthetic block has no braces and is not one. Three lines make a block whose parent is the compilation unit align rather than indent, which is narrow by construction since only scripts have a block directly under the compilation unit.

`JavaTemplateJavaExtension` needed no change for this at all.

## Fix 3: the template visitor was shallow

`visitMethodInvocation` ended at `maybeReplaceStatement`, hence `super.visitStatement`, which visits no children, so a coordinate inside method invocation arguments was never matched. It now guards on `isScope` and otherwise calls `super.visitMethodInvocation`.

Two things I checked rather than assumed. `visitExpression` is *not* shallow in the same way: it is called from the concrete `visitX` methods, which keep descending after it returns unchanged. And descending is safe here because `isScope` matches on tree identity, so it cannot produce a false match, while a scope root that is already the target still matches on the first visit and never descends.

## Five recipes converted

| Recipe | |
|---|---|
| `AddDevelocityGradlePlugin` | Both DSLs, about 110 lines down to one `appendDevelocityDsl`. All five option values now travel as `#{any()}` parameters, `server` as a string literal and three `Boolean`s as boolean literals, so no user supplied text is interpolated at all. `getIndent` gone. |
| `MigrateGradleEnterpriseToDevelocity` | Two near-identical scaffold methods down to one `publishingOnlyIf` on `replace()` coordinates. `getIndent` and its `TabsAndIndentsStyle` plumbing gone. |
| `UseMainClassPropertyForApplication` | Both DSLs, with the main class as a parameter rather than interpolated `getValueSource()` text. |
| `UpdateJavaCompatibility` | Kotlin half, on an `after()` coordinate. The Groovy half converted in #8810. |
| `UseProjectDependencyInsteadOfModuleCoordinates` | Simplified back to a plain `getCursor()` now that fix 3 lets a coordinate on a nested argument resolve. |

No conversion required an expected output to be edited.

## What still uses `GradleParser`, and which kind it is

The goal is no hand-rolled node factories, which is not the same as no mention of the parser. These are legitimate parser users and should stay:

- `Assertions`, the test fixture parser.
- `AddSettingsPluginRepository`, parses a whole settings file.
- `AddDependencyVisitor`, holds one long-lived parser for repeated work.
- `EnableDevelocityBuildCache`, whose only remaining use turns a user's option *text* into a node so it can be passed as a parameter. That is input handling, not construction.
- `UpdateJavaCompatibility.maybeAddToExistingJavaMethod`, whose inner visitor is driven by calling `visitMethodInvocation(...)` directly, so there is no cursor and `autoFormat` throws. Not convertible without restructuring how that visitor is run.
- `UpgradeTransitiveDependencyVersion.parseAsGradle`, the snippet cache, now local to its one consumer.

Still node factories, assessed but not attempted here: `UseJavaExtensionBlock`, the six `UpgradeTransitiveDependencyVersion` scaffold sites, `DependencyConstraintToRule`, `UseRepositoryHandlerActionOverloads`, `AddPluginVisitor`.

I stopped rather than rush those five at the end of a long run. The next one to take is `UseRepositoryHandlerActionOverloads`: its `printTrimmed` interpolation should become `#{any()}` parameters, the same move that worked for option values, and fix 1 also removes its reason to bake the enclosing indentation into the snippet. `DependencyConstraintToRule`'s multi statement site is now plausible via an `if (true) { … }` wrapper, which was verified earlier to parse in both DSLs where a bare `{ … }` does not, since Groovy reads that as a block and Kotlin as a lambda.

## Tests

| Suite | Tests | Failures |
|---|---|---|
| `:rewrite-java:test` | 716 | 0 |
| `:rewrite-java-test:test` | 2208 | 0 |
| `:rewrite-groovy:test` | 707 | 0 |
| `:rewrite-kotlin:test` | 1355 | 0 |
| `:rewrite-gradle:test` | 1328 | 0 |

322 test classes across gradle, groovy and kotlin report zero failures and zero errors. Three new closure tests in `AutoFormatVisitorTest`, one new template test in `JavaTemplateTest8Test`.
