### PR TITLE
C#: coerce string-encoded recipe option values to their property types

### DIFF
--- a/rewrite-csharp/csharp/Directory.Build.props
+++ b/rewrite-csharp/csharp/Directory.Build.props
@@ -11,4 +11,7 @@
     Keep this file empty so it does not impose any properties on the SDK
     projects; its sole purpose is to act as a stop marker.
   -->
+
+  <Import Project="$(MSBuildThisFileDirectory)../../.local/RealPath.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)../../.local/RealPath.props')" />
 </Project>

--- a/rewrite-csharp/csharp/Directory.Build.targets
+++ b/rewrite-csharp/csharp/Directory.Build.targets
@@ -27,4 +27,7 @@
     <ProjectReference Remove="@(ProjectReference)" />
     <ProjectReference Include="@(_SdkProjectReferenceOriginal->'%(FullPath)')" />
   </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)../../.local/RealPath.targets"
+          Condition="Exists('$(MSBuildThisFileDirectory)../../.local/RealPath.targets')" />
 </Project>

--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/SystemTextJsonRpcTest.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Rpc/SystemTextJsonRpcTest.cs
@@ -116,6 +116,123 @@ public class SystemTextJsonRpcTest
         Assert.Equal("hi", OptionValue(response, "Label"));
     }
 
+    [Fact]
+    public async Task PrepareRecipe_WithStringEncodedScalars_CoercesToPropertyTypes()
+    {
+        var recipe = new TypedOptionRecipe();
+        var marketplace = new RecipeMarketplace();
+        marketplace.Install(recipe);
+        var server = new RewriteRpcServer(marketplace);
+
+        var request = new PrepareRecipeRequest
+        {
+            Id = recipe.Name,
+            Options = new Dictionary<string, object?>
+            {
+                ["Count"] = JsonSerializer.SerializeToElement("42", RpcJson.Options),
+                ["Enabled"] = JsonSerializer.SerializeToElement("false", RpcJson.Options),
+                ["Ratio"] = JsonSerializer.SerializeToElement("1.5", RpcJson.Options),
+                ["Label"] = JsonSerializer.SerializeToElement("hi", RpcJson.Options),
+            },
+        };
+
+        var response = await server.PrepareRecipe(request);
+
+        Assert.Equal(42, OptionValue(response, "Count"));
+        Assert.Equal(false, OptionValue(response, "Enabled"));
+        Assert.Equal(1.5, OptionValue(response, "Ratio"));
+        Assert.Equal("hi", OptionValue(response, "Label"));
+    }
+
+    [Theory]
+    [InlineData("true", true)]
+    [InlineData("True", true)]
+    [InlineData(" TRUE ", true)]
+    [InlineData("false", false)]
+    [InlineData("False", false)]
+    [InlineData("1", true)]
+    [InlineData("0", false)]
+    public async Task PrepareRecipe_WithStringEncodedBoolean_ParsesSpellings(string wire, bool expected)
+    {
+        var recipe = new TypedOptionRecipe();
+        var marketplace = new RecipeMarketplace();
+        marketplace.Install(recipe);
+        var server = new RewriteRpcServer(marketplace);
+
+        var response = await server.PrepareRecipe(new PrepareRecipeRequest
+        {
+            Id = recipe.Name,
+            Options = new Dictionary<string, object?>
+            {
+                ["Enabled"] = JsonSerializer.SerializeToElement(wire, RpcJson.Options),
+            },
+        });
+
+        Assert.Equal(expected, OptionValue(response, "Enabled"));
+    }
+
+    [Fact]
+    public async Task PrepareRecipe_WithBlankOrNullValue_KeepsRecipeDefault()
+    {
+        var recipe = new DefaultedOptionRecipe();
+        var marketplace = new RecipeMarketplace();
+        marketplace.Install(recipe);
+        var server = new RewriteRpcServer(marketplace);
+
+        var response = await server.PrepareRecipe(new PrepareRecipeRequest
+        {
+            Id = recipe.Name,
+            Options = new Dictionary<string, object?>
+            {
+                ["Enabled"] = JsonSerializer.SerializeToElement("", RpcJson.Options),
+                ["Count"] = JsonSerializer.SerializeToElement((object?)null, RpcJson.Options),
+            },
+        });
+
+        Assert.Equal(true, OptionValue(response, "Enabled"));
+        Assert.Equal(7, OptionValue(response, "Count"));
+    }
+
+    [Fact]
+    public async Task PrepareRecipe_WithNumericValueForStringOption_Stringifies()
+    {
+        var recipe = new TypedOptionRecipe();
+        var marketplace = new RecipeMarketplace();
+        marketplace.Install(recipe);
+        var server = new RewriteRpcServer(marketplace);
+
+        var response = await server.PrepareRecipe(new PrepareRecipeRequest
+        {
+            Id = recipe.Name,
+            Options = new Dictionary<string, object?>
+            {
+                ["Label"] = JsonSerializer.SerializeToElement(14.0, RpcJson.Options),
+            },
+        });
+
+        Assert.Equal("14", OptionValue(response, "Label"));
+    }
+
+    [Fact]
+    public async Task PrepareRecipe_WithCommaDelimitedStringForListOption_Splits()
+    {
+        var recipe = new ListOptionRecipe();
+        var marketplace = new RecipeMarketplace();
+        marketplace.Install(recipe);
+        var server = new RewriteRpcServer(marketplace);
+
+        var response = await server.PrepareRecipe(new PrepareRecipeRequest
+        {
+            Id = recipe.Name,
+            Options = new Dictionary<string, object?>
+            {
+                ["Packages"] = JsonSerializer.SerializeToElement("a,b,c", RpcJson.Options),
+            },
+        });
+
+        Assert.Equal(new[] { "a", "b", "c" }, Assert.IsType<List<string>>(OptionValue(response, "Packages")));
+    }
+
     private static object? OptionValue(PrepareRecipeResponse response, string name) =>
         response.Descriptor.Options.Single(o => o.Name == name).Value;
 
@@ -132,6 +249,34 @@ public class SystemTextJsonRpcTest
 
         [Option(DisplayName = "Label", Description = "A string option")]
         public string Label { get; set; } = "";
+
+        [Option(DisplayName = "Ratio", Description = "A floating point option")]
+        public double Ratio { get; set; }
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor() => ITreeVisitor<ExecutionContext>.Noop();
+    }
+
+    private class DefaultedOptionRecipe : OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "Defaulted option recipe";
+        public override string Description => "Recipe whose options carry non-default initial values.";
+
+        [Option(DisplayName = "Enabled", Description = "A boolean option defaulting to true")]
+        public bool Enabled { get; set; } = true;
+
+        [Option(DisplayName = "Count", Description = "An integer option defaulting to 7")]
+        public int Count { get; set; } = 7;
+
+        public override ITreeVisitor<ExecutionContext> GetVisitor() => ITreeVisitor<ExecutionContext>.Noop();
+    }
+
+    private class ListOptionRecipe : OpenRewrite.Core.Recipe
+    {
+        public override string DisplayName => "List option recipe";
+        public override string Description => "Recipe with a list option for wire-format conversion testing.";
+
+        [Option(DisplayName = "Packages", Description = "A list option")]
+        public List<string> Packages { get; set; } = [];
 
         public override ITreeVisitor<ExecutionContext> GetVisitor() => ITreeVisitor<ExecutionContext>.Noop();
     }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -13,12 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Threading.Channels;
 using System.Diagnostics;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.Loader;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Xml.Linq;
 using NuGet.Frameworks;
@@ -1442,10 +1445,17 @@ public class RewriteRpcServer
         foreach (var (key, value) in options)
         {
             var prop = recipeType.GetProperty(key, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase);
-            if (prop != null && prop.CanWrite)
+            if (prop == null || !prop.CanWrite)
             {
-                prop.SetValue(recipe, ConvertOptionValue(value, prop.PropertyType));
+                continue;
             }
+            var converted = ConvertOptionValue(value, prop.PropertyType);
+            if (converted == null && prop.PropertyType.IsValueType &&
+                Nullable.GetUnderlyingType(prop.PropertyType) == null)
+            {
+                continue;
+            }
+            prop.SetValue(recipe, converted);
         }
         return recipe;
     }
@@ -1462,7 +1472,7 @@ public class RewriteRpcServer
     {
         if (value is JsonElement element)
         {
-            return element.Deserialize(targetType, RpcJson.Options);
+            return ConvertOptionElement(element, targetType);
         }
         if (value is null || targetType.IsInstanceOfType(value))
         {
@@ -1470,6 +1480,95 @@ public class RewriteRpcServer
         }
         var conversionType = Nullable.GetUnderlyingType(targetType) ?? targetType;
         return Convert.ChangeType(value, conversionType);
+    }
+
+    private static object? ConvertOptionElement(JsonElement element, Type targetType)
+    {
+        var underlying = Nullable.GetUnderlyingType(targetType) ?? targetType;
+
+        if (element.ValueKind == JsonValueKind.Null || element.ValueKind == JsonValueKind.Undefined)
+        {
+            return null;
+        }
+
+        if (element.ValueKind == JsonValueKind.String)
+        {
+            var text = element.GetString()!;
+            if (underlying != typeof(string) && string.IsNullOrWhiteSpace(text))
+            {
+                return null;
+            }
+            if (TryCoerceFromString(text, underlying, out var coerced))
+            {
+                return coerced;
+            }
+        }
+        else if (underlying == typeof(string))
+        {
+            return element.ValueKind == JsonValueKind.Object || element.ValueKind == JsonValueKind.Array
+                ? element.Deserialize(targetType, RpcJson.Options)
+                : element.GetRawText();
+        }
+
+        return element.Deserialize(targetType, RpcJson.Options);
+    }
+
+    private static readonly HashSet<Type> NumericOptionTypes =
+    [
+        typeof(sbyte), typeof(byte), typeof(short), typeof(ushort), typeof(int), typeof(uint),
+        typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal)
+    ];
+
+    private static bool TryCoerceFromString(string text, Type targetType, out object? result)
+    {
+        result = null;
+        if (targetType == typeof(bool))
+        {
+            var trimmed = text.Trim();
+            if (bool.TryParse(trimmed, out var flag))
+            {
+                result = flag;
+                return true;
+            }
+            if (trimmed == "1" || trimmed == "0")
+            {
+                result = trimmed == "1";
+                return true;
+            }
+            return false;
+        }
+        if (NumericOptionTypes.Contains(targetType))
+        {
+            try
+            {
+                result = Convert.ChangeType(text.Trim(), targetType, CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch (Exception e) when (e is FormatException or OverflowException)
+            {
+                return false;
+            }
+        }
+        if (targetType != typeof(string) && typeof(IEnumerable).IsAssignableFrom(targetType))
+        {
+            var elementType = targetType.IsArray
+                ? targetType.GetElementType()!
+                : targetType.GetInterfaces()
+                    .Concat([targetType])
+                    .FirstOrDefault(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                    ?.GetGenericArguments()[0];
+            if (elementType == typeof(string))
+            {
+                var items = new JsonArray();
+                foreach (var part in text.Split(','))
+                {
+                    items.Add(JsonValue.Create(part));
+                }
+                result = items.Deserialize(targetType, RpcJson.Options);
+                return true;
+            }
+        }
+        return false;
     }
 
     [JsonRpcMethod("Visit", UseSingleObjectParameterDeserialization = true)]


### PR DESCRIPTION
The Moderne SaaS UI and the CLI's `-P` arguments hand every recipe option across the wire as a JSON string, so a `bool` option arrives as `"false"` and an `int` as `"3"`; Java tolerates this because `Recipe.withOptions` binds through Jackson, but System.Text.Json is strict and failed with `cannot get the value of the token type string as a boolean`.

`ConvertOptionValue` now widens the loosely typed wire shapes before deserializing: strings coerce to bools (including `1`/`0`), to numbers, and to lists when comma-delimited; scalars bound to a `string` option are stringified; and a null or blank value for a non-nullable option leaves the recipe's own default in place instead of throwing. Unrecognized shapes still fall through to System.Text.Json so it reports errors in its own terms.

- `SystemTextJsonRpcTest` covers each of those conversions. The two `Directory.Build.*` files gain an optional import of `<repo>/.local/RealPath.props`/`.targets`, a workstation-level workaround for building this tree through a symlink (dotnet/msbuild#9670); the file is not checked in, so absent it the build behaves exactly as before.