### PR TITLE
Reject JUnit snapshots for integTest configurations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,6 +15,18 @@ allprojects {
 }
 
 subprojects {
+    // The shared build plugin requests the JUnit BOM as a `6.+` range, which a snapshot in a
+    // developer's local Maven repository satisfies. No snapshot carries `junit-platform-suite-*`,
+    // which several integTest suites need, so selecting one leaves them unresolvable.
+    // `latest.release` would exclude snapshots; a range cannot, so the candidate is filtered out.
+    configurations.matching { it.name.startsWith("integTest") }.configureEach {
+        resolutionStrategy.componentSelection.all {
+            if (candidate.group.startsWith("org.junit") && candidate.version.endsWith("-SNAPSHOT")) {
+                reject("no JUnit snapshot carries every artifact an integTest suite needs")
+            }
+        }
+    }
+
     tasks.withType<JavaExec>().configureEach {
         if (name == "generateAntlrSources") {
             doLast {


### PR DESCRIPTION
`:rewrite-javascript:integTestRuntimeClasspath` and `:rewrite-python:integTestRuntimeClasspath` fail to resolve on a machine that has a JUnit snapshot installed in `~/.m2`:

```
> Could not find org.junit.platform:junit-platform-suite-api:6.2.0-SNAPSHOT.
> Could not find org.junit.platform:junit-platform-suite-engine:6.2.0-SNAPSHOT.
```

The shared build plugin requests `org.junit:junit-bom:6.+`. The range is open, so it can select a snapshot, and `mavenLocal()` sits first in the repository list. On the machine above it picks a partial local install: the BOM, jupiter and `platform-commons`/`-engine`/`-launcher` are present at `6.2.0-SNAPSHOT`, while `junit-platform-suite-api` stops at `6.0.3`. Nothing remote fills the gap — maven-central storage-download and repo1 both 404 for the suite artifacts at that version.

**CI is unaffected, and so is a clean `~/.m2`**: with no local snapshot the range selects a release. This is still worth pinning, because a resolution that depends on what a developer happens to have installed is one nobody else can reproduce.

Resolution of `integTestRuntimeClasspath` with `--refresh-dependencies`, one worktree, before and after:

| module | declares `junit-platform-suite-*` | before | after |
|---|---|---|---|
| rewrite-javascript | yes | fails | 59 files, junit 6.1.3 |
| rewrite-python | yes | fails | 68 files, junit 6.1.3 |
| rewrite-csharp | yes | fails | 56 files, junit 6.1.3 |
| rewrite-go | no | 53 files, junit 6.2.0-SNAPSHOT | 52 files, junit 6.1.3 |

rewrite-go resolved before only because its integTest suite declares neither suite artifact — the range selected the snapshot there too.

`latest.release` would also exclude snapshots, but the range is set by the shared build plugin rather than by this repository. One declaration in the root `subprojects` block covers all four modules.
