### PR TITLE
Python: preserve CRLF line endings when the RPC server reads a file

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -170,9 +170,10 @@ class ParserVisitor(ast.NodeVisitor):
             source, file_path, ty_client,
             source_lines=source_lines, line_byte_offsets=line_byte_offsets)
 
-        # Normalize line endings for the tokenizer (it rejects mixed \r\n and \n),
-        # but keep the original source for whitespace extraction
-        tokenizer_source = source.replace('\r\n', '\n') if '\r\n' in source else source
+        # The tokenizer wants a single line-ending spelling (it rejects a mix), so it
+        # gets \n throughout while the original source keeps the spelling that
+        # whitespace extraction reproduces. The row/col scans below step over all three.
+        tokenizer_source = source.replace('\r\n', '\n').replace('\r', '\n') if '\r' in source else source
         self._tokens, self._paren_pairs = self._build_tokens(
             tokenize(BytesIO(tokenizer_source.encode('utf-8')).readline)
         )
@@ -215,7 +216,7 @@ class ParserVisitor(ast.NodeVisitor):
                     col = 0
                     scan += 2
                     continue
-                elif self._source[scan] == '\n':
+                elif self._source[scan] in ('\n', '\r'):
                     row += 1
                     col = 0
                 else:
@@ -264,7 +265,7 @@ class ParserVisitor(ast.NodeVisitor):
                     col = 0
                     scan_end += 2
                     continue
-                elif self._source[scan_end] == '\n':
+                elif self._source[scan_end] in ('\n', '\r'):
                     row += 1
                     col = 0
                 else:

--- a/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_version_detect.py
@@ -82,8 +82,9 @@ def detect_from_source(source: str) -> Optional[str]:
         source = source[1:]
 
     # Inspect only the first two lines — these are the only places PEP-263
-    # and shebang declarations are recognized by Python itself.
-    lines = source.split("\n", 2)[:2]
+    # and shebang declarations are recognized by Python itself. Any of the three
+    # line endings ends a line, so a file using \r throughout has more than one.
+    lines = source.replace("\r\n", "\n").replace("\r", "\n").split("\n", 2)[:2]
 
     for line in lines:
         m = _MAGIC_COMMENT_RE.search(line)

--- a/rewrite-python/rewrite/src/rewrite/result.py
+++ b/rewrite-python/rewrite/src/rewrite/result.py
@@ -7,5 +7,7 @@ class Result:
     def diff(before: str, after: str, path: Path) -> str:
         old_lines = before.splitlines(keepends=True)
         new_lines = after.splitlines(keepends=True)
-        diff = difflib.unified_diff(old_lines, new_lines, fromfile=str(path), tofile=str(path), lineterm='')
+        # The lines keep their own terminators, so the headers need theirs too
+        # (the difflib default) or they run into the content that follows.
+        diff = difflib.unified_diff(old_lines, new_lines, fromfile=str(path), tofile=str(path))
         return ''.join(diff)

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -359,6 +359,17 @@ def generate_id() -> str:
     return str(uuid4())
 
 
+def _source_path(path: str, relative_to: Optional[str]) -> Path:
+    """The path an LST carries: relative to the project root when it sits under it."""
+    source_path = Path(path)
+    if relative_to is not None:
+        try:
+            source_path = source_path.relative_to(relative_to)
+        except ValueError:
+            pass  # path is not under relative_to, keep absolute
+    return source_path
+
+
 def parse_python_file(path: str, relative_to: Optional[str] = None, ty_client=None,
                       language_level: Optional[str] = None,
                       project_language_level: Optional[str] = None,
@@ -402,13 +413,7 @@ def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optio
         or _python_version
     )
 
-    # Compute the source_path that will be stored on the LST
-    source_path = Path(path)
-    if relative_to is not None:
-        try:
-            source_path = source_path.relative_to(relative_to)
-        except ValueError:
-            pass  # path is not under relative_to, keep absolute
+    source_path = _source_path(path, relative_to)
 
     try:
         from rewrite import Markers
@@ -516,12 +521,7 @@ def _create_quark(path: str, relative_to: Optional[str]) -> dict:
     from ``sourcePath`` locally, so no content crosses the wire.
     """
     from rewrite import random_id
-    source_path = Path(path)
-    if relative_to is not None:
-        try:
-            source_path = source_path.relative_to(relative_to)
-        except ValueError:
-            pass  # path is not under relative_to, keep absolute
+    source_path = _source_path(path, relative_to)
     return {
         'id': str(random_id()),
         'sourceFileType': 'org.openrewrite.quark.Quark',
@@ -630,6 +630,7 @@ def handle_parse(params: dict) -> List[str]:
             # The client pairs this list to its input list by position, so every
             # input owes the batch one result — a file too broken to read included.
             path = '<unknown>'
+            source = ''
             try:
                 if isinstance(input_item, str):
                     path = input_item
@@ -639,10 +640,11 @@ def handle_parse(params: dict) -> List[str]:
                                                check_print=check_print)
                 elif input_item.get('text') is None and input_item.get('source') is None:
                     # An input carrying no text names a file the peer reads itself.
-                    path = (input_item.get('path') or input_item.get('sourcePath') or
-                            input_item.get('relativePath'))
-                    if path is None:
+                    named = (input_item.get('path') or input_item.get('sourcePath') or
+                             input_item.get('relativePath'))
+                    if named is None:
                         raise ValueError('input carries neither source text nor a path')
+                    path = named
                     result = parse_python_file(path, relative_to, ty_client,
                                                language_level=language_level,
                                                project_language_level=project_language_level,
@@ -674,7 +676,7 @@ def handle_parse(params: dict) -> List[str]:
                                                      check_print=check_print)
             except Exception as e:
                 logger.exception(f"Error parsing {path}: {e}")
-                result = _create_parse_error(str(path), str(e))
+                result = _create_parse_error(str(_source_path(path, relative_to)), str(e), source)
             results.append(result['id'])
     finally:
         if ty_client is not None:
@@ -764,7 +766,9 @@ def handle_parse_project(params: dict) -> List[dict]:
                                            check_print=check_print)
                 results.append(result)
             except Exception as e:
-                logger.error(f"Error parsing {path}: {e}")
+                logger.exception(f"Error parsing {path}: {e}")
+                # Every file the walk finds is accounted for in the response.
+                results.append(_create_parse_error(str(_source_path(path, relative_to)), str(e)))
     finally:
         if ty_client is not None:
             ty_client.shutdown()

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -44,8 +44,11 @@ except ImportError:  # not available on Windows
     resource = None
 
 from rewrite.discovery import RecipeAttribution, RecipeName, _normalize_package_name
+from rewrite.execution import ExecutionContext
 from rewrite.python._version_detect import (
     detect_from_project, detect_from_source, requested_python_version, ty_python_version)
+from rewrite.python.printer import PythonPrinter
+from rewrite.result import Result
 from rewrite.rpc.reference import ReferenceMap
 
 # Deeply nested LST nodes (e.g., 256 implicitly concatenated strings) can
@@ -358,18 +361,23 @@ def generate_id() -> str:
 
 def parse_python_file(path: str, relative_to: Optional[str] = None, ty_client=None,
                       language_level: Optional[str] = None,
-                      project_language_level: Optional[str] = None) -> dict:
+                      project_language_level: Optional[str] = None,
+                      check_print: bool = True) -> dict:
     """Parse a Python file and return its LST."""
-    with open(path, 'r', encoding='utf-8') as f:
+    # newline='' disables universal-newline translation, so the LST holds the
+    # file's own line endings and prints back byte-identically.
+    with open(path, 'r', encoding='utf-8', newline='') as f:
         source = f.read()
     return parse_python_source(source, path, relative_to, ty_client,
                                language_level=language_level,
-                               project_language_level=project_language_level)
+                               project_language_level=project_language_level,
+                               check_print=check_print)
 
 
 def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optional[str] = None, ty_client=None,
                         language_level: Optional[str] = None,
-                        project_language_level: Optional[str] = None) -> dict:
+                        project_language_level: Optional[str] = None,
+                        check_print: bool = True) -> dict:
     """Parse Python source code and return its LST.
 
     The parser used depends on the effective language version, resolved in
@@ -430,6 +438,15 @@ def parse_python_source(source: str, path: str = "<unknown>", relative_to: Optio
             cu = ParserVisitor(source, path, ty_client).visit(tree)
 
         cu = cu.replace(source_path=source_path, markers=Markers.EMPTY)
+
+        if check_print:
+            printed = PythonPrinter().print(cu)
+            if printed != source:
+                return _create_parse_error(
+                    str(source_path),
+                    f"{source_path} is not print idempotent. \n"
+                    f"{Result.diff(source, printed, source_path)}",
+                    source)
 
         # Store and return
         obj_id = str(cu.id)
@@ -544,6 +561,18 @@ def _infer_project_root(inputs: list) -> Optional[str]:
 _last_dependency_path: Optional[str] = None
 
 
+def _require_print_equals_input(options: dict) -> bool:
+    """Whether parse results must print back to their input, which they must
+    unless the client says otherwise. Option maps are loosely typed across
+    peers, so both the string and the bool form count."""
+    value = options.get(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() not in ('false', '0', 'no', 'off')
+    return True
+
+
 def handle_parse(params: dict) -> List[str]:
     """Handle a Parse RPC request."""
     import tempfile
@@ -555,6 +584,7 @@ def handle_parse(params: dict) -> List[str]:
     # Absent for older clients; absent or unknown keys are silently ignored.
     options = params.get('options') or {}
     language_level = options.get('languageLevel')
+    check_print = _require_print_equals_input(options)
     # Path to a virtual environment with the project's dependencies installed,
     # provisioned and forwarded by the caller (the CLI build step in production;
     # a test/template helper in-repo). Points ty-types at the deps so supertypes
@@ -600,13 +630,23 @@ def handle_parse(params: dict) -> List[str]:
             if isinstance(input_item, str):
                 result = parse_python_file(input_item, relative_to, ty_client,
                                            language_level=language_level,
-                                           project_language_level=project_language_level)
-            elif 'path' in input_item:
-                result = parse_python_file(input_item['path'], relative_to, ty_client,
+                                           project_language_level=project_language_level,
+                                           check_print=check_print)
+            elif input_item.get('text') is None and input_item.get('source') is None:
+                # An input carrying no text names a file the peer reads itself.
+                path = (input_item.get('path') or input_item.get('sourcePath') or
+                        input_item.get('relativePath'))
+                if path is None:
+                    logger.warning(f"  [{i}] input has neither source text nor a path")
+                    continue
+                result = parse_python_file(path, relative_to, ty_client,
                                            language_level=language_level,
-                                           project_language_level=project_language_level)
-            elif 'text' in input_item or 'source' in input_item:
-                source = input_item.get('text') if 'text' in input_item else input_item.get('source')
+                                           project_language_level=project_language_level,
+                                           check_print=check_print)
+            else:
+                source = input_item.get('text')
+                if source is None:
+                    source = input_item.get('source')
                 path = input_item.get('sourcePath') or input_item.get('relativePath', '<unknown>')
                 # For relative paths, write the source under the project root
                 # (tmpdir or relative_to) so ty-types can resolve imports from
@@ -615,18 +655,18 @@ def handle_parse(params: dict) -> List[str]:
                 if base_dir and not os.path.isabs(path):
                     disk_path = os.path.join(base_dir, path)
                     os.makedirs(os.path.dirname(disk_path), exist_ok=True)
-                    with open(disk_path, 'w', encoding='utf-8') as f:
+                    # ty must read the same bytes the LST was built from.
+                    with open(disk_path, 'w', encoding='utf-8', newline='') as f:
                         f.write(source)
                     result = parse_python_source(source, disk_path, base_dir, ty_client,
                                                  language_level=language_level,
-                                                 project_language_level=project_language_level)
+                                                 project_language_level=project_language_level,
+                                                 check_print=check_print)
                 else:
                     result = parse_python_source(source, path, relative_to, ty_client,
                                                  language_level=language_level,
-                                                 project_language_level=project_language_level)
-            else:
-                logger.warning(f"  [{i}] unknown input type: {type(input_item)}")
-                continue
+                                                 project_language_level=project_language_level,
+                                                 check_print=check_print)
             results.append(result['id'])
     finally:
         if ty_client is not None:
@@ -675,6 +715,7 @@ def handle_parse_project(params: dict) -> List[dict]:
     # Per-request explicit override (mirror of the Parse RPC options carrier).
     options = params.get('options') or {}
     language_level = options.get('languageLevel')
+    check_print = _require_print_equals_input(options)
     # Caller-provisioned dependency environment for ty-types (see handle_parse).
     dependency_path = params.get('dependencyPath')
     if dependency_path:
@@ -711,7 +752,8 @@ def handle_parse_project(params: dict) -> List[dict]:
             try:
                 result = parse_python_file(path, relative_to, ty_client,
                                            language_level=language_level,
-                                           project_language_level=project_language_level)
+                                           project_language_level=project_language_level,
+                                           check_print=check_print)
                 results.append(result)
             except Exception as e:
                 logger.error(f"Error parsing {path}: {e}")

--- a/rewrite-python/rewrite/src/rewrite/rpc/server.py
+++ b/rewrite-python/rewrite/src/rewrite/rpc/server.py
@@ -626,47 +626,55 @@ def handle_parse(params: dict) -> List[str]:
         ty_client = None  # ty-types not available
 
     try:
-        for i, input_item in enumerate(inputs):
-            if isinstance(input_item, str):
-                result = parse_python_file(input_item, relative_to, ty_client,
-                                           language_level=language_level,
-                                           project_language_level=project_language_level,
-                                           check_print=check_print)
-            elif input_item.get('text') is None and input_item.get('source') is None:
-                # An input carrying no text names a file the peer reads itself.
-                path = (input_item.get('path') or input_item.get('sourcePath') or
-                        input_item.get('relativePath'))
-                if path is None:
-                    logger.warning(f"  [{i}] input has neither source text nor a path")
-                    continue
-                result = parse_python_file(path, relative_to, ty_client,
-                                           language_level=language_level,
-                                           project_language_level=project_language_level,
-                                           check_print=check_print)
-            else:
-                source = input_item.get('text')
-                if source is None:
-                    source = input_item.get('source')
-                path = input_item.get('sourcePath') or input_item.get('relativePath', '<unknown>')
-                # For relative paths, write the source under the project root
-                # (tmpdir or relative_to) so ty-types can resolve imports from
-                # the project's .venv and dependencies.
-                base_dir = tmpdir or relative_to
-                if base_dir and not os.path.isabs(path):
-                    disk_path = os.path.join(base_dir, path)
-                    os.makedirs(os.path.dirname(disk_path), exist_ok=True)
-                    # ty must read the same bytes the LST was built from.
-                    with open(disk_path, 'w', encoding='utf-8', newline='') as f:
-                        f.write(source)
-                    result = parse_python_source(source, disk_path, base_dir, ty_client,
-                                                 language_level=language_level,
-                                                 project_language_level=project_language_level,
-                                                 check_print=check_print)
+        for input_item in inputs:
+            # The client pairs this list to its input list by position, so every
+            # input owes the batch one result — a file too broken to read included.
+            path = '<unknown>'
+            try:
+                if isinstance(input_item, str):
+                    path = input_item
+                    result = parse_python_file(path, relative_to, ty_client,
+                                               language_level=language_level,
+                                               project_language_level=project_language_level,
+                                               check_print=check_print)
+                elif input_item.get('text') is None and input_item.get('source') is None:
+                    # An input carrying no text names a file the peer reads itself.
+                    path = (input_item.get('path') or input_item.get('sourcePath') or
+                            input_item.get('relativePath'))
+                    if path is None:
+                        raise ValueError('input carries neither source text nor a path')
+                    result = parse_python_file(path, relative_to, ty_client,
+                                               language_level=language_level,
+                                               project_language_level=project_language_level,
+                                               check_print=check_print)
                 else:
-                    result = parse_python_source(source, path, relative_to, ty_client,
-                                                 language_level=language_level,
-                                                 project_language_level=project_language_level,
-                                                 check_print=check_print)
+                    source = input_item.get('text')
+                    if source is None:
+                        source = input_item.get('source')
+                    path = (input_item.get('sourcePath') or input_item.get('path') or
+                            input_item.get('relativePath', '<unknown>'))
+                    # For relative paths, write the source under the project root
+                    # (tmpdir or relative_to) so ty-types can resolve imports from
+                    # the project's .venv and dependencies.
+                    base_dir = tmpdir or relative_to
+                    if base_dir and not os.path.isabs(path):
+                        disk_path = os.path.join(base_dir, path)
+                        os.makedirs(os.path.dirname(disk_path), exist_ok=True)
+                        # ty must read the same bytes the LST was built from.
+                        with open(disk_path, 'w', encoding='utf-8', newline='') as f:
+                            f.write(source)
+                        result = parse_python_source(source, disk_path, base_dir, ty_client,
+                                                     language_level=language_level,
+                                                     project_language_level=project_language_level,
+                                                     check_print=check_print)
+                    else:
+                        result = parse_python_source(source, path, relative_to, ty_client,
+                                                     language_level=language_level,
+                                                     project_language_level=project_language_level,
+                                                     check_print=check_print)
+            except Exception as e:
+                logger.exception(f"Error parsing {path}: {e}")
+                result = _create_parse_error(str(path), str(e))
             results.append(result['id'])
     finally:
         if ty_client is not None:

--- a/rewrite-python/rewrite/tests/python/version_detect_test.py
+++ b/rewrite-python/rewrite/tests/python/version_detect_test.py
@@ -69,8 +69,9 @@ class TestSourceDetection:
         src = "#!/usr/bin/env python\n# -*- python: 2.7 -*-\nx = 1\n"
         assert detect_from_source(src) == "2.7"
 
-    def test_magic_comment_not_after_line_two(self):
-        src = "# foo\n# bar\n# -*- python: 2 -*-\n"
+    @pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"], ids=["lf", "crlf", "cr"])
+    def test_magic_comment_not_after_line_two(self, newline):
+        src = f"# foo{newline}# bar{newline}# -*- python: 2 -*-{newline}"
         assert detect_from_source(src) is None
 
     def test_magic_comment_beats_shebang(self):

--- a/rewrite-python/rewrite/tests/rpc/test_parse_inputs.py
+++ b/rewrite-python/rewrite/tests/rpc/test_parse_inputs.py
@@ -52,14 +52,21 @@ def test_a_file_keeps_its_own_line_endings(tmp_path, newline):
     assert PythonPrinter().print(_parse(path)) == source
 
 
-def test_an_unreadable_file_costs_only_its_own_slot(crlf_file):
+def test_every_input_gets_a_slot_whatever_is_wrong_with_it(crlf_file):
     ids = handle_parse({"inputs": [{"sourcePath": str(crlf_file)},
-                                   {"sourcePath": str(crlf_file.parent / "gone.py")}],
+                                   {"sourcePath": str(crlf_file.parent / "gone.py")},
+                                   {"sourcePath": None}],
                         "relativeTo": str(crlf_file.parent)})
 
-    assert len(ids) == 2
+    assert len(ids) == 3
     assert PythonPrinter().print(local_objects[ids[0]]) == CRLF_SOURCE
+
+    # An error result carries the same project-relative path a parsed one would.
     assert isinstance(local_objects[ids[1]], ParseError)
+    assert str(local_objects[ids[1]].source_path) == "gone.py"
+
+    assert isinstance(local_objects[ids[2]], ParseError)
+    assert str(local_objects[ids[2]].source_path) == "<unknown>"
 
 
 def test_parse_that_loses_source_becomes_a_parse_error(crlf_file, monkeypatch):
@@ -73,6 +80,16 @@ def test_the_print_check_is_off_when_the_client_says_so(crlf_file, monkeypatch):
     monkeypatch.setattr(server, "PythonPrinter", _LosingPrinter)
     options = {"org.openrewrite.requirePrintEqualsInput": "false"}
     assert not isinstance(_parse(crlf_file, options), ParseError)
+
+
+def test_a_project_parse_reports_a_file_it_cannot_read(crlf_file):
+    # Latin-1 bytes the UTF-8 read rejects.
+    (crlf_file.parent / "bad.py").write_bytes(b"x = '\xe9'\n")
+
+    parsed = {item["sourcePath"]: item["sourceFileType"].rsplit(".", 1)[-1]
+              for item in handle_parse_project({"projectPath": str(crlf_file.parent)})}
+
+    assert parsed == {"crlf.py": "Py$CompilationUnit", "bad.py": "ParseError"}
 
 
 def test_a_project_parse_honours_the_print_check_option(crlf_file, monkeypatch):

--- a/rewrite-python/rewrite/tests/rpc/test_parse_inputs.py
+++ b/rewrite-python/rewrite/tests/rpc/test_parse_inputs.py
@@ -1,0 +1,71 @@
+# Copyright 2025 the original author or authors.
+#
+# Licensed under the Moderne Source Available License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://docs.moderne.io/licensing/moderne-source-available-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Parse inputs that name a file the server reads itself.
+
+The parser and printer carry ``\\r\\n`` through when handed source text, so
+only an input read off disk covers the read that can lose it.
+"""
+import pytest
+
+from rewrite.parser import ParseError
+from rewrite.python.printer import PythonPrinter
+from rewrite.rpc import server
+from rewrite.rpc.server import handle_parse, local_objects
+
+CRLF_SOURCE = "import sys\r\n\r\n\r\ndef greet(name):\r\n    # a comment\r\n    print(name)\r\n"
+
+
+@pytest.fixture
+def crlf_file(tmp_path):
+    path = tmp_path / "crlf.py"
+    path.write_bytes(CRLF_SOURCE.encode("utf-8"))
+    return path
+
+
+def _parse(path, options=None):
+    # The shape a JVM peer sends for a file input: a path, and no source text.
+    ids = handle_parse({"inputs": [{"sourcePath": str(path)}],
+                        "relativeTo": str(path.parent),
+                        "options": options or {}})
+    assert len(ids) == 1
+    return local_objects[ids[0]]
+
+
+def test_file_input_is_read_from_disk_preserving_crlf(crlf_file):
+    assert PythonPrinter().print(_parse(crlf_file)) == CRLF_SOURCE
+
+
+def test_parse_that_loses_source_becomes_a_parse_error(crlf_file, monkeypatch):
+    monkeypatch.setattr(server, "PythonPrinter", _LosingPrinter)
+    parsed = _parse(crlf_file)
+    assert isinstance(parsed, ParseError)
+    assert "is not print idempotent" in _exception_message(parsed)
+
+
+def test_the_print_check_is_off_when_the_client_says_so(crlf_file, monkeypatch):
+    monkeypatch.setattr(server, "PythonPrinter", _LosingPrinter)
+    options = {"org.openrewrite.requirePrintEqualsInput": "false"}
+    assert not isinstance(_parse(crlf_file, options), ParseError)
+
+
+class _LosingPrinter:
+    """Stands in for a printer that drops part of its input."""
+
+    def print(self, _cu):
+        return ""
+
+
+def _exception_message(parse_error):
+    return parse_error.markers.markers[0].message

--- a/rewrite-python/rewrite/tests/rpc/test_parse_inputs.py
+++ b/rewrite-python/rewrite/tests/rpc/test_parse_inputs.py
@@ -22,7 +22,7 @@ import pytest
 from rewrite.parser import ParseError
 from rewrite.python.printer import PythonPrinter
 from rewrite.rpc import server
-from rewrite.rpc.server import handle_parse, local_objects
+from rewrite.rpc.server import handle_parse, handle_parse_project, local_objects
 
 CRLF_SOURCE = "import sys\r\n\r\n\r\ndef greet(name):\r\n    # a comment\r\n    print(name)\r\n"
 
@@ -43,8 +43,23 @@ def _parse(path, options=None):
     return local_objects[ids[0]]
 
 
-def test_file_input_is_read_from_disk_preserving_crlf(crlf_file):
-    assert PythonPrinter().print(_parse(crlf_file)) == CRLF_SOURCE
+@pytest.mark.parametrize("newline", ["\r\n", "\r"], ids=["crlf", "cr"])
+def test_a_file_keeps_its_own_line_endings(tmp_path, newline):
+    source = CRLF_SOURCE.replace("\r\n", newline)
+    path = tmp_path / "endings.py"
+    path.write_bytes(source.encode("utf-8"))
+
+    assert PythonPrinter().print(_parse(path)) == source
+
+
+def test_an_unreadable_file_costs_only_its_own_slot(crlf_file):
+    ids = handle_parse({"inputs": [{"sourcePath": str(crlf_file)},
+                                   {"sourcePath": str(crlf_file.parent / "gone.py")}],
+                        "relativeTo": str(crlf_file.parent)})
+
+    assert len(ids) == 2
+    assert PythonPrinter().print(local_objects[ids[0]]) == CRLF_SOURCE
+    assert isinstance(local_objects[ids[1]], ParseError)
 
 
 def test_parse_that_loses_source_becomes_a_parse_error(crlf_file, monkeypatch):
@@ -58,6 +73,20 @@ def test_the_print_check_is_off_when_the_client_says_so(crlf_file, monkeypatch):
     monkeypatch.setattr(server, "PythonPrinter", _LosingPrinter)
     options = {"org.openrewrite.requirePrintEqualsInput": "false"}
     assert not isinstance(_parse(crlf_file, options), ParseError)
+
+
+def test_a_project_parse_honours_the_print_check_option(crlf_file, monkeypatch):
+    monkeypatch.setattr(server, "PythonPrinter", _LosingPrinter)
+
+    def types(options):
+        return [item["sourceFileType"]
+                for item in handle_parse_project({"projectPath": str(crlf_file.parent),
+                                                  "options": options})]
+
+    assert types({}) == ["org.openrewrite.tree.ParseError"]
+
+    assert types({"org.openrewrite.requirePrintEqualsInput": "false"}) == [
+        "org.openrewrite.python.tree.Py$CompilationUnit"]
 
 
 class _LosingPrinter:

--- a/rewrite-python/src/main/java/org/openrewrite/python/PythonParser.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/PythonParser.java
@@ -34,8 +34,6 @@ import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import static java.util.Collections.singletonMap;
-
 /**
  * Parser for Python source files.
  * <p>
@@ -80,9 +78,8 @@ public class PythonParser implements Parser {
         Stream<SourceFile> smallFileStream = Stream.empty();
         if (!smallFiles.isEmpty()) {
             PythonValidator<Integer> validator = new PythonValidator<>();
-            Map<String, String> options = languageLevel != null
-                    ? singletonMap("languageLevel", languageLevel.version())
-                    : null;
+            Map<String, String> options = PythonRewriteRpc.parseOptions(ctx,
+                    languageLevel == null ? null : languageLevel.version());
             smallFileStream = PythonRewriteRpc.getOrStart().parse(smallFiles, relativeTo, this,
                     Py.CompilationUnit.class.getName(), ctx, options).map(source -> {
                 try {

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/ParseProject.java
@@ -21,6 +21,7 @@ import org.openrewrite.rpc.request.RpcRequest;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 
 /**
  * RPC request to parse an entire Python project.
@@ -60,4 +61,11 @@ class ParseProject implements RpcRequest {
      */
     @Nullable
     Path dependencyPath;
+
+    /**
+     * Parser options the server interprets by key, ignoring the ones it does not
+     * recognize. A peer that sends none gets the server's own defaults.
+     */
+    @Nullable
+    Map<String, String> options;
 }

--- a/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
+++ b/rewrite-python/src/main/java/org/openrewrite/python/rpc/PythonRewriteRpc.java
@@ -143,6 +143,30 @@ public class PythonRewriteRpc extends RewriteRpc {
     }
 
     /**
+     * Parser options forwarded to the Python server with every parse request, carrying
+     * this context's {@link ExecutionContext#REQUIRE_PRINT_EQUALS_INPUT} setting.
+     */
+    public static Map<String, String> parseOptions(ExecutionContext ctx) {
+        return parseOptions(ctx, null);
+    }
+
+    /**
+     * The same options, plus the per-parse language version a {@link PythonParser} carries.
+     *
+     * @param languageLevel The version string to parse with, or {@code null} to leave the
+     *                      server on its own default.
+     */
+    public static Map<String, String> parseOptions(ExecutionContext ctx, @Nullable String languageLevel) {
+        Map<String, String> options = new HashMap<>();
+        options.put(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT,
+                String.valueOf(ctx.getMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, true)));
+        if (languageLevel != null) {
+            options.put("languageLevel", languageLevel);
+        }
+        return options;
+    }
+
+    /**
      * Parses an entire Python project directory.
      * Discovers and parses all relevant source files.
      *
@@ -217,7 +241,7 @@ public class PythonRewriteRpc extends RewriteRpc {
             public boolean tryAdvance(Consumer<? super SourceFile> action) {
                 if (response == null) {
                     parsingListener.intermediateMessage("Starting project parsing: " + projectPath);
-                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo, dependencyPath), ParseProjectResponse.class);
+                    response = send("ParseProject", new ParseProject(projectPath, exclusions, relativeTo, dependencyPath, parseOptions(ctx)), ParseProjectResponse.class);
                     parsingListener.intermediateMessage(String.format("Discovered %,d files to parse", response.size()));
                 }
 

--- a/rewrite-python/src/test/java/org/openrewrite/python/PythonParserTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/PythonParserTest.java
@@ -18,6 +18,9 @@ package org.openrewrite.python;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
+import org.junit.jupiter.api.io.TempDir;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Parser;
 import org.openrewrite.SourceFile;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
@@ -25,6 +28,12 @@ import org.openrewrite.java.tree.J;
 import org.openrewrite.python.tree.Py;
 import org.openrewrite.test.RewriteTest;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.python.Assertions.python;
 
@@ -155,5 +164,23 @@ class PythonParserTest implements RewriteTest {
             softly.assertThat(sf.getMarkers().getMarkers()).isEmpty();
             softly.assertThat(sf.printAll()).isEqualTo(source);
         });
+    }
+
+    @Test
+    void crlfFileOnDiskPrintsBackIdentically(@TempDir Path tempDir) throws IOException {
+        // A file input reaches the RPC server as a path it reads itself, which
+        // the source text of the tests above never exercises.
+        String source = "import sys\r\n\r\n\r\ndef greet(name):\r\n    # a comment\r\n    print(name)\r\n";
+        Path file = tempDir.resolve("crlf.py");
+        Files.write(file, source.getBytes(UTF_8));
+
+        SourceFile sf = PythonParser.builder().build()
+          .parseInputs(singletonList(Parser.Input.fromFile(file)), tempDir,
+            new InMemoryExecutionContext(Throwable::printStackTrace))
+          .findFirst()
+          .orElseThrow();
+
+        assertThat(sf).isInstanceOf(Py.CompilationUnit.class);
+        assertThat(sf.printAll()).isEqualTo(source);
     }
 }

--- a/rewrite-python/src/test/java/org/openrewrite/python/rpc/PythonParseOptionsTest.java
+++ b/rewrite-python/src/test/java/org/openrewrite/python/rpc/PythonParseOptionsTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.python.rpc;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PythonParseOptionsTest {
+
+    @Test
+    void printIdempotencyIsRequestedByDefault() {
+        assertThat(PythonRewriteRpc.parseOptions(new InMemoryExecutionContext()))
+                .containsEntry(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "true");
+    }
+
+    @Test
+    void printIdempotencyFollowsTheExecutionContext() {
+        ExecutionContext ctx = new InMemoryExecutionContext();
+        ctx.putMessage(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, false);
+
+        assertThat(PythonRewriteRpc.parseOptions(ctx))
+                .containsEntry(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false");
+
+        assertThat(PythonRewriteRpc.parseOptions(ctx, "2.7"))
+                .containsEntry(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false")
+                .containsEntry("languageLevel", "2.7");
+    }
+
+    /**
+     * The server matches this key by its literal spelling, and a spelling it does not
+     * recognize reads as the default rather than as an error — so a rename on either
+     * side turns the check silently back on instead of failing.
+     */
+    @Test
+    void theOptionsFieldCarriesTheKeyLiteralThePythonServerMatches() throws Exception {
+        assertThat(new ObjectMapper().writeValueAsString(new ParseProject(Paths.get("."), null, null, null,
+                Collections.singletonMap(ExecutionContext.REQUIRE_PRINT_EQUALS_INPUT, "false"))))
+                .contains("\"options\":{\"org.openrewrite.requirePrintEqualsInput\":\"false\"}");
+    }
+}


### PR DESCRIPTION
A CRLF Python file does not survive a parse. `printAll()` on a freshly parsed, unmodified `Py.CompilationUnit` comes back shorter than the file by exactly its CRLF count — every `\r` is gone. Any recipe that edits such a file rewrites the whole thing to LF, so the diff touches every line. Three files from public repos, parsed and printed with no recipe applied:

| file | on disk | printed | delta | CRLFs |
|---|---|---|---|---|
| `tests/odm/test_json_schema_generation.py` (BeanieODM/beanie@226b3cd) | 3464 | 3358 | 106 | 106 |
| `tests/fastapi/test_openapi_schema_generation.py` (same repo) | 470 | 451 | 19 | 19 |
| `tests/test_main.py` (fastapi/sqlmodel@7fec3bc) | 7385 | 7167 | 218 | 218 |

## Mechanism

The LST was never at fault — `ParserVisitor` already scans the original source when it collects whitespace and rewrites NEWLINE/NL token text back to the source spelling. The loss happened one layer earlier, in the server's read:

```python
with open(path, 'r', encoding='utf-8') as f:   # newline=None
```

`newline=None` is universal-newlines mode: it translates `\r\n` and lone `\r` to `\n` while decoding, so the parser never saw a `\r`. Handing the parser untranslated text is the core of the fix.

```python
>>> open(p, 'r', encoding='utf-8').read()
'x = 1\ny = 2\n'
>>> open(p, 'r', encoding='utf-8', newline='').read()
'x = 1\r\ny = 2\r\n'
```

## The dispatch bug underneath it

The `Parse` handler had no branch for an input that carries a source path and no text, which is what a JVM peer sends for a file that exists on disk. The dispatch tested `'path' in input_item`, and the JVM sends `sourcePath`. Such inputs were skipped, the handler returned fewer ids than it was given inputs, and `RewriteRpc.parse` failed its `assert ids.size() == inputList.size()`.

The key has been `'path'` since the handler was written, so `PythonParser.parseInputs` over a file input never worked — which is why this only surfaced through `ParseProject`.

## The rest of the change

rewrite-python was also the only RPC-backed peer with no print-equals check at parse time. Go, JavaScript and C# each have one, and `require_print_equals_input` sat in `rewrite/parser.py` with zero callers. A parse that loses source is now a `ParseError` naming the file. Making the file-input path live, and adding that check, brought four more defects within reach:

- **The check could not be turned off from the JVM.** `PythonParser` sent only `languageLevel` as parse options, so `REQUIRE_PRINT_EQUALS_INPUT` never crossed the wire — including from `RewriteTest`, which disables it around every parse because it runs the check itself afterwards. `parseOptions` now builds both keys in one place, for `Parse` and `ParseProject` alike, as the other three peers already do.
- **A lone `\r` was mangled, not normalized.** Universal-newline mode used to fold classic-Mac endings to `\n`. Reading the file untouched exposed that the scanner treats `\r` as an ordinary character: `import sys\rdef f():\r    return 1\r` printed as `import sysdeff():return\rd`. The tokenizer now sees one line-ending spelling and the row/col scans step over all three. Over the 510-file corpus converted to CR endings: 510 round-trip, against 114 (and 367 errors) before.
- **One unreadable file cost the whole batch.** A non-UTF-8 or racily-deleted `.py` file raised out of the `Parse` handler and took every other file in the request with it. It now yields a `ParseError` in its own slot, which the caller needs since it pairs results to inputs by position.
- **`Result.diff` emitted malformed headers.** It fed `unified_diff` keepends lines with `lineterm=''`, so `---`, `+++` and `@@` ran into the content behind them — and that diff is what the print-equals message shows.

- **Error results were placed by a path the caller could not resolve.** The batch loop's own error path passed the raw input path, skipping the `relativeTo` relativization applied to parsed results — so one absolute `sourcePath` could arrive among relative ones. An input naming no path reported the string `None`.
- **`ParseProject` dropped what it could not read.** A project containing a latin-1 source returned only its siblings; the unreadable file left no trace beyond a log line. It now reports a `ParseError`, the same contract the `Parse` handler follows.
- **`detect_from_source` split on `\n` alone.** A CR-only file was therefore one line, so a `# python: 2` comment anywhere in it selected the Python 2 parser rather than only in the first two lines. Reachable because CR files now parse at all; `compute_source_line_data` is the only other place that counts lines and already handles all three endings.

## Scope

The newline bug is Python's alone. Go reads via `os.ReadFile`, JavaScript via `fs.readFileSync`, C# via `File.ReadAllText` — none translate line endings, and all three already guard with print-equals.

## Tests

`tests/rpc/test_parse_inputs.py` covers the parse handlers:

- a file read off disk keeps its own line endings, CRLF and CR
- every input gets a result slot whatever is wrong with it, at the project-relative path it was named by
- a parse that loses source becomes a `ParseError`, and a project parse reports a file it cannot read
- the client can turn the print check off on both the `Parse` and `ParseProject` paths

`version_detect_test.py` pins the two-line magic-comment scan across all three line endings, and `PythonParseOptionsTest` pins the options map and the key literal the server matches. `PythonParserTest.crlfFileOnDiskPrintsBackIdentically` covers the wire path end-to-end — the test that caught the `sourcePath` dispatch bug.

Every fix is mutation-checked: each injected mutation is caught by exactly one test. Python suite 2397 passed, `rewrite-python` Java suite 1971 across 128 classes, 0 failures. On the corpus the three files above are byte-identical, and 510/510 round-trip both as-is and CR-converted.

`PythonParserTest` is `@DisabledIfEnvironmentVariable(CI=true)`, so the Python tests are the CI-effective guard here.

Fixes #8842
