### PR TITLE
Carry a placeholder's markers onto the parameter replacing it

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
@@ -20,12 +20,15 @@ import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.groovy.GroovyParser;
+import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.kotlin.KotlinParser;
+import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.Markers;
 
@@ -38,6 +41,7 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static org.openrewrite.gradle.GradleParser.requireParsed;
@@ -281,56 +285,50 @@ public class DependencyConstraintToRule extends Recipe {
         public J.If visitIf(J.If iff, ExecutionContext ctx) {
             J.If anIf = super.visitIf(iff, ctx);
             if (predicateRelatesToGav(anIf, groupArtifactVersionBecause)) {
-                // The predicate of the if condition will already contain the relevant variable name
-                AtomicReference<String> variableName = new AtomicReference<>();
+                // The predicate of the if condition will already contain the relevant variable
+                AtomicReference<J.Identifier> variable = new AtomicReference<>();
                 new JavaIsoVisitor<Integer>() {
                     @Override
                     public J.FieldAccess visitFieldAccess(J.FieldAccess fieldAccess, Integer integer) {
                         // Comparison will involve "<variable name>.requested.group"
                         J.FieldAccess field = super.visitFieldAccess(fieldAccess, integer);
                         if (field.getTarget() instanceof J.Identifier) {
-                            variableName.set(((J.Identifier) field.getTarget()).getSimpleName());
+                            variable.set((J.Identifier) field.getTarget());
                         }
                         return fieldAccess;
                     }
                 }.visit(anIf.getIfCondition(), 0);
-                List<Statement> newStatements;
-                if (!isKotlinDsl) {
-                    @Language("groovy")
-                    String snippet = variableName + ".useVersion('" + groupArtifactVersionBecause.getVersion() + "')\n";
-                    if (groupArtifactVersionBecause.getBecause() != null) {
-                        snippet += variableName + ".because('" + groupArtifactVersionBecause.getBecause() + "')\n";
-                    }
-                    newStatements = GroovyParser.builder()
-                            .build()
-                            .parse(ctx, snippet)
-                            .map(requireParsed(G.CompilationUnit.class))
-                            .map(G.CompilationUnit::getStatements)
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("Unable to produce a new block statement"));
-                } else {
-                    @Language("kotlin")
-                    String snippet = variableName + ".useVersion(\"" + groupArtifactVersionBecause.getVersion() + "\")\n";
-                    if (groupArtifactVersionBecause.getBecause() != null) {
-                        snippet += variableName + ".because(\"" + groupArtifactVersionBecause.getBecause() + "\")\n";
-                    }
-                    newStatements = KotlinParser.builder()
-                            .isKotlinScript(true)
-                            .build()
-                            .parse(ctx, snippet)
-                            .map(requireParsed(K.CompilationUnit.class))
-                            .map(cu -> (J.Block) cu.getStatements().get(0))
-                            .map(J.Block::getStatements)
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("Unable to produce a new block statement"));
+                if (variable.get() == null) {
+                    return anIf;
                 }
-                J.Block block = (J.Block) anIf.getThenPart();
-                block = block.withStatements(newStatements);
-                block = autoFormat(block, ctx, getCursor());
-                anIf = anIf.withThenPart(block);
+
+                // The variable comes from the tree and the version and reason from the recipe's options, so all
+                // three travel as parameters rather than as text
+                StringBuilder rule = new StringBuilder("#{any()}.useVersion(#{any(String)})");
+                List<Object> values = new ArrayList<>();
+                values.add(variable.get().withPrefix(Space.EMPTY));
+                values.add(stringLiteral(groupArtifactVersionBecause.getVersion(), isKotlinDsl));
+                if (groupArtifactVersionBecause.getBecause() != null) {
+                    rule.append("\n#{any()}.because(#{any(String)})");
+                    values.add(variable.get().withPrefix(Space.EMPTY));
+                    values.add(stringLiteral(groupArtifactVersionBecause.getBecause(), isKotlinDsl));
+                }
+
+                J.Block block = ((J.Block) anIf.getThenPart()).withStatements(emptyList());
+                JavaTemplate template = isKotlinDsl ?
+                        KotlinTemplate.builder(rule.toString()).build() :
+                        GroovyTemplate.builder(rule.toString()).build();
+                anIf = anIf.withThenPart(template.apply(new Cursor(getCursor(), block),
+                        block.getCoordinates().lastStatement(), values.toArray()));
             }
             return anIf;
         }
+    }
+
+    // A value, not a construct: the quoting is the recipe's own, so there is nothing for a parser to tell us
+    private static J.Literal stringLiteral(String value, boolean kotlinDsl) {
+        String quote = kotlinDsl ? "\"" : "'";
+        return new J.Literal(Tree.randomId(), Space.EMPTY, Markers.EMPTY, value, quote + value + quote, null, JavaType.Primitive.String);
     }
 
     static class MaybeAddEachDependency extends JavaIsoVisitor<ExecutionContext> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseJavaExtensionBlock.java
@@ -18,6 +18,7 @@ package org.openrewrite.gradle.gradle9;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 import org.jspecify.annotations.Nullable;
+import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
@@ -25,6 +26,7 @@ import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.gradle.GradleParser;
 import org.openrewrite.gradle.IsBuildGradle;
+import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
 import org.openrewrite.java.JavaIsoVisitor;
@@ -35,6 +37,7 @@ import org.openrewrite.java.tree.JavaType;
 import org.openrewrite.java.tree.Space;
 import org.openrewrite.java.tree.Statement;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -71,7 +74,7 @@ public class UseJavaExtensionBlock extends Recipe {
                 // Top-level `sourceCompatibility` / `targetCompatibility` assignments delegate to the removed
                 // `JavaPluginConvention`; move them into a `java { }` block at the root of the build script.
                 G.CompilationUnit cu = (G.CompilationUnit) visited;
-                return cu.withStatements(moveCompatibility(cu.getStatements(), ctx));
+                return cu.withStatements(moveCompatibility(cu.getStatements(), new Cursor(getCursor(), cu), ctx));
             }
 
             @Override
@@ -86,7 +89,7 @@ public class UseJavaExtensionBlock extends Recipe {
                 J.Lambda lambda = (J.Lambda) m.getArguments().get(0);
                 J.Block body = (J.Block) lambda.getBody();
                 List<Statement> statements = body.getStatements();
-                List<Statement> mapped = moveCompatibility(statements, ctx);
+                List<Statement> mapped = moveCompatibility(statements, getCursor(), ctx);
                 if (mapped == statements) {
                     return m;
                 }
@@ -107,7 +110,7 @@ public class UseJavaExtensionBlock extends Recipe {
         return arg instanceof J.Lambda && ((J.Lambda) arg).getBody() instanceof J.Block;
     }
 
-    private static List<Statement> moveCompatibility(List<Statement> statements, ExecutionContext ctx) {
+    private static List<Statement> moveCompatibility(List<Statement> statements, Cursor scope, ExecutionContext ctx) {
         Map<String, Expression> versionsToMove = new LinkedHashMap<>();
         for (Statement s : statements) {
             String name = compatibilityName(s);
@@ -127,8 +130,6 @@ public class UseJavaExtensionBlock extends Recipe {
             versionsToMove.put(SOURCE, tgtVal);
         }
 
-        J.MethodInvocation incomingBlock = (J.MethodInvocation) buildJavaBlock(versionsToMove, ctx);
-
         boolean[] merged = {false};
         List<Statement> mapped = ListUtils.map(statements, s -> {
             if (compatibilityName(s) != null) {
@@ -141,16 +142,54 @@ public class UseJavaExtensionBlock extends Recipe {
                 return s;
             }
             merged[0] = true;
-            J.MethodInvocation mergedBlock = mergeIntoExistingJavaBlock(javaBlock, incomingBlock);
-            return s instanceof J.Return ? ((J.Return) s).withExpression(mergedBlock) : mergedBlock;
+            J.MethodInvocation withEntries = addMissingEntries(javaBlock, versionsToMove, scope);
+            return s instanceof J.Return ? ((J.Return) s).withExpression(withEntries) : withEntries;
         });
         if (!merged[0]) {
             // A blank line separates the new block from preceding statements, but not when it stands alone
             // as the first statement of its (sub)project block.
             Space prefix = Space.format(mapped.isEmpty() ? "\n" : "\n\n");
-            mapped = ListUtils.concat(mapped, incomingBlock.withPrefix(prefix));
+            mapped = ListUtils.concat(mapped, ((J.MethodInvocation) buildJavaBlock(versionsToMove, ctx)).withPrefix(prefix));
         }
         return mapped;
+    }
+
+    /**
+     * Adds only what the existing block is missing, so there is nothing to build and then dedupe against.
+     */
+    private static J.MethodInvocation addMissingEntries(J.MethodInvocation javaBlock, Map<String, Expression> entries, Cursor scope) {
+        J.Lambda lambda = (J.Lambda) javaBlock.getArguments().get(0);
+        if (!(lambda.getBody() instanceof J.Block)) {
+            return javaBlock;
+        }
+        J.Block body = (J.Block) lambda.getBody();
+        Map<String, Expression> missing = new LinkedHashMap<>(entries);
+        for (Statement statement : body.getStatements()) {
+            missing.remove(compatibilityName(statement));
+        }
+        if (missing.isEmpty()) {
+            return javaBlock;
+        }
+
+        StringBuilder assignments = new StringBuilder();
+        List<Object> values = new ArrayList<>();
+        for (Map.Entry<String, Expression> entry : missing.entrySet()) {
+            if (assignments.length() > 0) {
+                assignments.append('\n');
+            }
+            assignments.append(entry.getKey()).append(" = ");
+            Integer version = extractVersion(entry.getValue());
+            if (version == null) {
+                // A value the recipe cannot normalise travels as a parameter rather than as text
+                assignments.append("#{any()}");
+                values.add(entry.getValue().withPrefix(Space.EMPTY));
+            } else {
+                assignments.append(enumForm(version));
+            }
+        }
+        return GroovyTemplate.builder(assignments.toString())
+                .build()
+                .apply(new Cursor(scope, javaBlock), body.getCoordinates().lastStatement(), values.toArray());
     }
 
     private static J.@Nullable MethodInvocation asJavaBlock(Statement s) {
@@ -173,35 +212,6 @@ public class UseJavaExtensionBlock extends Recipe {
             }
         }
         return null;
-    }
-
-    private static J.MethodInvocation mergeIntoExistingJavaBlock(J.MethodInvocation existing, J.MethodInvocation incoming) {
-        J.Lambda existingLambda = (J.Lambda) existing.getArguments().get(0);
-        if (!(existingLambda.getBody() instanceof J.Block)) {
-            return existing;
-        }
-        J.Block existingBody = (J.Block) existingLambda.getBody();
-
-        Set<String> existingNames = new HashSet<>();
-        for (Statement bs : existingBody.getStatements()) {
-            String n = compatibilityName(bs);
-            if (n != null) {
-                existingNames.add(n);
-            }
-        }
-
-        J.Lambda incomingLambda = (J.Lambda) incoming.getArguments().get(0);
-        List<Statement> incomingStatements = ((J.Block) incomingLambda.getBody()).getStatements();
-        List<Statement> incomingToAdd = ListUtils.map(incomingStatements, s -> {
-            String n = compatibilityName(s);
-            return n != null && existingNames.contains(n) ? null : s;
-        });
-        if (incomingToAdd.isEmpty()) {
-            return existing;
-        }
-        List<Statement> merged = ListUtils.concatAll(existingBody.getStatements(), incomingToAdd);
-        return existing.withArguments(singletonList(
-                existingLambda.withBody(existingBody.withStatements(merged))));
     }
 
     private static Statement buildJavaBlock(Map<String, Expression> entries, ExecutionContext ctx) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseRepositoryHandlerActionOverloads.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/gradle9/UseRepositoryHandlerActionOverloads.java
@@ -25,7 +25,6 @@ import org.openrewrite.gradle.IsBuildGradle;
 import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.GroovyVisitor;
 import org.openrewrite.groovy.tree.G;
-import org.openrewrite.java.marker.OmitParentheses;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -36,7 +35,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import static java.util.Collections.singletonList;
-import static org.openrewrite.Tree.randomId;
 
 public class UseRepositoryHandlerActionOverloads extends Recipe {
 
@@ -85,8 +83,7 @@ public class UseRepositoryHandlerActionOverloads extends Recipe {
                         action.append("    dirs ");
                         for (int i = 0; i < dirs.size(); i++) {
                             action.append(i == 0 ? "#{any()}" : ", #{any()}");
-                            Expression dir = unprefixed(dirs.get(i));
-                            values.add(i == 0 || i == dirs.size() - 1 ? commandSyntax(dir) : dir);
+                            values.add(unprefixed(dirs.get(i)));
                         }
                         action.append('\n');
                     } else {
@@ -143,12 +140,6 @@ public class UseRepositoryHandlerActionOverloads extends Recipe {
             // The template's own spacing separates the arguments, so a value arrives without the one it had in the map
             private Expression unprefixed(Expression value) {
                 return value.withPrefix(Space.EMPTY);
-            }
-
-            // A placeholder reaches the parser as `__P__.<T>p()`, which Groovy will not take as a command-syntax
-            // argument, so the notation has to come from the marker the printer reads rather than the template text
-            private Expression commandSyntax(Expression value) {
-                return value.withMarkers(value.getMarkers().addIfAbsent(new OmitParentheses(randomId())));
             }
         });
     }

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
@@ -47,6 +47,21 @@ class GroovyTemplateTest implements RewriteTest {
         });
     }
 
+    // Replaces `placeholder(...)`, passing the placeholder's own arguments to the template as parameters
+    private static Recipe replacePlaceholderWithArguments(String template) {
+        return toRecipe(() -> new GroovyVisitor<>() {
+            @Override
+            public J visitMethodInvocation(J.MethodInvocation method, ExecutionContext ctx) {
+                if (!"placeholder".equals(method.getSimpleName())) {
+                    return super.visitMethodInvocation(method, ctx);
+                }
+                return GroovyTemplate.builder(template)
+                  .build()
+                  .apply(getCursor(), method.getCoordinates().replace(), method.getArguments().toArray());
+            }
+        });
+    }
+
     // A Groovy script holds its statements directly, so a coordinate on one can only be reached from the file
     private static Recipe insertAtTopLevel(boolean before) {
         return toRecipe(() -> new GroovyVisitor<>() {
@@ -391,6 +406,96 @@ class GroovyTemplateTest implements RewriteTest {
               ext['x'] = 'y'
               plugins {
                   id 'java'
+              }
+              """
+          ));
+    }
+
+    @Test
+    void commandSyntaxSurvivesASubstitutedArgument() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholderWithArguments(
+            """
+              flatDir {
+                  dirs #{any()}
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder('libs')
+              """,
+            """
+              flatDir {
+                  dirs 'libs'
+              }
+              """
+          ));
+    }
+
+    @Test
+    void commandSyntaxWithSeveralSubstitutedArguments() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholderWithArguments(
+            """
+              flatDir {
+                  dirs #{any()}, #{any()}, #{any()}
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder('libs', 'moreLibs', 'evenMoreLibs')
+              """,
+            """
+              flatDir {
+                  dirs 'libs', 'moreLibs', 'evenMoreLibs'
+              }
+              """
+          ));
+    }
+
+    @Test
+    void commandSyntaxAlongsideAParenthesizedCall() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholderWithArguments(
+            """
+              flatDir {
+                  dirs #{any()}
+                  println(#{any()})
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder('libs', 'done')
+              """,
+            """
+              flatDir {
+                  dirs 'libs'
+                  println('done')
+              }
+              """
+          ));
+    }
+
+    @Test
+    void parenthesesWrittenInTheTemplateAreKept() {
+        rewriteRun(
+          spec -> spec.recipe(replacePlaceholderWithArguments(
+            """
+              flatDir {
+                  dirs(#{any()})
+              }
+              """
+          )),
+          groovy(
+            """
+              placeholder('libs')
+              """,
+            """
+              flatDir {
+                  dirs('libs')
               }
               """
           ));

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/Substitutions.java
@@ -27,6 +27,7 @@ import org.openrewrite.java.RandomizeIdVisitor;
 import org.openrewrite.java.internal.grammar.TemplateParameterParser;
 import org.openrewrite.java.internal.grammar.TemplateParameterParser.TypeContext;
 import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Marker;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -420,6 +421,11 @@ public class Substitutions {
                 Integer param = parameterIndex(marker.getPrefix());
                 if (param != null) {
                     J j2 = spliceParameter(param);
+                    // Markers the parser put on the placeholder describe the position it occupied rather than the
+                    // placeholder itself — Groovy's `OmitParentheses`, say — so they belong to whatever takes it
+                    for (Marker m : replaced.getMarkers().getMarkers()) {
+                        j2 = j2.withMarkers(j2.getMarkers().addIfAbsent(m));
+                    }
                     return j2.withPrefix(j2.getPrefix().withWhitespace(replaced.getPrefix().getWhitespace()));
                 }
                 return null;


### PR DESCRIPTION
Stacked on #8818, itself on #8812, #8810, #8805 and #8803. Review those first.

Three commits: a fix in `Substitutions`, then two recipes that show what it buys.

## 1. The diagnosis in #8818 was wrong

That PR said Groovy's command expression grammar would not accept a `#{any()}` placeholder as a bare argument, because it arrives as a generic call with an explicit type witness. Plausible, and false. Feeding twelve argument shapes to `GroovyParser` in command position and checking where `OmitParentheses` lands:

| | |
|---|---|
| `dirs 'libs'` | marker set |
| `dirs foo()` | marker set |
| `dirs Foo.<String>bar()` | marker set |
| `dirs __P__.p()` | marker set |
| `dirs __P__.<java.lang.String>/*__p0__*/p()` | marker set, and this is the exact stub form |
| `dirs((Object) foo())` | no marker, the control |

**The stub parses as command syntax and the parser sets the marker.** Nothing is rejected.

The marker is lost afterwards, in `Substitutions.unsubstitute`. The placeholder *is* the argument node, so the parser's marker sits on it, and `maybeParameter` then swaps in the user's expression while carrying across only the whitespace:

```java
J j2 = spliceParameter(param);
return j2.withPrefix(j2.getPrefix().withWhitespace(replaced.getPrefix().getWhitespace()));
```

Everything else the parser attached is dropped.

The fix is six lines: copy the placeholder's markers onto the node replacing it. **In `Substitutions`, not `GroovySubstitutions`.** A marker the parser attaches to a node in a syntactic position describes that position, and whatever occupies the position should inherit it. Kotlin's `TrailingLambdaArgument` is the same shape of fact. The narrow alternative would also have been the more invasive one, since `maybeParameter` lives in an anonymous visitor a subclass cannot reach without restructuring.

**What it gives up.** `addIfAbsent` means a parameter's own markers win a collision, and a marker genuinely describing the *placeholder* rather than its position would ride along. None turned up, and 4,279 tests across `rewrite-java`, `rewrite-java-test` and `rewrite-kotlin` pass unchanged. Type attribution is untouched.

**This reverts part of #8818.** `commandSyntax(...)` and its imports are gone from `UseRepositoryHandlerActionOverloads`. That the workaround can be deleted is the proof it was compensating for this.

Four new tests in `GroovyTemplateTest` cover a bare argument, the varargs shape (which exercises the closing paren, taken from the *last* argument's marker), both notations in one template, and `dirs(#{any()})` staying parenthesised. The last holds structurally: parentheses are preserved by the *absence* of a marker, and this only copies markers the parser set, so deliberate parentheses cannot be stripped.

## 2. `DependencyConstraintToRule`, the `UpdateIf` path

The then-part of a constraint rule is now filled by a template at the block's `lastStatement()` coordinate, replacing two interpolations and two parses across both DSLs. The `if (true) { … }` wrapper this looked like it would need proved unnecessary: the statements were always destined for a block that already exists, and that block's own coordinate is the better anchor.

All three interpolated values are parameters. The variable travels as the `J.Identifier` captured from the if condition rather than as its name, the version and reason as literals with the DSL's own quoting. The site interpolates nothing.

**Nothing here needed a hand-applied marker or prefix**, including `#{any()}.useVersion(#{any(String)})`, a substituted *select* in command-syntax neighbourhood, which came out right first time. That is commit 1 in action.

## 3. `UseJavaExtensionBlock`, the merge path

This was the case that most tested whether "no node factories" holds, and it dissolves. The recipe used to build a whole `java { }` block and merge it into an existing one statement by statement, discarding entries whose names were already present. Nothing needs building: it now computes which entries are missing and templates only those, at the existing block's `lastStatement()` coordinate. 26 lines become 12, and the dedupe is deleted rather than ported.

Two things fall out. `buildJavaBlock`'s placeholder dance on this path is gone, where it wrote a stand-in version and re-visited the parsed tree to swap the real expression back in, because a parameter carries the expression directly. And `moveCompatibility` takes a `Cursor`, which both call sites already had, so it stays static. The recursive-descent fix from #8812 is what lets `apply` take a cursor at the `java { }` invocation and reach the block inside its lambda argument.

## What did not convert, and why each is a different kind of blocked

Three sites were attempted or assessed and left, and the distinctions matter more than the count.

**`DependencyConstraintToRule.MaybeAddIf` — a missing coordinate.** To extend an `else if` chain it constructs a `J.If.Else` by hand. `CoordinateBuilder` has no `J.If` specialisation, only the generic Statement before/after/replace, so there is no coordinate for an else branch. Replacing the enclosing `if` instead would need its then-part as a parameter, and a `J.Block` is a Statement rather than an Expression, so `#{any()}` cannot carry it. This is the second recipe in the stack to want a coordinate that does not exist, so the question worth putting is whether `CoordinateBuilder` should grow a `J.If` specialisation, since "add an else-if branch" is a real DSL-shaped edit.

**`DependencyConstraintToRule.MaybeAddEachDependency` — converted, then reverted.** The Groovy half was clean. The Kotlin half produced a stray blank line and a collapsed closing brace, because an empty lambda body's `end` space comes back from templating in a shape the later `MaybeAddIf` pass then inserts into wrongly. The existing code compensates with a hand-applied `withEnd(Space.format("\n"))`. Restoring that compensation would be papering over a machinery gap for the third time in this stack, so both halves went back to the parser rather than leaving a half-conversion inside one method.

**`UseJavaExtensionBlock`'s append path — a contract, not a body.** It is handed a detached `List<Statement>` rather than the container, so an append has no anchor: the coordinate would have to resolve against a tree that does not exist until the caller writes the list back. Passing the container would work, and both shapes it can take are now expressible since #8812 added top-level coordinates, but that changes the method's contract.

## Tests

| Suite | Tests | Failures |
|---|---|---|
| `:rewrite-java:test` | 716 | 0 |
| `:rewrite-java-test:test` | 2208 | 0 |
| `:rewrite-groovy:test` | 711 | 0 |
| `:rewrite-kotlin:test` | 1355 | 0 |
| `:rewrite-gradle:test` | 1328 | 0 |

`DependencyConstraintToRuleTest` 6 and `UseJavaExtensionBlockTest` 10, both re-run with `--rerun-tasks` to be sure they executed rather than hitting the build cache. No existing expectation was edited anywhere in this PR.

## Still on the parser

`DependencyConstraintToRule`'s two remaining paths and `UseJavaExtensionBlock`'s append, per above. `AddPluginVisitor`, whose parse is entangled with a hand-computed insertion index and license-header relocation. `AddDependencyVisitor`, which holds one long-lived parser for repeated work and is a legitimate parser user rather than a node factory. `requireParsed` stays on `GradleParser`, still used by four files.
