### PR TITLE
Go: skip stdlib corpus files the host toolchain excludes from the build

### DIFF
--- a/rewrite-go/pkg/format/subtree_indent_test.go
+++ b/rewrite-go/pkg/format/subtree_indent_test.go
@@ -17,6 +17,7 @@
 package format
 
 import (
+	"go/build"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -160,7 +161,11 @@ func TestSubtreeIndentMatchesWholeFileOnStdlib(t *testing.T) {
 			if err != nil {
 				t.Skip(err)
 			}
-			assertSubtreeIndentMatches(t, filepath.Base(rel), string(content))
+			src := string(content)
+			if !parser.MatchBuildContext(build.Default, filepath.Base(rel), src) {
+				t.Skipf("%s is excluded from the build under this toolchain", rel)
+			}
+			assertSubtreeIndentMatches(t, filepath.Base(rel), src)
 		})
 	}
 }

--- a/rewrite-go/pkg/parenthesize/golang_cases_test.go
+++ b/rewrite-go/pkg/parenthesize/golang_cases_test.go
@@ -17,6 +17,7 @@
 package parenthesize
 
 import (
+	"go/build"
 	goparser "go/parser"
 	gotoken "go/token"
 	"os"
@@ -125,9 +126,15 @@ func TestVisitorRegroupsStdlibToParseableCode(t *testing.T) {
 			if err != nil {
 				t.Skip(err)
 			}
-			cu, err := parser.NewGoParser().Parse(filepath.Base(rel), string(content))
+			src := string(content)
+			if !parser.MatchBuildContext(build.Default, filepath.Base(rel), src) {
+				t.Skipf("%s is excluded from the build under this toolchain", rel)
+			}
+			// Past the build filter, a parse failure is a gap in the parser, not
+			// a corpus the toolchain moved out from under.
+			cu, err := parser.NewGoParser().Parse(filepath.Base(rel), src)
 			if err != nil {
-				t.Skip(err)
+				t.Fatalf("parse: %v", err)
 			}
 			ungrouped := printer.Print(visitor.Init(&unwrapper{}).Visit(cu, nil))
 			got := printer.Print(NewVisitor().Visit(visitor.Init(&unwrapper{}).Visit(cu, nil), nil))

--- a/rewrite-go/test/selfparse_test.go
+++ b/rewrite-go/test/selfparse_test.go
@@ -17,6 +17,7 @@
 package test
 
 import (
+	"go/build"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/openrewrite/rewrite/rewrite-go/pkg/parser"
 	. "github.com/openrewrite/rewrite/rewrite-go/pkg/test"
 )
 
@@ -75,246 +77,138 @@ func TestSelfParseSpec(t *testing.T) {
 	)
 }
 
-func stdlibFile(path string) string {
-	return filepath.Join(runtime.GOROOT(), "src", path)
+// readStdlibFile returns the source of a $GOROOT/src file, skipping when the
+// host toolchain lacks it or excludes it from the build — the corpus is the
+// running toolchain's stdlib, and an excluded file yields no compilation unit.
+func readStdlibFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(runtime.GOROOT(), "src", path))
+	if err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+	src := string(data)
+	if !parser.MatchBuildContext(build.Default, filepath.Base(path), src) {
+		t.Skipf("skipping: %s is excluded from the build under this toolchain", path)
+	}
+	return src
 }
 
 func TestParseStdlibSort(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("sort/sort.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "sort/sort.go")))
 }
 
 func TestParseStdlibStrings(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("strings/strings.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "strings/strings.go")))
 }
 
 func TestParseStdlibFmt(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("fmt/print.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "fmt/print.go")))
 }
 
 func TestParseStdlibSync(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("sync/mutex.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "sync/mutex.go")))
 }
 
 func TestParseStdlibHTTP(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("net/http/server.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "net/http/server.go")))
 }
 
 func TestParseStdlibJSON(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("encoding/json/encode.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "encoding/json/encode.go")))
 }
 
 func TestParseStdlibReflect(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("reflect/type.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "reflect/type.go")))
 }
 
 func TestParseStdlibGoParser(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("go/parser/parser.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "go/parser/parser.go")))
 }
 
 func TestParseStdlibGoAST(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("go/ast/ast.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "go/ast/ast.go")))
 }
 
 func TestParseStdlibIO(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("io/io.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "io/io.go")))
 }
 
 func TestParseStdlibContext(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("context/context.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "context/context.go")))
 }
 
 func TestParseStdlibBytesBuffer(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("bytes/buffer.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "bytes/buffer.go")))
 }
 
 func TestParseStdlibRegexp(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("regexp/regexp.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "regexp/regexp.go")))
 }
 
 func TestParseStdlibOsFile(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("os/file.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "os/file.go")))
 }
 
 func TestParseStdlibTLS(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("crypto/tls/tls.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "crypto/tls/tls.go")))
 }
 
 func TestParseStdlibSQL(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("database/sql/sql.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "database/sql/sql.go")))
 }
 
 func TestParseStdlibTesting(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("testing/testing.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "testing/testing.go")))
 }
 
 func TestParseStdlibSlices(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("slices/slices.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "slices/slices.go")))
 }
 
 func TestParseStdlibMaps(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("maps/maps.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "maps/maps.go")))
 }
 
 func TestParseStdlibSlog(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("log/slog/handler.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "log/slog/handler.go")))
 }
 
 func TestParseStdlibAtomic(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("sync/atomic/value.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "sync/atomic/value.go")))
 }
 
 func TestParseStdlibBufio(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("bufio/bufio.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "bufio/bufio.go")))
 }
 
 func TestParseStdlibStrconv(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("strconv/atoi.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "strconv/quote.go")))
 }
 
 func TestParseStdlibPath(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("path/filepath/path.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "path/filepath/path.go")))
 }
 
 func TestParseStdlibExec(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("os/exec/exec.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "os/exec/exec.go")))
 }
 
 func TestParseStdlibTemplate(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("text/template/exec.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "text/template/exec.go")))
 }
 
 func TestParseStdlibScanner(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("go/scanner/scanner.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "go/scanner/scanner.go")))
 }
 
 func TestParseStdlibToken(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("go/token/token.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "go/token/token.go")))
 }
 
 func TestParseStdlibErrors(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("errors/wrap.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "errors/wrap.go")))
 }
 
 func TestParseStdlibUnicode(t *testing.T) {
-	data, err := os.ReadFile(stdlibFile("unicode/utf8/utf8.go"))
-	if err != nil {
-		t.Skipf("skipping: %v", err)
-	}
-	NewRecipeSpec().RewriteRun(t, GolangRaw(string(data)))
+	NewRecipeSpec().RewriteRun(t, GolangRaw(readStdlibFile(t, "unicode/utf8/utf8.go")))
 }


### PR DESCRIPTION
Two `rewrite-go` tests fail on a Go 1.27 toolchain, on pristine `main`:

```
--- FAIL: TestSubtreeIndentMatchesWholeFileOnStdlib/encoding/json/encode.go
        subtree_indent_test.go:163: no compilation unit produced
--- FAIL: TestParseStdlibJSON
        no compilation unit produced
```

## What happened

Go 1.27 makes jsonv2 the default, so `build.Default.ToolTags` now contains `goexperiment.jsonv2`. `$GOROOT/src/encoding/json/encode.go` carries `//go:build !goexperiment.jsonv2`, so `parser.MatchBuildContext` returns false, `ParsePackage` filters the file out, and `Parse` reports `no compilation unit produced`.

The parser is right. The defect is that three tests take stdlib files as a corpus and assume every one is buildable under the running toolchain. They already skip a file they cannot *read*; they need the same for one the build excludes.

## The fix

Each site checks `parser.MatchBuildContext` explicitly and skips when it is false. Treating a missing compilation unit as a skip would be shorter and wrong: it turns a future parser regression into a green skip. `TestVisitorRegroupsStdlibToParseableCode` is the demonstration — it did `t.Skip(err)` on any parse error, so it was already passing on Go 1.27 while silently dropping `encode.go`. Its parse-error arm is now `t.Fatalf`.

`test/selfparse_test.go` had the same read-and-skip prologue copied across 30 `TestParseStdlib*` functions. They now share a `readStdlibFile` helper doing both skips, so the whole set is covered rather than only the file that happened to fail.

## Scope

`pkg/parser/build_tags.go` is unchanged: excluding the file is the correct answer, and `goexperiment.jsonv2` needs no special handling. The `-tags gofmtaudit` audits already pair `MatchBuildContext` with `NewGoParserWithBuildContext`.

One unrelated repair: `strconv/atoi.go` no longer exists in Go 1.27, so `TestParseStdlibStrconv` was skipping on its read-error arm on every 1.27 machine. It now reads `strconv/quote.go`, present in both 1.25 and 1.27.

## Why CI is green

`rewrite-go/go.mod` declares `go 1.25.0` with no `toolchain` line, and the workflow pins no Go version, so CI runs whatever the runner image ships — currently below 1.27. This bites only a developer whose local Go is newer, and would reach CI when the runner image or the `go` directive moves.
