### PR TITLE
C#: draw LST ids from a per-thread generator

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Core/TreeRandomIdTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Core/TreeRandomIdTest.cs
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using CoreTree = OpenRewrite.Core.Tree;
+
+namespace OpenRewrite.Tests.Core;
+
+public class TreeRandomIdTest
+{
+    [Fact]
+    public void CarriesTheVersionAndVariantOfAV4Uuid()
+    {
+        for (int i = 0; i < 200; i++)
+        {
+            // Guid lays its first three fields out little-endian, so the nibbles are only in
+            // these positions if the bytes were stamped in RFC order.
+            var text = CoreTree.RandomId().ToString();
+
+            Assert.Equal('4', text[14]);
+            Assert.Contains(text[19], "89ab");
+        }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/AddUsing.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/AddUsing.cs
@@ -293,7 +293,7 @@ public class AddUsing<P> : CSharpVisitor<P>, IEquatable<AddUsing<P>>
     }
 
     private UsingDirective CreateUsing(Space prefix) =>
-        new(Guid.NewGuid(),
+        new(Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
@@ -307,12 +307,12 @@ public class AddUsing<P> : CSharpVisitor<P>, IEquatable<AddUsing<P>>
     private static TypeTree BuildNamespaceName(string ns)
     {
         var parts = ns.Split('.');
-        Expression name = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], parts[0], null, null);
+        Expression name = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], parts[0], null, null);
         for (var i = 1; i < parts.Length; i++)
         {
-            name = new FieldAccess(Guid.NewGuid(), Space.Empty, Markers.Empty, name,
+            name = new FieldAccess(Tree.RandomId(), Space.Empty, Markers.Empty, name,
                 new JLeftPadded<Identifier>(Space.Empty,
-                    new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], parts[i], null, null)),
+                    new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], parts[i], null, null)),
                 null);
         }
         return (TypeTree)J.SetPrefix((J)name, Space.SingleSpace);

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpFormatStyle.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpFormatStyle.cs
@@ -255,7 +255,7 @@ public sealed class CSharpFormatStyle : Marker, IRpcCodec<CSharpFormatStyle>, IE
 
     /// <summary>Default style matching Roslyn/Visual Studio defaults (Allman style).</summary>
     public static CSharpFormatStyle Default { get; } = new(
-        Guid.NewGuid(), DefaultFlags, indentSize: 4, tabSize: 4, newLine: "\n",
+        Tree.RandomId(), DefaultFlags, indentSize: 4, tabSize: 4, newLine: "\n",
         labelPositioning: 1, spacingAroundBinaryOperator: 0);
 
     public CSharpFormatStyle WithId(Guid id) =>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpParser.cs
@@ -110,12 +110,12 @@ public class CSharpParser
             }
 
             cu = (CompilationUnit)DirectiveBoundaryInjector.Inject(cu);
-            cu = cu.WithMarkers(cu.Markers.Add(new ConditionalBranchMarker(Guid.NewGuid(), definedSymbols.ToList())));
+            cu = cu.WithMarkers(cu.Markers.Add(new ConditionalBranchMarker(Tree.RandomId(), definedSymbols.ToList())));
             branches.Add(new JRightPadded<CompilationUnit>(cu, Space.Empty, Markers.Empty));
         }
 
         var directive = new ConditionalDirective(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             directiveLines,
@@ -124,7 +124,7 @@ public class CSharpParser
 
         var primaryCu = branches[0].Element;
         return new CompilationUnit(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             primaryCu.SourcePath,
@@ -205,12 +205,12 @@ public class CSharpParser
             cu = (CompilationUnit)DirectiveBoundaryInjector.Inject(cu);
 
             // Add ConditionalBranchMarker to identify this as a branch
-            cu = cu.WithMarkers(cu.Markers.Add(new ConditionalBranchMarker(Guid.NewGuid(), definedSymbols.ToList())));
+            cu = cu.WithMarkers(cu.Markers.Add(new ConditionalBranchMarker(Tree.RandomId(), definedSymbols.ToList())));
             branches.Add(new JRightPadded<CompilationUnit>(cu, Space.Empty, Markers.Empty));
         }
 
         var directive = new ConditionalDirective(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             directiveLines,
@@ -222,7 +222,7 @@ public class CSharpParser
         // everything including the trailing content from branch outputs.
         var primaryCu = branches[0].Element;
         return new CompilationUnit(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             primaryCu.SourcePath,
@@ -276,7 +276,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var result = Visit(node);
         if (result is Expression expr) return expr;
         if (result is Statement stmt)
-            return new StatementExpression(Guid.NewGuid(), Space.Empty, Markers.Empty, stmt);
+            return new StatementExpression(Tree.RandomId(), Space.Empty, Markers.Empty, stmt);
         throw new InvalidOperationException(
             $"Expected Expression or Statement from pattern but got {result?.GetType().Name} " +
             $"[node: {node.GetType().Name}, kind: {node.Kind()}, text: {node}]");
@@ -386,7 +386,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var eof = ExtractRemaining();
 
         return new CompilationUnit(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             node.SyntaxTree.FilePath ?? "source.cs",
@@ -448,7 +448,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var aliasPrefix = ExtractPrefix(node.Alias.Name);
             _cursor = node.Alias.Name.Identifier.Span.End;
             var aliasName = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 aliasPrefix,
                 Markers.Empty,
                 [],
@@ -469,7 +469,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.SemicolonToken.Span.End;
 
         return new UsingDirective(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<bool>(isGlobal, globalAfter, Markers.Empty),
@@ -540,10 +540,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             members.Add(new JRightPadded<Statement>(d, Space.Empty, Markers.Empty));
 
         // Use Semicolon marker on the Name padding to indicate file-scoped (no braces)
-        var nameMarkers = new Markers(Guid.NewGuid(), [new Semicolon(Guid.NewGuid())]);
+        var nameMarkers = new Markers(Tree.RandomId(), [new Semicolon(Tree.RandomId())]);
 
         return new NamespaceDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Expression>(nameExpr, nameAfter, nameMarkers),
@@ -618,7 +618,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBraceToken.Span.End;
 
         return new NamespaceDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Expression>(nameExpr, nameAfter, Markers.Empty),
@@ -657,7 +657,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBraceToken.Span.End;
 
         return new Block(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
@@ -678,7 +678,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
     public override J VisitStructDeclaration(StructDeclarationSyntax node)
     {
-        return AddClassDeclMarker(VisitTypeDeclaration(node), new Struct(Guid.NewGuid()));
+        return AddClassDeclMarker(VisitTypeDeclaration(node), new Struct(Tree.RandomId()));
     }
 
     public override J VisitRecordDeclaration(RecordDeclarationSyntax node)
@@ -688,13 +688,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // For record struct, add Struct marker (KindType is already Record)
         if (node.ClassOrStructKeyword.IsKind(SyntaxKind.StructKeyword))
         {
-            return AddClassDeclMarker(result, new Struct(Guid.NewGuid()));
+            return AddClassDeclMarker(result, new Struct(Tree.RandomId()));
         }
 
         // For "record class" (explicit class keyword), add RecordClass marker
         if (node.ClassOrStructKeyword.IsKind(SyntaxKind.ClassKeyword))
         {
-            return AddClassDeclMarker(result, new RecordClass(Guid.NewGuid()));
+            return AddClassDeclMarker(result, new RecordClass(Tree.RandomId()));
         }
 
         return result;
@@ -743,7 +743,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -795,7 +795,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     afterSpace = ExtractSpaceBefore(separator);
                     _cursor = separator.Span.End;
                     var suffix = ExtractSpaceBefore(node.CloseBraceToken);
-                    markers = markers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                    markers = markers.Add(new TrailingComma(Tree.RandomId(), suffix));
                 }
                 else
                 {
@@ -816,7 +816,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (closeBraceSpace != Space.Empty)
             {
                 emptyMembers.Add(new JRightPadded<Expression>(
-                    new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                    new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                     closeBraceSpace, Markers.Empty));
             }
             members = new JContainer<Expression>(membersPrefix, emptyMembers, Markers.Empty);
@@ -830,11 +830,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             SkipTo(node.SemicolonToken.SpanStart);
             SkipToken(node.SemicolonToken);
-            enumMarkers = Markers.Build([new Semicolon(Guid.NewGuid())]);
+            enumMarkers = Markers.Build([new Semicolon(Tree.RandomId())]);
         }
 
         return new EnumDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             enumMarkers,
             attributeLists.Count > 0 ? attributeLists : null,
@@ -860,7 +860,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Identifier.Span.End;
         var enumMemberVarType = _typeMapping?.VariableType(node);
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -883,7 +883,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new EnumMemberDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             attributeLists,
@@ -925,7 +925,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var kind = new ClassDeclaration.Kind(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             kindPrefix,
             Markers.Empty,
             [],
@@ -936,7 +936,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -1041,7 +1041,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Non-generic type with where clauses — create a synthetic empty type parameter container
             // and merge constraints into it. Mark as implicit so the printer skips <>.
             typeParameters = new JContainer<TypeParameter>(Space.Empty, [],
-                Markers.Build([new ImplicitTypeParameters(Guid.NewGuid())]));
+                Markers.Build([new ImplicitTypeParameters(Tree.RandomId())]));
             typeParameters = MergeConstraintClauses(typeParameters, node.ConstraintClauses);
         }
 
@@ -1059,9 +1059,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.SemicolonToken.Span.End;
 
             body = new Block(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 semicolonPrefix,
-                Markers.Build([new Semicolon(Guid.NewGuid())]),
+                Markers.Build([new Semicolon(Tree.RandomId())]),
                 new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
                 [],
                 Space.Empty
@@ -1081,7 +1081,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var classMarkers = trailingSemicolon
-            ? Markers.Build([new Semicolon(Guid.NewGuid())])
+            ? Markers.Build([new Semicolon(Tree.RandomId())])
             : Markers.Empty;
 
         // If there's a primary constructor, prepend it as the first statement in the body.
@@ -1095,7 +1095,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var classDecl = new ClassDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             attributeLists.Count > 0 ? Space.Empty : prefix,
             classMarkers,
             [],
@@ -1114,7 +1114,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -1150,7 +1150,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBraceToken.Span.End;
 
         return new Block(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
@@ -1185,7 +1185,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var targetPrefix = ExtractPrefix(node.Target);
             _cursor = node.Target.Identifier.Span.End;
             var targetId = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 targetPrefix,
                 Markers.Empty,
                 [],
@@ -1223,7 +1223,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBracketToken.Span.End;
 
         return new AttributeList(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             target,
@@ -1256,12 +1256,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     // Named argument with equals: b = c
                     var argPrefix = ExtractSpaceBefore(arg.NameEquals.Name.Identifier);
                     _cursor = arg.NameEquals.Name.Identifier.Span.End;
-                    var nameIdentifier = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [],
+                    var nameIdentifier = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [],
                         arg.NameEquals.Name.Identifier.Text, null, null);
                     var eqSpace = ExtractSpaceBefore(arg.NameEquals.EqualsToken);
                     _cursor = arg.NameEquals.EqualsToken.Span.End;
                     var valueExpr = (Expression)Visit(arg.Expression)!;
-                    expr = new Assignment(Guid.NewGuid(), argPrefix, Markers.Empty,
+                    expr = new Assignment(Tree.RandomId(), argPrefix, Markers.Empty,
                         nameIdentifier, new JLeftPadded<Expression>(eqSpace, valueExpr), null);
                 }
                 else if (arg.NameColon != null)
@@ -1269,12 +1269,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     // Named argument with colon: error: true
                     var argPrefix = ExtractSpaceBefore(arg.NameColon.Name.Identifier);
                     _cursor = arg.NameColon.Name.Identifier.Span.End;
-                    var nameIdentifier = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [],
+                    var nameIdentifier = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [],
                         arg.NameColon.Name.Identifier.Text, null, null);
                     var colonSpace = ExtractSpaceBefore(arg.NameColon.ColonToken);
                     _cursor = arg.NameColon.ColonToken.Span.End;
                     var valueExpr = (Expression)Visit(arg.Expression)!;
-                    expr = new NamedExpression(Guid.NewGuid(), argPrefix, Markers.Empty,
+                    expr = new NamedExpression(Tree.RandomId(), argPrefix, Markers.Empty,
                         new JRightPadded<Identifier>(nameIdentifier, colonSpace, Markers.Empty), valueExpr);
                 }
                 else
@@ -1308,7 +1308,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 if (!closeParenSpace.IsEmpty)
                 {
                     args.Add(new JRightPadded<Expression>(
-                        new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                        new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                         closeParenSpace,
                         Markers.Empty
                     ));
@@ -1320,7 +1320,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Annotation(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             annotationType!,
@@ -1368,7 +1368,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -1417,7 +1417,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (emptySpace != Space.Empty)
             {
                 parameters.Add(new JRightPadded<Statement>(
-                    new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                    new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                     emptySpace, Markers.Empty));
             }
         }
@@ -1454,9 +1454,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var semiSpace = ExtractSpaceBefore(node.SemicolonToken);
             _cursor = node.SemicolonToken.Span.End;
             body = new Block(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 semiSpace,
-                Markers.Build([new Semicolon(Guid.NewGuid())]),
+                Markers.Build([new Semicolon(Tree.RandomId())]),
                 new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
                 [],
                 Space.Empty
@@ -1465,13 +1465,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var methodMarkers = methodMarkers2;
         if (node.ExpressionBody != null)
-            methodMarkers = methodMarkers.Add(new ExpressionBodied(Guid.NewGuid()));
+            methodMarkers = methodMarkers.Add(new ExpressionBodied(Tree.RandomId()));
 
         var methodDeclPrefix = attributeLists.Count > 0
             ? hoistedReturnTypePrefix
             : explicitInterfaceSpec != null ? Space.Empty : prefix;
         var methodDecl = new MethodDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             methodDeclPrefix,
             methodMarkers,
             [],
@@ -1489,7 +1489,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         Statement result = explicitInterfaceSpec != null
             ? new ExplicitInterfaceMember(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 attributeLists.Count > 0 ? Space.Empty : prefix,
                 Markers.Empty,
                 explicitInterfaceSpec,
@@ -1499,7 +1499,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -1535,7 +1535,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // Parse name (class name)
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
-        var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], node.Identifier.Text, _typeMapping?.MethodType(node), null);
+        var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], node.Identifier.Text, _typeMapping?.MethodType(node), null);
 
         // Parse parameters (same pattern as VisitMethodDeclaration)
         var paramsPrefix = ExtractSpaceBefore(node.ParameterList.OpenParenToken);
@@ -1591,9 +1591,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var arguments = ParseArgumentList(node.Initializer.ArgumentList);
 
             var initInvocation = new MethodInvocation(
-                Guid.NewGuid(), kwPrefix, Markers.Empty,
+                Tree.RandomId(), kwPrefix, Markers.Empty,
                 null, // select
-                new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], kwName, null, null),
+                new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], kwName, null, null),
                 null, // typeParameters
                 arguments,
                 null // methodType
@@ -1608,7 +1608,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (node.ExpressionBody != null)
         {
             body = BuildExpressionBodiedBlock(node.ExpressionBody, node.SemicolonToken);
-            methodMarkers = Markers.Build([new ExpressionBodied(Guid.NewGuid())]);
+            methodMarkers = Markers.Build([new ExpressionBodied(Tree.RandomId())]);
         }
         else if (node.Body != null)
         {
@@ -1620,7 +1620,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var ctorDecl = new MethodDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             attributeLists.Count > 0 ? Space.Empty : prefix,
             methodMarkers,
             [],
@@ -1639,7 +1639,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -1670,7 +1670,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         // Use tildePrefix as the name's prefix to preserve attribute text (e.g., [Double(1)])
-        var name = new Identifier(Guid.NewGuid(), tildePrefix, Markers.Empty,
+        var name = new Identifier(Tree.RandomId(), tildePrefix, Markers.Empty,
             [],
             "~" + node.Identifier.Text, _typeMapping?.MethodType(node),
             null
@@ -1689,7 +1689,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (node.ExpressionBody != null)
         {
             body = BuildExpressionBodiedBlock(node.ExpressionBody, node.SemicolonToken);
-            methodMarkers = Markers.Build([new ExpressionBodied(Guid.NewGuid())]);
+            methodMarkers = Markers.Build([new ExpressionBodied(Tree.RandomId())]);
         }
         else if (node.Body != null)
         {
@@ -1701,7 +1701,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new MethodDeclaration(
-            Guid.NewGuid(), prefix, methodMarkers,
+            Tree.RandomId(), prefix, methodMarkers,
             [], modifiers,
             null, // TypeParameters
             null, // ReturnTypeExpression (destructors have none)
@@ -1741,7 +1741,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
-        var identifier = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], node.Identifier.Text, _typeMapping?.ClassType(node), null);
+        var identifier = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], node.Identifier.Text, _typeMapping?.ClassType(node), null);
 
         JContainer<TypeParameter>? typeParameters = null;
         if (node.TypeParameterList != null)
@@ -1790,7 +1790,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _pendingSemicolonSpace = ExtractSpaceBefore(node.SemicolonToken);
         _cursor = node.SemicolonToken.Span.End;
 
-        return new DelegateDeclaration(Guid.NewGuid(), prefix, Markers.Empty,
+        return new DelegateDeclaration(Tree.RandomId(), prefix, Markers.Empty,
             attributeLists, modifiers, returnTypePadded, identifier, typeParameters, paramsContainer);
     }
 
@@ -1831,7 +1831,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var eventVarType = _typeMapping?.VariableType(node);
-        var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], node.Identifier.Text, eventVarType?.Type, eventVarType);
+        var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], node.Identifier.Text, eventVarType?.Type, eventVarType);
 
         JContainer<Statement>? accessors = null;
         if (node.AccessorList != null)
@@ -1863,7 +1863,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.SemicolonToken.Span.End;
         }
 
-        return new EventDeclaration(Guid.NewGuid(), prefix, Markers.Empty,
+        return new EventDeclaration(Tree.RandomId(), prefix, Markers.Empty,
             attributeLists, modifiers, typePadded, interfaceSpecifier, name, accessors);
     }
 
@@ -1892,7 +1892,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var thisPrefix = ExtractSpaceBefore(node.ThisKeyword);
         _cursor = node.ThisKeyword.Span.End;
-        var indexer = (Expression)new Identifier(Guid.NewGuid(), thisPrefix, Markers.Empty, [], "this", null, null);
+        var indexer = (Expression)new Identifier(Tree.RandomId(), thisPrefix, Markers.Empty, [], "this", null, null);
 
         var bracketPrefix = ExtractSpaceBefore(node.ParameterList.OpenBracketToken);
         _cursor = node.ParameterList.OpenBracketToken.Span.End;
@@ -1914,7 +1914,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             {
                 afterSpace = ExtractSpaceBefore(node.ParameterList.CloseBracketToken);
             }
-            Expression paramExpr = new StatementExpression(Guid.NewGuid(), Space.Empty, Markers.Empty, paramStatement);
+            Expression paramExpr = new StatementExpression(Tree.RandomId(), Space.Empty, Markers.Empty, paramStatement);
             parameters.Add(new JRightPadded<Expression>(paramExpr, afterSpace, Markers.Empty));
         }
         _cursor = node.ParameterList.CloseBracketToken.Span.End;
@@ -1936,7 +1936,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             accessors = VisitAccessorList(node.AccessorList);
         }
 
-        return new IndexerDeclaration(Guid.NewGuid(), prefix, Markers.Empty,
+        return new IndexerDeclaration(Tree.RandomId(), prefix, Markers.Empty,
             modifiers, typeExpr, explicitInterfaceSpecifier, indexer,
             new JContainer<Expression>(bracketPrefix, parameters, Markers.Empty),
             expressionBody, accessors);
@@ -1973,14 +1973,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var operatorKeywordPrefix = ExtractSpaceBefore(node.OperatorKeyword);
         _cursor = node.OperatorKeyword.Span.End;
-        var operatorKeyword = new Keyword(Guid.NewGuid(), operatorKeywordPrefix, Markers.Empty, KeywordKind.Operator);
+        var operatorKeyword = new Keyword(Tree.RandomId(), operatorKeywordPrefix, Markers.Empty, KeywordKind.Operator);
 
         Keyword? checkedKeyword = null;
         if (node.CheckedKeyword != default && node.CheckedKeyword.Span.Length > 0)
         {
             var checkedPrefix = ExtractSpaceBefore(node.CheckedKeyword);
             _cursor = node.CheckedKeyword.Span.End;
-            checkedKeyword = new Keyword(Guid.NewGuid(), checkedPrefix, Markers.Empty, KeywordKind.Checked);
+            checkedKeyword = new Keyword(Tree.RandomId(), checkedPrefix, Markers.Empty, KeywordKind.Checked);
         }
 
         var opTokenPrefix = ExtractSpaceBefore(node.OperatorToken);
@@ -2034,7 +2034,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             {
                 afterSpace = ExtractSpaceBefore(node.ParameterList.CloseParenToken);
             }
-            Expression paramExpr = new StatementExpression(Guid.NewGuid(), Space.Empty, Markers.Empty, paramStatement);
+            Expression paramExpr = new StatementExpression(Tree.RandomId(), Space.Empty, Markers.Empty, paramStatement);
             parameters.Add(new JRightPadded<Expression>(paramExpr, afterSpace, Markers.Empty));
         }
         _cursor = node.ParameterList.CloseParenToken.Span.End;
@@ -2055,10 +2055,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var opMarkers = node.ExpressionBody != null
-            ? Markers.Build([new ExpressionBodied(Guid.NewGuid())])
+            ? Markers.Build([new ExpressionBodied(Tree.RandomId())])
             : Markers.Empty;
 
-        return new OperatorDeclaration(Guid.NewGuid(), prefix, opMarkers,
+        return new OperatorDeclaration(Tree.RandomId(), prefix, opMarkers,
             attributeLists, modifiers, explicitInterfaceSpecifier, operatorKeyword, checkedKeyword,
             operatorToken, returnType, new JContainer<Expression>(paramsPrefix, parameters, Markers.Empty),
             body, _typeMapping?.MethodType(node));
@@ -2145,7 +2145,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.SemicolonToken.Span.End;
         }
 
-        return new ConversionOperatorDeclaration(Guid.NewGuid(), prefix, Markers.Empty,
+        return new ConversionOperatorDeclaration(Tree.RandomId(), prefix, Markers.Empty,
             modifiers, kindPadded, interfaceSpecifier, returnTypePadded,
             new JContainer<Statement>(paramsPrefix, parameters, Markers.Empty),
             expressionBody, body);
@@ -2188,7 +2188,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Identifier.Span.End;
         var propVarType = _typeMapping?.VariableType(node);
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -2232,7 +2232,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var propertyDecl = new PropertyDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             attributeLists.Count > 0 ? Space.Empty : prefix,
             Markers.Empty,
             [],
@@ -2248,7 +2248,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -2275,7 +2275,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBraceToken.Span.End;
 
         return new Block(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
@@ -2339,11 +2339,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.SemicolonToken.Span.End;
             expressionBody = new JLeftPadded<Expression>(
                 Space.Empty,
-                new Empty(Guid.NewGuid(), emptyPrefix, Markers.Empty));
+                new Empty(Tree.RandomId(), emptyPrefix, Markers.Empty));
         }
 
         return new AccessorDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             attributeLists,
@@ -2402,7 +2402,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Identifier.Span.End;
         var paramVarType = _typeMapping?.VariableType(node);
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -2426,7 +2426,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var namedVar = new NamedVariable(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             name,
@@ -2436,7 +2436,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         );
 
         var varDecl = new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             attributeLists.Count > 0 ? hoistedTypePrefix : prefix,
             Markers.Empty,
             [],
@@ -2450,7 +2450,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -2481,7 +2481,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.SemicolonToken.Span.End;
 
         return new Return(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             expression
@@ -2507,7 +2507,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var condition = new ControlParentheses<Expression>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             conditionPrefix,
             Markers.Empty,
             new JRightPadded<Expression>(condExpression, conditionAfter, Markers.Empty)
@@ -2532,7 +2532,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (elseStmt is Statement elseStatement)
             {
                 elsePart = new If.Else(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     elsePrefix,
                     Markers.Empty,
                     PadStatement(elseStatement)
@@ -2541,7 +2541,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new If(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             condition,
@@ -2566,7 +2566,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 throw new InvalidOperationException($"Expected Expression but got {selectorExpr?.GetType().Name}");
 
             selector = new ControlParentheses<Expression>(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 selectorPrefix,
                 Markers.Build([OmitParentheses.Instance]),
                 new JRightPadded<Expression>(selectorExpression, Space.Empty, Markers.Empty)
@@ -2586,7 +2586,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.CloseParenToken.Span.End;
 
             selector = new ControlParentheses<Expression>(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 selectorPrefix,
                 Markers.Empty,
                 new JRightPadded<Expression>(selectorExpression, selectorAfter, Markers.Empty)
@@ -2611,7 +2611,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBraceToken.Span.End;
 
         var casesBlock = new Block(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             blockPrefix,
             Markers.Empty,
             new JRightPadded<bool>(false, Space.Empty, Markers.Empty), // not static
@@ -2620,7 +2620,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         );
 
         return new Switch(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             selector,
@@ -2684,7 +2684,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             }
 
             var switchArm = new SwitchExpressionArm(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 armPrefix,
                 Markers.Empty,
                 patternNode,
@@ -2709,7 +2709,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 armAfter = ExtractSpaceBefore(comma);
                 _cursor = comma.Span.End;
                 var suffix = ExtractSpaceBefore(node.CloseBraceToken);
-                armMarkers = armMarkers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                armMarkers = armMarkers.Add(new TrailingComma(Tree.RandomId(), suffix));
             }
             else
             {
@@ -2723,7 +2723,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBraceToken.Span.End;
 
         return new SwitchExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Expression>(selector, selectorAfter, Markers.Empty),
@@ -2773,7 +2773,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var caseStatements = (i == parsedLabels.Count - 1) ? statementsContainer : emptyStatements;
 
             yield return new Case(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 casePrefix,
                 Markers.Empty,
                 CaseType.Statement,
@@ -2814,7 +2814,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
             // Return an Identifier for 'default' with empty prefix (prefix is on the Case)
             var defaultId = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],
@@ -2886,7 +2886,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var pattern = VisitPatternAsExpression(node.Pattern);
 
         return new IsPattern(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             expression,
@@ -2914,16 +2914,16 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(varDesignation.Identifier);
             _cursor = varDesignation.Identifier.Span.End;
             var patternVarType = _typeMapping?.VariableType(varDesignation);
-            var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], varDesignation.Identifier.Text, patternVarType?.Type, patternVarType);
-            namedVar = new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, name, [], null, patternVarType);
+            var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], varDesignation.Identifier.Text, patternVarType?.Type, patternVarType);
+            namedVar = new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, name, [], null, patternVarType);
         }
         else if (node.Designation is DiscardDesignationSyntax discardDesignation)
         {
             // Type pattern with discard: case int _:
             var namePrefix = ExtractSpaceBefore(discardDesignation.UnderscoreToken);
             _cursor = discardDesignation.UnderscoreToken.Span.End;
-            var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], "_", null, null);
-            namedVar = new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, name, [], null, null);
+            var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], "_", null, null);
+            namedVar = new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, name, [], null, null);
         }
 
         var variables = namedVar != null
@@ -2931,7 +2931,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             : new List<JRightPadded<NamedVariable>>();
 
         var varDecl = new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             [],           // Leading annotations
@@ -2944,7 +2944,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         // Wrap in StatementExpression so it implements Pattern
         return new StatementExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             declPrefix,
             Markers.Empty,
             varDecl
@@ -2960,7 +2960,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.VarKeyword.Span.End;
 
         // Create 'var' as the type
-        var varType = new Identifier(Guid.NewGuid(), prefix, Markers.Empty, [], "var", null, null);
+        var varType = new Identifier(Tree.RandomId(), prefix, Markers.Empty, [], "var", null, null);
 
         // Handle the designation (variable name or discard)
         NamedVariable? namedVar = null;
@@ -2969,15 +2969,15 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(varDesignation.Identifier);
             _cursor = varDesignation.Identifier.Span.End;
             var varPatternVarType = _typeMapping?.VariableType(varDesignation);
-            var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], varDesignation.Identifier.Text, varPatternVarType?.Type, varPatternVarType);
-            namedVar = new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, name, [], null, varPatternVarType);
+            var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], varDesignation.Identifier.Text, varPatternVarType?.Type, varPatternVarType);
+            namedVar = new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, name, [], null, varPatternVarType);
         }
         else if (node.Designation is DiscardDesignationSyntax discardDesignation)
         {
             var namePrefix = ExtractSpaceBefore(discardDesignation.UnderscoreToken);
             _cursor = discardDesignation.UnderscoreToken.Span.End;
-            var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], "_", null, null);
-            namedVar = new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, name, [], null, null);
+            var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], "_", null, null);
+            namedVar = new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, name, [], null, null);
         }
 
         var variables = namedVar != null
@@ -2985,7 +2985,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             : new List<JRightPadded<NamedVariable>>();
 
         var varDecl = new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             [],
@@ -2998,7 +2998,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         // Wrap in StatementExpression so it implements Pattern
         return new StatementExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             varDecl
@@ -3029,7 +3029,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new RelationalPattern(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JLeftPadded<RelationalPattern.Type>(operatorPrefix, operatorType),
@@ -3042,7 +3042,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var prefix = ExtractPrefix(node);
         var value = (Expression)Visit(node.Expression)!;
         return new ConstantPattern(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             value
@@ -3053,7 +3053,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var prefix = ExtractPrefix(node);
         _cursor = node.UnderscoreToken.Span.End;
-        return new DiscardPattern(Guid.NewGuid(), prefix, Markers.Empty, null);
+        return new DiscardPattern(Tree.RandomId(), prefix, Markers.Empty, null);
     }
 
     public override J VisitTypePattern(TypePatternSyntax node)
@@ -3077,7 +3077,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var leftJ = Visit(node.Left)!;
         Expression left = leftJ is Expression leftExpr
             ? leftExpr
-            : new StatementExpression(Guid.NewGuid(), Space.Empty, Markers.Empty, (Statement)leftJ);
+            : new StatementExpression(Tree.RandomId(), Space.Empty, Markers.Empty, (Statement)leftJ);
 
         // Parse the operator — use CsBinary with And/Or which implements Pattern
         var operatorPrefix = ExtractSpaceBefore(node.OperatorToken);
@@ -3093,10 +3093,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var rightJ = Visit(node.Right)!;
         Expression right = rightJ is Expression rightExpr
             ? rightExpr
-            : new StatementExpression(Guid.NewGuid(), Space.Empty, Markers.Empty, (Statement)rightJ);
+            : new StatementExpression(Tree.RandomId(), Space.Empty, Markers.Empty, (Statement)rightJ);
 
         return new CsBinary(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             binaryPrefix,
             Markers.Empty,
             left,
@@ -3126,7 +3126,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             // Declaration patterns (e.g., "not Type name") produce VariableDeclarations
             // which is a Statement, not an Expression. Wrap in StatementExpression to bridge.
-            patternExpr = new StatementExpression(Guid.NewGuid(), Space.Empty, Markers.Empty, stmt);
+            patternExpr = new StatementExpression(Tree.RandomId(), Space.Empty, Markers.Empty, stmt);
         }
         else
         {
@@ -3134,7 +3134,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new CsUnary(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JLeftPadded<CsUnary.OperatorKind>(operatorPrefix, CsUnary.OperatorKind.Not),
@@ -3159,7 +3159,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         return new Parentheses<Expression>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Expression>(innerExpr, afterSpace, Markers.Empty)
@@ -3215,10 +3215,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // For typed patterns: typeQualifier has its own prefix from VisitType
             Expression deconstructor = typeQualifier is Expression te
                 ? te
-                : new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty);
+                : new Empty(Tree.RandomId(), Space.Empty, Markers.Empty);
 
             return new DeconstructionPattern(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 deconstructor,
@@ -3257,7 +3257,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     afterSpace = ExtractSpaceBefore(separator);
                     _cursor = separator.Span.End;
                     var suffix = ExtractSpaceBefore(clause.CloseBraceToken);
-                    elemMarkers = elemMarkers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                    elemMarkers = elemMarkers.Add(new TrailingComma(Tree.RandomId(), suffix));
                 }
                 else
                 {
@@ -3273,7 +3273,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             {
                 var endSpace = ExtractSpaceBefore(clause.CloseBraceToken);
                 elements.Add(new JRightPadded<Expression>(
-                    new Empty(Guid.NewGuid(), endSpace, Markers.Empty), Space.Empty, Markers.Empty));
+                    new Empty(Tree.RandomId(), endSpace, Markers.Empty), Space.Empty, Markers.Empty));
             }
             _cursor = clause.CloseBraceToken.Span.End;
             subpatterns = new JContainer<Expression>(containerPrefix, elements, Markers.Empty);
@@ -3292,7 +3292,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = varDesignation.Identifier.Span.End;
             var desigVarType = _typeMapping?.VariableType(varDesignation);
             designation = new Identifier(
-                Guid.NewGuid(), desigPrefix, Markers.Empty,
+                Tree.RandomId(), desigPrefix, Markers.Empty,
                 [],
                 varDesignation.Identifier.Text, desigVarType?.Type,
                 null
@@ -3300,7 +3300,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new PropertyPattern(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             typeQualifier,
@@ -3326,7 +3326,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             _cursor = node.NameColon.Name.Identifier.Span.End;
             var nameIdent = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],
@@ -3345,7 +3345,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var exprText = node.ExpressionColon.Expression.ToString();
             _cursor = node.ExpressionColon.Expression.Span.End;
             var nameIdent = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],
@@ -3368,7 +3368,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var patternExpr = VisitPatternAsExpression(node.Pattern);
 
         return new NamedExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             name,
@@ -3395,7 +3395,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var condition = new ControlParentheses<Expression>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             conditionPrefix,
             Markers.Empty,
             new JRightPadded<Expression>(condExpression, conditionAfter, Markers.Empty)
@@ -3409,7 +3409,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new WhileLoop(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             condition,
@@ -3447,7 +3447,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var condition = new ControlParentheses<Expression>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             conditionPrefix,
             Markers.Empty,
             new JRightPadded<Expression>(condExpression, conditionAfter, Markers.Empty)
@@ -3458,7 +3458,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipToken(node.SemicolonToken);
 
         return new DoWhileLoop(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             PadStatement(bodyStatement),
@@ -3472,7 +3472,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         // Parse the label identifier
         var labelName = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             [],
@@ -3492,7 +3492,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var statement = (Statement)Visit(node.Statement)!;
 
         return new Label(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             labelPadded,
@@ -3505,7 +3505,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var prefix = ExtractPrefix(node);
         _cursor = node.UnsafeKeyword.Span.End;
         var block = (Block)Visit(node.Block)!;
-        return new UnsafeStatement(Guid.NewGuid(), prefix, Markers.Empty, block);
+        return new UnsafeStatement(Tree.RandomId(), prefix, Markers.Empty, block);
     }
 
     public override J VisitFixedStatement(FixedStatementSyntax node)
@@ -3523,7 +3523,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var declarations = new ControlParentheses<VariableDeclarations>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             openParenPrefix,
             Markers.Empty,
             new JRightPadded<VariableDeclarations>(declaration, closeParenAfter, Markers.Empty)
@@ -3537,13 +3537,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
         else
         {
-            fixedBlock = new Block(Guid.NewGuid(), Space.Empty,
-                Markers.Empty.Add(new OmitBraces(Guid.NewGuid())),
+            fixedBlock = new Block(Tree.RandomId(), Space.Empty,
+                Markers.Empty.Add(new OmitBraces(Tree.RandomId())),
                 JRightPadded<bool>.Build(false),
                 [PadStatement(statement)], Space.Empty);
         }
 
-        return new FixedStatement(Guid.NewGuid(), prefix, Markers.Empty, declarations, fixedBlock);
+        return new FixedStatement(Tree.RandomId(), prefix, Markers.Empty, declarations, fixedBlock);
     }
 
     public override J VisitExternAliasDirective(ExternAliasDirectiveSyntax node)
@@ -3557,7 +3557,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var identifierPrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
 
-        var identifier = new Identifier(Guid.NewGuid(), identifierPrefix, Markers.Empty,
+        var identifier = new Identifier(Tree.RandomId(), identifierPrefix, Markers.Empty,
             [],
             node.Identifier.Text, null,
             null
@@ -3567,7 +3567,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _pendingSemicolonSpace = ExtractSpaceBefore(node.SemicolonToken);
         _cursor = node.SemicolonToken.Span.End;
 
-        return new ExternAlias(Guid.NewGuid(), prefix, Markers.Empty,
+        return new ExternAlias(Tree.RandomId(), prefix, Markers.Empty,
             new JLeftPadded<Identifier>(aliasPrefix, identifier));
     }
 
@@ -3596,7 +3596,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 afterSpace = ExtractSpaceBefore(sep);
                 _cursor = sep.Span.End;
                 var suffix = ExtractSpaceBefore(node.CloseBraceToken);
-                elemMarkers = elemMarkers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                elemMarkers = elemMarkers.Add(new TrailingComma(Tree.RandomId(), suffix));
             }
             else
             {
@@ -3613,14 +3613,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Use a sentinel Empty element to preserve the space before close brace
             var innerSpace = ExtractSpaceBefore(node.CloseBraceToken);
             elements.Add(new JRightPadded<Expression>(
-                new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                 innerSpace, Markers.Empty));
         }
 
         _cursor = node.CloseBraceToken.Span.End;
 
         var containerBefore = Space.Empty; // Space before { is in prefix
-        return new InitializerExpression(Guid.NewGuid(), prefix, Markers.Empty,
+        return new InitializerExpression(Tree.RandomId(), prefix, Markers.Empty,
             new JContainer<Expression>(containerBefore, elements, Markers.Empty));
     }
 
@@ -3644,7 +3644,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             Markers.Empty
         );
 
-        return new DefaultExpression(Guid.NewGuid(), prefix, Markers.Empty, typeContainer);
+        return new DefaultExpression(Tree.RandomId(), prefix, Markers.Empty, typeContainer);
     }
 
     // C# `lock` maps to J.Synchronized intentionally — do NOT replace with a Cs.LockStatement.
@@ -3671,7 +3671,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var controlParens = new ControlParentheses<Expression>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             openParenPrefix,
             Markers.Empty,
             new JRightPadded<Expression>(expr, closeParenPrefix, Markers.Empty)
@@ -3686,8 +3686,8 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
         else if (body is Statement stmt)
         {
-            block = new Block(Guid.NewGuid(), Space.Empty,
-                Markers.Empty.Add(new OmitBraces(Guid.NewGuid())),
+            block = new Block(Tree.RandomId(), Space.Empty,
+                Markers.Empty.Add(new OmitBraces(Tree.RandomId())),
                 JRightPadded<bool>.Build(false),
                 [PadStatement(stmt)], Space.Empty);
         }
@@ -3697,7 +3697,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Synchronized(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             controlParens,
@@ -3718,7 +3718,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             ? KeywordKind.Return
             : KeywordKind.Break;
 
-        var keyword = new Keyword(Guid.NewGuid(), keywordPrefix, Markers.Empty, kind);
+        var keyword = new Keyword(Tree.RandomId(), keywordPrefix, Markers.Empty, kind);
 
         // Parse optional expression (only for yield return)
         Expression? expression = null;
@@ -3736,7 +3736,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.SemicolonToken.Span.End;
 
         return new Yield(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             keyword,
@@ -3750,11 +3750,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Keyword.Span.End;
 
         var kind = node.Keyword.IsKind(SyntaxKind.CheckedKeyword) ? KeywordKind.Checked : KeywordKind.Unchecked;
-        var keyword = new Keyword(Guid.NewGuid(), Space.Empty, Markers.Empty, kind);
+        var keyword = new Keyword(Tree.RandomId(), Space.Empty, Markers.Empty, kind);
 
         var block = (Block)Visit(node.Block)!;
 
-        return new CheckedStatement(Guid.NewGuid(), prefix, Markers.Empty, keyword, block);
+        return new CheckedStatement(Tree.RandomId(), prefix, Markers.Empty, keyword, block);
     }
 
     public override J VisitCheckedExpression(CheckedExpressionSyntax node)
@@ -3763,7 +3763,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Keyword.Span.End;
 
         var kind = node.Keyword.IsKind(SyntaxKind.CheckedKeyword) ? KeywordKind.Checked : KeywordKind.Unchecked;
-        var keyword = new Keyword(Guid.NewGuid(), Space.Empty, Markers.Empty, kind);
+        var keyword = new Keyword(Tree.RandomId(), Space.Empty, Markers.Empty, kind);
 
         // Parse the parenthesized expression
         var openParenPrefix = ExtractSpaceBefore(node.OpenParenToken);
@@ -3775,13 +3775,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var controlParens = new ControlParentheses<Expression>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             openParenPrefix,
             Markers.Empty,
             new JRightPadded<Expression>(expr, closeParenPrefix, Markers.Empty)
         );
 
-        return new CheckedExpression(Guid.NewGuid(), prefix, Markers.Empty, keyword, controlParens);
+        return new CheckedExpression(Tree.RandomId(), prefix, Markers.Empty, keyword, controlParens);
     }
 
     public override J VisitRangeExpression(RangeExpressionSyntax node)
@@ -3806,7 +3806,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             end = (Expression)Visit(node.RightOperand)!;
         }
 
-        return new RangeExpression(Guid.NewGuid(), prefix, Markers.Empty, start, end);
+        return new RangeExpression(Tree.RandomId(), prefix, Markers.Empty, start, end);
     }
 
     public override J VisitStackAllocArrayCreationExpression(StackAllocArrayCreationExpressionSyntax node)
@@ -3839,9 +3839,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     {
                         var afterSpace = ExtractSpaceBefore(rankSpec.CloseBracketToken);
                         dimensions.Add(new ArrayDimension(
-                            Guid.NewGuid(), dimPrefix, Markers.Empty,
+                            Tree.RandomId(), dimPrefix, Markers.Empty,
                             new JRightPadded<Expression>(
-                                new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                                new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                                 afterSpace, Markers.Empty)));
                     }
                     else
@@ -3858,7 +3858,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                             afterSpace = ExtractSpaceBefore(rankSpec.CloseBracketToken);
                         }
                         dimensions.Add(new ArrayDimension(
-                            Guid.NewGuid(), dimPrefix, Markers.Empty,
+                            Tree.RandomId(), dimPrefix, Markers.Empty,
                             new JRightPadded<Expression>(sizeExpr, afterSpace, Markers.Empty)));
                     }
                 }
@@ -3875,10 +3875,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var newArray = new NewArray(
-            Guid.NewGuid(), arrayPrefix, Markers.Empty,
+            Tree.RandomId(), arrayPrefix, Markers.Empty,
             typeExpression, dimensions, initializer, null);
 
-        return new StackAllocExpression(Guid.NewGuid(), prefix, Markers.Empty, newArray);
+        return new StackAllocExpression(Tree.RandomId(), prefix, Markers.Empty, newArray);
     }
 
     public override J VisitCollectionExpression(CollectionExpressionSyntax node)
@@ -3917,7 +3917,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 afterSpace = ExtractSpaceBefore(separator);
                 _cursor = separator.Span.End;
                 var suffix = ExtractSpaceBefore(node.CloseBracketToken);
-                elemMarkers = elemMarkers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                elemMarkers = elemMarkers.Add(new TrailingComma(Tree.RandomId(), suffix));
             }
             else
             {
@@ -3936,14 +3936,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (innerSpace != Space.Empty)
             {
                 elements.Add(new JRightPadded<Expression>(
-                    new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                    new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                     innerSpace, Markers.Empty));
             }
         }
 
         _cursor = node.CloseBracketToken.Span.End;
 
-        return new CollectionExpression(Guid.NewGuid(), prefix, Markers.Empty, elements, null);
+        return new CollectionExpression(Tree.RandomId(), prefix, Markers.Empty, elements, null);
     }
 
     public override J VisitForStatement(ForStatementSyntax node)
@@ -3971,7 +3971,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var namePrefix = ExtractSpaceBefore(v.Identifier);
                 _cursor = v.Identifier.Span.End;
                 var forLoopVarType = _typeMapping?.VariableType(v);
-                var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], v.Identifier.Text, forLoopVarType?.Type, forLoopVarType);
+                var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], v.Identifier.Text, forLoopVarType?.Type, forLoopVarType);
 
                 JLeftPadded<Expression>? initializer = null;
                 if (v.Initializer != null)
@@ -3985,7 +3985,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     }
                 }
 
-                var namedVar = new NamedVariable(Guid.NewGuid(), varPrefix, Markers.Empty, name, [], initializer, _typeMapping?.VariableType(v));
+                var namedVar = new NamedVariable(Tree.RandomId(), varPrefix, Markers.Empty, name, [], initializer, _typeMapping?.VariableType(v));
 
                 Space afterSpace = Space.Empty;
                 if (i < node.Declaration.Variables.Count - 1)
@@ -3998,7 +3998,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 variables.Add(new JRightPadded<NamedVariable>(namedVar, afterSpace, Markers.Empty));
             }
 
-            var varDecl = new VariableDeclarations(Guid.NewGuid(), declPrefix, Markers.Empty, [], [], typeExpr, null, [], variables);
+            var varDecl = new VariableDeclarations(Tree.RandomId(), declPrefix, Markers.Empty, [], [], typeExpr, null, [], variables);
             init.Add(new JRightPadded<Statement>(varDecl, Space.Empty, Markers.Empty));
         }
         else
@@ -4010,7 +4010,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var initExpr = Visit(initNode);
                 if (initExpr is Expression expr)
                 {
-                    var exprStmt = new ExpressionStatement(Guid.NewGuid(), expr);
+                    var exprStmt = new ExpressionStatement(Tree.RandomId(), expr);
                     Space afterSpace = Space.Empty;
                     if (i < node.Initializers.Count - 1)
                     {
@@ -4029,7 +4029,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         if (init.Count == 0)
         {
-            var empty = new Empty(Guid.NewGuid(), firstSemiPrefix, Markers.Empty);
+            var empty = new Empty(Tree.RandomId(), firstSemiPrefix, Markers.Empty);
             init.Add(new JRightPadded<Statement>(empty, Space.Empty, Markers.Empty));
         }
 
@@ -4040,7 +4040,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var visited = Visit(node.Condition);
             if (visited is Expression e) condExpr = e;
         }
-        condExpr ??= new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty);
+        condExpr ??= new Empty(Tree.RandomId(), Space.Empty, Markers.Empty);
 
         // Second semicolon
         var secondSemiPrefix = ExtractSpaceBefore(node.SecondSemicolonToken);
@@ -4052,7 +4052,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             // No incrementors - create an Empty statement with any trailing space in its prefix
             var emptyPrefix = ExtractSpaceBefore(node.CloseParenToken);
-            var empty = new Empty(Guid.NewGuid(), emptyPrefix, Markers.Empty);
+            var empty = new Empty(Tree.RandomId(), emptyPrefix, Markers.Empty);
             update.Add(new JRightPadded<Statement>(empty, Space.Empty, Markers.Empty));
         }
         else
@@ -4063,7 +4063,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var incExpr = Visit(incNode);
                 if (incExpr is Expression expr)
                 {
-                    var exprStmt = new ExpressionStatement(Guid.NewGuid(), expr);
+                    var exprStmt = new ExpressionStatement(Tree.RandomId(), expr);
                     Space afterSpace;
                     if (i < node.Incrementors.Count - 1)
                     {
@@ -4085,7 +4085,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var control = new ForLoop.Control(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             controlPrefix,
             Markers.Empty,
             init,
@@ -4101,7 +4101,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new ForLoop(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             control,
@@ -4133,10 +4133,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var foreachVarType = _typeMapping?.VariableType(node);
-        var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], node.Identifier.Text, foreachVarType?.Type, foreachVarType);
-        var namedVar = new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, name, [], null, _typeMapping?.VariableType(node));
+        var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], node.Identifier.Text, foreachVarType?.Type, foreachVarType);
+        var namedVar = new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, name, [], null, _typeMapping?.VariableType(node));
         var varDecl = new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             [], [], typeExpr, null, [],
@@ -4159,7 +4159,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var control = new ForEachLoop.Control(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             controlPrefix,
             Markers.Empty,
             new JRightPadded<VariableDeclarations>(varDecl, inPrefix, Markers.Empty),
@@ -4174,7 +4174,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var forEachLoop = new ForEachLoop(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             hasAwait ? Space.Empty : prefix,
             Markers.Empty,
             control,
@@ -4184,10 +4184,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (hasAwait)
         {
             return new AwaitExpression(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
-                new StatementExpression(Guid.NewGuid(), awaitSuffix, Markers.Empty, forEachLoop),
+                new StatementExpression(Tree.RandomId(), awaitSuffix, Markers.Empty, forEachLoop),
                 null
             );
         }
@@ -4224,7 +4224,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var exNamePrefix = ExtractSpaceBefore(catchClause.Declaration.Identifier);
                     _cursor = catchClause.Declaration.Identifier.Span.End;
                     var catchVarType = _typeMapping?.VariableType(catchClause.Declaration);
-                    exName = new Identifier(Guid.NewGuid(), exNamePrefix, Markers.Empty, [], catchClause.Declaration.Identifier.Text, catchVarType?.Type, catchVarType);
+                    exName = new Identifier(Tree.RandomId(), exNamePrefix, Markers.Empty, [], catchClause.Declaration.Identifier.Text, catchVarType?.Type, catchVarType);
                 }
 
                 var closeParenPrefix = ExtractSpaceBefore(catchClause.Declaration.CloseParenToken);
@@ -4238,13 +4238,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 IList<JRightPadded<NamedVariable>> variables;
                 if (exName != null)
                 {
-                    variables = [new JRightPadded<NamedVariable>(new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, exName, [], whenInitializer, _typeMapping?.VariableType(catchClause.Declaration!)), Space.Empty, Markers.Empty)];
+                    variables = [new JRightPadded<NamedVariable>(new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, exName, [], whenInitializer, _typeMapping?.VariableType(catchClause.Declaration!)), Space.Empty, Markers.Empty)];
                 }
                 else if (whenInitializer != null)
                 {
                     // Type-only catch with when clause: create a NamedVariable with empty name to hold the when clause
-                    var emptyName = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], "", null, null);
-                    variables = [new JRightPadded<NamedVariable>(new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, emptyName, [], whenInitializer, null), Space.Empty, Markers.Empty)];
+                    var emptyName = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], "", null, null);
+                    variables = [new JRightPadded<NamedVariable>(new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, emptyName, [], whenInitializer, null), Space.Empty, Markers.Empty)];
                 }
                 else
                 {
@@ -4252,7 +4252,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 }
 
                 var varDecl = new VariableDeclarations(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     Space.Empty,
                     Markers.Empty,
                     [], [], typeExpr, null, [],
@@ -4260,7 +4260,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 );
 
                 parameter = new ControlParentheses<VariableDeclarations>(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     parenPrefix,
                     Markers.Empty,
                     new JRightPadded<VariableDeclarations>(varDecl, closeParenPrefix, Markers.Empty)
@@ -4278,18 +4278,18 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 if (whenInitializer != null)
                 {
                     // Bare catch with when clause: create a NamedVariable with empty name to hold the when clause
-                    var emptyName = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], "", null, null);
-                    variables = [new JRightPadded<NamedVariable>(new NamedVariable(Guid.NewGuid(), Space.Empty, Markers.Empty, emptyName, [], whenInitializer, null), Space.Empty, Markers.Empty)];
+                    var emptyName = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], "", null, null);
+                    variables = [new JRightPadded<NamedVariable>(new NamedVariable(Tree.RandomId(), Space.Empty, Markers.Empty, emptyName, [], whenInitializer, null), Space.Empty, Markers.Empty)];
                 }
                 else
                 {
                     variables = [];
                 }
                 var emptyVarDecl = new VariableDeclarations(
-                    Guid.NewGuid(), Space.Empty, Markers.Empty, [], [], null, null, [], variables
+                    Tree.RandomId(), Space.Empty, Markers.Empty, [], [], null, null, [], variables
                 );
                 parameter = new ControlParentheses<VariableDeclarations>(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     Space.Empty,
                     Markers.Empty,
                     new JRightPadded<VariableDeclarations>(emptyVarDecl, Space.Empty, Markers.Empty)
@@ -4299,7 +4299,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var catchBody = (Block)VisitBlock(catchClause.Block);
 
             catches.Add(new Try.Catch(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 catchPrefix,
                 Markers.Empty,
                 parameter,
@@ -4318,7 +4318,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Try(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             null,
@@ -4338,9 +4338,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var closeParenPrefix = ExtractSpaceBefore(filter.CloseParenToken);
         _cursor = filter.CloseParenToken.Span.End;
         var controlParens = new ControlParentheses<Expression>(
-            Guid.NewGuid(), openParenPrefix, Markers.Empty,
+            Tree.RandomId(), openParenPrefix, Markers.Empty,
             new JRightPadded<Expression>(filterExpr, closeParenPrefix, Markers.Empty));
-        var whenClause = new WhenClause(Guid.NewGuid(), Space.Empty, Markers.Empty, controlParens);
+        var whenClause = new WhenClause(Tree.RandomId(), Space.Empty, Markers.Empty, controlParens);
         return new JLeftPadded<Expression>(whenPrefix, whenClause);
     }
 
@@ -4362,7 +4362,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         else
         {
             // Re-throw (just 'throw;')
-            exception = new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty);
+            exception = new Empty(Tree.RandomId(), Space.Empty, Markers.Empty);
         }
 
         // Consume the semicolon
@@ -4370,7 +4370,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipToken(node.SemicolonToken);
 
         return new Throw(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             exception
@@ -4389,7 +4389,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new RefExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             RefKind.Ref,
@@ -4409,14 +4409,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var throwStatement = new Throw(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             e
         );
 
         return new StatementExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             throwStatement
@@ -4439,10 +4439,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipToken(node.CloseParenToken);
 
         return new InstanceOf(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
-            new JRightPadded<Expression>(new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty), spaceBeforeParen, Markers.Empty),
+            new JRightPadded<Expression>(new Empty(Tree.RandomId(), Space.Empty, Markers.Empty), spaceBeforeParen, Markers.Empty),
             type,
             null,
             _typeMapping?.Type(node),
@@ -4471,9 +4471,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             new JRightPadded<Expression>(typeExpr, closeParenSpace, Markers.Empty)
         ], Markers.Empty);
 
-        var name = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], "__refvalue", null, null);
+        var name = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], "__refvalue", null, null);
         return new MethodInvocation(
-            Guid.NewGuid(), prefix, Markers.Empty,
+            Tree.RandomId(), prefix, Markers.Empty,
             null, name, null, args, null);
     }
 
@@ -4493,9 +4493,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             new JRightPadded<Expression>(expr, closeParenSpace, Markers.Empty)
         ], Markers.Empty);
 
-        var name = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], "__reftype", null, null);
+        var name = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], "__reftype", null, null);
         return new MethodInvocation(
-            Guid.NewGuid(), prefix, Markers.Empty,
+            Tree.RandomId(), prefix, Markers.Empty,
             null, name, null, args, null);
     }
 
@@ -4515,9 +4515,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             new JRightPadded<Expression>(expr, closeParenSpace, Markers.Empty)
         ], Markers.Empty);
 
-        var name = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], "__makeref", null, null);
+        var name = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], "__makeref", null, null);
         return new MethodInvocation(
-            Guid.NewGuid(), prefix, Markers.Empty,
+            Tree.RandomId(), prefix, Markers.Empty,
             null, name, null, args, null);
     }
 
@@ -4537,7 +4537,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipToken(node.CloseParenToken);
 
         return new SizeOf(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             type,
@@ -4555,7 +4555,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipToken(node.SemicolonToken);
 
         return new Break(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             null // C# doesn't have labeled breaks
@@ -4572,7 +4572,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipToken(node.SemicolonToken);
 
         return new Continue(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             null // C# doesn't have labeled continues
@@ -4585,7 +4585,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.SemicolonToken.Span.End;
 
         return new Empty(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty
         );
@@ -4603,7 +4603,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _pendingSemicolonSpace = ExtractSpaceBefore(node.SemicolonToken);
         _cursor = node.SemicolonToken.Span.End;
 
-        return new ExpressionStatement(Guid.NewGuid(), expression);
+        return new ExpressionStatement(Tree.RandomId(), expression);
     }
 
     public override J VisitLiteralExpression(LiteralExpressionSyntax node)
@@ -4614,7 +4614,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (node.Kind() == SyntaxKind.DefaultLiteralExpression)
         {
             _cursor = node.Token.Span.End;
-            return new DefaultExpression(Guid.NewGuid(), prefix, Markers.Empty, null);
+            return new DefaultExpression(Tree.RandomId(), prefix, Markers.Empty, null);
         }
 
         var valueSource = node.Token.Text;
@@ -4636,7 +4636,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Literal(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             value,
@@ -4652,7 +4652,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Token.Span.End;
 
         return new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             [],
@@ -4668,7 +4668,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Token.Span.End;
 
         return new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             [],
@@ -4704,7 +4704,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.StringEndToken.Span.End;
 
         return new InterpolatedString(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             delimiter,
@@ -4720,7 +4720,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.TextToken.Span.End;
 
         return new Literal(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             node.TextToken.ValueText,  // Unescaped value
@@ -4770,7 +4770,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.FormatClause.FormatStringToken.Span.End;
             format = new JLeftPadded<Identifier>(
                 before,
-                new Identifier(Guid.NewGuid(), formatPrefix, Markers.Empty, [], formatText, null, null)
+                new Identifier(Tree.RandomId(), formatPrefix, Markers.Empty, [], formatText, null, null)
             );
         }
 
@@ -4779,7 +4779,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseBraceToken.Span.End;
 
         return new Interpolation(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,  // Space after '{' is stored in expression's prefix
             Markers.Empty,
             expr,
@@ -4799,7 +4799,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var (type, fieldType) = _typeMapping?.TypeAndFieldType(node) ?? (null, null);
         return new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             [],
@@ -4815,7 +4815,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Token.Span.End;
 
         return new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             [],
@@ -4849,7 +4849,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (operand is not Expression expr)
                 throw new InvalidOperationException($"Expected Expression but got {operand?.GetType().Name} in index expression: {Truncate(node.ToString())}");
             return new CsUnary(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 new JLeftPadded<CsUnary.OperatorKind>(Space.Empty, CsUnary.OperatorKind.FromEnd),
@@ -4863,7 +4863,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (operand is not Expression expr)
                 throw new InvalidOperationException($"Expected Expression but got {operand?.GetType().Name} in pointer indirection: {Truncate(node.ToString())}");
             return new PointerDereference(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 expr,
@@ -4876,7 +4876,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (operand is not Expression expr)
                 throw new InvalidOperationException($"Expected Expression but got {operand?.GetType().Name} in address-of: {Truncate(node.ToString())}");
             return new CsUnary(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 new JLeftPadded<CsUnary.OperatorKind>(Space.Empty, CsUnary.OperatorKind.AddressOf),
@@ -4894,7 +4894,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Unary(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JLeftPadded<Unary.OperatorType>(Space.Empty, opType),
@@ -4920,7 +4920,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.OperatorToken.Span.End;
 
             return new NullSafeExpression(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 new JRightPadded<Expression>(expr, bangPrefix, Markers.Empty)
@@ -4939,7 +4939,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var opType = MapPostfixUnaryOperator(node.Kind());
 
         return new Unary(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JLeftPadded<Unary.OperatorType>(operatorPrefix, opType),
@@ -4960,7 +4960,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new AwaitExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             expr,
@@ -5020,7 +5020,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 ? (J?)VisitType(rightType)
                 : Visit(node.Right);
             return new InstanceOf(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 new JRightPadded<Expression>(leftExpr, operatorPrefix, Markers.Empty),
@@ -5043,7 +5043,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 throw new InvalidOperationException($"Expected Expression but got {typeExpr?.GetType().Name} in as expression: {Truncate(node.ToString())}");
             }
             return new CsBinary(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 leftExpr,
@@ -5066,11 +5066,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Model as Ternary with NullCoalescing marker
             // condition ?? falsePart (truePart is empty)
             return new Ternary(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Build([NullCoalescing.Instance]),
                 leftExpr,
-                new JLeftPadded<Expression>(Space.Empty, new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty)),
+                new JLeftPadded<Expression>(Space.Empty, new Empty(Tree.RandomId(), Space.Empty, Markers.Empty)),
                 new JLeftPadded<Expression>(operatorPrefix, rightExpr),
                 _typeMapping?.Type(node)
             );
@@ -5087,7 +5087,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Binary(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             leftExpr,
@@ -5131,7 +5131,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Ternary(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             conditionExpr,
@@ -5169,7 +5169,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (node.Kind() == SyntaxKind.SimpleAssignmentExpression)
         {
             return new Assignment(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 leftExpr,
@@ -5182,7 +5182,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Compound assignment
             var opType = MapAssignmentOperator(node.Kind());
             return new AssignmentOperation(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 leftExpr,
@@ -5234,7 +5234,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         return new Parentheses<Expression>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Expression>(innerExpr, closeParenPrefix, Markers.Empty)
@@ -5261,7 +5261,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = arg.NameColon.Name.Identifier.Span.End;
 
                 var nameIdentifier = new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     Space.Empty,
                     Markers.Empty,
                     [],
@@ -5282,7 +5282,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 }
 
                 expr = new NamedExpression(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     argPrefix,
                     Markers.Empty,
                     new JRightPadded<Identifier>(nameIdentifier, colonSpace, Markers.Empty),
@@ -5318,7 +5318,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         return new TupleExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JContainer<Expression>(Space.Empty, args, Markers.Empty)
@@ -5343,7 +5343,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var clazz = new ControlParentheses<TypeTree>(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             openParenPrefix,
             Markers.Empty,
             new JRightPadded<TypeTree>(type, closeParenPrefix, Markers.Empty)
@@ -5357,7 +5357,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new TypeCast(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             clazz,
@@ -5401,12 +5401,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = argList.CloseBracketToken.Span.End;
 
             return new ArrayAccess(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 indexed,
                 new ArrayDimension(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     bracketPrefix,
                     Markers.Empty,
                     new JRightPadded<Expression>(index, closeBracketSpace, Markers.Empty)
@@ -5432,12 +5432,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // Innermost ArrayAccess (no marker)
         // Its dimension's After is empty because comma follows, not ]
         ArrayAccess current = new ArrayAccess(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             indexed,
             new ArrayDimension(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 bracketPrefix,
                 Markers.Empty,
                 new JRightPadded<Expression>(firstIndexExpr, Space.Empty, Markers.Empty)
@@ -5461,12 +5461,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = separator.Span.End;
 
                 current = new ArrayAccess(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     currentSpaceBeforeComma, // Prefix = space before this comma
                     Markers.Empty.Add(MultiDimensionalArray.Instance),
                     current,
                     new ArrayDimension(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         Space.Empty, // Space after comma is in index expression prefix
                         Markers.Empty,
                         new JRightPadded<Expression>(index, Space.Empty, Markers.Empty)
@@ -5482,12 +5482,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = argList.CloseBracketToken.Span.End;
 
                 current = new ArrayAccess(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     currentSpaceBeforeComma, // Prefix = space before this comma
                     Markers.Empty.Add(MultiDimensionalArray.Instance),
                     current,
                     new ArrayDimension(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         Space.Empty, // Space after comma is in index expression prefix
                         Markers.Empty,
                         new JRightPadded<Expression>(index, closeBracketSpace, Markers.Empty)
@@ -5526,7 +5526,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(genericName.Identifier);
             _cursor = genericName.Identifier.Span.End;
             name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -5543,7 +5543,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(simpleName.Identifier);
             _cursor = simpleName.Identifier.Span.End;
             name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -5556,13 +5556,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (node.OperatorToken.IsKind(SyntaxKind.MinusGreaterThanToken))
         {
             var deref = new PointerDereference(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
-                Markers.Build([new PointerMemberAccess(Guid.NewGuid())]),
+                Markers.Build([new PointerMemberAccess(Tree.RandomId())]),
                 targetExpr,
                 _typeMapping?.Type(node));
             return new FieldAccess(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 deref,
@@ -5575,7 +5575,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (typeArguments != null)
         {
             return new MemberReference(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 new JRightPadded<Expression>(targetExpr, dotPrefix, Markers.Empty),
@@ -5588,7 +5588,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new FieldAccess(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             targetExpr,
@@ -5617,14 +5617,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var targetPrefix = ExtractPrefix(genericTarget);
                 _cursor = genericTarget.Identifier.Span.End;
                 var clazz = new Identifier(
-                    Guid.NewGuid(), targetPrefix, Markers.Empty,
+                    Tree.RandomId(), targetPrefix, Markers.Empty,
                     [],
                     genericTarget.Identifier.Text, _typeMapping?.RawType(genericTarget),
                     null
                 );
                 var genTypeParams = ParseTypeArgumentList(genericTarget.TypeArgumentList);
                 targetExpr = new ParameterizedType(
-                    Guid.NewGuid(), Space.Empty, Markers.Empty,
+                    Tree.RandomId(), Space.Empty, Markers.Empty,
                     clazz, genTypeParams, _typeMapping?.Type(genericTarget)
                 );
             }
@@ -5646,9 +5646,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (memberAccess.OperatorToken.IsKind(SyntaxKind.MinusGreaterThanToken))
             {
                 selectExpr = new PointerDereference(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     Space.Empty,
-                    Markers.Build([new PointerMemberAccess(Guid.NewGuid())]),
+                    Markers.Build([new PointerMemberAccess(Tree.RandomId())]),
                     targetExpr,
                     null);
             }
@@ -5661,7 +5661,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var namePrefix = ExtractSpaceBefore(genericName.Identifier);
                 _cursor = genericName.Identifier.Span.End;
                 name = new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     namePrefix,
                     Markers.Empty,
                     [],
@@ -5678,7 +5678,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var namePrefix = ExtractSpaceBefore(simpleName.Identifier);
                 _cursor = simpleName.Identifier.Span.End;
                 name = new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     namePrefix,
                     Markers.Empty,
                     [],
@@ -5694,7 +5694,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(genericName.Identifier);
             _cursor = genericName.Identifier.Span.End;
             name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -5710,7 +5710,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(identifierName.Identifier);
             _cursor = identifierName.Identifier.Span.End;
             name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -5734,11 +5734,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
             // Create MethodInvocation with DelegateInvocation marker to indicate syntactic sugar
             return new MethodInvocation(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Build([DelegateInvocation.Instance]),
                 new JRightPadded<Expression>(targetExpr, Space.Empty, Markers.Empty),
-                new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], "Invoke", null, null),
+                new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], "Invoke", null, null),
                 null,
                 delegateArgs,
                 _typeMapping?.MethodType(node)
@@ -5749,7 +5749,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var arguments = ParseArgumentList(node.ArgumentList);
 
         return new MethodInvocation(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             select,
@@ -5778,7 +5778,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var paramElement = new JRightPadded<J>(param, Space.Empty, Markers.Empty);
 
         var parameters = new Lambda.Parameters(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             false, // Not parenthesized
@@ -5797,7 +5797,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var jLambda = new Lambda(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             modifiers.Count > 0 ? Space.Empty : prefix, // If modifiers, prefix goes on CsLambda
             Markers.Empty,
             parameters,
@@ -5810,7 +5810,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (modifiers.Count > 0)
         {
             return new CsLambda(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 [],
@@ -5894,7 +5894,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.ParameterList.CloseParenToken.Span.End;
 
         var parameters = new Lambda.Parameters(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             paramsPrefix,
             Markers.Empty,
             true, // Parenthesized
@@ -5913,7 +5913,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var jLambda = new Lambda(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             hasCsLambdaFeatures ? lambdaPrefix : prefix,
             Markers.Empty,
             parameters,
@@ -5926,7 +5926,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (hasCsLambdaFeatures)
         {
             return new CsLambda(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -5957,7 +5957,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = node.Identifier.Span.End;
             var lambdaParamVarType = _typeMapping?.VariableType(node);
             return new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix, // Use the param prefix as identifier prefix
                 Markers.Empty,
                 [],
@@ -5985,7 +5985,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.Identifier.Span.End;
         var typedLambdaParamVarType = _typeMapping?.VariableType(node);
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -6009,7 +6009,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var namedVar = new NamedVariable(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             name,
@@ -6019,7 +6019,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         );
 
         return new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             [],
@@ -6057,7 +6057,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             arguments = new JContainer<Expression>(
                 Space.Empty,
                 [new JRightPadded<Expression>(
-                    new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                    new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                     Space.Empty,
                     Markers.Empty
                 )],
@@ -6073,7 +6073,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new NewClass(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             null,  // enclosing
@@ -6104,7 +6104,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new NewClass(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             null,  // enclosing
@@ -6182,11 +6182,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                         }
 
                         dimensions.Add(new ArrayDimension(
-                            Guid.NewGuid(),
+                            Tree.RandomId(),
                             dimPrefix,
                             dimMarkers,
                             new JRightPadded<Expression>(
-                                new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                                new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                                 afterSpace,
                                 Markers.Empty
                             )
@@ -6215,7 +6215,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                         }
 
                         dimensions.Add(new ArrayDimension(
-                            Guid.NewGuid(),
+                            Tree.RandomId(),
                             dimPrefix,
                             dimMarkers,
                             new JRightPadded<Expression>(expr, afterSpace, Markers.Empty)
@@ -6228,11 +6228,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 // Empty rank specifier like int[]
                 var afterSpace = ExtractSpaceBefore(rankSpec.CloseBracketToken);
                 dimensions.Add(new ArrayDimension(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     bracketPrefix,
                     Markers.Empty,
                     new JRightPadded<Expression>(
-                        new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                        new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                         afterSpace,
                         Markers.Empty
                     )
@@ -6250,7 +6250,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new NewArray(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             typeExpression,
@@ -6278,11 +6278,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var dimensions = new List<ArrayDimension>
         {
             new ArrayDimension(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 bracketPrefix,
                 Markers.Empty,
                 new JRightPadded<Expression>(
-                    new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                    new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                     innerSpace,
                     Markers.Empty
                 )
@@ -6293,7 +6293,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var initializer = ParseArrayInitializer(node.Initializer);
 
         return new NewArray(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             null,  // No type expression for implicit arrays
@@ -6314,7 +6314,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Empty initializer: { } — use sentinel Empty to preserve inner space
             var innerSpace = ExtractSpaceBefore(initializer.CloseBraceToken);
             elements.Add(new JRightPadded<Expression>(
-                new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                 innerSpace, Markers.Empty));
         }
         else
@@ -6344,7 +6344,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     afterSpace = ExtractSpaceBefore(sep);
                     _cursor = sep.Span.End;
                     var suffix = ExtractSpaceBefore(initializer.CloseBraceToken);
-                    elemMarkers = elemMarkers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                    elemMarkers = elemMarkers.Add(new TrailingComma(Tree.RandomId(), suffix));
                 }
                 else
                 {
@@ -6373,7 +6373,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             var spacing = _source[_cursor..dotToken.Span.Start];
             nullSafe = spacing.Length > 0
-                ? new NullSafe(Guid.NewGuid(), Space.Format(spacing))
+                ? new NullSafe(Tree.RandomId(), Space.Format(spacing))
                 : NullSafe.Instance;
         }
         else
@@ -6417,7 +6417,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(genericName.Identifier);
                     _cursor = genericName.Identifier.Span.End;
                     name = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6432,7 +6432,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(memberBinding.Name.Identifier);
                     _cursor = memberBinding.Name.Identifier.Span.End;
                     name = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6445,7 +6445,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var arguments = ParseArgumentList(invocation.ArgumentList);
 
                 return new MethodInvocation(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Build([nullSafe]),
                     new JRightPadded<Expression>(targetExpr, operatorSpace, Markers.Empty),
@@ -6474,7 +6474,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(genericMethodName.Identifier);
                     _cursor = genericMethodName.Identifier.Span.End;
                     methodName = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6489,7 +6489,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(memberAccess.Name.Identifier);
                     _cursor = memberAccess.Name.Identifier.Span.End;
                     methodName = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6502,7 +6502,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var arguments = ParseArgumentList(invocation.ArgumentList);
 
                 return new MethodInvocation(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     new JRightPadded<Expression>(arrayAccess, dotSpace, Markers.Empty),
@@ -6531,7 +6531,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(memberBinding.Name.Identifier);
             _cursor = memberBinding.Name.Identifier.Span.End;
             var name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -6541,7 +6541,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             );
 
             return new FieldAccess(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Build([nullSafe]),
                 targetExpr,
@@ -6588,7 +6588,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(genericName.Identifier);
                     _cursor = genericName.Identifier.Span.End;
                     firstName = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6603,7 +6603,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(innerMemberBinding.Name.Identifier);
                     _cursor = innerMemberBinding.Name.Identifier.Span.End;
                     firstName = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6616,7 +6616,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var firstArgs = ParseArgumentList(innerInvocation.ArgumentList);
 
                 firstAccess = new MethodInvocation(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     Space.Empty,
                     Markers.Build([innerNullSafe]),
                     new JRightPadded<Expression>(targetExpr, operatorSpace, Markers.Empty),
@@ -6695,15 +6695,15 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // NullSafe.DotPrefix stores space between ? and [ (like space between ? and . in MI)
             var singleDimNs = bracketPrefix.IsEmpty
                 ? NullSafe.Instance
-                : new NullSafe(Guid.NewGuid(), bracketPrefix);
+                : new NullSafe(Tree.RandomId(), bracketPrefix);
 
             return new ArrayAccess(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Build([singleDimNs]),
                 target,
                 new ArrayDimension(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     operatorSpace,
                     Markers.Empty,
                     new JRightPadded<Expression>(index, closeBracketSpace, Markers.Empty)
@@ -6733,16 +6733,16 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var multiDimNs = firstBracketPrefix.IsEmpty
             ? NullSafe.Instance
-            : new NullSafe(Guid.NewGuid(), firstBracketPrefix);
+            : new NullSafe(Tree.RandomId(), firstBracketPrefix);
 
         // Innermost ArrayAccess with NullSafe marker on the ArrayAccess
         ArrayAccess current = new ArrayAccess(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Build([multiDimNs]),
             target,
             new ArrayDimension(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 operatorSpace,
                 Markers.Empty,
                 new JRightPadded<Expression>(firstIndexExpr, Space.Empty, Markers.Empty)
@@ -6769,12 +6769,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = separator.Span.End;
 
                 current = new ArrayAccess(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     currentSpaceBeforeComma,
                     Markers.Empty.Add(MultiDimensionalArray.Instance),
                     current,
                     new ArrayDimension(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         Space.Empty,
                         Markers.Empty,
                         new JRightPadded<Expression>(index, Space.Empty, Markers.Empty)
@@ -6789,12 +6789,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = argList.CloseBracketToken.Span.End;
 
                 current = new ArrayAccess(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     currentSpaceBeforeComma,
                     Markers.Empty.Add(MultiDimensionalArray.Instance),
                     current,
                     new ArrayDimension(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         Space.Empty,
                         Markers.Empty,
                         new JRightPadded<Expression>(index, closeBracketSpace, Markers.Empty)
@@ -6839,7 +6839,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var namePrefix = ExtractSpaceBefore(genericName.Identifier);
                 _cursor = genericName.Identifier.Span.End;
                 name = new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     namePrefix,
                     Markers.Empty,
                     [],
@@ -6854,7 +6854,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var namePrefix = ExtractSpaceBefore(memberBinding.Name.Identifier);
                 _cursor = memberBinding.Name.Identifier.Span.End;
                 name = new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     namePrefix,
                     Markers.Empty,
                     [],
@@ -6867,7 +6867,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var arguments = ParseArgumentList(invocation.ArgumentList);
 
             return new MethodInvocation(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Build([nullSafe]),
                 new JRightPadded<Expression>(target, operatorSpace, Markers.Empty),
@@ -6900,7 +6900,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(terminalBinding.Name.Identifier);
             _cursor = terminalBinding.Name.Identifier.Span.End;
             var name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -6909,7 +6909,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 null
             );
             return new FieldAccess(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Build([tbNullSafe]),
                 target,
@@ -6940,7 +6940,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(genericName.Identifier);
                     _cursor = genericName.Identifier.Span.End;
                     firstName = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6955,7 +6955,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(innerMemberBinding.Name.Identifier);
                     _cursor = innerMemberBinding.Name.Identifier.Span.End;
                     firstName = new Identifier(
-                        Guid.NewGuid(),
+                        Tree.RandomId(),
                         namePrefix,
                         Markers.Empty,
                         [],
@@ -6968,7 +6968,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var firstArgs = ParseArgumentList(innerInvocation.ArgumentList);
 
                 firstCall = new MethodInvocation(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     Space.Empty,
                     Markers.Build([innerNs]),
                     new JRightPadded<Expression>(target, operatorSpace, Markers.Empty),
@@ -7022,7 +7022,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(genericName.Identifier);
                     _cursor = genericName.Identifier.Span.End;
                     name = new Identifier(
-                        Guid.NewGuid(), namePrefix, Markers.Empty,
+                        Tree.RandomId(), namePrefix, Markers.Empty,
                         [],
                         genericName.Identifier.Text, null,
                         null
@@ -7034,14 +7034,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(memberBinding.Name.Identifier);
                     _cursor = memberBinding.Name.Identifier.Span.End;
                     name = new Identifier(
-                        Guid.NewGuid(), namePrefix, Markers.Empty,
+                        Tree.RandomId(), namePrefix, Markers.Empty,
                         [],
                         memberBinding.Name.Identifier.Text, null,
                         null
                         );
                 }
                 return new FieldAccess(
-                    Guid.NewGuid(), Space.Empty, Markers.Build([mbNs]),
+                    Tree.RandomId(), Space.Empty, Markers.Build([mbNs]),
                     target, new JLeftPadded<Identifier>(operatorSpace, name), null);
             }
 
@@ -7057,7 +7057,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(genericName.Identifier);
                     _cursor = genericName.Identifier.Span.End;
                     name = new Identifier(
-                        Guid.NewGuid(), namePrefix, Markers.Empty,
+                        Tree.RandomId(), namePrefix, Markers.Empty,
                         [],
                         genericName.Identifier.Text, null,
                         null
@@ -7069,14 +7069,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var namePrefix = ExtractSpaceBefore(memberAccess.Name.Identifier);
                     _cursor = memberAccess.Name.Identifier.Span.End;
                     name = new Identifier(
-                        Guid.NewGuid(), namePrefix, Markers.Empty,
+                        Tree.RandomId(), namePrefix, Markers.Empty,
                         [],
                         memberAccess.Name.Identifier.Text, null,
                         null
                         );
                 }
                 return new FieldAccess(
-                    Guid.NewGuid(), Space.Empty, Markers.Empty,
+                    Tree.RandomId(), Space.Empty, Markers.Empty,
                     inner, new JLeftPadded<Identifier>(dotSpace, name), null);
             }
 
@@ -7095,7 +7095,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                         var np = ExtractSpaceBefore(gn.Identifier);
                         _cursor = gn.Identifier.Span.End;
                         name = new Identifier(
-                            Guid.NewGuid(), np, Markers.Empty,
+                            Tree.RandomId(), np, Markers.Empty,
                             [],
                             gn.Identifier.Text, null,
                             null
@@ -7107,7 +7107,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                         var np = ExtractSpaceBefore(binding.Name.Identifier);
                         _cursor = binding.Name.Identifier.Span.End;
                         name = new Identifier(
-                            Guid.NewGuid(), np, Markers.Empty,
+                            Tree.RandomId(), np, Markers.Empty,
                             [],
                             binding.Name.Identifier.Text, null,
                             null
@@ -7125,7 +7125,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                         var np = ExtractSpaceBefore(gn.Identifier);
                         _cursor = gn.Identifier.Span.End;
                         name = new Identifier(
-                            Guid.NewGuid(), np, Markers.Empty,
+                            Tree.RandomId(), np, Markers.Empty,
                             [],
                             gn.Identifier.Text, null,
                             null
@@ -7137,7 +7137,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                         var np = ExtractSpaceBefore(memberAccess.Name.Identifier);
                         _cursor = memberAccess.Name.Identifier.Span.End;
                         name = new Identifier(
-                            Guid.NewGuid(), np, Markers.Empty,
+                            Tree.RandomId(), np, Markers.Empty,
                             [],
                             memberAccess.Name.Identifier.Text, null,
                             null
@@ -7153,7 +7153,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
                 var args = ParseArgumentList(invocation.ArgumentList);
                 return new MethodInvocation(
-                    Guid.NewGuid(), Space.Empty,
+                    Tree.RandomId(), Space.Empty,
                     nullSafeMarker != null ? Markers.Build([nullSafeMarker]) : Markers.Empty,
                     select, name, typeParams, args, null);
             }
@@ -7176,11 +7176,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = elemAccess.ArgumentList.CloseBracketToken.Span.End;
 
                 var dimension = new ArrayDimension(
-                    Guid.NewGuid(), bracketPrefix, Markers.Empty,
+                    Tree.RandomId(), bracketPrefix, Markers.Empty,
                     new JRightPadded<Expression>(indexArg, closeBracketSpace, Markers.Empty));
 
                 return new ArrayAccess(
-                    Guid.NewGuid(), Space.Empty, Markers.Empty,
+                    Tree.RandomId(), Space.Empty, Markers.Empty,
                     indexed, dimension, null);
             }
 
@@ -7190,7 +7190,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var inner = ParseConditionalAccessSegment(target, operatorSpace, postfix.Operand);
                 _cursor = postfix.OperatorToken.Span.End;
                 return new CsUnary(
-                    Guid.NewGuid(), Space.Empty, Markers.Empty,
+                    Tree.RandomId(), Space.Empty, Markers.Empty,
                     new JLeftPadded<CsUnary.OperatorKind>(Space.Empty, CsUnary.OperatorKind.SuppressNullableWarning),
                     inner, null);
             }
@@ -7206,7 +7206,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 if (assignment.Kind() == SyntaxKind.SimpleAssignmentExpression)
                 {
                     return new Assignment(
-                        Guid.NewGuid(), Space.Empty, Markers.Empty,
+                        Tree.RandomId(), Space.Empty, Markers.Empty,
                         left, new JLeftPadded<Expression>(opPrefix, right),
                         _typeMapping?.Type(assignment));
                 }
@@ -7214,7 +7214,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 {
                     var opType = MapAssignmentOperator(assignment.Kind());
                     return new AssignmentOperation(
-                        Guid.NewGuid(), Space.Empty, Markers.Empty,
+                        Tree.RandomId(), Space.Empty, Markers.Empty,
                         left, new JLeftPadded<AssignmentOperation.OperatorType>(opPrefix, opType),
                         right, _typeMapping?.Type(assignment));
                 }
@@ -7244,7 +7244,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = arg.NameColon.Name.Identifier.Span.End;
 
                 var nameIdentifier = new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     Space.Empty,
                     Markers.Empty,
                     [],
@@ -7265,7 +7265,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 }
 
                 expr = new NamedExpression(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     argPrefix,
                     Markers.Empty,
                     new JRightPadded<Identifier>(nameIdentifier, colonSpace, Markers.Empty),
@@ -7300,7 +7300,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             {
                 // Use an Empty element to hold the trailing space before )
                 args.Add(new JRightPadded<Expression>(
-                    new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                    new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                     emptySpace,
                     Markers.Empty
                 ));
@@ -7355,7 +7355,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var namePrefix = ExtractSpaceBefore(param.Identifier);
             _cursor = param.Identifier.Span.End;
             var name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -7380,7 +7380,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Create a ConstrainedTypeParameter without constraint data
             // (constraints will be merged later via MergeConstraintClauses)
             var ctp = new ConstrainedTypeParameter(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 attrLists,
@@ -7399,7 +7399,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             );
 
             var typeParam = new TypeParameter(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],    // Annotations
@@ -7440,7 +7440,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var constraintNamePrefix = ExtractSpaceBefore(clause.Name.Identifier);
             _cursor = clause.Name.Identifier.Span.End;
             var whereIdentifier = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 constraintNamePrefix,
                 Markers.Empty,
                 [],
@@ -7495,21 +7495,21 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                             // Duplicate where clause for same type param — create a separate
                             // synthetic type parameter entry so both where clauses round-trip
                             var dupCtp = new ConstrainedTypeParameter(
-                                Guid.NewGuid(), Space.Empty, Markers.Empty,
+                                Tree.RandomId(), Space.Empty, Markers.Empty,
                                 [], null, whereIdentifier, whereConstraint, constraintsContainer, null);
                             var syntheticTp = new TypeParameter(
-                                Guid.NewGuid(), Space.Empty, Markers.Empty, [], [],
-                                new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], paramName, null, null),
+                                Tree.RandomId(), Space.Empty, Markers.Empty, [], [],
+                                new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], paramName, null, null),
                                 new JContainer<TypeTree>(Space.Empty,
                                     [new JRightPadded<TypeTree>(dupCtp, Space.Empty, Markers.Empty)],
-                                    Markers.Build([new ImplicitTypeParameters(Guid.NewGuid())])));
+                                    Markers.Build([new ImplicitTypeParameters(Tree.RandomId())])));
                             typeParams.Add(new JRightPadded<TypeParameter>(syntheticTp, Space.Empty, Markers.Empty));
                             merged = true;
                         }
                         else
                         {
                             var updatedCtp = ctp.WithWhereConstraint(whereConstraint).WithConstraints(constraintsContainer)
-                                .WithMarkers(ctp.Markers.Add(new WhereClauseOrder(Guid.NewGuid(), whereOrder)));
+                                .WithMarkers(ctp.Markers.Add(new WhereClauseOrder(Tree.RandomId(), whereOrder)));
                             var updatedBounds = new JContainer<TypeTree>(
                                 tp.Element.Bounds!.Before,
                                 [new JRightPadded<TypeTree>(updatedCtp, Space.Empty, Markers.Empty)],
@@ -7526,14 +7526,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             {
                 // Unmatched constraint — create a synthetic type parameter to hold it
                 var ctp = new ConstrainedTypeParameter(
-                    Guid.NewGuid(), Space.Empty, Markers.Empty,
+                    Tree.RandomId(), Space.Empty, Markers.Empty,
                     [], null, whereIdentifier, whereConstraint, constraintsContainer, null);
                 var syntheticTp = new TypeParameter(
-                    Guid.NewGuid(), Space.Empty, Markers.Empty, [], [],
-                    new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], paramName, null, null),
+                    Tree.RandomId(), Space.Empty, Markers.Empty, [], [],
+                    new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], paramName, null, null),
                     new JContainer<TypeTree>(Space.Empty,
                         [new JRightPadded<TypeTree>(ctp, Space.Empty, Markers.Empty)],
-                        Markers.Build([new ImplicitTypeParameters(Guid.NewGuid())])));
+                        Markers.Build([new ImplicitTypeParameters(Tree.RandomId())])));
                 typeParams.Add(new JRightPadded<TypeParameter>(syntheticTp, Space.Empty, Markers.Empty));
             }
             whereOrder++;
@@ -7571,7 +7571,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     ? ClassOrStructConstraint.TypeKind.Class
                     : ClassOrStructConstraint.TypeKind.Struct;
                 return new ClassOrStructConstraint(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     kind,
@@ -7584,7 +7584,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var prefix = ExtractSpaceBefore(newConstraint.NewKeyword);
                 _cursor = newConstraint.CloseParenToken.Span.End;
                 return new ConstructorConstraint(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty
                 );
@@ -7595,7 +7595,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var prefix = ExtractSpaceBefore(defaultConstraint.DefaultKeyword);
                 _cursor = defaultConstraint.DefaultKeyword.Span.End;
                 return new DefaultConstraint(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty
                 );
@@ -7617,7 +7617,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                         {
                             var refPrefix = ExtractSpaceBefore(refStruct.RefKeyword);
                             _cursor = refStruct.StructKeyword.Span.End;
-                            expr = new RefStructConstraint(Guid.NewGuid(), refPrefix, Markers.Empty);
+                            expr = new RefStructConstraint(Tree.RandomId(), refPrefix, Markers.Empty);
                             break;
                         }
                         default:
@@ -7655,7 +7655,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 }
 
                 return new AllowsConstraintClause(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     new JContainer<Expression>(containerBefore, constraints, Markers.Empty)
@@ -7705,9 +7705,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         // Create a synthesized method name with Implicit marker (following Kotlin pattern)
         var methodName = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
-            Markers.Build([new Implicit(Guid.NewGuid())]),
+            Markers.Build([new Implicit(Tree.RandomId())]),
             [],
             "<constructor>",
             null,
@@ -7716,9 +7716,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         // Create the synthesized MethodDeclaration with PrimaryConstructor marker
         return new MethodDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
-            Markers.Build([new PrimaryConstructor(Guid.NewGuid())]),
+            Markers.Build([new PrimaryConstructor(Tree.RandomId())]),
             [],      // LeadingAnnotations
             [],      // Modifiers
             null,    // TypeParameters
@@ -7773,7 +7773,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             }
 
             return new RefExpression(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 refPrefix,
                 Markers.Empty,
                 refKind,
@@ -7806,7 +7806,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         Expression variables = ParseVariableDesignation(declExpr.Designation);
 
         return new DeclarationExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             typeExpr,
@@ -7827,7 +7827,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = singleVar.Identifier.Span.End;
 
             var varName = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],
@@ -7837,7 +7837,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             );
 
             return new SingleVariableDesignation(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 varPrefix,
                 Markers.Empty,
                 varName
@@ -7849,7 +7849,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = discard.UnderscoreToken.Span.End;
 
             var discardName = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],
@@ -7859,7 +7859,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             );
 
             return new DiscardVariableDesignation(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 discardPrefix,
                 Markers.Empty,
                 discardName
@@ -7892,7 +7892,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = parenDesig.CloseParenToken.Span.End;
 
             return new ParenthesizedVariableDesignation(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 parenPrefix,
                 Markers.Empty,
                 new JContainer<VariableDesignation>(Space.Empty, variables, Markers.Empty),
@@ -7975,7 +7975,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
             var localDeclVarType = _typeMapping?.VariableType(v);
             var name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -7999,7 +7999,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             }
 
             var namedVar = new NamedVariable(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 varPrefix,
                 Markers.Empty,
                 name,
@@ -8021,7 +8021,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             Space.Empty,
             Markers.Empty,
             [],
@@ -8118,7 +8118,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
             var fieldDeclVarType = _typeMapping?.VariableType(v);
             var name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -8142,7 +8142,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             }
 
             var namedVar = new NamedVariable(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 varPrefix,
                 Markers.Empty,
                 name,
@@ -8168,7 +8168,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.SemicolonToken.Span.End;
 
         var varDecl = new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             attributeLists.Count > 0 ? Space.Empty : prefix,
             Markers.Empty,
             [],
@@ -8182,7 +8182,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -8217,7 +8217,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var eventPrefix = ExtractSpaceBefore(node.EventKeyword);
         _cursor = node.EventKeyword.Span.End;
         modifiers.Add(new Modifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             eventPrefix,
             Markers.Empty,
             Modifier.ModifierType.LanguageExtension,
@@ -8242,7 +8242,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = v.Identifier.Span.End;
             var eventFieldVarType = _typeMapping?.VariableType(v);
             var name = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 namePrefix,
                 Markers.Empty,
                 [],
@@ -8265,7 +8265,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             }
 
             var namedVar = new NamedVariable(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 varPrefix,
                 Markers.Empty,
                 name,
@@ -8289,7 +8289,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         SkipToken(node.SemicolonToken);
 
         var varDecl = new VariableDeclarations(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             attributeLists.Count > 0 ? Space.Empty : prefix,
             Markers.Empty,
             [],
@@ -8303,7 +8303,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (attributeLists.Count > 0)
         {
             return new AnnotatedStatement(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 attributeLists,
@@ -8334,7 +8334,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var namePrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var name = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             namePrefix,
             Markers.Empty,
             [],
@@ -8395,10 +8395,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new MethodDeclaration(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             node.ExpressionBody != null
-                ? Markers.Build([new ExpressionBodied(Guid.NewGuid())])
+                ? Markers.Build([new ExpressionBodied(Tree.RandomId())])
                 : Markers.Empty,
             [],
             modifiers,
@@ -8426,12 +8426,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var blockPrefix = initExpr.Prefix;
         initExpr = initExpr.WithPrefix(Space.Empty);
         return new Block(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             blockPrefix,
             Markers.Empty,
             new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
             [new JRightPadded<Statement>(
-                new ExpressionStatement(Guid.NewGuid(), initExpr),
+                new ExpressionStatement(Tree.RandomId(), initExpr),
                 Space.Empty,
                 Markers.Empty
             )],
@@ -8453,7 +8453,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (kind == JavaType.PrimitiveKind.None)
             {
                 return new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     [],
@@ -8463,7 +8463,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 );
             }
             return new Primitive(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 kind
@@ -8476,7 +8476,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             if (identifier.Identifier.Text == "var")
             {
                 return new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     [],
@@ -8488,7 +8488,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             else
             {
                 return new Identifier(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     [],
@@ -8503,7 +8503,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Handle generic types like List<int>, Dictionary<string, int>
             _cursor = genericName.Identifier.Span.End;
             var clazz = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 [],
@@ -8515,7 +8515,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             var typeParams = ParseTypeArgumentList(genericName.TypeArgumentList);
 
             return new ParameterizedType(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 clazz,
@@ -8552,7 +8552,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 _cursor = rankSpec.CloseBracketToken.Span.End;
 
                 result = new ArrayType(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     result == elementType ? prefix : Space.Empty,
                     Markers.Empty,
                     result,
@@ -8589,11 +8589,11 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 {
                     var namePrefix = ExtractSpaceBefore(element.Identifier);
                     _cursor = element.Identifier.Span.End;
-                    elemName = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], element.Identifier.Text, null, null);
+                    elemName = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], element.Identifier.Text, null, null);
                 }
 
                 var tupleElement = new TupleElement(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     elemPrefix,
                     Markers.Empty,
                     elemType!,
@@ -8619,7 +8619,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = tupleType.CloseParenToken.Span.End;
 
             return new TupleType(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 new JContainer<TupleElement>(Space.Empty, elements, Markers.Empty),
@@ -8638,7 +8638,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = nullableType.QuestionToken.Span.End;
 
             return new NullableType(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 [],
@@ -8658,7 +8658,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = pointerType.AsteriskToken.Span.End;
 
             return new PointerType(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 new JRightPadded<TypeTree>(elementType, starPrefix, Markers.Empty)
@@ -8674,7 +8674,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             {
                 var readonlyPrefix = ExtractSpaceBefore(refType.ReadOnlyKeyword);
                 _cursor = refType.ReadOnlyKeyword.Span.End;
-                readonlyKeyword = new Modifier(Guid.NewGuid(), readonlyPrefix, Markers.Empty, Modifier.ModifierType.Readonly, []);
+                readonlyKeyword = new Modifier(Tree.RandomId(), readonlyPrefix, Markers.Empty, Modifier.ModifierType.Readonly, []);
             }
 
             var innerType = VisitType(refType.Type);
@@ -8683,7 +8683,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 throw new InvalidOperationException($"Unable to parse ref element type: {refType.Type}");
             }
 
-            return new RefType(Guid.NewGuid(), prefix, Markers.Empty, readonlyKeyword, innerType, _typeMapping?.Type(type));
+            return new RefType(Tree.RandomId(), prefix, Markers.Empty, readonlyKeyword, innerType, _typeMapping?.Type(type));
         }
         else if (type is ScopedTypeSyntax scopedType)
         {
@@ -8702,21 +8702,21 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         else if (type is AliasQualifiedNameSyntax aliasQualified)
         {
             _cursor = aliasQualified.Alias.Identifier.Span.End;
-            var alias = new Identifier(Guid.NewGuid(), prefix, Markers.Empty, [], aliasQualified.Alias.Identifier.Text, null, null);
+            var alias = new Identifier(Tree.RandomId(), prefix, Markers.Empty, [], aliasQualified.Alias.Identifier.Text, null, null);
 
             var colonColonPrefix = ExtractSpaceBefore(aliasQualified.ColonColonToken);
             _cursor = aliasQualified.ColonColonToken.Span.End;
 
             var name = (Expression)Visit(aliasQualified.Name)!;
 
-            return new AliasQualifiedName(Guid.NewGuid(), Space.Empty, Markers.Empty,
+            return new AliasQualifiedName(Tree.RandomId(), Space.Empty, Markers.Empty,
                 new JRightPadded<Identifier>(alias, colonColonPrefix, Markers.Empty), name);
         }
 
         // For now, handle other types as identifiers
         _cursor = type.Span.End;
         return new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             [],
@@ -8741,7 +8741,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             _cursor = leftIdent.Identifier.Span.End;
             left = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],
@@ -8755,7 +8755,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Fallback for other left types
             _cursor = qualified.Left.Span.End;
             left = new Identifier(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 Space.Empty,
                 Markers.Empty,
                 [],
@@ -8777,7 +8777,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             : qualified.Right.Identifier.Text;
         _cursor = qualified.Right.Span.End;
         var right = new Identifier(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             rightPrefix,
             Markers.Empty,
             [],
@@ -8787,7 +8787,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         );
 
         return new FieldAccess(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             left,
@@ -8846,7 +8846,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
     {
         var type = MapModifier(modToken.Kind());
         string? keyword = type == Modifier.ModifierType.LanguageExtension ? modToken.Text : null;
-        return new Modifier(Guid.NewGuid(), prefix, Markers.Empty, type, [], keyword);
+        return new Modifier(Tree.RandomId(), prefix, Markers.Empty, type, [], keyword);
     }
 
     #region Preprocessor Directive Processing
@@ -9055,13 +9055,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
     private RegionDirective ParseRegionDirective(Space prefix, string afterKeyword, string hashSpacing = "")
     {
-        return new RegionDirective(Guid.NewGuid(), prefix, Markers.Empty,
+        return new RegionDirective(Tree.RandomId(), prefix, Markers.Empty,
             afterKeyword.Length > 0 ? afterKeyword : null, hashSpacing);
     }
 
     private EndRegionDirective ParseEndRegionDirective(Space prefix, string afterKeyword, string hashSpacing = "")
     {
-        return new EndRegionDirective(Guid.NewGuid(), prefix, Markers.Empty,
+        return new EndRegionDirective(Tree.RandomId(), prefix, Markers.Empty,
             afterKeyword.Length > 0 ? afterKeyword : null, hashSpacing);
     }
 
@@ -9074,7 +9074,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (rest.StartsWith("checksum"))
         {
             var arguments = rest[8..]; // text after "checksum"
-            return new PragmaChecksumDirective(Guid.NewGuid(), prefix, Markers.Empty, keywordSpacing, arguments);
+            return new PragmaChecksumDirective(Tree.RandomId(), prefix, Markers.Empty, keywordSpacing, arguments);
         }
 
         if (!rest.StartsWith("warning")) return null;
@@ -9111,12 +9111,12 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 if (trimmed.Length == 0) continue;
                 var spaceLen = part.Length - trimmed.Length;
                 var codePrefix = spaceLen > 0 ? Space.Format(part[..spaceLen]) : Space.Empty;
-                var code = new Identifier(Guid.NewGuid(), codePrefix, Markers.Empty, [], trimmed, null, null);
+                var code = new Identifier(Tree.RandomId(), codePrefix, Markers.Empty, [], trimmed, null, null);
                 codes.Add(new JRightPadded<Expression>(code, Space.Empty, Markers.Empty));
             }
         }
 
-        return new PragmaWarningDirective(Guid.NewGuid(), prefix, Markers.Empty, action, codes, keywordSpacing, actionSpacing);
+        return new PragmaWarningDirective(Tree.RandomId(), prefix, Markers.Empty, action, codes, keywordSpacing, actionSpacing);
     }
 
     private NullableDirective ParseNullableDirective(Space prefix, string afterKeyword, string hashSpacing = "")
@@ -9163,7 +9163,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         // Capture any trailing comment (e.g., "// TODO: Fix this")
         var trailingComment = target != null ? remainder : (remainder.Length > 0 && settingEnd > 0 ? remainder : "");
 
-        return new NullableDirective(Guid.NewGuid(), prefix, Markers.Empty, setting, target, hashSpacing, trailingComment, keywordSpacing);
+        return new NullableDirective(Tree.RandomId(), prefix, Markers.Empty, setting, target, hashSpacing, trailingComment, keywordSpacing);
     }
 
     private DefineDirective ParseDefineDirective(Space prefix, string afterKeyword)
@@ -9171,8 +9171,8 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var spaceLen = afterKeyword.Length - afterKeyword.TrimStart().Length;
         var symbolPrefix = spaceLen > 0 ? Space.Format(afterKeyword[..spaceLen]) : Space.Empty;
         var symbolName = afterKeyword.TrimStart();
-        return new DefineDirective(Guid.NewGuid(), prefix, Markers.Empty,
-            new Identifier(Guid.NewGuid(), symbolPrefix, Markers.Empty, [], symbolName, null, null));
+        return new DefineDirective(Tree.RandomId(), prefix, Markers.Empty,
+            new Identifier(Tree.RandomId(), symbolPrefix, Markers.Empty, [], symbolName, null, null));
     }
 
     private UndefDirective ParseUndefDirective(Space prefix, string afterKeyword)
@@ -9180,18 +9180,18 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var spaceLen = afterKeyword.Length - afterKeyword.TrimStart().Length;
         var symbolPrefix = spaceLen > 0 ? Space.Format(afterKeyword[..spaceLen]) : Space.Empty;
         var symbolName = afterKeyword.TrimStart();
-        return new UndefDirective(Guid.NewGuid(), prefix, Markers.Empty,
-            new Identifier(Guid.NewGuid(), symbolPrefix, Markers.Empty, [], symbolName, null, null));
+        return new UndefDirective(Tree.RandomId(), prefix, Markers.Empty,
+            new Identifier(Tree.RandomId(), symbolPrefix, Markers.Empty, [], symbolName, null, null));
     }
 
     private ErrorDirective ParseErrorDirective(Space prefix, string afterKeyword)
     {
-        return new ErrorDirective(Guid.NewGuid(), prefix, Markers.Empty, afterKeyword.TrimStart());
+        return new ErrorDirective(Tree.RandomId(), prefix, Markers.Empty, afterKeyword.TrimStart());
     }
 
     private WarningDirective ParseWarningDirective(Space prefix, string afterKeyword)
     {
-        return new WarningDirective(Guid.NewGuid(), prefix, Markers.Empty, afterKeyword.TrimStart());
+        return new WarningDirective(Tree.RandomId(), prefix, Markers.Empty, afterKeyword.TrimStart());
     }
 
     private LineDirective ParseLineDirective(Space prefix, string afterKeyword)
@@ -9199,9 +9199,9 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var rest = afterKeyword.TrimStart();
 
         if (rest.StartsWith("hidden"))
-            return new LineDirective(Guid.NewGuid(), prefix, Markers.Empty, LineKind.Hidden, null, null);
+            return new LineDirective(Tree.RandomId(), prefix, Markers.Empty, LineKind.Hidden, null, null);
         if (rest.StartsWith("default"))
-            return new LineDirective(Guid.NewGuid(), prefix, Markers.Empty, LineKind.Default, null, null);
+            return new LineDirective(Tree.RandomId(), prefix, Markers.Empty, LineKind.Default, null, null);
 
         // Numeric: " 200" or " 200 \"file.cs\""
         var spaceLen = afterKeyword.Length - afterKeyword.TrimStart().Length;
@@ -9212,7 +9212,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         while (numEnd < rest.Length && char.IsDigit(rest[numEnd])) numEnd++;
         var lineNum = rest[..numEnd];
         var line = new Literal(
-            Guid.NewGuid(), linePrefix, Markers.Empty,
+            Tree.RandomId(), linePrefix, Markers.Empty,
             int.Parse(lineNum), lineNum, null,
             JavaType.Primitive.Of(JavaType.PrimitiveKind.Int)
         );
@@ -9228,14 +9228,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             {
                 var filePrefix = fileSpaceLen > 0 ? Space.Format(fileRest[..fileSpaceLen]) : Space.Empty;
                 file = new Literal(
-                    Guid.NewGuid(), filePrefix, Markers.Empty,
+                    Tree.RandomId(), filePrefix, Markers.Empty,
                     fileTrimmed.Trim('"'), fileTrimmed, null,
                     JavaType.Primitive.Of(JavaType.PrimitiveKind.String)
                 );
             }
         }
 
-        return new LineDirective(Guid.NewGuid(), prefix, Markers.Empty, LineKind.Numeric, line, file);
+        return new LineDirective(Tree.RandomId(), prefix, Markers.Empty, LineKind.Numeric, line, file);
     }
 
     #endregion
@@ -9250,7 +9250,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var body = (QueryBody)VisitQueryBody(node.Body);
 
         return new QueryExpression(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             fromClause,
@@ -9284,7 +9284,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new QueryBody(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             clauses,
@@ -9309,7 +9309,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var identPrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var ident = new Identifier(
-            Guid.NewGuid(), identPrefix, Markers.Empty,
+            Tree.RandomId(), identPrefix, Markers.Empty,
             [],
             node.Identifier.Text, null,
             null
@@ -9321,7 +9321,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var expression = (Expression)Visit(node.Expression)!;
 
         return new FromClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             typeIdentifier,
@@ -9339,7 +9339,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var identPrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var ident = new Identifier(
-            Guid.NewGuid(), identPrefix, Markers.Empty,
+            Tree.RandomId(), identPrefix, Markers.Empty,
             [],
             node.Identifier.Text, null,
             null
@@ -9350,7 +9350,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var expression = (Expression)Visit(node.Expression)!;
 
         return new LetClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Identifier>(ident, afterIdent, Markers.Empty),
@@ -9367,7 +9367,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var identPrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var ident = new Identifier(
-            Guid.NewGuid(), identPrefix, Markers.Empty,
+            Tree.RandomId(), identPrefix, Markers.Empty,
             [],
             node.Identifier.Text, null,
             null
@@ -9398,7 +9398,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new JoinClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Identifier>(ident, afterIdent, Markers.Empty),
@@ -9417,14 +9417,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var identPrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var ident = new Identifier(
-            Guid.NewGuid(), identPrefix, Markers.Empty,
+            Tree.RandomId(), identPrefix, Markers.Empty,
             [],
             node.Identifier.Text, null,
             null
         );
 
         return new JoinIntoClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             ident
@@ -9439,7 +9439,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var condition = (Expression)Visit(node.Condition)!;
 
         return new WhereClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             condition
@@ -9469,7 +9469,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new OrderByClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             orderings
@@ -9494,7 +9494,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         return new Ordering(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Expression>(expression, afterExpr, Markers.Empty),
@@ -9510,7 +9510,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var expression = (Expression)Visit(node.Expression)!;
 
         return new SelectClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             expression
@@ -9529,7 +9529,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var key = (Expression)Visit(node.ByExpression)!;
 
         return new GroupClause(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             new JRightPadded<Expression>(groupExpr, afterGroupExpr, Markers.Empty),
@@ -9545,7 +9545,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var identPrefix = ExtractSpaceBefore(node.Identifier);
         _cursor = node.Identifier.Span.End;
         var ident = new Identifier(
-            Guid.NewGuid(), identPrefix, Markers.Empty,
+            Tree.RandomId(), identPrefix, Markers.Empty,
             [],
             node.Identifier.Text, null,
             null
@@ -9554,7 +9554,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var body = (QueryBody)VisitQueryBody(node.Body);
 
         return new QueryContinuation(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             ident,
@@ -9621,8 +9621,8 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var beforeSemicolon = ExtractSpaceBefore(semicolonToken);
         _cursor = semicolonToken.Span.End;
 
-        var returnStmt = new Return(Guid.NewGuid(), Space.Empty, Markers.Empty, expr);
-        return new Block(Guid.NewGuid(), arrowPrefix, Markers.Empty,
+        var returnStmt = new Return(Tree.RandomId(), Space.Empty, Markers.Empty, expr);
+        return new Block(Tree.RandomId(), arrowPrefix, Markers.Empty,
             new JRightPadded<bool>(false, Space.Empty, Markers.Empty),
             [new JRightPadded<Statement>(returnStmt, beforeSemicolon, Markers.Empty)],
             Space.Empty);
@@ -9709,10 +9709,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             _cursor = argList.CloseParenToken.Span.End;
 
             var j = (J)typeTree;
-            return new TypeWithArguments(Guid.NewGuid(), j.Prefix, Markers.Empty,
+            return new TypeWithArguments(Tree.RandomId(), j.Prefix, Markers.Empty,
                 (TypeTree)((dynamic)typeTree).WithPrefix(Space.Empty),
                 new JContainer<Expression>(openParen, [
-                    new JRightPadded<Expression>(new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty), closeParen, Markers.Empty)
+                    new JRightPadded<Expression>(new Empty(Tree.RandomId(), Space.Empty, Markers.Empty), closeParen, Markers.Empty)
                 ], Markers.Empty));
         }
 
@@ -9741,7 +9741,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = argList.CloseParenToken.Span.End;
 
         var jTree = (J)typeTree;
-        return new TypeWithArguments(Guid.NewGuid(), jTree.Prefix, Markers.Empty,
+        return new TypeWithArguments(Tree.RandomId(), jTree.Prefix, Markers.Empty,
             (TypeTree)((dynamic)typeTree).WithPrefix(Space.Empty),
             new JContainer<Expression>(argsPrefix, args, Markers.Empty));
     }
@@ -9769,13 +9769,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         {
             var kwPrefix = ExtractSpaceBefore(node.CaseOrDefaultKeyword);
             _cursor = node.CaseOrDefaultKeyword.Span.End;
-            caseOrDefaultKeyword = new Keyword(Guid.NewGuid(), kwPrefix, Markers.Empty, KeywordKind.Case);
+            caseOrDefaultKeyword = new Keyword(Tree.RandomId(), kwPrefix, Markers.Empty, KeywordKind.Case);
         }
         else if (node.CaseOrDefaultKeyword.IsKind(SyntaxKind.DefaultKeyword))
         {
             var kwPrefix = ExtractSpaceBefore(node.CaseOrDefaultKeyword);
             _cursor = node.CaseOrDefaultKeyword.Span.End;
-            caseOrDefaultKeyword = new Keyword(Guid.NewGuid(), kwPrefix, Markers.Empty, KeywordKind.Default);
+            caseOrDefaultKeyword = new Keyword(Tree.RandomId(), kwPrefix, Markers.Empty, KeywordKind.Default);
         }
 
         Expression? target = null;
@@ -9785,7 +9785,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         _cursor = node.SemicolonToken.Span.End;
-        return new GotoStatement(Guid.NewGuid(), prefix, Markers.Empty, caseOrDefaultKeyword, target);
+        return new GotoStatement(Tree.RandomId(), prefix, Markers.Empty, caseOrDefaultKeyword, target);
     }
 
     public override J VisitUsingStatement(UsingStatementSyntax node)
@@ -9820,7 +9820,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 var namePrefix = ExtractSpaceBefore(v.Identifier);
                 _cursor = v.Identifier.Span.End;
                 var localVarType = _typeMapping?.VariableType(v);
-                var name = new Identifier(Guid.NewGuid(), namePrefix, Markers.Empty, [], v.Identifier.Text, localVarType?.Type, localVarType);
+                var name = new Identifier(Tree.RandomId(), namePrefix, Markers.Empty, [], v.Identifier.Text, localVarType?.Type, localVarType);
 
                 JLeftPadded<Expression>? initializer = null;
                 if (v.Initializer != null)
@@ -9834,7 +9834,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     }
                 }
 
-                var namedVar = new NamedVariable(Guid.NewGuid(), varPrefix, Markers.Empty, name, [], initializer, _typeMapping?.VariableType(v));
+                var namedVar = new NamedVariable(Tree.RandomId(), varPrefix, Markers.Empty, name, [], initializer, _typeMapping?.VariableType(v));
 
                 Space afterSpace = Space.Empty;
                 if (i < node.Declaration.Variables.Count - 1)
@@ -9847,8 +9847,8 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 variables.Add(new JRightPadded<NamedVariable>(namedVar, afterSpace, Markers.Empty));
             }
 
-            var varDecl = new VariableDeclarations(Guid.NewGuid(), declPrefix, Markers.Empty, [], [], typeExpr, null, [], variables);
-            innerExpr = new StatementExpression(Guid.NewGuid(), Space.Empty, Markers.Empty, varDecl);
+            var varDecl = new VariableDeclarations(Tree.RandomId(), declPrefix, Markers.Empty, [], [], typeExpr, null, [], variables);
+            innerExpr = new StatementExpression(Tree.RandomId(), Space.Empty, Markers.Empty, varDecl);
         }
         else
         {
@@ -9867,21 +9867,21 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
         else
         {
-            block = new Block(Guid.NewGuid(), Space.Empty,
-                Markers.Empty.Add(new OmitBraces(Guid.NewGuid())),
+            block = new Block(Tree.RandomId(), Space.Empty,
+                Markers.Empty.Add(new OmitBraces(Tree.RandomId())),
                 JRightPadded<bool>.Build(false),
                 [PadStatement(body)], Space.Empty);
         }
 
-        var usingStatement = new UsingStatement(Guid.NewGuid(), hasAwait ? Space.Empty : prefix, Markers.Empty, expressionPadded, block);
+        var usingStatement = new UsingStatement(Tree.RandomId(), hasAwait ? Space.Empty : prefix, Markers.Empty, expressionPadded, block);
 
         if (hasAwait)
         {
             return new AwaitExpression(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
-                new StatementExpression(Guid.NewGuid(), awaitSuffix, Markers.Empty, usingStatement),
+                new StatementExpression(Tree.RandomId(), awaitSuffix, Markers.Empty, usingStatement),
                 null
             );
         }
@@ -9918,14 +9918,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         _cursor = node.ArgumentList.CloseBracketToken.Span.End;
-        return new ImplicitElementAccess(Guid.NewGuid(), prefix, Markers.Empty, new JContainer<Expression>(bracketPrefix, args, Markers.Empty));
+        return new ImplicitElementAccess(Tree.RandomId(), prefix, Markers.Empty, new JContainer<Expression>(bracketPrefix, args, Markers.Empty));
     }
 
     public override J VisitSlicePattern(SlicePatternSyntax node)
     {
         var prefix = ExtractPrefix(node);
         _cursor = node.DotDotToken.Span.End;
-        return new SlicePattern(Guid.NewGuid(), prefix, Markers.Empty);
+        return new SlicePattern(Tree.RandomId(), prefix, Markers.Empty);
     }
 
     public override J VisitListPattern(ListPatternSyntax node)
@@ -9956,7 +9956,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         _cursor = node.CloseBracketToken.Span.End;
-        return new ListPattern(Guid.NewGuid(), prefix, Markers.Empty, new JContainer<Pattern>(bracketPrefix, patterns, Markers.Empty), null);
+        return new ListPattern(Tree.RandomId(), prefix, Markers.Empty, new JContainer<Pattern>(bracketPrefix, patterns, Markers.Empty), null);
     }
 
     public override J VisitAliasQualifiedName(AliasQualifiedNameSyntax node)
@@ -9998,7 +9998,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         _cursor = node.CloseParenToken.Span.End;
 
         var control = new ForEachVariableLoopControl(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             controlPrefix,
             Markers.Empty,
             new JRightPadded<Expression>(variable, inPrefix, Markers.Empty),
@@ -10009,7 +10009,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         var bodyStatement = (Statement)Visit(node.Statement)!;
 
         var forEachVariableLoop = new ForEachVariableLoop(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             hasAwait ? Space.Empty : prefix,
             Markers.Empty,
             control,
@@ -10019,10 +10019,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (hasAwait)
         {
             return new AwaitExpression(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
-                new StatementExpression(Guid.NewGuid(), awaitSuffix, Markers.Empty, forEachVariableLoop),
+                new StatementExpression(Tree.RandomId(), awaitSuffix, Markers.Empty, forEachVariableLoop),
                 null
             );
         }
@@ -10086,7 +10086,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 if (innerSpace != Space.Empty)
                 {
                     elements.Add(new JRightPadded<J>(
-                        new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                        new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                         innerSpace, Markers.Empty));
                 }
             }
@@ -10095,7 +10095,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
 
         var parameters = new Lambda.Parameters(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             paramsPrefix,
             Markers.Empty,
             parenthesized,
@@ -10109,10 +10109,10 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             throw new InvalidOperationException($"Expected J for anonymous method body but got {body?.GetType().Name}");
         }
 
-        var markers = Markers.Empty.Add(new AnonymousMethod(Guid.NewGuid()));
+        var markers = Markers.Empty.Add(new AnonymousMethod(Tree.RandomId()));
 
         var jLambda = new Lambda(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             modifiers.Count > 0 ? delegateKeywordPrefix : prefix,
             markers,
             parameters,
@@ -10124,7 +10124,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (modifiers.Count > 0)
         {
             return new CsLambda(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 [],
@@ -10155,16 +10155,16 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         // Create NewArray with no explicit type (implicit stackalloc[] { ... })
         var newArray = new NewArray(
-            Guid.NewGuid(), arrayPrefix, Markers.Empty,
+            Tree.RandomId(), arrayPrefix, Markers.Empty,
             null, // No type expression for implicit stack alloc
             [new ArrayDimension(
-                Guid.NewGuid(), Space.Empty, Markers.Empty,
+                Tree.RandomId(), Space.Empty, Markers.Empty,
                 new JRightPadded<Expression>(
-                    new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                    new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                     Space.Empty, Markers.Empty))],
             initializer, null);
 
-        return new StackAllocExpression(Guid.NewGuid(), prefix, Markers.Empty, newArray);
+        return new StackAllocExpression(Tree.RandomId(), prefix, Markers.Empty, newArray);
     }
 
     public override J VisitAnonymousObjectCreationExpression(AnonymousObjectCreationExpressionSyntax node)
@@ -10197,7 +10197,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                 afterSpace = ExtractSpaceBefore(sep);
                 _cursor = sep.Span.End;
                 var suffix = ExtractSpaceBefore(node.CloseBraceToken);
-                elemMarkers = elemMarkers.Add(new TrailingComma(Guid.NewGuid(), suffix));
+                elemMarkers = elemMarkers.Add(new TrailingComma(Tree.RandomId(), suffix));
             }
             else
             {
@@ -10212,13 +10212,13 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
             // Empty: new { } — use sentinel Empty to preserve inner space
             var innerSpace = ExtractSpaceBefore(node.CloseBraceToken);
             elements.Add(new JRightPadded<Expression>(
-                new Empty(Guid.NewGuid(), Space.Empty, Markers.Empty),
+                new Empty(Tree.RandomId(), Space.Empty, Markers.Empty),
                 innerSpace, Markers.Empty));
         }
 
         _cursor = node.CloseBraceToken.Span.End;
 
-        return new AnonymousObjectCreationExpression(Guid.NewGuid(), prefix, Markers.Empty,
+        return new AnonymousObjectCreationExpression(Tree.RandomId(), prefix, Markers.Empty,
             new JContainer<Expression>(beforeBrace, elements, Markers.Empty), null);
     }
 
@@ -10228,14 +10228,14 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         if (node.NameEquals != null)
         {
             var prefix = ExtractPrefix(node);
-            var name = new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], node.NameEquals.Name.Identifier.Text, null, null);
+            var name = new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], node.NameEquals.Name.Identifier.Text, null, null);
             _cursor = node.NameEquals.Name.Span.End;
 
             var eqSpace = ExtractSpaceBefore(node.NameEquals.EqualsToken);
             _cursor = node.NameEquals.EqualsToken.Span.End;
 
             var value = (Expression)Visit(node.Expression)!;
-            return new Assignment(Guid.NewGuid(), prefix, Markers.Empty, name,
+            return new Assignment(Tree.RandomId(), prefix, Markers.Empty, name,
                 new JLeftPadded<Expression>(eqSpace, value), null);
         }
         else
@@ -10254,7 +10254,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var initializer = (Expression)Visit(node.Initializer)!;
 
-        return new WithExpression(Guid.NewGuid(), prefix, Markers.Empty,
+        return new WithExpression(Tree.RandomId(), prefix, Markers.Empty,
             expression, new JLeftPadded<Expression>(withSpace, initializer), null);
     }
 
@@ -10265,7 +10265,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
 
         var expression = (Expression)Visit(node.Expression)!;
 
-        return new SpreadExpression(Guid.NewGuid(), prefix, Markers.Empty, expression, null);
+        return new SpreadExpression(Tree.RandomId(), prefix, Markers.Empty, expression, null);
     }
 
     public override J VisitFunctionPointerType(FunctionPointerTypeSyntax node)
@@ -10302,7 +10302,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
                     var convType = callingConventionList[i];
                     var typePrefix = ExtractSpaceBefore(convType.Name);
                     _cursor = convType.Name.Span.End;
-                    var id = new Identifier(Guid.NewGuid(), typePrefix, Markers.Empty, [], convType.Name.Text, null, null);
+                    var id = new Identifier(Tree.RandomId(), typePrefix, Markers.Empty, [], convType.Name.Text, null, null);
 
                     Space afterSpace;
                     if (i < callingConventionList.SeparatorCount)
@@ -10348,7 +10348,7 @@ internal class CSharpParserVisitor : CSharpSyntaxVisitor<J>
         }
         _cursor = node.ParameterList.GreaterThanToken.Span.End;
 
-        return new FunctionPointerType(Guid.NewGuid(), prefix, Markers.Empty,
+        return new FunctionPointerType(Tree.RandomId(), prefix, Markers.Empty,
             callingConvention, unmanagedConventionTypes,
             new JContainer<TypeTree>(angleBracketSpace, paramTypes, Markers.Empty), null);
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrecedences.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CSharpPrecedences.cs
@@ -76,7 +76,7 @@ internal static class CSharpPrecedences
     {
         if (expr is Parentheses<Expression> p) return p;
         return new Parentheses<Expression>(
-            Guid.NewGuid(), expr.Prefix, Markers.Empty,
+            Tree.RandomId(), expr.Prefix, Markers.Empty,
             new JRightPadded<Expression>(J.SetPrefix(expr, Space.Empty), Space.Empty, Markers.Empty));
     }
 

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/CsDocCommentParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/CsDocCommentParser.cs
@@ -132,7 +132,7 @@ public static class CsDocCommentParser
             var body = new List<CsDocComment>();
             var first = true;
             MapContent(doc.Content, body, ref first);
-            var docComment = new CsDocComment.DocComment(Guid.NewGuid(), Markers.Empty, body, suffix);
+            var docComment = new CsDocComment.DocComment(Tree.RandomId(), Markers.Empty, body, suffix);
             if (Print(docComment) == fullText)
             {
                 return docComment;
@@ -142,9 +142,9 @@ public static class CsDocCommentParser
         // Fallback: keep the whole body as literal text after the leading "///".
         var flat = new List<CsDocComment>
         {
-            new CsDocComment.XmlText(Guid.NewGuid(), Markers.Empty, fullText.Substring(3))
+            new CsDocComment.XmlText(Tree.RandomId(), Markers.Empty, fullText.Substring(3))
         };
-        return new CsDocComment.DocComment(Guid.NewGuid(), Markers.Empty, flat, suffix);
+        return new CsDocComment.DocComment(Tree.RandomId(), Markers.Empty, flat, suffix);
     }
 
     private static string Print(CsDocComment.DocComment docComment)
@@ -223,7 +223,7 @@ public static class CsDocCommentParser
         var innerFirst = false;
         MapContent(element.Content, content, ref innerFirst);
         return new CsDocComment.XmlElement(
-            Guid.NewGuid(), Markers.Empty,
+            Tree.RandomId(), Markers.Empty,
             start.Name.ToString(),
             MapAttributes(start.Attributes),
             LeadingAsList(start.GreaterThanToken),
@@ -233,7 +233,7 @@ public static class CsDocCommentParser
 
     private static CsDocComment MapEmptyElement(XmlEmptyElementSyntax element) =>
         new CsDocComment.XmlEmptyElement(
-            Guid.NewGuid(), Markers.Empty,
+            Tree.RandomId(), Markers.Empty,
             element.Name.ToString(),
             MapAttributes(element.Attributes),
             LeadingAsList(element.SlashGreaterThanToken));
@@ -256,14 +256,14 @@ public static class CsDocCommentParser
         {
             case XmlNameAttributeSyntax name:
                 return new CsDocComment.XmlNameAttribute(
-                    Guid.NewGuid(), Markers.Empty,
+                    Tree.RandomId(), Markers.Empty,
                     SpaceBeforeEquals(name.EqualsToken),
                     ValueList(name.StartQuoteToken.ToFullString() + name.Identifier.ToFullString() +
                               name.EndQuoteToken.ToFullString()),
                     null);
             case XmlCrefAttributeSyntax cref:
                 return new CsDocComment.XmlCrefAttribute(
-                    Guid.NewGuid(), Markers.Empty,
+                    Tree.RandomId(), Markers.Empty,
                     SpaceBeforeEquals(cref.EqualsToken),
                     ValueList(cref.StartQuoteToken.ToFullString() + cref.Cref.ToFullString() +
                               cref.EndQuoteToken.ToFullString()),
@@ -276,7 +276,7 @@ public static class CsDocCommentParser
                 }
                 valueText.Append(textAttr.EndQuoteToken.ToFullString());
                 return new CsDocComment.XmlAttribute(
-                    Guid.NewGuid(), Markers.Empty,
+                    Tree.RandomId(), Markers.Empty,
                     textAttr.Name.ToString(),
                     SpaceBeforeEquals(textAttr.EqualsToken),
                     ValueList(valueText.ToString()));
@@ -344,8 +344,8 @@ public static class CsDocCommentParser
     }
 
     private static CsDocComment.XmlText Text(string text) =>
-        new(Guid.NewGuid(), Markers.Empty, text);
+        new(Tree.RandomId(), Markers.Empty, text);
 
     private static CsDocComment.LineBreak LineBreak(string margin) =>
-        new(Guid.NewGuid(), margin, Markers.Empty);
+        new(Tree.RandomId(), margin, Markers.Empty);
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/DirectiveBoundaryInjector.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/DirectiveBoundaryInjector.cs
@@ -55,7 +55,7 @@ public partial class DirectiveBoundaryInjector : CSharpVisitor<int>
         var indices = FindDirectiveIndices(block.End);
         if (indices.Count > 0)
         {
-            var marker = new DirectiveBoundaryMarker(Guid.NewGuid(), indices);
+            var marker = new DirectiveBoundaryMarker(Tree.RandomId(), indices);
             block = block.WithMarkers(block.Markers.Add(marker));
         }
 
@@ -69,7 +69,7 @@ public partial class DirectiveBoundaryInjector : CSharpVisitor<int>
         var indices = FindDirectiveIndices(compilationUnit.Eof);
         if (indices.Count > 0)
         {
-            var marker = new DirectiveBoundaryMarker(Guid.NewGuid(), indices);
+            var marker = new DirectiveBoundaryMarker(Tree.RandomId(), indices);
             compilationUnit = compilationUnit.WithMarkers(compilationUnit.Markers.Add(marker));
         }
 
@@ -82,7 +82,7 @@ public partial class DirectiveBoundaryInjector : CSharpVisitor<int>
         if (indices.Count == 0)
             return node;
 
-        var marker = new DirectiveBoundaryMarker(Guid.NewGuid(), indices);
+        var marker = new DirectiveBoundaryMarker(Tree.RandomId(), indices);
         var newMarkers = node.Markers.Add(marker);
         return J.SetMarkers(node, newMarkers);
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/EditorConfigResolver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Format/EditorConfigResolver.cs
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using OpenRewrite.Core;
+
 namespace OpenRewrite.CSharp.Format;
 
 /// <summary>
@@ -311,7 +313,7 @@ public class EditorConfigResolver
         var wrappingKeepStatementsOnSingleLine = GetBoolSetting(settings, "csharp_preserve_single_line_statements", "true", true);
 
         return new CSharpFormatStyle(
-            Guid.NewGuid(), useTabs, indentSize, tabSize, newLine,
+            Tree.RandomId(), useTabs, indentSize, tabSize, newLine,
             // Indentation
             indentBlock, indentBraces, indentSwitchCaseSection,
             indentSwitchCaseSectionWhenBlock, indentSwitchSection, labelPositioning,

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -21,6 +21,8 @@ using OpenRewrite.Xml;
 using Serilog;
 using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 
+using OpenRewrite.Core;
+
 namespace OpenRewrite.CSharp;
 
 /// <summary>
@@ -107,11 +109,11 @@ public static class MSBuildProjectHelper
         var sdk = doc.Root.GetAttributeValue("Sdk");
 
         if (rootDir == null)
-            return new MSBuildProject(Guid.NewGuid(), sdk);
+            return new MSBuildProject(Tree.RandomId(), sdk);
 
         var projectPath = Path.GetFullPath(Path.Combine(rootDir, doc.SourcePath));
         if (!File.Exists(projectPath))
-            return new MSBuildProject(Guid.NewGuid(), sdk);
+            return new MSBuildProject(Tree.RandomId(), sdk);
 
         try
         {
@@ -119,7 +121,7 @@ public static class MSBuildProjectHelper
                 .ResolveProjectLockFileAsync(projectPath, null, CancellationToken.None)
                 .GetAwaiter().GetResult();
             if (lockFile == null)
-                return new MSBuildProject(Guid.NewGuid(), sdk);
+                return new MSBuildProject(Tree.RandomId(), sdk);
 
             var projectDir = Path.GetDirectoryName(projectPath)!;
             return CreateFromLockFile(sdk, lockFile, projectDir,
@@ -128,7 +130,7 @@ public static class MSBuildProjectHelper
         catch (Exception ex)
         {
             Log.Debug("Failed to resolve lock file for {Path}: {Error}", projectPath, ex.Message);
-            return new MSBuildProject(Guid.NewGuid(), sdk);
+            return new MSBuildProject(Tree.RandomId(), sdk);
         }
     }
 
@@ -333,7 +335,7 @@ public static class MSBuildProjectHelper
         var packageSources = ReadPackageSourcesFromTree(projectDir);
 
         return new MSBuildProject(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             sdk,
             new Dictionary<string, PropertyValue>(),
             packageSources,
@@ -513,7 +515,7 @@ public static class MSBuildProjectHelper
         string? tempDir = null;
         try
         {
-            tempDir = Path.Combine(Path.GetTempPath(), "openrewrite-dotnet-" + Guid.NewGuid().ToString("N")[..8]);
+            tempDir = Path.Combine(Path.GetTempPath(), "openrewrite-dotnet-" + Tree.RandomId().ToString("N")[..8]);
             Directory.CreateDirectory(tempDir);
 
             // Materialize all captured build files from the repository context

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
@@ -32,6 +32,8 @@ using NuGet.Versioning;
 using Serilog;
 using ILogger = NuGet.Common.ILogger;
 
+using OpenRewrite.Core;
+
 namespace OpenRewrite.CSharp.NuGet;
 
 /// <summary>
@@ -202,7 +204,7 @@ public static class NuGetResolver
         IDictionary<string, string>? extraGlobalProperties)
     {
         var outputPath = Path.Combine(Path.GetTempPath(),
-            "openrewrite-dg-" + Guid.NewGuid().ToString("N")[..8] + ".json");
+            "openrewrite-dg-" + Tree.RandomId().ToString("N")[..8] + ".json");
         try
         {
             var globalProps = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -422,7 +424,7 @@ public static class NuGetResolver
                     ProjectUniqueName = projectPath,
                     ProjectStyle = ProjectStyle.PackageReference,
                     OutputPath = Path.Combine(Path.GetTempPath(),
-                        "openrewrite-pcrestore-" + Guid.NewGuid().ToString("N")[..8]),
+                        "openrewrite-pcrestore-" + Tree.RandomId().ToString("N")[..8]),
                     OriginalTargetFrameworks = new List<string> { alias },
                     ConfigFilePaths = settings.GetConfigFilePaths(),
                     PackagesPath = SettingsUtility.GetGlobalPackagesFolder(settings),

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -334,7 +334,7 @@ public class RewriteRpcServer
             {
                 response.Items.Add(new ParseSolutionResponseItem
                 {
-                    Id = Guid.NewGuid().ToString(),
+                    Id = Tree.RandomId().ToString(),
                     SourceFileType = "org.openrewrite.quark.Quark",
                     SourcePath = relPath
                 });
@@ -1177,7 +1177,7 @@ public class RewriteRpcServer
             // this marketplace, so a miss means the host owns this recipe: answer with delegatesTo
             // so the host resolves the id locally (the Java recipe is on its classpath) rather than
             // failing with "Recipe not found".
-            var delegateId = Guid.NewGuid().ToString();
+            var delegateId = Tree.RandomId().ToString();
             return Task.FromResult(new PrepareRecipeResponse
             {
                 Id = delegateId,
@@ -1238,7 +1238,7 @@ public class RewriteRpcServer
             }
         }
 
-        var id = Guid.NewGuid().ToString();
+        var id = Tree.RandomId().ToString();
         _preparedRecipes[id] = recipe;
 
         var response = new PrepareRecipeResponse

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -650,7 +650,7 @@ public class SolutionParser
             Log.Debug("Failed to read project metadata from {ProjectPath}: {Error}", projectPath, ex.Message);
         }
 
-        return new DotNetProject(Guid.NewGuid(), projectName, tfms, sdk);
+        return new DotNetProject(Tree.RandomId(), projectName, tfms, sdk);
     }
 
     /// <summary>

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Template/TemplateEngine.cs
@@ -29,7 +29,7 @@ namespace OpenRewrite.CSharp.Template;
 public sealed class SyntheticBlockContainer : Marker
 {
     public static readonly SyntheticBlockContainer Instance = new();
-    public Guid Id { get; } = Guid.NewGuid();
+    public Guid Id { get; } = Tree.RandomId();
 }
 
 /// <summary>
@@ -603,7 +603,7 @@ internal static class TemplateEngine
 
         // Assign a fresh ID so FindById targets exactly this instance,
         // not a stale node from a prior application of the same template
-        tree = J.SetId(tree, Guid.NewGuid());
+        tree = J.SetId(tree, Tree.RandomId());
 
         var formatted = RoslynFormatter.FormatSubtree(cu, original.Id, tree, stopAfter: null);
 
@@ -624,7 +624,7 @@ internal static class TemplateEngine
         foreach (var s in blk.Statements)
         {
             var stmt = (J)s.Element;
-            stmt = J.SetId(stmt, Guid.NewGuid());
+            stmt = J.SetId(stmt, Tree.RandomId());
             var formatted = RoslynFormatter.FormatSubtree(cu, original.Id, stmt, stopAfter: null);
             formattedStmts.Add(s.WithElement((Statement)formatted));
         }

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Markers.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Markers.cs
@@ -65,7 +65,7 @@ public sealed class Markers(Guid id, IList<Marker> markerList) : IRpcCodec<Marke
     public static Markers Build(IEnumerable<Marker> markers)
     {
         var list = markers.ToList();
-        return list.Count == 0 ? Empty : new Markers(Guid.NewGuid(), list);
+        return list.Count == 0 ? Empty : new Markers(Tree.RandomId(), list);
     }
 
     public T? FindFirst<T>() where T : Marker =>

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Markup.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Markup.cs
@@ -46,25 +46,25 @@ public abstract class Markup(Guid id, string message, string? detail) : Marker, 
     /// Adds an Error markup marker to the given tree node.
     /// </summary>
     public static T CreateError<T>(T tree, string message, string? detail = null) where T : J
-        => AddMarker(tree, new Error(Guid.NewGuid(), message, detail));
+        => AddMarker(tree, new Error(Tree.RandomId(), message, detail));
 
     /// <summary>
     /// Adds a Warn markup marker to the given tree node.
     /// </summary>
     public static T CreateWarn<T>(T tree, string message, string? detail = null) where T : J
-        => AddMarker(tree, new Warn(Guid.NewGuid(), message, detail));
+        => AddMarker(tree, new Warn(Tree.RandomId(), message, detail));
 
     /// <summary>
     /// Adds an Info markup marker to the given tree node.
     /// </summary>
     public static T CreateInfo<T>(T tree, string message, string? detail = null) where T : J
-        => AddMarker(tree, new Info(Guid.NewGuid(), message, detail));
+        => AddMarker(tree, new Info(Tree.RandomId(), message, detail));
 
     /// <summary>
     /// Adds a Debug markup marker to the given tree node.
     /// </summary>
     public static T CreateDebug<T>(T tree, string message, string? detail = null) where T : J
-        => AddMarker(tree, new Debug(Guid.NewGuid(), message, detail));
+        => AddMarker(tree, new Debug(Tree.RandomId(), message, detail));
 
     public sealed class Error(Guid id, string message, string? detail) : Markup(id, message, detail), IRpcCodec<Error>
     {

--- a/rewrite-csharp/csharp/OpenRewrite/Core/ParseError.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/ParseError.cs
@@ -56,9 +56,9 @@ public sealed class ParseError(
     public static ParseError Build(string sourcePath, string source, Exception ex)
     {
         var marker = ParseExceptionResult.Build("CSharpParser", ex);
-        var markers = new Markers(Guid.NewGuid(), new List<Marker> { marker });
+        var markers = new Markers(Tree.RandomId(), new List<Marker> { marker });
         return new ParseError(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             markers,
             sourcePath,
             "UTF-8",

--- a/rewrite-csharp/csharp/OpenRewrite/Core/ParseExceptionResult.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/ParseExceptionResult.cs
@@ -38,7 +38,7 @@ public sealed class ParseExceptionResult(
     public static ParseExceptionResult Build(string parserType, Exception ex)
     {
         return new ParseExceptionResult(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             parserType,
             ex.GetType().Name,
             ex.ToString(),

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcReceiveQueue.cs
@@ -20,6 +20,8 @@ using OpenRewrite.CSharp;
 using OpenRewrite.Java;
 using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;
 
+using OpenRewrite.Core;
+
 namespace OpenRewrite.Core.Rpc;
 
 /// <summary>
@@ -314,7 +316,7 @@ public class RpcReceiveQueue
             else if (typeof(Marker).IsAssignableFrom(typeof(T)))
             {
                 // Unknown marker type from Java — use UnknownMarker as fallback
-                return (T)(object)new UnknownMarker(Guid.NewGuid());
+                return (T)(object)new UnknownMarker(Tree.RandomId());
             }
             else
             {
@@ -346,7 +348,7 @@ public class RpcReceiveQueue
         if (type.IsInterface || type.IsAbstract)
         {
             if (typeof(Marker).IsAssignableFrom(type))
-                return (T)(object)new UnknownMarker(Guid.NewGuid());
+                return (T)(object)new UnknownMarker(Tree.RandomId());
             throw new InvalidOperationException(
                 $"Cannot instantiate interface/abstract type: {type.FullName} (from {javaTypeName})");
         }
@@ -415,10 +417,10 @@ public class RpcReceiveQueue
             {
                 var id = je.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String
                     ? Guid.Parse(idProp.GetString()!)
-                    : Guid.NewGuid();
+                    : Tree.RandomId();
                 return (T)(object)new UnknownMarker(id);
             }
-            return (T)(object)new UnknownMarker(Guid.NewGuid());
+            return (T)(object)new UnknownMarker(Tree.RandomId());
         }
 
         if (value is JsonElement jeNormal)

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Rpc/RpcVisitor.cs
@@ -15,6 +15,8 @@
  */
 using OpenRewrite.CSharp.Rpc;
 
+using OpenRewrite.Core;
+
 namespace OpenRewrite.Core.Rpc;
 
 /// <summary>
@@ -45,7 +47,7 @@ public class RpcVisitor : TreeVisitor<Tree, ExecutionContext>
         var treeId = sf.Id.ToString();
         _rpc.StoreLocalObject(treeId, sf);
 
-        var ctxId = Guid.NewGuid().ToString();
+        var ctxId = Tree.RandomId().ToString();
         _rpc.StoreLocalObject(ctxId, ctx);
 
         var sourceFileType = RpcSendQueue.ToJavaTypeName(sf.GetType())

--- a/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/SearchResult.cs
@@ -36,7 +36,7 @@ public sealed class SearchResult(Guid id, string? description) : Marker, IRpcCod
     /// </summary>
     public static T Found<T>(T tree, string? description = null) where T : Tree
     {
-        var newMarkers = tree.Markers.Add(new SearchResult(Guid.NewGuid(), description));
+        var newMarkers = tree.Markers.Add(new SearchResult(Tree.RandomId(), description));
         if (tree is J j)
             return (T)J.SetMarkers(j, newMarkers);
 

--- a/rewrite-csharp/csharp/OpenRewrite/Core/Tree.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Core/Tree.cs
@@ -20,6 +20,20 @@ namespace OpenRewrite.Core;
 /// </summary>
 public interface Tree
 {
+    /// <summary>
+    /// An id names a node and carries no secret, so it is drawn in userspace from a per-thread
+    /// generator: a tree draws one per node, and the OS entropy source behind
+    /// <see cref="Guid.NewGuid"/> costs a syscall per draw. Mirrors Java's <c>Tree.randomId()</c>.
+    /// </summary>
+    static Guid RandomId()
+    {
+        Span<byte> b = stackalloc byte[16];
+        System.Random.Shared.NextBytes(b);
+        b[6] = (byte)((b[6] & 0x0F) | 0x40); // version 4
+        b[8] = (byte)((b[8] & 0x3F) | 0x80); // variant IETF
+        return new Guid(b, bigEndian: true);
+    }
+
     Guid Id { get; }
 
     Markers Markers { get; }

--- a/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/J.cs
@@ -1201,7 +1201,7 @@ public sealed class TypeParameters(
     /// Create a TypeParameters wrapper from a JContainer (for RPC sending).
     /// </summary>
     public static TypeParameters FromContainer(JContainer<TypeParameter> container) =>
-        new(Guid.NewGuid(), container.Before, Markers.Empty, [], container.Elements);
+        new(Tree.RandomId(), container.Before, Markers.Empty, [], container.Elements);
 
     /// <summary>
     /// Convert back to a JContainer (for RPC receiving).

--- a/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Java/Rpc/JavaReceiver.cs
@@ -444,7 +444,7 @@ public class JavaReceiver : JavaVisitor<RpcReceiveQueue>
         var typeParameters = tpReceived?.ToContainer();
         var returnTypeExpression = q.Receive((J?)method.ReturnTypeExpression, el => (J)VisitNonNull(el!, q));
         var nameAnnotations = q.ReceiveList(method.Name?.Annotations ?? [], el => (Annotation)VisitNonNull(el, q));
-        var name = q.Receive((J?)method.Name ?? new Identifier(Guid.NewGuid(), Space.Empty, Markers.Empty, [], "", null, null), el => (J)VisitNonNull(el, q));
+        var name = q.Receive((J?)method.Name ?? new Identifier(Tree.RandomId(), Space.Empty, Markers.Empty, [], "", null, null), el => (J)VisitNonNull(el, q));
         var parameters = q.Receive(method.Parameters, c => VisitContainer(c, q));
         var dimensionsAfterName = q.ReceiveList(method.DimensionsAfterName, lp => VisitLeftPadded(lp, q));
         var throws_ = q.Receive(method.Throws, c => VisitContainer(c, q));

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/AddToTagVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/AddToTagVisitor.cs
@@ -33,7 +33,7 @@ public class AddToTagVisitor<P>(Tag scope, Tag tagToAdd, Comparison<Content>? ta
             if (t.ClosingTag == null)
             {
                 t = t.WithClosingTag(new Tag.Closing(
-                        Guid.NewGuid(), "\n", Markers.Empty, t.Name, ""))
+                        Tree.RandomId(), "\n", Markers.Empty, t.Name, ""))
                     .WithBeforeTagDelimiterPrefix("");
             }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/ChangeTagValueVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/ChangeTagValueVisitor.cs
@@ -47,7 +47,7 @@ public class ChangeTagValueVisitor<P>(Tag? scope, string? value) : XmlVisitor<P>
 
             t = t.WithContentList(new List<Content>
             {
-                new CharData(Guid.NewGuid(), prefix, Markers.Empty, false, value, afterText)
+                new CharData(Tree.RandomId(), prefix, Markers.Empty, false, value, afterText)
             });
         }
 

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/CsprojParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/CsprojParser.cs
@@ -63,7 +63,7 @@ public class CsprojParser
         try
         {
             tempDir = Path.Combine(Path.GetTempPath(),
-                "openrewrite-csproj-" + Guid.NewGuid().ToString("N")[..8]);
+                "openrewrite-csproj-" + Tree.RandomId().ToString("N")[..8]);
             Directory.CreateDirectory(tempDir);
 
             // Write all files to the shared temp directory

--- a/rewrite-csharp/csharp/OpenRewrite/Xml/XmlParserVisitor.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Xml/XmlParserVisitor.cs
@@ -53,7 +53,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
     public override Xml VisitDocument(XMLParser.DocumentContext ctx)
     {
         return Convert(ctx, (c, prefix) => new Document(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             _path,
             prefix,
             Markers.Empty,
@@ -70,7 +70,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
     public override Xml VisitProlog(XMLParser.PrologContext ctx)
     {
         return Convert(ctx, (c, prefix) => new Prolog(
-            Guid.NewGuid(),
+            Tree.RandomId(),
             prefix,
             Markers.Empty,
             (XmlDecl?)VisitXmldecl(ctx.xmldecl()),
@@ -84,7 +84,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
         if (ctx.COMMENT() != null)
         {
             return Convert(ctx.COMMENT(), (comment, prefix) => new Comment(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 comment.GetText().Substring("<!--".Length, comment.GetText().Length - "<!--".Length - "-->".Length)));
@@ -124,7 +124,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             {
                 var prefix = Prefix(ctx);
                 AdvanceCursor(ctx.reference().EntityRef().Symbol.StopIndex + 1);
-                return new CharData(Guid.NewGuid(),
+                return new CharData(Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     false,
@@ -135,7 +135,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             {
                 var prefix = Prefix(ctx);
                 AdvanceCursor(ctx.reference().CharRef().Symbol.StopIndex + 1);
-                return new CharData(Guid.NewGuid(),
+                return new CharData(Tree.RandomId(),
                     prefix,
                     Markers.Empty,
                     false,
@@ -146,7 +146,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
         else if (ctx.COMMENT() != null)
         {
             return Convert(ctx.COMMENT(), (comment, prefix) => new Comment(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 comment.GetText().Substring("<!--".Length, comment.GetText().Length - "<!--".Length - "-->".Length)));
@@ -193,7 +193,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
         var valueStr = value.ToString();
         valueStr = valueStr.Substring(0, valueStr.Length - suffix.Length);
 
-        return new CharData(Guid.NewGuid(),
+        return new CharData(Tree.RandomId(),
             newPrefix.ToString(),
             Markers.Empty,
             cdata,
@@ -211,7 +211,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             var name = Convert(ctx.SPECIAL_OPEN_XML(), (n, p) => n.GetText()).Substring(2);
             var attributes = ctx.attribute().Select(a => (Attribute)VisitAttribute(a)).ToList();
             return new XmlDecl(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 name,
@@ -239,7 +239,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             }
 
             return new ProcessingInstruction(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 name,
@@ -259,7 +259,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             var attributes = ctx.attribute().Select(a => (Attribute)VisitAttribute(a)).ToList();
 
             return new JspDirective(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 beforeType,
@@ -279,7 +279,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             var content = scriptletText.Substring(2, scriptletText.Length - 4);
 
             return new JspScriptlet(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 content
@@ -296,7 +296,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             var content = expressionText.Substring(3, expressionText.Length - 5);
 
             return new JspExpression(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 content
@@ -313,7 +313,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             var content = declarationText.Substring(3, declarationText.Length - 5);
 
             return new JspDeclaration(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 content
@@ -330,7 +330,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
             var content = commentText.Substring(4, commentText.Length - 8);
 
             return new JspComment(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 content
@@ -368,7 +368,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
                 AdvanceCursor(_cursor + 2);
 
                 closeTag = new Tag.Closing(
-                    Guid.NewGuid(),
+                    Tree.RandomId(),
                     closeTagPrefix,
                     Markers.Empty,
                     Convert(ctx.Name(1), (n, p) => n.GetText()),
@@ -377,7 +377,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
                 AdvanceCursor(_cursor + 1);
             }
 
-            return new Tag(Guid.NewGuid(), prefix, Markers.Empty, name, attributes,
+            return new Tag(Tree.RandomId(), prefix, Markers.Empty, name, attributes,
                 content, closeTag, beforeTagDelimiterPrefix);
         })!;
     }
@@ -386,19 +386,19 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
     {
         return Convert(ctx, (c, prefix) =>
         {
-            var key = Convert(c.Name(), (t, p) => new Ident(Guid.NewGuid(), p, Markers.Empty, t.GetText()));
+            var key = Convert(c.Name(), (t, p) => new Ident(Tree.RandomId(), p, Markers.Empty, t.GetText()));
 
             var beforeEquals = Convert(c.EQUALS(), (e, p) => p);
 
             var val = Convert(c.STRING(), (v, p) => new Attribute.Value(
-                Guid.NewGuid(),
+                Tree.RandomId(),
                 p,
                 Markers.Empty,
                 v.GetText().StartsWith("'") ? Attribute.Value.Quote.Single : Attribute.Value.Quote.Double,
                 v.GetText().Substring(1, c.STRING().GetText().Length - 2)
             ));
 
-            return new Attribute(Guid.NewGuid(), prefix, Markers.Empty, key, beforeEquals, val);
+            return new Attribute(Tree.RandomId(), prefix, Markers.Empty, key, beforeEquals, val);
         })!;
     }
 
@@ -407,7 +407,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
         return Convert(ctx, (c, prefix) =>
         {
             Skip(c.DOCTYPE());
-            var name = Convert(c.Name(), (n, p) => new Ident(Guid.NewGuid(), p, Markers.Empty, n.GetText()));
+            var name = Convert(c.Name(), (n, p) => new Ident(Tree.RandomId(), p, Markers.Empty, n.GetText()));
             Ident? externalId = null;
             List<Ident>? internalSubset = null;
             if (!c.externalid().Start.Equals(c.DTD_CLOSE().Symbol))
@@ -415,10 +415,10 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
                 if (c.externalid().Name() != null)
                 {
                     externalId = Convert(c.externalid(),
-                        (n, p) => new Ident(Guid.NewGuid(), p, Markers.Empty, n.Name().GetText()));
+                        (n, p) => new Ident(Tree.RandomId(), p, Markers.Empty, n.Name().GetText()));
                 }
                 internalSubset = c.STRING()
-                    .Select(s => Convert(s, (attr, p) => new Ident(Guid.NewGuid(), p, Markers.Empty, attr.GetText())))
+                    .Select(s => Convert(s, (attr, p) => new Ident(Tree.RandomId(), p, Markers.Empty, attr.GetText())))
                     .ToList();
             }
 
@@ -436,7 +436,7 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
                     // Markup declarations are not fully implemented.
                     // n.GetText() includes element subsets.
                     var ident = Convert(element,
-                        (n, p) => new Ident(Guid.NewGuid(), p, Markers.Empty, n.GetText()));
+                        (n, p) => new Ident(Tree.RandomId(), p, Markers.Empty, n.GetText()));
 
                     var beforeElementTag = "";
                     if (i == children.Count - 1)
@@ -447,17 +447,17 @@ internal class XmlParserVisitor : XMLParserBaseVisitor<Xml>
 
                     elements.Add(
                         new Element(
-                            Guid.NewGuid(),
+                            Tree.RandomId(),
                             Prefix(element),
                             Markers.Empty,
                             new List<Ident> { ident },
                             beforeElementTag));
                 }
-                externalSubsets = new DocTypeDecl.ExternalSubsets(Guid.NewGuid(), subsetPrefix, Markers.Empty, elements);
+                externalSubsets = new DocTypeDecl.ExternalSubsets(Tree.RandomId(), subsetPrefix, Markers.Empty, elements);
             }
 
             var beforeTagDelimiterPrefix = Prefix(c.DTD_CLOSE());
-            return new DocTypeDecl(Guid.NewGuid(),
+            return new DocTypeDecl(Tree.RandomId(),
                 prefix,
                 Markers.Empty,
                 name,


### PR DESCRIPTION
Parsing 266 C# files spends 3.3% of the peer's managed CPU inside `Guid.NewGuid()` — 2,104 ms of a 63 s sampled window — with 28% of that under `CSharpParserVisitor.VisitIdentifierName` and most of the rest under `VisitType`, `ConvertParameter` and `VisitVariableDeclaration`. A tree draws one id per node, and on Unix `Guid.NewGuid()` reaches the OS entropy source on every call.

An id names a node and carries no secret, so the kernel's generator buys nothing here. Java has always drawn these from `ThreadLocalRandom`:

```java
static UUID randomId() {
    ThreadLocalRandom r = ThreadLocalRandom.current();
    long msb = (r.nextLong() & 0xffffffffffff0fffL) | 0x0000000000004000L; // version 4
    long lsb = (r.nextLong() & 0x3fffffffffffffffL) | 0x8000000000000000L; // variant IETF
    return new UUID(msb, lsb);
}
```

`Tree.RandomId()` is that on `Random.Shared`, a per-thread xoshiro256** in userspace. The 566 production call sites go through it; tests still call `Guid.NewGuid()`, where the cost does not matter.

`new Guid(bytes, bigEndian: true)` is load-bearing. `Guid` lays its first three fields out little-endian, so without that argument the version and variant nibbles land in the wrong bytes and the ids stop being v4. `TreeRandomIdTest` pins both positions and fails if it is dropped.

- Python made the same move in #8823, from `os.urandom(16)` to a userspace generator, for the same reason.
