### PR TITLE
C#: measure package graph depth from project references too

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/Xml/CsprojParserTests.cs
@@ -230,4 +230,79 @@ public class CsprojParserTests
         Assert.True(newtonsoft.HasLegacyContentFolder);
         Assert.Empty(newtonsoft.DependencyRanges);
     }
+
+    [Fact]
+    public void ReferencedProjectsAreGraphRootsForDepthComputation()
+    {
+        var lockFileJson = """
+            {
+              "version": 3,
+              "targets": {
+                "net8.0": {
+                  "Lib/1.0.0": {
+                    "type": "project",
+                    "dependencies": {
+                      "Newtonsoft.Json": "13.0.3"
+                    }
+                  },
+                  "Newtonsoft.Json/13.0.3": {
+                    "type": "package",
+                    "compile": {
+                      "lib/net6.0/Newtonsoft.Json.dll": {}
+                    }
+                  }
+                }
+              },
+              "libraries": {
+                "Lib/1.0.0": {
+                  "type": "project",
+                  "path": "../Lib/Lib.csproj",
+                  "msbuildProject": "../Lib/Lib.csproj"
+                },
+                "Newtonsoft.Json/13.0.3": {
+                  "type": "package",
+                  "path": "newtonsoft.json/13.0.3",
+                  "files": [ "lib/net6.0/Newtonsoft.Json.dll" ]
+                }
+              },
+              "projectFileDependencyGroups": {
+                "net8.0": []
+              },
+              "packageFolders": {},
+              "project": {
+                "version": "1.0.0",
+                "restore": {
+                  "projectName": "App",
+                  "projectStyle": "PackageReference",
+                  "originalTargetFrameworks": ["net8.0"],
+                  "frameworks": {
+                    "net8.0": {
+                      "targetAlias": "net8.0",
+                      "projectReferences": {
+                        "../Lib/Lib.csproj": {
+                          "projectPath": "../Lib/Lib.csproj"
+                        }
+                      }
+                    }
+                  }
+                },
+                "frameworks": {
+                  "net8.0": {
+                    "targetAlias": "net8.0",
+                    "dependencies": {}
+                  }
+                }
+              }
+            }
+            """;
+        var lockFile = new LockFileFormat().Parse(lockFileJson, "in-memory");
+
+        var marker = MSBuildProjectHelper.CreateFromLockFile(
+            "Microsoft.NET.Sdk", lockFile, Path.GetTempPath());
+
+        var tf = Assert.Single(marker.TargetFrameworks);
+        Assert.Equal(0, tf.ResolvedPackages.Single(p => p.Name == "Lib").Depth);
+        // Reached only through the project reference — depth 1, not a root.
+        Assert.Equal(1, tf.ResolvedPackages.Single(p => p.Name == "Newtonsoft.Json").Depth);
+    }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/MSBuildProjectHelper.cs
@@ -167,7 +167,9 @@ public static class MSBuildProjectHelper
     /// <summary>
     ///     Builds the marker from the in-memory NuGet lock file: declared package references
     ///     (from the restore's PackageSpec), the fully-linked resolved package graph with
-    ///     per-package asset information, and project references.
+    ///     per-package asset information, and project references. Graph depth is measured from
+    ///     both the declared packages and the referenced projects, so anything reachable only
+    ///     through a project reference is still reported at its true distance from the project.
     /// </summary>
     public static MSBuildProject CreateFromLockFile(string? sdk, LockFile lockFile, string projectDir,
         bool includeDeclaredPackageReferences = true)
@@ -176,6 +178,7 @@ public static class MSBuildProjectHelper
 
         // Declared dependencies per TFM alias (framework-specific + project-level)
         var declaredByTfm = new Dictionary<string, List<PackageReference>>(StringComparer.OrdinalIgnoreCase);
+        var referencedProjectsByTfm = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
         if (spec != null)
         {
             foreach (var tfi in spec.TargetFrameworks)
@@ -185,6 +188,19 @@ public static class MSBuildProjectHelper
                 foreach (var dep in tfi.Dependencies)
                     refs.Add(new PackageReference(dep.Name, dep.LibraryRange?.VersionRange?.MinVersion?.ToNormalizedString()));
                 declaredByTfm[tfm] = refs;
+            }
+
+            foreach (var restoreTfm in spec.RestoreMetadata?.TargetFrameworks ?? [])
+            {
+                var tfm = ShortTfm(restoreTfm.FrameworkName, restoreTfm.TargetAlias);
+                var names = new List<string>();
+                foreach (var reference in restoreTfm.ProjectReferences)
+                {
+                    var path = reference.ProjectPath ?? reference.ProjectUniqueName;
+                    if (!string.IsNullOrEmpty(path))
+                        names.Add(Path.GetFileNameWithoutExtension(path));
+                }
+                referencedProjectsByTfm[tfm] = names;
             }
         }
 
@@ -311,7 +327,10 @@ public static class MSBuildProjectHelper
                 }
             }
 
-            var depths = ComputeDepths(declared.Select(d => d.Include), nodes, dependencyNames);
+            referencedProjectsByTfm.TryGetValue(tfm, out var referencedProjects);
+            referencedProjects ??= referencedProjectsByTfm.Values.FirstOrDefault() ?? [];
+            var depths = ComputeDepths(
+                declared.Select(d => d.Include).Concat(referencedProjects), nodes, dependencyNames);
             var resolved = new List<ResolvedPackage>();
             foreach (var (name, node) in nodes)
                 resolved.Add(node.WithDepth(depths.TryGetValue(name, out var d) ? d : 0));


### PR DESCRIPTION
Packages reachable only through a `ProjectReference` were assigned depth 0 by `MSBuildProjectHelper.CreateFromLockFile`, making transitive dependencies look like direct ones because `ComputeDepths` was seeded solely from the declared `PackageReference`s.

The depth computation is now also seeded with the referenced projects from the lock file's restore metadata (falling back to any TFM's project references when the alias doesn't match), so a package pulled in via a project reference is reported at its true distance from the project. Added a `CsprojParserTests` case covering a project reference that transitively brings in a package, asserting the referenced project is depth 0 and the package behind it is depth 1.