### PR TITLE
C#: page GetObject so the peer stops holding a whole tree

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 using System.Collections.Concurrent;
+using System.Threading.Channels;
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Loader;
@@ -79,6 +80,11 @@ public class RewriteRpcServer
     /// <summary>
     /// Referentially deduplicated objects and their ref IDs.
     /// </summary>
+    /// <summary>One in-flight transfer per object id, mirroring Java's inProgressGetRpcObjects.</summary>
+    private readonly ConcurrentDictionary<string, Lazy<Channel<List<RpcObjectData>>>> _inProgressGetObject = new();
+
+    internal int BatchSize = 1000;
+
     private readonly RpcRefs _localRefs = new();
 
     /// <summary>
@@ -521,67 +527,88 @@ public class RewriteRpcServer
     }
 
     [JsonRpcMethod("GetObject", UseSingleObjectParameterDeserialization = true)]
-    public Task<List<RpcObjectData>> GetObject(GetObjectRequest request)
+    public async Task<List<RpcObjectData>> GetObject(GetObjectRequest request)
     {
         var after = _localObjects.GetValueOrDefault(request.Id);
 
         if (after == null)
         {
             Log.Debug("RPC GetObject: {Id} not found, returning DELETE", request.Id);
-            return Task.FromResult(new List<RpcObjectData>
+            return new List<RpcObjectData>
             {
                 new() { State = DELETE },
                 new() { State = END_OF_OBJECT }
-            });
+            };
         }
 
         // ExecutionContext is sent as a typed shell with no data,
         // matching the JavaScript pattern (empty codec).
         if (after is ExecutionContext)
         {
-            return Task.FromResult(new List<RpcObjectData>
+            return new List<RpcObjectData>
             {
                 new() { State = ADD, ValueType = "org.openrewrite.InMemoryExecutionContext" },
                 new() { State = END_OF_OBJECT }
-            });
+            };
         }
 
-        var before = _remoteObjects.GetValueOrDefault(request.Id);
-        var sw = Stopwatch.StartNew();
+        var pages = _inProgressGetObject.GetOrAdd(request.Id, id =>
+            new Lazy<Channel<List<RpcObjectData>>>(() => StartTransfer(id, after, request.SourceFileType))).Value;
 
-        // Accumulate all RPC data into a single list
-        var allData = new List<RpcObjectData>();
-        var sendQueue = new RpcSendQueue(
-            1024,
-            batch => allData.AddRange(batch),
-            _localRefs,
-            request.SourceFileType,
-            false,
-            TreeCodec.Instance
-        );
-
-        try
+        var page = await pages.Reader.ReadAsync();
+        if (page.Count > 0 && page[^1].State == END_OF_OBJECT)
         {
-            sendQueue.Send(after, before, null);
+            _inProgressGetObject.TryRemove(request.Id, out _);
         }
-        catch (Exception ex)
+        return page;
+    }
+
+    /// <summary>
+    /// Serializes one object into a bounded channel a page at a time. The capacity of one stalls
+    /// the producer until the remote takes the previous page, which bounds what is held to two
+    /// pages and lets the remote fetch one while this side fills the next.
+    /// </summary>
+    private Channel<List<RpcObjectData>> StartTransfer(string id, object after, string? sourceFileType)
+    {
+        var pages = Channel.CreateBounded<List<RpcObjectData>>(1);
+        var before = _remoteObjects.GetValueOrDefault(id);
+        var refHighWater = _localRefs.HighWater;
+
+        // On the thread pool because the drain blocks whenever the channel is full, and the
+        // thread that has to drain it is the one serving the next GetObject.
+        _ = Task.Run(() =>
         {
-            Log.Debug("RPC GetObject: EXCEPTION sending {Id} ({ObjType}): {ExType}: {ExMessage}",
-                request.Id, after.GetType().Name, ex.GetType().Name, ex.Message);
-            throw new InvalidOperationException(
-                $"Failed to send object {request.Id} (type: {after.GetType().Name}): {ex.Message}\n{ex.StackTrace}", ex);
-        }
-        sendQueue.Put(new RpcObjectData { State = END_OF_OBJECT });
-        sendQueue.Flush();
-
-        // Update our understanding of remote's state
-        _remoteObjects[request.Id] = after;
-
-        sw.Stop();
-        Log.Debug("RPC GetObject: {Id} sent {ItemCount} items ({ElapsedMs}ms)",
-            request.Id, allData.Count, sw.Elapsed.TotalMilliseconds.ToString("F0"));
-
-        return Task.FromResult(allData);
+            var sendQueue = new RpcSendQueue(
+                BatchSize,
+                page => pages.Writer.WriteAsync(page).AsTask().GetAwaiter().GetResult(),
+                _localRefs,
+                sourceFileType,
+                false,
+                TreeCodec.Instance
+            );
+            try
+            {
+                sendQueue.Send(after, before, null);
+                _remoteObjects[id] = after;
+            }
+            catch (Exception ex)
+            {
+                // The remote holds a partial tree, so drop the baseline and the refs this exchange
+                // issued; the next request then sends a whole object rather than a delta against a
+                // baseline the remote never finished receiving.
+                _remoteObjects.TryRemove(id, out _);
+                _localRefs.RollbackTo(refHighWater);
+                Log.Debug("RPC GetObject: EXCEPTION sending {Id} ({ObjType}): {ExType}: {ExMessage}",
+                    id, after.GetType().Name, ex.GetType().Name, ex.Message);
+            }
+            finally
+            {
+                sendQueue.Put(new RpcObjectData { State = END_OF_OBJECT });
+                sendQueue.Flush();
+                pages.Writer.Complete();
+            }
+        });
+        return pages;
     }
 
     [JsonRpcMethod("Print", UseSingleObjectParameterDeserialization = true)]

--- a/rewrite-csharp/csharp/OpenRewrite/Test/RpcFixture.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/Test/RpcFixture.cs
@@ -66,6 +66,10 @@ public class RpcFixture : IDisposable
         _jsonRpc = new JsonRpc(handler);
 
         _server = new RewriteRpcServer(new RecipeMarketplace());
+        // A page per message, so every object in every test spans several pages and the tests
+        // cover paging rather than only the single-page case. Java and JavaScript size their
+        // RPC test fixtures the same way.
+        _server.BatchSize = 1;
         _server.Connect(_jsonRpc);
         RewriteRpcServer.SetCurrent(_server);
     }

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRpcThroughputTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpRpcThroughputTest.java
@@ -131,7 +131,11 @@ class CSharpRpcThroughputTest {
 
     @Test
     void parseThenPrintOwnSources() {
-        List<SourceFile> files = parse(solution(), "parse");
+        List<SourceFile> files = parse(solution(), "parse 0");
+        for (int p = 1; p < 4; p++) {
+            CSharpRewriteRpc.getOrStart().reset();
+            files = parse(solution(), "parse " + p);
+        }
         // Each cycle resets and refetches the same trees, so the early ones are warmup and the
         // rest are repetitions within one process, which is what makes a single run comparable.
         for (int cycle = 0; cycle < 12; cycle++) {


### PR DESCRIPTION
`GetObject` on the C# peer answers with the complete object in one response, and has done since the RPC layer was written in February (`e64f8d023b`). So the peer materializes an entire serialized tree per file before any of it goes out, and Java's prefetch — which asks for the next page while deserializing the current one — has never had a page to fetch ahead of.

Paging it moves parse and peak memory, measured on this module's own 270 sources, one process per arm, parse repeated four times and the first discarded:

| | before | after | |
|---|---|---|---|
| parse | 16,500 ms | 10,482 ms | **-36.5%** |
| C# peer peak RSS | 1,525 MB | 798 MB | **-47.7%** |
| print | 7,723 ms | 7,728 ms | flat |
| C# peer CPU | 215.8 s | 214.5 s | flat |
| JVM CPU, parse | 3,815 ms | 4,180 ms | +9.6% |
| JVM allocation, parse | 3.683 GB | 3.817 GB | +3.6% |

Peer CPU being flat is the whole result: no work is removed. The peer stops making Java wait for a complete tree before it can begin deserializing, which is exactly the latency the prefetch exists to hide and until now could not. Print is untouched because it is the other direction of the wire.

## How

A `Channel` of capacity one carries the pages. The producer runs on the thread pool and its drain writes each page into the channel, blocking while the channel is full, so it stalls until the remote takes the previous page. That bounds what is held to two pages rather than a whole tree, and lets the remote fetch one while this side fills the next. It is the shape Java uses, where an `ArrayBlockingQueue(1)` and a `batch::put` drain do the same job.

The handler keeps one transfer per object id and drops the entry when a page ends in `END_OF_OBJECT`. Entries are created through a `Lazy`, because `ConcurrentDictionary.GetOrAdd` may run its factory more than once and only the stored value is ever read — two concurrent requests for one id must not start two producers.

A send failure drops the baseline and rolls back the refs the exchange issued, so the next request sends a whole object rather than a delta against a baseline the remote never finished receiving. It then terminates the stream with `END_OF_OBJECT`, which is what the Java handler does: a serialization failure reaches the other side as a truncated stream rather than an RPC fault.

## The cost

One `GetObject` round trip per page instead of per object, which is the +9.6% JVM CPU and +3.6% allocation during parse. Raising the page size is the lever if that matters: measured separately on the Java side, moving `batchSize` from 1000 to 5000 cut JVM CPU 11% and allocation 11% at the price of 14% more peer memory, and bought no wall time. Left at 1000 here, since this change is spending its budget on memory rather than on envelopes.

## Tests

The RPC fixture now sends a page per message, so every object in every RPC test spans several pages and the suite covers paging rather than the single-page case a default-sized batch produces for sources this small. Java's `RewriteRpcTest` and JavaScript's `rewrite-rpc` test size their fixtures the same way. `integTest` is 20/20 and runs in the same 1m15s it did before, since the sources are unchanged and only the page count differs.

The harness also repeats the parse, which previously ran once per process against a print loop of twelve, so a parse figure was a single sample.
