### PR TITLE
Go: log per-call RPC detail only under `--trace-rpc-messages`

### DIFF
--- a/rewrite-go/cmd/rpc/logging_test.go
+++ b/rewrite-go/cmd/rpc/logging_test.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerCallLoggingRequiresTraceRpcMessages(t *testing.T) {
+	logOfOneRequest := func(cfg serverConfig) string {
+		t.Helper()
+		cfg.logFile = filepath.Join(t.TempDir(), "server.log")
+		s := newServer(cfg)
+		t.Cleanup(s.closeMetrics)
+		s.safeHandleRequest(&jsonRPCRequest{JSONRPC: "2.0", ID: json.RawMessage("1"), Method: "GetLanguages"})
+		out, err := os.ReadFile(cfg.logFile)
+		require.NoError(t, err)
+		return string(out)
+	}
+
+	assert.Empty(t, logOfOneRequest(serverConfig{}), "a successful RPC call should log nothing by default")
+
+	assert.Contains(t, logOfOneRequest(serverConfig{traceRpcMessages: true}), "Handling: GetLanguages")
+}

--- a/rewrite-go/cmd/rpc/main.go
+++ b/rewrite-go/cmd/rpc/main.go
@@ -142,6 +142,10 @@ type server struct {
 	traceReceive bool
 	traceSend    bool
 
+	// Fixed at startup, unlike traceReceive/traceSend, which TraceGetObject
+	// toggles per session. See tracef.
+	traceCalls bool
+
 	metricsCsv string
 
 	configuredDataTableStore recipe.DataTableStore
@@ -248,6 +252,7 @@ func newServer(cfg serverConfig) *server {
 		batchSize:               1000,
 		traceReceive:            cfg.traceRpcMessages,
 		traceSend:               cfg.traceRpcMessages,
+		traceCalls:              cfg.traceRpcMessages,
 		metricsCsv:              cfg.metricsCsv,
 		reader:                  bufio.NewReader(os.Stdin),
 		writer:                  os.Stdout,
@@ -273,6 +278,15 @@ func newServer(cfg serverConfig) *server {
 	}
 
 	return s
+}
+
+// tracef logs detail that recurs once per RPC call or per resolved item, so it
+// is written only under --trace-rpc-messages. Lifecycle and error lines use
+// s.logger directly.
+func (s *server) tracef(format string, v ...any) {
+	if s.traceCalls {
+		s.logger.Printf(format, v...)
+	}
 }
 
 func (s *server) closeMetrics() {
@@ -331,7 +345,7 @@ func (s *server) recordMetric(method string, duration time.Duration, rpcErr *rpc
 func parseFlags() serverConfig {
 	var cfg serverConfig
 	flag.StringVar(&cfg.logFile, "log-file", "", "path to write server log; empty = OS temp file")
-	flag.BoolVar(&cfg.traceRpcMessages, "trace-rpc-messages", false, "log every GetObject batch send/receive")
+	flag.BoolVar(&cfg.traceRpcMessages, "trace-rpc-messages", false, "log every RPC call and every GetObject batch send/receive")
 	flag.StringVar(&cfg.metricsCsv, "metrics-csv", "", "path to write per-RPC metrics as CSV")
 	flag.StringVar(&cfg.recipeInstallDir, "recipe-install-dir", "", "directory used as the recipe installer workspace; if empty, a temporary directory is created and cleaned up on shutdown")
 	flag.Parse()
@@ -487,7 +501,7 @@ func (s *server) safeHandleRequest(req *jsonRPCRequest) (resp *jsonRPCResponse) 
 
 // handleRequest dispatches to the appropriate handler.
 func (s *server) handleRequest(req *jsonRPCRequest) *jsonRPCResponse {
-	s.logger.Printf("Handling: %s", req.Method)
+	s.tracef("Handling: %s", req.Method)
 
 	var result any
 	var rpcErr *rpcError
@@ -2994,7 +3008,7 @@ func (s *server) handleDependencyTypes(params json.RawMessage) (any, *rpcError) 
 		if err != nil {
 			return nil, &rpcError{Code: -32603, Message: err.Error()}
 		}
-		s.logger.Printf("DependencyTypes: %s %s -> %s", req.ModulePath, req.Version, dir)
+		s.tracef("DependencyTypes: %s %s -> %s", req.ModulePath, req.Version, dir)
 		types := goparser.ExportedTypes([]string{dir}, nil)
 
 		q := rpc.NewSendQueue(s.batchSize, func(batch []rpc.RpcObjectData) {
@@ -3013,7 +3027,7 @@ func (s *server) handleDependencyTypes(params json.RawMessage) (any, *rpcError) 
 			func(v any) { sender.Visit(v.(java.JavaType), q) })
 		q.Put(rpc.RpcObjectData{State: rpc.EndOfObject})
 		q.Flush()
-		s.logger.Printf("DependencyTypes: %d types, %d items", len(types), len(data))
+		s.tracef("DependencyTypes: %d types, %d items", len(types), len(data))
 	}
 
 	n := s.batchSize


### PR DESCRIPTION
Parsing a large repository leaves the Go RPC server's log almost entirely per-call chatter. Over `envoyproxy/envoy`, 4,193 of 4,488 log lines were `Handling: <method>` — one per `GetObject`/`Print`/`ParseProject` request — and another 282 were `DependencyTypes: <module> <version> -> <dir>`, one per resolved dependency.

Both are debug detail, and the server already has a flag for debug detail: `--trace-rpc-messages`. They now go through a `tracef` helper gated on it. The default log keeps startup and shutdown, parse errors, skipped modules, and `PANIC` traces.

```go
func (s *server) tracef(format string, v ...any) {
	if s.traceCalls {
		s.logger.Printf(format, v...)
	}
}
```

`traceCalls` is a field of its own rather than a reuse of `traceReceive`/`traceSend`, which the `TraceGetObject` RPC sets per session. The server log's verbosity is then fixed for the process: turning `GetObject` payload tracing on mid-session leaves it alone, and turning it off cannot silence the dispatch line.

## Why not `--log-level`

Two levels are all that is in play here. A `--log-level` flag would need a level enum, a level assigned to each of the ~30 existing call sites, and would still have to keep `--trace-rpc-messages` as an alias or a synonym for the verbose level. It starts paying for itself only once a third level exists, and nothing here wants one.

`TestPerCallLoggingRequiresTraceRpcMessages` asserts that a successful `GetLanguages` leaves the log file empty by default, and that it prints `Handling: GetLanguages` when the flag is set. The first assertion fails on `main`.
