### PR TITLE
Let the embedder cap a peer's memory

### DIFF
--- a/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
+++ b/rewrite-core/src/main/java/org/openrewrite/rpc/RewriteRpcProcess.java
@@ -41,6 +41,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -77,6 +78,8 @@ public class RewriteRpcProcess extends Thread {
     }
 
     private static final long GRACEFUL_EXIT_MILLIS = 200;
+
+    private static volatile long memoryLimit;
 
     private final String[] command;
 
@@ -141,10 +144,29 @@ public class RewriteRpcProcess extends Thread {
         return this;
     }
 
+    /**
+     * Caps what a peer may commit ({@code RLIMIT_DATA} on Linux, no effect elsewhere) so one that
+     * outgrows its budget dies alone rather than taking the host process with it. 0 is no cap.
+     */
+    public static void setMemoryLimit(long bytes) {
+        memoryLimit = bytes;
+    }
+
+    /** Best-effort: a hard limit already below the cap can't be raised unprivileged, so the tighter one stands. */
+    List<String> launchCommand() {
+        if (memoryLimit <= 0 || !System.getProperty("os.name").startsWith("Linux")) {
+            return Arrays.asList(command);
+        }
+        List<String> limited = new ArrayList<>(Arrays.asList("/bin/sh", "-c",
+                "ulimit -d " + memoryLimit / 1024 + "; exec \"$@\"", "sh"));
+        limited.addAll(Arrays.asList(command));
+        return limited;
+    }
+
     @Override
     public void run() {
         try {
-            ProcessBuilder pb = new ProcessBuilder(command);
+            ProcessBuilder pb = new ProcessBuilder(launchCommand());
             // Strip inherited vars BEFORE putAll so the caller's explicit
             // environment (which can re-set any of these names) wins.
             unsetEnvNames.forEach(pb.environment()::remove);

--- a/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
+++ b/rewrite-core/src/test/java/org/openrewrite/rpc/RewriteRpcProcessTest.java
@@ -17,6 +17,7 @@ package org.openrewrite.rpc;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
 import java.io.BufferedReader;
@@ -295,6 +296,30 @@ class RewriteRpcProcessTest {
             assertThat(peer.getLivenessCheck()).isNull();
         } finally {
             peerProcess.destroyForcibly();
+        }
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void memoryLimitLaunchesUnderUlimit() {
+        RewriteRpcProcess.setMemoryLimit(6L << 30);
+        try {
+            assertThat(new RewriteRpcProcess("noop", "--flag").launchCommand())
+                    .containsExactly("/bin/sh", "-c", "ulimit -d 6291456; exec \"$@\"", "sh", "noop", "--flag");
+        } finally {
+            RewriteRpcProcess.setMemoryLimit(0);
+        }
+        assertThat(new RewriteRpcProcess("noop", "--flag").launchCommand()).containsExactly("noop", "--flag");
+    }
+
+    @Test
+    @DisabledOnOs(OS.LINUX)
+    void memoryLimitOnlyAppliesOnLinux() {
+        RewriteRpcProcess.setMemoryLimit(6L << 30);
+        try {
+            assertThat(new RewriteRpcProcess("noop", "--flag").launchCommand()).containsExactly("noop", "--flag");
+        } finally {
+            RewriteRpcProcess.setMemoryLimit(0);
         }
     }
 


### PR DESCRIPTION
An embedder that runs RPC peers inside a memory-limited environment needs a peer that outgrows its
budget to die alone rather than take the host process with it. Today the command `RewriteRpcProcess`
executes is fixed at construction, and every language builder (Go, JavaScript, Python, C#)
constructs one, so there is no single place to bound a peer.

This adds one process-wide setting, `RewriteRpcProcess.setMemoryLimit(long bytes)`, a static like
the language `MANAGER` singletons — no builder plumbing, since the limit is a property of the host
process, not of one peer. With a limit set, on Linux a peer launches as

```
/bin/sh -c 'ulimit -d <KiB>; exec "$@"' sh <command…>
```

`ulimit -d` sets `RLIMIT_DATA`, the memory a process has actually committed, and is a POSIX `sh`
builtin. The `;` is deliberate: a hard limit already below the cap can't be raised unprivileged, and
the tighter one then stands rather than blocking every launch. Because of the `exec`, the `Process`
handle still points at the real peer, so exit codes, descendant cleanup and the liveness check keep
working. With no limit (the default, 0), or on any OS other than Linux, the command is unchanged.

Rewrite reads no cgroups and computes nothing: the number comes from the embedder, which alone knows
its own reserve.

`RewriteRpcProcessTest` covers the launched command shape under a limit on Linux, passthrough once
the limit is cleared, and passthrough off Linux.
