### PR TITLE
Kotlin: expand escape sequences in J.Literal values

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/tree/J.java
@@ -3654,10 +3654,18 @@ public interface J extends Tree {
         @With
         Markers markers;
 
+        /**
+         * The decoded value, with any escape sequence in {@link #valueSource} expanded; the source spelling
+         * instead when {@link #unicodeEscapes} is set.
+         */
         @With
         @Nullable
         Object value;
 
+        /**
+         * The literal as spelled in the source, delimiters included, minus any escape held in
+         * {@link #unicodeEscapes}. This is what gets printed, so a change to {@link #value} must be mirrored here.
+         */
         @With
         @Nullable
         String valueSource;

--- a/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
+++ b/rewrite-kotlin/src/main/java/org/openrewrite/kotlin/internal/KotlinTreeParserVisitor.java
@@ -552,15 +552,31 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
 
     @Override
     public J visitEscapeStringTemplateEntry(KtEscapeStringTemplateEntry entry, ExecutionContext data) {
+        String unescaped = entry.getUnescapedValue();
         return new J.Literal(
                 randomId(),
                 Space.EMPTY,
                 Markers.EMPTY,
-                entry.getText(),
+                hasUnpairedSurrogate(unescaped) ? entry.getText() : unescaped,
                 entry.getText(),
                 null,
                 JavaType.Primitive.String
         ).withPrefix(deepPrefix(entry));
+    }
+
+    /**
+     * A {@link J.Literal} value cannot hold a lone surrogate; see {@link J.Literal.UnicodeEscape}. Escape
+     * sequences that would decode to one keep their source spelling instead.
+     */
+    private static boolean hasUnpairedSurrogate(CharSequence s) {
+        for (int i = 0; i < s.length(); i++) {
+            if (Character.isHighSurrogate(s.charAt(i)) && i + 1 < s.length() && Character.isLowSurrogate(s.charAt(i + 1))) {
+                i++;
+            } else if (Character.isSurrogate(s.charAt(i))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -3272,23 +3288,29 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
         }
 
         StringBuilder valueSb = new StringBuilder();
-        Arrays.stream(entries).forEach(entry -> valueSb.append(maybeAdjustCRLF(entry))
-        );
+        StringBuilder sourceSb = new StringBuilder();
+        for (KtStringTemplateEntry entry : entries) {
+            String text = maybeAdjustCRLF(entry);
+            sourceSb.append(text);
+            valueSb.append(entry instanceof KtEscapeStringTemplateEntry ?
+                    ((KtEscapeStringTemplateEntry) entry).getUnescapedValue() : text);
+        }
 
-        String valueSource = getString(expression, valueSb);
+        String valueSource = getString(expression, sourceSb);
+        String value = hasUnpairedSurrogate(valueSb) ? sourceSb.toString() : valueSb.toString();
 
         return new J.Literal(
                 randomId(),
                 Space.EMPTY,
                 Markers.EMPTY,
-                valueSb.toString(),
+                value,
                 valueSource,
                 null,
                 JavaType.Primitive.String
         ).withPrefix(deepPrefix(expression));
     }
 
-    private static String getString(KtStringTemplateExpression expression, StringBuilder valueSb) {
+    private static String getString(KtStringTemplateExpression expression, StringBuilder sourceSb) {
         PsiElement openQuote;
         String prefix;
         if (expression.getInterpolationPrefix() == null) {
@@ -3306,7 +3328,7 @@ public class KotlinTreeParserVisitor extends KtVisitor<J, ExecutionContext> {
             throw new UnsupportedOperationException("This should never happen");
         }
 
-        return prefix + openQuote.getText() + valueSb + closingQuota.getText();
+        return prefix + openQuote.getText() + sourceSb + closingQuota.getText();
     }
 
     @Override

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/LiteralTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/LiteralTest.java
@@ -148,4 +148,45 @@ class LiteralTest implements RewriteTest {
           )
         );
     }
+
+    @Test
+    void escapeSequencesInString() {
+        rewriteRun(
+          kotlin("val s = \"a\\nb\\tc\\u2605d\\\\e\\$f\"", spec -> spec.afterRecipe(cu -> {
+              J.Literal lit = initializerOf(cu);
+              assertThat(lit.getValue()).isEqualTo("a\nb\tc★d\\e$f");
+              assertThat(lit.getValueSource()).isEqualTo("\"a\\nb\\tc\\u2605d\\\\e\\$f\"");
+          }))
+        );
+    }
+
+    @Test
+    void rawStringHasNoEscapeSequences() {
+        rewriteRun(
+          kotlin("val s = \"\"\"a\\nb\"\"\"", spec -> spec.afterRecipe(cu ->
+            assertThat(initializerOf(cu).getValue()).isEqualTo("a\\nb")))
+        );
+    }
+
+    @Test
+    void surrogateEscapes() {
+        rewriteRun(
+          kotlin("val paired = \"\\uD83D\\uDE00\"", spec -> spec.afterRecipe(cu ->
+            assertThat(initializerOf(cu).getValue()).isEqualTo("\uD83D\uDE00"))),
+
+          kotlin("val unpaired = \"x\\uD800y\"", spec -> spec.afterRecipe(cu ->
+            assertThat(initializerOf(cu).getValue()).isEqualTo("x\\uD800y"))),
+
+          kotlin("val id = 1\nval fragment = \"\\uD800${id}\"", spec -> spec.afterRecipe(cu -> {
+              J.VariableDeclarations vd = (J.VariableDeclarations) cu.getStatements().get(1);
+              K.StringTemplate template = (K.StringTemplate) vd.getVariables().getFirst().getInitializer();
+              assertThat(((J.Literal) template.getStrings().getFirst()).getValue()).isEqualTo("\\uD800");
+          }))
+        );
+    }
+
+    private static J.Literal initializerOf(K.CompilationUnit cu) {
+        J.VariableDeclarations vd = (J.VariableDeclarations) cu.getStatements().getFirst();
+        return (J.Literal) vd.getVariables().getFirst().getInitializer();
+    }
 }

--- a/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/StringTemplateTest.java
+++ b/rewrite-kotlin/src/test/java/org/openrewrite/kotlin/tree/StringTemplateTest.java
@@ -17,8 +17,12 @@ package org.openrewrite.kotlin.tree;
 
 import org.junit.jupiter.api.Test;
 import org.openrewrite.Issue;
+import org.openrewrite.java.tree.J;
 import org.openrewrite.test.RewriteTest;
 
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.openrewrite.kotlin.Assertions.kotlin;
 
 @SuppressWarnings({"KotlinConstantConditions", "ControlFlowWithEmptyBody"})
@@ -100,6 +104,21 @@ class StringTemplateTest implements RewriteTest {
               }
               """
           )
+        );
+    }
+
+    @Test
+    void escapeFragmentValueIsUnescaped() {
+        rewriteRun(
+          kotlin("val id = 1\nval s = \"a\\nb\\u2605${id}\"", spec -> spec.afterRecipe(cu -> {
+              J.VariableDeclarations vd = (J.VariableDeclarations) cu.getStatements().get(1);
+              K.StringTemplate template = (K.StringTemplate) vd.getVariables().getFirst().getInitializer();
+              List<J> strings = template.getStrings();
+              J.Literal newline = (J.Literal) strings.get(1);
+              assertThat(newline.getValue()).isEqualTo("\n");
+              assertThat(newline.getValueSource()).isEqualTo("\\n");
+              assertThat(((J.Literal) strings.get(3)).getValue()).isEqualTo("★");
+          }))
         );
     }
 }


### PR DESCRIPTION
`J.Literal` fragments inside a `K.StringTemplate` carried the raw source spelling in `getValue()`, so an escape sequence never decoded — a consumer reconstructing the string a template builds got two characters where the program has a newline. Plain Kotlin string literals had it too.

| Kotlin source | `getValue()` was |
|---|---|
| `val a = "a\nb"` | 4 chars: `a`, `\`, `n`, `b` |
| `val b = "a\tb★c\\d\$e"` | 17 chars, entirely raw |
| `val d = "-- for $id\nselect *"` | the `\n` fragment's value was `\`, `n` |
| `val c = """a⏎b"""` | 3 chars — correct |

The last row is a control case, not a second data point: a Kotlin raw string produces no escape entries at all.

## Why this was a bug, not deliberate

Print idempotency is the plausible motive, but it was never load-bearing on the raw value: `JavaPrinter.visitLiteral` emits `getValueSource()` and never `getValue()`, and nothing overrides it for `J.Literal`.

Two further signals:

- The Kotlin parser already decodes `Char` literals through its own `unescape()` helper, and `LiteralTest.literalCharacter` asserts exactly the decoded-value/source-spelling split for `'\n'`. Strings were the inconsistency.
- Java keeps javac's decoded value alongside the source text, and C# splits the two explicitly — `VisitInterpolatedStringText` uses `TextToken.ValueText` for the value, `TextToken.Text` for the source.

## The fix

Both sites delegate to the Kotlin PSI's own `KtEscapeStringTemplateEntry.getUnescapedValue()` rather than re-implementing Kotlin's escape table: `visitEscapeStringTemplateEntry` for template fragments, and the no-interpolation branch of `visitStringTemplateExpression`, which now builds the decoded value and the source spelling in separate buffers.

A bare `\u` with no hex digits comes back verbatim, so `value` still equals `valueSource` wherever nothing can be decoded. One carve-out goes further: an escape decoding to an *unpaired* surrogate keeps its source spelling, since a lone surrogate in `value` is unserializable.

```
JsonGenerationException: Invalid surrogate pair, starts with valid high surrogate (0xD800)
but ends with invalid low surrogate (0x0079), not in valid range [0xDC00, 0xDFFF]
```

An escaped pair still decodes, so `"\uD83D\uDE00"` yields 😀. This is the hazard `J.Literal.UnicodeEscape` exists for; routing Kotlin's surrogate escapes into that mechanism, as the Java parser does, would be the fuller fix and is not attempted here.

## Tests

All four assert on characters, since a real newline and a literal backslash-`n` render identically through most escaping helpers.

- `LiteralTest.escapeSequencesInString` — decoded value against source spelling for `\n`, `\t`, `\uXXXX`, `\\`, `\$`.
- `LiteralTest.rawStringHasNoEscapeSequences` — fails if decoding ever moves from per-escape-entry to a pass over the assembled string.
- `LiteralTest.surrogateEscapes` — the carve-out at both call sites, plus the paired case.
- `StringTemplateTest.escapeFragmentValueIsUnescaped` — the reported fragment case.

## Scope

`J.Literal`'s `value` and `valueSource` now document the contract, including the pre-existing `unicodeEscapes` carve-out under which `value` holds the source spelling.

Groovy has the same defect in `GroovyParserVisitor`, for plain String literals and `G.GString` fragments both; that is left to a follow-up.
