### PR TITLE
Unspecified scope for managed dependency is all scopes

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -248,8 +248,11 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                         VersionComparator versionComparator = requireNonNull(versionValidation.getValue());
                         try {
                             // The version of the dependency currently in use (if any) might influence the version comparator
-                            // For example, "latest.patch" gives very different results depending on the version in use
-                            String currentVersion = getResolutionResult().findDependencies(convertedGroup, convertedArtifact, Scope.fromName(scope)).stream()
+                            // For example, "latest.patch" gives very different results depending on the version in use.
+                            // `scope` here is the *new* managed dependency's tag scope, not a filter for where to look
+                            // for the current version, so only apply it when explicitly set; otherwise search all scopes
+                            // rather than defaulting to Compile via Scope.fromName(null).
+                            String currentVersion = getResolutionResult().findDependencies(convertedGroup, convertedArtifact, scope == null ? null : Scope.fromName(scope)).stream()
                                     .map(ResolvedDependency::getVersion)
                                     .findFirst()
                                     .orElse(existingManagedDependencyVersion());

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -286,7 +286,7 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
             }
 
             private @Nullable String existingManagedDependencyVersion() {
-                return getResolutionResult().getPom().getDependencyManagement().stream()
+                String version = getResolutionResult().getPom().getDependencyManagement().stream()
                         .map(resolvedManagedDep -> {
                             if (resolvedManagedDep.matches(groupId, artifactId, type, classifier)) {
                                 return resolvedManagedDep.getGav().getVersion();
@@ -298,6 +298,20 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                             return null;
                         })
                         .filter(Objects::nonNull)
+                        .findFirst().orElse(null);
+                if (version != null) {
+                    return version;
+                }
+                // An already-added "import" entry whose target has no dependencyManagement of its own (e.g. a
+                // plain jar coordinate, rather than a real BOM) contributes nothing to the resolved dependency
+                // management above, so it can never be detected as already present that way - the resolved
+                // model only records imports via the managed dependencies they in turn contribute. Fall back to
+                // this pom's own raw (unexpanded) managed dependency declarations to detect that case, so the
+                // recipe doesn't keep re-adding an already-present import on every cycle.
+                return getResolutionResult().getPom().getRequested().getDependencyManagement().stream()
+                        .filter(ManagedDependency.Imported.class::isInstance)
+                        .filter(d -> Objects.equals(groupId, d.getGroupId()) && artifactId.equals(d.getArtifactId()))
+                        .map(ManagedDependency::getVersion)
                         .findFirst().orElse(null);
             }
         });

--- a/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/AddManagedDependency.java
@@ -247,12 +247,15 @@ public class AddManagedDependency extends ScanningRecipe<AddManagedDependency.Sc
                     if (versionValidation.isValid()) {
                         VersionComparator versionComparator = requireNonNull(versionValidation.getValue());
                         try {
-                            // The version of the dependency currently in use (if any) might influence the version comparator
+                            // The version of the dependency currently in use (if any) might influence the version comparator.
                             // For example, "latest.patch" gives very different results depending on the version in use.
-                            // `scope` here is the *new* managed dependency's tag scope, not a filter for where to look
-                            // for the current version, so only apply it when explicitly set; otherwise search all scopes
-                            // rather than defaulting to Compile via Scope.fromName(null).
-                            String currentVersion = getResolutionResult().findDependencies(convertedGroup, convertedArtifact, scope == null ? null : Scope.fromName(scope)).stream()
+                            // `scope` is not a dependency search scope: it's what scope to tag the *new* managed
+                            // dependency entry with, and has no bearing on which scope(s) the dependency is actually
+                            // used in elsewhere in the project. Filtering this lookup by Scope.fromName(scope) would be
+                            // wrong even for a resolvable scope value - e.g. tagging a new entry "provided" doesn't
+                            // mean the dependency's real current usage is provided-scoped too, it could be compile,
+                            // test, etc. So search across all scopes here, regardless of `scope`.
+                            String currentVersion = getResolutionResult().findDependencies(convertedGroup, convertedArtifact, null).stream()
                                     .map(ResolvedDependency::getVersion)
                                     .findFirst()
                                     .orElse(existingManagedDependencyVersion());

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
@@ -15,12 +15,17 @@
  */
 package org.openrewrite.maven;
 
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.Validated;
 import org.openrewrite.test.RewriteTest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.java.Assertions.mavenProject;
@@ -301,10 +306,12 @@ class AddManagedDependencyTest implements RewriteTest {
         );
     }
 
-    @Test
-    void fabricatesAncientVersionWhenTargetOnlyExistsInNonCompileScope() {
+    @ParameterizedTest
+    @NullSource
+    @ValueSource(strings = {"test", "provided", "runtime"})
+    void currentVersionLookupIgnoresTagScopeRegardlessOfValue(@Nullable String scope) {
         rewriteRun(
-          spec -> spec.recipe(new AddManagedDependency("com.tngtech.archunit", "archunit", "latest.patch", null,
+          spec -> spec.recipe(new AddManagedDependency("com.tngtech.archunit", "archunit", "latest.patch", scope,
             null, null, null, null, null, false)),
           pomXml(
             """
@@ -322,30 +329,65 @@ class AddManagedDependencyTest implements RewriteTest {
                 </dependencies>
               </project>
               """,
-            """
-              <project>
-                <groupId>com.mycompany.app</groupId>
-                <artifactId>my-app</artifactId>
-                <version>1</version>
-                <dependencyManagement>
-                  <dependencies>
-                    <dependency>
-                      <groupId>com.tngtech.archunit</groupId>
-                      <artifactId>archunit</artifactId>
-                      <version>1.3.2</version>
-                    </dependency>
-                  </dependencies>
-                </dependencyManagement>
-                <dependencies>
-                  <dependency>
-                    <groupId>com.tngtech.archunit</groupId>
-                    <artifactId>archunit-junit5</artifactId>
-                    <version>1.3.0</version>
-                    <scope>test</scope>
-                  </dependency>
-                </dependencies>
-              </project>
-              """
+            spec2 -> spec2.after(actual -> {
+                Matcher matcher = Pattern.compile("<groupId>com\\.tngtech\\.archunit</groupId>\\s*" +
+                  "<artifactId>archunit</artifactId>\\s*<version>1\\.3\\.(\\d+)</version>").matcher(actual);
+                assertThat(matcher.find()).as("expected a managed com.tngtech.archunit:archunit version of the " +
+                  "form 1.3.x, but was:\n%s", actual).isTrue();
+                int patch = Integer.parseInt(matcher.group(1));
+                assertThat(patch).as("expected the managed archunit version's patch number to be >= 2 (i.e. " +
+                  "newer than the real current version 1.3.0), but was 1.3.%d:\n%s", patch, actual).isGreaterThanOrEqualTo(2);
+                return scope == null ?
+                  """
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencyManagement>
+                      <dependencies>
+                        <dependency>
+                          <groupId>com.tngtech.archunit</groupId>
+                          <artifactId>archunit</artifactId>
+                          <version>1.3.%d</version>
+                        </dependency>
+                      </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.tngtech.archunit</groupId>
+                        <artifactId>archunit-junit5</artifactId>
+                        <version>1.3.0</version>
+                        <scope>test</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(patch) :
+                  """
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencyManagement>
+                      <dependencies>
+                        <dependency>
+                          <groupId>com.tngtech.archunit</groupId>
+                          <artifactId>archunit</artifactId>
+                          <version>1.3.%d</version>
+                          <scope>%s</scope>
+                        </dependency>
+                      </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.tngtech.archunit</groupId>
+                        <artifactId>archunit-junit5</artifactId>
+                        <version>1.3.0</version>
+                        <scope>test</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(patch, scope);
+            })
           )
         );
     }

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
@@ -302,6 +302,55 @@ class AddManagedDependencyTest implements RewriteTest {
     }
 
     @Test
+    void fabricatesAncientVersionWhenTargetOnlyExistsInNonCompileScope() {
+        rewriteRun(
+          spec -> spec.recipe(new AddManagedDependency("com.tngtech.archunit", "archunit", "latest.patch", null,
+            null, null, null, null, null, false)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.tngtech.archunit</groupId>
+                    <artifactId>archunit-junit5</artifactId>
+                    <version>1.3.0</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencyManagement>
+                  <dependencies>
+                    <dependency>
+                      <groupId>com.tngtech.archunit</groupId>
+                      <artifactId>archunit</artifactId>
+                      <version>1.3.2</version>
+                    </dependency>
+                  </dependencies>
+                </dependencyManagement>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.tngtech.archunit</groupId>
+                    <artifactId>archunit-junit5</artifactId>
+                    <version>1.3.0</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """
+          )
+        );
+    }
+
+    @Test
     void doesNotAddManagedDependencyIfTransitiveVersionIsTheSameAsRequested() {
         rewriteRun(
           spec -> spec.recipe(new AddManagedDependency("com.fasterxml.jackson.core", "jackson-databind", "2.18.0", null,

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/AddManagedDependencyTest.java
@@ -393,6 +393,66 @@ class AddManagedDependencyTest implements RewriteTest {
     }
 
     @Test
+    void currentVersionLookupIgnoresTagScopeRegardlessOfValueImport() {
+        rewriteRun(
+          spec -> spec.recipe(new AddManagedDependency("com.tngtech.archunit", "archunit", "latest.patch", "import",
+              "pom", null, null, null, null, false)),
+          pomXml(
+            """
+              <project>
+                <groupId>com.mycompany.app</groupId>
+                <artifactId>my-app</artifactId>
+                <version>1</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>com.tngtech.archunit</groupId>
+                    <artifactId>archunit-junit5</artifactId>
+                    <version>1.3.0</version>
+                    <scope>test</scope>
+                  </dependency>
+                </dependencies>
+              </project>
+              """,
+            spec2 -> spec2.after(actual -> {
+                Matcher matcher = Pattern.compile("<groupId>com\\.tngtech\\.archunit</groupId>\\s*" +
+                  "<artifactId>archunit</artifactId>\\s*<version>1\\.3\\.(\\d+)</version>").matcher(actual);
+                assertThat(matcher.find()).as("expected a managed com.tngtech.archunit:archunit version of the " +
+                  "form 1.3.x, but was:\n%s", actual).isTrue();
+                int patch = Integer.parseInt(matcher.group(1));
+                assertThat(patch).as("expected the managed archunit version's patch number to be >= 2 (i.e. " +
+                  "newer than the real current version 1.3.0), but was 1.3.%d:\n%s", patch, actual).isGreaterThanOrEqualTo(2);
+                return """
+                  <project>
+                    <groupId>com.mycompany.app</groupId>
+                    <artifactId>my-app</artifactId>
+                    <version>1</version>
+                    <dependencyManagement>
+                      <dependencies>
+                        <dependency>
+                          <groupId>com.tngtech.archunit</groupId>
+                          <artifactId>archunit</artifactId>
+                          <version>1.3.%d</version>
+                          <type>pom</type>
+                          <scope>import</scope>
+                        </dependency>
+                      </dependencies>
+                    </dependencyManagement>
+                    <dependencies>
+                      <dependency>
+                        <groupId>com.tngtech.archunit</groupId>
+                        <artifactId>archunit-junit5</artifactId>
+                        <version>1.3.0</version>
+                        <scope>test</scope>
+                      </dependency>
+                    </dependencies>
+                  </project>
+                  """.formatted(patch);
+            })
+          )
+        );
+    }
+
+    @Test
     void doesNotAddManagedDependencyIfTransitiveVersionIsTheSameAsRequested() {
         rewriteRun(
           spec -> spec.recipe(new AddManagedDependency("com.fasterxml.jackson.core", "jackson-databind", "2.18.0", null,


### PR DESCRIPTION
See the unit test.
`AddManagedDependency` with unspecified scope adds a dependency where initial version is `null`, (i.e. 0.0.0) hence if the parameter is the "latest.patch" one would end up with `0.0.X` for example