### PR TITLE
Don't override a managed version property a local parent owns

### DIFF
--- a/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
+++ b/rewrite-maven/src/main/java/org/openrewrite/maven/UpgradeDependencyVersion.java
@@ -351,6 +351,26 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                 return false;
             }
 
+            /**
+             * Check if a local parent POM (in the same repository) declares the property that holds the
+             * managed version. The parent's own pass changes it there, so adding an override to the child
+             * leaves two places to maintain and pins the child if the parent later moves.
+             */
+            private boolean isPropertyDeclaredByLocalParent(String propertyKey) {
+                MavenResolutionResult current = getResolutionResult().getParent();
+                while (current != null) {
+                    ResolvedPom parentPom = current.getPom();
+                    if (!accumulator.projectArtifacts.contains(new GroupArtifact(parentPom.getGroupId(), parentPom.getArtifactId()))) {
+                        break; // Reached a non-local (remote) parent
+                    }
+                    if (parentPom.getRequested().getProperties().containsKey(propertyKey)) {
+                        return true;
+                    }
+                    current = current.getParent();
+                }
+                return false;
+            }
+
             private Xml.Tag upgradeDependency(ExecutionContext ctx, Xml.Tag t) throws MavenDownloadingException {
                 ResolvedDependency d = findDependency(t);
                 if (isExternalDependency(accumulator, d)) {
@@ -364,10 +384,13 @@ public class UpgradeDependencyVersion extends ScanningRecipe<UpgradeDependencyVe
                             // if a managed dependency is expressed as a property, change the property value
                             // do this only when a requested bom is absent, otherwise changing property has no effect
                             if (dm != null && isProperty(dm.getRequested().getVersion()) && dm.getRequestedBom() == null) {
-                                // if a local parent also declares this dependency, it will handle the property change
-                                if (!isDeclaredByLocalParent(d.getGroupId(), d.getArtifactId())) {
-                                    doAfterVisit(new ChangePropertyValue(dm.getRequested().getVersion().substring(2,
-                                            dm.getRequested().getVersion().length() - 1),
+                                String propertyKey = dm.getRequested().getVersion().substring(2,
+                                        dm.getRequested().getVersion().length() - 1);
+                                // if a local parent declares this dependency or owns the property itself, it will
+                                // handle the property change, and an override here would only shadow it
+                                if (!isDeclaredByLocalParent(d.getGroupId(), d.getArtifactId()) &&
+                                    !isPropertyDeclaredByLocalParent(propertyKey)) {
+                                    doAfterVisit(new ChangePropertyValue(propertyKey,
                                             newerVersion, overrideManagedVersion, false).getVisitor());
                                 }
                             } else if (dm != null && dm.getBomGav() == null) {

--- a/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
+++ b/rewrite-maven/src/test/java/org/openrewrite/maven/UpgradeDependencyVersionTest.java
@@ -1112,6 +1112,78 @@ class UpgradeDependencyVersionTest implements RewriteTest {
     }
 
     @Test
+    void overrideManagedVersionDoesNotShadowPropertyOwnedByLocalParent() {
+        // The parent owns both the managed version and the property behind it, so bumping the property
+        // there fixes every module. Adding an override to the child as well leaves two places to
+        // maintain, and pins the child if the parent later moves.
+        rewriteRun(
+          spec -> spec.recipe(new UpgradeDependencyVersion("com.google.guava", "guava", "14.0", "", true, null)),
+          pomXml(
+            """
+              <project>
+                  <groupId>com.mycompany</groupId>
+                  <artifactId>my-parent</artifactId>
+                  <version>1</version>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <guava.version>13.0</guava.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.google.guava</groupId>
+                              <artifactId>guava</artifactId>
+                              <version>${guava.version}</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """,
+            """
+              <project>
+                  <groupId>com.mycompany</groupId>
+                  <artifactId>my-parent</artifactId>
+                  <version>1</version>
+                  <packaging>pom</packaging>
+                  <properties>
+                    <guava.version>14.0</guava.version>
+                  </properties>
+                  <dependencyManagement>
+                      <dependencies>
+                          <dependency>
+                              <groupId>com.google.guava</groupId>
+                              <artifactId>guava</artifactId>
+                              <version>${guava.version}</version>
+                          </dependency>
+                      </dependencies>
+                  </dependencyManagement>
+              </project>
+              """
+          ),
+          mavenProject("my-child",
+            pomXml(
+              """
+                <project>
+                    <parent>
+                        <groupId>com.mycompany</groupId>
+                        <artifactId>my-parent</artifactId>
+                        <version>1</version>
+                    </parent>
+                    <artifactId>my-child</artifactId>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.google.guava</groupId>
+                            <artifactId>guava</artifactId>
+                        </dependency>
+                    </dependencies>
+                </project>
+                """
+            )
+          )
+        );
+    }
+
+    @Test
     void upgradeVersionDefinedViaImplicitPropertyInDependencyManagementBom() {
         rewriteRun(
           spec -> spec.recipe(new UpgradeDependencyVersion("org.flywaydb", "flyway-core", "10.15.0", "", true, null)),


### PR DESCRIPTION
## What's changed

With `overrideManagedVersion` set, a versionless dependency in a child module whose version is
managed by a local parent through a property got a copy of that property written into the child as
well as bumped in the parent:

```xml
<!-- parent, correctly bumped -->
<properties>
    <guava.version>14.0</guava.version>
</properties>
<dependencyManagement>
    <dependencies>
        <dependency>
            <groupId>com.google.guava</groupId>
            <artifactId>guava</artifactId>
            <version>${guava.version}</version>
        </dependency>
    </dependencies>
</dependencyManagement>

<!-- child, before this change -->
<properties>
    <guava.version>14.0</guava.version>   <!-- added, and not wanted -->
</properties>
<dependencies>
    <dependency>
        <groupId>com.google.guava</groupId>
        <artifactId>guava</artifactId>
    </dependency>
</dependencies>
```

The build is fixed either way, so this is not a correctness bug, but the override leaves two places
to maintain and pins the child if the parent later moves.

## Why it happened

`isDeclaredByLocalParent` was already guarding this case, and its comment says as much — "if a
local parent also declares this dependency, it will handle the property change". It only looks at
the parent's `<dependencies>` though, so a parent that manages the dependency through
`<dependencyManagement>` and a property never matched and the child got the override.

One level down, `AddProperty` reads `getResolutionResult().getPom().getRequested().getProperties()`
into a variable named `parentValue`, which is the pom's own declared properties rather than the
parent's. It therefore never sees a property inherited from a parent and always adds one. I left
that alone, since changing its semantics would move behavior for every recipe that calls it, and
guarded at the call site instead.

## The change

`isPropertyDeclaredByLocalParent` walks the same local-parent chain as the two existing helpers,
stopping at the first artifact outside the project, and returns true when a parent declares the
property itself. The child's `ChangePropertyValue` is skipped when it does, because the parent's
own pass changes it there.

## Testing

`overrideManagedVersionDoesNotShadowPropertyOwnedByLocalParent` covers it: parent owns the property
and the managed version, child declares the dependency without a version, and only the parent
changes. I checked that it fails without the guard (the child gains
`<guava.version>14.0</guava.version>`) rather than passing for the wrong reason. The rest of
`UpgradeDependencyVersionTest` and the full `rewrite-maven` suite pass.
