### PR TITLE
C#: recover a project's sources when MSBuild cannot evaluate it

### DIFF
--- a/rewrite-csharp/csharp/OpenRewrite.Tests/UnevaluatedProjectRecoveryTests.cs
+++ b/rewrite-csharp/csharp/OpenRewrite.Tests/UnevaluatedProjectRecoveryTests.cs
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2026 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using OpenRewrite.Core;
+using OpenRewrite.CSharp;
+
+namespace OpenRewrite.Tests;
+
+public class UnevaluatedProjectRecoveryTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public UnevaluatedProjectRecoveryTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), "UnevaluatedProject_" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); }
+        catch { /* best effort cleanup */ }
+    }
+
+    private string WriteFile(string relativePath, string content)
+    {
+        var fullPath = Path.Combine(_tempDir, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(fullPath)!);
+        File.WriteAllText(fullPath, content);
+        return fullPath;
+    }
+
+    /// <summary>
+    /// A build-only task whose assembly path only exists after a real build. MSBuild fails
+    /// evaluation with "The result "" of evaluating the value ... of the "AssemblyFile"
+    /// attribute in element &lt;UsingTask&gt; is not valid."
+    /// </summary>
+    private void WriteBuildOnlyTargets(string relativePath) => WriteFile(relativePath, """
+        <Project>
+          <UsingTask TaskName="PdbGitTask" AssemblyFile="$(_PdbGitAssemblyFile)" />
+        </Project>
+        """);
+
+    [Fact]
+    public async Task ProjectFailingMSBuildEvaluationIsFlagged()
+    {
+        WriteBuildOnlyTargets("PdbGit.targets");
+        WriteFile("Broken.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <Import Project="PdbGit.targets" />
+            </Project>
+            """);
+        WriteFile("A.cs", "class A { }\n");
+
+        var parser = new SolutionParser();
+        var projectPath = Path.Combine(_tempDir, "Broken.csproj");
+        var solution = await parser.LoadAsync(projectPath);
+
+        // MSBuild hands back the project stripped of every document.
+        Assert.Empty(parser.ParseProject(solution, projectPath, _tempDir));
+
+        var flagged = Assert.Single(parser.UnevaluatedProjects);
+        Assert.Equal(projectPath, flagged.Key);
+        Assert.Contains("UsingTask", flagged.Value);
+    }
+
+    [Fact]
+    public async Task SourcesOfAnUnevaluatedProjectAreRecoveredFromDisk()
+    {
+        WriteBuildOnlyTargets("PdbGit.targets");
+        WriteFile("Broken.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <Import Project="PdbGit.targets" />
+            </Project>
+            """);
+        WriteFile("A.cs", "class A { }\n");
+        WriteFile("nested/B.cs", "class B { }\n");
+        // Build output and tool directories are not repository sources.
+        WriteFile("obj/Debug/Generated.cs", "class Generated { }\n");
+        WriteFile("bin/Debug/Copied.cs", "class Copied { }\n");
+
+        var parser = new SolutionParser();
+        var projectPath = Path.Combine(_tempDir, "Broken.csproj");
+        await parser.LoadAsync(projectPath);
+
+        var recovered = parser.ParseProjectWithoutMSBuild(projectPath, _tempDir);
+
+        Assert.Equal(new[] { "A.cs", "nested/B.cs" },
+            recovered.Select(sf => sf.SourcePath).OrderBy(p => p, StringComparer.Ordinal));
+        foreach (var sourceFile in recovered)
+        {
+            var cu = Assert.IsType<CompilationUnit>(sourceFile);
+            // Recovered without a semantic model: syntax is intact, types are not attested.
+            Assert.Equal(File.ReadAllText(Path.Combine(_tempDir, cu.SourcePath)),
+                new CSharpPrinter<int>().Print(cu));
+        }
+    }
+
+    [Fact]
+    public async Task AlreadyParsedSourcesAreNotRecoveredTwice()
+    {
+        WriteBuildOnlyTargets("PdbGit.targets");
+        WriteFile("Broken.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <Import Project="PdbGit.targets" />
+            </Project>
+            """);
+        WriteFile("A.cs", "class A { }\n");
+        WriteFile("B.cs", "class B { }\n");
+
+        var parser = new SolutionParser();
+        var projectPath = Path.Combine(_tempDir, "Broken.csproj");
+        await parser.LoadAsync(projectPath);
+
+        var recovered = parser.ParseProjectWithoutMSBuild(projectPath, _tempDir,
+            alreadyParsed: new HashSet<string> { "A.cs" });
+
+        Assert.Equal("B.cs", Assert.Single(recovered).SourcePath);
+    }
+
+    [Fact]
+    public async Task SubtreesOwnedByAnotherProjectAreLeftToThatProject()
+    {
+        WriteBuildOnlyTargets("PdbGit.targets");
+        WriteFile("Broken.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <Import Project="PdbGit.targets" />
+            </Project>
+            """);
+        WriteFile("A.cs", "class A { }\n");
+        WriteFile("Nested/Nested.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        WriteFile("Nested/N.cs", "class N { }\n");
+
+        var parser = new SolutionParser();
+        var projectPath = Path.Combine(_tempDir, "Broken.csproj");
+        await parser.LoadAsync(projectPath);
+
+        var recovered = parser.ParseProjectWithoutMSBuild(projectPath, _tempDir);
+
+        Assert.Equal("A.cs", Assert.Single(recovered).SourcePath);
+    }
+
+    [Fact]
+    public async Task OnlyTheUnevaluatedProjectOfASolutionIsRecovered()
+    {
+        WriteBuildOnlyTargets("PdbGit.targets");
+        WriteFile("Broken/Broken.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <Import Project="../PdbGit.targets" />
+            </Project>
+            """);
+        WriteFile("Broken/A.cs", "class A { }\n");
+        WriteFile("Good/Good.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        WriteFile("Good/C.cs", "class C { }\n");
+        WriteFile("Test.sln", """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Broken", "Broken\Broken.csproj", "{00000000-0000-0000-0000-000000000001}"
+            EndProject
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Good", "Good\Good.csproj", "{00000000-0000-0000-0000-000000000002}"
+            EndProject
+            Global
+            	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+            		Debug|Any CPU = Debug|Any CPU
+            	EndGlobalSection
+            EndGlobal
+            """);
+
+        var parser = new SolutionParser();
+        var solution = await parser.LoadAsync(Path.Combine(_tempDir, "Test.sln"));
+
+        var flagged = Assert.Single(parser.UnevaluatedProjects);
+        Assert.Equal(Path.Combine(_tempDir, "Broken", "Broken.csproj"), flagged.Key);
+
+        var good = solution.Projects.Single(p => p.FilePath!.EndsWith("Good.csproj", StringComparison.Ordinal));
+        Assert.Equal("Good/C.cs", Assert.Single(parser.ParseProject(solution, good.FilePath!, _tempDir)).SourcePath);
+
+        var recovered = parser.ParseProjectWithoutMSBuild(flagged.Key, _tempDir);
+        Assert.Equal("Broken/A.cs", Assert.Single(recovered).SourcePath);
+    }
+}

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/Rpc/RewriteRpcServer.cs
@@ -304,6 +304,78 @@ public class RewriteRpcServer
         var projectList = solution.Projects.Where(p => p.FilePath != null).ToList();
         Log.Debug("RPC ParseSolution: {ProjectCount} projects to parse", projectList.Count);
 
+        // Repository-relative paths already emitted, so a project recovered from disk after an
+        // MSBuild evaluation failure does not re-emit a file another project already contributed.
+        var emittedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var emittedProjectFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var projectsWithSources = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        void EmitSourceFiles(List<SourceFile> sourceFiles)
+        {
+            foreach (var sourceFile in sourceFiles)
+            {
+                var id = sourceFile.Id.ToString();
+                var sourceFileType = sourceFile is ParseError
+                    ? "org.openrewrite.tree.ParseError"
+                    : "org.openrewrite.csharp.tree.Cs$CompilationUnit";
+
+                emittedPaths.Add(sourceFile.SourcePath);
+                _localObjects[id] = sourceFile;
+                response.Items.Add(new ParseSolutionResponseItem
+                {
+                    Id = id,
+                    SourceFileType = sourceFileType
+                });
+            }
+
+            // Oversize source files skipped during parsing are emitted as Quarks; the Java
+            // side builds each Quark from SourcePath locally, so they carry no content and
+            // are deliberately not registered in _localObjects (no GetObject round-trip).
+            foreach (var relPath in solutionParser.LastOversizePaths)
+            {
+                emittedPaths.Add(relPath);
+                response.Items.Add(new ParseSolutionResponseItem
+                {
+                    Id = Tree.RandomId().ToString(),
+                    SourceFileType = "org.openrewrite.quark.Quark",
+                    SourcePath = relPath
+                });
+            }
+        }
+
+        // Parse the .csproj file itself as an Xml.Document LST with MSBuildProject marker.
+        // The in-process restore during solution loading produced the in-memory LockFile
+        // for each project; fall back to a fresh in-process resolve when absent.
+        void EmitProjectFile(string projectPath)
+        {
+            if (!emittedProjectFiles.Add(Path.GetFullPath(projectPath)))
+                return;
+            try
+            {
+                var content = ReadFilePreservingBom(projectPath);
+                var relativePath = Path.GetRelativePath(rootDir, projectPath);
+                var xmlParser = new OpenRewrite.Xml.XmlParser();
+                var csprojDoc = xmlParser.Parse(content, relativePath);
+                var projectFullPath = Path.GetFullPath(projectPath);
+                var marker = solutionParser.RestoredLockFiles.TryGetValue(projectFullPath, out var lockFile)
+                    ? MSBuildProjectHelper.CreateMarker(csprojDoc, lockFile, Path.GetDirectoryName(projectFullPath)!)
+                    : MSBuildProjectHelper.CreateMarker(csprojDoc, rootDir);
+                if (marker != null)
+                    csprojDoc = csprojDoc.WithMarkers(csprojDoc.Markers.Add(marker));
+                _localObjects[csprojDoc.Id.ToString()] = csprojDoc;
+                response.Items.Add(new ParseSolutionResponseItem
+                {
+                    Id = csprojDoc.Id.ToString(),
+                    SourceFileType = "org.openrewrite.xml.tree.Xml$Document"
+                });
+            }
+            catch (Exception ex)
+            {
+                Log.Debug("RPC ParseSolution: failed to parse csproj for {ProjectPath}: {ExType}: {ExMessage}",
+                    projectPath, ex.GetType().Name, ex.Message);
+            }
+        }
+
         var projectIndex = 0;
         foreach (var project in projectList)
         {
@@ -327,61 +399,37 @@ public class RewriteRpcServer
                 throw;
             }
 
-            foreach (var sourceFile in sourceFiles)
-            {
-                var id = sourceFile.Id.ToString();
-                var sourceFileType = sourceFile is ParseError
-                    ? "org.openrewrite.tree.ParseError"
-                    : "org.openrewrite.csharp.tree.Cs$CompilationUnit";
+            if (sourceFiles.Count > 0 || solutionParser.LastOversizePaths.Count > 0)
+                projectsWithSources.Add(Path.GetFullPath(project.FilePath!));
+            EmitSourceFiles(sourceFiles);
+            EmitProjectFile(project.FilePath!);
+        }
 
-                _localObjects[id] = sourceFile;
-                response.Items.Add(new ParseSolutionResponseItem
-                {
-                    Id = id,
-                    SourceFileType = sourceFileType
-                });
-            }
+        // Projects MSBuild could not evaluate come back with no documents, which would silently
+        // drop every source file they own — a build-only task (a source-control/PDB <UsingTask>,
+        // say) must not make source code disappear from an analysis build. Recover their sources
+        // straight off disk instead: syntax-only LSTs, no type attestation, but present.
+        foreach (var (projectPath, reason) in solutionParser.UnevaluatedProjects)
+        {
+            // A diagnostic can name a project that nonetheless evaluated far enough to yield its
+            // documents (an unresolvable ProjectReference, say). Recovering from disk there would
+            // resurrect files the project deliberately excludes, so leave those projects alone.
+            if (projectsWithSources.Contains(Path.GetFullPath(projectPath)))
+                continue;
 
-            // Oversize source files skipped during parsing are emitted as Quarks; the Java
-            // side builds each Quark from SourcePath locally, so they carry no content and
-            // are deliberately not registered in _localObjects (no GetObject round-trip).
-            foreach (var relPath in solutionParser.LastOversizePaths)
-            {
-                response.Items.Add(new ParseSolutionResponseItem
-                {
-                    Id = Tree.RandomId().ToString(),
-                    SourceFileType = "org.openrewrite.quark.Quark",
-                    SourcePath = relPath
-                });
-            }
+            var recovered = solutionParser.ParseProjectWithoutMSBuild(projectPath, rootDir,
+                requirePrintEqualsInput, emittedPaths);
+            var oversize = solutionParser.LastOversizePaths.Count;
+            if (recovered.Count == 0 && oversize == 0)
+                continue;
 
-            // Parse the .csproj file itself as an Xml.Document LST with MSBuildProject marker.
-            // The in-process restore during solution loading produced the in-memory LockFile
-            // for each project; fall back to a fresh in-process resolve when absent.
-            try
-            {
-                var content = ReadFilePreservingBom(project.FilePath!);
-                var relativePath = Path.GetRelativePath(rootDir, project.FilePath!);
-                var xmlParser = new OpenRewrite.Xml.XmlParser();
-                var csprojDoc = xmlParser.Parse(content, relativePath);
-                var projectFullPath = Path.GetFullPath(project.FilePath!);
-                var marker = solutionParser.RestoredLockFiles.TryGetValue(projectFullPath, out var lockFile)
-                    ? MSBuildProjectHelper.CreateMarker(csprojDoc, lockFile, Path.GetDirectoryName(projectFullPath)!)
-                    : MSBuildProjectHelper.CreateMarker(csprojDoc, rootDir);
-                if (marker != null)
-                    csprojDoc = csprojDoc.WithMarkers(csprojDoc.Markers.Add(marker));
-                _localObjects[csprojDoc.Id.ToString()] = csprojDoc;
-                response.Items.Add(new ParseSolutionResponseItem
-                {
-                    Id = csprojDoc.Id.ToString(),
-                    SourceFileType = "org.openrewrite.xml.tree.Xml$Document"
-                });
-            }
-            catch (Exception ex)
-            {
-                Log.Debug("RPC ParseSolution: failed to parse csproj for {ProjectPath}: {ExType}: {ExMessage}",
-                    project.FilePath, ex.GetType().Name, ex.Message);
-            }
+            Log.Warning("MSBuild could not evaluate {ProjectPath}, so it contributed no source files: {Reason}. " +
+                        "Recovered {FileCount} source file(s) from disk without type attestation; " +
+                        "recipes that match on type will not see them",
+                projectPath, reason, recovered.Count + oversize);
+
+            EmitSourceFiles(recovered);
+            EmitProjectFile(projectPath);
         }
 
         // Capture build context files from disk for reattestation

--- a/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
+++ b/rewrite-csharp/csharp/OpenRewrite/CSharp/SolutionParser.cs
@@ -227,12 +227,23 @@ public class SolutionParser
     private IReadOnlyDictionary<string, LockFile> _restoredLockFiles =
         new Dictionary<string, LockFile>(StringComparer.OrdinalIgnoreCase);
 
+    private readonly Dictionary<string, string> _unevaluatedProjects = new(StringComparer.OrdinalIgnoreCase);
+
     /// <summary>
     /// In-memory NuGet lock files (keyed by absolute project path) from the most recent
     /// <see cref="LoadAsync"/>. Used for MSBuildProject marker attestation without reading
     /// <c>project.assets.json</c> from disk.
     /// </summary>
     public IReadOnlyDictionary<string, LockFile> RestoredLockFiles => _restoredLockFiles;
+
+    /// <summary>
+    /// C# projects the most recent <see cref="LoadAsync"/> could not evaluate, keyed by absolute
+    /// project path with the MSBuild failure message as the value. Such a project either never
+    /// reached <c>Solution.Projects</c> or reached it stripped of its documents, so its sources
+    /// would silently vanish from the LST. Callers recover them with
+    /// <see cref="ParseProjectWithoutMSBuild"/>.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> UnevaluatedProjects => _unevaluatedProjects;
 
     /// <summary>
     /// Load a solution or project via MSBuildWorkspace.
@@ -282,13 +293,36 @@ public class SolutionParser
             Log.Debug("MSBuild progress: {Operation} {FilePath}", p.Operation, Path.GetFileName(p.FilePath));
         });
 
+        _unevaluatedProjects.Clear();
+
+        // The C# projects the entry path declares, so a project MSBuild drops entirely (or
+        // strips of its documents) can still be recognized and recovered from disk.
+        var declaredProjects = NuGetResolver.EnumerateProjects(path)
+            .Where(p => p.EndsWith(".csproj", StringComparison.OrdinalIgnoreCase))
+            .Select(Path.GetFullPath)
+            .ToList();
+
         Solution solution;
         Log.Debug(">> MSBuildWorkspace.Open ({FileName})", Path.GetFileName(path));
-        if (path.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
-            path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
-            solution = await workspace.OpenSolutionAsync(path, progress, cancellationToken: ct);
-        else
-            solution = (await workspace.OpenProjectAsync(path, progress, cancellationToken: ct)).Solution;
+        try
+        {
+            if (path.EndsWith(".sln", StringComparison.OrdinalIgnoreCase) ||
+                path.EndsWith(".slnx", StringComparison.OrdinalIgnoreCase))
+                solution = await workspace.OpenSolutionAsync(path, progress, cancellationToken: ct);
+            else
+                solution = (await workspace.OpenProjectAsync(path, progress, cancellationToken: ct)).Solution;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Opening failed outright — degrade to an empty solution and let every declared
+            // project fall back to syntax-only parsing rather than dropping the whole tree.
+            Log.Warning("MSBuildWorkspace could not open {Path} ({ExType}: {ExMessage}); " +
+                        "its {ProjectCount} project(s) will be parsed without type attestation",
+                path, ex.GetType().Name, ex.Message, declaredProjects.Count);
+            foreach (var declared in declaredProjects)
+                _unevaluatedProjects[declared] = ex.Message;
+            return workspace.CurrentSolution;
+        }
         Log.Debug("<< MSBuildWorkspace.Open ({FileName}) ({Elapsed})", Path.GetFileName(path), sw.Elapsed);
 
         // Report any workspace diagnostics
@@ -301,6 +335,8 @@ public class SolutionParser
             if (diags.Count > 10)
                 Log.Debug("  ... and {Remaining} more diagnostics", diags.Count - 10);
         }
+
+        RecordUnevaluatedProjects(declaredProjects, solution, diags);
 
         var projects = solution.Projects.ToList();
         var docCount = projects.Sum(p => p.Documents.Count());
@@ -333,6 +369,43 @@ public class SolutionParser
         const string marker = "with message: ";
         var index = diagnostic.Message.IndexOf(marker, StringComparison.Ordinal);
         return (index < 0 ? diagnostic.Message : diagnostic.Message[(index + marker.Length)..]).Trim();
+    }
+
+    /// <summary>
+    /// Flags declared C# projects that MSBuild failed to evaluate: those a workspace failure
+    /// diagnostic names (a build-only <c>UsingTask</c>, an unresolvable <c>Import</c>, ...) and
+    /// those that never reached the solution at all. Both cases surface as a project with no
+    /// documents, which would otherwise be indistinguishable from a genuinely empty project.
+    /// </summary>
+    private void RecordUnevaluatedProjects(
+        IReadOnlyList<string> declaredProjects,
+        Solution solution,
+        IReadOnlyList<WorkspaceDiagnostic> diagnostics)
+    {
+        if (declaredProjects.Count == 0)
+            return;
+
+        var loaded = new HashSet<string>(
+            solution.Projects.Where(p => p.FilePath != null).Select(p => Path.GetFullPath(p.FilePath!)),
+            StringComparer.OrdinalIgnoreCase);
+
+        foreach (var declared in declaredProjects)
+        {
+            if (!loaded.Contains(declared))
+            {
+                _unevaluatedProjects[declared] = "not loaded by MSBuildWorkspace";
+                continue;
+            }
+            foreach (var diagnostic in diagnostics)
+            {
+                if (diagnostic.Kind == WorkspaceDiagnosticKind.Failure &&
+                    diagnostic.Message.Contains(declared, StringComparison.OrdinalIgnoreCase))
+                {
+                    _unevaluatedProjects[declared] = FailureReason(diagnostic);
+                    break;
+                }
+            }
+        }
     }
 
     /// <summary>
@@ -392,6 +465,86 @@ public class SolutionParser
         Log.Debug("ParseProject: {ProjectName} has {UserDocCount} user source files (of {TotalDocCount} total)",
             projectName, userDocs.Count, project.Documents.Count());
 
+        var units = userDocs
+            .Select(doc => new ParseUnit(
+                doc.FilePath!,
+                () => doc.GetTextAsync().Result?.ToString(),
+                () =>
+                {
+                    if (compilation == null)
+                        return null;
+                    var syntaxTree = doc.GetSyntaxTreeAsync().Result;
+                    return syntaxTree == null ? null : compilation.GetSemanticModel(syntaxTree);
+                }))
+            .ToList();
+
+        return ParseUnits(projectPath, rootDir, units, configSymbolSets, requirePrintEqualsInput);
+    }
+
+    /// <summary>
+    /// Parse a project's C# sources straight off disk, without MSBuild. Used when MSBuild could
+    /// not evaluate the project (see <see cref="UnevaluatedProjects"/>) and therefore reported it
+    /// with no documents: the resulting LSTs carry no type attestation, but the files are present
+    /// instead of silently missing. Paths in <paramref name="alreadyParsed"/> (repository-relative,
+    /// forward slashes) are skipped so a file another project already contributed is not duplicated.
+    /// </summary>
+    public List<SourceFile> ParseProjectWithoutMSBuild(
+        string projectPath, string rootDir,
+        bool requirePrintEqualsInput = true,
+        ISet<string>? alreadyParsed = null)
+    {
+        LastOversizePaths.Clear();
+        var projectName = Path.GetFileNameWithoutExtension(projectPath);
+
+        var filePaths = EnumerateProjectSourceFiles(projectPath);
+        if (alreadyParsed is { Count: > 0 })
+            filePaths = filePaths
+                .Where(p => !alreadyParsed.Contains(Path.GetRelativePath(rootDir, p).Replace('\\', '/')))
+                .ToList();
+
+        var ignoredPaths = GetGitIgnoredPaths(rootDir, filePaths);
+        if (ignoredPaths.Count > 0)
+            filePaths = filePaths.Where(p => !ignoredPaths.Contains(p)).ToList();
+
+        Log.Debug("ParseProjectWithoutMSBuild: {ProjectName} recovered {FileCount} source files from disk",
+            projectName, filePaths.Count);
+
+        var units = filePaths
+            .Select(filePath => new ParseUnit(filePath, () => ReadSource(filePath), () => null))
+            .ToList();
+
+        return ParseUnits(projectPath, rootDir, units, new List<HashSet<string>> { new() },
+            requirePrintEqualsInput);
+    }
+
+    /// <summary>
+    /// A single file to parse: where it lives, how to read it, and how to obtain its semantic
+    /// model (null when the project could not be evaluated, yielding a syntax-only LST).
+    /// </summary>
+    private sealed record ParseUnit(
+        string FilePath,
+        Func<string?> ReadSource,
+        Func<SemanticModel?> GetSemanticModel);
+
+    private static string? ReadSource(string filePath)
+    {
+        try
+        {
+            return File.ReadAllText(filePath);
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("Failed to read {FilePath}: {ExType}: {ExMessage}", filePath, ex.GetType().Name, ex.Message);
+            return null;
+        }
+    }
+
+    private List<SourceFile> ParseUnits(
+        string projectPath, string rootDir, IReadOnlyList<ParseUnit> units,
+        List<HashSet<string>> configSymbolSets, bool requirePrintEqualsInput)
+    {
+        var projectName = Path.GetFileNameWithoutExtension(projectPath);
+
         // Create an EditorConfigResolver to detect formatting style from .editorconfig files.
         // The resolver caches results per directory, so files in the same directory share
         // the same CSharpFormatStyle marker instance.
@@ -408,41 +561,35 @@ public class SolutionParser
         var results = new List<SourceFile>();
         var fileIndex = 0;
         var projectSw = Stopwatch.StartNew();
-        foreach (var doc in userDocs)
+        foreach (var unit in units)
         {
             fileIndex++;
 
             // Files too large to parse into a Roslyn tree/LST are recorded as Quarks
             // (path only) by the RPC layer; skip the expensive parse entirely.
             long docSize;
-            try { docSize = new FileInfo(doc.FilePath!).Length; } catch { docSize = 0; }
+            try { docSize = new FileInfo(unit.FilePath).Length; } catch { docSize = 0; }
             if (docSize > MaxParseableSizeBytes)
             {
-                LastOversizePaths.Add(Path.GetRelativePath(rootDir, doc.FilePath!).Replace('\\', '/'));
+                LastOversizePaths.Add(Path.GetRelativePath(rootDir, unit.FilePath).Replace('\\', '/'));
                 continue;
             }
 
-            var source = doc.GetTextAsync().Result?.ToString();
+            var source = unit.ReadSource();
             if (source == null) continue;
 
-            var relativePath = Path.GetRelativePath(rootDir, doc.FilePath!);
+            var relativePath = Path.GetRelativePath(rootDir, unit.FilePath);
             // Normalize path separators to forward slashes for cross-platform consistency
             relativePath = relativePath.Replace('\\', '/');
 
             // Detect UTF-8 BOM — Roslyn's SourceText.ToString() strips the BOM character,
             // so we check the raw file bytes to preserve the flag for patch fidelity.
-            var charsetBomMarked = HasUtf8Bom(doc.FilePath!);
+            var charsetBomMarked = HasUtf8Bom(unit.FilePath);
 
             var fileSw = Stopwatch.StartNew();
             try
             {
-                SemanticModel? semanticModel = null;
-                if (compilation != null)
-                {
-                    var syntaxTree = doc.GetSyntaxTreeAsync().Result;
-                    if (syntaxTree != null)
-                        semanticModel = compilation.GetSemanticModel(syntaxTree);
-                }
+                var semanticModel = unit.GetSemanticModel();
 
                 CompilationUnit cu;
                 if (configSymbolSets.Count > 1)
@@ -456,7 +603,7 @@ public class SolutionParser
                 }
 
                 // Attach formatting style marker from .editorconfig
-                var formatStyle = editorConfigResolver.Resolve(doc.FilePath!);
+                var formatStyle = editorConfigResolver.Resolve(unit.FilePath);
                 cu = cu.WithMarkers(cu.Markers.Add(formatStyle));
 
                 if (requirePrintEqualsInput)
@@ -465,7 +612,7 @@ public class SolutionParser
                     if (printed != source)
                     {
                         Log.Debug("  IDEMPOTENCY [{FileIndex}/{TotalFiles}] {RelativePath}",
-                            fileIndex, userDocs.Count, relativePath);
+                            fileIndex, units.Count, relativePath);
                         var diff = DiffUtils.UnifiedDiff(source, printed, relativePath);
                         results.Add(ParseError.Build(relativePath, source,
                             new InvalidOperationException(relativePath + " is not print idempotent. \n" + diff)));
@@ -481,13 +628,13 @@ public class SolutionParser
                 // Log every file with duration — slow files (>1s) get a warning prefix
                 var prefix = fileSw.Elapsed.TotalSeconds > 1.0 ? "SLOW " : "";
                 Log.Debug("  {Prefix}[{FileIndex}/{TotalFiles}] {RelativePath} ({ElapsedMs}ms)",
-                    prefix, fileIndex, userDocs.Count, relativePath, fileSw.Elapsed.TotalMilliseconds.ToString("F0"));
+                    prefix, fileIndex, units.Count, relativePath, fileSw.Elapsed.TotalMilliseconds.ToString("F0"));
             }
             catch (Exception ex)
             {
                 fileSw.Stop();
                 Log.Debug("  ERROR [{FileIndex}/{TotalFiles}] {RelativePath} ({ElapsedMs}ms): {ExType}: {ExMessage}",
-                    fileIndex, userDocs.Count, relativePath, fileSw.Elapsed.TotalMilliseconds.ToString("F0"),
+                    fileIndex, units.Count, relativePath, fileSw.Elapsed.TotalMilliseconds.ToString("F0"),
                     ex.GetType().Name, ex.Message);
                 results.Add(ParseError.Build(relativePath, source, ex));
             }
@@ -497,6 +644,48 @@ public class SolutionParser
         Log.Debug("ParseProject: {ProjectName} completed {ResultCount} files in {ElapsedSec}s",
             projectName, results.Count, projectSw.Elapsed.TotalSeconds.ToString("F1"));
         return results;
+    }
+
+    /// <summary>
+    /// Enumerates the C# sources that belong to a project directory when MSBuild cannot say
+    /// which they are: every <c>.cs</c> file under the project directory, skipping build output
+    /// and tool directories, and skipping subtrees owned by another project file (which is
+    /// parsed — or recovered — on its own).
+    /// </summary>
+    private static List<string> EnumerateProjectSourceFiles(string projectPath)
+    {
+        var projectDir = Path.GetDirectoryName(Path.GetFullPath(projectPath));
+        var files = new List<string>();
+        if (projectDir == null || !Directory.Exists(projectDir))
+            return files;
+        CollectSourceFiles(projectDir, files, isProjectRoot: true);
+        files.Sort(StringComparer.Ordinal);
+        return files;
+    }
+
+    private static readonly string[] NonSourceDirectories =
+        { "bin", "obj", ".vs", ".git", "packages", "node_modules", "TestResults" };
+
+    private static void CollectSourceFiles(string dir, List<string> files, bool isProjectRoot)
+    {
+        try
+        {
+            if (!isProjectRoot && Directory.EnumerateFiles(dir, "*.*proj").Any())
+                return;
+            files.AddRange(Directory.EnumerateFiles(dir, "*.cs"));
+            foreach (var subDir in Directory.EnumerateDirectories(dir))
+            {
+                var name = Path.GetFileName(subDir);
+                if (NonSourceDirectories.Contains(name, StringComparer.OrdinalIgnoreCase))
+                    continue;
+                CollectSourceFiles(subDir, files, isProjectRoot: false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.Debug("Failed to enumerate sources under {Dir}: {ExType}: {ExMessage}",
+                dir, ex.GetType().Name, ex.Message);
+        }
     }
 
     /// <summary>

--- a/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpParseProjectTest.java
+++ b/rewrite-csharp/src/integTest/java/org/openrewrite/csharp/rpc/CSharpParseProjectTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.io.TempDir;
 import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.SourceFile;
 import org.openrewrite.csharp.CSharpParser;
@@ -263,6 +264,42 @@ class CSharpParseProjectTest implements RewriteTest {
               """
           )
         );
+    }
+
+    /**
+     * A build-only MSBuild task (a source-control/PDB {@code <UsingTask>} whose assembly only
+     * exists after a real build) makes MSBuild fail evaluation, and the workspace then reports
+     * the project with no documents at all. Its sources must still reach the LST — parsed as
+     * text, without type attestation — rather than silently disappearing from the build.
+     */
+    @Test
+    void sourcesSurviveAProjectMSBuildCannotEvaluate(@TempDir Path tempDir) throws Exception {
+        Files.writeString(tempDir.resolve("PdbGit.targets"),
+          """
+            <Project>
+              <UsingTask TaskName="PdbGitTask" AssemblyFile="$(_PdbGitAssemblyFile)" />
+            </Project>
+            """);
+        Files.writeString(tempDir.resolve("Broken.csproj"),
+          """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <Import Project="PdbGit.targets" />
+            </Project>
+            """);
+        Files.writeString(tempDir.resolve("A.cs"), "class A { }\n");
+        Files.createDirectories(tempDir.resolve("nested"));
+        Files.writeString(tempDir.resolve("nested/B.cs"), "class B { }\n");
+
+        CSharpRewriteRpc rpc = CSharpRewriteRpc.getOrStart();
+        List<SourceFile> sourceFiles = rpc.parseSolution(
+          tempDir.resolve("Broken.csproj"), tempDir, new InMemoryExecutionContext()).toList();
+
+        assertThat(sourceFiles).noneMatch(ParseError.class::isInstance);
+        assertThat(sourceFiles).extracting(sf -> sf.getSourcePath().toString())
+          .containsExactlyInAnyOrder("A.cs", "nested/B.cs", "Broken.csproj");
     }
 
     // ---- Full working set sweep ----


### PR DESCRIPTION
A build-only MSBuild task — a source-control/PDB `<UsingTask>` whose assembly only exists after a real build, say — makes MSBuild fail project evaluation, and `MSBuildWorkspace` then hands the project back stripped of every document, so every source file it owns silently vanishes from the LST.

`SolutionParser` now records such projects in `UnevaluatedProjects`: the ones a workspace failure diagnostic names, the ones that never reached the solution at all, and — when `MSBuildWorkspace.Open` throws outright — every project the entry path declares.

`ParseProjectWithoutMSBuild` then recovers their `.cs` files straight off disk, skipping build output, git-ignored paths, subtrees owned by another project file, and anything another project already emitted; the resulting LSTs carry no type attestation (a warning says so), but the files are present instead of missing.

Covered by five xUnit tests in `UnevaluatedProjectRecoveryTests` and an end-to-end RPC integration test in `CSharpParseProjectTest`.