### PR TITLE
Go: withhold GoResultionResult content on incomplete resolution

### DIFF
--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2545,6 +2545,9 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		// versions of the same module, only one of which is on disk.
 		buildList []golang.GoResolvedDependency
 		goProject golang.GoProject // lightweight per-CU marker; one shared instance per module
+		// unresolved lists imports that resolved to no module; when non-empty the
+		// package->module map was withheld and a warning is attached to the go.mod.
+		unresolved []string
 	}
 	mods := make(map[string]*modCtx, len(disc.goMods))
 	for _, modPath := range disc.goMods {
@@ -2575,7 +2578,8 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		// the go.sum-only result (never fail the parse).
 		moduleDir := filepath.Dir(modPath)
 		var buildList []golang.GoResolvedDependency
-		if resolved, pkgs, incomplete, rerr := goparser.ResolveModuleGraph(moduleDir); rerr != nil {
+		var unresolved []string
+		if resolved, pkgs, rerr := goparser.ResolveModuleGraph(moduleDir); rerr != nil {
 			s.logger.Printf("ParseProject: module resolution failed for %s (go.sum-only): %v", moduleDir, rerr)
 		} else {
 			buildList = resolved
@@ -2583,17 +2587,19 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 			// A partial package->module map omits the modules that failed to resolve, so a
 			// still-used require would look unused. Withhold it and let require-removal
 			// no-op (its gate is len(PackageModules)==0) rather than break the build.
-			if incomplete {
-				s.logger.Printf("ParseProject: incomplete module resolution for %s; withholding package->module map to avoid unsafe require removal", moduleDir)
+			if pkgs.Incomplete {
+				unresolved = pkgs.Unresolved
+				s.logger.Printf("ParseProject: incomplete module resolution for %s; withholding package->module map to avoid unsafe require removal (unresolved imports: %v)", moduleDir, pkgs.Unresolved)
 			} else {
-				mrr.PackageModules = pkgs
+				mrr.PackageModules = pkgs.Packages
 			}
 		}
 		mods[filepath.Dir(modPath)] = &modCtx{
-			dir:       filepath.Dir(modPath),
-			mrr:       mrr,
-			buildList: buildList,
-			goProject: golang.NewGoProject(mrr.ModulePath, mrr.ModulePath),
+			dir:        filepath.Dir(modPath),
+			mrr:        mrr,
+			buildList:  buildList,
+			goProject:  golang.NewGoProject(mrr.ModulePath, mrr.ModulePath),
+			unresolved: unresolved,
 		}
 	}
 
@@ -2860,6 +2866,11 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		}
 		if m, ok := mods[filepath.Dir(modPath)]; ok && m.mrr != nil {
 			gm.Markers.Entries = append(gm.Markers.Entries, *m.mrr, m.goProject)
+			if len(m.unresolved) > 0 {
+				gm.Markers = java.AddMarkupWarn(gm.Markers,
+					"Go module resolution was incomplete, so unused-require removal was skipped to avoid dropping a still-used dependency. Re-run once the modules below can be resolved.",
+					"unresolved imports: "+strings.Join(m.unresolved, ", "))
+			}
 		}
 		id := gm.Ident.String()
 		s.localObjects[id] = gm

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -2575,12 +2575,19 @@ func (s *server) handleParseProject(params json.RawMessage) (any, *rpcError) {
 		// the go.sum-only result (never fail the parse).
 		moduleDir := filepath.Dir(modPath)
 		var buildList []golang.GoResolvedDependency
-		if resolved, pkgs, rerr := goparser.ResolveModuleGraph(moduleDir); rerr != nil {
+		if resolved, pkgs, incomplete, rerr := goparser.ResolveModuleGraph(moduleDir); rerr != nil {
 			s.logger.Printf("ParseProject: module resolution failed for %s (go.sum-only): %v", moduleDir, rerr)
 		} else {
 			buildList = resolved
 			mrr.ResolvedDependencies = goparser.MergeResolvedDependencies(mrr.ResolvedDependencies, resolved)
-			mrr.PackageModules = pkgs
+			// A partial package->module map omits the modules that failed to resolve, so a
+			// still-used require would look unused. Withhold it and let require-removal
+			// no-op (its gate is len(PackageModules)==0) rather than break the build.
+			if incomplete {
+				s.logger.Printf("ParseProject: incomplete module resolution for %s; withholding package->module map to avoid unsafe require removal", moduleDir)
+			} else {
+				mrr.PackageModules = pkgs
+			}
 		}
 		mods[filepath.Dir(modPath)] = &modCtx{
 			dir:       filepath.Dir(modPath),

--- a/rewrite-go/pkg/parser/gomod_resolve.go
+++ b/rewrite-go/pkg/parser/gomod_resolve.go
@@ -41,12 +41,17 @@ const resolveTimeout = 120 * time.Second
 // marker coupling, no mutation of go.mod/go.sum (readonly + -e).
 //
 // It degrades gracefully: any hard toolchain/network failure returns an error
-// so the caller can keep today's go.sum-only behavior. Partial output from an
-// untidy module (surfaced via -e) is kept rather than discarded.
-func ResolveModuleGraph(moduleDir string) (mods []golang.GoResolvedDependency, pkgs []golang.GoPackageModule, err error) {
+// so the caller can keep today's go.sum-only behavior.
+//
+// The returned incomplete flag reports that `go list -deps` could not fully
+// resolve every imported package (e.g. a private module the toolchain could not
+// fetch). When it is set the package->module map is untrustworthy — a still-used
+// import may be missing from it — so callers must not use it to drive require
+// removal, or they will drop a required module and break the build.
+func ResolveModuleGraph(moduleDir string) (mods []golang.GoResolvedDependency, pkgs []golang.GoPackageModule, incomplete bool, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			mods, pkgs, err = nil, nil, fmt.Errorf("resolve panicked: %v", r)
+			mods, pkgs, incomplete, err = nil, nil, false, fmt.Errorf("resolve panicked: %v", r)
 		}
 	}()
 
@@ -54,15 +59,15 @@ func ResolveModuleGraph(moduleDir string) (mods []golang.GoResolvedDependency, p
 	// failure here propagates and the caller falls back to go.sum-only.
 	mods, err = goListModules(moduleDir)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, false, err
 	}
 	// Graph edges and the package map are best-effort: a partial build list is
 	// still useful, so sub-failures are swallowed rather than discarding mods.
 	if edges, gerr := goModGraph(moduleDir); gerr == nil {
 		attachEdges(mods, edges)
 	}
-	pkgs, _ = goListPackages(moduleDir)
-	return mods, pkgs, nil
+	pkgs, incomplete, _ = goListPackages(moduleDir)
+	return mods, pkgs, incomplete, nil
 }
 
 // goModule is the subset of `go list -m -json` / `go list -deps -json` output we consume.
@@ -78,7 +83,13 @@ type goModule struct {
 type goPackage struct {
 	ImportPath string
 	Standard   bool
+	Incomplete bool // go list -e: this package or one of its deps failed to resolve
+	Error      *goPackageError
 	Module     *goModule
+}
+
+type goPackageError struct {
+	Err string
 }
 
 func goListModules(dir string) ([]golang.GoResolvedDependency, error) {
@@ -114,31 +125,47 @@ func goListModules(dir string) ([]golang.GoResolvedDependency, error) {
 	return out, nil
 }
 
-func goListPackages(dir string) ([]golang.GoPackageModule, error) {
-	stdout, err := runGo(dir, "list", "-mod=readonly", "-e", "-deps", "-test", "-json", "./...")
-	if err != nil && len(stdout) == 0 {
-		return nil, err
+func goListPackages(dir string) ([]golang.GoPackageModule, bool, error) {
+	stdout, runErr := runGo(dir, "list", "-mod=readonly", "-e", "-deps", "-test", "-json", "./...")
+	if runErr != nil && len(stdout) == 0 {
+		return nil, false, runErr
 	}
-	var out []golang.GoPackageModule
+	pkgs, incomplete, err := parseGoListPackages(stdout)
+	// A non-empty stdout past a process-level error means `-e` recovered partial
+	// output: usable, but by definition something did not resolve — don't trust it.
+	if runErr != nil {
+		incomplete = true
+	}
+	return pkgs, incomplete, err
+}
+
+// parseGoListPackages decodes the `go list -e -deps -json ./...` stream into the
+// import-path -> module map. incomplete is true when any package (or one of its
+// transitive deps) failed to resolve, which `go list -e` surfaces via the
+// per-package Error/Incomplete fields instead of a process-level failure.
+func parseGoListPackages(stdout []byte) (pkgs []golang.GoPackageModule, incomplete bool, err error) {
 	dec := json.NewDecoder(bytes.NewReader(stdout))
 	for {
 		var p goPackage
 		if derr := dec.Decode(&p); derr == io.EOF {
 			break
 		} else if derr != nil {
-			return out, fmt.Errorf("go list -deps decode: %w", derr)
+			return pkgs, true, fmt.Errorf("go list -deps decode: %w", derr)
 		}
 		if p.ImportPath == "" {
 			continue
+		}
+		if p.Error != nil || p.Incomplete {
+			incomplete = true
 		}
 		pm := golang.GoPackageModule{ImportPath: p.ImportPath, Standard: p.Standard}
 		if p.Module != nil {
 			pm.ModulePath = p.Module.Path
 			pm.Version = p.Module.Version
 		}
-		out = append(out, pm)
+		pkgs = append(pkgs, pm)
 	}
-	return out, nil
+	return pkgs, incomplete, nil
 }
 
 type moduleEdge struct {

--- a/rewrite-go/pkg/parser/gomod_resolve.go
+++ b/rewrite-go/pkg/parser/gomod_resolve.go
@@ -42,16 +42,10 @@ const resolveTimeout = 120 * time.Second
 //
 // It degrades gracefully: any hard toolchain/network failure returns an error
 // so the caller can keep today's go.sum-only behavior.
-//
-// The returned incomplete flag reports that `go list -deps` could not fully
-// resolve every imported package (e.g. a private module the toolchain could not
-// fetch). When it is set the package->module map is untrustworthy — a still-used
-// import may be missing from it — so callers must not use it to drive require
-// removal, or they will drop a required module and break the build.
-func ResolveModuleGraph(moduleDir string) (mods []golang.GoResolvedDependency, pkgs []golang.GoPackageModule, incomplete bool, err error) {
+func ResolveModuleGraph(moduleDir string) (mods []golang.GoResolvedDependency, pkgs PackageResolution, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			mods, pkgs, incomplete, err = nil, nil, false, fmt.Errorf("resolve panicked: %v", r)
+			mods, pkgs, err = nil, PackageResolution{}, fmt.Errorf("resolve panicked: %v", r)
 		}
 	}()
 
@@ -59,15 +53,27 @@ func ResolveModuleGraph(moduleDir string) (mods []golang.GoResolvedDependency, p
 	// failure here propagates and the caller falls back to go.sum-only.
 	mods, err = goListModules(moduleDir)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, PackageResolution{}, err
 	}
 	// Graph edges and the package map are best-effort: a partial build list is
 	// still useful, so sub-failures are swallowed rather than discarding mods.
 	if edges, gerr := goModGraph(moduleDir); gerr == nil {
 		attachEdges(mods, edges)
 	}
-	pkgs, incomplete, _ = goListPackages(moduleDir)
-	return mods, pkgs, incomplete, nil
+	pkgs = goListPackages(moduleDir)
+	return mods, pkgs, nil
+}
+
+// PackageResolution is the imported-package -> module map from `go list`, plus a
+// signal of whether that resolution was complete. Incomplete is set when any
+// import failed to resolve (e.g. a private module the toolchain could not
+// fetch); the map is then untrustworthy for require removal, because a still-used
+// module may be missing from it. Unresolved lists the specific import paths that
+// resolved to no module, for diagnostics.
+type PackageResolution struct {
+	Packages   []golang.GoPackageModule
+	Incomplete bool
+	Unresolved []string
 }
 
 // goModule is the subset of `go list -m -json` / `go list -deps -json` output we consume.
@@ -125,47 +131,53 @@ func goListModules(dir string) ([]golang.GoResolvedDependency, error) {
 	return out, nil
 }
 
-func goListPackages(dir string) ([]golang.GoPackageModule, bool, error) {
+func goListPackages(dir string) PackageResolution {
 	stdout, runErr := runGo(dir, "list", "-mod=readonly", "-e", "-deps", "-test", "-json", "./...")
 	if runErr != nil && len(stdout) == 0 {
-		return nil, false, runErr
+		return PackageResolution{Incomplete: true}
 	}
-	pkgs, incomplete, err := parseGoListPackages(stdout)
+	res := parseGoListPackages(stdout)
 	// A non-empty stdout past a process-level error means `-e` recovered partial
 	// output: usable, but by definition something did not resolve — don't trust it.
 	if runErr != nil {
-		incomplete = true
+		res.Incomplete = true
 	}
-	return pkgs, incomplete, err
+	return res
 }
 
 // parseGoListPackages decodes the `go list -e -deps -json ./...` stream into the
-// import-path -> module map. incomplete is true when any package (or one of its
+// import-path -> module map. Incomplete is set when any package (or one of its
 // transitive deps) failed to resolve, which `go list -e` surfaces via the
-// per-package Error/Incomplete fields instead of a process-level failure.
-func parseGoListPackages(stdout []byte) (pkgs []golang.GoPackageModule, incomplete bool, err error) {
+// per-package Error/Incomplete fields instead of a process-level failure; the
+// non-standard imports that resolved to no module are collected in Unresolved.
+func parseGoListPackages(stdout []byte) PackageResolution {
+	var res PackageResolution
 	dec := json.NewDecoder(bytes.NewReader(stdout))
 	for {
 		var p goPackage
 		if derr := dec.Decode(&p); derr == io.EOF {
 			break
 		} else if derr != nil {
-			return pkgs, true, fmt.Errorf("go list -deps decode: %w", derr)
+			res.Incomplete = true
+			break
 		}
 		if p.ImportPath == "" {
 			continue
 		}
 		if p.Error != nil || p.Incomplete {
-			incomplete = true
+			res.Incomplete = true
+			if p.Module == nil && !p.Standard {
+				res.Unresolved = append(res.Unresolved, p.ImportPath)
+			}
 		}
 		pm := golang.GoPackageModule{ImportPath: p.ImportPath, Standard: p.Standard}
 		if p.Module != nil {
 			pm.ModulePath = p.Module.Path
 			pm.Version = p.Module.Version
 		}
-		pkgs = append(pkgs, pm)
+		res.Packages = append(res.Packages, pm)
 	}
-	return pkgs, incomplete, nil
+	return res
 }
 
 type moduleEdge struct {

--- a/rewrite-go/pkg/parser/gomod_resolve_test.go
+++ b/rewrite-go/pkg/parser/gomod_resolve_test.go
@@ -106,8 +106,9 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 	writeFile(t, dir, "main.go", "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
 
 	// when
-	mods, pkgs, err := ResolveModuleGraph(dir)
+	mods, pkgs, incomplete, err := ResolveModuleGraph(dir)
 	require.NoError(t, err, "resolve failed")
+	assert.False(t, incomplete, "stdlib-only module should resolve completely")
 
 	// then: the build list contains the main module
 	var main *golang.GoResolvedDependency
@@ -131,6 +132,52 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 	}
 	assert.Truef(t, sawStdlib, "expected stdlib package fmt with Standard=true in %+v", pkgs)
 	assert.Truef(t, sawMain, "expected the main package mapped to its module in %+v", pkgs)
+}
+
+// TestParseGoListPackagesComplete: a fully-resolved stream maps every import to
+// its module and is not flagged incomplete.
+func TestParseGoListPackagesComplete(t *testing.T) {
+	// given: `go list -e -deps -json ./...` output where everything resolved
+	stream := `
+{"ImportPath":"fmt","Standard":true}
+{"ImportPath":"github.com/cof-primary/otter-actuation/app","Module":{"Path":"github.com/cof-primary/otter-actuation"}}
+{"ImportPath":"github.com/cof-primary/go-shared-libraries/gotel","Module":{"Path":"github.com/cof-primary/go-shared-libraries","Version":"v1.2.0"}}
+`
+
+	// when
+	pkgs, incomplete, err := parseGoListPackages([]byte(stream))
+
+	// then
+	require.NoError(t, err)
+	assert.False(t, incomplete, "no package errored, so resolution is complete")
+	assert.Len(t, pkgs, 3)
+	var sawShared bool
+	for _, p := range pkgs {
+		if p.ImportPath == "github.com/cof-primary/go-shared-libraries/gotel" {
+			sawShared = p.ModulePath == "github.com/cof-primary/go-shared-libraries" && p.Version == "v1.2.0"
+		}
+	}
+	assert.True(t, sawShared, "used import should map to its providing module")
+}
+
+// TestParseGoListPackagesIncomplete reproduces #3118: a private module the
+// toolchain cannot fetch. `go list -e` keeps going, but the importing package is
+// flagged Incomplete and the unresolvable package carries an Error with no
+// Module. Without the incomplete signal its require looks unused and gets dropped.
+func TestParseGoListPackagesIncomplete(t *testing.T) {
+	// given: the used module (go-shared-libraries) failed to resolve
+	stream := `
+{"ImportPath":"fmt","Standard":true}
+{"ImportPath":"github.com/cof-primary/otter-actuation/app","Module":{"Path":"github.com/cof-primary/otter-actuation"},"Incomplete":true,"Error":{"Err":"no required module provides package github.com/cof-primary/go-shared-libraries/cof/cofsecrets"}}
+{"ImportPath":"github.com/cof-primary/go-shared-libraries/cof/cofsecrets","Error":{"Err":"no required module provides package github.com/cof-primary/go-shared-libraries/cof/cofsecrets"},"Incomplete":true}
+`
+
+	// when
+	_, incomplete, err := parseGoListPackages([]byte(stream))
+
+	// then: the map cannot be trusted for require removal
+	require.NoError(t, err)
+	assert.True(t, incomplete, "an unresolvable imported package must flag the map incomplete")
 }
 
 func writeFile(t *testing.T, dir, name, content string) {

--- a/rewrite-go/pkg/parser/gomod_resolve_test.go
+++ b/rewrite-go/pkg/parser/gomod_resolve_test.go
@@ -106,9 +106,11 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 	writeFile(t, dir, "main.go", "package main\n\nimport \"fmt\"\n\nfunc main() { fmt.Println(\"hi\") }\n")
 
 	// when
-	mods, pkgs, incomplete, err := ResolveModuleGraph(dir)
+	mods, res, err := ResolveModuleGraph(dir)
 	require.NoError(t, err, "resolve failed")
-	assert.False(t, incomplete, "stdlib-only module should resolve completely")
+	assert.False(t, res.Incomplete, "stdlib-only module should resolve completely")
+	assert.Empty(t, res.Unresolved, "stdlib-only module should have no unresolved imports")
+	pkgs := res.Packages
 
 	// then: the build list contains the main module
 	var main *golang.GoResolvedDependency
@@ -134,8 +136,6 @@ func TestResolveModuleGraphStdlibOnly(t *testing.T) {
 	assert.Truef(t, sawMain, "expected the main package mapped to its module in %+v", pkgs)
 }
 
-// TestParseGoListPackagesComplete: a fully-resolved stream maps every import to
-// its module and is not flagged incomplete.
 func TestParseGoListPackagesComplete(t *testing.T) {
 	// given: `go list -e -deps -json ./...` output where everything resolved
 	stream := `
@@ -145,14 +145,14 @@ func TestParseGoListPackagesComplete(t *testing.T) {
 `
 
 	// when
-	pkgs, incomplete, err := parseGoListPackages([]byte(stream))
+	res := parseGoListPackages([]byte(stream))
 
 	// then
-	require.NoError(t, err)
-	assert.False(t, incomplete, "no package errored, so resolution is complete")
-	assert.Len(t, pkgs, 3)
+	assert.False(t, res.Incomplete, "no package errored, so resolution is complete")
+	assert.Empty(t, res.Unresolved)
+	assert.Len(t, res.Packages, 3)
 	var sawShared bool
-	for _, p := range pkgs {
+	for _, p := range res.Packages {
 		if p.ImportPath == "github.com/cof-primary/go-shared-libraries/gotel" {
 			sawShared = p.ModulePath == "github.com/cof-primary/go-shared-libraries" && p.Version == "v1.2.0"
 		}
@@ -160,10 +160,6 @@ func TestParseGoListPackagesComplete(t *testing.T) {
 	assert.True(t, sawShared, "used import should map to its providing module")
 }
 
-// TestParseGoListPackagesIncomplete reproduces #3118: a private module the
-// toolchain cannot fetch. `go list -e` keeps going, but the importing package is
-// flagged Incomplete and the unresolvable package carries an Error with no
-// Module. Without the incomplete signal its require looks unused and gets dropped.
 func TestParseGoListPackagesIncomplete(t *testing.T) {
 	// given: the used module (go-shared-libraries) failed to resolve
 	stream := `
@@ -173,11 +169,12 @@ func TestParseGoListPackagesIncomplete(t *testing.T) {
 `
 
 	// when
-	_, incomplete, err := parseGoListPackages([]byte(stream))
+	res := parseGoListPackages([]byte(stream))
 
-	// then: the map cannot be trusted for require removal
-	require.NoError(t, err)
-	assert.True(t, incomplete, "an unresolvable imported package must flag the map incomplete")
+	// then: the map cannot be trusted for require removal, and the culprit import is reported
+	assert.True(t, res.Incomplete, "an unresolvable imported package must flag the map incomplete")
+	assert.Contains(t, res.Unresolved, "github.com/cof-primary/go-shared-libraries/cof/cofsecrets",
+		"the import that resolved to no module should be reported for diagnostics")
 }
 
 func writeFile(t *testing.T, dir, name, content string) {

--- a/rewrite-go/pkg/rpc/marker_codec_test.go
+++ b/rewrite-go/pkg/rpc/marker_codec_test.go
@@ -86,6 +86,24 @@ func TestPartialTypeAttributionMarkerRoundTrip(t *testing.T) {
 	assert.Equal(t, reason, got.Reason)
 }
 
+func TestMarkupWarnMarkerRoundTrip(t *testing.T) {
+	// given
+	message := "Go module resolution was incomplete, so unused-require removal was skipped."
+	detail := "unresolved imports: github.com/cof-primary/go-shared-libraries/gotel"
+	before := java.AddMarkupWarn(java.Markers{ID: uuid.New()}, message, detail)
+
+	// when
+	after := roundTripMarkers(t, before)
+
+	// then
+	require.Len(t, after.Entries, 1, "entries")
+	got, ok := after.Entries[0].(java.GenericMarker)
+	require.Truef(t, ok, "entry is %T, want java.GenericMarker", after.Entries[0])
+	assert.Equal(t, "org.openrewrite.marker.Markup$Warn", got.JavaType)
+	assert.Equal(t, message, got.Data["message"])
+	assert.Equal(t, detail, got.Data["detail"])
+}
+
 func TestGoResolutionResultMarkerRoundTrip(t *testing.T) {
 	id := uuid.MustParse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 	mrr := golang.GoResolutionResult{

--- a/rewrite-go/pkg/tree/java/markers.go
+++ b/rewrite-go/pkg/tree/java/markers.go
@@ -186,3 +186,14 @@ func MarkupInfo(markers Markers, message string) Markers {
 func MarkupError(markers Markers, message string) Markers {
 	return AddMarker(markers, NewMarkup(MarkupErrorLevel, message, ""))
 }
+
+const markupWarnJavaType = "org.openrewrite.marker.Markup$Warn"
+
+func AddMarkupWarn(markers Markers, message, detail string) Markers {
+	id := uuid.New()
+	data := map[string]any{"id": id.String(), "message": message}
+	if detail != "" {
+		data["detail"] = detail
+	}
+	return AddMarker(markers, GenericMarker{Ident: id, JavaType: markupWarnJavaType, Data: data})
+}


### PR DESCRIPTION
## What's changed?

Changing how `GoResolutionResult` is constructed in case of partial failures (e.g. failure to look up some of the modules). Now withholding the whole resolution map and attaching a warning. Similar to what we do for Maven.

## What's your motivation?

So that Moderne's `GoModTiny` has enough information on how to proceed with the module.