### PR TITLE
Go RPC throughput: one serialization, one decode pass, overlapped paging

### DIFF
--- a/rewrite-go/cmd/rpc/cross_ecosystem_test.go
+++ b/rewrite-go/cmd/rpc/cross_ecosystem_test.go
@@ -35,7 +35,7 @@ type goDelegatingRecipe struct{ recipe.Base }
 
 func (*goDelegatingRecipe) Name() string           { return "org.openrewrite.go.test.Delegating" }
 func (*goDelegatingRecipe) DisplayName() string    { return "Delegating" }
-func (*goDelegatingRecipe) Description() string     { return "Delegates to a Java recipe." }
+func (*goDelegatingRecipe) Description() string    { return "Delegates to a Java recipe." }
 func (*goDelegatingRecipe) JavaRecipeName() string { return "org.openrewrite.java.ChangeType" }
 func (*goDelegatingRecipe) JavaOptions() map[string]any {
 	return map[string]any{
@@ -48,9 +48,13 @@ func (*goDelegatingRecipe) JavaOptions() map[string]any {
 // cross-ecosystem case the host's whole-tree path resolves from the prepared recipeList.
 type goCompositeWithJavaChild struct{ recipe.Base }
 
-func (*goCompositeWithJavaChild) Name() string        { return "org.openrewrite.go.test.CompositeWithJavaChild" }
+func (*goCompositeWithJavaChild) Name() string {
+	return "org.openrewrite.go.test.CompositeWithJavaChild"
+}
 func (*goCompositeWithJavaChild) DisplayName() string { return "Composite with Java child" }
-func (*goCompositeWithJavaChild) Description() string { return "A composite whose child delegates to a Java recipe." }
+func (*goCompositeWithJavaChild) Description() string {
+	return "A composite whose child delegates to a Java recipe."
+}
 func (*goCompositeWithJavaChild) RecipeList() []recipe.Recipe {
 	return []recipe.Recipe{&goDelegatingRecipe{}}
 }

--- a/rewrite-go/cmd/rpc/exported_types_test.go
+++ b/rewrite-go/cmd/rpc/exported_types_test.go
@@ -285,7 +285,7 @@ func TestHandleDependencyTypes_VendorTree(t *testing.T) {
 			byFqn[cls.FullyQualifiedName] = cls
 		}
 	}
-	assert.NotNilf(t,byFqn["example.com/foo.Greeter"], "vendored Greeter not enumerated; got %v", keys(byFqn))
+	assert.NotNilf(t, byFqn["example.com/foo.Greeter"], "vendored Greeter not enumerated; got %v", keys(byFqn))
 }
 
 // A coordinate found in neither the vendor tree nor the module cache is a per-dependency

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1095,16 +1095,22 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 	// to whatever request comes next.
 	outstanding := false
 	drainPage := func() {
-		if outstanding {
-			outstanding = false
+		if !outstanding {
+			return
+		}
+		outstanding = false
+		// A message carrying a method is a request Java initiated, which Go cannot
+		// answer from here; it is read past so the page behind it still arrives.
+		for {
 			msg, err := s.readMessage()
 			if err != nil {
 				s.logger.Printf("Error draining prefetched page: %v", err)
-			} else if msg.Method != "" {
-				// A message carrying a method is a request Java initiated, so the page
-				// is still queued behind it for the next read to take as its own reply.
-				s.logger.Printf("Expected the prefetched GetObject page, got a %s request", msg.Method)
+				return
 			}
+			if msg.Method == "" {
+				return
+			}
+			s.logger.Printf("Expected the prefetched GetObject page, got a %s request", msg.Method)
 		}
 	}
 
@@ -1140,7 +1146,9 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 		// END_OF_OBJECT closes the transfer, so a page carrying it has no successor
 		// to ask for; asking anyway would restart the transfer on the Java side.
 		if len(batch) > 0 && batch[len(batch)-1].State != rpc.EndOfObject {
-			if err = requestPage(); err == nil {
+			if err = requestPage(); err != nil {
+				s.logger.Printf("Error requesting next object page: %v", err)
+			} else {
 				outstanding = true
 			}
 		}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1075,7 +1075,7 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 
 	strIntern := make(map[string]string)
 
-	fetchBatch := func() []rpc.RpcObjectData {
+	requestPage := func() error {
 		reqParams := getObjectRequest{ID: id, SourceFileType: sourceFileType}
 		paramsJSON, _ := json.Marshal(reqParams)
 		rpcReq := map[string]any{
@@ -1085,7 +1085,32 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 			"params":  json.RawMessage(paramsJSON),
 		}
 		body, _ := json.Marshal(rpcReq)
-		_ = s.writeFramed(body)
+		return s.writeFramed(body)
+	}
+
+	// The request for the next page goes out before the current one is handed back,
+	// so Java serializes it while Go is still deserializing what it already has.
+	// At most one request is outstanding, and drainPage below consumes it before
+	// this call returns -- an unread response would otherwise be read as the reply
+	// to whatever request comes next.
+	outstanding := false
+	drainPage := func() {
+		if outstanding {
+			outstanding = false
+			if _, err := s.readMessage(); err != nil {
+				s.logger.Printf("Error draining prefetched page: %v", err)
+			}
+		}
+	}
+
+	fetchBatch := func() []rpc.RpcObjectData {
+		if !outstanding {
+			if err := requestPage(); err != nil {
+				s.logger.Printf("Error requesting object page: %v", err)
+				return nil
+			}
+		}
+		outstanding = false
 
 		resp, err := s.readMessage()
 		if err != nil {
@@ -1107,6 +1132,13 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 			s.logger.Printf("Error parsing response result: %v", err)
 			return nil
 		}
+		// END_OF_OBJECT closes the transfer, so a page carrying it has no successor
+		// to ask for; asking anyway would restart the transfer on the Java side.
+		if len(batch) > 0 && batch[len(batch)-1].State != rpc.EndOfObject {
+			if err = requestPage(); err == nil {
+				outstanding = true
+			}
+		}
 		return batch
 	}
 
@@ -1116,6 +1148,8 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 
 	var obj any
 	func() {
+		// Registered first so it runs last, after the recover below re-panics.
+		defer drainPage()
 		// A panic mid-receive leaves Go's per-id baseline diverged from Java's:
 		// Java records remoteObjects[id] when it generates the diff, so its next
 		// send would be a CHANGE delta against a baseline Go never finished

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -1097,8 +1097,13 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 	drainPage := func() {
 		if outstanding {
 			outstanding = false
-			if _, err := s.readMessage(); err != nil {
+			msg, err := s.readMessage()
+			if err != nil {
 				s.logger.Printf("Error draining prefetched page: %v", err)
+			} else if msg.Method != "" {
+				// A message carrying a method is a request Java initiated, so the page
+				// is still queued behind it for the next read to take as its own reply.
+				s.logger.Printf("Expected the prefetched GetObject page, got a %s request", msg.Method)
 			}
 		}
 	}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -234,7 +234,7 @@ func newServer(cfg serverConfig) *server {
 		remoteObjects:           make(map[string]any),
 		localRefs:               rpc.NewReferenceMap(),
 		inProgressGetObjects:    make(map[string]*getObjectTransfer),
-		pendingDependencyTypes:       make(map[string][]rpc.RpcObjectData),
+		pendingDependencyTypes:  make(map[string][]rpc.RpcObjectData),
 		reverseRemoteObjects:    make(map[string]any),
 		reverseRemoteRefs:       make(map[int]any),
 		reverseTypePool:         make(map[string]java.JavaType),
@@ -434,8 +434,26 @@ func (s *server) writeMessage(resp *jsonRPCResponse) error {
 	if err != nil {
 		return err
 	}
-	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))
-	_, err = s.writer.Write(append([]byte(header), body...))
+	return s.writeFramed(body)
+}
+
+// Frame buffers are pooled rather than held on the server: a framed write is
+// reachable from the request loop and from a transfer goroutine, so a shared
+// scratch buffer would race.
+var framePool = sync.Pool{New: func() any { b := make([]byte, 0, 1<<16); return &b }}
+
+// Writes one Content-Length framed message in a single Write. The frame is
+// assembled in a pooled buffer, so the payload is not copied into a freshly
+// allocated one, and the header does not cost a second write.
+func (s *server) writeFramed(body []byte) error {
+	bp := framePool.Get().(*[]byte)
+	b := append((*bp)[:0], "Content-Length: "...)
+	b = strconv.AppendInt(b, int64(len(body)), 10)
+	b = append(b, '\r', '\n', '\r', '\n')
+	b = append(b, body...)
+	_, err := s.writer.Write(b)
+	*bp = b
+	framePool.Put(bp)
 	return err
 }
 
@@ -1067,8 +1085,7 @@ func (s *server) getObjectFromJava(id string, sourceFileType string) any {
 			"params":  json.RawMessage(paramsJSON),
 		}
 		body, _ := json.Marshal(rpcReq)
-		header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))
-		s.writer.Write(append([]byte(header), body...))
+		_ = s.writeFramed(body)
 
 		resp, err := s.readMessage()
 		if err != nil {

--- a/rewrite-go/cmd/rpc/metrics_test.go
+++ b/rewrite-go/cmd/rpc/metrics_test.go
@@ -26,8 +26,9 @@ import (
 	"sync"
 	"testing"
 	"time"
-	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // newTestServer wires a server pointed at a temp metrics CSV. Cleanup is

--- a/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
+++ b/rewrite-go/cmd/rpc/parse_project_gitignore_test.go
@@ -67,7 +67,7 @@ func TestParseProjectExcludesGitIgnored(t *testing.T) {
 		}
 	}
 	for _, want := range []string{"probe.go", "pkg/build/legit.go"} {
-		assert.Truef(t,parsed[want], "expected %q to be parsed, but it was not", want)
+		assert.Truef(t, parsed[want], "expected %q to be parsed, but it was not", want)
 	}
 	for _, unwanted := range []string{"build/generated/rootbuild.go", "sub/build/generated/subbuild.go"} {
 		assert.Falsef(t, parsed[unwanted], "expected gitignored %q to be excluded, but it was parsed", unwanted)

--- a/rewrite-go/cmd/rpc/receive_resilience_test.go
+++ b/rewrite-go/cmd/rpc/receive_resilience_test.go
@@ -21,23 +21,51 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"path/filepath"
 	"testing"
 	"github.com/stretchr/testify/require"
 )
+
+func frame(t *testing.T, msg map[string]any) []byte {
+	t.Helper()
+	body, err := json.Marshal(msg)
+	require.NoError(t, err, "marshal message")
+	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))), body...)
+}
 
 // frameReverseGetObjectReply renders one Content-Length framed JSON-RPC
 // response carrying `result` — the shape Java sends back when Go issues a
 // reverse GetObject during Print/Visit.
 func frameReverseGetObjectReply(t *testing.T, result any) []byte {
 	t.Helper()
-	body, err := json.Marshal(map[string]any{
+	return frame(t, map[string]any{
 		"jsonrpc": "2.0",
 		"id":      "go-GetObject",
 		"result":  result,
 	})
-	require.NoError(t, err, "marshal reply")
-	return append([]byte(fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))), body...)
+}
+
+// frameReverseRequest renders a request Java initiates, as opposed to a reply to Go's.
+func frameReverseRequest(t *testing.T, method string) []byte {
+	t.Helper()
+	return frame(t, map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "java-1",
+		"method":  method,
+		"params":  map[string]any{},
+	})
+}
+
+// newResilienceTestServer returns a server with its log captured, since the
+// receive paths report desync by logging.
+func newResilienceTestServer(t *testing.T) (*server, *bytes.Buffer) {
+	t.Helper()
+	s := newServer(serverConfig{logFile: filepath.Join(t.TempDir(), "server.log")})
+	t.Cleanup(s.closeMetrics)
+	var logs bytes.Buffer
+	s.logger = log.New(&logs, "", 0)
+	return s, &logs
 }
 
 // TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs reproduces the
@@ -51,9 +79,7 @@ func frameReverseGetObjectReply(t *testing.T, result any) []byte {
 // only on Reset), so discarding Go's would make Java's bare {ref:N} look-ups
 // fail with "received reference to unknown object: N".
 func TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs(t *testing.T) {
-	dir := t.TempDir()
-	s := newServer(serverConfig{logFile: filepath.Join(dir, "server.log")})
-	t.Cleanup(s.closeMetrics)
+	s, logs := newResilienceTestServer(t)
 
 	// Java's two scripted replies on the reverse GetObject stream:
 	//  1) a bare reference to an object Go never received -> panics mid-receive
@@ -113,4 +139,24 @@ func TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs(t *testing.T) {
 	if s.reverseRemoteObjects[id] != "package main\n" {
 		t.Errorf("transfer 2: baseline should be repopulated, got %#v", s.reverseRemoteObjects[id])
 	}
+	require.NotContains(t, logs.String(), "Expected the prefetched GetObject page",
+		"draining Java's own reply is the ordinary case and must not be reported as a desync")
+}
+
+func TestDrainPageReportsAMessageThatIsNotTheGetObjectReply(t *testing.T) {
+	s, logs := newResilienceTestServer(t)
+
+	// A bare ref to an object Go never received panics mid-receive, so the
+	// deferred drain runs against whatever comes next — here a Visit request
+	// Java initiated rather than the page Go prefetched.
+	stream := append(
+		frameReverseGetObjectReply(t, []map[string]any{{"state": "ADD", "ref": 7}}),
+		frameReverseRequest(t, "Visit")...,
+	)
+	s.reader = bufio.NewReader(bytes.NewReader(stream))
+	s.writer = &bytes.Buffer{}
+
+	require.Panics(t, func() { s.getObjectFromJava("tree-X", "") })
+	require.Contains(t, logs.String(), "Expected the prefetched GetObject page, got a Visit request",
+		"a swallowed request drops Java's call and leaves the page for a later one to misread")
 }

--- a/rewrite-go/cmd/rpc/receive_resilience_test.go
+++ b/rewrite-go/cmd/rpc/receive_resilience_test.go
@@ -24,6 +24,7 @@ import (
 	"log"
 	"path/filepath"
 	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/rewrite-go/cmd/rpc/receive_resilience_test.go
+++ b/rewrite-go/cmd/rpc/receive_resilience_test.go
@@ -144,20 +144,32 @@ func TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs(t *testing.T) {
 		"draining Java's own reply is the ordinary case and must not be reported as a desync")
 }
 
-func TestDrainPageReportsAMessageThatIsNotTheGetObjectReply(t *testing.T) {
+func TestDrainPageReadsPastARequestToReachTheGetObjectReply(t *testing.T) {
 	s, logs := newResilienceTestServer(t)
 
 	// A bare ref to an object Go never received panics mid-receive, so the
 	// deferred drain runs against whatever comes next — here a Visit request
-	// Java initiated rather than the page Go prefetched.
+	// Java initiated ahead of the page Go prefetched.
 	stream := append(
 		frameReverseGetObjectReply(t, []map[string]any{{"state": "ADD", "ref": 7}}),
-		frameReverseRequest(t, "Visit")...,
+		append(
+			frameReverseRequest(t, "Visit"),
+			append(
+				frameReverseGetObjectReply(t, []map[string]any{{"state": "END_OF_OBJECT"}}),
+				frameReverseGetObjectReply(t, []map[string]any{
+					{"state": "ADD", "value": "package main\n"},
+					{"state": "END_OF_OBJECT"},
+				})...,
+			)...,
+		)...,
 	)
 	s.reader = bufio.NewReader(bytes.NewReader(stream))
 	s.writer = &bytes.Buffer{}
 
-	require.Panics(t, func() { s.getObjectFromJava("tree-X", "") })
-	require.Contains(t, logs.String(), "Expected the prefetched GetObject page, got a Visit request",
-		"a swallowed request drops Java's call and leaves the page for a later one to misread")
+	const id = "tree-X"
+	require.Panics(t, func() { s.getObjectFromJava(id, "") })
+	require.Contains(t, logs.String(), "Expected the prefetched GetObject page, got a Visit request")
+
+	// The drain having consumed the page, the next transfer reads its own reply.
+	require.Equal(t, "package main\n", s.getObjectFromJava(id, ""))
 }

--- a/rewrite-go/cmd/rpc/receive_resilience_test.go
+++ b/rewrite-go/cmd/rpc/receive_resilience_test.go
@@ -59,13 +59,19 @@ func TestGetObjectFromJavaPanicResetsBaselineButKeepsRefs(t *testing.T) {
 	//  1) a bare reference to an object Go never received -> panics mid-receive
 	//     ("received reference to unknown object: 7"), a documented cascade
 	//     signature.
-	//  2) a clean full ADD of a simple value -> the follow-up request.
+	//  2) the page Go asks for ahead of the panic, since reply 1 does not close
+	//     the transfer; the failed transfer drains it rather than leaving it for
+	//     the next request to misread.
+	//  3) a clean full ADD of a simple value -> the follow-up request.
 	stream := append(
 		frameReverseGetObjectReply(t, []map[string]any{{"state": "ADD", "ref": 7}}),
-		frameReverseGetObjectReply(t, []map[string]any{
-			{"state": "ADD", "value": "package main\n"},
-			{"state": "END_OF_OBJECT"},
-		})...,
+		append(
+			frameReverseGetObjectReply(t, []map[string]any{{"state": "END_OF_OBJECT"}}),
+			frameReverseGetObjectReply(t, []map[string]any{
+				{"state": "ADD", "value": "package main\n"},
+				{"state": "END_OF_OBJECT"},
+			})...,
+		)...,
 	)
 	s.reader = bufio.NewReader(bytes.NewReader(stream))
 	s.writer = &bytes.Buffer{} // the GetObject requests Go writes are irrelevant here

--- a/rewrite-go/pkg/recipe/installer/installer_test.go
+++ b/rewrite-go/pkg/recipe/installer/installer_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/rewrite-go/pkg/recipe/registry_test.go
+++ b/rewrite-go/pkg/recipe/registry_test.go
@@ -18,8 +18,9 @@ package recipe
 
 import (
 	"testing"
-	"github.com/stretchr/testify/require"
+
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // leafRecipe is a minimal standalone recipe used as a composite child.

--- a/rewrite-go/pkg/rpc/decode_batch_edge_test.go
+++ b/rewrite-go/pkg/rpc/decode_batch_edge_test.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/rewrite-go/pkg/rpc/numeric_wire_test.go
+++ b/rewrite-go/pkg/rpc/numeric_wire_test.go
@@ -48,7 +48,11 @@ func TestMarshalKeepsFloatsFloating(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			// when
-			data, err := json.Marshal(RpcObjectData{State: Change, Value: tc.value})
+			var out []RpcObjectData
+			q := NewSendQueue(1000, func(b []RpcObjectData) { out = append(out, b...) }, NewReferenceMap())
+			q.Put(RpcObjectData{State: Change, Value: tc.value})
+			q.Flush()
+			data, err := json.Marshal(out[0])
 
 			// then
 			require.NoError(t, err)
@@ -106,7 +110,12 @@ func TestDecodeBatchCanonicalizesNestedNumbers(t *testing.T) {
 func TestNumbersSurviveTheReturnLeg(t *testing.T) {
 	for _, value := range []any{int64(1), int64(math.MaxInt64), bigWire("300000000000000000000"), 3e20, 1.5, 3.0} {
 		// when
-		data, err := json.Marshal([]RpcObjectData{{State: Change, Value: value}})
+		// Through the queue, which is where a value is shaped for the wire.
+		var out []RpcObjectData
+		q := NewSendQueue(1000, func(b []RpcObjectData) { out = append(out, b...) }, NewReferenceMap())
+		q.Put(RpcObjectData{State: Change, Value: value})
+		q.Flush()
+		data, err := json.Marshal(out)
 		require.NoError(t, err)
 		batch, err := DecodeBatch(data, nil)
 

--- a/rewrite-go/pkg/rpc/reference_test.go
+++ b/rewrite-go/pkg/rpc/reference_test.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/rewrite-go/pkg/rpc/rpc_object_data.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data.go
@@ -111,19 +111,132 @@ func DecodeBatch(data []byte, intern map[string]string) ([]RpcObjectData, error)
 		return nil, fmt.Errorf("expected JSON array, got %v", open)
 	}
 	batch := make([]RpcObjectData, 0, len(data)/40+1)
-	var w wireObjectData
 	for dec.More() {
-		w = wireObjectData{}
-		if err := dec.Decode(&w); err != nil {
+		d, err := decodeObjectData(dec, intern)
+		if err != nil {
 			return nil, err
-		}
-		d := RpcObjectData{State: parseState(w.State), ValueType: w.ValueType, Ref: w.Ref}
-		if w.Value != nil {
-			d.Value = decodeValue(w.Value, intern)
 		}
 		batch = append(batch, d)
 	}
 	return batch, nil
+}
+
+// Reads one message straight off the token stream. Binding into a struct whose value
+// is an `any` materializes a map/slice tree that a second walk then has to revisit to
+// intern strings and give numbers the type their JSON shape implies; the tokens carry
+// enough to build the final value in one pass.
+func decodeObjectData(dec *json.Decoder, tbl map[string]string) (RpcObjectData, error) {
+	var d RpcObjectData
+	t, err := dec.Token()
+	if err != nil {
+		return d, err
+	}
+	if delim, ok := t.(json.Delim); !ok || delim != '{' {
+		return d, fmt.Errorf("expected JSON object, got %v", t)
+	}
+	for dec.More() {
+		kt, err := dec.Token()
+		if err != nil {
+			return d, err
+		}
+		key, ok := kt.(string)
+		if !ok {
+			return d, fmt.Errorf("expected member name, got %v", kt)
+		}
+		switch key {
+		case "state":
+			v, err := dec.Token()
+			if err != nil {
+				return d, err
+			}
+			name, ok := v.(string)
+			if !ok {
+				return d, fmt.Errorf("state is not a string: %v", v)
+			}
+			d.State = parseState(name)
+		case "valueType":
+			v, err := dec.Token()
+			if err != nil {
+				return d, err
+			}
+			if name, ok := v.(string); ok {
+				name = internString(name, tbl)
+				d.ValueType = &name
+			}
+		case "ref":
+			v, err := dec.Token()
+			if err != nil {
+				return d, err
+			}
+			if n, ok := v.(json.Number); ok {
+				ref, err := strconv.Atoi(n.String())
+				if err != nil {
+					return d, err
+				}
+				d.Ref = &ref
+			}
+		case "value":
+			if d.Value, err = decodeTokenValue(dec, tbl); err != nil {
+				return d, err
+			}
+		default:
+			var skipped any
+			if err := dec.Decode(&skipped); err != nil {
+				return d, err
+			}
+		}
+	}
+	if _, err := dec.Token(); err != nil { // closing brace
+		return d, err
+	}
+	return d, nil
+}
+
+func decodeTokenValue(dec *json.Decoder, tbl map[string]string) (any, error) {
+	t, err := dec.Token()
+	if err != nil {
+		return nil, err
+	}
+	switch v := t.(type) {
+	case json.Delim:
+		switch v {
+		case '[':
+			arr := []any{}
+			for dec.More() {
+				e, err := decodeTokenValue(dec, tbl)
+				if err != nil {
+					return nil, err
+				}
+				arr = append(arr, e)
+			}
+			_, err = dec.Token() // closing bracket
+			return arr, err
+		case '{':
+			m := map[string]any{}
+			for dec.More() {
+				kt, err := dec.Token()
+				if err != nil {
+					return nil, err
+				}
+				k, ok := kt.(string)
+				if !ok {
+					return nil, fmt.Errorf("expected member name, got %v", kt)
+				}
+				if m[internString(k, tbl)], err = decodeTokenValue(dec, tbl); err != nil {
+					return nil, err
+				}
+			}
+			_, err = dec.Token() // closing brace
+			return m, err
+		}
+		return nil, fmt.Errorf("unexpected delimiter %v", v)
+	case string:
+		return internString(v, tbl), nil
+	case json.Number:
+		return decodeNumber(v), nil
+	default:
+		return v, nil
+	}
 }
 
 func decodeValue(v any, tbl map[string]string) any {

--- a/rewrite-go/pkg/rpc/rpc_object_data.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data.go
@@ -263,11 +263,30 @@ func decodeValue(v any, tbl map[string]string) any {
 // The remote's numbers arrive as text (see UseNumber above) and take the Go type
 // their JSON shape implies, so a value keeps both its kind and its full precision
 // across a round trip.
+// Converting an int64 to an interface allocates unless the runtime holds the value
+// statically, which it does only for 0..255. List positions are small and dominated
+// by ADDED_LIST_ITEM, so the range that covers them is pre-boxed once.
+var boxedInts = func() [1025]any {
+	var b [1025]any
+	for i := range b {
+		b[i] = int64(i - 1)
+	}
+	return b
+}()
+
+func boxInt(v int64) any {
+	// Bounded before the shift: v+1 overflows for MaxInt64 and would index negatively.
+	if v >= -1 && v < int64(len(boxedInts))-1 {
+		return boxedInts[v+1]
+	}
+	return v
+}
+
 func decodeNumber(n json.Number) any {
 	s := n.String()
 	if !strings.ContainsAny(s, ".eE") {
 		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
-			return i
+			return boxInt(i)
 		}
 		if i, ok := new(big.Int).SetString(s, 10); ok {
 			return i

--- a/rewrite-go/pkg/rpc/rpc_object_data.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data.go
@@ -87,13 +87,6 @@ func wireNumber(v any) any {
 	return json.Number(s)
 }
 
-type wireObjectData struct {
-	State     string  `json:"state"`
-	ValueType *string `json:"valueType"`
-	Value     any     `json:"value"`
-	Ref       *int    `json:"ref"`
-}
-
 func DecodeBatch(data []byte, intern map[string]string) ([]RpcObjectData, error) {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.UseNumber()
@@ -236,27 +229,6 @@ func decodeTokenValue(dec *json.Decoder, tbl map[string]string) (any, error) {
 		return decodeNumber(v), nil
 	default:
 		return v, nil
-	}
-}
-
-func decodeValue(v any, tbl map[string]string) any {
-	switch x := v.(type) {
-	case string:
-		return internString(x, tbl)
-	case json.Number:
-		return decodeNumber(x)
-	case []any:
-		for i := range x {
-			x[i] = decodeValue(x[i], tbl)
-		}
-		return x
-	case map[string]any:
-		for k, val := range x {
-			x[k] = decodeValue(val, tbl)
-		}
-		return x
-	default:
-		return v
 	}
 }
 

--- a/rewrite-go/pkg/rpc/rpc_object_data.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data.go
@@ -36,6 +36,12 @@ const (
 	EndOfObject
 )
 
+// Text, not JSON: the encoder quotes and escapes this directly, where a Marshaler's
+// JSON bytes would have to be reparsed and re-emitted to splice into the stream.
+func (s State) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
 func (s State) String() string {
 	switch s {
 	case NoChange:
@@ -62,21 +68,6 @@ type RpcObjectData struct {
 	ValueType *string `json:"valueType,omitempty"`
 	Value     any     `json:"value,omitempty"`
 	Ref       *int    `json:"ref,omitempty"`
-}
-
-func (d RpcObjectData) MarshalJSON() ([]byte, error) {
-	type Alias struct {
-		State     string  `json:"state"`
-		ValueType *string `json:"valueType,omitempty"`
-		Value     any     `json:"value,omitempty"`
-		Ref       *int    `json:"ref,omitempty"`
-	}
-	return json.Marshal(Alias{
-		State:     d.State.String(),
-		ValueType: d.ValueType,
-		Value:     wireNumber(d.Value),
-		Ref:       d.Ref,
-	})
 }
 
 // A value that carries no valueType is bound on the JVM side by its JSON shape,

--- a/rewrite-go/pkg/rpc/rpc_object_data_test.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data_test.go
@@ -19,6 +19,7 @@ package rpc
 import (
 	"testing"
 	"unsafe"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/rewrite-go/pkg/rpc/rpc_object_data_wire_test.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data_wire_test.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Pins the exact bytes each message shape serialises to, so the encoding can be
+// made cheaper without moving the wire. A peer binds a value with no valueType by
+// its JSON shape, so the integer/float distinction below is load-bearing.
+func TestRpcObjectDataWireFormat(t *testing.T) {
+	vt := "org.openrewrite.java.tree.J$Identifier"
+	ref := 7
+
+	cases := []struct {
+		name string
+		in   RpcObjectData
+		want string
+	}{
+		{"state only", RpcObjectData{State: NoChange}, `{"state":"NO_CHANGE"}`},
+		{"delete", RpcObjectData{State: Delete}, `{"state":"DELETE"}`},
+		{"value type", RpcObjectData{State: Add, ValueType: &vt}, `{"state":"ADD","valueType":"` + vt + `"}`},
+		{"ref", RpcObjectData{State: Add, Ref: &ref}, `{"state":"ADD","ref":7}`},
+		{"string value", RpcObjectData{State: Add, Value: "A"}, `{"state":"ADD","value":"A"}`},
+		{"list positions", RpcObjectData{State: Change, Value: []any{0, -1, 2}}, `{"state":"CHANGE","value":[0,-1,2]}`},
+		{"empty positions", RpcObjectData{State: Change, Value: []any{}}, `{"state":"CHANGE","value":[]}`},
+		{"bool value", RpcObjectData{State: Add, Value: true}, `{"state":"ADD","value":true}`},
+		{"int value", RpcObjectData{State: Add, Value: 42}, `{"state":"ADD","value":42}`},
+		{"shaped float", RpcObjectData{State: Add, Value: json.Number("3.0")}, `{"state":"ADD","value":3.0}`},
+		{"map value", RpcObjectData{State: Add, Value: map[string]any{"b": 1, "a": "x"}}, `{"state":"ADD","value":{"a":"x","b":1}}`},
+		{"everything", RpcObjectData{State: Change, ValueType: &vt, Value: "v", Ref: &ref},
+			`{"state":"CHANGE","valueType":"` + vt + `","value":"v","ref":7}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := json.Marshal(tc.in)
+			require.NoError(t, err)
+			require.JSONEq(t, tc.want, string(got))
+			require.Equal(t, tc.want, string(got), "byte-for-byte, not just semantically")
+		})
+	}
+}

--- a/rewrite-go/pkg/rpc/rpc_object_data_wire_test.go
+++ b/rewrite-go/pkg/rpc/rpc_object_data_wire_test.go
@@ -54,7 +54,6 @@ func TestRpcObjectDataWireFormat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := json.Marshal(tc.in)
 			require.NoError(t, err)
-			require.JSONEq(t, tc.want, string(got))
 			require.Equal(t, tc.want, string(got), "byte-for-byte, not just semantically")
 		})
 	}

--- a/rewrite-go/pkg/rpc/send_list_test.go
+++ b/rewrite-go/pkg/rpc/send_list_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package rpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func drainList(after, before []any) []RpcObjectData {
+	var got []RpcObjectData
+	q := NewSendQueue(1000, func(batch []RpcObjectData) { got = append(got, batch...) }, NewReferenceMap())
+	q.sendList(after, before, func(v any) any { return v }, nil, false)
+	q.Flush()
+	return got
+}
+
+func states(batch []RpcObjectData) []State {
+	s := make([]State, len(batch))
+	for i, d := range batch {
+		s[i] = d.State
+	}
+	return s
+}
+
+// The positions array is what lets a reorder cost one integer per element instead of
+// re-sending the elements themselves; an event stream without a move event cannot.
+func TestSendList_ReorderedElementsAreRepositionedNotResent(t *testing.T) {
+	got := drainList([]any{"C", "A", "B"}, []any{"A", "B", "C"})
+
+	require.Equal(t, []State{Change, Change, NoChange, NoChange, NoChange}, states(got))
+	require.Equal(t, []any{2, 0, 1}, got[1].Value)
+}
+
+func TestSendList_EveryElementIsAddedWhenTheBeforeListIsEmpty(t *testing.T) {
+	got := drainList([]any{"A", "B"}, []any{})
+
+	require.Equal(t, []State{Change, Change, Add, Add}, states(got))
+	require.Equal(t, []any{AddedListItem, AddedListItem}, got[1].Value)
+	require.Equal(t, "A", got[2].Value)
+	require.Equal(t, "B", got[3].Value)
+}
+
+func TestSendList_MixedAddsAndRemovals(t *testing.T) {
+	got := drainList([]any{"A", "E", "F", "C"}, []any{"A", "B", "C", "D"})
+
+	require.Equal(t, []State{Change, Change, NoChange, Add, Add, NoChange}, states(got))
+	require.Equal(t, []any{0, AddedListItem, AddedListItem, 2}, got[1].Value)
+}
+
+func TestSendList_UnchangedListIsNoChange(t *testing.T) {
+	before := []any{"A", "B"}
+
+	require.Equal(t, []State{NoChange}, states(drainList(before, before)))
+}

--- a/rewrite-go/pkg/rpc/send_queue.go
+++ b/rewrite-go/pkg/rpc/send_queue.go
@@ -59,6 +59,11 @@ func (q *SendQueue) DiscardNewReferences() {
 }
 
 func (q *SendQueue) Put(data RpcObjectData) {
+	// Every message reaching the wire is shaped here, which is what lets RpcObjectData
+	// stay a plain tagged struct the encoder writes field by field. Construct sendable
+	// messages only through Put: a whole float marshaled without this reads as an
+	// integer on the far side (see wireNumber).
+	data.Value = wireNumber(data.Value)
 	q.batch = append(q.batch, data)
 	if len(q.batch) == q.batchSize {
 		q.Flush()

--- a/rewrite-go/pkg/rpc/send_queue.go
+++ b/rewrite-go/pkg/rpc/send_queue.go
@@ -154,29 +154,34 @@ func (q *SendQueue) sendList(after, before []any, id func(any) any, onChange fun
 			return
 		}
 
-		// Build before index map
-		beforeIdx := make(map[any]int)
-		if before != nil {
+		positions := make([]any, len(after))
+		if len(before) == 0 {
+			// Every element is an addition, so the positions are a constant that needs
+			// neither an index map nor a key computed per element.
+			for i := range positions {
+				positions[i] = AddedListItem
+			}
+		} else {
+			beforeIdx := make(map[any]int, len(before))
 			for i, b := range before {
 				beforeIdx[id(b)] = i
 			}
-		}
-
-		// Send positions
-		positions := make([]any, len(after))
-		for i, a := range after {
-			if pos, ok := beforeIdx[id(a)]; ok {
-				positions[i] = pos
-			} else {
-				positions[i] = AddedListItem
+			for i, a := range after {
+				if pos, ok := beforeIdx[id(a)]; ok {
+					positions[i] = pos
+				} else {
+					positions[i] = AddedListItem
+				}
 			}
 		}
 		q.Put(RpcObjectData{State: Change, Value: positions})
 
 		// Send each item
-		for _, a := range after {
-			aid := id(a)
-			pos, existed := beforeIdx[aid]
+		for i, a := range after {
+			pos, existed := 0, false
+			if p, ok := positions[i].(int); ok && p != AddedListItem {
+				pos, existed = p, true
+			}
 			var onChangeRun func(any)
 			if onChange != nil {
 				item := a

--- a/rewrite-go/pkg/rpc/send_queue_ref_test.go
+++ b/rewrite-go/pkg/rpc/send_queue_ref_test.go
@@ -18,6 +18,7 @@ package rpc
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/rewrite-go/pkg/template/placeholder_test.go
+++ b/rewrite-go/pkg/template/placeholder_test.go
@@ -18,6 +18,7 @@ package template
 
 import (
 	"testing"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/rewrite-go/pkg/test/java_rpc.go
+++ b/rewrite-go/pkg/test/java_rpc.go
@@ -32,6 +32,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
 	"github.com/stretchr/testify/require"
 )
 

--- a/rewrite-go/pkg/tree/java/j.go
+++ b/rewrite-go/pkg/tree/java/j.go
@@ -925,9 +925,9 @@ func (n *ForEachControl) WithMarkers(markers Markers) *ForEachControl {
 // and the case block. Go's optional init clause (`switch x := f(); x {}`) has no
 // slot here — it lives on a wrapping golang.StatementWithInit instead.
 type Switch struct {
-	ID      uuid.UUID
-	Prefix  Space
-	Markers Markers
+	ID       uuid.UUID
+	Prefix   Space
+	Markers  Markers
 	Selector *ControlParentheses // selector expression (matching J.Switch); Go has no parens, so the wrapper carries no whitespace and the inner element holds the tag. Tree.Element is an Empty for a tagless `switch {}`. Tree.After = space before {
 	Body     *Block              // contains Case statements
 }

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcThroughputTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcThroughputTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.golang.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Measurement harness, not a correctness test: parse and print exercise opposite
+ * directions of the wire, so one run measures both peers.
+ */
+@Timeout(value = 1800, unit = TimeUnit.SECONDS)
+class GoRpcThroughputTest {
+
+    @TempDir
+    Path tempDir;
+
+    static final com.sun.management.ThreadMXBean ALLOC =
+            (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    static {
+        ThreadMXBean t = ManagementFactory.getThreadMXBean();
+        if (t.isThreadCpuTimeSupported() && !t.isThreadCpuTimeEnabled()) {
+            t.setThreadCpuTimeEnabled(true);
+        }
+    }
+
+    /**
+     * Summed across threads because a send runs on a traversal thread. Both counters
+     * are cumulative per thread, so the difference of two readings is the work between.
+     */
+    static long cpuNanos() {
+        ThreadMXBean t = ManagementFactory.getThreadMXBean();
+        long total = 0;
+        for (long id : t.getAllThreadIds()) {
+            long c = t.getThreadCpuTime(id);
+            if (c > 0) {
+                total += c;
+            }
+        }
+        return total;
+    }
+
+    static long allocated() {
+        long total = 0;
+        for (long id : ManagementFactory.getThreadMXBean().getAllThreadIds()) {
+            long b = ALLOC.getThreadAllocatedBytes(id);
+            if (b > 0) {
+                total += b;
+            }
+        }
+        return total;
+    }
+
+    @BeforeEach
+    void before() {
+        // Tracing is deliberately off: it logs every batch, which is the thing being timed.
+        GoRewriteRpc.setFactory(GoRewriteRpc.builder()
+                .goBinaryPath(Paths.get("build/rewrite-go-rpc").toAbsolutePath())
+                .log(tempDir.resolve("go-rpc.log")));
+    }
+
+    @AfterEach
+    void after() {
+        GoRewriteRpc.shutdownCurrent();
+    }
+
+    @Test
+    void parseThenPrintOwnSources() {
+        Path project = Paths.get("").toAbsolutePath();
+        List<String> exclusions = List.of("**/vendor/**", "**/build/**");
+
+        // Parsing is measured in cycles too, because Java requests a page per batch here
+        // and so is the side that waits, which print does not exercise. Each cycle resets
+        // first, so the trees a peer retains for one cycle do not weigh on the next.
+        for (int cycle = 0; cycle < 3; cycle++) {
+            GoRewriteRpc.getOrStart().reset();
+            List<SourceFile> files = parse(project, exclusions, "cycle " + cycle);
+            printAfterReset(files, "cycle " + cycle);
+        }
+    }
+
+    List<SourceFile> parse(Path project, List<String> exclusions, String label) {
+        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        List<SourceFile> files = GoRewriteRpc.getOrStart()
+                .parseProject(project, exclusions, new InMemoryExecutionContext(Throwable::printStackTrace))
+                .collect(toList());
+        report("PARSE", label, files.size(), nanos, cpu, alloc, 0);
+        return files;
+    }
+
+    void printAfterReset(List<SourceFile> files, String label) {
+        // Reset drops the peer's view of every tree, so each print that follows makes
+        // the peer fetch it back, which is what exercises its receive path.
+        GoRewriteRpc.getOrStart().reset();
+
+        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        long chars = 0;
+        for (SourceFile f : files) {
+            chars += GoRewriteRpc.getOrStart().print(f).length();
+        }
+        report("PRINT", label, files.size(), nanos, cpu, alloc, chars);
+    }
+
+    static void report(String phase, String label, int files, long startNanos, long startCpu, long startAlloc, long chars) {
+        System.out.printf("%s  %-10s %4d files  wall %,6d ms  jvmCpu %,6d ms  %,15d bytes%s%n",
+                phase, label, files,
+                (System.nanoTime() - startNanos) / 1_000_000,
+                (cpuNanos() - startCpu) / 1_000_000,
+                allocated() - startAlloc,
+                chars == 0 ? "" : String.format("  %,d chars", chars));
+    }
+}

--- a/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcThroughputTest.java
+++ b/rewrite-go/src/integTest/java/org/openrewrite/golang/rpc/GoRpcThroughputTest.java
@@ -27,8 +27,11 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.LongUnaryOperator;
 
 import static java.util.stream.Collectors.toList;
 
@@ -53,28 +56,35 @@ class GoRpcThroughputTest {
     }
 
     /**
-     * Summed across threads because a send runs on a traversal thread. Both counters
-     * are cumulative per thread, so the difference of two readings is the work between.
+     * Kept per thread because a send runs on a traversal thread, and the live set changes
+     * within a phase: totalling first would let a thread that exits mid-phase subtract the
+     * baseline it contributed. Both counters are cumulative per thread.
      */
-    static long cpuNanos() {
+    static Map<Long, Long> cpuNanos() {
         ThreadMXBean t = ManagementFactory.getThreadMXBean();
-        long total = 0;
-        for (long id : t.getAllThreadIds()) {
-            long c = t.getThreadCpuTime(id);
-            if (c > 0) {
-                total += c;
-            }
-        }
-        return total;
+        return byThread(t.getAllThreadIds(), t::getThreadCpuTime);
     }
 
-    static long allocated() {
-        long total = 0;
-        for (long id : ManagementFactory.getThreadMXBean().getAllThreadIds()) {
-            long b = ALLOC.getThreadAllocatedBytes(id);
-            if (b > 0) {
-                total += b;
+    static Map<Long, Long> allocated() {
+        return byThread(ManagementFactory.getThreadMXBean().getAllThreadIds(), ALLOC::getThreadAllocatedBytes);
+    }
+
+    static Map<Long, Long> byThread(long[] ids, LongUnaryOperator counter) {
+        Map<Long, Long> reading = new HashMap<>();
+        for (long id : ids) {
+            long c = counter.applyAsLong(id);
+            if (c > 0) {
+                reading.put(id, c);
             }
+        }
+        return reading;
+    }
+
+    /** Work a thread did between the two readings; one absent from the first started inside them. */
+    static long since(Map<Long, Long> start, Map<Long, Long> end) {
+        long total = 0;
+        for (Map.Entry<Long, Long> e : end.entrySet()) {
+            total += e.getValue() - start.getOrDefault(e.getKey(), 0L);
         }
         return total;
     }
@@ -108,7 +118,8 @@ class GoRpcThroughputTest {
     }
 
     List<SourceFile> parse(Path project, List<String> exclusions, String label) {
-        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        Map<Long, Long> cpu = cpuNanos(), alloc = allocated();
+        long nanos = System.nanoTime();
         List<SourceFile> files = GoRewriteRpc.getOrStart()
                 .parseProject(project, exclusions, new InMemoryExecutionContext(Throwable::printStackTrace))
                 .collect(toList());
@@ -121,7 +132,8 @@ class GoRpcThroughputTest {
         // the peer fetch it back, which is what exercises its receive path.
         GoRewriteRpc.getOrStart().reset();
 
-        long cpu = cpuNanos(), alloc = allocated(), nanos = System.nanoTime();
+        Map<Long, Long> cpu = cpuNanos(), alloc = allocated();
+        long nanos = System.nanoTime();
         long chars = 0;
         for (SourceFile f : files) {
             chars += GoRewriteRpc.getOrStart().print(f).length();
@@ -129,12 +141,12 @@ class GoRpcThroughputTest {
         report("PRINT", label, files.size(), nanos, cpu, alloc, chars);
     }
 
-    static void report(String phase, String label, int files, long startNanos, long startCpu, long startAlloc, long chars) {
+    static void report(String phase, String label, int files, long startNanos, Map<Long, Long> startCpu, Map<Long, Long> startAlloc, long chars) {
         System.out.printf("%s  %-10s %4d files  wall %,6d ms  jvmCpu %,6d ms  %,15d bytes%s%n",
                 phase, label, files,
                 (System.nanoTime() - startNanos) / 1_000_000,
-                (cpuNanos() - startCpu) / 1_000_000,
-                allocated() - startAlloc,
+                since(startCpu, cpuNanos()) / 1_000_000,
+                since(startAlloc, allocated()),
                 chars == 0 ? "" : String.format("  %,d chars", chars));
     }
 }

--- a/rewrite-go/test/multi_file_package_test.go
+++ b/rewrite-go/test/multi_file_package_test.go
@@ -41,7 +41,7 @@ func TestParsePackageResolvesCrossFileSymbols(t *testing.T) {
 	require.Len(t, cus, 2, "expected 2 CUs")
 
 	mainTypes := collectIdentTypes(cus[0])
-	assert.NotNil(t,mainTypes["helper"], "expected `helper` reference in main.go to have a non-nil Type after multi-file parse; got nil (cross-file resolution still broken)")
+	assert.NotNil(t, mainTypes["helper"], "expected `helper` reference in main.go to have a non-nil Type after multi-file parse; got nil (cross-file resolution still broken)")
 }
 
 // TestGoProjectMultiFilePackageResolves is the harness-level integration:
@@ -56,7 +56,7 @@ func TestGoProjectMultiFilePackageResolves(t *testing.T) {
 	mainSrc.AfterRecipe = func(t *testing.T, cu *golang.CompilationUnit) {
 		t.Helper()
 		ids := collectIdentTypes(cu)
-		assert.NotNil(t,ids["helper"], "`helper` reference should have a resolved Type when parsed alongside helper.go; got nil")
+		assert.NotNil(t, ids["helper"], "`helper` reference should have a resolved Type when parsed alongside helper.go; got nil")
 	}
 
 	helperSrc := test.Golang(`

--- a/rewrite-go/test/project_type_attribution_test.go
+++ b/rewrite-go/test/project_type_attribution_test.go
@@ -88,8 +88,8 @@ func TestGoProjectWiresImporterIntoHarness(t *testing.T) {
 		// these would all be nil because importer.Default() doesn't know
 		// about example.com/foo/sub.
 		identTypes := collectIdentTypes(cu)
-		assert.NotNil(t,identTypes["sub"], "expected `sub` identifier in main.go to have a resolved Type, got nil")
-		assert.NotNil(t,identTypes["Hello"], "expected `Hello` identifier in main.go to have a resolved Type, got nil")
+		assert.NotNil(t, identTypes["sub"], "expected `sub` identifier in main.go to have a resolved Type, got nil")
+		assert.NotNil(t, identTypes["Hello"], "expected `Hello` identifier in main.go to have a resolved Type, got nil")
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/require_resolution_test.go
+++ b/rewrite-go/test/require_resolution_test.go
@@ -76,7 +76,7 @@ func TestGoProjectThirdPartyImportResolves(t *testing.T) {
 		// identifier should now have a non-nil Type. Without require-driven
 		// stubbing this would be nil.
 		ids := collectIdentTypes(cu)
-		assert.NotNil(t,ids["y"], "expected `y` import identifier to have a non-nil Type via the require stub; got nil")
+		assert.NotNil(t, ids["y"], "expected `y` import identifier to have a non-nil Type via the require stub; got nil")
 	}
 
 	spec := test.NewRecipeSpec()

--- a/rewrite-go/test/whitespace_collapse_repro_test.go
+++ b/rewrite-go/test/whitespace_collapse_repro_test.go
@@ -20,10 +20,10 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/stretchr/testify/require"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/tree/java"
 	"github.com/openrewrite/rewrite/rewrite-go/pkg/visitor"
+	"github.com/stretchr/testify/require"
 )
 
 const collapseReproSrc = `package main


### PR DESCRIPTION
Parsing this repository's own Go sources over the RPC bridge took 14.7 s, and printing them back took 6.6 s. Almost none of that was the parser: both phases were dominated by the send and receive loops on either side of the wire.

Each message was serialized twice and decoded in two passes, every response body was copied once to prepend a Content-Length header, and a page of an object was requested only after the previous one had been fully drained — so the two processes took turns idling.

Measured against `main`, both arms in fresh worktrees, interleaved reps:

| phase | wall | JVM CPU | JVM allocation |
|---|---|---|---|
| parse | 14,676 → 4,929 ms (**-66%**) | -17.0% | +0.5% |
| print | 6,649 → 4,549 ms (**-32%**) | -31.8% | -11.2% |

### What each commit buys

Each of these was measured against the tree as it stood at that commit, so they neither chain nor sum to the totals above — several shorten the same receive loop.

- **Decode a message in one pass** — print -20%, Go CPU -7.5%, and Go allocation **+18%**. That commit makes the trade deliberately: holding more of the message at once is what buys the wall time.
- **Serialize each message once instead of twice** — -1.20 GB of a 13 GB Go allocation profile.
- **Frame a response without copying its body** — -1.15 GB of the same profile.
- **Request the next page before draining the current one** — print -12.7%, JVM CPU unchanged: the work is overlapped, not removed.

Allocation reads flat on parse partly because the branch adds test files, so that row understates the change rather than flattering it.

### What the drain is allowed to consume

Prefetching means a page can still be outstanding when a transfer ends or panics, so it is drained before returning. Review caught the drain doing a bare read and discarding the result, which on a bidirectional peer consumes and drops a request Java initiated while leaving the page queued.

That matters because Go's reverse client correlates replies by position, not by id: `fetchBatch` takes whatever message comes next as its page. A page left queued puts every later transfer one reply behind.

```go
if msg.Method == "" {
	return
}
s.logger.Printf("Expected the prefetched GetObject page, got a %s request", msg.Method)
```

The drain now loops until the reply arrives, logging each request it reads past. Those requests are lost either way — Go cannot answer one from inside a transfer. `TestDrainPageReadsPastARequestToReachTheGetObjectReply` scripts a panic-inducing reply, a `Visit` request, then the page, and asserts the *next* transfer reads its own reply; without the skip it returns nil. The existing panic test asserts the complaint stays absent on Java's real reply, so an over-strict check fails too.

Two smaller things on the same path: the prefetch request's write error was discarded where the identical call above it logs, and `wireObjectData` and `decodeValue` were unreferenced once `decodeObjectData` and `decodeTokenValue` took over.

### How the numbers were taken

`GoRpcThroughputTest` (integTest, opt-in) parses and prints this repository's Go sources, reporting wall, JVM CPU and JVM allocation per cycle. Parse and print exercise opposite directions of the wire, so one run measures both peers.

JVM allocation comes from `getThreadAllocatedBytes`, a cumulative per-thread total insensitive to machine load; wall clock is not, so those figures are paired interleaved runs, three reps, both arms in equivalent worktrees asserted to parse the same file count. Readings are differenced per thread rather than summed first, so a thread exiting mid-phase cannot subtract the baseline it contributed.

A separate commit runs `gofmt` over the module: eighteen files had drifted on comma spacing, struct alignment, and import blocks running the third-party group on from the standard-library one. Formatting only — every file's character content is unchanged.

Split out of #8808; this is the `rewrite-go` half.
