### PR TITLE
Python: a type alias's value is modelled as a type

### DIFF
--- a/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/_parser_visitor.py
@@ -1758,7 +1758,7 @@ class ParserVisitor(ast.NodeVisitor):
             Markers.EMPTY,
             name,
             type_parameters,
-            self.__pad_left(self.__source_before('='), self.__convert(node.value)),
+            self.__pad_left(self.__source_before('='), self.__convert_type(node.value)),
             self._type_mapping.type(node)
         )
 

--- a/rewrite-python/rewrite/src/rewrite/python/format/spaces_visitor.py
+++ b/rewrite-python/rewrite/src/rewrite/python/format/spaces_visitor.py
@@ -8,7 +8,7 @@ from rewrite.java import (J, Assignment, JLeftPadded, AssignmentOperation, Membe
                            ControlParentheses, TrailingComma, TypeParameter)
 from rewrite.python import (PythonVisitor, SpacesStyle, Binary, ChainedAssignment, Slice, CollectionLiteral,
                              DictLiteral, KeyValue, TypeHint, MultiImport, ExpressionTypeTree,
-                             ComprehensionExpression, NamedArgument)
+                             ComprehensionExpression, NamedArgument, TypeAlias)
 from rewrite.visitor import P, Cursor
 
 J2 = TypeVar('J2', bound=J)
@@ -482,7 +482,7 @@ class SpacesVisitor(PythonVisitor):
         # Under these parents the wrapper's prefix is meaningful source space, so clearing it
         # would join the type to the punctuation before it.
         parent = self.cursor.parent_tree_cursor()
-        if not (parent and isinstance(parent.value, (ClassDeclaration, TypeParameter))):
+        if not (parent and isinstance(parent.value, (ClassDeclaration, TypeParameter, TypeAlias))):
             ett = space_before(ett, False)
         return ett
 

--- a/rewrite-python/rewrite/tests/python/py312/type_alias_test.py
+++ b/rewrite-python/rewrite/tests/python/py312/type_alias_test.py
@@ -1,3 +1,6 @@
+from rewrite.java.tree import ParameterizedType
+from rewrite.python import AutoFormat
+from rewrite.python.markers import Quoted
 from rewrite.test import RecipeSpec, python
 
 
@@ -9,5 +12,40 @@ def test_type_alias():
         from typing import Tuple
     
         type Coordinates = Tuple[float, float]
+        """
+    ))
+
+
+def test_alias_value_is_modelled_as_a_type():
+    values = []
+
+    def collect(source_file):
+        values.append(source_file.statements[0].value)
+
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        """\
+        type Coordinates = list[int]
+        """,
+        after_recipe=collect,
+    ))
+    assert isinstance(values[-1], ParameterizedType)
+
+    # language=python
+    RecipeSpec().rewrite_run(python(
+        """\
+        type Coordinates = "list[int]"
+        """,
+        after_recipe=collect,
+    ))
+    assert isinstance(values[-1], ParameterizedType)
+    assert values[-1].markers.find_first(Quoted).style is Quoted.Style.DOUBLE
+
+
+def test_alias_value_without_a_type_tree_form_keeps_its_space():
+    # language=python
+    RecipeSpec().with_recipe(AutoFormat()).rewrite_run(python(
+        """\
+        type Constraints = (int, str)
         """
     ))


### PR DESCRIPTION
- `type A = list[int]` put a `j.ArrayAccess` in the alias's value slot, and `type A = "list[int]"` a `j.Literal`. The PEP 695 `type` statement's right-hand side was the last syntactic type position still converted with `__convert`, so it missed both `ParameterizedType` and the forward-reference structuring added in #8833.

| `type A = …` | before | after |
|---|---|---|
| `list[int]` | `ArrayAccess` | `ParameterizedType` |
| `"list[int]"` | `Literal` | `ParameterizedType` + `Quoted` |
| `int \| str` | `Binary` | `UnionType` |
| `(int, str)` | `CollectionLiteral` | `ExpressionTypeTree` |

An alias RHS is a type position by grammar, needing no name resolution, so `visit_TypeAlias` converts it with `__convert_type` like every other type slot. `Py.TypeAlias.value` is declared `JLeftPadded<J>`, so the model is unchanged. `test_alias_value_is_modelled_as_a_type` pins the quoted and unquoted forms separately, so a failure says whether routing or structuring broke.

- `__convert_type` wraps a value with no `TypeTree` form in `Py.ExpressionTypeTree` and puts the prefix on that wrapper, which `SpacesVisitor.visit_expression_type_tree` clears — AutoFormat rendered `type A =(int, str)`. The exemption #8820 added for `ClassDeclaration` and `TypeParameter` now covers `TypeAlias`, pinned by `test_alias_value_without_a_type_tree_form_keeps_its_space`.

### Scope

`cast("list[int]", x)`, `TypeVar(bound="list[int]")` and `A: TypeAlias = list[int]` stay as they are. Each needs to know the call resolves to the `typing` API — all three names can be shadowed or aliased — so converting them would make LST shape depend on whether type attribution ran, and a tree parsed with a `ty_client` would differ structurally from one parsed without.
