### PR TITLE
Python: give PEP 695 type parameters the scope that binds them

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/scope_utils.py
@@ -14,23 +14,28 @@
 
 """Which names a Python scope binds, and which scope binds a name at a given cursor."""
 
-from typing import Any, Callable, Dict, FrozenSet, Iterator, List, Optional, Set, Tuple
+from typing import (Any, Callable, Dict, FrozenSet, Iterator, List, NamedTuple, Optional, Set,
+                    Union)
 
 from rewrite import Cursor
 from rewrite.java import J
 from rewrite.java.tree import (Assignment, AssignmentOperation, Case, ClassDeclaration,
                                ForEachLoop, Identifier, Import, Lambda, MethodDeclaration,
-                               Parentheses, VariableDeclarations)
+                               Parentheses, TypeParameters, VariableDeclarations)
 from rewrite.python.import_utils import get_alias_name, get_qualid_name
 from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, CompilationUnit,
                                  ComprehensionExpression, ExpressionStatement, MatchCase,
-                                 MultiImport, Star, TypeHintedExpression, VariableScope)
+                                 MultiImport, Star, TypeAlias, TypeHintedExpression,
+                                 VariableScope)
 from rewrite.python.visitor import PythonVisitor
 
 _NO_NAMES: FrozenSet[str] = frozenset()
 
 # The nodes _BindingScan answers for; everything else binds nothing and is not a scope.
 _SCOPES = (MethodDeclaration, Lambda, ClassDeclaration, ComprehensionExpression, CompilationUnit)
+
+# The declarations PEP 695 lets carry type parameters, each wrapped in an annotation scope.
+_TYPE_PARAM_HOLDERS = (MethodDeclaration, ClassDeclaration, TypeAlias)
 
 # The names a pattern can stand on without capturing: `_` matches anything, and the parser
 # spells the singletons as identifiers.
@@ -60,30 +65,40 @@ def captures(pattern: Optional[J]) -> Iterator[Identifier]:
             yield from captures(child)
 
 
+class _Frame(NamedTuple):
+    """One link of the chain a reference resolves through."""
+
+    scope: J
+    # The class body statement holding the reference, None for every scope but a class body.
+    cut: Optional[J] = None
+    # Whether this is the declaration's PEP 695 annotation scope rather than the declaration's
+    # own: the two bind different names over different regions of the same node.
+    type_params: bool = False
+
+
 class Scope:
     """One scope: the names it binds itself, the scopes around it, and what they answer
     together. Reached through :func:`scope_of`."""
 
-    __slots__ = ('_chain', '_cuts', '_index', '_cache')
+    __slots__ = ('_chain', '_index', '_cache')
 
-    def __init__(self, chain: List[J], cuts: List[Optional[J]], index: int,
+    def __init__(self, chain: List[_Frame], index: int,
                  cache: Dict[Any, FrozenSet[str]]) -> None:
         self._chain = chain
-        self._cuts = cuts
         self._index = index
         self._cache = cache
 
     def names(self) -> FrozenSet[str]:
         """The names this scope binds itself where the cursor stands, which is not what it
         reaches: for that, ask :meth:`declares`."""
-        return (_names(self._chain[self._index], self._cuts[self._index], self._cache)
+        return (_names(self._chain[self._index], self._cache)
                 if self._index < len(self._chain) else _NO_NAMES)
 
     def walk(self, visit: Callable[['Scope'], bool]) -> None:
         """Visit this scope and then each one enclosing it, innermost first, stopping where
         ``visit`` returns False."""
         for index in range(self._index, len(self._chain)):
-            if not visit(Scope(self._chain, self._cuts, index, self._cache)):
+            if not visit(Scope(self._chain, index, self._cache)):
                 return
 
     def declares(self, name: str) -> bool:
@@ -96,8 +111,8 @@ class Scope:
         holding it — or None where nothing in scope does. A caller holding a declaration asks
         whether this is the node it came from: anything nearer shadows it."""
         for index in range(self._index, len(self._chain)):
-            if name in _names(self._chain[index], self._cuts[index], self._cache):
-                return self._chain[index]
+            if name in _names(self._chain[index], self._cache):
+                return self._chain[index].scope
         return None
 
 
@@ -109,8 +124,9 @@ def scope_of(cursor: Cursor, binding: bool = False) -> Scope:
     Syntactic, because ``field_type`` cannot decide it: it is unset for every identifier
     when type attribution is unavailable.
     """
-    scopes, cuts = _enclosing_scopes(cursor)
-    return Scope(scopes, [None] * len(cuts) if binding else cuts, 0, _names_cache(cursor))
+    chain = _enclosing_scopes(cursor)
+    return Scope([frame._replace(cut=None) for frame in chain] if binding else chain,
+                 0, _names_cache(cursor))
 
 
 class LocalBindings:
@@ -136,45 +152,63 @@ def _names_cache(cursor: Cursor) -> Dict[Any, FrozenSet[str]]:
     return {}
 
 
-def _names(scope: J, cut: Optional[J], cache: Dict[Any, FrozenSet[str]]) -> FrozenSet[str]:
-    """The names ``scope`` binds — for a class body, the ones bound before ``cut``, the
+def _names(frame: _Frame, cache: Dict[Any, FrozenSet[str]]) -> FrozenSet[str]:
+    """The names ``frame`` binds — for a class body, the ones bound before its cut, the
     statement of it the reference sits in. A class body looks a name up in the module until
     its own binding runs, so ``json = json`` re-exports the import."""
-    names = cache.get((scope, cut))
+    names = cache.get(frame)
     if names is not None:
         return names
+    if frame.type_params:
+        cache[frame] = names = _type_parameter_names(frame.scope)
+        return names
+    scope, cut = frame.scope, frame.cut
     scan = _BindingScan(scope)
     if cut is None or not isinstance(scope, ClassDeclaration):
-        cache[(scope, None)] = names = frozenset(scan.run())
+        cache[_Frame(scope)] = names = frozenset(scan.run())
         return names
     for stmt in scope.body.statements:
-        cache[(scope, stmt)] = frozenset(scan.names())
+        cache[_Frame(scope, stmt)] = frozenset(scan.names())
         scan.run(stmt)
-    return cache.get((scope, cut), frozenset(scan.names()))
+    return cache.get(frame, frozenset(scan.names()))
 
 
-def _enclosing_scopes(cursor: Optional[Cursor]) -> Tuple[List[J], List[Optional[J]]]:
-    """The scopes a reference resolves through, innermost first, each paired with the class
-    body statement holding the reference, None for every scope but a class body.
+def _type_parameter_names(
+        scope: Union[MethodDeclaration, ClassDeclaration, TypeAlias]) -> FrozenSet[str]:
+    """The names a declaration's type parameters bind. A ``def`` holds them in a
+    ``TypeParameters`` and everything else in a container, and both hold the same list."""
+    held = scope.padding.type_parameters
+    if held is None:
+        return _NO_NAMES
+    parameters = held.type_parameters if isinstance(held, TypeParameters) else held.elements
+    return frozenset(parameter.name.simple_name for parameter in parameters
+                     if isinstance(parameter.name, Identifier))
+
+
+def _enclosing_scopes(cursor: Optional[Cursor]) -> List[_Frame]:
+    """The scopes a reference resolves through, innermost first.
 
     A scope covers only the region Python evaluates inside it: a ``def``'s decorators,
     annotations and parameter defaults belong to the scope enclosing it. A class body is
     reachable only from directly within it, never from a function nested in it, nor from
-    a class nested in it.
+    a class nested in it. PEP 695 type parameters get a scope of their own around the
+    declaration carrying them — see :func:`_governs_type_params`.
     """
     path = _tree_path(cursor)
-    scopes: List[J] = []
-    cuts: List[Optional[J]] = []
+    frames: List[_Frame] = []
+    scopes = 0
     for i, node in enumerate(path):
-        if not isinstance(node, _SCOPES):
-            continue
-        if not _governs(node, i, path):
-            continue
-        if isinstance(node, ClassDeclaration) and scopes:
-            continue
-        scopes.append(node)
-        cuts.append(path[i - 2] if isinstance(node, ClassDeclaration) and i >= 2 else None)
-    return scopes, cuts
+        if isinstance(node, _SCOPES) and _governs(node, i, path) and not (
+                isinstance(node, ClassDeclaration) and scopes):
+            scopes += 1
+            frames.append(_Frame(node, path[i - 2] if isinstance(node, ClassDeclaration)
+                                 and i >= 2 else None))
+        # The field test comes first because it rejects every node that cannot carry an
+        # annotation scope, and this loop runs over every node of every path.
+        if getattr(node, '_type_parameters', None) is not None and isinstance(
+                node, _TYPE_PARAM_HOLDERS) and _governs_type_params(node, i, path):
+            frames.append(_Frame(node, type_params=True))
+    return frames
 
 
 def _tree_path(cursor: Optional[Cursor]) -> List[Any]:
@@ -208,9 +242,38 @@ def _governs(scope: J, index: int, path: List[Any]) -> bool:
     return True
 
 
+def _governs_type_params(scope: Union[MethodDeclaration, ClassDeclaration, TypeAlias],
+                         index: int, path: List[Any]) -> bool:
+    """Whether ``scope``'s type parameters reach ``path[:index]``. PEP 695 evaluates the
+    declaration inside the scope holding them, so they cover its bounds and defaults, its
+    annotations and a class's bases, and everything nested deeper — but not the decorators
+    and parameter defaults the enclosing scope evaluates before that scope exists."""
+    if index == 0 or not _type_parameter_names(scope):
+        return False
+    child = path[index - 1]
+    if isinstance(scope, MethodDeclaration):
+        return (child is scope.body or child is scope.return_type_expression
+                or child is scope.padding.type_parameters
+                or _is_parameter_annotation(index, path))
+    if isinstance(scope, ClassDeclaration):
+        # `implements` carries the bases and the header keywords alike.
+        return (child is scope.body
+                or any(held is child for held in (scope.type_parameters or ()))
+                or any(base is child for base in (scope.implements or ())))
+    # A type alias has neither decorators nor parameters, so everything it holds is inside.
+    return True
+
+
 def _is_parameter_name(path: List[Any]) -> bool:
     return (len(path) > 1 and isinstance(path[1], VariableDeclarations.NamedVariable)
             and path[1].name is path[0])
+
+
+def _is_parameter_annotation(index: int, path: List[Any]) -> bool:
+    """Whether the path reaches a parameter's annotation, which hangs off the parameter
+    itself, while its name and its default hang off the ``NamedVariable`` under it."""
+    return (index >= 2 and isinstance(path[index - 1], VariableDeclarations)
+            and not isinstance(path[index - 2], VariableDeclarations.NamedVariable))
 
 
 def _bound_import_name(imp: Import, from_: Optional[Any]) -> str:
@@ -287,6 +350,10 @@ class _BindingScan(PythonVisitor[Any]):
         if self._is_nested(comp):
             return comp
         return super().visit_comprehension_expression(comp, p)
+
+    def visit_type_alias(self, alias: TypeAlias, p: Any) -> J:
+        self._bind(alias.name)
+        return super().visit_type_alias(alias, p)
 
     def visit_variable_scope(self, scope: VariableScope, p: Any) -> J:
         for name in scope.names:

--- a/rewrite-python/rewrite/tests/python/py313/scope_test.py
+++ b/rewrite-python/rewrite/tests/python/py313/scope_test.py
@@ -1,0 +1,24 @@
+# Copyright 2026 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PEP 696 — a type parameter default is part of the annotation scope (Python 3.13+)."""
+
+from tests.python.test_scope import _scope_at_anchor
+
+
+def test_a_type_parameter_reaches_the_default_of_a_later_one():
+    assert _scope_at_anchor("""
+        def f[List, T = anchor()]():
+            pass
+        """).declares('List') is True

--- a/rewrite-python/rewrite/tests/python/test_scope.py
+++ b/rewrite-python/rewrite/tests/python/test_scope.py
@@ -17,7 +17,8 @@
 from typing import List
 
 from rewrite import Cursor
-from rewrite.java.tree import ClassDeclaration, Identifier, MethodDeclaration, MethodInvocation
+from rewrite.java.tree import (ClassDeclaration, Identifier, MethodDeclaration, MethodInvocation,
+                               TypeParameter)
 from rewrite.python.scope_utils import LocalBindings, Scope, scope_of
 from rewrite.python.tree import CompilationUnit
 from rewrite.python.visitor import PythonVisitor
@@ -90,7 +91,7 @@ def test_is_bound_answers_for_a_local_alone_so_a_module_import_stays_attributabl
     assert bindings.is_bound(reachable, 'json') is False
 
 
-def test_a_defs_decorators_and_parameter_defaults_belong_to_the_enclosing_scope():
+def test_a_defs_decorators_annotations_and_parameter_defaults_belong_to_the_enclosing_scope():
     default = _scope_at_anchor("""
         def outer():
             def f(p=anchor()):
@@ -106,6 +107,13 @@ def test_a_defs_decorators_and_parameter_defaults_belong_to_the_enclosing_scope(
                 pass
         """)
     assert decorator.declares('p') is False
+
+    annotation = _scope_at_anchor("""
+        def outer():
+            def f(p: anchor()):
+                pass
+        """)
+    assert annotation.declares('p') is False
 
 
 def test_a_class_body_is_reachable_from_directly_within_it_and_nowhere_else():
@@ -271,3 +279,101 @@ def test_a_cursor_on_a_scope_node_sits_outside_it_except_the_module():
         """, after_recipe=lambda sf: Peek().visit(sf, None)))
 
     assert answers == {'comprehension': False, 'lambda': False, 'module': True}
+
+
+def test_a_type_parameter_reaches_the_annotations_and_bounds_of_the_declaration_carrying_it():
+    # Only the type parameter list spells `List`, so PEP 695's annotation scope is the one
+    # thing that can put it in scope at these positions.
+    assert _scope_at_anchor("""
+        def f[List: int](x: anchor()) -> List:
+            pass
+        """).declares('List') is True
+
+    assert _scope_at_anchor("""
+        def f[List: int](x: List) -> anchor():
+            pass
+        """).declares('List') is True
+
+    assert _scope_at_anchor("""
+        def f[List, T: anchor()]():
+            pass
+        """).declares('List') is True
+
+    assert _scope_at_anchor("""
+        def f[List]():
+            anchor()
+        """).declares('List') is True
+
+
+def test_a_type_parameter_is_bound_where_its_own_name_stands():
+    found: List[Cursor] = []
+
+    class Finder(PythonVisitor):
+        def visit_identifier(self, ident: Identifier, p):
+            parent = self.cursor.parent.value
+            if isinstance(parent, TypeParameter) and parent.name is ident:
+                found.append(self.cursor)
+            return super().visit_identifier(ident, p)
+
+    RecipeSpec(type_attribution=False).rewrite_run(python("""
+        from typing import List
+        def f[List: int]() -> List:
+            pass
+        """, after_recipe=lambda sf: Finder().visit(sf, None)))
+    assert len(found) == 1
+    # A rename following the import must not rewrite the type parameter's own declaration.
+    assert LocalBindings().is_bound(found[0], 'List') is True
+
+
+def test_a_declarations_decorators_and_parameter_defaults_stay_outside_its_type_parameters():
+    # CPython evaluates these before the annotation scope exists: `def f[T](x=T)` is a NameError.
+    assert _scope_at_anchor("""
+        def f[List](p=anchor()):
+            pass
+        """).declares('List') is False
+
+    assert _scope_at_anchor("""
+        @deco(anchor())
+        def f[List]():
+            pass
+        """).declares('List') is False
+
+    assert _scope_at_anchor("""
+        @deco(anchor())
+        class C[List]:
+            pass
+        """).declares('List') is False
+
+
+def test_a_classs_type_parameters_reach_where_its_body_bindings_do_not():
+    assert _scope_at_anchor("""
+        class C[List](anchor()):
+            pass
+        """).declares('List') is True
+
+    assert _scope_at_anchor("""
+        class C[List]:
+            anchor()
+        """).declares('List') is True
+
+    # The annotation scope is not the class body: a nested function reads a type parameter as
+    # a closure variable, while a class-body binding is out of its reach.
+    assert _scope_at_anchor("""
+        class C[List]:
+            def m(self):
+                anchor()
+        """).declares('List') is True
+
+
+def test_a_type_alias_binds_its_name_and_its_type_parameters_reach_its_value():
+    assert _scope_at_anchor("""
+        type X[List] = anchor()
+        """).declares('List') is True
+
+    shadowed = _cursor_at_anchor("""
+        from typing import List
+        def f():
+            type List = int
+            anchor()
+        """)
+    assert LocalBindings().is_bound(shadowed, 'List') is True


### PR DESCRIPTION
`LocalBindings` records no binding for a PEP 695 type parameter, so every recipe using it as a shadowing guard reads `List` in `def f[List](x: List)` as a reference to a module-level import. A recipe replacing deprecated `typing` aliases with their builtins turns this:

```python
from typing import List

def shadow[List: int](x: List) -> List: ...

class K[List: int]:
    def m(self, y: List) -> List: ...

type Alias[List] = List

ok: List[int] = []
```

into this:

```python
def shadow[list: int](x: list) -> list: ...

class K[list: int]:
    def m(self, y: list) -> list: ...

type Alias[List] = list

ok: list[int] = []
```

The type parameter's own declaration is renamed to the builtin it shadows, and `type Alias[List] = List` loses its right-hand side. Nothing raises — the file still parses, and now means something else.

## Why binding the name is not enough

`_governs` gave a `def` its body and its parameter names, on the documented rule that a declaration's annotations belong to the scope enclosing it. That rule holds before PEP 695 and breaks after it: the annotation scope PEP 695 wraps around a declaration is exactly where its annotations are evaluated.

That scope cannot be a widening of either existing one, because it differs from the declaration's own scope on both axes at once:

| a name read from | sees the declaration's own bindings | sees its type parameters |
|---|---|---|
| a method nested in `class C[T]` | ✗ — the class body is out of reach | ✓ |
| a parameter annotation on `def f[T]` | ✗ — `def f(json: json)` still means the import | ✓ |

So `_enclosing_scopes` emits a second frame for a declaration that carries type parameters, and `_governs_type_params` draws its region from what CPython evaluates inside it, checked against 3.13.12 and 3.14.3:

| position | in scope |
|---|---|
| bounds, and PEP 696 defaults, which the LST also holds in `bounds` | ✓ |
| parameter annotations and return type | ✓ |
| a class's bases and its header keywords | ✓ |
| function body, class body, anything nested deeper | ✓ |
| the declaration's own parameter defaults | ✗ |
| the declaration's decorators | ✗ |

`type X[T] = ...` gets the same scope over its value, and `_BindingScan` now binds a type alias's own name, without which a local `type List = int` leaves the identical hole.

## What stays as it was

A declaration carrying no type parameters produces exactly the frame list it produced before, so the recipes sharing this guard are untouched on pre-695 code. Three assertions pin it: a decorator, a parameter default and an annotation on a plain `def` all still resolve to the enclosing scope.

## Tests

`test_scope.py` covers each region of the new scope and each exclusion, and separately the type parameter's own name position — there `declares` answers True either way, and only `is_bound` catches a frame that reports the wrong owning node. The PEP 696 case is version-gated under `tests/python/py313/`; it pins the parser's encoding of those defaults rather than a second branch.
