### PR TITLE
YAML: an anchored sequence keeps its dash, and a scalar's anchor precedes its tag

### DIFF
--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/YamlParser.java
@@ -431,12 +431,17 @@ public class YamlParser implements org.openrewrite.Parser {
                             anchor = buildYamlAnchor(reader, lastEnd, fmt, sse.getAnchor(), nextLastEnd, false);
                             anchors.put(sse.getAnchor(), anchor);
 
+                            // The sequence's prefix keeps the delimiter: the enclosing builder locates it there to
+                            // split the prefix and to decide whether a sequence entry has a dash.
+                            int delimiterIndex = anchorPrefixStart(fmt);
+                            String prefixThroughDelimiter = delimiterIndex == -1 ? fmt : fmt.substring(0, delimiterIndex + 1);
                             lastEnd = lastEnd + sse.getAnchor().length() + fmt.length() + 1;
                             fmt = reader.readStringFromBuffer(lastEnd, nextLastEnd);
                             int dashPrefixIndex = commentAwareIndexOf('-', fmt);
                             if (dashPrefixIndex > -1) {
                                 fmt = fmt.substring(0, dashPrefixIndex);
                             }
+                            fmt = prefixThroughDelimiter + fmt;
                         }
                         String fullPrefix = reader.readStringFromBuffer(lastEnd, nextLastEnd);
                         String startBracketPrefix = null;
@@ -622,13 +627,19 @@ public class YamlParser implements org.openrewrite.Parser {
 
         String prefix = "";
         if (!isForScalar) {
-            int prefixStart = commentAwareIndexOf(':', eventPrefix);
-            if (prefixStart == -1) {
-                prefixStart = commentAwareIndexOf('-', eventPrefix);
-            }
+            int prefixStart = anchorPrefixStart(eventPrefix);
             prefix = (prefixStart > -1 && eventPrefix.length() > prefixStart + 1) ? eventPrefix.substring(prefixStart + 1) : "";
         }
         return new Yaml.Anchor(randomId(), prefix, postFix.toString(), Markers.EMPTY, anchorKey);
+    }
+
+    /**
+     * The index within an event prefix of the delimiter introducing the anchored block: a mapping entry's colon or a
+     * sequence entry's dash, or -1 when it has neither. Whatever follows the delimiter is the anchor's own prefix.
+     */
+    private static int anchorPrefixStart(String eventPrefix) {
+        int colonIndex = commentAwareIndexOf(':', eventPrefix);
+        return colonIndex == -1 ? commentAwareIndexOf('-', eventPrefix) : colonIndex;
     }
 
     private static int commentAwareIndexOf(char target, String s) {

--- a/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
+++ b/rewrite-yaml/src/main/java/org/openrewrite/yaml/internal/YamlPrinter.java
@@ -130,11 +130,12 @@ public class YamlPrinter<P> extends YamlVisitor<PrintOutputCapture<P>> {
     @Override
     public Yaml visitScalar(Yaml.Scalar scalar, PrintOutputCapture<P> p) {
         beforeSyntax(scalar, p);
-        if (scalar.getTag() != null) {
-            visit(scalar.getTag(), p);
-        }
+        // A leading tag fails to parse, so a scalar carrying both properties always had the anchor first in source.
         if (scalar.getAnchor() != null) {
             visit(scalar.getAnchor(), p);
+        }
+        if (scalar.getTag() != null) {
+            visit(scalar.getTag(), p);
         }
         switch (scalar.getStyle()) {
             case DOUBLE_QUOTED:

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/ScalarTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/ScalarTest.java
@@ -66,6 +66,17 @@ class ScalarTest implements RewriteTest {
     }
 
     @Test
+    void anchorBeforeTag() {
+        rewriteRun(
+          yaml(
+            """
+              key: &anchor !!str value
+              """
+          )
+        );
+    }
+
+    @Test
     void loneScalar() {
         rewriteRun(
           yaml(

--- a/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/SequenceTest.java
+++ b/rewrite-yaml/src/test/java/org/openrewrite/yaml/tree/SequenceTest.java
@@ -136,6 +136,35 @@ class SequenceTest implements RewriteTest {
     }
 
     @Test
+    void anchoredInlineSequenceAsBlockSequenceEntry() {
+        rewriteRun(
+          yaml(
+            """
+              pairs:
+                - &first [ 'alpha', 'beta' ]
+                - &second [ 'gamma', 'delta' ]
+              """
+          )
+        );
+    }
+
+    @Test
+    void anchoredBlockSequenceAsBlockSequenceEntry() {
+        rewriteRun(
+          yaml(
+            """
+              groups:
+                - &first
+                  - alpha
+                  - beta
+                - &second
+                  - gamma
+              """
+          )
+        );
+    }
+
+    @Test
     void inlineSequenceWithWhitespaceBeforeCommas() {
         rewriteRun(
           yaml(


### PR DESCRIPTION
Parsing and then printing a real-world YAML file is not idempotent: in a block sequence whose entries are anchored sequences, every entry loses its `- ` and they all collapse onto one line. `Parser#requirePrintEqualsInput` turns that into a `ParseError`, so the file cannot be rewritten at all.

```diff
 pairs:
-  - &first [ 'alpha', 'beta' ]
-  - &second [ 'gamma', 'delta' ]
+   &first [ 'alpha', 'beta' ] &second [ 'gamma', 'delta' ]
```

### How the dash goes missing

In `case SequenceStart:`, a sequence carrying an anchor recomputes its prefix from the text that follows the anchor name:

```java
lastEnd = lastEnd + sse.getAnchor().length() + fmt.length() + 1;
fmt = reader.readStringFromBuffer(lastEnd, nextLastEnd);
```

`fmt` arrives holding `"\n  - "` and leaves holding `" [ "`. That prefix is exactly what the enclosing builder reads back to split the entry:

```java
int dashIndex = commentAwareIndexOf('-', rawPrefix);
boolean hasDash = dashIndex != -1;
```

With no dash left in the prefix the entry records `dash=false` and the printer emits none. An anchored mapping escapes this because `MappingStart` never overwrites its prefix.

### The fix

Keep the `:` or `-` delimiter at the head of the recomputed prefix. `buildYamlAnchor` claims everything *after* that delimiter as the anchor's own prefix, so the two are exact complements of the original and no character is lost or duplicated. Both halves now share one delimiter search, `anchorPrefixStart`.

### A scalar's anchor and its tag

The second commit fixes a separate reordering: `key: &anchor !!str value` printed as `key: !!str &anchor value`, because `visitScalar` emitted the tag first unconditionally. Both nodes already carry the surrounding whitespace, so emitting them in source order is the whole fix.

A tag ahead of an anchor fails to parse, so every scalar the parser produces with both properties had the anchor first in source. Nothing has to record the order for the printer to choose correctly.

### Tests

- `anchoredInlineSequenceAsBlockSequenceEntry` and `anchoredBlockSequenceAsBlockSequenceEntry` pin the two prefix shapes: the flow form never enters the dash-truncation branch, the block form does.
- `anchorBeforeTag` pins the printer's emission order; the suite stayed green with that order reversed, so nothing covered it.
- Each fails without its own commit. Second entries are load-bearing: with one entry a regression that dropped only the newline would pass.

### Not fixed here

A tag *preceding* an anchor still fails to parse — `key: !!seq &a [1, 2]` and `key: !!str &a value` are both `ParseError`s, as is an anchored sequence at a document root (`--- &a`). Those need the node-property offsets reworked and are left for separate changes.
