### PR TITLE
Add a coordinate for an if's else branch

### DIFF
--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
@@ -29,9 +29,6 @@ import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.Markers;
 
-import java.io.ByteArrayInputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -41,7 +38,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
-import static org.openrewrite.gradle.GradleParser.requireParsed;
 
 @Value
 @EqualsAndHashCode(callSuper = false)
@@ -337,85 +333,31 @@ public class DependencyConstraintToRule extends Recipe {
                 if (alreadyExists) {
                     return sourceFile;
                 }
-                // Prefer to insert before the dependencies block for readability
-                if (sourceFile instanceof G.CompilationUnit) {
-                    G.CompilationUnit cu = (G.CompilationUnit) sourceFile;
-                    int insertionIndex = 0;
-                    while (insertionIndex < cu.getStatements().size()) {
-                        Statement s = cu.getStatements().get(insertionIndex);
-                        if (s instanceof J.MethodInvocation && DEPENDENCIES_DSL_MATCHER.matches((J.MethodInvocation) s)) {
-                            break;
-                        }
-                        insertionIndex++;
-                    }
-                    J.MethodInvocation m = GradleParser.builder()
-                            .build()
-                            .parse(ctx,
-                                    "configurations.all {\n" +
-                                            "    resolutionStrategy.eachDependency { details ->\n" +
-                                            "    }\n" +
-                                            "}")
-                            .map(requireParsed(G.CompilationUnit.class))
-                            .map(G.CompilationUnit::getStatements)
-                            .map(it -> it.get(0))
-                            .map(J.MethodInvocation.class::cast)
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("Unable to create a new configurations.all block"))
-                            .withPrefix(Space.format("\n"));
-                    List<Statement> newStatements = ListUtils.insert(cu.getStatements(), m, insertionIndex);
-                    if (insertionIndex == 0) {
-                        newStatements = ListUtils.map(newStatements, (i, stat) ->
-                                i == 1 && stat.getPrefix().getWhitespace().isEmpty()
-                                        ? stat.withPrefix(stat.getPrefix().withWhitespace("\n\n"))
-                                        : stat);
-                    }
-                    return cu.withStatements(newStatements);
-                } else {
-                    K.CompilationUnit cu = (K.CompilationUnit) sourceFile;
-                    assert cu != null;
-                    J.Block block = (J.Block) cu.getStatements().get(0);
-                    int insertionIndex = 0;
-                    while (insertionIndex < block.getStatements().size()) {
-                        Statement s = block.getStatements().get(insertionIndex);
-                        if (s instanceof J.MethodInvocation && "dependencies".equals(((J.MethodInvocation) s).getSimpleName())) {
-                            break;
-                        }
-                        insertionIndex++;
-                    }
-                    J.MethodInvocation m = GradleParser.builder()
-                            .build()
-                            .parseInputs(singletonList(
-                                    new Parser.Input(
-                                            Paths.get("build.gradle.kts"),
-                                            () -> new ByteArrayInputStream(
-                                                    ("\n" +
-                                                            "configurations.all {\n" +
-                                                            "    resolutionStrategy.eachDependency { details ->\n" +
-                                                            "    }\n" +
-                                                            "}").getBytes(StandardCharsets.UTF_8)))
-                            ), null, ctx)
-                            .map(requireParsed(K.CompilationUnit.class))
-                            .map(k -> (J.Block) k.getStatements().get(0))
-                            .map(J.Block::getStatements)
-                            .map(it -> it.get(0))
-                            .map(J.MethodInvocation.class::cast)
-                            .findFirst()
-                            .orElseThrow(() -> new IllegalStateException("Unable to create a new configurations.all block"));
-                    final int finalInsertionIndex = insertionIndex;
-                    return cu.withStatements(ListUtils.mapFirst(cu.getStatements(), arg -> {
-                        if (arg == block) {
-                            List<Statement> newStatements = ListUtils.insert(block.getStatements(), m, finalInsertionIndex);
-                            if (finalInsertionIndex == 0) {
-                                newStatements = ListUtils.map(newStatements, (i, stat) ->
-                                        i == 1 && stat.getPrefix().getWhitespace().isEmpty()
-                                                ? stat.withPrefix(stat.getPrefix().withWhitespace("\n\n"))
-                                                : stat);
-                            }
-                            return block.withStatements(newStatements);
-                        }
-                        return arg;
-                    }));
+                boolean isKotlinDsl = sourceFile instanceof K.CompilationUnit;
+                List<Statement> statements = isKotlinDsl ?
+                        ((J.Block) ((K.CompilationUnit) sourceFile).getStatements().get(0)).getStatements() :
+                        ((G.CompilationUnit) sourceFile).getStatements();
+                if (statements.isEmpty()) {
+                    return sourceFile;
                 }
+                // Prefer to insert before the dependencies block for readability
+                Statement anchor = null;
+                for (Statement s : statements) {
+                    if (s instanceof J.MethodInvocation && isDependenciesBlock((J.MethodInvocation) s, isKotlinDsl)) {
+                        anchor = s;
+                        break;
+                    }
+                }
+                String snippet = "configurations.all {\n" +
+                        "    resolutionStrategy.eachDependency { details ->\n" +
+                        "    }\n" +
+                        "}";
+                JavaTemplate eachDependency = isKotlinDsl ?
+                        KotlinTemplate.builder(snippet).build() :
+                        GroovyTemplate.builder(snippet).build();
+                return eachDependency.apply(new Cursor(getCursor(), sourceFile), anchor == null ?
+                        statements.get(statements.size() - 1).getCoordinates().after() :
+                        anchor.getCoordinates().before());
             }
             return super.visit(tree, ctx);
         }
@@ -430,6 +372,11 @@ public class DependencyConstraintToRule extends Recipe {
             }
             return m;
         }
+    }
+
+    // The Kotlin DSL has no type attribution to match against, so it goes by name
+    private static boolean isDependenciesBlock(J.MethodInvocation m, boolean isKotlinDsl) {
+        return isKotlinDsl ? "dependencies".equals(m.getSimpleName()) : DEPENDENCIES_DSL_MATCHER.matches(m);
     }
 
     private static boolean isEmptyDependenciesBlock(J.MethodInvocation m) {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/DependencyConstraintToRule.java
@@ -16,10 +16,8 @@
 package org.openrewrite.gradle;
 
 import lombok.*;
-import org.intellij.lang.annotations.Language;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
-import org.openrewrite.groovy.GroovyParser;
 import org.openrewrite.groovy.GroovyTemplate;
 import org.openrewrite.groovy.tree.G;
 import org.openrewrite.internal.ListUtils;
@@ -27,7 +25,6 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.MethodMatcher;
 import org.openrewrite.java.tree.*;
-import org.openrewrite.kotlin.KotlinParser;
 import org.openrewrite.kotlin.KotlinTemplate;
 import org.openrewrite.kotlin.tree.K;
 import org.openrewrite.marker.Markers;
@@ -197,64 +194,50 @@ public class DependencyConstraintToRule extends Recipe {
             if (!(maybeClosure instanceof J.Lambda) || !(((J.Lambda) maybeClosure).getBody() instanceof J.Block)) {
                 return m;
             }
-            J.Lambda closure = (J.Lambda) maybeClosure;
-            J.Block closureBody = (J.Block) closure.getBody();
+            J.Block closureBody = (J.Block) ((J.Lambda) maybeClosure).getBody();
             J rawParam = ((J.Lambda) maybeClosure).getParameters().getParameters().get(0);
             if (!(rawParam instanceof J.VariableDeclarations)) {
                 return m;
             }
-            String p = ((J.VariableDeclarations) rawParam).getVariables().get(0).getSimpleName();
-            J.If newIf;
-            if (!isKotlinDsl) {
-                @SuppressWarnings("GroovyEmptyStatementBody") @Language("groovy")
-                String snippet = "Object " + p + " = null\n" +
-                        "if (" + p + ".requested.group == '" + groupArtifactVersion.getGroupId() + "' && " +
-                        p + ".requested.name == '" + groupArtifactVersion.getArtifactId() + "') {\n}";
-                newIf = GroovyParser.builder().build()
-                        .parse(ctx, snippet)
-                        .map(requireParsed(G.CompilationUnit.class))
-                        .map(cu -> cu.getStatements().get(1))
-                        .map(J.If.class::cast)
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("Unable to produce a new if statement"));
-            } else {
-                String snippet = "var " + p + ": Any = null\n" +
-                        "if (" + p + ".requested.group == \"" + groupArtifactVersion.getGroupId() + "\" && " +
-                        p + ".requested.name == \"" + groupArtifactVersion.getArtifactId() + "\") {\n}";
-                newIf = KotlinParser.builder().isKotlinScript(true).build()
-                        .parse(ctx, snippet)
-                        .map(requireParsed(K.CompilationUnit.class))
-                        .map(cu -> (J.Block) cu.getStatements().get(0))
-                        .map(block -> (J.If) block.getStatements().get(1))
-                        .findFirst()
-                        .orElseThrow(() -> new IllegalStateException("Unable to produce a new if statement"));
-            }
-            if (containsAnyIfStatement) {
-                m = (J.MethodInvocation) new JavaIsoVisitor<Integer>() {
-                    boolean inserted;
+            J.Identifier p = ((J.VariableDeclarations) rawParam).getVariables().get(0).getName();
 
-                    @Override
-                    public J.If visitIf(J.If iff, Integer integer) {
-                        J.If anIf = super.visitIf(iff, integer);
-                        J.If.Else currentElse = anIf.getElsePart();
-                        if (!inserted && (currentElse == null || currentElse.getBody() instanceof J.Block)) {
-                            inserted = true;
-                            J.If.Else newElsePart = new J.If.Else(Tree.randomId(), Space.SINGLE_SPACE, Markers.EMPTY,
-                                    JRightPadded.build(newIf
-                                            .withPrefix(Space.SINGLE_SPACE)
-                                            .withElsePart(currentElse)));
-                            anIf = autoFormat(anIf.withElsePart(newElsePart), 0, requireNonNull(getCursor().getParent()));
-                        }
-                        return anIf;
-                    }
-                }.visitNonNull(m, 0, requireNonNull(getCursor().getParent()));
-            } else {
-                J.Block newBody = autoFormat(closureBody.withStatements(ListUtils.concat(newIf, closureBody.getStatements())), ctx, getCursor());
-                m = m.withArguments(singletonList(closure.withBody(newBody)));
+            // The closure parameter comes from the tree and the coordinates from the recipe's options, so the
+            // predicate is assembled from parameters and needs no declaration of `p` to parse against
+            String predicate = "if (#{any()}.requested.group == #{any(String)} && #{any()}.requested.name == #{any(String)}) {\n}";
+            JavaTemplate branch = isKotlinDsl ?
+                    KotlinTemplate.builder(predicate).build() :
+                    GroovyTemplate.builder(predicate).build();
+            Object[] values = {
+                    p.withPrefix(Space.EMPTY),
+                    stringLiteral(groupArtifactVersion.getGroupId(), isKotlinDsl),
+                    p.withPrefix(Space.EMPTY),
+                    stringLiteral(groupArtifactVersion.getArtifactId(), isKotlinDsl)
+            };
+
+            Cursor scope = new Cursor(getCursor().getParentOrThrow(), m);
+            if (containsAnyIfStatement) {
+                J.If endOfChain = endOfChain(m);
+                return endOfChain == null ? m :
+                        branch.apply(scope, endOfChain.getCoordinates().addElseBranch(), values);
             }
-            return m;
+            return branch.apply(scope, closureBody.getCoordinates().firstStatement(), values);
         }
 
+        // The innermost `if` of a chain, which is the one a new branch hangs off
+        private static J.@Nullable If endOfChain(J.MethodInvocation m) {
+            AtomicReference<J.If> end = new AtomicReference<>();
+            new JavaIsoVisitor<Integer>() {
+                @Override
+                public J.If visitIf(J.If iff, Integer p) {
+                    super.visitIf(iff, p);
+                    if (end.get() == null && (iff.getElsePart() == null || iff.getElsePart().getBody() instanceof J.Block)) {
+                        end.set(iff);
+                    }
+                    return iff;
+                }
+            }.visit(m, 0);
+            return end.get();
+        }
 
         @Override
         public J.If visitIf(J.If iff, ExecutionContext ctx) {
@@ -407,7 +390,8 @@ public class DependencyConstraintToRule extends Recipe {
                                             () -> new ByteArrayInputStream(
                                                     ("\n" +
                                                             "configurations.all {\n" +
-                                                            "    resolutionStrategy.eachDependency { details ->}\n" +
+                                                            "    resolutionStrategy.eachDependency { details ->\n" +
+                                                            "    }\n" +
                                                             "}").getBytes(StandardCharsets.UTF_8)))
                             ), null, ctx)
                             .map(requireParsed(K.CompilationUnit.class))
@@ -416,17 +400,6 @@ public class DependencyConstraintToRule extends Recipe {
                             .map(it -> it.get(0))
                             .map(J.MethodInvocation.class::cast)
                             .findFirst()
-                            .map(m2 -> m2.withArguments(ListUtils.mapFirst(m2.getArguments(), arg -> {
-                                J.Lambda lambda1 = (J.Lambda) arg;
-                                J.Block block1 = (J.Block) lambda1.getBody();
-                                return lambda1.withBody(block1.withStatements(ListUtils.mapFirst(block1.getStatements(), arg2 -> {
-                                    J.MethodInvocation m3 = (J.MethodInvocation) arg2;
-                                    return m3.withArguments(ListUtils.mapFirst(m3.getArguments(), arg3 -> {
-                                        J.Lambda lambda2 = (J.Lambda) arg3;
-                                        return lambda2.withBody(((J.Block) lambda2.getBody()).withEnd(Space.format("\n")));
-                                    }));
-                                })));
-                            })))
                             .orElseThrow(() -> new IllegalStateException("Unable to create a new configurations.all block"));
                     final int finalInsertionIndex = insertionIndex;
                     return cu.withStatements(ListUtils.mapFirst(cu.getStatements(), arg -> {

--- a/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
+++ b/rewrite-gradle/src/main/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersion.java
@@ -774,7 +774,7 @@ public class UpgradeTransitiveDependencyVersion extends ScanningRecipe<UpgradeTr
                                         return arg;
                                     }
                                     J.Block body = (J.Block) lambda.getBody();
-                                    return lambda.withBody(body.withEnd(Space.format("\n")));
+                                    return lambda.withBody(body);
                                 })))
                                 .orElseThrow(() -> new IllegalStateException("Unable to parse dependencies block"))
                                 .withPrefix(Space.format("\n\n"));

--- a/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
+++ b/rewrite-gradle/src/test/java/org/openrewrite/gradle/UpgradeTransitiveDependencyVersionTest.java
@@ -1227,7 +1227,6 @@ class UpgradeTransitiveDependencyVersionTest implements RewriteTest {
               repositories { mavenCentral() }
 
               dependencies {
-
                   constraints {
                       implementation("org.jetbrains.kotlin:kotlin-stdlib:2.1.0") {
                           because("CVE-2022-24329")

--- a/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
+++ b/rewrite-groovy/src/test/java/org/openrewrite/groovy/GroovyTemplateTest.java
@@ -79,6 +79,22 @@ class GroovyTemplateTest implements RewriteTest {
         });
     }
 
+    // Anchors on the second statement, which a blank line separates from the first
+    private static Recipe insertBeforeSecondTopLevelStatement() {
+        return toRecipe(() -> new GroovyVisitor<>() {
+            @Override
+            public J visitCompilationUnit(G.CompilationUnit cu, ExecutionContext ctx) {
+                G.CompilationUnit c = (G.CompilationUnit) super.visitCompilationUnit(cu, ctx);
+                if (c.getStatements().size() != 2) {
+                    return c;
+                }
+                return GroovyTemplate.builder("ext['x'] = 'y'")
+                  .build()
+                  .apply(updateCursor(c), c.getStatements().get(1).getCoordinates().before());
+            }
+        });
+    }
+
     @DocumentExample
     @Test
     void replaceContextFreeStatement() {
@@ -406,6 +422,31 @@ class GroovyTemplateTest implements RewriteTest {
               ext['x'] = 'y'
               plugins {
                   id 'java'
+              }
+              """
+          ));
+    }
+
+    @Test
+    void insertBeforeTopLevelScriptStatementLeavesItsBlankLineAlone() {
+        rewriteRun(
+          spec -> spec.recipe(insertBeforeSecondTopLevelStatement()),
+          groovy(
+            """
+              plugins {
+                  id 'java'
+              }
+
+              dependencies {
+              }
+              """,
+            """
+              plugins {
+                  id 'java'
+              }
+              ext['x'] = 'y'
+
+              dependencies {
               }
               """
           ));

--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest8Test.java
@@ -766,4 +766,144 @@ class JavaTemplateTest8Test implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void addElseBranchToAnIfThatHasNone() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.If visitIf(J.If iff, ExecutionContext ctx) {
+                  if (iff.getElsePart() != null) {
+                      return iff;
+                  }
+                  return JavaTemplate.apply("if (true) {\n}", getCursor(), iff.getCoordinates().addElseBranch());
+              }
+          })),
+          java(
+            """
+              class Test {
+                  void test(int n) {
+                      if (n == 1) {
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int n) {
+                      if (n == 1) {
+                      } else if (true) {
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addElseBranchExtendsAnExistingChain() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.If visitIf(J.If iff, ExecutionContext ctx) {
+                  // Only the head of the chain, and only while it still falls through to a plain else
+                  if (getCursor().getParentTreeCursor().getValue() instanceof J.If.Else ||
+                      iff.getElsePart() == null || !(iff.getElsePart().getBody() instanceof J.Block)) {
+                      return super.visitIf(iff, ctx);
+                  }
+                  return JavaTemplate.apply("if (true) {\n}", getCursor(), iff.getCoordinates().addElseBranch());
+              }
+          })),
+          java(
+            """
+              class Test {
+                  void test(int n) {
+                      if (n == 1) {
+                      } else {
+                          System.out.println(n);
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int n) {
+                      if (n == 1) {
+                      } else if (true) {
+                      } else {
+                          System.out.println(n);
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addElseBranchWithABlockMakesAPlainElse() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaIsoVisitor<>() {
+              @Override
+              public J.If visitIf(J.If iff, ExecutionContext ctx) {
+                  if (iff.getElsePart() != null) {
+                      return iff;
+                  }
+                  return JavaTemplate.apply("{\n    System.out.println(\"fallthrough\");\n}", getCursor(),
+                    iff.getCoordinates().addElseBranch());
+              }
+          })),
+          java(
+            """
+              class Test {
+                  void test(int n) {
+                      if (n == 1) {
+                      }
+                  }
+              }
+              """,
+            """
+              class Test {
+                  void test(int n) {
+                      if (n == 1) {
+                      } else {
+                          System.out.println("fallthrough");
+                      }
+                  }
+              }
+              """
+          )
+        );
+    }
+
+    @Test
+    void addElseBranchRejectsANonIfWhenAnElseAlreadyExists() {
+        J.CompilationUnit cu = JavaParser.fromJavaVersion().build()
+          .parse(
+            """
+              class Test {
+                  void test(int n) {
+                      if (n == 1) {
+                      } else {
+                      }
+                  }
+              }
+              """
+          )
+          .map(J.CompilationUnit.class::cast)
+          .findFirst()
+          .orElseThrow();
+
+        assertThatThrownBy(() -> new JavaIsoVisitor<Integer>() {
+            @Override
+            public J.If visitIf(J.If iff, Integer p) {
+                return JavaTemplate.apply("{\n}", getCursor(), iff.getCoordinates().addElseBranch());
+            }
+        }.visit(cu, 0))
+          .rootCause()
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("requires a template that produces an `if`");
+    }
+
 }

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -132,8 +132,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                 for (int i = 0; i < gen.size(); i++) {
                     Statement s = gen.get(i);
                     if (anchorBeginsLine) {
-                        gen.set(i, autoFormat(i == 0 ?
-                                s.withPrefix(anchor.getPrefix().withComments(emptyList())) : s, p, parent));
+                        gen.set(i, autoFormat(i == 0 ? s.withPrefix(lineBreakBefore(anchor)) : s, p, parent));
                     } else {
                         gen.set(i, autoFormat(s, p, parent).withPrefix(leadingPrefix(anchor, i)));
                     }
@@ -147,6 +146,15 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                     default:
                         return gen;
                 }
+            }
+
+            /**
+             * A blank line above the anchor separates it from what precedes and stays with it, so a statement
+             * joining the anchor's line gets a single break at the same indent rather than that separation again.
+             */
+            private Space lineBreakBefore(Statement anchor) {
+                String whitespace = anchor.getPrefix().getWhitespace();
+                return Space.format("\n" + whitespace.substring(whitespace.lastIndexOf('\n') + 1));
             }
 
             private Space leadingPrefix(Statement anchor, int i) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -303,6 +303,35 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             }
 
             @Override
+            public J visitIf(J.If iff, Integer p) {
+                if (loc == ELSE_PREFIX && isScope(iff)) {
+                    List<Statement> gen = unsubstitute(templateParser.parseBlockStatements(
+                            new Cursor(getCursor(), insertionPoint), Statement.class, substitutedTemplate,
+                            substitutions.getTypeVariables(), loc, mode));
+                    if (gen.size() != 1) {
+                        throw new IllegalArgumentException("Expected a template that would generate exactly one " +
+                                                           "statement to become an else branch, but generated " + gen.size() +
+                                                           ". Template:\n" + substitutedTemplate);
+                    }
+                    Statement branch = gen.get(0);
+                    J.If.Else existing = iff.getElsePart();
+                    if (existing != null) {
+                        // Keep the chain: what this `if` used to fall through to now hangs off the new branch
+                        if (!(branch instanceof J.If)) {
+                            throw new IllegalArgumentException("Adding an else branch to an `if` that already has " +
+                                                               "one requires a template that produces an `if`, so that " +
+                                                               "the existing branch has somewhere to hang. Template:\n" + substitutedTemplate);
+                        }
+                        branch = ((J.If) branch).withElsePart(existing);
+                    }
+                    J.If.Else elsePart = new J.If.Else(randomId(), Space.SINGLE_SPACE, Markers.EMPTY,
+                            JRightPadded.build(branch.withPrefix(Space.SINGLE_SPACE)));
+                    return autoFormat(iff.withElsePart(elsePart), p, getCursor().getParentOrThrow());
+                }
+                return super.visitIf(iff, p);
+            }
+
+            @Override
             public J visitIdentifier(J.Identifier ident, Integer p) {
                 // ONLY for backwards compatibility, otherwise the same as expression replacement
                 if (loc == IDENTIFIER_PREFIX && isScope(ident)) {

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/CoordinateBuilder.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/CoordinateBuilder.java
@@ -171,6 +171,21 @@ public abstract class CoordinateBuilder {
         }
     }
 
+    public static class If extends Statement {
+        If(J.If tree) {
+            super(tree);
+        }
+
+        /**
+         * Adds a branch to this {@code if}: a template producing an {@code if} becomes an {@code else if},
+         * anything else a plain {@code else}. An existing {@code else} is chained onto the new branch
+         * rather than replaced.
+         */
+        public JavaCoordinates addElseBranch() {
+            return new JavaCoordinates(tree, Space.Location.ELSE_PREFIX, JavaCoordinates.Mode.AFTER, null);
+        }
+    }
+
     public static class Identifier extends Expression {
         public Identifier(J.Identifier tree) {
             super(tree);

--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -2750,8 +2750,8 @@ public interface J extends Tree {
 
         @Override
         @Transient
-        public CoordinateBuilder.Statement getCoordinates() {
-            return new CoordinateBuilder.Statement(this);
+        public CoordinateBuilder.If getCoordinates() {
+            return new CoordinateBuilder.If(this);
         }
 
         @ToString

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -587,6 +587,10 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
             J.Block body = (J.Block) requireNonNull(ktFunctionLiteral.getBodyExpression()).accept(this, data);
             body = body.withEnd(endFixAndSuffix(ktFunctionLiteral.getBodyExpression()));
+            if (body.getStatements().isEmpty()) {
+                // With no statement to own it, the body's whitespace is still what precedes the closing brace
+                body = body.withEnd(merge(body.getPrefix(), body.getEnd())).withPrefix(Space.EMPTY);
+            }
 
             return new J.Lambda(
                     randomId(),


### PR DESCRIPTION
Stacked on #8819, itself on #8818, #8812, #8810, #8805 and #8803. Review those first.

Six commits: a new coordinate, two defects it exposed, the two recipe sites that motivated them, and one line of dead code the fixes left behind. `DependencyConstraintToRule` now has no parser-based sites left.

## 1. A coordinate for an if's else branch

Extending an `else if` chain had no coordinate, so recipes built a `J.If.Else` by hand with a random id and a right-padded wrapper. `CoordinateBuilder.If` grows one method:

```java
public JavaCoordinates addElseBranch() {
    return new JavaCoordinates(tree, Space.Location.ELSE_PREFIX, JavaCoordinates.Mode.AFTER, null);
}
```

`ELSE_PREFIX` already existed, so the shared `Space.Location` enum is untouched.

**The coordinate takes a statement and the machinery decides what it means** — a `J.If` becomes `else if`, anything else a plain `else`. That shape is forced rather than chosen: a template produces statements and expressions, and `J.If.Else` is neither, so no parser can yield one.

Where the `if` already has an else, the existing branch is chained onto the new one, so a coordinate inserts *into* a chain rather than truncating it. A template producing a non-`if` when an else already exists has nowhere to hang the old branch, and says so with a specific diagnostic.

**No then-part coordinate.** `anIf.getThenPart().getCoordinates().replace()` already works through the generic Statement path, so a `replaceThenPart()` would be a synonym rather than a capability.

`JavaTemplateJavaExtension` gains a `visitIf`, about 29 lines, routed through the mixin's `autoFormat` override so `applyWithoutFormatting` is honoured like every other branch.

**Tested as Java, not only through Gradle.** Four tests in `JavaTemplateTest8Test` drive the coordinate directly through a `JavaIsoVisitor`: attaching an else to a bare `if`, inserting before an existing plain else and keeping it, a block template yielding a plain else, and the diagnostic.

## 2. An empty Kotlin lambda body's whitespace was on the wrong node

Converting the recipe exposed this immediately: `.kts` output lost the indent on a closing brace.

For a lambda body **with** statements, the parser puts the whitespace before `}` on the block's `end`, which is where the format visitors look. For an **empty** body it put that whitespace on the block's `prefix` instead, so it printed before anything inserted into the block rather than after:

```
{ details ->}         prefix=''       end=''
{ details ->\n    }   prefix='\n    ' end=''      wrong
{ details ->\n x\n }  prefix=''       end='\n    ' right
```

Printed output is identical for an untouched tree, which is why it survived: the characters are the same and only the attribution differs. It shows up the moment a recipe inserts into such a block.

Two recipes carry hand-applied `withEnd(Space.format("\n"))` to compensate, dating to the original Kotlin DSL support in #5158. This is the fourth time in this stack that a recipe-level workaround turned out to be covering a machinery gap, so it is fixed in the parser rather than compensated for a fifth time. Four lines.

**One expectation changes with it, and it is the only one in this PR.** `UpgradeTransitiveDependencyVersionTest.kotlinDslAddConstraintForPluginProvidedDependency` had baked in a blank line after `dependencies {`:

```kotlin
// before
dependencies {

    constraints {

// after
dependencies {
    constraints {
```

Its Groovy sibling twenty lines above expects no blank line. That blank line was the empty body's prefix printing ahead of the inserted statement's own, so the two DSLs now agree. `UpgradeTransitiveDependencyVersion` still carries its own `withEnd` workaround at line 776, which is now a no-op and can go separately.

## 3. The recipe that motivated both

`DependencyConstraintToRule.MaybeAddIf` parsed a scaffold in each DSL, where a leading `Object p = null` / `var p: Any = null` existed only so the closure parameter would resolve at parse time, then picked statement 1 out of the result.

Both go. The closure parameter travels as a `J.Identifier` parameter, so nothing needs to resolve it and the scaffold has no reason to exist. The two insertion sites each take a coordinate: `addElseBranch()` at the end of a chain, `firstStatement()` in an empty closure body. The group and artifact are parameters too, so the recipe interpolates nothing.

**No hand-applied marker, prefix or space.** The end space it used to apply to an empty Kotlin lambda body went with the parser fix. Its 6 tests pass unchanged, including `updateExistingResolutionStrategyBlock`, which is the else-if path.

Net −27 lines, and three imports gone.

## 4. An inserted statement repeated the anchor's blank line

Converting the second recipe site broke three `UpgradeTransitiveDependencyVersion` tests, which reach the same code path. Identical signature in all three: one extra blank line before the inserted statement.

In `spliceAround`, when the anchor begins its own line, the generated statement took the anchor's **whole** prefix while the anchor kept it as well, so an anchor preceded by a blank line had that separation emitted twice. A blank line above the anchor belongs to the anchor — it separates the anchor from what precedes — so the inserted statement now gets a single break at the anchor's indent.

Three recipes had hard-coded a line break to paper over this. Fixed at the source, and no expectation needed editing; all three went green on their own.

**The branch had no test coverage at all.** The three existing `spliceAround` tests use a single-statement file, which takes the other branch. A regression test pins it now. This path also serves ordinary Java block insertion, not only scripts, which is why both Java suites are in the table below.

## 5. `MaybeAddEachDependency`, the site blocked in #8819

It was reverted there because the Kotlin half produced a stray blank line and a collapsed brace. The parser fix in commit 2 closed that completely: the empty `{ details -> }` body now arrives with its whitespace on `end`, and the site converts in both DSLs with nothing hand-applied.

85 lines of hand-built parser, byte stream, statement picking and index arithmetic become a four line snippet, a template chosen by DSL, and one coordinate. Both index-zero prefix fix-ups go, since insertion handles that case. Net −54 lines.

**This was the file's last parser-based site, so `DependencyConstraintToRule` releases `requireParsed` entirely.** Three files still use it: `UpgradeTransitiveDependencyVersion`, `EnableDevelocityBuildCache` and `AddDependencyVisitor`.

## Tests

564 test classes across `rewrite-gradle`, `rewrite-kotlin`, `rewrite-java`, `rewrite-java-test` and `rewrite-groovy` report zero failures and zero errors.

| Suite | Tests |
|---|---|
| `:rewrite-java:test` | 716 |
| `:rewrite-java-test:test` | 2212 |
| `:rewrite-groovy:test` | 711 |
| `:rewrite-kotlin:test` | 1355 |
| `:rewrite-gradle:test` | 1328 |

`JavaTemplateTest8Test` 18, `DependencyConstraintToRuleTest` 6, `UpgradeTransitiveDependencyVersionTest` 48.

## Still on the parser

`UseJavaExtensionBlock`'s append path, which needs `moveCompatibility` to take the container rather than a detached list. `AddPluginVisitor`, whose parse is entangled with a hand-computed insertion index and license-header relocation. `AddDependencyVisitor` holds one long-lived parser for repeated work and should stay.

A sixth commit removes one `withEnd(Space.format("\n"))` in `UpgradeTransitiveDependencyVersion` that the parser fix in commit 2 turned into an identity operation.

It has to be here rather than on an earlier PR in the stack: on #8819's branch, without the parser fix, that line is still load-bearing, and removing it there fails `kotlinDslAddConstraintForPluginProvidedDependency`. Tested both ways rather than assumed.

The **sibling call further down the same file is not dead and stays.** It operates on a body the recipe has already filled, so the parser fix does not reach it, and removing it fails two Kotlin tests.

Worth noting how these interlock: on #8819 that `withEnd` is what produces the blank line the expectation encoded; here the parser produces the correct result without it, which is why the blank line came out of the expectation in commit 2. Same test throughout.

## A pattern, now five for five

Every machinery gap in this stack was found the same way: a recipe reaching for a marker, prefix or space by hand. The closure expansion three recipes dodged with pre-indented scaffolds. The dropped `OmitParentheses` behind a hand-set marker. The Kotlin empty-body whitespace behind two hand-applied end spaces. And now a duplicated blank line behind three hard-coded line breaks. In each case the workaround was load-bearing for exactly as long as nobody looked underneath it, and in each case the underlying branch had no test coverage.
