### PR TITLE
Read an annotation array element value that has neither array set

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -833,8 +833,10 @@ public interface JavaType {
             }
 
             public List<?> getValues() {
-                //noinspection DataFlowIssue
-                return Arrays.asList(constantValues != null ? constantValues : referenceValues);
+                // Neither array is set when the argument was a null array literal, which C#
+                // allows (`[Foo(null)]`) and sends over RPC.
+                Object[] values = constantValues != null ? constantValues : referenceValues;
+                return values == null ? emptyList() : Arrays.asList(values);
             }
         }
 

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavaTypeAnnotationRpcTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavaTypeAnnotationRpcTest.java
@@ -16,6 +16,7 @@
 package org.openrewrite.java.internal.rpc;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.java.internal.DefaultJavaTypeSignatureBuilder;
 import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.rpc.Reference;
 import org.openrewrite.rpc.RpcObjectData;
@@ -131,6 +132,23 @@ class JavaTypeAnnotationRpcTest {
         assertThat(((Number) intSev.getConstantValue()).intValue()).isEqualTo(42);
         assertThat(strSev.getConstantValue()).isEqualTo("hello");
         assertThat(arrAev.getConstantValues()).containsExactly("x", "y");
+    }
+
+    @Test
+    void roundTripsAnnotationWithNeitherArrayValuesSet() {
+        JavaType.Method element = methodOn("com.example.Foo", "value", JavaType.Primitive.String);
+        JavaType.Annotation original = annotation("com.example.Foo", List.of(
+                new JavaType.Annotation.ArrayElementValue(element, null, null)));
+
+        // Sending the annotations of a JavaType.Method keys the list diff on each
+        // annotation's signature, so this value has to have one.
+        assertThat(new DefaultJavaTypeSignatureBuilder().signature(original))
+                .isEqualTo("@com.example.Foo(com.example.Foo{name=value,return=String,parameters=[]}=[])");
+
+        JavaType.Annotation.ArrayElementValue aev =
+                (JavaType.Annotation.ArrayElementValue) sendAndReceive(original).getValues().get(0);
+        assertThat(aev.getConstantValues()).isNull();
+        assertThat(aev.getReferenceValues()).isNull();
     }
 
     @Test


### PR DESCRIPTION
Printing a C#-parsed compilation unit over RPC fails with what reads as a wire-format desync:

```
Print: Failed to receive tree <uuid> (type: org.openrewrite.csharp.tree.Cs$CompilationUnit):
  Failed to receive object <uuid>: Expected CHANGE with positions in receiveList, got END_OF_OBJECT
```

The wire contract was being kept. The Java sender threw partway through the tree, and `GetObject.Handler`'s `finally` block appended `END_OF_OBJECT` to the truncated stream, so the receiver reported the first field it could not complete.

## What threw

```
Caused by: java.lang.NullPointerException
	at java.util.Arrays.asList(Arrays.java:4223)
	at JavaType$Annotation$ArrayElementValue.getValues(JavaType.java:837)
	at DefaultJavaTypeSignatureBuilder.annotationSignature(DefaultJavaTypeSignatureBuilder.java:191)
	at RpcSendQueue.putListPositions(RpcSendQueue.java:186)
	at JavaTypeSender.visitMethod(JavaTypeSender.java:123)
	at JavaTypeSender.lambda$visitClass$21(JavaTypeSender.java:82)
```

That lines up with the receiver's own stack: Java aborts in `visitMethod`'s `getAnnotations` inside `visitClass`'s `getMethods`, and C# reports at `method.Annotations` inside `cls.Methods`.

`ArrayElementValue` declares both of its arrays `@Nullable`, and `getValues()` handed whichever was non-null to `Arrays.asList`, which throws when neither is. `AttributeMapping.MapAnnotationElementValue` produces that state two ways:

- the attribute argument is a null array literal
- the attribute argument is an array with no elements

`JavaTypeReceiver` rebuilds it verbatim, so a tree parsed by that peer holds one and sending the tree back reads it.

## The fix

`getValues()` now reads as the empty list when neither array is set, which is what the C# signature builder already renders for the same value, so both sides agree on the signature. `JvmsTypeSignatureBuilder` reads element values the same way and needed it too.

The alternative was to have the C# mapper emit an empty `constantValues`. That leaves the state representable and every other peer exposed, since the nullability is declared on the Java model. `TypeUtils.isOfTypeAnnotationElement` and `JavaTypeVisitor.visitAnnotationElementValue` already guard both fields; `getValues()` was the only unguarded reader.

## Tests

`roundTripsAnnotationWithNeitherArrayValuesSet` builds the value, asserts its signature, and round-trips it through `JavaTypeSender` to `JavaTypeReceiver`. It asserts the signature directly rather than leaving it to the send path, because `putListPositions` only keys a list diff when there is a previous list to diff against.

Verified end to end by parsing and printing 266 C# files over six cycles, which reproduces this on `main` and now completes with identical output per cycle.
