### PR TITLE
Python: a name re-exported through `__all__` keeps its import

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/import_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/import_utils.py
@@ -22,8 +22,11 @@ from rewrite.java.tree import (Assignment, AssignmentOperation, Block, Empty, Fi
                                Identifier, If, Import, Literal, MethodInvocation)
 from rewrite.markers import Markers
 from rewrite.python.markers import Quoted
-from rewrite.python.tree import (CollectionLiteral, ExpressionStatement, StatementExpression,
-                                 TypeHintedExpression)
+from rewrite.python.tree import (ChainedAssignment, CollectionLiteral, ExpressionStatement,
+                                 StatementExpression, TypeHintedExpression)
+
+# List methods that reorder or read `__all__` without changing which names it holds.
+_MEMBERSHIP_PRESERVING_CALLS = frozenset({'sort', 'index', 'count', 'copy'})
 
 
 def unconditional_body(if_: If) -> Optional[Block]:
@@ -59,12 +62,14 @@ def _unwrap(expr):
 
 def _exported_entries(value) -> Optional[Set[str]]:
     """The strings a list or tuple literal holds, or None for any other value or
-    any entry that is not a string literal."""
+    any entry that is not a string literal. An empty literal holds one `Empty`."""
     if not isinstance(value, CollectionLiteral) or value.kind not in (
             CollectionLiteral.Kind.LIST, CollectionLiteral.Kind.TUPLE):
         return None
     names: Set[str] = set()
     for element in value.elements:
+        if isinstance(element, Empty):
+            continue
         if not isinstance(element, Literal) or not isinstance(element.value, str):
             return None
         names.add(element.value)
@@ -77,32 +82,62 @@ def _binds_all(expr) -> bool:
     return isinstance(target, Identifier) and target.simple_name == '__all__'
 
 
+def _every_mention_read(cu, read: Set[int]) -> bool:
+    """True when every ``__all__`` in the file is one this already read. A mention
+    anywhere else — a tuple target, an `if`/`else` or `try` body, `__all__.append(...)` —
+    contributes members by a route with no literal to read."""
+    from rewrite.python.visitor import PythonVisitor  # its module imports this one
+
+    unread = False
+
+    class Scan(PythonVisitor):
+        def visit_identifier(self, ident: Identifier, p):
+            nonlocal unread
+            if ident.simple_name == '__all__' and id(ident) not in read:
+                unread = True
+            return ident
+
+    Scan().visit(cu, None)
+    return not unread
+
+
 def module_exported_names(cu) -> Optional[Set[str]]:
     """The names a module re-exports through a module-scope ``__all__``, empty when it
     declares none, None once one is written in a shape whose entries cannot be read.
 
-    `type_mapping._module_all_names` is the same rule over `ast`; keep the two in step.
-    That one classifies a public surface and may skip an entry, while an entry missed
-    here would drop an import the module still needs, so anything unreadable is None.
+    `type_mapping._module_all_names` answers the same question over `ast`, for
+    attribution, but classifies a public surface and may skip an entry it cannot read.
+    An entry missed here would drop an import, so anything unreadable is None instead.
     """
     statements = list(cu.statements)
     for block in module_scope_blocks(cu.statements):
         statements.extend(block.statements)
 
     names: Set[str] = set()
+    read: Set[int] = set()
     for stmt in statements:
         stmt = _unwrap(stmt)
         if isinstance(stmt, (Assignment, AssignmentOperation)):
-            if not _binds_all(stmt.variable):
-                continue
-            entries = _exported_entries(stmt.assignment)
-            if entries is None:
-                return None
-            names.update(entries)
-        elif isinstance(stmt, MethodInvocation) and _binds_all(stmt.select):
-            # `__all__.extend(...)` and `.append(...)` put the entries beyond a literal read.
+            targets = [stmt.variable]
+        elif isinstance(stmt, ChainedAssignment):
+            targets = list(stmt.variables)
+        elif isinstance(stmt, MethodInvocation) and _binds_all(stmt.select) and \
+                stmt.name.simple_name in _MEMBERSHIP_PRESERVING_CALLS:
+            read.add(id(_unwrap(stmt.select)))
+            continue
+        else:
+            continue
+
+        bound = [target for target in targets if _binds_all(target)]
+        if not bound:
+            continue
+        entries = _exported_entries(stmt.assignment)
+        if entries is None:
             return None
-    return names
+        names.update(entries)
+        read.update(id(_unwrap(target)) for target in bound)
+
+    return names if _every_mention_read(cu, read) else None
 
 
 def get_qualid_name(qualid) -> str:

--- a/rewrite-python/rewrite/src/rewrite/python/import_utils.py
+++ b/rewrite-python/rewrite/src/rewrite/python/import_utils.py
@@ -15,12 +15,15 @@
 """Shared utility functions for Python import handling."""
 
 import ast
-from typing import Iterator, Optional, Sequence, Tuple
+from typing import Iterator, Optional, Sequence, Set, Tuple
 
 from rewrite.java.support_types import JavaType, JRightPadded, Space, Statement
-from rewrite.java.tree import Block, Empty, FieldAccess, Identifier, If, Import
+from rewrite.java.tree import (Assignment, AssignmentOperation, Block, Empty, FieldAccess,
+                               Identifier, If, Import, Literal, MethodInvocation)
 from rewrite.markers import Markers
 from rewrite.python.markers import Quoted
+from rewrite.python.tree import (CollectionLiteral, ExpressionStatement, StatementExpression,
+                                 TypeHintedExpression)
 
 
 def unconditional_body(if_: If) -> Optional[Block]:
@@ -44,6 +47,62 @@ def module_scope_blocks(statements: Sequence[Statement]) -> Iterator[Block]:
         if body is not None:
             yield body
             yield from module_scope_blocks(body.statements)
+
+
+def _unwrap(expr):
+    """The expression under the statement and annotation wrappers, so that
+    `__all__: list = [...]` reaches the same identifier as `__all__ = [...]`."""
+    while isinstance(expr, (ExpressionStatement, StatementExpression, TypeHintedExpression)):
+        expr = expr.expression
+    return expr
+
+
+def _exported_entries(value) -> Optional[Set[str]]:
+    """The strings a list or tuple literal holds, or None for any other value or
+    any entry that is not a string literal."""
+    if not isinstance(value, CollectionLiteral) or value.kind not in (
+            CollectionLiteral.Kind.LIST, CollectionLiteral.Kind.TUPLE):
+        return None
+    names: Set[str] = set()
+    for element in value.elements:
+        if not isinstance(element, Literal) or not isinstance(element.value, str):
+            return None
+        names.add(element.value)
+    return names
+
+
+def _binds_all(expr) -> bool:
+    """True when ``expr`` names ``__all__``."""
+    target = _unwrap(expr)
+    return isinstance(target, Identifier) and target.simple_name == '__all__'
+
+
+def module_exported_names(cu) -> Optional[Set[str]]:
+    """The names a module re-exports through a module-scope ``__all__``, empty when it
+    declares none, None once one is written in a shape whose entries cannot be read.
+
+    `type_mapping._module_all_names` is the same rule over `ast`; keep the two in step.
+    That one classifies a public surface and may skip an entry, while an entry missed
+    here would drop an import the module still needs, so anything unreadable is None.
+    """
+    statements = list(cu.statements)
+    for block in module_scope_blocks(cu.statements):
+        statements.extend(block.statements)
+
+    names: Set[str] = set()
+    for stmt in statements:
+        stmt = _unwrap(stmt)
+        if isinstance(stmt, (Assignment, AssignmentOperation)):
+            if not _binds_all(stmt.variable):
+                continue
+            entries = _exported_entries(stmt.assignment)
+            if entries is None:
+                return None
+            names.update(entries)
+        elif isinstance(stmt, MethodInvocation) and _binds_all(stmt.select):
+            # `__all__.extend(...)` and `.append(...)` put the entries beyond a literal read.
+            return None
+    return names
 
 
 def get_qualid_name(qualid) -> str:

--- a/rewrite-python/rewrite/src/rewrite/python/remove_import.py
+++ b/rewrite-python/rewrite/src/rewrite/python/remove_import.py
@@ -22,8 +22,8 @@ from rewrite.java.support_types import JContainer, JRightPadded, Statement
 from rewrite.java.tree import Identifier, If, Import, Space
 from rewrite.python.binding_utils import is_reference
 from rewrite.python.import_utils import (get_qualid_name, get_name_string, get_alias_name,
-                                         get_canonical_fqn, referenced_names,
-                                         unconditional_body)
+                                         get_canonical_fqn, module_exported_names,
+                                         referenced_names, unconditional_body)
 from rewrite.python.scope_utils import LocalBindings
 from rewrite.python.tree import CompilationUnit, MultiImport
 from rewrite.python.visitor import PythonVisitor
@@ -97,7 +97,14 @@ class RemoveImport(PythonVisitor):
         self._cu: Optional[CompilationUnit] = None
 
     def visit_compilation_unit(self, cu: CompilationUnit, p) -> J:
-        self._used = self._collect_used_identifiers(cu) if self.only_if_unused else None
+        if self.only_if_unused:
+            exported = module_exported_names(cu)
+            if exported is None:
+                # An `__all__` this cannot read may re-export any import in the file.
+                return cu
+            self._used = self._collect_used_identifiers(cu) | exported
+        else:
+            self._used = None
         self._cu = cu
         return self._remove_import(cu)
 

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -135,7 +135,10 @@ def _module_scope_statements(body: Sequence[ast.stmt]) -> Iterator[ast.stmt]:
 
 def _module_all_names(tree: ast.Module) -> Optional[Set[str]]:
     """The names ``__all__`` declares via top-level literal list/tuple assignments
-    (plain, annotated, or augmented), or None when the module has no such ``__all__``."""
+    (plain, annotated, or augmented), or None when the module has no such ``__all__``.
+
+    `import_utils.module_exported_names` is the same rule over the LST, for
+    `RemoveImport`; keep the two in step."""
     names: Optional[Set[str]] = None
     for stmt in tree.body:
         if isinstance(stmt, ast.Assign):

--- a/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
+++ b/rewrite-python/rewrite/src/rewrite/python/type_mapping.py
@@ -137,8 +137,8 @@ def _module_all_names(tree: ast.Module) -> Optional[Set[str]]:
     """The names ``__all__`` declares via top-level literal list/tuple assignments
     (plain, annotated, or augmented), or None when the module has no such ``__all__``.
 
-    `import_utils.module_exported_names` is the same rule over the LST, for
-    `RemoveImport`; keep the two in step."""
+    `import_utils.module_exported_names` answers the same question over the LST, for
+    `RemoveImport`, but conservatively: an `__all__` it cannot fully read gives None."""
     names: Optional[Set[str]] = None
     for stmt in tree.body:
         if isinstance(stmt, ast.Assign):

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -863,3 +863,64 @@ class TestRemoveImportStringAnnotations:
                 """,
             )
         )
+
+
+class TestRemoveImportAllReExports:
+    """A name listed in `__all__` is re-exported, so the module still needs its
+    import even where nothing else reads the name."""
+
+    @pytest.mark.parametrize('all_form', ['["List"]', '("List",)'])
+    def test_re_exported_name_keeps_its_import(self, arm, all_form):
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
+        spec.rewrite_run(
+            python(
+                f"""\
+                from typing import List
+
+                __all__ = {all_form}
+                """,
+            )
+        )
+
+    def test_augmented_all_keeps_its_import(self, arm):
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
+        spec.rewrite_run(
+            python(
+                """\
+                from typing import List
+
+                __all__ = []
+                __all__ += ["List"]
+                """,
+            )
+        )
+
+    def test_unrelated_export_does_not_keep_an_unrelated_import(self, arm):
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'Any')))
+        spec.rewrite_run(
+            python(
+                """\
+                from typing import Any, List
+
+                __all__ = ["List"]
+                """,
+                """\
+                from typing import List
+
+                __all__ = ["List"]
+                """,
+            )
+        )
+
+    def test_unreadable_all_keeps_the_import(self, arm):
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
+        spec.rewrite_run(
+            python(
+                """\
+                from typing import List
+
+                __all__ = []
+                __all__.extend(["List"])
+                """,
+            )
+        )

--- a/rewrite-python/rewrite/tests/python/test_remove_import.py
+++ b/rewrite-python/rewrite/tests/python/test_remove_import.py
@@ -915,10 +915,27 @@ class TestRemoveImportAllReExports:
         spec.rewrite_run(
             python(
                 """\
-                from typing import List
+                from typing import Any, List
 
-                __all__ = []
+                __all__ = ["Any"]
                 __all__ += ["List"]
+                """,
+            )
+        )
+
+    @pytest.mark.parametrize('unreadable_all', [
+        pytest.param('__all__ = ["Any"]\n__all__.extend(["List"])', id='extend'),
+        pytest.param('if True:\n    __all__ = ["List"]\nelse:\n    __all__ = []', id='if_else'),
+    ])
+    def test_unreadable_all_keeps_the_import(self, arm, unreadable_all):
+        body = unreadable_all.replace('\n', '\n                ')
+        spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
+        spec.rewrite_run(
+            python(
+                f"""\
+                from typing import Any, List
+
+                {body}
                 """,
             )
         )
@@ -940,15 +957,27 @@ class TestRemoveImportAllReExports:
             )
         )
 
-    def test_unreadable_all_keeps_the_import(self, arm):
+    @pytest.mark.parametrize('readable_all', [
+        pytest.param('__all__ = []', id='empty'),
+        pytest.param('__all__ = _x = ["Any"]', id='chained'),
+        pytest.param('__all__ = ["Any"]\n__all__.sort()', id='sort'),
+        pytest.param('__all__ = []\n__all__ += ["Any"]', id='augmented'),
+        pytest.param('if True:\n    __all__ = ["Any"]', id='nested_if'),
+    ])
+    def test_readable_all_leaves_unrelated_imports_removable(self, arm, readable_all):
+        body = readable_all.replace('\n', '\n                ')
         spec = RecipeSpec(recipe=from_visitor(_remove_import_visitor(arm, 'typing', 'List')))
         spec.rewrite_run(
             python(
-                """\
-                from typing import List
+                f"""\
+                from typing import Any, List
 
-                __all__ = []
-                __all__.extend(["List"])
+                {body}
+                """,
+                f"""\
+                from typing import Any
+
+                {body}
                 """,
             )
         )


### PR DESCRIPTION
`RemoveImport`'s `only_if_unused` census does not count a name re-exported through a module-level `__all__`, so it deletes an import the module still needs. The module is left advertising a name it no longer binds, and `from m import *` then raises `AttributeError: module 'm' has no attribute 'List'`.

```python
# before
from typing import List

__all__ = ["List"]

# after — the import is gone, __all__ still names it
__all__ = ["List"]
```

## Why the census misses it

- The census runs a visitor whose only hook is `visit_identifier`, so it sees names that appear as `Identifier` nodes. An `__all__` entry is a string `Literal` and never reaches it. That is structural rather than a matter of the guard conditions; #8750 fixed the sibling case, a name inside a string annotation.

## The fix

`import_utils.module_exported_names` reads a module-scope `__all__` off the LST and the census unions those names in, so every caller of `RemoveImport` is covered rather than each recipe repeating the scan.

`type_mapping._module_all_names` already computes this set from `ast` during the parse, and reusing it would avoid a second implementation. It is not available here: that helper runs as part of type attribution, and `RemoveImport` has to work with attribution off. The two cross-reference instead.

## Accounting for every `__all__`

A statement that fails the `__all__` test can mean "unrelated" or "binds it in a shape I cannot read", and treating the second as the first deletes the re-exported import — the bug this set out to fix. So every `__all__` in the file must be accounted for, or the module is opaque and removal is a file-wide no-op.

| shape | |
|---|---|
| `__all__ = ["List"]`, `("List",)`, `__all__: list = [...]` | read |
| `__all__ = []` | read, empty |
| `__all__ += [...]` | read |
| `__all__ = _x = [...]` | read |
| `if TYPE_CHECKING: __all__ = [...]` | read |
| `__all__.sort()`, `.index()`, `.count()`, `.copy()` | read |
| `__all__.extend(...)`, `.append(...)` | opaque |
| `__all__` under `if`/`else` or `try:` | opaque |
| `__all__, _x = [...], 1` | opaque |

The empty literal is worth calling out: `[]` holds a single `J.Empty` placeholder rather than no elements, so reading it as a non-string entry made removal a no-op for every file using `__all__ = []` as the base of the `+=` idiom.

## Tests

`TestRemoveImportAllReExports` covers the literal forms, the shapes above, and a negative case pinning that an unrelated name in `__all__` leaves an unrelated import removable. Mutation-checked: nine mutants over these branches, none surviving. Both arms of the fixture get this free, since the Java visitor sends `only_if_unused` over RPC and does not evaluate it.

The rows pinning "this shape is read" assert that an unrelated import still gets removed. An unreadable `__all__` keeps the import too, so a no-change assertion cannot tell the two apart — two earlier drafts passed while exercising neither branch they named.
