### PR TITLE
C#: warn when a project resolves no reference metadata

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/SolutionParserTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/SolutionParserTests.cs
@@ -16,6 +16,9 @@
 using LibGit2Sharp;
 using OpenRewrite.CSharp;
 using OpenRewrite.CSharp.NuGet;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
 
 namespace OpenRewrite.Tests;
 
@@ -241,6 +244,38 @@ public class SolutionParserTests : IDisposable
     }
 
     [Fact]
+    public async Task ProjectsThatResolveNoReferencesAreWarnedAboutOnce()
+    {
+        WriteFile("Unsupported.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net99.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        WriteFile("Widget.cs", "class Widget { }\n");
+
+        var warnings = new List<string>();
+        var previousLogger = Log.Logger;
+        Log.Logger = new LoggerConfiguration()
+            .MinimumLevel.Warning()
+            .WriteTo.Sink(new CollectingSink(warnings))
+            .CreateLogger();
+        try
+        {
+            await new SolutionParser().LoadAsync(Path.Combine(_tempDir, "Unsupported.csproj"));
+        }
+        finally
+        {
+            Log.Logger = previousLogger;
+        }
+
+        var warning = Assert.Single(warnings, w => w.Contains("Unsupported.csproj") &&
+                                                   w.Contains("resolved no reference metadata"));
+        Assert.Contains("1 of 1", warning);
+    }
+
+    [Fact]
     public void WindowsTargetedProjectProducesRestoreGraph()
     {
         var csproj = WriteFile("MultiTarget.csproj", """
@@ -295,5 +330,14 @@ public class SolutionParserTests : IDisposable
         var results = parser.ParseProject(solution, project.FilePath!, _tempDir);
 
         Assert.Single(results);
+    }
+
+    private sealed class CollectingSink(List<string> messages) : ILogEventSink
+    {
+        public void Emit(LogEvent logEvent)
+        {
+            lock (messages)
+                messages.Add(logEvent.RenderMessage());
+        }
     }
 }

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -279,10 +279,37 @@ public class SolutionParser
                 Log.Debug("  ... and {Remaining} more diagnostics", diags.Count - 10);
         }
 
-        var projectCount = solution.Projects.Count();
-        var docCount = solution.Projects.Sum(p => p.Documents.Count());
-        Log.Debug("LoadAsync: loaded {ProjectCount} projects, {DocCount} documents", projectCount, docCount);
+        var projects = solution.Projects.ToList();
+        var docCount = projects.Sum(p => p.Documents.Count());
+        Log.Debug("LoadAsync: loaded {ProjectCount} projects, {DocCount} documents", projects.Count, docCount);
+
+        var unreferenced = projects.Where(p => !p.MetadataReferences.Any()).ToList();
+        if (unreferenced.Count > 0)
+            Log.Warning("{UnreferencedCount} of {ProjectCount} projects in {FileName} resolved no reference " +
+                        "metadata; their source parses without type attestation: {Projects}. Cause(s): {Reasons}",
+                unreferenced.Count, projects.Count, Path.GetFileName(path),
+                Summarize(unreferenced.Select(p => p.Name)),
+                Summarize(diags.Where(d => d.Kind == WorkspaceDiagnosticKind.Failure)
+                    .Select(FailureReason).Distinct(), limit: 3));
+
         return solution;
+    }
+
+    private static string Summarize(IEnumerable<string> items, int limit = 5)
+    {
+        var list = items.ToList();
+        if (list.Count == 0)
+            return "(none reported)";
+        return list.Count <= limit
+            ? string.Join("; ", list)
+            : string.Join("; ", list.Take(limit)) + $"; and {list.Count - limit} more";
+    }
+
+    private static string FailureReason(WorkspaceDiagnostic diagnostic)
+    {
+        const string marker = "with message: ";
+        var index = diagnostic.Message.IndexOf(marker, StringComparison.Ordinal);
+        return (index < 0 ? diagnostic.Message : diagnostic.Message[(index + marker.Length)..]).Trim();
     }
 
     /// <summary>


### PR DESCRIPTION
`MSBuildWorkspace` can open a project successfully while resolving no metadata references at all — for example when the target framework is unavailable — and the resulting source is then parsed without any type attestation, silently and with no indication that anything went wrong.

`SolutionParser.LoadAsync` now emits a single warning when any loaded project has no metadata references, naming the affected projects and the distinct MSBuild failure reasons extracted from the workspace diagnostics. Counts and lists are truncated so the message stays readable on large solutions.