### PR TITLE
Let an RPC peer exit on stdin EOF before force-killing it

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -296,17 +296,19 @@ public class RewriteRpcProcess extends Thread {
         }
         // EOF on stdin is every peer's exit signal, and taking it lets them flush metrics
         // and logs and remove their temp dirs. SIGTERM would not do: of the four peers only
-        // the JS one installs a handler. The wait is bounded so a wedged peer still dies.
-        if (process != null) {
+        // the JS one installs a handler.
+        Process p = process;
+        if (p != null) {
+            // Closing stdin needs the monitor that HeaderDelimitedMessageHandler holds across
+            // a send, so against a peer that stopped draining it blocks until the kill below
+            // releases the writer. Only the exit is waited on, which keeps that wait bounded.
+            severStdin(p);
             try {
-                process.getOutputStream().close();
-                if (!process.waitFor(GRACEFUL_EXIT_MILLIS, TimeUnit.MILLISECONDS)) {
-                    process.destroyForcibly();
+                if (!p.waitFor(GRACEFUL_EXIT_MILLIS, TimeUnit.MILLISECONDS)) {
+                    p.destroyForcibly();
                 }
-            } catch (IOException e) {
-                process.destroyForcibly();
             } catch (InterruptedException e) {
-                process.destroyForcibly();
+                p.destroyForcibly();
                 Thread.currentThread().interrupt();
             }
         }
@@ -321,6 +323,19 @@ public class RewriteRpcProcess extends Thread {
             }
             stderrDrainThread = null;
         }
+    }
+
+    /** Signals the peer to exit by closing its stdin, on a daemon thread that may never return. */
+    private static void severStdin(Process p) {
+        Thread closer = new Thread(() -> {
+            try {
+                p.getOutputStream().close();
+            } catch (IOException ignored) {
+                // The peer is going away regardless; the caller force-kills on timeout.
+            }
+        }, "rpc-stdin-close");
+        closer.setDaemon(true);
+        closer.start();
     }
 
     /** The peer's descendants as {@code ProcessHandle}s, empty on Java 8 or if unobtainable. */

--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -76,6 +76,8 @@ public class RewriteRpcProcess extends Thread {
         PROCESS_HANDLE_DESTROY_FORCIBLY = destroyForcibly;
     }
 
+    private static final long GRACEFUL_EXIT_MILLIS = 200;
+
     private final String[] command;
 
     @Setter
@@ -292,9 +294,21 @@ public class RewriteRpcProcess extends Thread {
             }
             shutdownHook = null;
         }
-        // Force-kill the direct child; a wedged peer may not exit gracefully.
+        // EOF on stdin is every peer's exit signal, and taking it lets them flush metrics
+        // and logs and remove their temp dirs. SIGTERM would not do: of the four peers only
+        // the JS one installs a handler. The wait is bounded so a wedged peer still dies.
         if (process != null) {
-            process.destroyForcibly();
+            try {
+                process.getOutputStream().close();
+                if (!process.waitFor(GRACEFUL_EXIT_MILLIS, TimeUnit.MILLISECONDS)) {
+                    process.destroyForcibly();
+                }
+            } catch (IOException e) {
+                process.destroyForcibly();
+            } catch (InterruptedException e) {
+                process.destroyForcibly();
+                Thread.currentThread().interrupt();
+            }
         }
         // Force-kill the descendants captured above; empty on Java 8 or a single-process peer.
         destroyDescendantsForcibly(descendants);

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -20,7 +20,9 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
@@ -29,6 +31,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -209,12 +212,47 @@ class RewriteRpcProcessTest {
         try {
             peer.shutdown();
 
-            assertThat(peerProcess.isAlive())
-                    .as("shutdown() should have waited for the peer's own exit")
-                    .isFalse();
+            // A force-kill is asynchronous, so the exit status only settles once the peer has gone.
+            await(() -> peerProcess.isAlive() ? null : Boolean.TRUE);
             assertThat(peerProcess.exitValue())
                     .as("exit status should be the peer's own, not 128+SIGKILL")
                     .isZero();
+        } finally {
+            peerProcess.destroyForcibly();
+        }
+    }
+
+    /**
+     * A wedged peer leaves the RPC writer holding the monitor that {@code close()} needs,
+     * so severing stdin must not be what the shutdown thread waits on.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void shutdownIsBoundedWhenAWriterHoldsAWedgedPeersStdin() throws Exception {
+        Process peerProcess = new ProcessBuilder("sh", "-c", "sleep 300").start();
+        RewriteRpcProcess peer = peerWrapping(peerProcess);
+        OutputStream stdin = peerProcess.getOutputStream();
+        CountDownLatch holdingMonitor = new CountDownLatch(1);
+        Thread writer = new Thread(() -> {
+            //noinspection SynchronizationOnLocalVariableOrMethodParameter
+            synchronized (stdin) { // the monitor HeaderDelimitedMessageHandler.send() holds
+                holdingMonitor.countDown();
+                try {
+                    // Outruns the pipe buffer, so this blocks until the peer is killed.
+                    stdin.write(new byte[8 * 1024 * 1024]);
+                    stdin.flush();
+                } catch (IOException ignored) {
+                }
+            }
+        }, "rpc-writer");
+        writer.setDaemon(true);
+        writer.start();
+        assertThat(holdingMonitor.await(10, TimeUnit.SECONDS)).isTrue();
+        try {
+            assertTimeoutPreemptively(Duration.ofSeconds(30), peer::shutdown);
+
+            await(() -> peerProcess.isAlive() ? null : Boolean.TRUE);
+            assertThat(peerProcess.isAlive()).isFalse();
         } finally {
             peerProcess.destroyForcibly();
         }

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static java.lang.ProcessBuilder.Redirect.DISCARD;
 import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -192,6 +193,29 @@ class RewriteRpcProcessTest {
         } finally {
             wedged.descendants().forEach(ProcessHandle::destroyForcibly);
             wedged.destroyForcibly();
+            peerProcess.destroyForcibly();
+        }
+    }
+
+    /**
+     * Taking the EOF path is what lets a peer flush its metrics and logs and remove its
+     * temp directories before exiting.
+     */
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void shutdownLetsAPeerExitOnStdinEof() throws Exception {
+        Process peerProcess = new ProcessBuilder("cat").redirectOutput(DISCARD).start();
+        RewriteRpcProcess peer = peerWrapping(peerProcess);
+        try {
+            peer.shutdown();
+
+            assertThat(peerProcess.isAlive())
+                    .as("shutdown() should have waited for the peer's own exit")
+                    .isFalse();
+            assertThat(peerProcess.exitValue())
+                    .as("exit status should be the peer's own, not 128+SIGKILL")
+                    .isZero();
+        } finally {
             peerProcess.destroyForcibly();
         }
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -28,6 +28,7 @@ using OpenRewrite.Java;
 using Serilog;
 using StreamJsonRpc;
 using StreamJsonRpc.Protocol;
+using StreamJsonRpc.Reflection;
 using static OpenRewrite.Core.Rpc.RpcObjectData.ObjectState;
 using ExecutionContext = OpenRewrite.Core.ExecutionContext;
 
@@ -2057,7 +2058,7 @@ internal sealed class RpcMetricsWriter : IDisposable
 /// Wraps the message handler to record a metrics row when each inbound request's response is
 /// written. Notifications (Evict) get no response and aren't recorded; outbound requests are ignored.
 /// </summary>
-internal sealed class MetricsMessageHandler : IJsonRpcMessageHandler, IDisposable
+internal sealed class MetricsMessageHandler : IJsonRpcMessageHandler, IJsonRpcMessageBufferManager, IDisposable
 {
     private readonly IJsonRpcMessageHandler _inner;
     private readonly RpcMetricsWriter _metrics;
@@ -2072,6 +2073,13 @@ internal sealed class MetricsMessageHandler : IJsonRpcMessageHandler, IDisposabl
     public bool CanRead => _inner.CanRead;
     public bool CanWrite => _inner.CanWrite;
     public IJsonRpcMessageFormatter Formatter => _inner.Formatter;
+
+    // JsonRpc looks for this interface on the outermost handler only, so a wrapper that
+    // omits it strands the callback that lets the inner handler advance past a consumed
+    // message: its read buffer then grows for the life of the connection, and the final
+    // read sees leftover bytes instead of the empty buffer that means a clean disconnect.
+    public void DeserializationComplete(JsonRpcMessage message) =>
+        (_inner as IJsonRpcMessageBufferManager)?.DeserializationComplete(message);
 
     public async ValueTask<JsonRpcMessage?> ReadAsync(CancellationToken cancellationToken)
     {

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpGracefulShutdownIntegTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpGracefulShutdownIntegTest.java
@@ -41,7 +41,11 @@ class CSharpGracefulShutdownIntegTest {
     void serverExitsCleanlyWhenStdinCloses(@TempDir Path tempDir) throws Exception {
         // --metrics-csv is what wraps the message handler, and only the wrapper has to
         // forward the buffer-release callback; without the flag nothing is under test.
-        Process server = new ProcessBuilder("dotnet", locateTool().toString(),
+        Process server = new ProcessBuilder("dotnet", "run",
+          "--project", locateToolProject().toString(),
+          "--framework", "net10.0",
+          // An implicit build would stream MSBuild output into the JSON-RPC pipe.
+          "--no-build",
           "--metrics-csv=" + tempDir.resolve("metrics.csv"))
           .redirectError(ProcessBuilder.Redirect.DISCARD)
           .start();
@@ -63,16 +67,16 @@ class CSharpGracefulShutdownIntegTest {
         }
     }
 
-    /** The tool assembly produced by the {@code csharpBuild} Gradle task this suite depends on. */
-    private static Path locateTool() {
+    /** The server project, built by the {@code csharpBuild} Gradle task this suite depends on. */
+    private static Path locateToolProject() {
         Path base = Paths.get(System.getProperty("user.dir"));
         for (Path csharpDir : new Path[]{base.resolve("csharp"), base.resolve("rewrite-csharp/csharp")}) {
-            Path tool = csharpDir.resolve("OpenRewrite.Tool/bin/Debug/net10.0/OpenRewrite.Tool.dll");
-            if (Files.exists(tool)) {
-                return tool.toAbsolutePath().normalize();
+            Path csproj = csharpDir.resolve("OpenRewrite.Tool/OpenRewrite.Tool.csproj");
+            if (Files.exists(csproj)) {
+                return csproj.toAbsolutePath().normalize();
             }
         }
-        throw new IllegalStateException("Could not find OpenRewrite.Tool.dll; run the csharpBuild task");
+        throw new IllegalStateException("Could not find the C# Rewrite project");
     }
 
     /** Sends a parameterless JSON-RPC request and drains the reply off the header-delimited stream. */

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpGracefulShutdownIntegTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpGracefulShutdownIntegTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.openrewrite.csharp.rpc;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Closing the server's stdin is how the Java host asks it to shut down, and the exit
+ * status is the only signal it gets back.
+ */
+@Timeout(value = 120, unit = TimeUnit.SECONDS)
+class CSharpGracefulShutdownIntegTest {
+
+    @Test
+    void serverExitsCleanlyWhenStdinCloses(@TempDir Path tempDir) throws Exception {
+        // --metrics-csv is what wraps the message handler, and only the wrapper has to
+        // forward the buffer-release callback; without the flag nothing is under test.
+        Process server = new ProcessBuilder("dotnet", locateTool().toString(),
+          "--metrics-csv=" + tempDir.resolve("metrics.csv"))
+          .redirectError(ProcessBuilder.Redirect.DISCARD)
+          .start();
+        try {
+            // One consumed message is enough to leave bytes in the buffer, and it also
+            // guarantees the server is listening rather than racing an EOF at startup.
+            request(server, "GetLanguages");
+
+            server.getOutputStream().close();
+
+            assertThat(server.waitFor(60, TimeUnit.SECONDS))
+              .as("server should exit on its own once stdin closes")
+              .isTrue();
+            assertThat(server.exitValue())
+              .as("an aborted process reports 134, not 0")
+              .isZero();
+        } finally {
+            server.destroyForcibly();
+        }
+    }
+
+    /** The tool assembly produced by the {@code csharpBuild} Gradle task this suite depends on. */
+    private static Path locateTool() {
+        Path base = Paths.get(System.getProperty("user.dir"));
+        for (Path csharpDir : new Path[]{base.resolve("csharp"), base.resolve("rewrite-csharp/csharp")}) {
+            Path tool = csharpDir.resolve("OpenRewrite.Tool/bin/Debug/net10.0/OpenRewrite.Tool.dll");
+            if (Files.exists(tool)) {
+                return tool.toAbsolutePath().normalize();
+            }
+        }
+        throw new IllegalStateException("Could not find OpenRewrite.Tool.dll; run the csharpBuild task");
+    }
+
+    /** Sends a parameterless JSON-RPC request and drains the reply off the header-delimited stream. */
+    private static void request(Process server, String method) throws IOException {
+        byte[] body = ("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"" + method + "\",\"params\":{}}")
+          .getBytes(StandardCharsets.UTF_8);
+        OutputStream out = server.getOutputStream();
+        out.write(("Content-Length: " + body.length + "\r\n\r\n").getBytes(StandardCharsets.UTF_8));
+        out.write(body);
+        out.flush();
+
+        InputStream in = server.getInputStream();
+        int contentLength = -1;
+        for (String line = readLine(in); ; line = readLine(in)) {
+            if (line.isEmpty()) {
+                if (contentLength < 0) {
+                    throw new IOException("Reply had no Content-Length header");
+                }
+                break;
+            }
+            if (line.regionMatches(true, 0, "Content-Length:", 0, 15)) {
+                contentLength = Integer.parseInt(line.substring(15).trim());
+            }
+        }
+        for (int read = 0; read < contentLength; ) {
+            long skipped = in.skip(contentLength - read);
+            if (skipped <= 0) {
+                throw new IOException("Reply body truncated");
+            }
+            read += (int) skipped;
+        }
+    }
+
+    private static String readLine(InputStream in) throws IOException {
+        StringBuilder line = new StringBuilder();
+        for (int c = in.read(); c != '\n'; c = in.read()) {
+            if (c == -1) {
+                throw new IOException("Server closed stdout before replying");
+            }
+            if (c != '\r') {
+                line.append((char) c);
+            }
+        }
+        return line.toString();
+    }
+}


### PR DESCRIPTION
`RewriteRpcProcess.shutdown()` sends SIGKILL to the peer process it spawned. Every peer runs cleanup on its own exit path — flushing metrics and logs, removing temp directories — and none of it has ever run. A host that spawns a peer per unit of work leaks a workspace directory on every shutdown:

```
JS peer — is a stale workspace still present after shutdown?
  stdin EOF   no    (DependencyWorkspace.cleanupOldWorkspaces ran)
  SIGKILL     yes
```

## Why stdin EOF

There is no Shutdown or Exit RPC method, and SIGTERM is not the signal — of the four peers only the JS one installs a handler. All four already exit on EOF:

| peer | SIGTERM handler | on stdin EOF |
|---|---|---|
| Python | none | `read_message()` returns `None` → `_close_metrics()` |
| Go | none | `io.EOF` breaks the loop → `closeMetrics()` + recipe workspace cleanup |
| JS | yes | `connection.onClose` → pyroscope stop, recipe + workspace cleanup |
| C# | none | `jsonRpc.Completion` resolves → `finally` disposes metrics |

Descendants are still captured before the wait and swept forcibly after — they never see the EOF.

## Severing stdin cannot be what we wait on

`HeaderDelimitedMessageHandler.send()` holds the monitor on the child's `OutputStream` across its write and flush. Against a peer that has stopped draining its stdin, the RPC writer blocks mid-write still holding it, and `close()` then blocks on the same monitor — released only by the force-kill it is supposed to precede:

```
close() returned within 3s? false
closer state=BLOCKED
   java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:203)
after destroyForcibly, close() returned? true
```

Since `shutdown()` also runs from the JVM shutdown hook, waiting on the close would hang the host at exit. So stdin is severed on a daemon thread and only the peer's exit is waited on, which keeps the 200 ms bound real.

## The grace period

EOF → exit, measured after one request, 9 reps:

| peer | median | max |
|---|---|---|
| Go | 1.3 ms | 1.3 ms |
| JS | 8.9 ms | 8.9 ms |
| C# | 8.9 ms | 8.9 ms |
| Python | 37.5 ms | 38.2 ms |

SIGKILL is 1.3 ms for comparison, so shutdown costs at most ~37 ms more; that holds at 8x CPU oversubscription. A peer overrunning the budget is force-killed exactly as before.

## The C# peer aborted rather than exiting

It reported 134 (SIGABRT) on EOF and left its metrics CSV truncated at 104 of 171 bytes. `MetricsMessageHandler` wraps the message handler but did not implement `IJsonRpcMessageBufferManager`, which `JsonRpc` looks for only on the outermost handler:

```csharp
(this.MessageHandler as IJsonRpcMessageBufferManager)?.DeserializationComplete(protocolMessage);
```

That callback is what calls `Reader.AdvanceTo(...)`. Unforwarded, the read buffer never advances past a consumed message, so the final read finds leftover bytes and raises `EndOfStreamException` instead of returning `null` for a clean disconnect. Forwarding it restores exit 0 and a complete CSV.

## Tests

`shutdownLetsAPeerExitOnStdinEof` asserts a peer exiting on EOF keeps its own exit status rather than 128+SIGKILL. `shutdownIsBoundedWhenAWriterHoldsAWedgedPeersStdin` blocks a writer on a wedged peer's stdin; it hangs without the daemon-thread sever. `CSharpGracefulShutdownIntegTest` drives the built server over the wire and reports 134 without the handler change.

## Not fixed here

The C# server does not delete its recipe install workspace on the EOF path, unlike Go and JS. The JS dependency-workspace base is also hardcoded under `os.tmpdir()`, so reaping it is charged to shutdown; letting the host own that directory would take the work off this path.
