### PR TITLE
Python: a type alias's type parameters are part of the traversal

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/visitor.py
@@ -595,6 +595,9 @@ class PythonVisitor(JavaVisitor[P]):
         alias = alias.replace(
             name=cast(j.Identifier, self.visit(alias.name, p))
         )
+        alias = alias.replace(
+            type_parameters=self.visit_container(alias.padding.type_parameters, p)
+        )
         alias = alias.padding.replace(
             value=self.visit_left_padded(alias.padding.value, p)
         )

--- a/rewrite-python/rewrite/tests/python/py312/type_alias_with_params_test.py
+++ b/rewrite-python/rewrite/tests/python/py312/type_alias_with_params_test.py
@@ -1,4 +1,5 @@
-from rewrite.test import RecipeSpec, python
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec, from_visitor, python
 
 
 def test_type_alias_simple():
@@ -33,5 +34,21 @@ def test_type_alias_with_bound():
     RecipeSpec().rewrite_run(python(
         """\
         type Foo[T: int] = list[T]
+        """
+    ))
+
+
+def test_type_parameter_bound_is_rewritten():
+    class RenameVisitor(PythonVisitor):
+        def visit_identifier(self, ident, p):
+            return ident.replace(simple_name='New') if ident.simple_name == 'Old' else ident
+
+    # language=python
+    RecipeSpec(recipe=from_visitor(RenameVisitor())).rewrite_run(python(
+        """\
+        type Foo[T: Old] = list[T]
+        """,
+        """\
+        type Foo[T: New] = list[T]
         """
     ))

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -520,6 +520,20 @@ class TestRemoveImportUsageScoping:
                 )
             )
 
+    def test_keep_import_referenced_in_a_type_alias_type_parameter(self, arm):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=self._remove(arm, 'typing', 'Deque'),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    from typing import Deque
+
+                    type Queues[U: Deque[int]] = dict[str, U]
+                    """,
+                )
+            )
+
     def test_keep_import_referenced_in_function_body(self, arm):
         for type_attribution in (False, True):
             spec = RecipeSpec(recipe=self._remove(arm, 'os.path', 'join'),

--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
@@ -303,6 +303,7 @@ public class PythonVisitor<P> extends JavaVisitor<P>
         typeAlias = (Py.TypeAlias) tempStatement;
         typeAlias = typeAlias.withMarkers(visitMarkers(typeAlias.getMarkers(), p));
         typeAlias = typeAlias.withName(visitAndCast(typeAlias.getName(), p));
+        typeAlias = typeAlias.getPadding().withTypeParameters(visitContainer(typeAlias.getPadding().getTypeParameters(), JContainer.Location.TYPE_PARAMETERS, p));
         typeAlias = typeAlias.getPadding().withValue(visitLeftPadded(typeAlias.getPadding().getValue(), PyLeftPadded.Location.TYPE_ALIAS_VALUE, p));
         return typeAlias.getPadding().withValue(typeAlias.getPadding().getValue().withElement(visitTypeNameIfNameTree(typeAlias.getPadding().getValue().getElement(), p)));
     }

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonVisitorCompletenessTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonVisitorCompletenessTest.java
@@ -199,6 +199,7 @@ class PythonVisitorCompletenessTest {
       "d = {**a, **b}\n",
       // type alias (3.12)
       "type Alias = int\n",
+      "type Alias[\n    T: int,\n] = list[T]\n",
       // no trailing newline
       "x = 1",
       "def f():\n    pass",

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonVisitorTypeAliasTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonVisitorTypeAliasTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.Tree;
+import org.openrewrite.java.tree.*;
+import org.openrewrite.marker.Markers;
+import org.openrewrite.python.tree.Py;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Builds the node rather than parsing one, so this runs without the Python peer that
+ * {@link PythonVisitorCompletenessTest} needs.
+ */
+class PythonVisitorTypeAliasTest {
+
+    @Test
+    void visitsTypeParameterBounds() {
+        Py.TypeAlias alias = typeAlias(ident("Old"));
+
+        Py.TypeAlias renamed = (Py.TypeAlias) new PythonVisitor<Integer>() {
+            @Override
+            public J visitIdentifier(J.Identifier ident, Integer p) {
+                return "Old".equals(ident.getSimpleName()) ? ident.withSimpleName("New") : ident;
+            }
+        }.visitTypeAlias(alias, 0);
+
+        assertThat(boundName(renamed)).isEqualTo("New");
+    }
+
+    private static Py.TypeAlias typeAlias(J.Identifier bound) {
+        J.TypeParameter typeParam = new J.TypeParameter(
+                Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), emptyList(), ident("T"),
+                JContainer.build(Space.EMPTY, List.of(JRightPadded.build((TypeTree) bound)), Markers.EMPTY));
+        return new Py.TypeAlias(
+                Tree.randomId(), Space.EMPTY, Markers.EMPTY, ident("X"),
+                JContainer.build(Space.EMPTY, List.of(JRightPadded.build(typeParam)), Markers.EMPTY),
+                JLeftPadded.build((J) ident("int")).withBefore(Space.SINGLE_SPACE),
+                null);
+    }
+
+    private static String boundName(Py.TypeAlias alias) {
+        //noinspection DataFlowIssue
+        return ((J.Identifier) alias.getTypeParameters().get(0).getBounds().get(0)).getSimpleName();
+    }
+
+    private static J.Identifier ident(String name) {
+        return new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, emptyList(), name, null, null);
+    }
+}


### PR DESCRIPTION
`RemoveImport` deletes an import that a PEP 695 type alias still references, leaving a module that raises `NameError` when the alias is evaluated. Renaming `List` in

```python
from typing import List
type A[U: List[int]] = dict[str, U]
x: List[int] = []
```

yields

```python
type A[U: List[int]] = dict[str, U]
x: list[int] = []
```

## Mechanism

`PythonVisitor.visit_type_alias` visited `prefix`, `markers`, `name` and the padded `value`, then returned. `TypeAlias._type_parameters` is a populated `JContainer` that no visitor ever descended into, so the names in a bound were invisible to every traversal — including the `PythonVisitor` subclass `RemoveImport` counts references with, which is why the import looked unused.

`visit_method_declaration` and `visit_class_declaration` already visit theirs, so `def f[U: List[int]]` and `class C[U: List[int]]` behaved correctly; only the `type` form was affected. The Java `PythonVisitor` skipped the same container.

## Fix

One `visit_container` call in each of the two visitors. `TypeAlias` already exposed both `type_parameters` and `padding.type_parameters`, and both RPC sender/receiver pairs already carried the field, so nothing else needed adding. The Java side reuses `JContainer.Location.TYPE_PARAMETERS` rather than introducing a `PyContainer.Location` constant, since these are ordinary `J.TypeParameter`s.

## Tests

Four, each confirmed to fail with the corresponding line removed:

- `test_keep_import_referenced_in_a_type_alias_type_parameter` — the case above, as an import-retention assertion.
- `test_type_parameter_bound_is_rewritten` — renames a name inside the bound. This one pins write-back: an implementation that visits the container but drops the result passes the first test and fails this one.
- `PythonVisitorTypeAliasTest` — the same rename against a hand-built `Py.TypeAlias`, so it needs no Python peer and runs in CI. Without it the Java line could be deleted with every job green: the remove-import tests' `java` arm dispatches to the Python implementation over RPC and never reaches `visitTypeAlias`, and `PythonVisitorCompletenessTest` is disabled when `CI` is set.
- A `PythonVisitorCompletenessTest` snippet, `type Alias[\n    T: int,\n] = list[T]\n`. That test compares newlines reached through the visitor against newlines printed, so a skipped container holding newlines fails it. It keeps this shape in that test's sweep, which is what would catch a future unvisited slot on `TypeAlias`.


