### PR TITLE
Python: a JavaType renders its identity, not its graph

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/java/support_types.py
+++ b/rewrite-python/rewrite/src/rewrite/java/support_types.py
@@ -217,6 +217,14 @@ class MethodCall(Expression):
     __slots__ = ()
 
 
+def _fully_qualified_repr(self) -> str:
+    """A type's identity, not its graph: `object` is reachable from nearly every
+    method signature, so expanding fields re-prints everything reachable at every
+    position it occupies. Assigned in each subclass body because `dataclass`
+    generates a `__repr__` unless the body defines one."""
+    return f"{type(self).__qualname__}({self.fully_qualified_name!r})"
+
+
 class JavaType(ABC):
     class FullyQualified:
         __slots__ = ()
@@ -239,6 +247,11 @@ class JavaType(ABC):
     class Unknown(FullyQualified):
         __slots__ = ()
 
+        # Carries no name to render, and a heap address would make the repr of every
+        # node holding one differ run to run.
+        def __repr__(self) -> str:
+            return 'JavaType.Unknown()'
+
     # Identity equality, as for the other `lst_dataclass` types here: a type graph is
     # cyclic through members and methods, and Java compares these on name and type
     # parameters alone.
@@ -257,6 +270,8 @@ class JavaType(ABC):
         _members: Optional[List[JavaType.Variable]] = None
         _methods: Optional[List[JavaType.Method]] = None
 
+        __repr__ = _fully_qualified_repr
+
         def __post_init__(self):
             if self._kind is None:
                 self._kind = JavaType.FullyQualified.Kind.Class
@@ -272,6 +287,8 @@ class JavaType(ABC):
     class Parameterized(FullyQualified):
         _type: Optional[JavaType.FullyQualified] = None
         _type_parameters: Optional[List[JavaType]] = None
+
+        __repr__ = _fully_qualified_repr
 
         @property
         def type(self) -> JavaType.FullyQualified:
@@ -302,6 +319,8 @@ class JavaType(ABC):
     class Annotation(FullyQualified):
         _type: Optional[JavaType.FullyQualified] = None
         _values: Optional[List[JavaType.Annotation.ElementValue]] = None
+
+        __repr__ = _fully_qualified_repr
 
         @property
         def type(self) -> JavaType.FullyQualified:

--- a/rewrite-python/rewrite/tests/python/test_type_repr.py
+++ b/rewrite-python/rewrite/tests/python/test_type_repr.py
@@ -1,0 +1,54 @@
+# Copyright 2025 the original author or authors.
+# <p>
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# <p>
+# https://docs.moderne.io/licensing/moderne-source-available-license
+# <p>
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""How much a type-attributed node's `repr` prints."""
+from rewrite.java import JavaType
+from rewrite.java.tree import Identifier
+from rewrite.python.visitor import PythonVisitor
+from rewrite.test import RecipeSpec
+from rewrite.test.spec import python
+
+_SOURCE = '''\
+from typing import List
+
+x: List[int] = []
+'''
+
+
+def _annotated_identifier() -> Identifier:
+    captured = []
+
+    def capture(cu):
+        class Capture(PythonVisitor):
+            def visit_identifier(self, ident, p):
+                if ident.simple_name == 'x' and not captured:
+                    captured.append(ident)
+                return ident
+
+        Capture().visit(cu, None)
+        return cu
+
+    RecipeSpec(type_attribution=True).rewrite_run(python(_SOURCE, before_recipe=capture))
+    return captured[0]
+
+
+def test_java_type_repr_renders_an_identity_not_a_graph():
+    # Ordered first: a regression fails here in microseconds, where the attributed
+    # node below would exhaust memory before failing.
+    cls = JavaType.Class(_fully_qualified_name='a.B')
+    assert repr(cls) == "JavaType.Class('a.B')"
+    assert repr(JavaType.Parameterized(_type=cls)) == "JavaType.Parameterized('a.B')"
+    assert repr(JavaType.Annotation(_type=cls)) == "JavaType.Annotation('a.B')"
+    assert repr(JavaType.Unknown()) == 'JavaType.Unknown()'
+
+    assert len(repr(_annotated_identifier())) < 2000


### PR DESCRIPTION
Any `repr()` of a type-attributed LST node in `rewrite-python` walks the whole `JavaType` graph. For `x: List[int] = []`, taking `repr()` of the `x` identifier reached 6.21 GB RSS in 12 seconds and was still growing at ~0.5 GB/s when killed.

That fires on every ordinary test failure, because pytest's `saferepr` renders the node held by a failing assertion: a red run takes minutes, can exhaust the machine, and is indistinguishable from a hang while it does.

## What broke

- `JavaType.Class`, `ShallowClass` and `Parameterized` were bare-annotation classes until #8823 made them dataclasses. `repr=True` is the `dataclass` default, so they gained generated reprs walking `_supertype`, `_interfaces`, `_members` and `_methods` — which also removed the `object.__repr__` stop that had been bounding `Method` and `Variable`.

Counting the node visits a generated `__repr__` makes for `repr(J.Identifier('x'))`:

| commit | visits |
|---|---|
| `688ca2ab05` (pre-#8823) | 17 |
| `main` | >5,000,000, aborted |
| this change | 17 |

Cycles are not the cause. `dataclasses` wraps its generated `__repr__` in `reprlib.recursive_repr`, so a cycle prints `...` and terminates. The cost is combinatorial breadth: `object` is reachable from nearly every method signature, and a correctly interned graph of a few thousand types re-expands at millions of distinct positions.

## Why cutting at `FullyQualified` is sufficient

Every cycle in a type graph crosses one. `Union`, `Intersection`, `GenericTypeVariable` and `Array` hold no field that can reach another of themselves without passing through a named type, so `type Rec = int | list[Rec]` goes `Union -> Parameterized(list) -> stop`.

Measured on a corpus of recursive aliases, mutually recursive classes and a self-referential TypeVar bound: 1,225 type objects, 963 cycles, none of them avoiding a `FullyQualified`. Post-change maxima are 714 chars for `Method`, 211 for `Union` and 137 for `GenericTypeVariable`, so `Method` and `Variable` need nothing of their own.

The rendering follows Java, where every `JavaType.toString()` gives a signature rather than a field dump:

```
_type=JavaType.Parameterized('list'), _field_type=JavaType.Variable(_flags_bit_map=0, _name='x', _owner=None, _type=JavaType.Parameterized('list'), _annotations=None)
```

`JavaType.Unknown` gains one too. It has no name to render, and `object.__repr__` put a heap address into 128 `Method`/`Variable` reprs in a six-line file, making them differ run to run. It gets a literal rather than a `fully_qualified_name` property, since `python_sender.py` sends that value over the wire.

## Tests

`test_java_type_repr_renders_an_identity_not_a_graph` pins the four short forms, then bounds `len(repr(...))` of a real attributed identifier. The hand-built assertions come first deliberately: they fail in 0.03s, where the attributed node exhausts memory before it can fail. Verified by deleting `Class`'s assignment and re-running.

## Deliberately not fixed

`Parameterized` renders its raw type, so `List[int]` and `List[str]` both print `JavaType.Parameterized('list')`. Java includes the arguments via `DefaultJavaTypeSignatureBuilder`; `rewrite-python` has no signature builder, and porting one is a larger change than this.
