### PR TITLE
Python: a type parameter bound is modelled as a type

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -1554,15 +1554,15 @@ class ParserVisitor(ast.NodeVisitor):
                 bounds = JContainer(
                     self.__source_before(':'),
                     [
-                        self.__pad_right(self.__convert(node.bound), self.__source_before('=')),
-                        self.__pad_right(self.__convert(default), Space.EMPTY),
+                        self.__pad_right(self.__convert_type(node.bound), self.__source_before('=')),
+                        self.__pad_right(self.__convert_type(default), Space.EMPTY),
                     ],
                     Markers.EMPTY
                 )
             else:
                 bounds = JContainer(
                     self.__source_before(':'),
-                    [self.__pad_right(self.__convert(node.bound), Space.EMPTY)],
+                    [self.__pad_right(self.__convert_type(node.bound), Space.EMPTY)],
                     Markers.EMPTY
                 )
         elif default:
@@ -1570,7 +1570,7 @@ class ParserVisitor(ast.NodeVisitor):
                 self.__source_before('='),
                 [
                     self.__pad_right(j.Empty(random_id(), Space.EMPTY, Markers.EMPTY), Space.EMPTY),
-                    self.__pad_right(self.__convert(default), Space.EMPTY),
+                    self.__pad_right(self.__convert_type(default), Space.EMPTY),
                 ],
                 Markers.EMPTY
             )
@@ -1604,7 +1604,7 @@ class ParserVisitor(ast.NodeVisitor):
                 self.__source_before('='),
                 [
                     self.__pad_right(j.Empty(random_id(), Space.EMPTY, Markers.EMPTY), Space.EMPTY),
-                    self.__pad_right(self.__convert(default), Space.EMPTY),
+                    self.__pad_right(self.__convert_type(default), Space.EMPTY),
                 ],
                 Markers.EMPTY
             )
@@ -1638,7 +1638,7 @@ class ParserVisitor(ast.NodeVisitor):
                 self.__source_before('='),
                 [
                     self.__pad_right(j.Empty(random_id(), Space.EMPTY, Markers.EMPTY), Space.EMPTY),
-                    self.__pad_right(self.__convert(default), Space.EMPTY),
+                    self.__pad_right(self.__convert_type(default), Space.EMPTY),
                 ],
                 Markers.EMPTY
             )

--- a/rewrite-python/rewrite/src/rewrite/python/format/spaces_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/format/spaces_visitor.py
@@ -5,7 +5,7 @@ from rewrite import Tree, list_map
 from rewrite.java import (J, Assignment, JLeftPadded, AssignmentOperation, MemberReference, MethodInvocation,
                            MethodDeclaration, Empty, ArrayAccess, Space, If, Block, ClassDeclaration,
                            VariableDeclarations, JRightPadded, Import, ParameterizedType, Parentheses, Try,
-                           ControlParentheses, TrailingComma)
+                           ControlParentheses, TrailingComma, TypeParameter)
 from rewrite.python import (PythonVisitor, SpacesStyle, Binary, ChainedAssignment, Slice, CollectionLiteral,
                              DictLiteral, KeyValue, TypeHint, MultiImport, ExpressionTypeTree,
                              ComprehensionExpression, NamedArgument)
@@ -479,9 +479,10 @@ class SpacesVisitor(PythonVisitor):
 
     def visit_expression_type_tree(self, expr_tree: ExpressionTypeTree, p: P) -> J:
         ett = cast(ExpressionTypeTree, super().visit_expression_type_tree(expr_tree, p))
-        # Don't remove space when inside ClassDeclaration (handled by visit_class_declaration)
+        # Under these parents the wrapper's prefix is meaningful source space, so clearing it
+        # would join the type to the punctuation before it.
         parent = self.cursor.parent_tree_cursor()
-        if not (parent and isinstance(parent.value, ClassDeclaration)):
+        if not (parent and isinstance(parent.value, (ClassDeclaration, TypeParameter))):
             ett = space_before(ett, False)
         return ett
 

--- a/rewrite-python/rewrite/tests/python/py312/type_params_test.py
+++ b/rewrite-python/rewrite/tests/python/py312/type_params_test.py
@@ -21,6 +21,43 @@ def test_class_type_param_with_bound():
     ))
 
 
+def test_class_type_param_with_constraint_tuple():
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        """\
+        class Foo[T: (int, str)]:
+            pass
+        """
+    ))
+
+
+def test_bound_is_modelled_as_a_type():
+    bounds = []
+
+    def collect(source_file):
+        bounds.append(type(source_file.statements[0].type_parameters[0].bounds[0]).__name__)
+
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        """\
+        class Foo[T: list[int]]:
+            pass
+        """,
+        after_recipe=collect,
+    ))
+    assert bounds[-1] == "ParameterizedType"
+
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        """\
+        class Foo[T: int | str]:
+            pass
+        """,
+        after_recipe=collect,
+    ))
+    assert bounds[-1] == "UnionType"
+
+
 def test_class_type_var_tuple():
     # language=python
     RecipeSpec().rewrite_run(python(


### PR DESCRIPTION
`J.TypeParameter.bounds` is declared `JContainer<TypeTree>`, but the PEP 695/696 visitors filled it with whatever expression the source spelled. Four ordinary bound shapes produce an ill-formed tree:

| source | `bounds[0]` |
|---|---|
| `class Foo[T: list[int]]` | `ArrayAccess` |
| `class Foo[T: int \| str]` | `Binary` |
| `class Foo[T: 'Fwd']` | `Literal` |
| `class Foo[T: (int, str)]` | `CollectionLiteral` |

```
CompilationUnit.statements[0].type_parameters[0].bounds[0] holds ArrayAccess, expected TypeTree (TypeParameter.bounds)
```

## Why main is green

No test exercised a bound the parser gets wrong: `tests/python/py312/type_params_test.py` covered only `T: int`, an `Identifier` that is already a `TypeTree`. The PEP 696 defaults under `tests/python/py313/` do fail the same check, but `ast` exposes `default_value` only from 3.13, so that directory skips on older interpreters.

## The fix

`visit_TypeVar`, `visit_ParamSpec` and `visit_TypeVarTuple` converted their bound and their default with `__convert`. All six sites now use `__convert_type`, the routine already used for every other type position, which returns a real `TypeTree` and falls back to `Py.ExpressionTypeTree` only where Python has no type form for the syntax:

```
class Foo[T: list[int]]            ['ParameterizedType']
class Foo[T: int | str]            ['UnionType']
class Foo[T: 'Fwd']                ['Identifier']
class Foo[T: (int, str)]           ['ExpressionTypeTree']
class Foo[T: str = "default"]      ['Identifier', 'Identifier']
class Foo[**P = [int, str]]        ['Empty', 'ExpressionTypeTree']
class Foo[*Ts = *tuple[int, ...]]  ['Empty', 'Star']
```

Wrapping every bound in `Py.ExpressionTypeTree` also satisfies the slot, but leaves `list[int]` modelled as a subscript expression rather than a type, so a type-directed recipe sees no type reference in a bound.

## AutoFormat

`__convert_type` puts the leading space on the wrapper, where `SpacesVisitor.visit_expression_type_tree` cleared it, rendering `class Foo[T:(int, str)]` and `class Foo[**P =[int, str]]`. That method already skips a `ClassDeclaration` parent for the same reason, and now skips `TypeParameter` too.

## Tests

`test_class_type_param_with_constraint_tuple` pins the wrapper fallback; `test_bound_is_modelled_as_a_type` pins the rich shape. Both are needed: a round trip and the well-formedness check pass on a wrapped `ArrayAccess`, so only a shape assertion catches the weak modelling. Mutation-checked — rewrapping the bound fails the second test and leaves the first green.
