### PR TITLE
Declare `JavaType.Annotation.ElementValue.getValue()` nullable

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/JavaType.java
@@ -785,6 +785,11 @@ public interface JavaType {
         public interface ElementValue {
             JavaType getElement();
 
+            /**
+             * Null when the element's value is itself null, which the Java language forbids but
+             * peers such as C# permit ({@code [Foo(null)]}).
+             */
+            @Nullable
             Object getValue();
         }
 
@@ -807,8 +812,7 @@ public interface JavaType {
             }
 
             @Override
-            public Object getValue() {
-                //noinspection DataFlowIssue
+            public @Nullable Object getValue() {
                 return constantValue != null ? constantValue : referenceValue;
             }
         }

--- a/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavaTypeAnnotationRpcTest.java
+++ b/rewrite-java/src/test/java/org/openrewrite/java/internal/rpc/JavaTypeAnnotationRpcTest.java
@@ -72,6 +72,23 @@ class JavaTypeAnnotationRpcTest {
     }
 
     @Test
+    void roundTripsAnnotationWithNullValue() {
+        // e.g. C#'s `[Foo(null)]` — the value is null, so neither slot is set
+        JavaType.Method element = methodOn("com.example.Foo", "value", JavaType.Primitive.String);
+        JavaType.Annotation original = annotation("com.example.Foo", List.of(
+                new JavaType.Annotation.SingleElementValue(element, null, null)));
+
+        JavaType.Annotation roundTripped = sendAndReceive(original);
+
+        JavaType.Annotation.SingleElementValue sev =
+                (JavaType.Annotation.SingleElementValue) roundTripped.getValues().get(0);
+        assertThat(sev.getValue()).isNull();
+
+        // the type signature builder is the one production caller that reads getValue()
+        assertThat(roundTripped.toString()).endsWith("=null)");
+    }
+
+    @Test
     void roundTripsAnnotationWithArrayConstantValues() {
         // e.g. @SuppressWarnings({"a", "b"}) — array of strings
         JavaType.Method element = methodOn("java.lang.SuppressWarnings", "value", JavaType.Primitive.String);


### PR DESCRIPTION
`JavaType.Annotation.SingleElementValue.getValue()` returns null when neither `constantValue` nor `referenceValue` is set, but `org.openrewrite.java.tree` is `@NullMarked` and `ElementValue.getValue()` declared a bare `Object`. The original author suppressed the complaint rather than resolving it:

```java
@Override
public Object getValue() {
    //noinspection DataFlowIssue
    return constantValue != null ? constantValue : referenceValue;
}
```

Nothing crashes today: the only production callers are `DefaultJavaTypeSignatureBuilder` and `JvmsTypeSignatureBuilder`, which reach it through `StringBuilder.append((Object) null)` and get `"null"`. This is a declared-contract violation, not a runtime one.

## Where the state comes from

Both slots unset is not corruption — it is how a **null annotation argument** is encoded. The Java language forbids `null` as an element value, which is why the Java parsers never produce this and `SingleElementValue.from` cannot.

C# attributes do permit it. In `AttributeMapping.MapAnnotationConstant`, a `[Foo(null)]` on a non-array parameter yields `(null, null)`, and `JavaTypeReceiver` rebuilds that verbatim through the public constructor. There is a value here; it is null.

## Why nullable rather than unrepresentable

The alternative was to close the constructor path so every producer upholds "exactly one slot is set". Rejected:

- **There is a real state to represent.** Any narrowing forces the C# mapper to lie — dropping the element, or inventing `JavaType.Unknown` for a value that is known, and known to be null.
- **The all-args constructor is the deserialization entry point.** `ElementValue` is Jackson-polymorphic and Lombok `@Value`; removing it breaks every peer's sender/receiver and LST round trips, to buy a guarantee the wire still cannot make — a receiver stays defensive against a peer that sends both-unset regardless.
- **`JavaType.Primitive.Null` in `referenceValue`** was also considered: it overloads "the value references this type" with "the value is null", so every consumer reading `referenceValue` gains a special case.

Fixing the callers turned out to be a no-op. `ArrayElementValue.getValue()` stays non-null by narrowing the override, which is the right split: the array case has an honest empty answer, the single case does not.

## `TypeUtils` needs nothing

Confirmed with a throwaway test, since the sibling array case did need work. Two both-unset `SingleElementValue`s are of the same type: `isOfTypeAnnotationElement` compares `referenceValue` via `isOfType`, whose `type1 == type2` fast path holds for two nulls, and `constantValue` via `Objects.equals`. Against an `ArrayElementValue` it correctly reports unequal.

## Tests

`roundTripsAnnotationWithNullValue` sends an element value with neither slot set through the real `JavaTypeSender`/`JavaTypeReceiver` pair, then asserts the shape survives, `getValue()` reads as null, and the signature builder renders it. The six existing tests in that class each set exactly one slot, so none reaches this path.

## Scope

- Deliberately leaves the sibling array case (#8813) and the C# mapper alone. Tightening the mapper would discard the fact that the argument was written as `null`.
