### PR TITLE
Compare empty annotation array element values as equal

### DIFF
--- a/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
+++ b/rewrite-java-tck/src/main/java/org/openrewrite/java/tree/TypeUtilsTest.java
@@ -15,6 +15,7 @@
  */
 package org.openrewrite.java.tree;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.InMemoryExecutionContext;
@@ -444,6 +445,32 @@ class TypeUtilsTest implements RewriteTest {
             }.visit(cu, new InMemoryExecutionContext()))
           )
         );
+    }
+
+    @Test
+    void annotationArrayElementValuesWithoutValuesAreOfSameType() {
+        // Hand-built because the parser routes through `ArrayElementValue.from`, which sets
+        // exactly one of the two arrays; an RPC peer builds the type directly and can set neither.
+        JavaType.Method element = new JavaType.Method(null, 0L, JavaType.ShallowClass.build("com.example.Foo"),
+          "value", JavaType.Primitive.String, emptyList(), emptyList(), emptyList(), emptyList(), null, emptyList());
+        JavaType.Annotation neither = annotationWithArray(element, null, null);
+        JavaType.Annotation empty = annotationWithArray(element, new Object[0], null);
+        JavaType.Annotation constants = annotationWithArray(element, new Object[]{"a"}, null);
+        JavaType.Annotation references = annotationWithArray(element, null,
+          new JavaType[]{JavaType.ShallowClass.build("java.lang.String")});
+
+        assertTrue(TypeUtils.isOfType(neither, annotationWithArray(element, null, null)));
+        assertTrue(TypeUtils.isOfType(neither, empty));
+        assertTrue(TypeUtils.isOfType(empty, neither));
+
+        assertFalse(TypeUtils.isOfType(neither, constants));
+        assertFalse(TypeUtils.isOfType(neither, references));
+    }
+
+    private static JavaType.Annotation annotationWithArray(JavaType.Method element, Object @Nullable [] constantValues,
+                                                           JavaType @Nullable [] referenceValues) {
+        return new JavaType.Annotation(JavaType.ShallowClass.build("com.example.Foo"),
+          singletonList(new JavaType.Annotation.ArrayElementValue(element, constantValues, referenceValues)));
     }
 
     @Test

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/TypeUtils.java
@@ -282,6 +282,11 @@ public class TypeUtils {
         } else if (value2 instanceof JavaType.Annotation.ArrayElementValue) {
             JavaType.Annotation.ArrayElementValue arrayValue1 = (JavaType.Annotation.ArrayElementValue) value1;
             JavaType.Annotation.ArrayElementValue arrayValue2 = (JavaType.Annotation.ArrayElementValue) value2;
+            // `@Foo({})` parses to an empty `constantValues`, while a peer can send an empty
+            // array as neither slot set. With no elements there is no distinction to draw.
+            if (isEmptyArray(arrayValue1) || isEmptyArray(arrayValue2)) {
+                return isEmptyArray(arrayValue1) && isEmptyArray(arrayValue2);
+            }
             if (arrayValue1.getConstantValues() != null) {
                 Object[] constantValues1 = arrayValue1.getConstantValues();
                 if (arrayValue2.getConstantValues() == null || arrayValue2.getConstantValues().length != constantValues1.length) {
@@ -310,6 +315,13 @@ public class TypeUtils {
             return isOfTypeAnnotationElement(value2, value1);
         }
         return false;
+    }
+
+    private static boolean isEmptyArray(JavaType.Annotation.ArrayElementValue value) {
+        Object[] constantValues = value.getConstantValues();
+        JavaType[] referenceValues = value.getReferenceValues();
+        return (constantValues == null || constantValues.length == 0) &&
+                (referenceValues == null || referenceValues.length == 0);
     }
 
     private static boolean isOfTypeCore(@Nullable JavaType to, @Nullable JavaType from, ComparisonContext context) {


### PR DESCRIPTION
`TypeUtils.isOfType` reports two structurally identical annotation element values as different types whenever both of them are empty, because "empty" has two spellings and the comparison only understood one of them:

| source | encoding |
|---|---|
| Java `@Foo({})` | `constantValues = []`, `referenceValues = null` |
| a peer building the type over RPC | both slots null |

`ArrayElementValue` declares both arrays `@Nullable`, and the factory that upholds "exactly one is set" — `ArrayElementValue.from` — is not on the wire's path, since `JavaTypeReceiver` rebuilds the value through the public constructor. So `isOfTypeAnnotationElement` dispatched on `constantValues != null`, then on `referenceValues != null`, and fell through to `return false` when neither held.

One disagreeing element value makes `isOfTypeAnnotation` reject the whole annotation, which propagates into `isOfType`. Nothing caught it because `isOfType` short-circuits on reference identity (`TypeUtils.java:145`), so a value compared with itself never reaches the branch — and distinct-but-equal instances are exactly what a round trip produces.

```java
if (isEmptyArray(arrayValue1) || isEmptyArray(arrayValue2)) {
    return isEmptyArray(arrayValue1) && isEmptyArray(arrayValue2);
}
```

`isEmptyArray` treats a null slot and a zero-length array alike, so the two encodings reconcile in either argument order.

The alternative was normalizing at the source, having the C# mapper emit `constantValues = []` for an empty attribute array. That would not unify the encodings, only move C# onto Java's, and it would label an empty `Type[]` a constant array. With no elements there is no constant-versus-reference distinction left to preserve, so the comparison is the right place to reconcile the two.

`annotationArrayElementValuesWithoutValuesAreOfSameType` pins all of it: a both-null pair, both argument orders of both-null against `@Foo({})`, and two negatives that keep the predicate honest — a non-empty constants array and a non-empty references array are each still not empty. The first three assertions fail on main.

- ## Relationship to #8813

- #8813 fixes the sibling read path, `ArrayElementValue.getValues()`, which throws on a both-null value. This change does not depend on it — the comparison reads the arrays directly — but the two together are what make signature identity and `isOfType` agree on the same pair of values.
