### PR TITLE
C#: group NuGet source failures by endpoint instead of one line per package

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/NuGetSourceFailuresTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/NuGetSourceFailuresTests.cs
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using NuGet.Common;
+using OpenRewrite.CSharp.NuGet;
+
+namespace OpenRewrite.Tests;
+
+public class NuGetSourceFailuresTests
+{
+    private const string Feed = "https://pkgs.dev.azure.com/contoso/_packaging/tools/nuget/v3/index.json";
+    private const string OtherFeed = "https://pkgs.dev.azure.com/contoso/_packaging/legacy/nuget/v3/index.json";
+    private const string Public = "https://api.nuget.org/v3/index.json";
+
+    private static readonly string[] Sources = [Feed, OtherFeed, Public];
+
+    private sealed class RestoreMessage : IRestoreLogMessage
+    {
+        public LogLevel Level { get; set; } = LogLevel.Warning;
+        public WarningLevel WarningLevel { get; set; } = WarningLevel.Severe;
+        public NuGetLogCode Code { get; set; } = NuGetLogCode.Undefined;
+        public string Message { get; set; } = string.Empty;
+        public string? ProjectPath { get; set; }
+        public DateTimeOffset Time { get; set; } = DateTimeOffset.UnixEpoch;
+        public string? FilePath { get; set; }
+        public int StartLineNumber { get; set; }
+        public int StartColumnNumber { get; set; }
+        public int EndLineNumber { get; set; }
+        public int EndColumnNumber { get; set; }
+        public string? LibraryId { get; set; }
+        public IReadOnlyList<string> TargetGraphs { get; set; } = [];
+        public bool ShouldDisplay { get; set; } = true;
+    }
+
+    private static RestoreMessage ServiceIndexFailure(string feed, string package, string project) => new()
+    {
+        Level = LogLevel.Warning,
+        Code = NuGetLogCode.NU1301,
+        Message = $"Unable to load the service index for source {feed}.",
+        LibraryId = package,
+        ProjectPath = $"/repo/src/{project}/{project}.csproj",
+    };
+
+    [Fact]
+    public void GroupsRepeatedServiceIndexFailuresIntoOneEndpoint()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+        foreach (var project in new[] { "Api", "Web", "Worker" })
+        foreach (var package in new[] { "Serilog", "Newtonsoft.Json", "Polly" })
+            Assert.True(failures.Record(ServiceIndexFailure(Feed, package, project)));
+
+        var summary = failures.BuildSummary();
+
+        Assert.Equal($"NuGet: 9 package source diagnostic(s) from 1 source(s) while restoring " +
+                     "Contoso.sln; grouped by endpoint below", summary[0]);
+        Assert.Equal($"  source {Feed}: 9 diagnostic(s), unused - every package resolved from another source",
+            summary[1]);
+        Assert.Equal($"    [Warning NU1301] x9: Unable to load the service index for source {Feed}.", summary[2]);
+        Assert.Equal("    affected packages (3): Newtonsoft.Json, Polly, Serilog", summary[3]);
+        Assert.Equal("    affected projects (3): Api.csproj, Web.csproj, Worker.csproj", summary[4]);
+        Assert.Equal(5, summary.Count);
+    }
+
+    [Fact]
+    public void AttributesResourceUrlsToTheConfiguredFeedTheyBelongTo()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+        failures.Record(new RestoreMessage
+        {
+            Code = NuGetLogCode.Undefined,
+            Message = "Retrying 'https://pkgs.dev.azure.com/contoso/_packaging/tools/nuget/v3/flat2/serilog/index.json' " +
+                       $"for source '{Feed}'.",
+            LibraryId = "Serilog",
+        });
+        failures.Record(ServiceIndexFailure(Feed, "Serilog", "Api"));
+
+        var summary = failures.BuildSummary();
+
+        Assert.Contains($"  source {Feed}: 2 diagnostic(s)", summary[1]);
+        Assert.Equal(2, summary.Count(l => l.TrimStart().StartsWith('[')));
+    }
+
+    [Fact]
+    public void KeepsSeparateFeedsOnTheSameHostApart()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+        failures.Record(ServiceIndexFailure(Feed, "Serilog", "Api"));
+        failures.Record(ServiceIndexFailure(OtherFeed, "Serilog", "Api"));
+
+        var summary = failures.BuildSummary();
+
+        Assert.StartsWith("NuGet: 2 package source diagnostic(s) from 2 source(s)", summary[0]);
+        Assert.Contains(summary, l => l.StartsWith($"  source {Feed}:"));
+        Assert.Contains(summary, l => l.StartsWith($"  source {OtherFeed}:"));
+    }
+
+    [Fact]
+    public void ReportsAFeedAsRequiredWhenItBlockedAPackage()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+        failures.Record(ServiceIndexFailure(Feed, "Contoso.Internal.Core", "Api"));
+        failures.Record(new RestoreMessage
+        {
+            Level = LogLevel.Error,
+            Code = NuGetLogCode.NU1101,
+            Message = "Unable to find package Contoso.Internal.Core. No packages exist with this id in " +
+                       $"source(s): {Feed}",
+            LibraryId = "Contoso.Internal.Core",
+        });
+
+        var summary = failures.BuildSummary();
+
+        Assert.Contains("REQUIRED - blocked 1 package(s): Contoso.Internal.Core", summary[1]);
+    }
+
+    [Fact]
+    public void ReportsAFeedAsNotRequiredWhenSomethingElseFailedToResolve()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+        failures.Record(ServiceIndexFailure(Feed, "Serilog", "Api"));
+        failures.MarkUnresolved("Contoso.Internal.Core");
+
+        var summary = failures.BuildSummary();
+
+        Assert.Contains("not required - none of the 1 unresolved package(s) were looked up here", summary[1]);
+    }
+
+    [Fact]
+    public void FlagsAFeedAsPossiblyRequiredWhenItNamedNoPackageAtAll()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+        failures.Record(new RestoreMessage
+        {
+            Code = NuGetLogCode.NU1801,
+            Message = $"Unable to load the service index for source {Feed}.",
+            ProjectPath = "/repo/src/Api/Api.csproj",
+        });
+        failures.MarkUnresolved("Contoso.Internal.Core");
+
+        var summary = failures.BuildSummary();
+
+        Assert.Contains("possibly required - 1 package(s) resolved from no source: Contoso.Internal.Core",
+            summary[1]);
+    }
+
+    [Fact]
+    public void LeavesInformationalHttpTraceAlone()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+
+        Assert.False(failures.Record(new RestoreMessage
+        {
+            Level = LogLevel.Information,
+            Message = $"  OK {Public} 108ms",
+        }));
+        Assert.Empty(failures.BuildSummary());
+    }
+
+    [Fact]
+    public void LeavesMessagesThatNameNoSourceAlone()
+    {
+        var failures = new NuGetSourceFailures("Contoso.sln", Sources);
+
+        Assert.False(failures.Record(new RestoreMessage
+        {
+            Code = NuGetLogCode.NU1603,
+            Message = "Serilog 2.0.0 was not found. An approximate best match of Serilog 2.1.0 was resolved.",
+            LibraryId = "Serilog",
+        }));
+        Assert.Empty(failures.BuildSummary());
+    }
+
+    [Fact]
+    public void GroupsFailuresRaisedOutsideNuGetsLogger()
+    {
+        var failures = new NuGetSourceFailures("packages.config", Sources);
+
+        Assert.True(failures.RecordSourceFailure(Feed, "Serilog", "The remote name could not be resolved"));
+        Assert.True(failures.RecordSourceFailure(Feed, "Polly", "The remote name could not be resolved"));
+        Assert.False(failures.RecordSourceFailure(string.Empty, "Polly", "boom"));
+
+        var summary = failures.BuildSummary();
+
+        Assert.Contains($"  source {Feed}: 2 diagnostic(s)", summary[1]);
+        Assert.Equal(1, summary.Count(l => l.TrimStart().StartsWith('[')));
+        Assert.Contains("    affected packages (2): Polly, Serilog", summary);
+    }
+
+    [Fact]
+    public void CollapseElidesUrlsPathsAndThePackageUnderResolution()
+    {
+        var collapsed = NuGetSourceFailures.Collapse(
+            $"Unable to load the service index for source {Feed}\n  while restoring " +
+            "/repo/src/Api/Api.csproj for Serilog", "Serilog", Sources, null);
+
+        Assert.Equal("Unable to load the service index for source {source} while restoring {path} for {package}",
+            collapsed);
+    }
+
+    [Fact]
+    public void CollapseFallsBackToTheAuthorityForUnconfiguredSources()
+    {
+        var endpoints = new List<string>();
+        NuGetSourceFailures.Collapse("Unable to load the service index for source https://nuget.example.com/a/b.json.",
+            null, Sources, endpoints);
+
+        Assert.Equal(["https://nuget.example.com"], endpoints);
+    }
+
+    [Fact]
+    public void CollapseDoesNotMistakeOrdinaryProseForAPath()
+    {
+        Assert.Equal("either and/or both", NuGetSourceFailures.Collapse("either and/or both", null, null, null));
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetResolver.cs
@@ -77,8 +77,12 @@ public static class NuGetResolver
     {
         public static readonly SerilogNuGetLogger Instance = new();
 
-        public override void Log(ILogMessage message) =>
+        public override void Log(ILogMessage message)
+        {
+            if (NuGetSourceFailures.TryRecord(message))
+                return;
             Serilog.Log.Debug("NuGet: {Message}", message.Message);
+        }
 
         public override Task LogAsync(ILogMessage message)
         {
@@ -91,6 +95,28 @@ public static class NuGetResolver
 
     public static ISettings LoadSettings(string startDirectory) =>
         Settings.LoadDefaultSettings(startDirectory, null, new XPlatMachineWideSetting());
+
+    /// <summary>
+    /// The enabled package source URLs configured for <paramref name="startDirectory"/>, used to
+    /// attribute a failing resource URL back to the feed it came from. Empty when settings
+    /// cannot be read — grouping then falls back to the URL authority.
+    /// </summary>
+    public static IReadOnlyList<string> EnabledSourceUrls(string startDirectory)
+    {
+        try
+        {
+            return SettingsUtility.GetEnabledSources(LoadSettings(startDirectory))
+                .Select(s => s.Source)
+                .Where(s => !string.IsNullOrEmpty(s))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("NuGetResolver: failed to read package sources from {Dir}: {Error}",
+                startDirectory, ex.Message);
+            return [];
+        }
+    }
 
     #region Restore graph generation (PackageReference projects)
 
@@ -574,13 +600,20 @@ public static class NuGetResolver
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    Log.Debug("NuGetResolver: {Package} not available from {Source}: {Error}",
-                        identity, repository.PackageSource.Source, ex.Message);
+                    if (!NuGetSourceFailures.TryRecordSourceFailure(
+                            repository.PackageSource.Source, identity.Id, ex.Message))
+                    {
+                        Log.Debug("NuGetResolver: {Package} not available from {Source}: {Error}",
+                            identity, repository.PackageSource.Source, ex.Message);
+                    }
                 }
             }
 
             if (!installed)
+            {
+                NuGetSourceFailures.RecordUnresolved(identity.Id);
                 Log.Debug("NuGetResolver: failed to install {Package} from any source", identity);
+            }
         }
     }
 
@@ -599,6 +632,8 @@ public static class NuGetResolver
         CancellationToken ct)
     {
         var projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath))!;
+        using var sourceFailures = NuGetSourceFailures.Begin(
+            Path.GetFileName(projectPath), EnabledSourceUrls(projectDir));
         var packagesConfig = Path.Combine(projectDir, "packages.config");
         if (File.Exists(packagesConfig))
         {

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetSourceFailures.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/NuGet/NuGetSourceFailures.cs
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System.Text.RegularExpressions;
+using NuGet.Common;
+using Serilog;
+
+namespace OpenRewrite.CSharp.NuGet;
+
+/// <summary>
+/// Collapses NuGet's per-package, per-project source diagnostics into one grouped summary per
+/// package source. An unreachable feed otherwise emits an "Unable to load the service index"
+/// line for every package times every project — hundreds of identical lines that bury the
+/// diagnostics worth acting on.
+/// <para>
+/// While a scope is open, every warning or error naming a package source is withheld and
+/// replayed as a single per-endpoint summary: one verbatim example with its occurrence count,
+/// the affected packages and projects, and whether the source was actually needed to resolve a
+/// dependency (a feed nothing depended on being unreachable is noise; one that blocked a package
+/// is not). Informational HTTP trace and messages that name no source pass through untouched.
+/// </para>
+/// </summary>
+internal sealed class NuGetSourceFailures : IDisposable
+{
+    private const int MaxEndpointsReported = 10;
+    private const int MaxExamplesPerEndpoint = 5;
+    private const int MaxIdsListed = 10;
+    private const int MaxIdsTracked = 500;
+
+    private static readonly Regex UrlPattern =
+        new(@"https?://[^\s'""<>|,;)\]]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    private static readonly Regex PathPattern =
+        new(@"(?:[a-zA-Z]:[\\/]|(?<![\w.])[\\/])(?:[^\s'""<>|*?,;()\[\]]*[\\/])+[^\s'""<>|*?,;()\[\]]*",
+            RegexOptions.Compiled);
+
+    private static readonly Regex WhitespacePattern = new(@"\s+", RegexOptions.Compiled);
+
+    private static readonly HashSet<NuGetLogCode> UnresolvedCodes =
+    [
+        NuGetLogCode.NU1100, NuGetLogCode.NU1101, NuGetLogCode.NU1102, NuGetLogCode.NU1103,
+    ];
+
+    private static readonly object Sync = new();
+    private static NuGetSourceFailures? _current;
+
+    private readonly object _lock = new();
+    private readonly string _context;
+    private readonly IReadOnlyList<string> _sources;
+    private readonly Dictionary<string, Endpoint> _endpoints = new(StringComparer.OrdinalIgnoreCase);
+    private readonly SortedSet<string> _unresolved = new(StringComparer.OrdinalIgnoreCase);
+
+    internal NuGetSourceFailures(string context, IReadOnlyList<string> sources)
+    {
+        _context = context;
+        _sources = sources;
+    }
+
+    /// <summary>
+    /// Opens a collection scope covering one restore. Nested calls join the outermost scope, so
+    /// the summary is written once when that scope is disposed. <paramref name="sources"/> are
+    /// the configured package sources, used to attribute a resource URL to the feed it belongs
+    /// to (a flat-container URL shares only a prefix with the feed's service index).
+    /// </summary>
+    public static IDisposable Begin(string context, IReadOnlyList<string> sources)
+    {
+        lock (Sync)
+        {
+            if (_current != null)
+                return NestedScope.Instance;
+            _current = new NuGetSourceFailures(context, sources);
+            return _current;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (Sync)
+        {
+            if (!ReferenceEquals(_current, this))
+                return;
+            _current = null;
+        }
+        WriteSummary();
+    }
+
+    private sealed class NestedScope : IDisposable
+    {
+        public static readonly NestedScope Instance = new();
+        public void Dispose() { }
+    }
+
+    private static NuGetSourceFailures? Current
+    {
+        get { lock (Sync) return _current; }
+    }
+
+    /// <summary>
+    /// Offers a NuGet log message to the open scope. Returns true when the message was absorbed
+    /// into an endpoint group and must not be logged individually.
+    /// </summary>
+    public static bool TryRecord(ILogMessage message) => Current?.Record(message) == true;
+
+    internal bool Record(ILogMessage message)
+    {
+        var text = message.Message ?? string.Empty;
+        var libraryId = (message as IRestoreLogMessage)?.LibraryId;
+
+        if (UnresolvedCodes.Contains(message.Code) && !string.IsNullOrEmpty(libraryId))
+            MarkUnresolved(libraryId);
+
+        if (message.Level < LogLevel.Warning)
+            return false;
+
+        var endpoints = new List<string>();
+        var template = Collapse(text, libraryId, _sources, endpoints);
+        if (endpoints.Count == 0)
+            return false;
+
+        var absorbed = false;
+        foreach (var endpoint in endpoints)
+            absorbed |= Add(endpoint, message.Level, message.Code, text, libraryId, message.ProjectPath, template);
+        return absorbed;
+    }
+
+    internal bool RecordSourceFailure(string source, string? packageId, string reason)
+    {
+        if (string.IsNullOrEmpty(source))
+            return false;
+        return Add(EndpointOf(source), LogLevel.Warning, NuGetLogCode.Undefined,
+            $"{packageId} is not available from {source}: {reason}", packageId, projectPath: null);
+    }
+
+    internal void MarkUnresolved(string packageId)
+    {
+        lock (_lock)
+        {
+            if (_unresolved.Count < MaxIdsTracked)
+                _unresolved.Add(packageId);
+        }
+    }
+
+    /// <summary>
+    /// Records a per-source failure raised outside NuGet's own logger (the flat install path
+    /// walks repositories itself). Returns true when it was absorbed into an endpoint group.
+    /// </summary>
+    public static bool TryRecordSourceFailure(string source, string? packageId, string reason) =>
+        Current?.RecordSourceFailure(source, packageId, reason) == true;
+
+    /// <summary>Marks a package as unresolvable from any source.</summary>
+    public static void RecordUnresolved(string packageId)
+    {
+        if (!string.IsNullOrEmpty(packageId))
+            Current?.MarkUnresolved(packageId);
+    }
+
+    private bool Add(string endpoint, LogLevel level, NuGetLogCode code, string text,
+        string? libraryId, string? projectPath, string? template = null)
+    {
+        lock (_lock)
+        {
+            if (!_endpoints.TryGetValue(endpoint, out var group))
+            {
+                group = new Endpoint();
+                _endpoints[endpoint] = group;
+            }
+            group.Add(level, code, text, template ?? Collapse(text, libraryId, _sources, null),
+                libraryId, projectPath);
+            return true;
+        }
+    }
+
+    private void WriteSummary()
+    {
+        var lines = BuildSummary();
+        if (lines.Count == 0)
+            return;
+        var actionable = AnythingUnresolved();
+        foreach (var line in lines)
+        {
+            if (actionable)
+                Log.Warning("{SourceFailureSummary}", line);
+            else
+                Log.Debug("{SourceFailureSummary}", line);
+        }
+    }
+
+    private bool AnythingUnresolved()
+    {
+        lock (_lock)
+            return _unresolved.Count > 0;
+    }
+
+    internal IReadOnlyList<string> BuildSummary()
+    {
+        lock (_lock)
+        {
+            var lines = new List<string>();
+            if (_endpoints.Count == 0)
+                return lines;
+
+            var total = _endpoints.Values.Sum(e => e.Total);
+            lines.Add($"NuGet: {total} package source diagnostic(s) from {_endpoints.Count} source(s) " +
+                      $"while restoring {_context}; grouped by endpoint below");
+
+            var ordered = _endpoints.OrderByDescending(p => p.Value.Total)
+                .ThenBy(p => p.Key, StringComparer.OrdinalIgnoreCase).ToList();
+            foreach (var (endpoint, group) in ordered.Take(MaxEndpointsReported))
+            {
+                var blocking = group.Packages.Intersect(_unresolved, StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(id => id, StringComparer.OrdinalIgnoreCase).ToList();
+                string verdict;
+                if (_unresolved.Count == 0)
+                    verdict = "unused - every package resolved from another source";
+                else if (blocking.Count > 0)
+                    verdict = $"REQUIRED - blocked {blocking.Count} package(s): {Join(blocking)}";
+                else if (group.Packages.Count == 0)
+                    verdict = $"possibly required - {_unresolved.Count} package(s) resolved from no " +
+                              $"source: {Join(_unresolved)}";
+                else
+                    verdict = $"not required - none of the {_unresolved.Count} unresolved package(s) " +
+                              "were looked up here";
+
+                lines.Add($"  source {endpoint}: {group.Total} diagnostic(s), {verdict}");
+                foreach (var example in group.Examples.Values
+                             .OrderByDescending(e => e.Count).ThenBy(e => e.Text, StringComparer.Ordinal)
+                             .Take(MaxExamplesPerEndpoint))
+                {
+                    lines.Add($"    [{example.Level} {example.Code}] x{example.Count}: {example.Text}");
+                }
+                if (group.Examples.Count > MaxExamplesPerEndpoint)
+                    lines.Add($"    ... and {group.Examples.Count - MaxExamplesPerEndpoint} more distinct message(s)");
+                if (group.Packages.Count > 0)
+                    lines.Add($"    affected packages ({group.Packages.Count}): {Join(group.Packages)}");
+                if (group.Projects.Count > 0)
+                    lines.Add($"    affected projects ({group.Projects.Count}): " +
+                              $"{Join(group.Projects.Select(p => Path.GetFileName(p) ?? p))}");
+            }
+            if (ordered.Count > MaxEndpointsReported)
+                lines.Add($"  ... and {ordered.Count - MaxEndpointsReported} more source(s)");
+            return lines;
+        }
+    }
+
+    private static string Join(IEnumerable<string> ids)
+    {
+        var list = ids.Take(MaxIdsListed + 1).ToList();
+        return list.Count > MaxIdsListed
+            ? string.Join(", ", list.Take(MaxIdsListed)) + ", ..."
+            : string.Join(", ", list);
+    }
+
+    internal static string Collapse(string message, string? libraryId,
+        IReadOnlyList<string>? sources, ICollection<string>? endpoints)
+    {
+        var template = UrlPattern.Replace(message, match =>
+        {
+            if (endpoints != null)
+            {
+                var endpoint = EndpointOf(match.Value, sources);
+                if (!endpoints.Contains(endpoint, StringComparer.OrdinalIgnoreCase))
+                    endpoints.Add(endpoint);
+            }
+            return "{source}";
+        });
+        template = PathPattern.Replace(template, "{path}");
+        if (!string.IsNullOrEmpty(libraryId))
+            template = template.Replace(libraryId, "{package}", StringComparison.OrdinalIgnoreCase);
+        return WhitespacePattern.Replace(template, " ").Trim();
+    }
+
+    private string EndpointOf(string url) => EndpointOf(url, _sources);
+
+    private static string EndpointOf(string url, IReadOnlyList<string>? sources)
+    {
+        string? best = null;
+        var bestLength = 0;
+        foreach (var source in sources ?? [])
+        {
+            var shared = CommonPrefixLength(url, source);
+            if (shared > bestLength && shared >= AuthorityLength(source))
+            {
+                bestLength = shared;
+                best = source;
+            }
+        }
+        if (best != null)
+            return best;
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+            ? uri.GetLeftPart(UriPartial.Authority)
+            : url;
+    }
+
+    private static int CommonPrefixLength(string a, string b)
+    {
+        var max = Math.Min(a.Length, b.Length);
+        var i = 0;
+        while (i < max && char.ToLowerInvariant(a[i]) == char.ToLowerInvariant(b[i]))
+            i++;
+        return i;
+    }
+
+    private static int AuthorityLength(string source) =>
+        Uri.TryCreate(source, UriKind.Absolute, out var uri) && uri.IsAbsoluteUri && !uri.IsFile
+            ? uri.GetLeftPart(UriPartial.Authority).Length
+            : int.MaxValue;
+
+    private sealed class Endpoint
+    {
+        public int Total { get; private set; }
+        public Dictionary<string, Example> Examples { get; } = new(StringComparer.Ordinal);
+        public SortedSet<string> Packages { get; } = new(StringComparer.OrdinalIgnoreCase);
+        public SortedSet<string> Projects { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+        public void Add(LogLevel level, NuGetLogCode code, string text, string template,
+            string? libraryId, string? projectPath)
+        {
+            Total++;
+            if (Examples.TryGetValue(template, out var example))
+            {
+                example.Count++;
+                if (level > example.Level)
+                {
+                    example.Level = level;
+                    example.Code = code;
+                }
+            }
+            else if (Examples.Count < MaxIdsTracked)
+            {
+                Examples[template] = new Example { Level = level, Code = code, Text = text, Count = 1 };
+            }
+            if (!string.IsNullOrEmpty(libraryId) && Packages.Count < MaxIdsTracked)
+                Packages.Add(libraryId);
+            if (!string.IsNullOrEmpty(projectPath) && Projects.Count < MaxIdsTracked)
+                Projects.Add(projectPath);
+        }
+    }
+
+    private sealed class Example
+    {
+        public LogLevel Level { get; set; }
+        public NuGetLogCode Code { get; set; }
+        public required string Text { get; init; }
+        public int Count { get; set; }
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -91,6 +91,9 @@ internal static class SolutionRestore
             var lockFiles = new Dictionary<string, LockFile>(StringComparer.OrdinalIgnoreCase);
             var rootDir = Path.GetDirectoryName(key) ?? ".";
 
+            using var sourceFailures = NuGetSourceFailures.Begin(
+                Path.GetFileName(path), NuGetResolver.EnabledSourceUrls(rootDir));
+
             if (hasPackagesConfig)
             {
                 // Materialize the solution-local packages/ folder for legacy HintPaths.
@@ -167,6 +170,8 @@ internal static class SolutionRestore
                 return _buildAssets;
 
             var cacheDir = Path.Combine(Path.GetTempPath(), "openrewrite-netfx-build-assets");
+            using var sourceFailures = NuGetSourceFailures.Begin(
+                "the .NET Framework build assets", NuGetResolver.EnabledSourceUrls(cacheDir));
             var vsToolsPath = Path.Combine(cacheDir, WebTargetsPackage, "tools", "VSToolsPath");
             var targetFrameworkRootPath = Path.Combine(cacheDir, ReferenceAssembliesPackage, "build");
 
@@ -267,11 +272,21 @@ public class SolutionParser
         var diags = workspace.Diagnostics;
         if (diags.Count > 0)
         {
-            Log.Debug("MSBuildWorkspace: {DiagCount} diagnostics", diags.Count);
-            foreach (var d in diags.Take(10))
-                Log.Debug("  MSBuild diagnostic {Kind}: {Message}", d.Kind, d.Message);
-            if (diags.Count > 10)
-                Log.Debug("  ... and {Remaining} more diagnostics", diags.Count - 10);
+            var grouped = new Dictionary<string, (int Count, WorkspaceDiagnosticKind Kind, string Message)>(
+                StringComparer.Ordinal);
+            foreach (var d in diags)
+            {
+                var key = NuGetSourceFailures.Collapse(d.Message ?? string.Empty, null, null, null);
+                grouped[key] = grouped.TryGetValue(key, out var seen)
+                    ? (seen.Count + 1, seen.Kind, seen.Message)
+                    : (1, d.Kind, d.Message ?? string.Empty);
+            }
+            Log.Debug("MSBuildWorkspace: {DiagCount} diagnostics ({DistinctCount} distinct)",
+                diags.Count, grouped.Count);
+            foreach (var g in grouped.Values.OrderByDescending(g => g.Count).Take(10))
+                Log.Debug("  MSBuild diagnostic {Kind} x{Count}: {Message}", g.Kind, g.Count, g.Message);
+            if (grouped.Count > 10)
+                Log.Debug("  ... and {Remaining} more distinct diagnostics", grouped.Count - 10);
         }
 
         var projectCount = solution.Projects.Count();


### PR DESCRIPTION
- Fixes moderneinc/support-morganstanley#309.

An unreachable NuGet feed made NuGet log "Unable to load the service index for source <url>" once per package per project, so a single solution produced hundreds of identical lines that buried anything actionable; MSBuildWorkspace diagnostics repeated the same way. Warnings and errors naming a package source are now withheld for the duration of a restore and replayed as one summary per endpoint — a verbatim example with its occurrence count, the affected packages and projects, and whether the source was actually needed — while informational HTTP trace and messages naming no source pass through untouched. A feed that everything resolved around is reported as unused at debug level; one that coincided with a package resolving from nowhere is reported at warning level. Resource URLs are attributed to the configured feed sharing the longest prefix, so a flat-container retry groups under its service index and two feeds on the same host stay apart, and MSBuildWorkspace diagnostics are grouped on the same normalized message with counts.

`./gradlew :rewrite-csharp:csharpTest` passes, including the new `NuGetSourceFailuresTests` coverage.
