### PR TITLE
JavaScript RPC: drain and page in linear time, and let a prefetched page arrive

### DIFF
--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -210,15 +210,16 @@ export class RpcSendQueue {
                 throw new Error("A DELETE event should have been sent.");
             }
 
-            const beforeIdx = this.putListPositions(after, before, id);
+            const positions = this.putListPositions(after, before, id);
 
-            for (const anAfter of after) {
-                const beforePos = beforeIdx.get(id(anAfter));
+            for (let i = 0; i < after.length; i++) {
+                const anAfter = after[i];
+                const beforePos = positions === undefined ? -1 : positions[i];
                 const onChangeRun = onChange ? () => onChange(anAfter) : undefined;
-                if (beforePos === undefined) {
+                if (beforePos === -1) {
                     await this.add(anAfter, onChangeRun);
                 } else {
-                    const aBefore = before?.[beforePos];
+                    const aBefore = before![beforePos];
                     if (aBefore === anAfter) {
                         this.put({state: RpcObjectState.NO_CHANGE});
                     } else if (anAfter !== undefined && (isRef(anAfter) || this.typesAreDifferent(anAfter, aBefore))) {
@@ -237,14 +238,22 @@ export class RpcSendQueue {
         });
     }
 
+    /**
+     * Emits the positions message and returns the same positions for the caller to walk,
+     * or undefined when every element is new.
+     */
     private putListPositions<T>(after: T[],
                                 before: T[] | undefined,
-                                id: (value: T) => any): Map<any, number> {
+                                id: (value: T) => any): number[] | undefined {
+        if (!before || before.length === 0) {
+            // Every element is an addition, so the positions are a constant that needs
+            // neither an index map nor a key computed per element.
+            this.put({state: RpcObjectState.CHANGE, value: new Array(after.length).fill(-1)});
+            return undefined;
+        }
         const beforeIdx = new Map<any, number>();
-        if (before) {
-            for (let i = 0; i < before.length; i++) {
-                beforeIdx.set(id(before[i]), i);
-            }
+        for (let i = 0; i < before.length; i++) {
+            beforeIdx.set(id(before[i]), i);
         }
         const positions: number[] = [];
         for (const t of after) {
@@ -252,7 +261,7 @@ export class RpcSendQueue {
             positions.push(beforePos === undefined ? -1 : beforePos);
         }
         this.put({state: RpcObjectState.CHANGE, value: positions});
-        return beforeIdx;
+        return positions;
     }
 
     private async add(after: any, onChange: (() => Promise<any>) | undefined): Promise<void> {

--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -319,6 +319,7 @@ export class RpcSendQueue {
 export class RpcReceiveQueue {
     private batch: RpcObjectData[] = [];
     private batchIndex = 0;
+    private sinceYield = 0;
 
     constructor(private readonly refs: Map<number, any>,
                 private readonly sourceFileType: string | undefined,
@@ -331,6 +332,14 @@ export class RpcReceiveQueue {
         if (this.batchIndex >= this.batch.length) {
             this.batch = await this.pull();
             this.batchIndex = 0;
+        }
+        // Awaiting a resolved value only queues a microtask, and Node drains those
+        // before it polls the socket, so without an occasional macrotask a page
+        // requested ahead is never delivered. 256 is where delivery balances the
+        // cost of scheduling.
+        if (++this.sinceYield >= 256) {
+            this.sinceYield = 0;
+            await new Promise(resolve => setImmediate(resolve));
         }
         // An index keeps draining a batch linear; Array.shift() copies the remaining
         // elements on every call, which is quadratic over the batch.

--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -328,7 +328,18 @@ export class RpcReceiveQueue {
                 private readonly trace: boolean) {
     }
 
-    async take(): Promise<RpcObjectData> {
+    // Returns a value rather than a promise for all but the message that refills the
+    // batch or yields, so the common path costs neither a promise nor an async frame.
+    take(): RpcObjectData | Promise<RpcObjectData> {
+        if (this.batchIndex < this.batch.length && ++this.sinceYield < 256) {
+            // An index keeps draining a batch linear; Array.shift() copies the remaining
+            // elements on every call, which is quadratic over the batch.
+            return this.batch[this.batchIndex++]!;
+        }
+        return this.takeSlow();
+    }
+
+    private async takeSlow(): Promise<RpcObjectData> {
         if (this.batchIndex >= this.batch.length) {
             this.batch = await this.pull();
             this.batchIndex = 0;
@@ -337,12 +348,10 @@ export class RpcReceiveQueue {
         // before it polls the socket, so without an occasional macrotask a page
         // requested ahead is never delivered. 256 is where delivery balances the
         // cost of scheduling.
-        if (++this.sinceYield >= 256) {
+        if (this.sinceYield >= 256) {
             this.sinceYield = 0;
             await new Promise(resolve => setImmediate(resolve));
         }
-        // An index keeps draining a batch linear; Array.shift() copies the remaining
-        // elements on every call, which is quadratic over the batch.
         return this.batch[this.batchIndex++]!;
     }
 
@@ -376,7 +385,8 @@ export class RpcReceiveQueue {
         before: T | undefined,
         onChange?: (before: T) => T | Promise<T | undefined> | undefined
     ): Promise<T> {
-        const message = await this.take();
+        const taken = this.take();
+        const message = taken instanceof Promise ? await taken : taken;
         RpcObjectData.logTrace(message, this.trace, this.logger);
         let ref: number | undefined;
         switch (message.state) {
@@ -460,7 +470,8 @@ export class RpcReceiveQueue {
         before: T[] | undefined,
         onChange?: (before: T) => T | Promise<T | undefined> | undefined
     ): Promise<T[] | undefined> {
-        const message = await this.take();
+        const taken = this.take();
+        const message = taken instanceof Promise ? await taken : taken;
         RpcObjectData.logTrace(message, this.trace, this.logger);
         switch (message.state) {
             case RpcObjectState.NO_CHANGE:
@@ -472,7 +483,8 @@ export class RpcReceiveQueue {
             // Intentional fall-through...
             case RpcObjectState.CHANGE:
                 // The next message should be a CHANGE with a list of positions
-                const d = await this.take();
+                const takenD = this.take();
+                const d = takenD instanceof Promise ? await takenD : takenD;
                 const positions = d.value as number[];
                 if (!positions) {
                     throw new Error(`Expected positions array but got: ${JSON.stringify(d)}`);

--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -328,8 +328,11 @@ export class RpcReceiveQueue {
                 private readonly trace: boolean) {
     }
 
-    // Returns a value rather than a promise for all but the message that refills the
-    // batch or yields, so the common path costs neither a promise nor an async frame.
+    /**
+     * Returns a value rather than a promise for all but the message that refills the
+     * batch or yields, so the common path costs neither a promise nor an async frame.
+     * @internal
+     */
     take(): RpcObjectData | Promise<RpcObjectData> {
         if (this.batchIndex < this.batch.length && ++this.sinceYield < 256) {
             // An index keeps draining a batch linear; Array.shift() copies the remaining
@@ -341,6 +344,11 @@ export class RpcReceiveQueue {
 
     private async takeSlow(): Promise<RpcObjectData> {
         if (this.batchIndex >= this.batch.length) {
+            // Every object the sender emits is terminated by END_OF_OBJECT, so a refill
+            // after one means the receiver asked for a field the sender never sent.
+            if (this.batch[this.batchIndex - 1]?.state === RpcObjectState.END_OF_OBJECT) {
+                throw new Error("Read past END_OF_OBJECT: the sender and receiver disagree on this object's shape.");
+            }
             this.batch = await this.pull();
             this.batchIndex = 0;
         }

--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -364,63 +364,73 @@ export class RpcReceiveQueue {
         before: T | undefined,
         onChange?: (before: T) => T | Promise<T | undefined> | undefined
     ): Promise<T> {
-        return saveTrace(this.trace, async () => {
-            const message = await this.take();
-            RpcObjectData.logTrace(message, this.trace, this.logger);
-            let ref: number | undefined;
-            switch (message.state) {
-                case RpcObjectState.NO_CHANGE:
-                    return before!;
-                case RpcObjectState.DELETE:
-                    return undefined as T;
-                case RpcObjectState.ADD:
-                    ref = message.ref;
-                    if (ref !== undefined && message.valueType === undefined && message.value === undefined) {
-                        // This is a pure reference to an existing object
-                        if (this.refs.has(ref)) {
-                            return this.refs.get(ref);
-                        } else {
-                            throw new Error(`Received a reference to an object that was not previously sent: ${ref}`);
-                        }
+        // Tracing is a debugging feature, and the closure is allocated on every
+        // call to decide not to use it; this runs once per field of every tree.
+        if (this.trace) {
+            return saveTrace(true, () => this.receiveImpl(before, onChange));
+        }
+        return this.receiveImpl(before, onChange);
+    }
+
+    private async receiveImpl<T extends any | undefined>(
+        before: T | undefined,
+        onChange?: (before: T) => T | Promise<T | undefined> | undefined
+    ): Promise<T> {
+        const message = await this.take();
+        RpcObjectData.logTrace(message, this.trace, this.logger);
+        let ref: number | undefined;
+        switch (message.state) {
+            case RpcObjectState.NO_CHANGE:
+                return before!;
+            case RpcObjectState.DELETE:
+                return undefined as T;
+            case RpcObjectState.ADD:
+                ref = message.ref;
+                if (ref !== undefined && message.valueType === undefined && message.value === undefined) {
+                    // This is a pure reference to an existing object
+                    if (this.refs.has(ref)) {
+                        return this.refs.get(ref);
                     } else {
-                        // This is either a new object or a forward declaration with ref
-                        before = message.valueType === undefined ?
-                            message.value :
-                            this.newObj(message.valueType);
-                        if (ref !== undefined) {
-                            // For an object like JavaType that we will mutate in place rather than using
-                            // immutable updates because of its cyclic nature, the before instance will ultimately
-                            // be the same as the after instance below.
-                            this.refs.set(ref, before);
-                        }
+                        throw new Error(`Received a reference to an object that was not previously sent: ${ref}`);
                     }
-                // Intentional fall-through...
-                case RpcObjectState.CHANGE:
-                    let after;
-                    let codec;
-                    if (onChange) {
-                        after = await onChange(before!);
-                    } else if ((codec = RpcCodecs.forInstance(before, this.sourceFileType))) {
-                        after = await codec.rpcReceive(before, this);
-                    } else if (message.value !== undefined) {
-                        after = message.valueType ? {kind: message.valueType, ...message.value} : message.value;
-                    } else if (message.state === RpcObjectState.ADD && message.valueType) {
-                        throw new Error(
-                            `No RPC codec registered on the TypeScript side for '${message.valueType}'. ` +
-                            `The Java side has a codec and sent property messages that will not be consumed, ` +
-                            `causing RPC queue desynchronization.`
-                        );
-                    } else {
-                        after = before;
-                    }
+                } else {
+                    // This is either a new object or a forward declaration with ref
+                    before = message.valueType === undefined ?
+                        message.value :
+                        this.newObj(message.valueType);
                     if (ref !== undefined) {
-                        this.refs.set(ref, after);
+                        // For an object like JavaType that we will mutate in place rather than using
+                        // immutable updates because of its cyclic nature, the before instance will ultimately
+                        // be the same as the after instance below.
+                        this.refs.set(ref, before);
                     }
-                    return after;
-                default:
-                    throw new Error(`Unknown state type ${message.state}`);
-            }
-        });
+                }
+            // Intentional fall-through...
+            case RpcObjectState.CHANGE:
+                let after;
+                let codec;
+                if (onChange) {
+                    after = await onChange(before!);
+                } else if ((codec = RpcCodecs.forInstance(before, this.sourceFileType))) {
+                    after = await codec.rpcReceive(before, this);
+                } else if (message.value !== undefined) {
+                    after = message.valueType ? {kind: message.valueType, ...message.value} : message.value;
+                } else if (message.state === RpcObjectState.ADD && message.valueType) {
+                    throw new Error(
+                        `No RPC codec registered on the TypeScript side for '${message.valueType}'. ` +
+                        `The Java side has a codec and sent property messages that will not be consumed, ` +
+                        `causing RPC queue desynchronization.`
+                    );
+                } else {
+                    after = before;
+                }
+                if (ref !== undefined) {
+                    this.refs.set(ref, after);
+                }
+                return after;
+            default:
+                throw new Error(`Unknown state type ${message.state}`);
+        }
     }
 
     /**
@@ -438,36 +448,46 @@ export class RpcReceiveQueue {
         before: T[] | undefined,
         onChange?: (before: T) => T | Promise<T | undefined> | undefined
     ): Promise<T[] | undefined> {
-        return saveTrace(this.trace, async () => {
-            const message = await this.take();
-            RpcObjectData.logTrace(message, this.trace, this.logger);
-            switch (message.state) {
-                case RpcObjectState.NO_CHANGE:
-                    return before;
-                case RpcObjectState.DELETE:
-                    return undefined;
-                case RpcObjectState.ADD:
-                    before = [];
-                // Intentional fall-through...
-                case RpcObjectState.CHANGE:
-                    // The next message should be a CHANGE with a list of positions
-                    const d = await this.take();
-                    const positions = d.value as number[];
-                    if (!positions) {
-                        throw new Error(`Expected positions array but got: ${JSON.stringify(d)}`);
-                    }
-                    const after: T[] = new Array(positions.length);
-                    for (let i = 0; i < positions.length; i++) {
-                        const beforeIdx = positions[i];
-                        const b: T = await (beforeIdx >= 0 ? before![beforeIdx] as T : undefined) as T;
-                        let received: Promise<T> = this.receive<T>(b, onChange);
-                        after[i] = await received;
-                    }
-                    return after;
-                default:
-                    throw new Error(`${message.state} is not supported for lists.`);
-            }
-        });
+        // Tracing is a debugging feature, and the closure is allocated on every
+        // call to decide not to use it; this runs once per field of every tree.
+        if (this.trace) {
+            return saveTrace(true, () => this.receiveListImpl(before, onChange));
+        }
+        return this.receiveListImpl(before, onChange);
+    }
+
+    private async receiveListImpl<T>(
+        before: T[] | undefined,
+        onChange?: (before: T) => T | Promise<T | undefined> | undefined
+    ): Promise<T[] | undefined> {
+        const message = await this.take();
+        RpcObjectData.logTrace(message, this.trace, this.logger);
+        switch (message.state) {
+            case RpcObjectState.NO_CHANGE:
+                return before;
+            case RpcObjectState.DELETE:
+                return undefined;
+            case RpcObjectState.ADD:
+                before = [];
+            // Intentional fall-through...
+            case RpcObjectState.CHANGE:
+                // The next message should be a CHANGE with a list of positions
+                const d = await this.take();
+                const positions = d.value as number[];
+                if (!positions) {
+                    throw new Error(`Expected positions array but got: ${JSON.stringify(d)}`);
+                }
+                const after: T[] = new Array(positions.length);
+                for (let i = 0; i < positions.length; i++) {
+                    const beforeIdx = positions[i];
+                    const b: T = await (beforeIdx >= 0 ? before![beforeIdx] as T : undefined) as T;
+                    let received: Promise<T> = this.receive<T>(b, onChange);
+                    after[i] = await received;
+                }
+                return after;
+            default:
+                throw new Error(`${message.state} is not supported for lists.`);
+        }
     }
 
     private newObj<T>(type: string): T {

--- a/rewrite-javascript/rewrite/src/rpc/queue.ts
+++ b/rewrite-javascript/rewrite/src/rpc/queue.ts
@@ -318,6 +318,7 @@ export class RpcSendQueue {
 
 export class RpcReceiveQueue {
     private batch: RpcObjectData[] = [];
+    private batchIndex = 0;
 
     constructor(private readonly refs: Map<number, any>,
                 private readonly sourceFileType: string | undefined,
@@ -327,10 +328,13 @@ export class RpcReceiveQueue {
     }
 
     async take(): Promise<RpcObjectData> {
-        if (this.batch.length === 0) {
+        if (this.batchIndex >= this.batch.length) {
             this.batch = await this.pull();
+            this.batchIndex = 0;
         }
-        return this.batch.shift()!;
+        // An index keeps draining a batch linear; Array.shift() copies the remaining
+        // elements on every call, which is quadratic over the batch.
+        return this.batch[this.batchIndex++]!;
     }
 
     receiveMarkers(markers?: Markers): Promise<Markers> {

--- a/rewrite-javascript/rewrite/src/rpc/request/get-object.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/get-object.ts
@@ -32,7 +32,7 @@ export class GetObject {
         trace: () => boolean,
         metricsCsv?: string,
     ): void {
-        const pendingData = new Map<string, { data: RpcObjectData[], offset: number }>();
+        const pendingData = new Map<string, { data: (RpcObjectData | undefined)[], offset: number }>();
 
         connection.onRequest(
             new rpc.RequestType<GetObject, any, Error>("GetObject"),
@@ -83,9 +83,13 @@ export class GetObject {
                     }
 
                     // Advancing an offset keeps paging linear; removing the head copies the
-                    // remaining elements on every page.
-                    const batch = pending.data.slice(pending.offset, pending.offset + batchSize);
-                    pending.offset += batch.length;
+                    // remaining elements on every page. The whole object is materialized as
+                    // messages up front, so a sent page stays reachable through its slots
+                    // until they are cleared.
+                    const end = Math.min(pending.offset + batchSize, pending.data.length);
+                    const batch = pending.data.slice(pending.offset, end);
+                    pending.data.fill(undefined, pending.offset, end);
+                    pending.offset = end;
 
                     // If we've sent all data, remove from pending
                     if (pending.offset >= pending.data.length) {

--- a/rewrite-javascript/rewrite/src/rpc/request/get-object.ts
+++ b/rewrite-javascript/rewrite/src/rpc/request/get-object.ts
@@ -32,7 +32,7 @@ export class GetObject {
         trace: () => boolean,
         metricsCsv?: string,
     ): void {
-        const pendingData = new Map<string, RpcObjectData[]>();
+        const pendingData = new Map<string, { data: RpcObjectData[], offset: number }>();
 
         connection.onRequest(
             new rpc.RequestType<GetObject, any, Error>("GetObject"),
@@ -58,8 +58,8 @@ export class GetObject {
                     const obj = localObjects.get(objId);
                     context.target = extractSourcePath(obj);
 
-                    let allData = pendingData.get(objId);
-                    if (!allData) {
+                    let pending = pendingData.get(objId);
+                    if (!pending) {
                         const after = obj;
                         const before = remoteObjects.get(objId);
 
@@ -68,9 +68,12 @@ export class GetObject {
                         // was added during this exchange.
                         const savedRefCount = localRefs.snapshot();
                         try {
-                            allData = await new RpcSendQueue(localRefs, request.sourceFileType, trace())
-                                .generate(after, before);
-                            pendingData.set(objId, allData);
+                            pending = {
+                                data: await new RpcSendQueue(localRefs, request.sourceFileType, trace())
+                                    .generate(after, before),
+                                offset: 0
+                            };
+                            pendingData.set(objId, pending);
                             remoteObjects.set(objId, after);
                         } catch (e) {
                             remoteObjects.delete(objId);
@@ -79,10 +82,13 @@ export class GetObject {
                         }
                     }
 
-                    const batch = allData.splice(0, batchSize);
+                    // Advancing an offset keeps paging linear; removing the head copies the
+                    // remaining elements on every page.
+                    const batch = pending.data.slice(pending.offset, pending.offset + batchSize);
+                    pending.offset += batch.length;
 
                     // If we've sent all data, remove from pending
-                    if (allData.length === 0) {
+                    if (pending.offset >= pending.data.length) {
                         pendingData.delete(objId);
                     }
 

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -280,7 +280,8 @@ export class RewriteRpc {
             throw e;
         }
 
-        const eof = (await q.take());
+        const takenEof = q.take();
+        const eof = takenEof instanceof Promise ? await takenEof : takenEof;
         if (eof.state !== RpcObjectState.END_OF_OBJECT) {
             RpcObjectData.logTrace(eof, this.traceGetObject.receive, this.logger);
             throw new Error(`Expected END_OF_OBJECT but got: ${eof.state}`);

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -267,24 +267,23 @@ export class RewriteRpc {
         let remoteObject: P;
         try {
             remoteObject = await q.receive<P>(before as P);
+            const takenEof = q.take();
+            const eof = takenEof instanceof Promise ? await takenEof : takenEof;
+            if (eof.state !== RpcObjectState.END_OF_OBJECT) {
+                RpcObjectData.logTrace(eof, this.traceGetObject.receive, this.logger);
+                throw new Error(`Expected END_OF_OBJECT but got: ${eof.state}`);
+            }
         } catch (e) {
             // Reset our tracking of the remote state so the next interaction
             // forces a full object sync (ADD) instead of a delta (CHANGE).
             this.remoteObjects.delete(id);
             if (nextPage) {
-                // The remote has advanced past this page; leaving it would hand it to
-                // whichever request asks next.
+                // At most one page is ever requested ahead; settling it leaves no request
+                // outstanding on an object this side has stopped receiving.
                 await nextPage.catch(() => {
                 });
             }
             throw e;
-        }
-
-        const takenEof = q.take();
-        const eof = takenEof instanceof Promise ? await takenEof : takenEof;
-        if (eof.state !== RpcObjectState.END_OF_OBJECT) {
-            RpcObjectData.logTrace(eof, this.traceGetObject.receive, this.logger);
-            throw new Error(`Expected END_OF_OBJECT but got: ${eof.state}`);
         }
 
         this.remoteObjects.set(id, remoteObject);

--- a/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
+++ b/rewrite-javascript/rewrite/src/rpc/rewrite-rpc.ts
@@ -235,11 +235,33 @@ export class RewriteRpc {
         // (e.g., via a local recipe) since the remote doesn't know about those changes.
         const before = this.remoteObjects.get(id);
 
-        const q = new RpcReceiveQueue(this.remoteRefs, sourceFileType, () => {
-            return this.connection.sendRequest(
+        const requestPage = () => {
+            const page = this.connection.sendRequest(
                 new rpc.RequestType<GetObject, RpcObjectData[], Error>("GetObject"),
                 new GetObject(id, sourceFileType),
             );
+            // Marks the promise handled so a rejection on a page that is requested but
+            // never awaited is not reported as an unhandled rejection; awaiting it later
+            // still throws.
+            page.catch(() => {
+            });
+            return page;
+        };
+
+        // The following page is requested before this one is handed to the queue, so the
+        // remote serializes it while this side deserializes what it already has.
+        let nextPage: Promise<RpcObjectData[]> | undefined;
+        const q = new RpcReceiveQueue(this.remoteRefs, sourceFileType, async () => {
+            const pending = nextPage;
+            nextPage = undefined;
+            const page = await (pending ?? requestPage());
+            // A page ending in END_OF_OBJECT has no successor; the remote drops its
+            // transfer state when it sends that marker, so asking again would restart
+            // the transfer rather than return nothing.
+            if (page.length > 0 && page[page.length - 1].state !== RpcObjectState.END_OF_OBJECT) {
+                nextPage = requestPage();
+            }
+            return page;
         }, this.logger, this.traceGetObject.receive);
 
         let remoteObject: P;
@@ -249,6 +271,12 @@ export class RewriteRpc {
             // Reset our tracking of the remote state so the next interaction
             // forces a full object sync (ADD) instead of a delta (CHANGE).
             this.remoteObjects.delete(id);
+            if (nextPage) {
+                // The remote has advanced past this page; leaving it would hand it to
+                // whichever request asks next.
+                await nextPage.catch(() => {
+                });
+            }
             throw e;
         }
 

--- a/rewrite-javascript/rewrite/test/rpc/queue.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/queue.test.ts
@@ -4,6 +4,56 @@ import type {RpcObjectData} from "../../src/rpc";
 
 describe("RPC queues", () => {
 
+    async function sendList<T>(after: T[] | undefined, before: T[] | undefined): Promise<RpcObjectData[]> {
+        const queue = new RpcSendQueue(new ReferenceMap(), Json.Kind.Document, false);
+        await queue.sendList(after, before, t => t);
+        return queue.finish();
+    }
+
+    // The positions array is what lets a reorder cost one integer per element instead
+    // of re-sending the elements themselves.
+    test("reordered elements are repositioned, not resent", async () => {
+        const batch = await sendList(["C", "A", "B"], ["A", "B", "C"]);
+
+        expect(batch.map(d => d.state)).toEqual([
+            RpcObjectState.CHANGE, RpcObjectState.CHANGE,
+            RpcObjectState.NO_CHANGE, RpcObjectState.NO_CHANGE, RpcObjectState.NO_CHANGE,
+            RpcObjectState.END_OF_OBJECT,
+        ]);
+        expect(batch[1].value).toEqual([2, 0, 1]);
+    });
+
+    test("every element is added when the before list is empty", async () => {
+        const batch = await sendList(["A", "B"], []);
+
+        expect(batch.map(d => d.state)).toEqual([
+            RpcObjectState.CHANGE, RpcObjectState.CHANGE,
+            RpcObjectState.ADD, RpcObjectState.ADD,
+            RpcObjectState.END_OF_OBJECT,
+        ]);
+        expect(batch[1].value).toEqual([-1, -1]);
+    });
+
+    test("mixed adds and removals", async () => {
+        const batch = await sendList(["A", "E", "F", "C"], ["A", "B", "C", "D"]);
+
+        expect(batch.map(d => d.state)).toEqual([
+            RpcObjectState.CHANGE, RpcObjectState.CHANGE,
+            RpcObjectState.NO_CHANGE, RpcObjectState.ADD, RpcObjectState.ADD, RpcObjectState.NO_CHANGE,
+            RpcObjectState.END_OF_OBJECT,
+        ]);
+        expect(batch[1].value).toEqual([0, -1, -1, 2]);
+    });
+
+    test("an unchanged list is a single NO_CHANGE", async () => {
+        const before = ["A", "B"];
+        const batch = await sendList(before, before);
+
+        expect(batch.map(d => d.state)).toEqual([
+            RpcObjectState.NO_CHANGE, RpcObjectState.END_OF_OBJECT,
+        ]);
+    });
+
     test("asRef doesn't create a new instance", () => {
         const space = {kind: Json.Kind.Space, comments: [], whitespace: "\n"};
 

--- a/rewrite-javascript/rewrite/test/rpc/queue.test.ts
+++ b/rewrite-javascript/rewrite/test/rpc/queue.test.ts
@@ -54,6 +54,15 @@ describe("RPC queues", () => {
         ]);
     });
 
+    test("reading past END_OF_OBJECT fails rather than re-serving the batch", async () => {
+        const batch = await sendList(["A"], []);
+        const q = new RpcReceiveQueue(new Map(), undefined, async () => batch, undefined, false);
+
+        await q.receiveList<string>(undefined);
+        expect((await q.take()).state).toBe(RpcObjectState.END_OF_OBJECT);
+        await expect(q.take()).rejects.toThrow(/past END_OF_OBJECT/);
+    });
+
     test("asRef doesn't create a new instance", () => {
         const space = {kind: Json.Kind.Space, comments: [], whitespace: "\n"};
 

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRpcThroughputTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRpcThroughputTest.java
@@ -26,7 +26,9 @@ import org.openrewrite.SourceFile;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static java.util.stream.Collectors.toList;
@@ -52,28 +54,41 @@ class JavaScriptRpcThroughputTest {
     }
 
     /**
-     * Summed across threads because a send runs on a traversal thread. Both counters
-     * are cumulative per thread, so the difference of two readings is the work between.
+     * Keyed by thread id because a send runs on a traversal thread, so a phase's cost is
+     * spread over threads that come and go within it.
      */
-    static long cpuNanos() {
+    static Map<Long, Long> cpuSnapshot() {
         java.lang.management.ThreadMXBean t = ManagementFactory.getThreadMXBean();
-        long total = 0;
+        Map<Long, Long> snapshot = new HashMap<>();
         for (long id : t.getAllThreadIds()) {
             long c = t.getThreadCpuTime(id);
             if (c > 0) {
-                total += c;
+                snapshot.put(id, c);
             }
         }
-        return total;
+        return snapshot;
     }
 
-    static long allocated() {
-        long total = 0;
+    static Map<Long, Long> allocSnapshot() {
+        Map<Long, Long> snapshot = new HashMap<>();
         for (long id : ManagementFactory.getThreadMXBean().getAllThreadIds()) {
             long b = ALLOC.getThreadAllocatedBytes(id);
             if (b > 0) {
-                total += b;
+                snapshot.put(id, b);
             }
+        }
+        return snapshot;
+    }
+
+    /**
+     * Both counters are cumulative per thread, so a phase costs each thread's growth across it.
+     * Keying on the later snapshot counts a thread that started mid-phase in full and one that
+     * ended mid-phase not at all, which bounds the result from below.
+     */
+    static long delta(Map<Long, Long> before, Map<Long, Long> after) {
+        long total = 0;
+        for (Map.Entry<Long, Long> e : after.entrySet()) {
+            total += e.getValue() - before.getOrDefault(e.getKey(), 0L);
         }
         return total;
     }
@@ -103,7 +118,8 @@ class JavaScriptRpcThroughputTest {
     }
 
     List<SourceFile> parse(Path project, List<String> exclusions, String label) {
-        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        Map<Long, Long> cpu = cpuSnapshot(), alloc = allocSnapshot();
+        long nanos = System.nanoTime();
         List<SourceFile> files = JavaScriptRewriteRpc.getOrStart()
                 .parseProject(project, exclusions, new InMemoryExecutionContext(Throwable::printStackTrace))
                 .collect(toList());
@@ -116,7 +132,8 @@ class JavaScriptRpcThroughputTest {
         // the peer fetch it back, which is what exercises its receive path.
         JavaScriptRewriteRpc.getOrStart().reset();
 
-        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        Map<Long, Long> cpu = cpuSnapshot(), alloc = allocSnapshot();
+        long nanos = System.nanoTime();
         long chars = 0;
         for (SourceFile f : files) {
             chars += JavaScriptRewriteRpc.getOrStart().print(f).length();
@@ -124,12 +141,13 @@ class JavaScriptRpcThroughputTest {
         report("PRINT", label, files.size(), nanos, cpu, alloc, chars);
     }
 
-    static void report(String phase, String label, int files, long startNanos, long startCpu, long startAlloc, long chars) {
+    static void report(String phase, String label, int files, long startNanos,
+                       Map<Long, Long> startCpu, Map<Long, Long> startAlloc, long chars) {
         System.out.printf("%s  %-10s %4d files  wall %,6d ms  jvmCpu %,6d ms  %,15d bytes%s%n",
                 phase, label, files,
                 (System.nanoTime() - startNanos) / 1_000_000,
-                (cpuNanos() - startCpu) / 1_000_000,
-                allocated() - startAlloc,
+                delta(startCpu, cpuSnapshot()) / 1_000_000,
+                delta(startAlloc, allocSnapshot()),
                 chars == 0 ? "" : String.format("  %,d chars", chars));
     }
 }

--- a/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRpcThroughputTest.java
+++ b/rewrite-javascript/src/integTest/java/org/openrewrite/javascript/rpc/JavaScriptRpcThroughputTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.javascript.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+
+import java.lang.management.ManagementFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Measurement harness, not a correctness test: parse and print exercise opposite
+ * directions of the wire, so one run measures both peers.
+ */
+@Timeout(value = 1800, unit = TimeUnit.SECONDS)
+class JavaScriptRpcThroughputTest {
+
+    @TempDir
+    Path tempDir;
+
+    static final com.sun.management.ThreadMXBean ALLOC =
+            (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    static {
+        java.lang.management.ThreadMXBean t = ManagementFactory.getThreadMXBean();
+        if (t.isThreadCpuTimeSupported() && !t.isThreadCpuTimeEnabled()) {
+            t.setThreadCpuTimeEnabled(true);
+        }
+    }
+
+    /**
+     * Summed across threads because a send runs on a traversal thread. Both counters
+     * are cumulative per thread, so the difference of two readings is the work between.
+     */
+    static long cpuNanos() {
+        java.lang.management.ThreadMXBean t = ManagementFactory.getThreadMXBean();
+        long total = 0;
+        for (long id : t.getAllThreadIds()) {
+            long c = t.getThreadCpuTime(id);
+            if (c > 0) {
+                total += c;
+            }
+        }
+        return total;
+    }
+
+    static long allocated() {
+        long total = 0;
+        for (long id : ManagementFactory.getThreadMXBean().getAllThreadIds()) {
+            long b = ALLOC.getThreadAllocatedBytes(id);
+            if (b > 0) {
+                total += b;
+            }
+        }
+        return total;
+    }
+
+    @BeforeEach
+    void before() {
+        JavaScriptRewriteRpc.setFactory(JavaScriptRewriteRpc.builder()
+                .recipeInstallDir(tempDir)
+                .log(tempDir.resolve("rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        JavaScriptRewriteRpc.shutdownCurrent();
+    }
+
+    @Test
+    void parseThenPrintOwnSources() {
+        Path project = Paths.get("rewrite").toAbsolutePath();
+        List<String> exclusions = List.of("**/node_modules/**", "**/dist/**", "**/build/**");
+
+        List<SourceFile> files = parse(project, exclusions, "parse");
+        // Each cycle resets and refetches the same trees, so the early ones are warmup.
+        for (int cycle = 0; cycle < 6; cycle++) {
+            printAfterReset(files, "cycle " + cycle);
+        }
+    }
+
+    List<SourceFile> parse(Path project, List<String> exclusions, String label) {
+        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        List<SourceFile> files = JavaScriptRewriteRpc.getOrStart()
+                .parseProject(project, exclusions, new InMemoryExecutionContext(Throwable::printStackTrace))
+                .collect(toList());
+        report("PARSE", label, files.size(), nanos, cpu, alloc, 0);
+        return files;
+    }
+
+    void printAfterReset(List<SourceFile> files, String label) {
+        // Reset drops the peer's view of every tree, so each print that follows makes
+        // the peer fetch it back, which is what exercises its receive path.
+        JavaScriptRewriteRpc.getOrStart().reset();
+
+        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        long chars = 0;
+        for (SourceFile f : files) {
+            chars += JavaScriptRewriteRpc.getOrStart().print(f).length();
+        }
+        report("PRINT", label, files.size(), nanos, cpu, alloc, chars);
+    }
+
+    static void report(String phase, String label, int files, long startNanos, long startCpu, long startAlloc, long chars) {
+        System.out.printf("%s  %-10s %4d files  wall %,6d ms  jvmCpu %,6d ms  %,15d bytes%s%n",
+                phase, label, files,
+                (System.nanoTime() - startNanos) / 1_000_000,
+                (cpuNanos() - startCpu) / 1_000_000,
+                allocated() - startAlloc,
+                chars == 0 ? "" : String.format("  %,d chars", chars));
+    }
+}


### PR DESCRIPTION
Parsing this repository's own TypeScript sources through the JavaScript peer took 38 seconds. Two of that peer's RPC paths drain an array from the head, which makes both quadratic in the number of messages an object transfers; fixing that, and letting a page requested ahead actually arrive, brings parse to 27 seconds.

| phase | wall | JVM CPU | JVM allocation |
|---|---|---|---|
| parse | 38,038 → 26,847 ms (**−29%**) | −10.2% | +0.1% |
| print | 6,872 → 6,316 ms (−8.1%) | **−31.2%** | −10.2% |

Print gains little wall time but a third of its CPU. The JVM was never the constraint on that phase; it now does the same work with far less of the machine.

## Where the quadratic time was

- `RpcReceiveQueue.take()` drained its batch with `Array.shift()`, copying the batch remainder on every message.
- `GetObject` paged a generated object with `splice(0, batchSize)`, copying the object remainder on every page. Across the 394 files here an object spans 31.8 pages on average, and the largest — a generated Yarn PnP lockfile fixture — spans 1,083.

The C# and Python peers already drained in constant time, with `Queue.Dequeue` and `deque.popleft`. This also explains why a larger batch size never paid on this peer: `shift()` costs O(N·B), so a bigger batch buys fewer round trips at the price of more copying.

## Why the prefetch was worth nothing on its own

The receive path already requested the next page before draining the current one. That prefetch fired on 97% of pulls, and on not one of them had the page arrived.

Receiving is a chain of `await`s on already-resolved values, and those only queue microtasks, which Node drains to exhaustion before it polls the socket — so a page requested ahead sat unread until the receiver blocked on it anyway. Yielding to a macrotask every 256 messages is what lets one arrive:

```
time blocked in the receive loop:  28,379 ms  →  3,418 ms
```

The prefetch and the yield are each worth nothing without the other, so they belong together rather than as two independent wins.

## Per-change wall-clock

Measured one at a time against `origin/main`. These do not chain, and they do not sum to the totals above.

- Drain a receive batch by index rather than `Array.shift()` — print −5.8%, 14/15 paired cycles
- Page a pending object by offset rather than `splice(0, n)` — parse −5.4%, 12/12
- Yield to a macrotask so a requested page is delivered — print −14.1%, 15/15
- Return a message without a promise on the common path — print −10.0% and −8.3% over two runs, 10/10
- Call the receive path directly when nothing traces it — no measurable effect (−5.6%, −1.4%, +4.0%); kept because it removes a closure allocated once per field of every tree, not because it showed up

## Retention

Paging by offset alone leaves every message of an object reachable through its slot until the last page is taken, where `splice` had shrunk the array as pages went out. Each page now clears the slots it came from. Live heap held by the pending entry for one large object, sampled after a forced GC:

```
src/javascript/parser.ts — 638,310 messages, 639 pages of 1000

              page 200   page 400   page 639
  offset      100.5 MB   100.5 MB   100.5 MB
  + clear      85.2 MB    68.9 MB    48.4 MB
```

## Also in this PR

A review of the split raised three defects in the receive path, each fixed in its own commit:

- `getObject` reset its view of the remote and drained the page requested ahead on the receive failure but not on the `END_OF_OBJECT` check that follows it, so a desynchronized stream left a stale baseline and an unread response. One `try` covers both exits. Its abort comment also claimed an unread page would be handed to whichever request asks next, which cannot happen — responses correlate to requests by id.
- Reading past `END_OF_OBJECT` answered from the top of the batch just finished rather than failing, so a sender and receiver that disagree would spin instead of erroring.
- The harness summed per-thread CPU and allocation counters over the live thread set, which under-reports and can print a negative when a phase retires a worker. It now diffs per-thread snapshots.

The same three are present in the C#, Go and Python ports of these commits.

## Tests

The retention change needs no test of its own. `test/rpc/rewrite-rpc.test.ts` builds its client with `batchSize: 1`, so every print and parse in it pages the `GetObject` handler many times over, and mutating the slot clear to overrun by one fails 13 of its 26 tests.

One test is new, for the `END_OF_OBJECT` guard below, which nothing else reaches: removing the guard fails it and leaves the other ten in its file passing. Suite total 2,278, all green.

## Method

- Both arms in equivalent fresh worktrees, interleaved in one session, three repetitions minimum, with the parsed file count asserted equal. An earlier run comparing a `/tmp` worktree against a working one produced a phantom 20% allocation regression that survived two rounds of bisecting before a file-count mismatch explained it.
- JVM allocation is `getThreadAllocatedBytes` — a cumulative total rather than a peak, and insensitive to machine load. Wall clock is not, hence the pairing and the per-rep win counts above.
- The 31.8-page average and the 1,083-page maximum come from a 394-file snapshot of this module; it is 395 files today, a test file having landed on `main` in between. Reproducing gives the larger count.
- `--cpu-prof` on the Node peer profiles the launcher rather than the peer, so the microtask finding came from blocked-time instrumentation in the receive loop instead.

## Scope

- `DependencyTypes` pages with `splice(0, batchSize)` too, in `src/rpc/request/dependency-types.ts`. It is the same shape over much smaller arrays and is deliberately left for a follow-up, to keep this PR to the object-transfer path.

This is the JavaScript half of #8808; the C#, Go and Python halves are being split out separately, so the two commits here that originally spanned several languages carry only their `rewrite-javascript/` paths.

The commit that added this harness also carried an 11-line `componentSelection` block rejecting JUnit snapshots from the `integTest` configurations. That block is left out here: it was duplicated verbatim across several modules on the source branch, and is landing separately as a single root-build declaration.




