### PR TITLE
Python: model a quoted annotation as the type nodes it contains

### DIFF
--- a/rewrite-python/rewrite/pyproject.toml
+++ b/rewrite-python/rewrite/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 requires-python = ">=3.12"
 dependencies = [
     "more_itertools>=10.0.0",
-    "ty-types>=0.0.79",  # Type inference CLI for Python type attribution
+    "ty-types>=0.0.80",  # Type inference CLI for Python type attribution
     "parso>=0.7.1,<0.8",  # Python 2/3 parser with CST support (0.8+ dropped Python 2.7 grammar)
 ]
 

--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -1,5 +1,6 @@
 import ast
 import contextlib
+import keyword
 import dataclasses
 import sys
 import token
@@ -10,12 +11,14 @@ from tokenize import tokenize, TokenInfo
 from typing import Optional, TypeVar, cast, Callable, List, Tuple, Dict, Sequence, Union, Iterable, NamedTuple
 
 from rewrite import random_id, Markers
+from rewrite.utils import replace_if_changed
 from rewrite.java import Space, JRightPadded, JContainer, JLeftPadded, JavaType, J, Statement, Semicolon, TrailingComma, \
     NameTree, OmitParentheses, Expression, TypeTree, TypedTree, Comment
 from rewrite.java import tree as j
 from rewrite.java.support_types import TextComment
 from . import tree as py
 from .markers import KeywordArguments, KeywordOnlyArguments, Quoted
+from .printer import PythonPrinter
 from .type_mapping import PythonTypeMapping, compute_source_line_data
 
 T = TypeVar('T')
@@ -59,6 +62,84 @@ class _ParenStackEntry(NamedTuple):
     open_paren_idx: int                    # Token index of the '(' itself
 
 
+class _EmbeddedTypeMapping:
+    """The types of a quoted annotation's body, read from the enclosing file's index.
+
+    A body position is the file position it was cut from, less the quote's own, so
+    every lookup restates its node's position before delegating. ty reports a quoted
+    annotation as one string node, so nothing matches until ty-types descends into the
+    body, whose nodes carry file offsets.
+    """
+
+    def __init__(self, enclosing: PythonTypeMapping, line_offset: int, col_offset: int):
+        self._enclosing = enclosing
+        self._line_offset = line_offset
+        self._col_offset = col_offset
+
+    def __getattr__(self, name: str):
+        delegate = getattr(self._enclosing, name)
+        if not callable(delegate):
+            return delegate
+
+        def in_file_positions(*args, **kwargs):
+            with self.__shifted(args[0] if args else None):
+                return delegate(*args, **kwargs)
+
+        return in_file_positions
+
+    @contextlib.contextmanager
+    def __shifted(self, node):
+        """``node`` and its descendants at their positions in the enclosing file.
+
+        A lookup for a call reads its callee's position too, so the whole subtree moves.
+        """
+        if not isinstance(node, ast.AST):
+            yield
+            return
+        moved = []
+        for descendant in ast.walk(node):
+            if getattr(descendant, 'lineno', None) is None:
+                continue
+            moved.append((descendant, descendant.lineno, descendant.col_offset,
+                          descendant.end_lineno, descendant.end_col_offset))
+            descendant.lineno, descendant.col_offset = \
+                self.__in_file(descendant.lineno, descendant.col_offset)
+            if descendant.end_lineno is not None:
+                descendant.end_lineno, descendant.end_col_offset = \
+                    self.__in_file(descendant.end_lineno, descendant.end_col_offset)
+        try:
+            yield
+        finally:
+            for descendant, line, col, end_line, end_col in moved:
+                (descendant.lineno, descendant.col_offset,
+                 descendant.end_lineno, descendant.end_col_offset) = line, col, end_line, end_col
+
+    def __in_file(self, line: int, col: int) -> Tuple[int, int]:
+        # Only the body's first line shares a line with the opening quote.
+        return line + self._line_offset, (col + self._col_offset) if line == 1 else col
+
+
+# The subscripts whose arguments from this index on are values rather than types, so a
+# string there names nothing. ``Annotated``'s first argument is still the annotated type.
+_VALUE_SUBSCRIPTS = {'Literal': 0, 'Annotated': 1}
+
+
+def _subscript_head(node) -> Optional[str]:
+    """The trailing name of a subscript's head, as spelled in the source."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _with_type(node: T, resolved: Optional[JavaType]) -> T:
+    """``node`` carrying ``resolved``, unless it has a type already or no slot for one."""
+    if getattr(node, 'type', None) is not None or not hasattr(node, '_type'):
+        return node
+    return replace_if_changed(node, _type=resolved)
+
+
 class ParserVisitor(ast.NodeVisitor):
     _source: str
     _parentheses_stack: List[_ParenStackEntry]
@@ -70,7 +151,8 @@ class ParserVisitor(ast.NodeVisitor):
     # UTF-8 BOM character
     _BOM = '\ufeff'
 
-    def __init__(self, source: str, file_path: Optional[str] = None, ty_client=None):
+    def __init__(self, source: str, file_path: Optional[str] = None, ty_client=None,
+                 type_mapping: Optional['_EmbeddedTypeMapping'] = None):
         super().__init__()
         # Detect and strip UTF-8 BOM if present
         if source.startswith(self._BOM):
@@ -84,9 +166,9 @@ class ParserVisitor(ast.NodeVisitor):
 
         # Single pass: compute lines, byte offsets, and byte-to-char mapping together
         source_lines, line_byte_offsets, self._byte_to_char = compute_source_line_data(source)
-        self._type_mapping = PythonTypeMapping(source, file_path, ty_client,
-                                               source_lines=source_lines,
-                                               line_byte_offsets=line_byte_offsets)
+        self._type_mapping = type_mapping if type_mapping is not None else PythonTypeMapping(
+            source, file_path, ty_client,
+            source_lines=source_lines, line_byte_offsets=line_byte_offsets)
 
         # Normalize line endings for the tokenizer (it rejects mixed \r\n and \n),
         # but keep the original source for whitespace extraction
@@ -2923,6 +3005,48 @@ class ParserVisitor(ast.NodeVisitor):
                 converted_type
             )
 
+    def __structured_string_annotation(self, node: ast.Constant, body: str,
+                                       quote_style: Quoted.Style,
+                                       prefix: Space) -> Optional[TypeTree]:
+        """The type nodes a quoted annotation contains, or None to keep it flat text.
+
+        The body has to reproduce byte-identically to become structure, since a type
+        node has no slot for text it cannot print, such as padding inside the quotes.
+        """
+        try:
+            return self.__structure(node, body, quote_style, prefix)
+        except Exception:
+            # The body is text first and structure second: a gap anywhere in the attempt
+            # leaves the flat identifier rather than failing the file.
+            return None
+
+    def __structure(self, node: ast.Constant, body: str, quote_style: Quoted.Style,
+                    prefix: Space) -> Optional[TypeTree]:
+        # A body that is one plain name already models as the identifier the caller
+        # falls back to, so it does not need re-parsing. Keywords do not: `None` and
+        # `...` are types of their own.
+        if body.isidentifier() and not keyword.iskeyword(body):
+            return None
+        body_ast = ast.parse(body, mode='eval')
+        sub = ParserVisitor(body, type_mapping=_EmbeddedTypeMapping(
+            self._type_mapping, node.lineno - 1, node.col_offset + len(quote_style.quote)))
+        tree = sub.__convert_type(body_ast.body)
+        if not isinstance(tree, TypeTree):
+            return None
+        # `find_first` reads one Quoted marker per node, so a body that is itself a
+        # quoted string has nowhere to record both its own quotes and the outer ones.
+        if tree.markers.find_first(Quoted) is not None:
+            return None
+
+        tree = tree.replace(prefix=Space.EMPTY)
+        if PythonPrinter().print(tree) != body:
+            return None
+
+        tree = _with_type(tree, self._type_mapping.string_annotation_type(node))
+        return tree.replace(
+            prefix=prefix,
+            markers=Markers.build(random_id(), [Quoted(random_id(), quote_style)]))
+
     def __convert_type_mapper(self, node) -> Optional[TypeTree]:
         if isinstance(node, ast.Constant):
             if node.value is None or node.value is Ellipsis:
@@ -2990,13 +3114,24 @@ class ParserVisitor(ast.NodeVisitor):
                     # Non-string literal: use value_source to preserve case (e.g., 1J vs 1j)
                     name = source
 
+                if quote_style is not None:
+                    structured = self.__structured_string_annotation(
+                        node, name, quote_style, literal.prefix)
+                    if structured is not None:
+                        return structured
+
+                if quote_style is None:
+                    # A constant that is not a forward reference is the value it spells.
+                    return expression
+
                 return j.Identifier(
                     random_id(),
                     literal.prefix,
-                    Markers.build(random_id(), [Quoted(random_id(), quote_style)]) if quote_style else Markers.EMPTY,
+                    Markers.build(random_id(), [Quoted(random_id(), quote_style)]),
                     _EMPTY_LIST,
                     name,
-                    self._type_mapping.type(node),
+                    self._type_mapping.string_annotation_type(node)
+                    if quote_style else self._type_mapping.type(node),
                     None
                 )
         elif isinstance(node, ast.Subscript):
@@ -3016,6 +3151,7 @@ class ParserVisitor(ast.NodeVisitor):
             else:
                 slices = [node.slice]
 
+            values_from = _VALUE_SUBSCRIPTS.get(_subscript_head(node.value))
             return j.ParameterizedType(
                 random_id(),
                 prefix,
@@ -3023,9 +3159,11 @@ class ParserVisitor(ast.NodeVisitor):
                 converted_value,
                 JContainer(
                     bracket_prefix,
-                    [self.__pad_list_element(self.__convert_type(s), last=i == len(slices) - 1, end_delim=']') for
-                     i, s in
-                     enumerate(slices)],
+                    [self.__pad_list_element(
+                        self.__convert(s) if values_from is not None and i >= values_from
+                        else self.__convert_type(s),
+                        last=i == len(slices) - 1, end_delim=']')
+                     for i, s in enumerate(slices)],
                     Markers.EMPTY
                 ),
                 self._type_mapping.type(node)
@@ -3036,9 +3174,8 @@ class ParserVisitor(ast.NodeVisitor):
             if isinstance(node.op, ast.BitOr):
                 prefix = self.__whitespace()
                 # FIXME consider flattening nested unions
-                left = self.__pad_right(self.__convert_internal(node.left, self.__convert_type),
-                                        self.__source_before('|'))
-                right = self.__pad_right(self.__convert_internal(node.right, self.__convert_type), Space.EMPTY)
+                left = self.__pad_right(self.__convert_type(node.left), self.__source_before('|'))
+                right = self.__pad_right(self.__convert_type(node.right), Space.EMPTY)
                 return py.UnionType(
                     random_id(),
                     prefix,

--- a/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/binding_utils.py
@@ -101,8 +101,8 @@ class ImportBindings:
     def reference(self, cursor: Cursor, ident: Identifier) -> Optional[Binding]:
         """The binding ``ident`` reads, or None where it reads something else: a name in
         member position, a name nothing imports, or one an enclosing scope rebinds. None is not
-        "unused": a quoted forward reference holds an expression, so a use census composes
-        :func:`is_reference` with :func:`referenced_names` rather than calling this. Check
+        "unused": a forward reference can name a symbol the identifier does not spell, so a
+        use census composes :func:`is_reference` with :func:`referenced_names`, not this. Check
         :attr:`Binding.guarded` before emitting a runtime reference."""
         binding = self._by_name.get(ident.simple_name)
         if binding is None or not is_reference(cursor, ident):

--- a/rewrite-python/rewrite/src/rewrite/python/import_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/import_utils.py
@@ -103,10 +103,10 @@ def get_canonical_fqn(imp: Import) -> Optional[str]:
 
 
 def referenced_names(ident: Identifier) -> Tuple[str, ...]:
-    """The names ``ident`` looks up. A quoted identifier is a forward reference
-    holding a whole expression, so its names come from parsing it; a string that
-    is not an expression names nothing."""
-    if ident.markers.find_first(Quoted) is None:
+    """The names ``ident`` looks up. A quoted identifier is a forward reference, naming
+    one symbol where it spells one; text the parser kept whole names whatever parsing it
+    finds, and text that is not an expression names nothing."""
+    if ident.markers.find_first(Quoted) is None or ident.simple_name.isidentifier():
         return (ident.simple_name,)
     try:
         reference = ast.parse(ident.simple_name.strip(), mode='eval')

--- a/rewrite-python/rewrite/src/rewrite/python/printer.py
+++ b/rewrite-python/rewrite/src/rewrite/python/printer.py
@@ -115,6 +115,19 @@ class PrintOutputCapture:
         return None
 
 
+def _quotes_around(tree: Union[Py, J]) -> Optional[str]:
+    """The quotes to print around ``tree``, or None when its own text carries them.
+
+    A literal's ``value_source`` holds its delimiters, so there the marker records the
+    style and nothing more.
+    """
+    quoted = tree.markers.find_first(Quoted)
+    if quoted is None:
+        return None
+    from rewrite.java import tree as j
+    return None if isinstance(tree, j.Literal) else quoted.style.quote
+
+
 class PythonPrinter:
     """
     Python printer for generating source code from LST.
@@ -269,9 +282,18 @@ class PythonPrinter:
                 marker, Cursor(self.get_cursor(), marker), self._java_marker_wrapper
             ))
 
+        if markers.markers:
+            quotes = _quotes_around(tree)
+            if quotes:
+                p.append(quotes)
+
     def _after_syntax(self, tree: Union[Py, J], p: PrintOutputCapture) -> None:
         """Handle marker printing after syntax."""
         markers = tree.markers
+        if markers.markers:
+            quotes = _quotes_around(tree)
+            if quotes:
+                p.append(quotes)
         for marker in markers.markers:
             p.append(p.get_marker_printer().after_syntax(
                 marker, Cursor(self.get_cursor(), marker), self._java_marker_wrapper
@@ -1028,9 +1050,18 @@ class PythonJavaPrinter:
                 marker, Cursor(self.get_cursor(), marker), self._java_marker_wrapper
             ))
 
+        if markers.markers:
+            quotes = _quotes_around(tree)
+            if quotes:
+                p.append(quotes)
+
     def _after_syntax(self, tree: J, p: PrintOutputCapture) -> None:
         """Handle marker printing after syntax."""
         markers = tree.markers
+        if markers.markers:
+            quotes = _quotes_around(tree)
+            if quotes:
+                p.append(quotes)
         for marker in markers.markers:
             p.append(p.get_marker_printer().after_syntax(
                 marker, Cursor(self.get_cursor(), marker), self._java_marker_wrapper
@@ -1470,12 +1501,7 @@ class PythonJavaPrinter:
     def visit_identifier(self, ident: 'j.Identifier', p: PrintOutputCapture) -> J:
         """Visit an identifier."""
         self._before_syntax(ident, p)
-        quoted = ident.markers.find_first(Quoted)
-        if quoted:
-            p.append(quoted.style.quote)
         p.append(ident.simple_name)
-        if quoted:
-            p.append(quoted.style.quote)
         self._after_syntax(ident, p)
         return ident
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -916,6 +916,16 @@ class PythonTypeMapping:
 
         return None
 
+    def string_annotation_type(self, node: ast.Constant) -> Optional[JavaType]:
+        """The type a string in a type slot denotes, rather than ``str``.
+
+        ty resolves the annotation and reports the result on the string literal's own
+        range, which :meth:`type` never reaches because a constant short-circuits to
+        the type of its own value.
+        """
+        type_id = self._lookup_type_id(node)
+        return self._resolve_type(type_id) if type_id is not None else None
+
     def _constant_type(self, node: ast.Constant) -> Optional[JavaType]:
         """Get the type for a constant/literal node."""
         if isinstance(node.value, (str, bytes)):

--- a/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
+++ b/rewrite-python/rewrite/tests/python/all/tree/type_hint_test.py
@@ -1,6 +1,10 @@
+import ast
+
 from rewrite.java.support_types import JavaType
-from rewrite.java.tree import VariableDeclarations
-from rewrite.python.tree import CompilationUnit
+from rewrite.java.tree import Identifier, Literal as JLiteral, ParameterizedType, VariableDeclarations
+from rewrite.python._parser_visitor import _EmbeddedTypeMapping
+from rewrite.python.markers import Quoted
+from rewrite.python.tree import CompilationUnit, LiteralType, UnionType
 from rewrite.python.visitor import PythonVisitor
 from rewrite.test import RecipeSpec, python
 
@@ -315,3 +319,202 @@ def test_optional_str_type_attribution():
         after_recipe=check_types,
     ))
     assert not errors, "Type attribution errors:\n" + "\n".join(f"  - {e}" for e in errors)
+
+
+def _annotations(source_file):
+    """The type expression of each annotated declaration, in source order."""
+    found = []
+
+    class _Collector(PythonVisitor):
+        def visit_type_hint(self, hint, p):
+            found.append(hint.type_tree)
+            return hint
+
+    _Collector().visit(source_file, None)
+    return found
+
+
+def _annotation(source_file):
+    """The type expression of the file's single annotated declaration."""
+    found = _annotations(source_file)
+    assert len(found) == 1, f"expected one annotation, found {len(found)}"
+    return found[0]
+
+
+def _parsed_annotation(source: str):
+    """Parse ``source`` asserting it round-trips, and return its annotation."""
+    seen = []
+    RecipeSpec().rewrite_run(python(source, after_recipe=lambda sf: seen.append(_annotation(sf))))
+    return seen[0]
+
+
+def test_quoted_parameterized_annotation_is_structured():
+    """The quotes come back around a J node, which the Java printer delegate re-adds."""
+    # language=python
+    annotation = _parsed_annotation('''x: "Dict[str, int]" = None''')
+    assert isinstance(annotation, ParameterizedType)
+    assert annotation.markers.find_first(Quoted).style is Quoted.Style.DOUBLE
+    assert [t.simple_name for t in annotation.type_parameters] == ['str', 'int']
+
+
+def test_quoted_union_annotation_is_structured():
+    """The quotes come back around a Py node, whose printer is a separate one."""
+    # language=python
+    annotation = _parsed_annotation('''x: "int | None" = None''')
+    assert isinstance(annotation, UnionType)
+    assert annotation.markers.find_first(Quoted) is not None
+
+
+def test_a_quoted_union_operand_is_structured():
+    """A `|` operand reaches the type mapper the way a subscript's argument does."""
+    # language=python
+    annotation = _parsed_annotation("""x: int | 'Later' = None""")
+    later = annotation.types[1]
+    assert isinstance(later, Identifier) and later.simple_name == 'Later'
+    assert later.markers.find_first(Quoted).style is Quoted.Style.SINGLE
+
+    # language=python
+    annotation = _parsed_annotation('''x: 'int | "Later"' = None''')
+    assert annotation.markers.find_first(Quoted).style is Quoted.Style.SINGLE
+    assert annotation.types[1].markers.find_first(Quoted).style is Quoted.Style.DOUBLE
+
+
+def test_nested_forward_reference_is_structured():
+    # language=python
+    annotation = _parsed_annotation("""x: "Union['Foo', str]" = None""")
+    inner = annotation.type_parameters[0]
+    assert isinstance(inner, Identifier) and inner.simple_name == 'Foo'
+    assert inner.markers.find_first(Quoted).style is Quoted.Style.SINGLE
+
+
+def test_unparseable_quoted_annotation_stays_a_flat_identifier():
+    # language=python
+    annotation = _parsed_annotation('''x: "not python(" = None''')
+    assert isinstance(annotation, Identifier)
+    assert annotation.simple_name == 'not python('
+
+
+def test_a_constants_position_decides_whether_it_is_a_value_or_a_type():
+    """``Literal``'s arguments are values, so a string there names nothing; the same text
+    as the annotation itself is the type it denotes."""
+    # language=python
+    argument = _parsed_annotation('''x: Literal["1"] = "1"''').type_parameters[0]
+    assert isinstance(argument, JLiteral) and argument.value_source == '"1"'
+
+    # language=python
+    assert isinstance(_parsed_annotation('''x: "None" = None'''), LiteralType)
+
+
+def test_annotated_keeps_its_first_argument_a_type_and_the_rest_values():
+    """``Annotated[T, ...]`` annotates ``T`` with metadata that is not itself a type, so
+    the same spelling means a reference in one position and a string in the next."""
+    # language=python
+    annotated, metadata = _parsed_annotation('''x: Annotated["A", "A"] = None''').type_parameters
+    assert isinstance(annotated, Identifier) and annotated.markers.find_first(Quoted)
+    assert isinstance(metadata, JLiteral) and metadata.value_source == '"A"'
+
+
+def test_a_body_that_is_itself_quoted_stays_text():
+    """A node records one quote style, so a body that is already quoted has nowhere to
+    keep both its own quotes and the outer ones."""
+    # language=python
+    annotation = _parsed_annotation('''x: "'Foo'" = None''')
+    assert isinstance(annotation, Identifier) and annotation.simple_name == "'Foo'"
+
+
+def test_quoted_annotation_that_would_not_print_back_stays_flat():
+    # language=python
+    annotation = _parsed_annotation('''x: "Foo " = None''')
+    assert isinstance(annotation, Identifier)
+    assert annotation.simple_name == 'Foo '
+
+
+def _type_label(resolved) -> str:
+    """A short name for a resolved type: a failure has to print a word, not a type graph.
+
+    An LST node's dataclass ``repr`` walks its whole type graph, which for an attributed
+    file runs to gigabytes.
+    """
+    if resolved is None:
+        return 'unattributed'
+    if isinstance(resolved, Parameterized):
+        return f'{_type_label(resolved.type)}[...]'
+    if isinstance(resolved, JavaType.Union):
+        return 'union(' + ', '.join(_type_label(b) for b in resolved.bounds) + ')'
+    if isinstance(resolved, JavaType.FullyQualified):
+        return resolved.fully_qualified_name.rsplit('.', 1)[-1]
+    return str(resolved)
+
+
+def _type_labels(node) -> list:
+    """The resolved types down ``node``: its own, its head name, and its members.
+
+    A union keeps its members in ``types`` where a parameterized type keeps its
+    arguments in ``type_parameters``.
+    """
+    labels = [_type_label(node.type)]
+    head = getattr(node, 'clazz', None)
+    if head is not None:
+        labels.append('head ' + _type_label(head.type))
+    for member in (getattr(node, 'types', None) or []) + (getattr(node, 'type_parameters', None) or []):
+        labels.extend(_type_labels(member))
+    return labels
+
+
+def _annotation_labels(source: str) -> list:
+    """The labels of each annotation in ``source``, in source order."""
+    seen = []
+    RecipeSpec(type_attribution=True).rewrite_run(
+        python(source, after_recipe=lambda sf: seen.extend(_annotations(sf))))
+    return [_type_labels(annotation) for annotation in seen]
+
+
+def test_quoted_annotation_attributes_like_an_unquoted_one():
+    """A quoted annotation resolves as the same annotation unquoted does, heads included."""
+    # language=python
+    quoted, unquoted = _annotation_labels(
+        '''\
+        from typing import Dict, List
+
+        x: "Dict[str, List[int]]" = {}
+        y: Dict[str, List[int]] = {}
+        ''')
+
+    assert quoted == ['dict[...]', 'head Dict', 'Primitive.String',
+                      'list[...]', 'head List', 'Primitive.Int']
+    assert quoted == unquoted
+
+
+def test_quoted_union_attributes_each_member_and_the_union():
+    """A union keeps its members in a slot of its own, so reaching them is a separate path."""
+    # language=python
+    quoted, unquoted = _annotation_labels(
+        '''\
+        x: "str | int" = ""
+        y: str | int = ""
+        ''')
+
+    assert quoted == ['union(Primitive.String, Primitive.Int)',
+                      'Primitive.String', 'Primitive.Int']
+    assert quoted == unquoted
+
+
+def test_quoted_body_positions_resolve_against_the_enclosing_file():
+    looked_up = []
+
+    class _Recorder:
+        def type(self, node):
+            # A lookup reads a callee's or argument's position as well as the node's own.
+            looked_up.extend((n.lineno, n.col_offset) for n in ast.walk(node)
+                             if getattr(n, 'lineno', None) is not None)
+
+    first_line, second_line = 'x: """Dict[str,', ' int]""" = None'
+    mapping = _EmbeddedTypeMapping(_Recorder(), 0, first_line.index('"""') + 3)
+    mapping.type(ast.parse('Dict[str,\n int]', mode='eval').body)
+
+    # Each shifted position names the same text in the file it was read from.
+    assert sorted(set(looked_up)) == [
+        (1, first_line.index('Dict')),
+        (1, first_line.index('str')),
+        (2, second_line.index('int')),
+    ]

--- a/rewrite-python/rewrite/tests/recipes/test_change_import.py
+++ b/rewrite-python/rewrite/tests/recipes/test_change_import.py
@@ -1098,9 +1098,7 @@ class TestChangeImportPythonScopeRules:
             """,
         )
 
-    def test_a_quoted_annotation_renames_when_the_name_stands_alone(self):
-        """A quoted annotation parses to a single identifier, so only a name that is the
-        whole annotation is in reach."""
+    def test_a_quoted_annotation_renames_the_names_it_contains(self):
         self._run(
             """\
             from time import clock
@@ -1113,7 +1111,7 @@ class TestChangeImportPythonScopeRules:
             from time import perf_counter
 
 
-            def f(x: 'perf_counter', y: 'List[clock]'):
+            def f(x: 'perf_counter', y: 'List[perf_counter]'):
                 pass
             """,
         )

--- a/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/service/PythonAddImportVisitor.java
@@ -153,9 +153,9 @@ public class PythonAddImportVisitor<P> extends RpcImportVisitor<P> {
                 return multi;
             }
 
-            // A quoted identifier is a forward reference holding a whole expression, so the
-            // target can be one name within it. Spelling it is enough: the Python side parses
-            // the reference, and this predicate may only over-approximate.
+            // A quoted identifier is a forward reference, which can name the target within a
+            // larger expression. Spelling it is enough: the Python side resolves it, and this
+            // predicate may only over-approximate.
             @Override
             public J visitIdentifier(J.Identifier identifier, AtomicBoolean found) {
                 String simpleName = identifier.getSimpleName();


### PR DESCRIPTION
`x: "Optional[int]"` parsed to a single `j.Identifier` whose `simple_name` was the entire string body — one identifier literally named `Optional[int]`. Nothing type-shaped reached it: a visitor hooking `ParameterizedType` or `UnionType` never fired, and `ChangeImport` renaming `clock` rewrote `x: 'clock'` but not `y: 'List[clock]'`. Downstream recipes worked around it by `ast.parse`-ing the body and splicing names back by byte offset.

Those workarounds can go.

The body now parses into the type nodes it holds, with `Quoted` on the outer node:

```
x: "Dict[str, List['Node'] | None]"

ParameterizedType      «DOUBLE»    dict[str, list[Node]]
  head: Identifier Dict            typing.Dict
  Identifier str                   str
  UnionType                        list[Node]
    | ParameterizedType            list[Node]
        head: Identifier List      typing.List
        Identifier Node  «SINGLE»  Node
    | LiteralType                  None
```

Quote emission moved from the printer's `visit_identifier` into `_before_syntax`/`_after_syntax`, so any marked node round-trips — a `py.UnionType` marked `Quoted` previously printed identically to an unmarked one, silently dropping the quotes. `j.Literal` is excluded: its `value_source` already holds its delimiters, which is how the Python 2 parser uses the marker.

## Where a string is a type, and where it is a value

A string is a forward reference wherever a type belongs — now including a `|` operand, which was converted without the type mapper and arrived as a bare `j.Literal`. `Literal`'s arguments and `Annotated`'s metadata are the opposite, and this splits them as ty does:

| written | node | ty |
|---|---|---|
| `int \| "A"`, `Union[int, "A"]` | `Identifier(A)` + `Quoted` | instance of `A` |
| `Literal["A"]`, `Literal["1"]` | `j.Literal` | `stringLiteral` |
| `Annotated["A", "meta"]` | `Identifier(A)` + `Quoted`, then `j.Literal` | reference, then `stringLiteral` |

Constants in a type position were all identifiers named after their own source text — only `None` and `Ellipsis` were modelled properly — so `Literal[1.5]` produced an identifier named `1.5`, and `Literal["1"]` differed from `Literal[1]` only by the `Quoted` marker.

The head is matched on its trailing name as spelled, so `typing.Literal` is covered but `from typing import Literal as L` is not.

## What stays flat text

Structuring is gated on the body printing back byte-identically:

| body | outcome |
|---|---|
| `Optional[int]`, `int \| None`, `Union['Foo', str]` | structured; `'Foo'` nests as its own `Quoted` node |
| `'Foo'` | a node records one quote style → stays flat |
| `Foo `, `Foo # c`, a line continuation | prints back as `Foo` → stays flat |
| `not python(`, `List[\d]` | unparseable → stays flat |

Anything else raised inside the attempt also falls back, so a gap degrades a body rather than failing the file. Prefixed strings (`r"..."`) keep their `ExpressionTypeTree`, as `Quoted` records a style and not a prefix.

## Types

A quoted annotation attributes exactly as its unquoted twin, head names included. `_EmbeddedTypeMapping` shifts the body's positions — the whole subtree, since a lookup reads its callee's position too — onto the enclosing file, which is where ty-types reports them. This needs **ty-types 0.0.80**, so the dependency floor moves with it.

## One thing for recipe authors

A recipe that *replaces* a whole annotation rather than editing it in place now silently unquotes it, because markers do not survive construction. That is new: such a recipe previously no-oped on a quoted body.

It is not cosmetic — `"Optional[Foo]"` is usually quoted because `Foo` is a forward reference, so an unquoted `Foo | None` is a runtime `NameError`. Carrying the replaced node's markers is the fix; in-place renames are unaffected.

## Verification

Parse-and-print verdicts over 1200 stdlib files are identical to the previous parser. Every expression in this repo's own sources was also placed in a quoted annotation slot and round-tripped: **43,951 checked, 0 mismatches, 0 crashes**. Full suite 2452 passed against the released 0.0.80.

Parse cost for a body that is one plain name is unchanged; a compound body costs about 4x, paid only per quoted annotation. Printing is unchanged for files with no quoted node.

