### PR TITLE
Preserve the anchor's blank-line prefix on REPLACEMENT

### DIFF
--- a/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest4Test.java
+++ b/rewrite-java-test/src/test/java/org/openrewrite/java/JavaTemplateTest4Test.java
@@ -314,6 +314,49 @@ class JavaTemplateTest4Test implements RewriteTest {
         );
     }
 
+    @SuppressWarnings("UnusedAssignment")
+    @Test
+    void replaceStatementInBlockPreservesLeadingBlankLine() {
+        rewriteRun(
+          spec -> spec.recipe(toRecipe(() -> new JavaVisitor<>() {
+              @Override
+              public J visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext p) {
+                  var statement = method.getBody().getStatements().get(1);
+                  if (statement instanceof J.Unary) {
+                      return JavaTemplate.builder("n = 2;\nn = 3;")
+                        .contextSensitive()
+                        .build()
+                        .apply(getCursor(), statement.getCoordinates().replace());
+                  }
+                  return method;
+              }
+          })),
+          java(
+            """
+              class Test {
+                  int n;
+                  void test() {
+                      n = 1;
+
+                      n++;
+                  }
+              }
+              """,
+            """
+              class Test {
+                  int n;
+                  void test() {
+                      n = 1;
+
+                      n = 2;
+                      n = 3;
+                  }
+              }
+              """
+          )
+        );
+    }
+
     @Test
     void beforeStatementInBlock() {
         rewriteRun(

--- a/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/internal/template/JavaTemplateJavaExtension.java
@@ -132,7 +132,7 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
                 for (int i = 0; i < gen.size(); i++) {
                     Statement s = gen.get(i);
                     if (anchorBeginsLine) {
-                        gen.set(i, autoFormat(i == 0 ? s.withPrefix(lineBreakBefore(anchor)) : s, p, parent));
+                        gen.set(i, autoFormat(i == 0 ? s.withPrefix(firstPrefix(anchor)) : s, p, parent));
                     } else {
                         gen.set(i, autoFormat(s, p, parent).withPrefix(leadingPrefix(anchor, i)));
                     }
@@ -149,10 +149,15 @@ public class JavaTemplateJavaExtension extends JavaTemplateLanguageExtension {
             }
 
             /**
-             * A blank line above the anchor separates it from what precedes and stays with it, so a statement
-             * joining the anchor's line gets a single break at the same indent rather than that separation again.
+             * The prefix for the first generated statement. When the anchor stays in the tree (BEFORE, AFTER) any
+             * blank-line separator above it belongs to the anchor and the new statement joins on a single break at
+             * the same indent. When the anchor is removed (REPLACEMENT) the new statement takes its position, so
+             * it also takes its whitespace — comments are dropped since replacement removes what they annotated.
              */
-            private Space lineBreakBefore(Statement anchor) {
+            private Space firstPrefix(Statement anchor) {
+                if (mode == JavaCoordinates.Mode.REPLACEMENT) {
+                    return anchor.getPrefix().withComments(emptyList());
+                }
                 String whitespace = anchor.getPrefix().getWhitespace();
                 return Space.format("\n" + whitespace.substring(whitespace.lastIndexOf('\n') + 1));
             }


### PR DESCRIPTION
## Problem

- `JavaTemplateJavaExtension.spliceAround` (introduced in #8837) reduces the first generated statement's prefix to a single newline plus indent for every mode:

```java
gen.set(i, autoFormat(i == 0 ? s.withPrefix(lineBreakBefore(anchor)) : s, p, parent));
```

- That's the right call for `BEFORE` and `AFTER` — the anchor stays in the tree and carries its blank-line separator with it, so the new statement joining the anchor's line shouldn't repeat the separation. That's what the test #8837 added (`insertBeforeTopLevelScriptStatementLeavesItsBlankLineAlone`) pins.

For `REPLACEMENT` the anchor is removed and the new statement takes its position. Any blank-line separator above the anchor has nowhere to stay, and gets dropped.

## Repro

Concrete downstream shape from `rewrite-testing-frameworks` `EasyMockVerifyToMockitoVerify` (single-`verify` fanning out into per-method calls). Input:

```java
expect(dependency3.action3(3.3)).andReturn("result");

verify(dependency);      // ← blank line separates setup from verify
verify(dependency2);
```

Output before this fix:

```java
expect(dependency3.action3(3.3)).andReturn("result");
verify(dependency).action("", 2);   // ← blank line lost
verify(dependency2).action("", 2);
```

Output with this fix: the blank line is preserved.

## Fix

Rename `lineBreakBefore` to `firstPrefix` and branch on `mode`:

- `REPLACEMENT` → `anchor.getPrefix().withComments(emptyList())`. The new statement inherits the anchor's whitespace since it takes the anchor's position. Comments are cleared because replacement removes what they annotated.
- `BEFORE` / `AFTER` → single newline + indent, unchanged from #8837.

## Tests

- New test `JavaTemplateTest4Test.replaceStatementInBlockPreservesLeadingBlankLine` — replace one statement (with a blank-line separator above it) with two, assert the separator survives on the first inserted statement.
- `insertBeforeTopLevelScriptStatementLeavesItsBlankLineAlone` from #8837 continues to pass — the `BEFORE`-mode intent is unchanged.
- `:rewrite-java-test:test`, `:rewrite-java:test`, `:rewrite-groovy:test`, `:rewrite-kotlin:test` all green locally.