### PR TITLE
Python: a dotted module import binds its root, not its last segment

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/add_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/add_import.py
@@ -26,7 +26,8 @@ from rewrite.java.tree import Empty, FieldAccess, Identifier, Import, Literal, S
 from rewrite.markers import Markers
 from rewrite.python.binding_utils import is_reference
 from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
-                                         get_canonical_fqn, pad_right, referenced_names)
+                                         get_canonical_fqn, module_binding_name, pad_right,
+                                         referenced_names)
 from rewrite.python.tree import CompilationUnit, ExpressionStatement, MultiImport
 from rewrite.python.visitor import PythonVisitor
 
@@ -202,7 +203,7 @@ class AddImport(PythonVisitor):
 
     def _is_referenced(self, cu: CompilationUnit) -> bool:
         """Check if the identifier we're importing is actually used."""
-        target_name = self.alias or self.name or self.module.split('.')[-1]
+        target_name = self.alias or self.name or module_binding_name(self.module)
 
         class ReferenceChecker(PythonVisitor):
             def __init__(self):

--- a/rewrite-python/rewrite/src/rewrite/python/import_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/import_utils.py
@@ -83,6 +83,12 @@ def get_alias_name(imp: Import) -> Optional[str]:
     return None
 
 
+def module_binding_name(module: str) -> str:
+    """The name ``import <module>`` binds: its root package, since ``import os.path``
+    binds ``os`` and that is what a reference through the module reads."""
+    return module.split('.')[0]
+
+
 def get_canonical_fqn(imp: Import) -> Optional[str]:
     """The fully qualified name of the symbol ``imp`` binds, at the module defining it,
     read off the qualid's own type, or None when unattributed."""

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -22,8 +22,8 @@ from rewrite.java.support_types import JContainer, JRightPadded, Statement
 from rewrite.java.tree import Identifier, If, Import, Space
 from rewrite.python.binding_utils import is_reference
 from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
-                                         get_canonical_fqn, referenced_names,
-                                         unconditional_body)
+                                         get_canonical_fqn, module_binding_name,
+                                         referenced_names, unconditional_body)
 from rewrite.python.scope_utils import LocalBindings
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
@@ -230,7 +230,7 @@ class RemoveImport(PythonVisitor):
         if self.name is not None:
             return imp
         name = get_qualid_name(imp.qualid)
-        if name == self.module and self._is_removable(imp, self.module.split('.')[-1]):
+        if name == self.module and self._is_removable(imp, module_binding_name(self.module)):
             return None
         return imp
 
@@ -259,7 +259,7 @@ class RemoveImport(PythonVisitor):
             for padded_imp in multi.padding.names.padding.elements:
                 name = get_qualid_name(padded_imp.element.qualid)
                 if name != self.module or not self._is_removable(
-                        padded_imp.element, name.split('.')[-1]):
+                        padded_imp.element, module_binding_name(name)):
                     new_padded.append(padded_imp)
 
         return self._prune_names(multi, new_padded)

--- a/rewrite-python/rewrite/tests/python/test_add_import.py
+++ b/rewrite-python/rewrite/tests/python/test_add_import.py
@@ -179,6 +179,21 @@ class TestMaybeAddImport:
             )
         )
 
+    def test_only_if_referenced_adds_a_dotted_module_read_through_its_root(self, arm):
+        spec = RecipeSpec(recipe=from_visitor(
+            _add_import_visitor(arm, 'os.path', only_if_referenced=True)))
+        spec.rewrite_run(
+            python(
+                """
+                x = os.path.join('a', 'b')
+                """,
+                """
+                import os.path
+                x = os.path.join('a', 'b')
+                """,
+            )
+        )
+
     @pytest.mark.parametrize('annotation_position, source', [
         ('variable', 'm: "Dict[Any, Any]" = {}'),
         ('parameter', 'def f(m: "Dict[Any, Any]") -> None: ...'),

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -557,6 +557,20 @@ class TestRemoveImportUsageScoping:
                 )
             )
 
+    def test_keep_a_dotted_module_import_referenced_through_its_root(self, arm):
+        for type_attribution in (False, True):
+            spec = RecipeSpec(recipe=self._remove(arm, 'os.path', None),
+                              type_attribution=type_attribution)
+            spec.rewrite_run(
+                python(
+                    """\
+                    import os.path
+
+                    x = os.path.join("a", "b")
+                    """,
+                )
+            )
+
     def test_remove_import_shadowed_in_every_function(self, arm):
         for type_attribution in (False, True):
             spec = RecipeSpec(recipe=self._remove(arm, 'os.path', 'join'),


### PR DESCRIPTION
`import os.path` binds `os`, but both Python import visitors read the bound name as the module's last segment. `RemoveImport` therefore dropped an import the code still read:

```python
import os.path

x = os.path.join("a", "b")   # import removed, NameError at runtime
```

`path` cannot occur as a reference — in `os.path.join(...)` it sits in member position, where `is_reference` returns False. The usage census looked for a name that never appears, found nothing, and judged every dotted module import unused. `AddImport` failed identically in the other direction, adding nothing for `module='os.path', only_if_referenced=True` against that same file.

Both now take the name from one function rather than spelling the rule inline, matching what `binding_utils._binding` already recorded for the same import:

```python
def module_binding_name(module: str) -> str:
    """The name ``import <module>`` binds: its root package, since ``import os.path``
    binds ``os`` and that is what a reference through the module reads."""
    return module.split('.')[0]
```

One test per direction, each confirmed failing before the fix on both the native and the Java RPC arm: `test_keep_a_dotted_module_import_referenced_through_its_root` and `test_only_if_referenced_adds_a_dotted_module_read_through_its_root`.

The Java gates `PythonAddImportVisitor.isReferenced` and `PythonRemoveImportVisitor.mightChange` keep `lastIndexOf('.')`. Both over-approximate and dispatch into the Python implementation, so neither can turn a change into a skip — the passing Java arm confirms it. Also unchanged: with `import os.path` and `import os` both present, `_bound_by_another_import` still allows removing the former while `os.path.join` reads it.
