### PR TITLE
C#: parse Windows-targeted projects on Linux and macOS

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/SolutionParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/SolutionParserTests.cs
@@ -15,6 +15,7 @@
  */
 using LibGit2Sharp;
 using OpenRewrite.CSharp;
+using OpenRewrite.CSharp.NuGet;
 
 namespace OpenRewrite.Tests;
 
@@ -212,6 +213,49 @@ public class SolutionParserTests : IDisposable
 
         // Both files should be parsed since there's no git repo
         Assert.Equal(2, results.Count);
+    }
+
+    [Fact]
+    public async Task WindowsTargetedProjectResolvesReferencesOnAnyOperatingSystem()
+    {
+        WriteFile("Win.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0-windows</TargetFramework>
+                <UseWindowsForms>true</UseWindowsForms>
+              </PropertyGroup>
+            </Project>
+            """);
+        WriteFile("Widget.cs", "class Widget { }\n");
+
+        var parser = new SolutionParser();
+        var solution = await parser.LoadAsync(Path.Combine(_tempDir, "Win.csproj"));
+
+        // Without EnableWindowsTargeting the SDK fails evaluation with NETSDK1100 on
+        // Linux/macOS, and the project loads with no references to attest against.
+        var project = Assert.Single(solution.Projects);
+        Assert.NotEmpty(project.MetadataReferences);
+
+        var results = parser.ParseProject(solution, Path.Combine(_tempDir, "Win.csproj"), _tempDir);
+        Assert.Single(results);
+    }
+
+    [Fact]
+    public void WindowsTargetedProjectProducesRestoreGraph()
+    {
+        var csproj = WriteFile("MultiTarget.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFrameworks>net48;net10.0-windows</TargetFrameworks>
+                <UseWPF>true</UseWPF>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        var dgSpec = NuGetResolver.CreateDependencyGraphSpec(csproj);
+
+        Assert.NotNull(dgSpec);
+        Assert.NotEmpty(dgSpec.Projects);
     }
 
     [Fact]

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
@@ -183,6 +183,21 @@ public static class NuGetResolver
         }
     }
 
+    /// <summary>
+    /// Sets <c>EnableWindowsTargeting=true</c> on non-Windows hosts, where the SDK otherwise
+    /// fails every project with a Windows target platform (<c>net10.0-windows</c>, WPF/WinForms)
+    /// with <c>NETSDK1100</c>. Analysis never runs the produced binaries, so cross-targeting is
+    /// always safe here. Skipped when the variable is set in the environment: MSBuild already
+    /// seeds that as a property and an explicit choice must win over this default.
+    /// </summary>
+    public static void ApplyWindowsTargetingDefault(IDictionary<string, string> properties)
+    {
+        if (OperatingSystem.IsWindows() ||
+            !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("EnableWindowsTargeting")))
+            return;
+        properties["EnableWindowsTargeting"] = "true";
+    }
+
     // Serialize graph generation: concurrent SDK msbuild processes contend on obj/ and
     // the NuGet http cache without adding throughput for our one-at-a-time callers.
     private static readonly object BuildGate = new();
@@ -219,6 +234,7 @@ public static class NuGetResolver
                 // Avoid restore-time package imports polluting evaluation
                 ["ExcludeRestorePackageImports"] = "true",
             };
+            ApplyWindowsTargetingDefault(globalProps);
             if (extraGlobalProperties != null)
             {
                 foreach (var (k, v) in extraGlobalProperties)

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -242,6 +242,11 @@ public class SolutionParser
                 msbuildProperties["TargetFrameworkRootPath"] = buildAssets.TargetFrameworkRootPath;
         }
 
+        // Windows-targeted projects (net*-windows with WPF/WinForms or a Windows SDK version)
+        // otherwise fail evaluation with NETSDK1100 on Linux/macOS, and one failing project
+        // reference takes the reference metadata of everything that depends on it with it.
+        NuGetResolver.ApplyWindowsTargetingDefault(msbuildProperties);
+
         _restoredLockFiles = await SolutionRestore.RunAsync(path, hasPackagesConfig, msbuildProperties, ct);
 
         var sw = Stopwatch.StartNew();


### PR DESCRIPTION
Projects that pull a Windows targeting pack (`net*-windows` with `UseWPF`/`UseWindowsForms`, or a `windows10.x` TFM) fail with `NETSDK1100` on non-Windows hosts unless `EnableWindowsTargeting` is set, so restore graph generation produces nothing and `MSBuildWorkspace` resolves no references — which spreads to every project referencing the desktop one.

This sets `EnableWindowsTargeting=true` as a global property for both the `GenerateRestoreGraphFile` child build and `MSBuildWorkspace` when running off Windows. Analysis never runs the built output, so cross-targeting is always safe here; setting `EnableWindowsTargeting` in the environment opts out, since MSBuild seeds it as a property and an explicit choice should win.

Adds two `SolutionParserTests` covering reference resolution and restore graph generation for a Windows-targeted project on any OS.