### PR TITLE
Build repository action blocks from a template

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseRepositoryHandlerActionOverloads.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseRepositoryHandlerActionOverloads.java
@@ -20,21 +20,23 @@ import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
-import org.openrewrite.SourceFile;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.GroovyVisitor;
 import org.openrewrite.groovy.tree.G;
+import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
-import org.openrewrite.java.tree.Statement;
+import org.openrewrite.java.tree.Space;
 
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.StringJoiner;
+
+import static java.util.Collections.singletonList;
+import static org.openrewrite.Tree.randomId;
 
 public class UseRepositoryHandlerActionOverloads extends Recipe {
 
@@ -53,8 +55,6 @@ public class UseRepositoryHandlerActionOverloads extends Recipe {
         // The Map overloads only exist in the Groovy DSL, so GroovyVisitor skipping Kotlin scripts is the scoping this wants.
         return Preconditions.check(new IsBuildGradle<>(), new GroovyVisitor<ExecutionContext>() {
 
-            private @Nullable GradleParser parser;
-
             @Override
             public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
                 J.MethodInvocation m = (J.MethodInvocation) super.visitMethodInvocation(method, ctx);
@@ -68,15 +68,36 @@ public class UseRepositoryHandlerActionOverloads extends Recipe {
                 if (entries == null) {
                     return m;
                 }
-                List<String> configuration = new ArrayList<>(entries.size());
+
+                // Only the map entry values come from the source, and they travel as parameters. Everything in the
+                // template text is the recipe's own, including the repository name, which the guard above pins to
+                // one of two literals.
+                StringBuilder action = new StringBuilder(m.getSimpleName()).append(" {\n");
+                List<Expression> values = new ArrayList<>();
                 for (G.MapEntry entry : entries) {
-                    String statement = toConfigurationStatement(m.getSimpleName(), entry);
-                    if (statement == null) {
+                    String key = keyName(entry);
+                    if ("name".equals(key)) {
+                        action.append("    name = #{any()}\n");
+                        values.add(unprefixed(entry.getValue()));
+                    } else if ("dirs".equals(key) && "flatDir".equals(m.getSimpleName())) {
+                        // A list becomes varargs, so the template grows a placeholder per element
+                        List<Expression> dirs = elementsOf(entry.getValue());
+                        action.append("    dirs ");
+                        for (int i = 0; i < dirs.size(); i++) {
+                            action.append(i == 0 ? "#{any()}" : ", #{any()}");
+                            Expression dir = unprefixed(dirs.get(i));
+                            values.add(i == 0 || i == dirs.size() - 1 ? commandSyntax(dir) : dir);
+                        }
+                        action.append('\n');
+                    } else {
                         return m;
                     }
-                    configuration.add(statement);
                 }
-                return buildActionInvocation(m, configuration, ctx);
+                action.append('}');
+
+                return GroovyTemplate.builder(action.toString())
+                        .build()
+                        .apply(getCursor(), m.getCoordinates().replace(), values.toArray());
             }
 
             private boolean isInsideRepositoriesBlock() {
@@ -105,17 +126,6 @@ public class UseRepositoryHandlerActionOverloads extends Recipe {
                 return entries;
             }
 
-            private @Nullable String toConfigurationStatement(String repository, G.MapEntry entry) {
-                String key = keyName(entry);
-                if ("name".equals(key)) {
-                    return "name = " + sourceOf(entry.getValue());
-                }
-                if ("dirs".equals(key) && "flatDir".equals(repository)) {
-                    return "dirs " + spreadListIntoVarargs(entry.getValue());
-                }
-                return null;
-            }
-
             private @Nullable String keyName(G.MapEntry entry) {
                 if (entry.getKey() instanceof J.Literal && ((J.Literal) entry.getKey()).getType() == JavaType.Primitive.String) {
                     return (String) ((J.Literal) entry.getKey()).getValue();
@@ -126,55 +136,19 @@ public class UseRepositoryHandlerActionOverloads extends Recipe {
                 return null;
             }
 
-            private String spreadListIntoVarargs(Expression value) {
-                if (value instanceof G.ListLiteral) {
-                    StringJoiner arguments = new StringJoiner(", ");
-                    for (Expression element : ((G.ListLiteral) value).getElements()) {
-                        arguments.add(sourceOf(element));
-                    }
-                    return arguments.toString();
-                }
-                return sourceOf(value);
+            private List<Expression> elementsOf(Expression value) {
+                return value instanceof G.ListLiteral ? ((G.ListLiteral) value).getElements() : singletonList(value);
             }
 
-            private String sourceOf(Expression expression) {
-                return expression.printTrimmed(getCursor());
+            // The template's own spacing separates the arguments, so a value arrives without the one it had in the map
+            private Expression unprefixed(Expression value) {
+                return value.withPrefix(Space.EMPTY);
             }
 
-            private J buildActionInvocation(J.MethodInvocation original, List<String> configuration, ExecutionContext ctx) {
-                String indent = indentOfEnclosingLine();
-                StringBuilder snippet = new StringBuilder(original.getSimpleName()).append(" {\n");
-                for (String statement : configuration) {
-                    snippet.append(indent).append("    ").append(statement).append('\n');
-                }
-                snippet.append(indent).append("}\n");
-
-                if (parser == null) {
-                    parser = GradleParser.builder().build();
-                }
-                SourceFile parsed = parser.parse(ctx, snippet.toString()).findFirst().orElse(null);
-                if (!(parsed instanceof G.CompilationUnit) || ((G.CompilationUnit) parsed).getStatements().isEmpty()) {
-                    return original;
-                }
-                Statement replacement = ((G.CompilationUnit) parsed).getStatements().get(0);
-                return replacement.withPrefix(original.getPrefix());
-            }
-
-            private String indentOfEnclosingLine() {
-                for (Iterator<Object> path = getCursor().getPath(); path.hasNext(); ) {
-                    Object value = path.next();
-                    if (value instanceof J.Block || value instanceof G.CompilationUnit) {
-                        break;
-                    }
-                    if (value instanceof J) {
-                        String whitespace = ((J) value).getPrefix().getWhitespace();
-                        int lastNewline = whitespace.lastIndexOf('\n');
-                        if (lastNewline != -1) {
-                            return whitespace.substring(lastNewline + 1);
-                        }
-                    }
-                }
-                return "";
+            // A placeholder reaches the parser as `__P__.<T>p()`, which Groovy will not take as a command-syntax
+            // argument, so the notation has to come from the marker the printer reads rather than the template text
+            private Expression commandSyntax(Expression value) {
+                return value.withMarkers(value.getMarkers().addIfAbsent(new OmitParentheses(randomId())));
             }
         });
     }


### PR DESCRIPTION
- Stacked on #8812, itself on #8810, #8805 and #8803. Review those first.

One recipe, one file, +41 −67. All 9 of its tests pass unchanged.

## What changed

`UseRepositoryHandlerActionOverloads` assembled its replacement as text: each map entry's value came from `printTrimmed`, and the enclosing line's indentation was baked into the snippet so the result would line up.

The values are already `Expression` nodes in the tree, so they now travel as `#{any()}` parameters. `flatDir name: 'localLibs', dirs: ['a', 'b']` builds the template text `flatDir {\n    name = #{any()}\n    dirs #{any()}, #{any()}\n}` with three parameters, each stripped to `Space.EMPTY` because the template's own spacing separates them.

**No user text is interpolated any more.** `printTrimmed` is gone from the file. What remains in the template is the recipe's own literals, `name`, `dirs` and the braces, plus `getSimpleName()`, which the guard at the top of the method pins to exactly `flatDir` or `mavenCentral` before the builder is reached. That one is still read from the tree, so "provably one of two constants" is the honest phrasing rather than "not user text".

A `replace()` coordinate supplies the prefix and formatting supplies the indentation, so `indentOfEnclosingLine` and its 20 lines of cursor walking go, along with `buildActionInvocation`, `sourceOf`, `spreadListIntoVarargs`, `toConfigurationStatement`, the `GradleParser` field, and the hand-applied `withPrefix`.

## A general limit worth knowing: `#{any()}` cannot sit in Groovy command position

The first run produced `dirs('libs')` where the tests want `dirs 'libs'`. Dumping the stub shows why:

```
dirs __P__.<String>/*__p0__*/p()
```

A `#{any()}` placeholder reaches the parser as a generic method call with an explicit type witness, and Groovy's command expression grammar will not accept that as a bare argument. So `dirs #{any()}` parses parenthesised however the template text is written.

This is a property of `#{any()}` in the Groovy DSL, not of this recipe, and command syntax is everywhere in Gradle build files. Anyone converting a recipe that emits `implementation 'a:b:c'` or similar will meet it.

The notation has to travel in the tree rather than in the text. `GroovyPrinter` decides parentheses from an `OmitParentheses` marker on the **first** argument for the opening paren and the **last** for the closing one, so the recipe puts one on the outer values before passing them as parameters. Two lines, no post-hoc visitor, and the same mechanism `UseProjectDependencyInsteadOfModuleCoordinates` already uses to preserve command syntax. No expected output was edited; the marker restores exactly what the tests already required.

Whether `GroovyTemplate` should handle this itself, so that a template written in command syntax stays in command syntax, is a real question. It is not attempted here.

## The multi-line form survived

- This was the first conversion that deliberately wants a multi-line block, so it is the first real test of #8812's closure formatting fix. It holds: `isSingleLineClosureBody` inspects the incoming block's own whitespace, and the template's block arrives with `"\n    "` statement prefixes and a `"\n"` end, so the guard never fires. The fix declines to expand a closure written on one line and leaves a closure with line breaks alone, exactly as reported.

## Tests

| Suite / class | Tests | Failures |
|---|---|---|
| `:rewrite-gradle:test` | 1328 | 0 |
| `:rewrite-groovy:test` | 707 | 0 |
| `UseRepositoryHandlerActionOverloadsTest` | 9 | 0 |

## What is left

Node factories still standing: `UseJavaExtensionBlock`, the six `UpgradeTransitiveDependencyVersion` scaffold sites, `DependencyConstraintToRule`, `AddPluginVisitor`.

`UseJavaExtensionBlock` is the one to take next, and not because it is easiest. `buildJavaBlock`'s product is used two ways, appended as a new `java { }` or merged statement by statement into an existing one with dedup, and it is called from a static method with no cursor while that same method also removes the statements it moves. The interesting possibility is that the merge path may need no node at all: build a template containing only the entries the existing block lacks and apply it at that block's `lastStatement()` coordinate, which deletes the dedup logic rather than porting it. If that works it is the strongest evidence yet for the no-node-factories position; if it does not, the reason will be specific.

`DependencyConstraintToRule` is tractable but large, six sites, with its multi statement one solvable by an `if (true) { … }` wrapper — verified earlier to parse in both DSLs, where a bare `{ … }` does not, since Groovy reads that as a block and Kotlin as a lambda. `AddPluginVisitor` remains entangled with a hand-computed insertion index and license-header relocation. `AddDependencyVisitor` holds one long-lived parser for repeated work and should stay as it is.
