### PR TITLE
Drop the stale "auto generated" banner from three visitors

### DIFF
--- a/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpIsoVisitor.java
+++ b/rewrite-csharp/src/main/java/org/openrewrite/csharp/CSharpIsoVisitor.java
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * -------------------THIS FILE IS AUTO GENERATED--------------------------
- * Changes to this file may cause incorrect behavior and will be lost if
- * the code is regenerated.
-*/
-
 package org.openrewrite.csharp;
 
 import org.openrewrite.csharp.tree.Cs;

--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonIsoVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonIsoVisitor.java
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * -------------------THIS FILE IS AUTO GENERATED--------------------------
- * Changes to this file may cause incorrect behavior and will be lost if
- * the code is regenerated.
-*/
-
 package org.openrewrite.python;
 
 import org.openrewrite.java.tree.J;

--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonVisitor.java
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-/*
- * -------------------THIS FILE IS AUTO GENERATED--------------------------
- * Changes to this file may cause incorrect behavior and will be lost if
- * the code is regenerated.
-*/
-
 package org.openrewrite.python;
 
 import org.jspecify.annotations.Nullable;


### PR DESCRIPTION
`PythonVisitor.java` tells anyone who opens it that their edits will be lost:

```java
/*
 * -------------------THIS FILE IS AUTO GENERATED--------------------------
 * Changes to this file may cause incorrect behavior and will be lost if
 * the code is regenerated.
*/
```

- No generator for it exists. The string `THIS FILE IS AUTO GENERATED` appears in exactly three places in the tree — the three files it is being deleted from — so nothing emits it; there is no Gradle task, no script, and no template that writes any of these paths. The banner is a copy-paste leftover from the initial language drops (#6508, #6678).

- Every commit since has been a hand edit, which is the behaviour the banner warns against: #8403 added the private helper `visitTypeNameIfNameTree` to `PythonVisitor` with its own explanatory comment, #8314 fixed space traversal by hand, #8729 added a `Shebang` case to both Python visitors. `CSharpIsoVisitor` picked up model-consolidation edits in #6981 and #7152.

Two more signals that it is decoration rather than a contract: `CSharpVisitor` carries no banner while `CSharpIsoVisitor` does — a generator producing the pair would have stamped both — and none of the sibling model files (`Py`, `PySpace`, `PyLeftPadded`, `PyRightPadded`, `PyContainer`) carry it either.

Scope is the three files above. Genuinely generated sources elsewhere keep their banners: the ANTLR output under `rewrite-csharp/csharp/OpenRewrite/Xml/Grammar/`, and the `.pyi` stubs written by `rewrite-python/rewrite/scripts/generate_stubs.py`.

Comment-only, so no test. `./gradlew :rewrite-python:compileJava :rewrite-csharp:compileJava` passes.
