### PR TITLE
C#: measure RPC throughput, and stop rescanning every assembly per tree node

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CsDocCommentRpcTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/CSharp/CsDocCommentRpcTest.cs
@@ -39,7 +39,7 @@ public class CsDocCommentRpcTest
 
         var batches = new Queue<List<RpcObjectData>>();
         var sendQueue = new RpcSendQueue(1, batch => batches.Enqueue(Encode(batch)),
-            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+            new RpcRefs(), null, false);
         new CSharpSender().VisitSpace(space, sendQueue);
         sendQueue.Flush();
 

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/ChangedMarkerRoundTripTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/ChangedMarkerRoundTripTest.cs
@@ -35,7 +35,7 @@ public class ChangedMarkerRoundTripTest
         var after = before.WithMarkerList([afterMarker]);
 
         var data = new List<RpcObjectData>();
-        var sendRefs = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+        var sendRefs = new RpcRefs();
         var sendQueue = new RpcSendQueue(1024, batch => data.AddRange(batch), sendRefs, null, false);
         sendQueue.Send(after, before, null);
         sendQueue.Flush();
@@ -52,7 +52,7 @@ public class ChangedMarkerRoundTripTest
         // against an empty before keeps it off the NO_CHANGE path.
         var secondData = new List<RpcObjectData>();
         var secondSend = new RpcSendQueue(1024, batch => secondData.AddRange(batch),
-            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+            new RpcRefs(), null, false);
         secondSend.Send(received, null, null);
         secondSend.Flush();
         Assert.Contains(secondData, d => (d.Value as string) == "com.example.After");

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/JavaTypeAnnotationRpcTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/JavaTypeAnnotationRpcTest.cs
@@ -106,7 +106,7 @@ public class JavaTypeAnnotationRpcTest
 
         var data = new List<RpcObjectData>();
         var q = new RpcSendQueue(1024, batch => data.AddRange(batch),
-            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+            new RpcRefs(), null, false);
 
         q.Send(after, before, () => new JavaSender().VisitType(after, q));
         q.Flush();
@@ -125,7 +125,7 @@ public class JavaTypeAnnotationRpcTest
     {
         var data = new List<RpcObjectData>();
         var q = new RpcSendQueue(1024, batch => data.AddRange(batch),
-            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+            new RpcRefs(), null, false);
         q.Send(Reference.AsRef(after), before == null ? null : Reference.AsRef(before),
             () => new JavaSender().VisitType(after, q));
         q.Flush();

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/LiteralValueReceiveTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/LiteralValueReceiveTest.cs
@@ -40,7 +40,7 @@ public class LiteralValueReceiveTest
 
         var data = new List<RpcObjectData>();
         var sendQueue = new RpcSendQueue(1024, batch => data.AddRange(batch),
-            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+            new RpcRefs(), null, false);
         sendQueue.Send(after, before, () => new JavaSender().Visit(after, sendQueue));
         sendQueue.Flush();
 

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcReceiveQueueTypeCacheTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcReceiveQueueTypeCacheTest.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Reflection;
+using System.Reflection.Emit;
+using OpenRewrite.Core.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+public class RpcReceiveQueueTypeCacheTest
+{
+    [Fact]
+    public void NameResolvesOnceItsAssemblyLoads()
+    {
+        const string javaName = "org.openrewrite.java.tree.J$TypeCacheProbe";
+        Assert.Null(RpcReceiveQueue.FromJavaTypeName(javaName));
+
+        var module = AssemblyBuilder
+            .DefineDynamicAssembly(new AssemblyName("TypeCacheProbeAssembly"), AssemblyBuilderAccess.Run)
+            .DefineDynamicModule("TypeCacheProbeModule");
+        module.DefineType("OpenRewrite.Java.TypeCacheProbe", TypeAttributes.Public).CreateType();
+
+        Assert.NotNull(RpcReceiveQueue.FromJavaTypeName(javaName));
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcRefsTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcRefsTest.cs
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections.Concurrent;
+using OpenRewrite.Core.Rpc;
+
+namespace OpenRewrite.Tests.Rpc;
+
+public class RpcRefsTest
+{
+    [Fact]
+    public void ConcurrentRequestsNeverShareAnId()
+    {
+        var refs = new RpcRefs();
+        var issued = new ConcurrentBag<int>();
+
+        Parallel.For(0, 8, _ =>
+        {
+            for (int i = 0; i < 2000; i++)
+            {
+                issued.Add(refs.NextId());
+            }
+        });
+
+        Assert.Equal(16000, issued.Distinct().Count());
+    }
+
+    [Fact]
+    public void RollbackDropsLaterRefsAndReissuesFromTheMark()
+    {
+        var refs = new RpcRefs();
+        var kept = new object();
+        refs[kept] = refs.NextId();
+        var mark = refs.HighWater;
+
+        var evicted = new object();
+        refs[evicted] = refs.NextId();
+
+        refs.RollbackTo(mark);
+
+        Assert.False(refs.ContainsKey(evicted));
+        Assert.Equal(1, refs[kept]);
+
+        // Reissuing from the mark is what keeps a later checkpoint's mark meaningful.
+        Assert.Equal(2, refs.NextId());
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcRefsTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcRefsTest.cs
@@ -38,7 +38,7 @@ public class RpcRefsTest
     }
 
     [Fact]
-    public void RollbackDropsLaterRefsAndReissuesFromTheMark()
+    public void RollbackDropsLaterRefsWithoutReusingTheirIds()
     {
         var refs = new RpcRefs();
         var kept = new object();
@@ -53,7 +53,8 @@ public class RpcRefsTest
         Assert.False(refs.ContainsKey(evicted));
         Assert.Equal(1, refs[kept]);
 
-        // Reissuing from the mark is what keeps a later checkpoint's mark meaningful.
-        Assert.Equal(2, refs.NextId());
+        // Not 2: an id names one object for the life of the connection, so a send running
+        // concurrently with the rollback cannot have its id handed to a different object.
+        Assert.Equal(3, refs.NextId());
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueListTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueListTest.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 using OpenRewrite.Core.Rpc;
+using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;
 
 namespace OpenRewrite.Tests.Rpc;
 
@@ -35,6 +36,58 @@ public class RpcSendQueueListTest
         var after = new List<string> { "A", "B" };
 
         Assert.Equal(after, RoundTripList(after, before));
+    }
+
+    /// <summary>
+    /// The positions array is what lets a reorder cost one integer per element instead
+    /// of re-sending the elements themselves.
+    /// </summary>
+    [Fact]
+    public void ReorderedElementsAreRepositionedNotResent()
+    {
+        var batch = SendList(["C", "A", "B"], ["A", "B", "C"]);
+
+        Assert.Equal([CHANGE, CHANGE, NO_CHANGE, NO_CHANGE, NO_CHANGE], batch.Select(d => d.State));
+        Assert.Equal([2, 0, 1], (IEnumerable<int>)batch[1].Value!);
+    }
+
+    [Fact]
+    public void EveryElementIsAddedWhenTheBeforeListIsEmpty()
+    {
+        var batch = SendList(["A", "B"], []);
+
+        Assert.Equal([CHANGE, CHANGE, ADD, ADD], batch.Select(d => d.State));
+        Assert.Equal([-1, -1], (IEnumerable<int>)batch[1].Value!);
+        Assert.Equal("A", batch[2].Value);
+        Assert.Equal("B", batch[3].Value);
+    }
+
+    [Fact]
+    public void MixedAddsAndRemovals()
+    {
+        var batch = SendList(["A", "E", "F", "C"], ["A", "B", "C", "D"]);
+
+        Assert.Equal([CHANGE, CHANGE, NO_CHANGE, ADD, ADD, NO_CHANGE], batch.Select(d => d.State));
+        Assert.Equal([0, -1, -1, 2], (IEnumerable<int>)batch[1].Value!);
+    }
+
+    [Fact]
+    public void UnchangedListIsNoChange()
+    {
+        var before = new List<string> { "A", "B" };
+
+        Assert.Equal([NO_CHANGE], SendList(before, before).Select(d => d.State));
+    }
+
+    private static List<RpcObjectData> SendList(IList<string> after, IList<string> before)
+    {
+        var batch = new List<RpcObjectData>();
+        var sq = new RpcSendQueue(1000, b => batch.AddRange(b),
+            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+
+        sq.SendList(after, before, x => x, null, false);
+        sq.Flush();
+        return batch;
     }
 
     private static IList<string>? RoundTripList(IList<string> after, IList<string> before)

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueListTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueListTest.cs
@@ -83,7 +83,7 @@ public class RpcSendQueueListTest
     {
         var batch = new List<RpcObjectData>();
         var sq = new RpcSendQueue(1000, b => batch.AddRange(b),
-            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+            new RpcRefs(), null, false);
 
         sq.SendList(after, before, x => x, null, false);
         sq.Flush();
@@ -94,7 +94,7 @@ public class RpcSendQueueListTest
     {
         var batches = new Queue<List<RpcObjectData>>();
         var sq = new RpcSendQueue(1, batches.Enqueue,
-            new Dictionary<object, int>(ReferenceEqualityComparer.Instance), null, false);
+            new RpcRefs(), null, false);
         var rq = new RpcReceiveQueue(new Dictionary<int, object>(), batches.Dequeue, null);
 
         sq.SendList(after, before, x => x, null, false);

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueRefTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendQueueRefTest.cs
@@ -33,7 +33,7 @@ public class RpcSendQueueRefTest
     public void ChangedRefSlotIsReAddedInsteadOfChanged()
     {
         var sent = new List<RpcObjectData>();
-        var refs = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+        var refs = new RpcRefs();
         var q = new RpcSendQueue(100, batch => sent.AddRange(batch), refs, null, false);
 
         var t1 = new Payload { Value = 1 };

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendReceiveCycleTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/RpcSendReceiveCycleTest.cs
@@ -60,7 +60,7 @@ public class RpcSendReceiveCycleTest
 
         // Diff node2 against node1 as the before state
         var allData = new List<RpcObjectData>();
-        var sendRefs = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+        var sendRefs = new RpcRefs();
         var sendQueue = new RpcSendQueue(1024, batch => allData.AddRange(batch),
             sendRefs, null, false);
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -79,7 +79,7 @@ public class RewriteRpcServer
     /// <summary>
     /// Referentially deduplicated objects and their ref IDs.
     /// </summary>
-    private readonly ConcurrentDictionary<object, int> _localRefs = new(ReferenceEqualityComparer.Instance);
+    private readonly RpcRefs _localRefs = new();
 
     /// <summary>
     /// Refs received from the remote process (Java) for deduplication.
@@ -87,7 +87,7 @@ public class RewriteRpcServer
     private readonly ConcurrentDictionary<int, object> _remoteRefs = new();
 
     /// <summary>
-    /// Ref high-water per source file (send-side _localRefs count, receive-side max _remoteRefs
+    /// Ref high-water per source file (send-side highest id issued, receive-side max _remoteRefs
     /// key), captured before first visit so <see cref="Evict"/> rolls back exactly its refs.
     /// </summary>
     private readonly ConcurrentDictionary<string, (int LocalRefs, int RemoteRefsMax)> _refCheckpoints = new();
@@ -434,7 +434,7 @@ public class RewriteRpcServer
             var types = AssemblyTypeEnumerator.Enumerate(own, references);
 
             data = new List<RpcObjectData>();
-            var sendRefs = new Dictionary<object, int>(ReferenceEqualityComparer.Instance);
+            var sendRefs = new RpcRefs();
             var q = new RpcSendQueue(1024, batch => data.AddRange(batch), sendRefs,
                 "org.openrewrite.java.tree.JavaType$Class", false);
             var sender = new OpenRewrite.Java.Rpc.JavaSender();
@@ -1850,7 +1850,7 @@ public class RewriteRpcServer
                     remoteMax = key;
                 }
             }
-            return (_localRefs.Count, remoteMax);
+            return (_localRefs.HighWater, remoteMax);
         });
     }
 
@@ -1869,13 +1869,7 @@ public class RewriteRpcServer
         _remoteObjects.TryRemove(request.Id, out _);
         if (_refCheckpoints.TryRemove(request.Id, out var cp))
         {
-            foreach (var kv in _localRefs)
-            {
-                if (kv.Value > cp.LocalRefs)
-                {
-                    _localRefs.TryRemove(kv.Key, out _);
-                }
-            }
+            _localRefs.RollbackTo(cp.LocalRefs);
             foreach (var key in _remoteRefs.Keys)
             {
                 if (key > cp.RemoteRefsMax)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -671,7 +671,9 @@ public class RewriteRpcServer
                 // Collect remaining items for debugging
                 var remaining = new System.Text.StringBuilder();
                 remaining.Append($"[0] State={endMarker.State}, Value={endMarker.Value}, ValueType={endMarker.ValueType}");
-                for (int i = 1; i < 20; i++)
+                // Only what is already buffered: pulling here would ask the remote for a page of a
+                // transfer it has finished, starting a fresh one that nothing will drain.
+                for (int i = 1; i < 20 && q.Buffered > 0; i++)
                 {
                     try
                     {
@@ -1692,7 +1694,7 @@ public class RewriteRpcServer
         {
             metrics = new RpcMetricsWriter(metricsCsv, () =>
                 (server._localObjects.Count, server._remoteObjects.Count,
-                    server._localRefs.Count + server._remoteRefs.Count));
+                    server._localRefs.HighWater + server._remoteRefs.Count));
             handler = new MetricsMessageHandler(handler, metrics);
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -629,12 +629,30 @@ public class RewriteRpcServer
     {
         var localObject = _localObjects.GetValueOrDefault(id);
 
+        Task<List<RpcObjectData>> RequestPage() =>
+            _jsonRpc!.InvokeWithParameterObjectAsync<List<RpcObjectData>>(
+                "GetObject",
+                new GetObjectRequest { Id = id, SourceFileType = sourceFileType });
+
+        // The following page is requested before this one is handed to the queue, so the
+        // remote serializes it while this side deserializes what it already has.
+        Task<List<RpcObjectData>>? nextPage = null;
         var q = new RpcReceiveQueue(
             _remoteRefs,
-            () => _jsonRpc!.InvokeWithParameterObjectAsync<List<RpcObjectData>>(
-                "GetObject",
-                new GetObjectRequest { Id = id, SourceFileType = sourceFileType })
-                .GetAwaiter().GetResult(),
+            () =>
+            {
+                var pending = nextPage;
+                nextPage = null;
+                var page = (pending ?? RequestPage()).GetAwaiter().GetResult();
+                // A page ending in END_OF_OBJECT has no successor; the remote drops its
+                // transfer state when it sends that marker, so asking again would restart
+                // the transfer rather than return nothing.
+                if (page.Count > 0 && page[^1].State != END_OF_OBJECT)
+                {
+                    nextPage = RequestPage();
+                }
+                return page;
+            },
             sourceFileType,
             TreeCodec.Instance
         );
@@ -643,29 +661,52 @@ public class RewriteRpcServer
         try
         {
             remoteObject = q.Receive(localObject, (Func<object, object>?)null);
+
+            // Inside the try so that a missing end marker unwinds the same way a failed
+            // receive does: a page is in flight here whenever the last one did not end in
+            // END_OF_OBJECT, which is the condition this rejects.
+            var endMarker = q.Take();
+            if (endMarker.State != END_OF_OBJECT)
+            {
+                // Collect remaining items for debugging
+                var remaining = new System.Text.StringBuilder();
+                remaining.Append($"[0] State={endMarker.State}, Value={endMarker.Value}, ValueType={endMarker.ValueType}");
+                for (int i = 1; i < 20; i++)
+                {
+                    try
+                    {
+                        var next = q.Take();
+                        remaining.Append($" | [{i}] State={next.State}, Value={next.Value}, ValueType={next.ValueType}");
+                        if (next.State == END_OF_OBJECT) break;
+                    }
+                    catch { break; }
+                }
+                throw new InvalidOperationException($"Expected END_OF_OBJECT. Remaining: {remaining}");
+            }
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException(
-                $"Failed to receive object {id} (type: {sourceFileType}): {ex.Message}\n{ex.StackTrace}", ex);
-        }
-        var endMarker = q.Take();
-        if (endMarker.State != END_OF_OBJECT)
-        {
-            // Collect remaining items for debugging
-            var remaining = new System.Text.StringBuilder();
-            remaining.Append($"[0] State={endMarker.State}, Value={endMarker.Value}, ValueType={endMarker.ValueType}");
-            for (int i = 1; i < 20; i++)
+            // Reset our tracking of the remote state so the next interaction
+            // forces a full object sync (ADD) instead of a delta (CHANGE).
+            _remoteObjects.TryRemove(id, out _);
+            var pending = nextPage;
+            nextPage = null;
+            if (pending != null)
             {
+                // Awaited rather than abandoned so the remote's serialization of it is
+                // finished before the next request; the response itself is correlated by
+                // id, so an unawaited one is dropped rather than misdelivered.
                 try
                 {
-                    var next = q.Take();
-                    remaining.Append($" | [{i}] State={next.State}, Value={next.Value}, ValueType={next.ValueType}");
-                    if (next.State == END_OF_OBJECT) break;
+                    pending.GetAwaiter().GetResult();
                 }
-                catch { break; }
+                catch
+                {
+                    // the original failure is the one worth reporting
+                }
             }
-            throw new InvalidOperationException($"Expected END_OF_OBJECT. Remaining: {remaining}");
+            throw new InvalidOperationException(
+                $"Failed to receive object {id} (type: {sourceFileType}): {ex.Message}\n{ex.StackTrace}", ex);
         }
 
         if (remoteObject != null)

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -70,6 +70,10 @@ public class RpcReceiveQueue
         _treeCodec = treeCodec;
     }
 
+    /// <summary>Messages already pulled and not yet taken, which a caller can drain without asking
+    /// the remote for another page.</summary>
+    internal int Buffered => _batch.Count;
+
     public RpcObjectData Take()
     {
         if (_batch.Count == 0 && _pull != null)

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
@@ -30,6 +31,21 @@ namespace OpenRewrite.Core.Rpc;
 /// </summary>
 public class RpcReceiveQueue
 {
+    /// <summary>
+    /// Memoizes <see cref="FromJavaTypeName"/>, which scans every loaded assembly for a name a
+    /// receive resolves once per tree node. A plugin assembly can make a name that resolved to
+    /// null resolve, so an entry records the generation it was resolved in and an assembly load
+    /// makes every entry from an earlier generation a miss.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, (int Generation, Type? Type)> TypeByJavaName = new();
+
+    private static int _assemblyGeneration;
+
+    static RpcReceiveQueue()
+    {
+        AppDomain.CurrentDomain.AssemblyLoad += (_, _) => Interlocked.Increment(ref _assemblyGeneration);
+    }
+
     private readonly Queue<RpcObjectData> _batch = new();
     private readonly IDictionary<int, object> _refs;
     private readonly Func<List<RpcObjectData>>? _pull;
@@ -440,7 +456,20 @@ public class RpcReceiveQueue
     /// <summary>
     /// Maps a Java type name to its C# Type. Reverse of RpcSendQueue.ToJavaTypeName.
     /// </summary>
-    private static Type? FromJavaTypeName(string javaTypeName)
+    internal static Type? FromJavaTypeName(string javaTypeName)
+    {
+        var generation = Volatile.Read(ref _assemblyGeneration);
+        if (TypeByJavaName.TryGetValue(javaTypeName, out var cached) && cached.Generation == generation)
+            return cached.Type;
+
+        // Stamped with the generation read before resolving, so a store that lands after a load
+        // carries the earlier generation and is rejected rather than surviving as a stale miss.
+        var resolved = ResolveJavaTypeName(javaTypeName);
+        TypeByJavaName[javaTypeName] = (generation, resolved);
+        return resolved;
+    }
+
+    private static Type? ResolveJavaTypeName(string javaTypeName)
     {
         // Known direct mappings
         return javaTypeName switch

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcRefs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcRefs.cs
@@ -35,7 +35,12 @@ public sealed class RpcRefs : IDictionary<object, int>
 
     public int NextId() => Interlocked.Increment(ref _lastId);
 
-    /// <summary>Drops every ref issued after <paramref name="highWater"/> and reissues from there.</summary>
+    /// <summary>
+    /// Drops every ref issued after <paramref name="highWater"/>. The counter keeps climbing, so
+    /// an id names one object for the life of the connection: a send running concurrently with
+    /// this has its entry dropped and re-sends the object whole, rather than having its id handed
+    /// to a different object while the remote still holds the binding.
+    /// </summary>
     public void RollbackTo(int highWater)
     {
         foreach (var kv in _ids)
@@ -45,7 +50,6 @@ public sealed class RpcRefs : IDictionary<object, int>
                 _ids.TryRemove(kv.Key, out _);
             }
         }
-        Interlocked.Exchange(ref _lastId, highWater);
     }
 
     public bool TryGetValue(object key, out int value) => _ids.TryGetValue(key, out value);

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcRefs.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcRefs.cs
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Collections;
+using System.Collections.Concurrent;
+
+namespace OpenRewrite.Core.Rpc;
+
+/// <summary>
+/// Identity map from an object to the ref id the remote knows it by, shared across the send
+/// queues of concurrent requests. Ids come from a counter rather than the entry count, because
+/// <see cref="ConcurrentDictionary{TKey,TValue}.Count"/> takes every bucket lock, and because a
+/// count read separately from the insert hands the same id to two threads.
+/// </summary>
+public sealed class RpcRefs : IDictionary<object, int>
+{
+    private readonly ConcurrentDictionary<object, int> _ids = new(ReferenceEqualityComparer.Instance);
+
+    private int _lastId;
+
+    /// <summary>The highest id handed out, which <see cref="RollbackTo"/> takes as a mark.</summary>
+    public int HighWater => Volatile.Read(ref _lastId);
+
+    public int NextId() => Interlocked.Increment(ref _lastId);
+
+    /// <summary>Drops every ref issued after <paramref name="highWater"/> and reissues from there.</summary>
+    public void RollbackTo(int highWater)
+    {
+        foreach (var kv in _ids)
+        {
+            if (kv.Value > highWater)
+            {
+                _ids.TryRemove(kv.Key, out _);
+            }
+        }
+        Interlocked.Exchange(ref _lastId, highWater);
+    }
+
+    public bool TryGetValue(object key, out int value) => _ids.TryGetValue(key, out value);
+
+    public int this[object key]
+    {
+        get => _ids[key];
+        set => _ids[key] = value;
+    }
+
+    public int Count => _ids.Count;
+
+    public void Clear()
+    {
+        _ids.Clear();
+        Interlocked.Exchange(ref _lastId, 0);
+    }
+
+    public void Add(object key, int value) => _ids[key] = value;
+
+    public bool ContainsKey(object key) => _ids.ContainsKey(key);
+
+    public bool Remove(object key) => _ids.TryRemove(key, out _);
+
+    public ICollection<object> Keys => _ids.Keys;
+
+    public ICollection<int> Values => _ids.Values;
+
+    public bool IsReadOnly => false;
+
+    public void Add(KeyValuePair<object, int> item) => _ids[item.Key] = item.Value;
+
+    public bool Contains(KeyValuePair<object, int> item) =>
+        _ids.TryGetValue(item.Key, out var v) && v == item.Value;
+
+    public void CopyTo(KeyValuePair<object, int>[] array, int arrayIndex) =>
+        ((ICollection<KeyValuePair<object, int>>)_ids).CopyTo(array, arrayIndex);
+
+    public bool Remove(KeyValuePair<object, int> item) =>
+        ((ICollection<KeyValuePair<object, int>>)_ids).Remove(item);
+
+    public IEnumerator<KeyValuePair<object, int>> GetEnumerator() => _ids.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -202,21 +202,21 @@ public class RpcSendQueue
             if (after == null)
                 throw new InvalidOperationException("A DELETE event should have been sent.");
 
-            var beforeIdx = PutListPositions(after, before, id);
+            var positions = PutListPositions(after, before, id);
 
-            foreach (var anAfter in after)
+            for (int i = 0; i < after.Count; i++)
             {
-                var itemId = id(anAfter);
-                var beforePos = beforeIdx.GetValueOrDefault(itemId, -1);
+                var anAfter = after[i];
+                var beforePos = positions == null ? AddedListItem : positions[i];
                 Action? onChangeRun = onChange == null ? null : () => onChange(anAfter);
 
-                if (!beforeIdx.ContainsKey(itemId))
+                if (beforePos == AddedListItem)
                 {
                     Add(asRef ? Reference.AsRef(anAfter) : anAfter!, onChangeRun);
                 }
                 else
                 {
-                    var aBefore = before == null ? default : before[beforePos];
+                    var aBefore = before![beforePos];
                     if (ReferenceEquals(aBefore, anAfter))
                     {
                         Put(new RpcObjectData { State = NO_CHANGE });
@@ -236,32 +236,39 @@ public class RpcSendQueue
         });
     }
 
-    private Dictionary<object, int> PutListPositions<T>(IList<T> after, IList<T>? before, Func<T, object> id)
+    /// <summary>
+    /// Emits the positions message and returns the same positions for the caller to walk,
+    /// or null when every element is new.
+    /// </summary>
+    private List<int>? PutListPositions<T>(IList<T> after, IList<T>? before, Func<T, object> id)
     {
-        var beforeIdx = new Dictionary<object, int>();
-        if (before != null)
+        if (before == null || before.Count == 0)
         {
-            for (int i = 0; i < before.Count; i++)
+            // Every element is an addition, so the positions are a constant that needs
+            // neither an index map nor a key computed per element.
+            var added = new List<int>(after.Count);
+            for (int i = 0; i < after.Count; i++)
             {
-                beforeIdx[id(before[i])] = i;
+                added.Add(AddedListItem);
             }
+            Put(new RpcObjectData { State = CHANGE, Value = added });
+            return null;
         }
 
-        var positions = new List<int>();
+        var beforeIdx = new Dictionary<object, int>(before.Count);
+        for (int i = 0; i < before.Count; i++)
+        {
+            beforeIdx[id(before[i])] = i;
+        }
+
+        var positions = new List<int>(after.Count);
         foreach (var t in after)
         {
-            if (beforeIdx.TryGetValue(id(t), out var beforePos))
-            {
-                positions.Add(beforePos);
-            }
-            else
-            {
-                positions.Add(AddedListItem);
-            }
+            positions.Add(beforeIdx.TryGetValue(id(t), out var beforePos) ? beforePos : AddedListItem);
         }
 
         Put(new RpcObjectData { State = CHANGE, Value = positions });
-        return beforeIdx;
+        return positions;
     }
 
     private void Add(object after, Action? onChange)

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcSendQueue.cs
@@ -42,7 +42,7 @@ public class RpcSendQueue
     private readonly int _batchSize;
     private readonly List<RpcObjectData> _batch;
     private readonly Action<List<RpcObjectData>> _drain;
-    private readonly IDictionary<object, int> _refs;
+    private readonly RpcRefs _refs;
     private readonly string? _sourceFileType;
     private readonly bool _trace;
     private readonly IRpcCodec? _treeCodec;
@@ -50,7 +50,7 @@ public class RpcSendQueue
     private object? _before;
 
     public RpcSendQueue(int batchSize, Action<List<RpcObjectData>> drain,
-                        IDictionary<object, int> refs, string? sourceFileType, bool trace,
+                        RpcRefs refs, string? sourceFileType, bool trace,
                         IRpcCodec? treeCodec = null)
     {
         _batchSize = batchSize;
@@ -283,7 +283,7 @@ public class RpcSendQueue
                 Put(new RpcObjectData { State = ADD, Ref = existingRef });
                 return;
             }
-            refValue = _refs.Count + 1;
+            refValue = _refs.NextId();
             _refs[afterVal] = refValue.Value;
         }
 

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRpcThroughputTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRpcThroughputTest.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.SourceFile;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.stream.Collectors.toList;
+
+/**
+ * Measurement harness, not a correctness test: parse and print exercise opposite
+ * directions of the wire, so one run measures both peers.
+ */
+// This module's `check` runs integTest, and the tag is what keeps a measurement
+// off that path; `-PincludeSlow` opts back in.
+@Tag("slow")
+@Timeout(value = 1800, unit = TimeUnit.SECONDS)
+class CSharpRpcThroughputTest {
+
+    static final com.sun.management.ThreadMXBean ALLOC =
+            (com.sun.management.ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    static {
+        ThreadMXBean t = ManagementFactory.getThreadMXBean();
+        if (t.isThreadCpuTimeSupported() && !t.isThreadCpuTimeEnabled()) {
+            t.setThreadCpuTimeEnabled(true);
+        }
+    }
+
+    /**
+     * Per thread because a send runs on a traversal thread and both counters are cumulative
+     * per thread. Kept keyed so that a thread which ends during a phase, and so is absent from
+     * the later reading, does not subtract its whole total from the difference.
+     */
+    static Map<Long, Long> cpuNanos() {
+        ThreadMXBean t = ManagementFactory.getThreadMXBean();
+        Map<Long, Long> perThread = new HashMap<>();
+        for (long id : t.getAllThreadIds()) {
+            long c = t.getThreadCpuTime(id);
+            if (c > 0) {
+                perThread.put(id, c);
+            }
+        }
+        return perThread;
+    }
+
+    static Map<Long, Long> allocated() {
+        Map<Long, Long> perThread = new HashMap<>();
+        for (long id : ManagementFactory.getThreadMXBean().getAllThreadIds()) {
+            long b = ALLOC.getThreadAllocatedBytes(id);
+            if (b > 0) {
+                perThread.put(id, b);
+            }
+        }
+        return perThread;
+    }
+
+    /** Only threads in the later reading contribute, each net of what it had already accrued. */
+    static long since(Map<Long, Long> start, Map<Long, Long> end) {
+        long total = 0;
+        for (Map.Entry<Long, Long> e : end.entrySet()) {
+            total += e.getValue() - start.getOrDefault(e.getKey(), 0L);
+        }
+        return total;
+    }
+
+    @BeforeEach
+    void before() {
+        CSharpRewriteRpc.setFactory(CSharpRewriteRpc.builder()
+                .csharpServerEntry(serverEntry())
+                .log(Paths.get(System.getProperty("java.io.tmpdir"), "csharp-rpc-throughput.log")));
+    }
+
+    @AfterEach
+    void after() {
+        CSharpRewriteRpc.shutdownCurrent();
+    }
+
+    /**
+     * The module is the working directory under Gradle and the repository root when a
+     * run is launched from there, so the entry is looked up under both.
+     */
+    static Path serverEntry() {
+        Path base = Paths.get(System.getProperty("user.dir"));
+        for (Path candidate : List.of(base.resolve("csharp"), base.resolve("rewrite-csharp/csharp"))) {
+            Path csproj = candidate.resolve("OpenRewrite.Tool/OpenRewrite.Tool.csproj");
+            if (csproj.toFile().exists()) {
+                return csproj.toAbsolutePath().normalize();
+            }
+        }
+        throw new IllegalStateException("Could not find the C# Rewrite project");
+    }
+
+    static Path solution() {
+        Path base = Paths.get(System.getProperty("user.dir"));
+        for (Path candidate : List.of(base.resolve("csharp"), base.resolve("rewrite-csharp/csharp"))) {
+            Path sln = candidate.resolve("OpenRewrite.sln");
+            if (sln.toFile().exists()) {
+                return sln.toAbsolutePath().normalize();
+            }
+        }
+        throw new IllegalStateException("Could not find OpenRewrite.sln");
+    }
+
+    @Test
+    void parseThenPrintOwnSources() {
+        List<SourceFile> files = parse(solution(), "parse");
+        // Each cycle resets and refetches the same trees, so the early ones are warmup and the
+        // rest are repetitions within one process, which is what makes a single run comparable.
+        for (int cycle = 0; cycle < 12; cycle++) {
+            printAfterReset(files, "cycle " + cycle);
+        }
+    }
+
+    List<SourceFile> parse(Path sln, String label) {
+        Map<Long, Long> cpu = cpuNanos(), alloc = allocated();
+        long nanos = System.nanoTime();
+        List<SourceFile> files = CSharpRewriteRpc.getOrStart()
+                .parseSolution(sln, sln.getParent(), new InMemoryExecutionContext(Throwable::printStackTrace))
+                .collect(toList());
+        report("PARSE", label, files.size(), nanos, cpu, alloc, 0);
+        return files;
+    }
+
+    void printAfterReset(List<SourceFile> files, String label) {
+        // Reset drops the peer's view of every tree, so each print that follows makes
+        // the peer fetch it back, which is what exercises its receive path.
+        CSharpRewriteRpc.getOrStart().reset();
+
+        Map<Long, Long> cpu = cpuNanos(), alloc = allocated();
+        long nanos = System.nanoTime();
+        long chars = 0;
+        for (SourceFile f : files) {
+            chars += CSharpRewriteRpc.getOrStart().print(f).length();
+        }
+        report("PRINT", label, files.size(), nanos, cpu, alloc, chars);
+    }
+
+    static void report(String phase, String label, int files, long startNanos, Map<Long, Long> startCpu, Map<Long, Long> startAlloc, long chars) {
+        System.out.printf("%s  %-10s %4d files  wall %,6d ms  jvmCpu %,6d ms  %,15d bytes%s%n",
+                phase, label, files,
+                (System.nanoTime() - startNanos) / 1_000_000,
+                since(startCpu, cpuNanos()) / 1_000_000,
+                since(startAlloc, allocated()),
+                chars == 0 ? "" : String.format("  %,d chars", chars));
+    }
+}


### PR DESCRIPTION
The C# peer spent a third of its CPU resolving type names and a fifth of its parse-phase CPU inside a lock. A sampled profile of the peer during a reset-and-print loop over its own sources attributes 31.4% of managed CPU to `RpcReceiveQueue.FindType`, whose inclusive cost equals `FromJavaTypeName`'s — so every call reaching the convention path paid a full scan of every loaded assembly:

```
 31.4%  RpcReceiveQueue.FindType        (inclusive)
 17.5%    RuntimeAssembly.GetTypeCore   (self)
 13.0%    AppDomain.GetAssemblies       (self)
```

`NewObj` resolves the Java type name of every node it creates, and `FindType` loops `AppDomain.CurrentDomain.GetAssemblies()` calling `assembly.GetType(name)`, then again per generic arity — up to four fresh `Assembly[]` per tree node. The GC that funds is the other half of the profile: `Thread.PollGCWorker` and `GC.RunFinalizers` at 17.4% and 25.9% of self time.

## What this carries

Three commits are the C# half of #8808, unchanged apart from trimmed messages. Two are new, from the profiling round the other peers got and C# did not.

Isolating the memo, two processes per arm, five usable reset-and-print cycles each after discarding the first. The arms differ only by it:

| | without memo | with memo | |
|---|---|---|---|
| print, mean cycle | 18,027 ms | 7,805 ms | **-56.7%** |
| C# peer CPU, whole run | 182.6 s | 105.3 s | **-42.3%** |
| JVM CPU, mean cycle | 2,710 ms | 2,606 ms | -3.8% |

Every paired cycle favours it and the ranges do not overlap: 17,681-18,428 ms against 7,540-8,935 ms. The JVM column barely moves because the work removed is the peer's.

## A ref id is a counter, not a count

`RpcSendQueue` assigned each new ref id as `_refs.Count + 1`. The send path shares one `ConcurrentDictionary` across the queues of concurrent requests, and its `Count` acquires every bucket lock, so a read per reference serialised the traversal threads. `Monitor.Enter_Slowpath` was 21.5% of parse-phase managed CPU, 46% of it directly under `RpcSendQueue.Add`.

Reading the count separately from the insert also handed **the same id to two threads** whenever their sends interleaved, after which the remote maps one object over another. `RpcRefs` owns the map and the counter together and `Evict` rolls both back, the checkpoint recording the highest id issued rather than the entry count. `RpcRefsTest` covers both; each fails against the obvious mutant.

This is cheap in Java, where `ConcurrentHashMap.size()` sums counter cells rather than locking, which is why it survived the port.

## Why the memo cannot go stale

A recipe bundle loads assemblies long after a receive has resolved names, so a name that resolved to null must resolve once its assembly is present. Each entry records the generation it was resolved in, and an `AssemblyLoad` increments that generation, making every earlier entry a miss. The generation is read *before* resolving and stored with the value, so a store landing after a load carries the earlier generation and is rejected on the next read. `RpcReceiveQueueTypeCacheTest` resolves a name to null, defines that type in a fresh dynamic assembly, and asserts it then resolves; dropping the `Interlocked.Increment` fails it.

## Cumulative effect

These figures cover this PR together with #8825 and #8808, both since merged, rather than this PR alone — median of cycles 2-11, one process per arm:

| | pre-#8808 main | this stack | |
|---|---|---|---|
| print, per file | 87.3 ms | 28.8 ms | **-67.0%** |
| parse | 34,768 ms | 30,303 ms | -12.8% |
| C# peer CPU | 330.1 s | 172.8 s | **-47.6%** |
| JVM CPU | 2,767 ms | 2,070 ms | -25.2% |
| JVM allocation | 3.503 GB | 3.003 GB | -14.3% |
| C# peer peak RSS | 983 MB | 1,075 MB | **+9.4%** |

Parse measured 34,594 ms on the #8808 tip, so its gain belongs entirely to #8825 and the ref counter above; the JVM columns are largely #8808's. Peak RSS is a regression, higher on the branch across three independent pairings, most likely the prefetched page held in flight.

## What else the profile turned up

Nothing else worth changing on the receive path. The peer is now GC-bound rather than hot in any method: the stack under `CSharpReceiver.Visit` is 15% inclusive, down from 41%, and GC plus lock contention account for two thirds of what is left. Two candidates were rejected: `Take()` is a `Queue.Dequeue`, so JavaScript's quadratic `Array.shift()`/`splice` shape has no analogue here, and caching the per-type field list in `InitializeFields` buys about 1%, its cost being `field.SetValue` rather than the `GetFields` a cache removes.

## Measurement notes

`csharpBuild` passes no `--configuration`, so the harness measures a Debug peer; the shipped package comes from `csharpBuildRelease`. Arms parse 266 to 270 files, each level adding its own test file to the parsed solution, which works against the arm that wins. The cumulative baseline was taken in an earlier session on a quieter machine, so that column is a floor rather than a point estimate. The loop repeats print only, so every parse figure is one sample per run.


